### PR TITLE
[RHACS] Added the missing rollback-central-forced module

### DIFF
--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -86,6 +86,8 @@ You can roll back to a previous version of Central if the upgrade to a new versi
 
 include::modules/rollback-central-normal.adoc[leveloffset=+2]
 
+include::modules/rollback-central-forced.adoc[leveloffset=+2]
+
 include::modules/verify-upgrades.adoc[leveloffset=+1]
 
 include::modules/revoke-the-api-token.adoc[leveloffset=+1]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-14496

Preview: https://55245--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl.html#rollback-central-forced_upgrade-roxctl

Cherry pick into:
- `rhacs-docs-3.74`
- `rhacs-docs-3.73`
- `rhacs-docs-3.72`
- `rhacs-docs-3.71`
- `rhacs-docs-3.70`
- `rhacs-docs-3.69`
- `rhacs-docs-3.68`
- `rhacs-docs-3.67`
