### PR TITLE
OSSM-3242: update doc to say “2.1 or later” in federation section

### DIFF
--- a/modules/ossm-federation-create-meshPeer.adoc
+++ b/modules/ossm-federation-create-meshPeer.adoc
@@ -12,7 +12,7 @@ This module included in the following assemblies:
 * Two or more {product-title} 4.6 or above clusters.
 * The clusters must already be networked.
 * The load balancers supporting the services associated with the federation gateways must be configured to support raw TLS traffic.
-* Each cluster must have a version 2.1 `ServiceMeshControlPlane` configured to support federation deployed.
+* Each cluster must have a version 2.1 or later `ServiceMeshControlPlane` configured to support federation deployed.
 * An account with the `cluster-admin` role.
 
 ////

--- a/modules/ossm-federation-prerequisites.adoc
+++ b/modules/ossm-federation-prerequisites.adoc
@@ -9,7 +9,7 @@ This module included in the following assemblies:
 The {SMProductName} federated approach to joining meshes has the following prerequisites:
 
 * Two or more {product-title} 4.6 or above clusters.
-* Federation was introduced in {SMProductName} 2.1. You must have the {SMProductName} 2.1 Operator installed on each mesh that you want to federate.
-* You must have a version 2.1 `ServiceMeshControlPlane` deployed on each mesh that you want to federate.
+* Federation was introduced in {SMProductName} 2.1 or later. You must have the {SMProductName} 2.1 or later Operator installed on each mesh that you want to federate.
+* You must have a version 2.1 or later `ServiceMeshControlPlane` deployed on each mesh that you want to federate.
 * You must configure the load balancers supporting the services associated with the federation gateways to support raw TLS traffic. Federation traffic consists of HTTPS for discovery and raw encrypted TCP for service traffic.
 * Services that you want to expose to another mesh should be deployed before you can export and import them. However, this is not a strict requirement. You can specify service names that do not yet exist for export/import. When you deploy the services named in the `ExportedServiceSet` and `ImportedServiceSet` they will be automatically made available for export/import.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-3242
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://55235--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-federation.html#ossm-federation-prerequisites_federation
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

QA Review: fjglira
