### PR TITLE
OCPBUGS#6800: change the MTU in Local Zones deployments

### DIFF
--- a/installing/installing_aws/installing-aws-localzone.adoc
+++ b/installing/installing_aws/installing-aws-localzone.adoc
@@ -78,6 +78,12 @@ include::modules/installation-generate-aws-user-infra-install-config.adoc[levelo
 
 include::modules/installation-localzone-generate-k8s-manifest.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../networking/changing-cluster-network-mtu.adoc#mtu-value-selection_changing-cluster-network-mtu[Changing the MTU for the cluster network]
+* xref:../../networking/changing-cluster-network-mtu.adoc#nw-ovn-ipsec-enable_configuring-ipsec-ovn[Enabling IPsec encryption]
+
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
 include::modules/cli-installing-cli.adoc[leveloffset=+1]

--- a/modules/installation-localzone-generate-k8s-manifest.adoc
+++ b/modules/installation-localzone-generate-k8s-manifest.adoc
@@ -26,8 +26,53 @@ $ ./openshift-install create manifests --dir <installation_directory> <1>
 <1> For `<installation_directory>`, specify the installation directory that
 contains the `install-config.yaml` file you created.
 
-. Create the machine set manifests for the worker nodes in your Local Zone.
+. Set the default Maximum Transmission Unit (MTU) according to the network plugin:
++
+[IMPORTANT]
+====
+Generally, the Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. See link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation. 
+The cluster network MTU must be always less than the EC2 MTU to account for the overhead. The specific overhead is determined by your network plugin, for example:
 
+- OVN-Kubernetes: `100 bytes`
+- OpenShift SDN: `50 bytes`
+
+The network plugin could provide additional features, like IPsec, that also must be decreased the MTU. Check the documentation for additional information.
+
+====
+
+.. If you are using the `OVN-Kubernetes` network plugin, enter the following command:
++
+[source,terminal]
+----
+$ cat <<EOF > <installation_directory>/manifests/cluster-network-03-config.yml
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    ovnKubernetesConfig:
+      mtu: 1200
+EOF
+----
+
+.. If you are using the `OpenShift SDN` network plugin, enter the following command:
++
+[source,terminal]
+----
+$ cat <<EOF > <installation_directory>/manifests/cluster-network-03-config.yml
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  defaultNetwork:
+    openshiftSDNConfig:
+      mtu: 1250
+EOF
+----
+
+. Create the machine set manifests for the worker nodes in your Local Zone.
 .. Export a local variable that contains the name of the Local Zone that you opted your AWS account into by running the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s): 4.12+
Issue:  https://issues.redhat.com/browse/OCPBUGS-6800

This PR changes the default MTU on the Day-0 guide for installing a cluster in existing VPC with AWS Local Zone subnets.

The MTU of 1200 should be the maximum allowed considering 1300 (from AWS Documentation to LZ nodes communicate with nodes in regular zones [parent region]) and 100 of OVN overhead.

Link to docs preview:  https://55327--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone.html#installation-localzone-generate-k8s-manifestinstalling-aws-localzone


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Required reviewers:
- [x] SPLAT @mtulio 
- [x] Installer @makentenza
- [x] Network @knobunc
- [x] QE @yunjiang29 
- [x] Docs