### PR TITLE
MIG-1282: Configure DVM to use alternative network connection strategies

### DIFF
--- a/modules/migration-about-configuring-proxies.adoc
+++ b/modules/migration-about-configuring-proxies.adoc
@@ -132,7 +132,26 @@ spec:
     type: Deny
 ----
 
-[id="configuring-supplemental-groups-for-rsync-pods{context}"]
+[id="choosing-alternate-endpoints-for-data-transfer_{context}"]
+=== Choosing alternate endpoints for data transfer
+
+By default, DVM uses an {product-title} route as an endpoint to transfer PV data to destination clusters. You can choose another type of supported endpoint, if cluster topologies allow.
+
+For each cluster, you can configure an endpoint by setting the `rsync_endpoint_type` variable on the appropriate *destination* cluster in your `MigrationController` CR:
+
+[source, yaml]
+----
+apiVersion: migration.openshift.io/v1alpha1
+kind: MigrationController
+metadata:
+  name: migration-controller
+  namespace: openshift-migration
+spec:
+  [...]
+  rsync_endpoint_type: [NodePort|ClusterIP|Route]
+----
+
+[id="configuring-supplemental-groups-for-rsync-pods_{context}"]
 === Configuring supplemental groups for Rsync pods
 When your PVCs use a shared storage, you can configure the access to that storage by adding supplemental groups to Rsync pod definitions in order for the pods to allow access:
 


### PR DESCRIPTION
MTC 1.7.7, OCP 4.9+

Resolves https://issues.redhat.com/browse/MIG-1282 by adding a new section, "Choosing alternate endpoints for data transfer" to the MTC installation instructions for unrestricted and restricted environments.

Preview: "Choosing alternate endpoints for data transfer" in https://55296--docspreview.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/installing-mtc.html#tuning-network-policies-for-migrations_installing-mtc (near the end)
