### PR TITLE
Support branches other than main for github codespaces and gitpod

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,7 +4,7 @@
   "image": "mcr.microsoft.com/vscode/devcontainers/ruby:2.7",
   //"image": "quay.io/rhn_support_gmcgoldr/vscode-ruby27-asciibinder",
 
-  "postCreateCommand": "gem install asciidoctor asciidoctor-diagram ascii_binder && asciibinder build --distro=openshift-enterprise && cd _preview/openshift-enterprise/main &&  ln -s welcome/index.html index.html && ruby -run -ehttpd . -p8000"
+  "postCreateCommand": "gem install asciidoctor asciidoctor-diagram ascii_binder && asciibinder build --distro=openshift-enterprise && BR=\"$(git branch --show-current)\" && cd _preview/openshift-enterprise/$BR &&  ln -s welcome/index.html index.html && ruby -run -ehttpd . -p8000"
   //"postCreateCommand": "asciibinder build --distro=openshift-enterprise && cd _preview/openshift-enterprise/main &&  ln -s welcome/index.html index.html && ruby -run -ehttpd . -p8000"
 
   // Features to add to the dev container. More info: https://containers.dev/features.a

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -10,6 +10,7 @@ tasks:
 #      pip3 install aura.tar.gz
     command: |
       asciibinder build --distro=openshift-enterprise
-      cd _preview/openshift-enterprise/main
+      BR="$(git branch --show-current)"
+      cd _preview/openshift-enterprise/$BR
       ln -s welcome/index.html index.html
       python -m http.server


### PR DESCRIPTION
Version(s):
Main branch only

Issue:
Support branches other than main in github codespaces and gitpod
