### PR TITLE
OSDOCS-4978 add errata link to release notes MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -13,11 +13,11 @@ toc::[]
 [id="microshift-4-12-about-this-release"]
 == About this release
 
-{product-title} is now available as a Developer Preview software. Features and known issues that pertain to {product-title} {product-version} are included in this topic. For more information about the support scope of Red Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
+{product-title} (link:https://access.redhat.com/errata/RHBA-2023:0452-03 rpm[RHSA-2023:0452-03]) is now available as a Developer Preview software. Features and known issues that pertain to {product-title} {product-version} are included in this topic. For more information about the support scope of Red Hat Developer Preview software, see link:https://access.redhat.com/support/offerings/devpreview/[Developer Preview Support Scope].
 
 [IMPORTANT]
 ====
-Red Hat will not provide or support an update or upgrade path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation will be necessary.
+Red Hat does not provide or support an update or upgrade path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation is necessary.
 ====
 
 [id="microshift-known-issues"]
@@ -70,3 +70,24 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 ====
 
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
+
+[id="microshift-4-12-1-dp"]
+=== RHSA-2023:0452-03 - {product-title} 4.12.1 release advisory
+
+Issued: 2023-01-30
+
+{product-title} release 4.12.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0452-03[RHBA-2023:0452-03] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-RHBA-2023:0452-03[RHBA-2023:0452-03] advisory.
+
+
+//no images in microshift release; rpms only
+
+//[id="microshift-4-12-1-bug-fixes"]
+//==== Bug fixes
+
+//sample bug-fix bullet
+//* Previously, `cluster-image-registry-operator` would default to using persistent volume claim (PVC) when it failed to reach Swift. With this update, failure to connect to {rh-openstack-first} API or other incidental failures cause `cluster-image-registry-operator` to retry the probe. During the retry, the default to PVC only occurs if the {rh-openstack} catalog is correctly found, and it does not contain object storage; or alternatively, if {rh-openstack} catalog is there and the current user does not have permission to list containers. (link:https://issues.redhat.com/browse/OCPBUGS-5154[*OCPBUGS-5154*])
+
+//[id="microshift-4-12-1-updating"]
+//==== Updating
+
+//To update an existing {product-title} installation to this latest release, see


### PR DESCRIPTION

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-4978

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
Not needed, internal docs work

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
