### PR TITLE
OCPBUGS#4333 Removing capabilities stanza from bare metal sample yaml

### DIFF
--- a/modules/install-sno-generating-the-install-iso-manually.adoc
+++ b/modules/install-sno-generating-the-install-iso-manually.adoc
@@ -109,13 +109,6 @@ bootstrapInPlace:
 pullSecret: '<pull_secret>' <8>
 sshKey: |
   <ssh_key> <9>
-capabilities:
-  baselineCapabilitySet: v4.12 <10>
-  additionalEnabledCapabilities: <11>
-  - CSISnapshot
-  - Insights
-  - Storage
-
 ----
 <1> Add the cluster domain name.
 <2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
@@ -126,13 +119,6 @@ capabilities:
 <7> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
 <8> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
 <9> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
-<10> Activate a predefined set of cluster capabilities.
-<11> Add the additional cluster capabilities you want to enable here.
-+
-[IMPORTANT]
-====
-Removing a capability from a cluster alters the behavior of that cluster and could require you to provide alternative methods to perform the functions associated with that capability. For example, if you remove the storage capability, you need to provide your own storage to, for example, support metrics persistence.
-====
 
 . Generate {product-title} assets by running the following commands:
 +

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -178,7 +178,7 @@ ifndef::ibm-z,ibm-z-kvm[]
 endif::ibm-z,ibm-z-kvm[]
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <13>
+additionalTrustBundle: | <14>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
@@ -200,16 +200,6 @@ ifndef::ibm-z,ibm-z-kvm[]
 endif::ibm-z,ibm-z-kvm[]
 endif::openshift-origin[]
 endif::restricted[]
-ifndef::ibm-z,ibm-z-kvm,ibm-power,agnostic,rhv[]
-ifndef::restricted[]
-capabilities:
-  baselineCapabilitySet: v4.12 <15>
-  additionalEnabledCapabilities: <16>
-  - CSISnapshot
-  - Insights
-  - Storage
-endif::restricted[]
-endif::ibm-z,ibm-z-kvm,ibm-power,agnostic,rhv[]
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
 <2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
@@ -302,17 +292,6 @@ endif::openshift-origin[]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
-ifndef::ibm-z,ibm-z-kvm,ibm-power,agnostic,rhv[]
-ifndef::restricted[]
-<15> Activate a predefined set of cluster capabilities.
-<16> Add the additional cluster capabilities you want to enable here.
-+
-[IMPORTANT]
-====
-Removing a capability from a cluster alters the behavior of that cluster and could require you to provide alternative methods to perform the functions associated with that capability. For example, if you remove the storage capability, you need to provide your own storage to, for example, support metrics persistence.
-====
-endif::restricted[]
-endif::ibm-z,ibm-z-kvm,ibm-power,agnostic,rhv[]
 ifdef::openshift-origin[]
 <13> The SSH public key for the `core` user in {op-system-first}.
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.12 and 4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-4333

Link to docs preview:
[Bare metal restricted install](https://55334--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-bare-metal-config-yaml_installing-restricted-networks-bare-metal)
[SNO install (step 7)](https://55334--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#generating-the-install-iso-manually_install-sno-installing-sno-with-the-assisted-installer)

QE review:
- QE approval was given in the original PR https://github.com/openshift/openshift-docs/pull/53345

Removing the capabilities stanza from the bare sample yaml and SNO sample yaml files to keep in line with the other platforms. Users are expected to find the capabilities flags and features from `installing/cluster-capabilities.adoc` and the installation configuration parameters table.

Also fixed a callout numbering error.