### PR TITLE
BZ2061949:Rewrite the unsupportedConfigOverrides table entry

### DIFF
--- a/rest_api/operator_apis/kubeapiserver-operator-openshift-io-v1.adoc
+++ b/rest_api/operator_apis/kubeapiserver-operator-openshift-io-v1.adoc
@@ -84,7 +84,7 @@ Type::
 | managementState indicates whether and how the operator should manage the component
 
 | `observedConfig`
-| ``
+| -
 | observedConfig holds a sparse config that controller has observed from the cluster state.  It exists in spec because it is an input to the level for the operator
 
 | `operatorLogLevel`
@@ -97,8 +97,10 @@ Type::
 | succeededRevisionLimit is the number of successful static pod installer revisions to keep on disk and in the api -1 = unlimited, 0 or unset = 5 (default)
 
 | `unsupportedConfigOverrides`
-| ``
-| unsupportedConfigOverrides holds a sparse config that will override any previously set options.  It only needs to be the fields to override it will end up overlaying in the following order: 1. hardcoded defaults 2. observedConfig 3. unsupportedConfigOverrides
+| -
+| You can use `unsupportedConfigOverrides` to add configuration changes that are not supported by an operator. Consider seeking guidance from the Red Hat support team before you use this property, because using this property without knowledge of its capabilities could lead to unexpected behavior or conflict with other configuration options.
+
+Additionally, using this property blocks cluster upgrades, so remove this setting before you upgrade your cluster.
 
 |===
 === .status


### PR DESCRIPTION
Version(s):
4.9+

Issue:
[bz2061949](https://bugzilla.redhat.com/show_bug.cgi?id=2061949)

Link to docs preview: [.spec file in REST API doc](https://55319--docspreview.netlify.app/openshift-enterprise/latest/rest_api/operator_apis/kubeapiserver-operator-openshift-io-v1.html#spec) . See the table entry for `unsupportedConfigOverrides`.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
