### PR TITLE
Updates regarding RHDEVDOCS-4758

### DIFF
--- a/modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-form-view.adoc
+++ b/modules/odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-form-view.adoc
@@ -12,13 +12,14 @@ You can customize a developer catalog by using the form view in the Web Console.
 .Prerequisites
 
 * An OpenShift web console session with cluster administrator privileges.
+* The Developer perspective is enabled.
 
 .Procedure
 
 . In the *Administrator* perspective, navigate to *Administration* -> *Cluster Settings*.
 . Select the *Configuration* tab and click the *Console (operator.openshift.io)* resource.
 . Click *Actions* -> *Customize*.
-. In the respective sections, enable or disable the items in the list.
+. Enable or disable items in the *Pre-pinned navigation items*, *Add page*, and *Developer Catalog* sections.
 +
 .Verification
 After you have customized the developer catalog, your changes are automatically saved in the system and take effect in the browser after a refresh.
@@ -26,6 +27,11 @@ After you have customized the developer catalog, your changes are automatically 
 image::odc_customizing_developer_catalog.png[]
 
 [NOTE]
+====
+As an administrator, you can define the navigation items that appeaer by default for all users. You can also reorder the navigation items.
+====
+
+[TIP]
 ====
 You can use a similar procedure to customize Web UI items such as Quick starts, Cluster roles, and Actions.
 ====


### PR DESCRIPTION
Change type: Doc update; Allow admins to define pre-pinned resources on Dev navigation
Doc JIRA: https://issues.redhat.com/browse/RHDEVDOCS-4758
Dev JIRA: https://issues.redhat.com/browse/ODC-5012
Fix Version: Openshift 4.13 Freeze

Doc Preview: https://55298--docspreview.netlify.app/openshift-enterprise/latest/web_console/customizing-the-web-console.html#odc_customizing-a-developer-catalog-or-its-sub-catalogs-using-the-form-view_customizing-web-console

SME Review: @jerolimov 
QE Review: @hemantsaini-7 
Peer Review: @rolfedh 