### PR TITLE
OCPBUGS-6102 - Deploying a managed cluster with SiteConfig and ZTP procedure is missing info

### DIFF
--- a/modules/ztp-deploying-a-site.adoc
+++ b/modules/ztp-deploying-a-site.adoc
@@ -16,7 +16,12 @@ Use the following procedure to create a `SiteConfig` custom resource (CR) and re
 
 * You configured the hub cluster for generating the required installation and policy CRs.
 
-* You created a Git repository where you manage your custom site configuration data. The repository must be accessible from the hub cluster and be defined as a source repository for the Argo CD application.
+* You created a Git repository where you manage your custom site configuration data. The repository must be accessible from the hub cluster and you must configure it as a source repository for the ArgoCD application. See "Preparing the GitOps ZTP site configuration repository" for more information.
++
+[NOTE]
+====
+When you create the source repository, ensure that you patch the ArgoCD application with the `argocd/deployment/argocd-openshift-gitops-patch.json` patch-file that you extract from the `ztp-site-generate` container. See "Configuring the hub cluster with ArgoCD".
+====
 
 * To be ready for provisioning managed clusters, you require the following for each bare-metal host:
 +

--- a/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
@@ -24,6 +24,10 @@ include::modules/ztp-deploying-a-site.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster[Preparing the GitOps ZTP site configuration repository]
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-configuring-hub-cluster-with-argocd_ztp-preparing-the-hub-cluster[Configuring the hub cluster with ArgoCD]
+
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-creating-a-validator-inform-policy_ztp-advanced-policy-config[Signalling ZTP cluster deployment completion with validator inform policies]
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc#ztp-creating-the-site-secrets_ztp-manual-install[Creating the managed bare-metal host secrets]


### PR DESCRIPTION
Deploying a managed cluster with SiteConfig and ZTP procedure is missing info related to generating source CRs with `ztp-site-generate` container.

Version(s):
main, 4.10, 4.11, 4.12, 4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-6102

Link to docs preview:
https://55259--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.html#ztp-deploying-a-site_ztp-deploying-far-edge-sites

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
