### PR TITLE
OSDOCS-4820:adds zstream update

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -70,3 +70,12 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 ====
 
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
+
+[id="microshift-4-12-1-dp"]
+=== RHBA-2023:0452 - {product-title} 4.12.1 bug fix
+
+Issued: 2022-01-30
+
+{product-title} release 4.12.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0452[RHBA-2023:0452] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0449[RHBA-2023:0449] advisory.
+
+For the TopoLVM refer to link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -887,7 +887,7 @@ With this update, in installer-provisioned infrastructure clusters, the `ingress
 [id="ocp-4-12-bf2-switching-dpu-nic"]
 ==== Support for switching the Bluefield-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode (Technology Preview)
 
-With this update, you can switch the BlueField-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode. 
+With this update, you can switch the BlueField-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode.
 
 For more information, see xref:../networking/hardware_networks/switching-bf2-nic-dpu.adoc#switching-bf2-nic-dpu[Switching Bluefield-2 from DPU to NIC].
 
@@ -3110,3 +3110,28 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.12.0 --pullspecs
 ----
 //replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.
+[id="ocp-4-12-1"]
+=== RHSA-2023:0449 - {product-title} 4.12.1 bug fix and security update
+
+Issued: 2022-01-30
+
+{product-title} release 4.12.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0449[RHSA-2023:0449] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2022:0448[RHBA-2023:0448] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.1 --pullspecs
+----
+
+[id="ocp-4-12-1-bug-fixes"]
+==== Bug fixes
+
+* Previously, due to a wrong check in the OpenStack cloud provider, the load balancers were populated with External IP addresses when all of the Octavia load balancers were created. This increased the time for the load balancers to be handled. With this update, load balancers are still created sequentially and External IP addresses are populated one-by-one. (link:https://issues.redhat.com/browse/OCPBUGS-5403[*OCPBUGS-5403*])
+
+* Previously, the `cluster-image-registry-operator` would default to using persistent volume claim (PVC) when it failed to reach Swift. With this update, failure to connect to {rh-openstack-first} API or other incidental failures cause the `cluster-image-registry-operator` to retry the probe. During the retry, the default to PVC only occurs if the {rh-openstack} catalog is correctly found, and it does not contain object storage; or alternatively, if {rh-openstack} catalog is there and the current user does not have permission to list containers. (link:https://issues.redhat.com/browse/OCPBUGS-5154[*OCPBUGS-5154*])
+
+[id="ocp-4-12-1-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4820](https://issues.redhat.com//browse/OSDOCS-4820): adds zstream update for 4.12.1
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-4820
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://55266--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-1 

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
