### PR TITLE
OCPBUGS-908 updating custom seccomp profile procedures

### DIFF
--- a/modules/creating-custom-seccomp-profile.adoc
+++ b/modules/creating-custom-seccomp-profile.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * security/seccomp-profiles.adoc
+
+:_content-type: PROCEDURE
+[id="creating-custom-seccomp-profile_{context}"]
+= Creating seccomp profiles
+You can use the `MachineConfig` object to create profiles.
+
+Seccomp can restrict system calls (syscalls) within a container, limiting the access of your application.
+
+.Prerequisites
+
+* You have cluster admin permissions.
+* You have created a custom security context constraints (SCC). For more information, see _Additional resources_.
+
+.Procedure
+
+* Create the `MachineConfig` object:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: custom-seccomp
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64,<hash>
+        filesystem: root
+        mode: 0644
+        path: /var/lib/kubelet/seccomp/seccomp-nostat.json
+----

--- a/security/seccomp-profiles.adoc
+++ b/security/seccomp-profiles.adoc
@@ -7,9 +7,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 An {product-title} container or a pod runs a single application that performs one or more well-defined tasks. The application usually requires only a small subset of the underlying operating system kernel APIs.
-Secure computing mode, seccomp, is a  Linux kernel feature that can be used to limit the process running in a container to only using a subset of the available system calls. 
+Secure computing mode, seccomp, is a  Linux kernel feature that can be used to limit the process running in a container to only using a subset of the available system calls.
 
-The `restricted-v2` SCC applies to all newly created pods in {product-version}. The default seccomp profile `runtime/default` is applied to these pods.  
+The `restricted-v2` SCC applies to all newly created pods in {product-version}. The default seccomp profile `runtime/default` is applied to these pods.
 
 Seccomp profiles are stored as JSON files on the disk.
 
@@ -24,6 +24,9 @@ include::modules/configuring-default-seccomp-profile.adoc[leveloffset=+1]
 == Configuring a custom seccomp profile
 You can configure a custom seccomp profile, which allows you to update the filters based on the application requirements. This allows cluster administrators to have greater control over the security of workloads running in OpenShift Container Platform.
 
+Seccomp security profiles list the system calls (syscalls) a process can make. Permissions are broader than SELinux, which restrict operations, such as `write`, system-wide.
+
+include::modules/creating-custom-seccomp-profile.adoc[leveloffset=+2]
 include::modules/setting-custom-seccomp-profile.adoc[leveloffset=+2]
 include::modules/applying-custom-seccomp-profile.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-908

Link to docs preview:
[Configuring seccomp profiles](http://file.rdu.redhat.com/antaylor/OCPBUGS-908/security/seccomp-profiles.html)
[Creating custom seccomp profiles](http://file.rdu.redhat.com/antaylor/OCPBUGS-908/security/seccomp-profiles.html#spo-creating-profiles_configuring-seccomp-profiles)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None