### PR TITLE
[enterprise-4.10] Fixed a broken ID in LokiStack

### DIFF
--- a/modules/cluster-logging-feature-reference.adoc
+++ b/modules/cluster-logging-feature-reference.adoc
@@ -2,7 +2,6 @@
 //cluster-logging-loki.adoc
 :_content-type: REFERENCE
 [id="logging-feature-ref_{context}"]
-id="cluster-logging-about-vector"]
 = About Vector
 Vector is a log collector offered as an alternative to Fluentd for the {logging}.
 


### PR DESCRIPTION
This PR is a continuation of #53099 that fixes a broken ID present in the 4.10 version of the documentation.

Version: 
`enterprise-4.10`