### PR TITLE
GH#41215: Duplicate context values.

### DIFF
--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -16,7 +16,7 @@ For more information about the features activated by the `TechPreviewNoUpgrade` 
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration]
 ** xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Using Container Storage Interface (CSI)]
 ** xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-s2i[Source-to-image (S2I) build volumes] and xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-docker[Docker build volumes]
-** xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-jobs[Swap memory on nodes]
+** xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-managing[Swap memory on nodes]
 ** xref:../../machine_management/capi-machine-management.adoc#capi-machine-management[Managing machines with the Cluster API] 
 ** xref:../../nodes/clusters/nodes-cluster-cgroups-2.adoc#nodes-cluster-cgroups-2[Enabling Linux control group version 2 (cgroup v2)]
 ** xref:../../nodes/containers/nodes-containers-using.adoc#nodes-containers-runtimes[About the container engine and container runtime]

--- a/nodes/index.adoc
+++ b/nodes/index.adoc
@@ -48,7 +48,7 @@ through several tasks:
 * Change node configuration using a custom resource definition (CRD), or the `kubeletConfig` object.
 * Configure nodes to allow or disallow the scheduling of pods. Healthy worker nodes with a `Ready` status allow pod placement by default while the control plane nodes do not; you can change this default behavior by xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-marking_nodes-nodes-working[configuring the worker nodes to be unschedulable] and xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-marking_nodes-nodes-working[the control plane nodes to be schedulable].
 * xref:../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring[Allocate resources for nodes] using the `system-reserved` setting. You can allow {product-title} to automatically determine the optimal `system-reserved` CPU and memory resources for your nodes, or you can manually determine and set the best resources for your nodes.
-* xref:../nodes/nodes/nodes-nodes-managing-max-pods.adoc#nodes-nodes-managing-max-pods-about_nodes-nodes-jobs[Configure the number of pods that can run on a node] based on the number of processor cores on the node, a hard limit, or both.
+* xref:../nodes/nodes/nodes-nodes-managing-max-pods.adoc#nodes-nodes-managing-max-pods-about_nodes-nodes-managing-max-pods[Configure the number of pods that can run on a node] based on the number of processor cores on the node, a hard limit, or both.
 * Reboot a node gracefully using xref:../nodes/nodes/nodes-nodes-rebooting.adoc#nodes-nodes-rebooting-affinity_nodes-nodes-rebooting[pod anti-affinity].
 * xref:../nodes/nodes/nodes-nodes-working.adoc#deleting-nodes[Delete a node from a cluster] by scaling down the cluster using a compute machine set. To delete a node from a bare-metal cluster, you must first drain all pods on the node and then manually delete the node.
 
@@ -61,7 +61,7 @@ through several tasks:
 * Enable TLS security profiles on the node to protect communication between the kubelet and the Kubernetes API server.
 * xref:../nodes/jobs/nodes-pods-daemonsets.adoc#nodes-pods-daemonsets[Run background tasks on nodes automatically with daemon sets]. You can create and use daemon sets to create shared storage, run a logging pod on every node, or deploy a monitoring agent on all nodes.
 * xref:../nodes/nodes/nodes-nodes-garbage-collection.adoc#nodes-nodes-garbage-collection[Free node resources using garbage collection]. You can ensure that your nodes are running efficiently by removing terminated containers and the images not referenced by any running pods.
-* xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-jobs[Add kernel arguments to a set of nodes].
+* xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-managing[Add kernel arguments to a set of nodes].
 * Configure an {product-title} cluster to have worker nodes at the network edge (remote worker nodes). For information on the challenges of having remote worker nodes in an {product-title} cluster and some recommended approaches for managing pods on a remote worker node, see xref:../nodes/edge/nodes-edge-remote-workers.adoc#nodes-edge-remote-workers[Using remote worker nodes at the network edge].
 
 

--- a/nodes/nodes/nodes-nodes-managing-max-pods.adoc
+++ b/nodes/nodes/nodes-nodes-managing-max-pods.adoc
@@ -2,10 +2,9 @@
 [id="nodes-nodes-managing-max-pods"]
 = Managing the maximum number of pods per node
 include::_attributes/common-attributes.adoc[]
-:context: nodes-nodes-jobs
+:context: nodes-nodes-managing-max-pods
 
 toc::[]
-
 
 In {product-title}, you can configure the number of pods that can run on a node based on the number of
 processor cores on the node, a hard limit or both. If you use both options,

--- a/nodes/nodes/nodes-nodes-managing.adoc
+++ b/nodes/nodes/nodes-nodes-managing.adoc
@@ -2,7 +2,7 @@
 [id="nodes-nodes-managing"]
 = Managing nodes
 include::_attributes/common-attributes.adoc[]
-:context: nodes-nodes-jobs
+:context: nodes-nodes-managing
 
 toc::[]
 

--- a/security/compliance_operator/compliance-operator-remediation.adoc
+++ b/security/compliance_operator/compliance-operator-remediation.adoc
@@ -35,4 +35,4 @@ include::modules/compliance-inconsistent.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-*  xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing-about_nodes-nodes-jobs[Modifying nodes].
+*  xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing-about_nodes-nodes-managing[Modifying nodes].

--- a/security/container_security/security-hardening.adoc
+++ b/security/container_security/security-hardening.adoc
@@ -41,7 +41,7 @@ include::modules/security-hardening-how.adoc[leveloffset=+1]
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[Creating the Kubernetes manifest and Ignition config files]
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-machines-iso_installing-bare-metal[Installing {op-system} by using an ISO image]
 * xref:../../installing/install_config/installing-customizing.adoc#installing-customizing[Customizing nodes]
-* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-jobs[Adding kernel arguments to Nodes]
+* xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-managing[Adding kernel arguments to Nodes]
 ifndef::openshift-origin[]
 * xref:../../installing/installing_aws/installing-aws-customizations.adoc#installation-configuration-parameters_installing-aws-customizations[Installation configuration parameters] - see `fips`
 * xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]


### PR DESCRIPTION
Multiple assemblies use `nodes-nodes-jobs' as the context statement. Only one of them should.

`nodes/nodes/nodes-nodes-managing-max-pods.adoc`
`nodes/nodes/nodes-nodes-managing.adoc`
`nodes/nodes/nodes-nodes-jobs.adoc`

https://github.com/openshift/openshift-docs/issues/41215

No QE needed

Previews
Understanding feature gates [Swap memory on nodes](https://55275--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling) link

Nodes -> Index -> About Nodes:
* Management operations -> [Configure the number of pods that can run on a node](https://55275--docspreview.netlify.app/openshift-enterprise/latest/nodes/index.html#nodes-overview) link
* Enhancement operations -> [Add kernel arguments to a set of nodes](https://55275--docspreview.netlify.app/openshift-enterprise/latest/nodes/index.html#pods-overview) link

Security -> Compliance Operator -> Managing Compliance Operator result and remediation  -> [Additonal resources](https://55275--docspreview.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-remediation.html#additional-resources) link

Security -> Container security -> Hardening RHCOS -> -> Hardening after the cluster is running -> Additional resources -> [Add kernel arguments to a set of nodes](https://55275--docspreview.netlify.app/openshift-enterprise/latest/security/container_security/security-hardening.html#security-harden-after-installation_security-hardening) link

