### PR TITLE
OSDOCS-4926: Doc node port issue workaround procedure

### DIFF
--- a/microshift_troubleshooting/microshift-troubleshooting.adoc
+++ b/microshift_troubleshooting/microshift-troubleshooting.adoc
@@ -11,3 +11,5 @@ Read about troubleshooting and possible solutions for known issues.
 include::modules/microshift-ki-cni-iptables-deleted.adoc[leveloffset=+1]
 
 include::modules/microshift-troubleshooting-nodeport.adoc[leveloffset=+1]
+
+include::modules/microshift-nodeport-unreachable-workaround.adoc[leveloffset=+1]

--- a/modules/microshift-about.adoc
+++ b/modules/microshift-about.adoc
@@ -7,7 +7,7 @@
 
 Working with resource-constrained field environments and hardware presents many challenges not experienced with cloud computing. {product-title} enables you to solve problems for edge devices by:
 
-* Overcoming the operational challenge of minimal system resources, for example, a {op-system-chip}.
+* Overcoming the operational challenge of minimal system resources, for example, a dual-core processor.
 * Addressing the environmental challenges of severe networking constraints such as low or no connectivity.
 * Meeting the physical constraint of hard-to-access locations by installing your system images directly on edge devices.
 * Building on and integrating with edge-optimized operating systems such as {op-system-first}.

--- a/modules/microshift-installing-from-rpm.adoc
+++ b/modules/microshift-installing-from-rpm.adoc
@@ -11,7 +11,7 @@ Use the following procedure to install {product-title} from an RPM package.
 .Prerequisites
 
 * The system requirements for installing {product-title} have been met.
-* You have completed the steps of preparing to install {product-title}from an RPM package.
+* You have completed the steps of preparing to install {product-title} from an RPM package.
 
 .Procedure
 

--- a/modules/microshift-nodeport-unreachable-workaround.adoc
+++ b/modules/microshift-nodeport-unreachable-workaround.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * microshift_troubleshooting/microshift-known-issues.adoc
+:_content-type: PROCEDURE
+[id="microshift-nodeport-unreachable-workaround_{context}"]
+= Manually restarting the `ovnkube-master` pod to resume node port traffic
+
+After you install {product-title}, NodePort service traffic might stop. To troubleshoot this issue, manually restart the `ovnkube-master` pod in the `openshift-ovn-kubernetes` namespace.
+
+.Prerequisites
+
+* The OpenShift CLI (`oc`) is installed.
+* A cluster installed on infrastructure configured with the Open Virtual Network (OVN)-Kubernetes network plugin.
+* Access to the `kubeconfig` file.
+* The KUBECONFIG environment variable is set.
+
+.Procedure
+
+Run the commands listed in each step that follows to restore the `NodePort` service traffic after you install{product-title}:
+
+. Find the name of the ovn-master pod that you want to restart by running the following command:
++
+[source, terminal]
+----
+$ pod=$(oc get pods -n openshift-ovn-kubernetes | grep ovnkube-master | awk -F " " '{print $1}')
+----
+
+. Force a restart of the of the ovnkube-master pod by running the following command:
++
+[source, terminal]
+----
+$ oc -n openshift-ovn-kubernetes delete pod $pod
+----
+
+. Optional: To confirm that the ovnkube-master pod restarted, run the following command:
++
+[source, terminal]
+----
+$ oc get pods -n openshift-ovn-kubernetes
+----
+If the pod restarted, the listing of the running pods shows a different ovnkube-master pod name and age consistent with the procedure you just completed.
+
+. Verify that the `NodePort` service can now be reached.
+

--- a/modules/microshift-troubleshooting-nodeport.adoc
+++ b/modules/microshift-troubleshooting-nodeport.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="microshift-troubleshooting-nodeport_{context}"]
-= Troubleshooting the NodePort service
+= Troubleshooting the NodePort service iptable rules
 
 OVN-Kubernetes sets up an iptable chain in the NAT table to handle incoming traffic to the NodePort service. When the NodePort service is not reachable or the connection is refused, check the iptable rules on the host to make sure the relevant rules are properly inserted.
 //procedure here


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-4926

Link to docs preview:
https://55215--docspreview.netlify.app/microshift/latest/microshift_troubleshooting/microshift-troubleshooting.html#microshift-nodeport-unreachable-workaround_microshift-known-issues

QE review:
Developer preview, external QE not required
SME ack required

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
