### PR TITLE
OCPBUGS-6269 replaced version information with attributes

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -114,7 +114,7 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 
 * See xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-load-balancing-user-infra_installing-bare-metal[Load balancing requirements for user-provisioned infrastructure] for more information on the API and application ingress load balancing requirements.
 * See xref:../../post_installation_configuration/enabling-cluster-capabilities.adoc[Enabling cluster capabilities] for more information on enabling cluster capabilities that were disabled prior to installation.
-* See xref:../../installing/cluster-capabilities.html#explanation_of_capabilities_cluster-capabilities[Optional cluster capabilities in OpenShift Container Platform Branch Build] for more information on the features provided by each capability.
+* See xref:../../installing/cluster-capabilities.html#explanation_of_capabilities_cluster-capabilities[Optional cluster capabilities in {product-title} {product-version}] for more information about the features provided by each capability.
 
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -38,8 +38,8 @@ include::modules/install-sno-generating-the-install-iso-manually.adoc[leveloffse
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../post_installation_configuration/enabling-cluster-capabilities.adoc[Enabling cluster capabilities] for more information on enabling cluster capabilities that were disabled prior to installation.
-* See xref:../../installing/cluster-capabilities.html#explanation_of_capabilities_cluster-capabilities[Optional cluster capabilities in OpenShift Container Platform Branch Build] for more information on the features provided by each capability.
+* See xref:../../post_installation_configuration/enabling-cluster-capabilities.adoc[Enabling cluster capabilities] for more information about enabling cluster capabilities that were disabled prior to installation.
+* See xref:../../installing/cluster-capabilities.html#explanation_of_capabilities_cluster-capabilities[Optional cluster capabilities in OpenShift Container Platform {product-title} {product-version}] for more information about the features provided by each capability.
 
 include::modules/install-sno-monitoring-the-installation-manually.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-6269

Link to docs preview:
[Sample install-config.yaml file for bare metal](http://file.rdu.redhat.com/antaylor/OCPBUGS-6269/installing/installing_bare_metal/installing-bare-metal.html#installation-bare-metal-config-yaml_installing-bare-metal)

(See the additional resources at the bottom of the section, or `ctrl+f` for "See Optional cluster capabilities")

Additional information:
This updates changes the plain text "Optional cluster capabilities in OpenShift Container Platform Branch Build" to attributes `{product-title} {product-version}`. While it still renders the same text in the build preview, it will render correctly when merged. 