### PR TITLE
Revert "WINC add redirect for 4.12 -- WMCO 7.0.0"

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -302,12 +302,6 @@ AddType text/vtt                            vtt
     # To activate the redirects, uncomment the next line and update the version number to the pending release.
     # RewriteRule container-platform/4\.12/virt/(?!about-virt\.html)(.+)$ /container-platform/4.12/virt/about-virt.html [NE,R=302]
 
-    # Red Hat OpenShift support for Windows Containers (WMCO) catchall redirect; use when WMCO releases asynchronously from OCP. Do not change the 302 to a 301.
-    # When uncommented, this redirects all `windows_containers` directory traffic to the /windows_containers/index.html page.
-    # To activate the redirects, uncomment the next line and update the version number to the pending release.
-    RewriteRule container-platform/4\.12/windows_containers/(?!index\.html)(.+)$ /container-platform/4.12/windows_containers/index.html [NE,R=302]
-    RewriteRule ^container-platform/4\.12/support/troubleshooting/troubleshooting-windows-container-workload-issues\.html(.*)$ /container-platform/4.12/windows_containers/index.html [NE,R=302]
-
     # Serverless Redirects
     RewriteRule container-platform/(4\.5|4\.6)/serverless/knative_eventing/(serverless-subscriptions\.html|serverless-channels\.html|serverless-subscriptions\.html) /container-platform/$1/serverless/event_workflows/serverless-channels.html [NE,R=301]
 

--- a/.s2i/httpd-cfg/01-community.conf
+++ b/.s2i/httpd-cfg/01-community.conf
@@ -164,12 +164,6 @@ AddType text/vtt                            vtt
     # To activate the redirects, uncomment the next line and update the version number to the pending release.
     # RewriteRule ^(latest|4\.12)/virt/(?!about-virt\.html)(.+)$ /$1/virt/about-virt.html [NE,R=302]
 
-    # Red Hat OpenShift support for Windows Containers (WMCO) catchall redirect; use when WMCO releases asynchronously from OCP. Do not change the 302 to a 301.
-    # When uncommented, this redirects all `windows_containers` directory traffic to the /windows_containers/index.html page.
-    # To activate the redirects, uncomment the next line and update the version number to the pending release.
-    RewriteRule ^(latest|4\.12)/windows_containers/(?!index\.html)(.+)$ /$1/windows_containers/index.html [NE,R=302]
-    RewriteRule ^(latest|4\.12)/support/troubleshooting/troubleshooting-windows-container-workload-issues\.html(.*)$ /$1/windows_containers/index.html [NE,R=302]
-
   </Directory>
 </IfModule>
 

--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Documentation for {productwinc} will be available for {product-title} {product-version} in the near future.
-
-////
 {productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/windows-containers-release-notes-6-x.adoc#windows-containers-release-notes-6-x[release notes]. 
 
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
@@ -36,4 +33,4 @@ You can xref:../windows_containers/disabling-windows-container-workloads.adoc#di
 
 * Uninstalling the Windows Machine Config Operator
 * Deleting the Windows Machine Config Operator namespace
-////
+


### PR DESCRIPTION
Reverts openshift/openshift-docs#50315

Redirects do not work in Customer Portal. Using the previous method of hiding the WINC docs until WMCO 7.0.0. is released via https://github.com/openshift/openshift-docs/pull/55210