### PR TITLE
OSDOCS-3949: Describe data sent off-cluster in ROSA/OSD docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -655,6 +655,10 @@ Name: Troubleshooting
 Dir: rosa_support
 Distros: openshift-rosa
 Topics:
+- Name: Remote health monitoring with connected clusters
+  Dir: remote_health_monitoring
+  - Name: Showing data collected by remote health monitoring
+    File: showing-data-collected-by-remote-health-monitoring
 - Name: Troubleshooting expired offline access tokens
   File: rosa-troubleshooting-expired-tokens
 - Name: Troubleshooting installations

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -657,6 +657,7 @@ Distros: openshift-rosa
 Topics:
 - Name: Remote health monitoring with connected clusters
   Dir: remote_health_monitoring
+  Distros: openshift-rosa
   - Name: Showing data collected by remote health monitoring
     File: showing-data-collected-by-remote-health-monitoring
 - Name: Troubleshooting expired offline access tokens

--- a/rosa_support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc
+++ b/rosa_support/remote_health_monitoring/showing-data-collected-by-remote-health-monitoring.adoc
@@ -1,0 +1,16 @@
+:_content-type: ASSEMBLY
+[id="showing-data-collected-by-remote-health-monitoring"]
+= Showing data collected by remote health monitoring
+include::_attributes/common-attributes.adoc[]
+ifdef::openshift-dedicated[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+endif::[]
+:context: showing-data-collected-by-remote-health-monitoring
+
+toc::[]
+
+As an administrator, you can review the metrics collected by Telemetry and the Insights Operator.
+
+include::modules/telemetry-showing-data-collected-from-the-cluster.adoc[leveloffset=+1]
+
+include::modules/insights-operator-showing-data-collected-from-the-cluster.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-3949

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
