### PR TITLE
Revert "Add updated index file for WINC redirects"

### DIFF
--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Documentation for {productwinc} will be available for {product-title} {product-version} in the near future.
-
-////
 {productwinc} is a feature providing the ability to run Windows compute nodes in an {product-title} cluster. This is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With a Red Hat subscription, you can get support for running Windows workloads in {product-title}. Windows instances deployed by the WMCO are configured with the containerd container runtime. For more information, see the xref:../windows_containers/windows-containers-release-notes-6-x.adoc#windows-containers-release-notes-6-x[release notes]. 
 
 You can add Windows nodes either by creating a xref:../windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc#creating-windows-machineset-aws[compute machine set] or by specifying existing Bring-Your-Own-Host (BYOH) Window instances through a xref:../windows_containers/byoh-windows-instance.adoc#byoh-windows-instance[configuration map].
@@ -36,4 +33,4 @@ You can xref:../windows_containers/disabling-windows-container-workloads.adoc#di
 
 * Uninstalling the Windows Machine Config Operator
 * Deleting the Windows Machine Config Operator namespace
-////
+


### PR DESCRIPTION
Reverts openshift/openshift-docs#54519

Redirects do not work in Customer Portal. Using the previous method of hiding the WINC docs until WMCO 7.0.0. is released via https://github.com/openshift/openshift-docs/pull/55210