### PR TITLE
OSDOCS-4276: Adding release notes for Kubernetes 1.26 API removals

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -122,6 +122,17 @@ For more information, see xref:../installing/installing_gcp/installing-gcp-share
 ==== Installing a cluster on GCP using Shielded VMs
 In {product-title} {product-version}, you can use Shielded VMs when installing your cluster. Shielded VMs have extra security features including secure boot, firmware and integrity monitoring, and rootkit detection. For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-enabling-shielded-vms_installing-gcp-customizations[Enabling Shielded VMs] and Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
 
+[id="ocp-4-13-admin-ack-upgrading"]
+==== Required administrator acknowledgment when upgrading from {product-title} 4.12 to 4.13
+
+{product-title} 4.13 uses Kubernetes 1.26, which removed xref:../release_notes/ocp-4-13-release-notes.adoc#ocp-4-13-removed-kube-1-26-apis[several deprecated APIs].
+
+A cluster administrator must provide a manual acknowledgment before the cluster can be upgraded from {product-title} 4.12 to 4.13. This is to help prevent issues after upgrading to {product-title} 4.13, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
+
+All {product-title} 4.12 clusters require this administrator acknowledgment before they can be upgraded to {product-title} 4.13.
+
+For more information, see xref:../updating/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.13].
+
 [id="ocp-4-13-post-installation"]
 === Post-installation configuration
 
@@ -676,6 +687,39 @@ The toolbox library is deprecated and support will be removed from a future {pro
 
 [id="ocp-4-13-removed-features"]
 === Removed features
+
+[id="ocp-4-13-removed-kube-1-26-apis"]
+==== Beta APIs removed from Kubernetes 1.26
+
+Kubernetes 1.26 removed the following deprecated APIs, so you must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-26[Kubernetes documentation].
+
+.APIs removed from Kubernetes 1.26
+[cols="2,2,2",options="header",]
+|===
+|Resource |Removed API |Migrate to
+
+|`FlowSchema`
+|`flowcontrol.apiserver.k8s.io/v1beta1`
+|`flowcontrol.apiserver.k8s.io/v1beta3`
+
+|`HorizontalPodAutoscaler`
+|`autoscaling/v2beta2`
+|`autoscaling/v2`
+
+|`PriorityLevelConfiguration`
+|`flowcontrol.apiserver.k8s.io/v1beta1`
+|`flowcontrol.apiserver.k8s.io/v1beta3`
+
+|===
+
+[id="ocp-4-13-future-removals"]
+=== Future Kubernetes API removals
+
+The next minor release of {product-title} is expected to use Kubernetes 1.27. Currently, Kubernetes 1.27 is scheduled to remove a deprecated API.
+
+See the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-27[Deprecated API Migration Guide] in the upstream Kubernetes documentation for the list of planned Kubernetes API removals.
+
+See link:https://access.redhat.com/articles/6955985[Navigating Kubernetes API deprecations and removals] for information about how to check your cluster for Kubernetes APIs that are planned for removal.
 
 [id="ocp-4-13-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-4276

Link to docs preview:
* http://file.rdu.redhat.com/~ahoffer/2023/OSDOCS-4276/release_notes/ocp-4-13-release-notes.html#ocp-4-13-admin-ack-upgrading
* http://file.rdu.redhat.com/~ahoffer/2023/OSDOCS-4276/release_notes/ocp-4-13-release-notes.html#ocp-4-13-removed-kube-1-26-apis

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The wording in these sections were pulled from their similar sections in the 4.12 release notes: https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html

Also note that the link to the preparing to upgrade section will read 4.12, but that's fine because it's being taken care of being updated to 4.13 in #55224

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
