### PR TITLE
OSDOCS: Hid the ROSA Release Notes

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -32,13 +32,13 @@ Topics:
   File: legal-notice
   Distros: openshift-rosa
 ---
-Name: Release notes
-Dir: rosa_release_notes
-Distros: openshift-rosa
-Topics:
-- Name: Red Hat OpenShift Service on AWS release notes
-  File: rosa-release-notes
----
+#Name: Release notes
+#Dir: rosa_release_notes
+#Distros: openshift-rosa
+#Topics:
+#- Name: Red Hat OpenShift Service on AWS release notes
+#  File: rosa-release-notes
+#---
 Name: Introduction to ROSA
 Dir: rosa_architecture
 Distros: openshift-rosa


### PR DESCRIPTION
Version(s):
`enterprise-4.12+`

Link to docs preview:
* ROSA without release notes   
![image](https://user-images.githubusercontent.com/16167833/215216536-d6b4da4f-a5ac-43e2-85df-bad2cffd64ff.png)

* [ROSA with release notes](https://docs.openshift.com/rosa/welcome/index.html) (live doc)
    ![image](https://user-images.githubusercontent.com/16167833/215184408-201bbaa7-bca8-42e1-b2df-0db13eef56d1.png)

Removed the Release Notes from the ROSA distribution