### PR TITLE
OSDOCS-5037:updates anchor ids for updating in 4.10 branch

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2581,7 +2581,7 @@ Workaround: Use OpenShift OAuth for authentication. (link:https://bugzilla.redha
 
 * Google Cloud Platform (GCP) UPI installation fails when the instance group name is longer than the maximum size of 64 characters. You are restricted in the naming process after adding the "-instance-group" suffix. Shorten the suffix to "-ig" to reduce the number of characters. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1921627[*BZ#1921627*])
 
-* For clusters that run on {rh-openstack} and use Kuryr, a bug in the OVN Provider driver for Octavia can cause load balancer listeners to be stuck in a `PENDING_UPDATE` state while the load balancer that they are attached to remains in an `ACTIVE` state. As a result, the `kuryr-controller` pod can crash. To resolve this problem, update {rh-openstack} to version 16.1.9 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019980[*BZ#2019980*]) or version 16.2.4 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2045088[*BZ#2045088*]). 
+* For clusters that run on {rh-openstack} and use Kuryr, a bug in the OVN Provider driver for Octavia can cause load balancer listeners to be stuck in a `PENDING_UPDATE` state while the load balancer that they are attached to remains in an `ACTIVE` state. As a result, the `kuryr-controller` pod can crash. To resolve this problem, update {rh-openstack} to version 16.1.9 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2019980[*BZ#2019980*]) or version 16.2.4 (link:https://bugzilla.redhat.com/show_bug.cgi?id=2045088[*BZ#2045088*]).
 
 * If an incorrect network is specified in the vSphere `install-config.yaml` file, then an error message from Terraform is generated after a while. Add a check during the creation of manifests to notify the user if the network is invalid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1956776[*BZ#1956776*])
 
@@ -2687,7 +2687,7 @@ $ oc adm release info 4.10.4 --pullspecs
 [id="ocp-4-10-4-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-5"]
 === RHBA-2022:0928 - {product-title} 4.10.5 bug fix and security update
@@ -2716,7 +2716,7 @@ $ oc adm release info 4.10.5 --pullspecs
 [id="ocp-4-10-5-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-6"]
 === RHBA-2022:1026 - {product-title} 4.10.6 bug fix and security update
@@ -2754,7 +2754,7 @@ This update contains changes from Kubernetes 1.23.3 up to 1.23.5. More informati
 [id="ocp-4-10-6-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-8"]
 === RHSA-2022:1162 - {product-title} 4.10.8 bug fix and security update
@@ -2797,7 +2797,7 @@ With {product-title} 4.10.21, support for using GCP Workload Identity with the i
 [id="ocp-4-10-8-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-9"]
 === RHBA-2022:1241 - {product-title} 4.10.9 bug fix update
@@ -2821,7 +2821,7 @@ $ oc adm release info 4.10.9 --pullspecs
 [id="ocp-4-10-9-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-10"]
 === RHSA-2022:1357 - {product-title} 4.10.10 bug fix and security update
@@ -2845,7 +2845,7 @@ $ oc adm release info 4.10.10 --pullspecs
 [id="ocp-4-10-10-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-11"]
 === RHBA-2022:1431 - {product-title} 4.10.11 bug fix update
@@ -2868,7 +2868,7 @@ $ oc adm release info 4.10.11 --pullspecs
 [id="ocp-4-10-11-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-10-12"]
 === RHBA-2022:1601 - {product-title} 4.10.12 bug fix and security update
@@ -2891,7 +2891,7 @@ $ oc adm release info 4.10.12 --pullspecs
 [id="ocp-4-10-12-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-10-13"]
 === RHBA-2022:1690 - {product-title} 4.10.13 bug fix update
@@ -2921,7 +2921,7 @@ $ oc adm release info 4.10.13 --pullspecs
 [id="ocp-4-10-13-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-10-14"]
 === RHBA-2022:2178 - {product-title} 4.10.14 bug fix update
@@ -2959,7 +2959,7 @@ With this update, you can deploy control plane and compute nodes with the `premi
 [id="ocp-4-10-14-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-10-15"]
 === RHBA-2022:2258 - {product-title} 4.10.15 bug fix update
@@ -2983,7 +2983,7 @@ $ oc adm release info 4.10.15 --pullspecs
 [id="ocp-4-10-15-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-10-16"]
 === RHBA-2022:4754 - {product-title} 4.10.16 bug fix update
@@ -3002,7 +3002,7 @@ $ oc adm release info 4.10.16 --pullspecs
 [id="ocp-4-10-16-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-10-17"]
 === RHBA-2022:4882 - {product-title} 4.10.17 bug fix update
@@ -3031,7 +3031,7 @@ With this update, you can now change how long Thanos Ruler metrics data is retai
 [id="ocp-4-10-17-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-18"]
 === RHBA-2022:4944 - {product-title} 4.10.18 bug fix and security update
@@ -3058,7 +3058,7 @@ $ oc adm release info 4.10.18 --pullspecs
 [id="ocp-4-10-18-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-20"]
 === RHBA-2022:5172 - {product-title} 4.10.20 bug fix update
@@ -3084,7 +3084,7 @@ $ oc adm release info 4.10.20 --pullspecs
 [id="ocp-4-10-20-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-21"]
 === RHBA-2022:5428 - {product-title} 4.10.21 bug fix update
@@ -3108,7 +3108,7 @@ The feature change in {product-title} 4.10.8 to remove support for Google Cloud 
 [id="ocp-4-10-21-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-22"]
 === RHBA-2022:5513 - {product-title} 4.10.22 bug fix update
@@ -3127,7 +3127,7 @@ $ oc adm release info 4.10.22 --pullspecs
 [id="ocp-4-10-22-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-23"]
 === RHBA-2022:5568 - {product-title} 4.10.23 bug fix update
@@ -3261,7 +3261,7 @@ sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller).Start.func2
 [id="ocp-4-10-23-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-24"]
 === RHSA-2022:5664 - {product-title} 4.10.24 bug fix and security update
@@ -3280,7 +3280,7 @@ $ oc adm release info 4.10.24 --pullspecs
 [id="ocp-4-10-24-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-25"]
 === RHSA-2022:5730 - {product-title} 4.10.25 bug fix and security update
@@ -3306,7 +3306,7 @@ $ oc adm release info 4.10.25 --pullspecs
 [id="ocp-4-10-25-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-26"]
 === RHSA-2022:5875 - {product-title} 4.10.26 bug fix and security update
@@ -3335,7 +3335,7 @@ This is a new AWS permission and you must update credentials for manual mode clu
 [id="ocp-4-10-26-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-28"]
 === RHBA-2022:6095 - {product-title} 4.10.28 bug fix and security update
@@ -3354,7 +3354,7 @@ $ oc adm release info 4.10.28 --pullspecs
 [id="ocp-4-10-28-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-30"]
 === RHSA-2022:6133 - {product-title} 4.10.30 bug fix and security update
@@ -3385,7 +3385,7 @@ $ oc adm release info 4.10.30 --pullspecs
 [id="ocp-4-10-30-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-31"]
 === RHSA-2022:6258 - {product-title} 4.10.31 bug fix and security update
@@ -3404,7 +3404,7 @@ $ oc adm release info 4.10.31 --pullspecs
 [id="ocp-4-10-31-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-32"]
 === RHBA-2022:6372 - {product-title} 4.10.32 bug fix
@@ -3428,7 +3428,7 @@ $ oc adm release info 4.10.32 --pullspecs
 [id="ocp-4-10-32-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-33"]
 === RHBA-2022:6532 - {product-title} 4.10.33 bug fix and security update
@@ -3447,7 +3447,7 @@ $ oc adm release info 4.10.33 --pullspecs
 [id="ocp-4-10-33-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-34"]
 === RHBA-2022:6663 - {product-title} 4.10.34 bug fix and security update
@@ -3466,7 +3466,7 @@ $ oc adm release info 4.10.34 --pullspecs
 [id="ocp-4-10-34-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-35"]
 === RHBA-2022:6728 - {product-title} 4.10.35 bug fix update
@@ -3490,7 +3490,7 @@ $ oc adm release info 4.10.35 --pullspecs
 [id="ocp-4-10-35-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-36"]
 === RHSA-2022:6805 - {product-title} 4.10.36 bug fix update
@@ -3514,7 +3514,7 @@ $ oc adm release info 4.10.36 --pullspecs
 [id="ocp-4-10-36-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-37"]
 === RHBA-2022:6901 - {product-title} 4.10.37 bug fix update
@@ -3538,7 +3538,7 @@ $ oc adm release info 4.10.37 --pullspecs
 [id="ocp-4-10-37-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-38"]
 === RHBA-2022:7035 - {product-title} 4.10.38 bug fix update
@@ -3557,7 +3557,7 @@ $ oc adm release info 4.10.38 --pullspecs
 [id="ocp-4-10-38-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-39"]
 === RHSA-2022:7211 - {product-title} 4.10.39 bug fix and security update
@@ -3583,7 +3583,7 @@ For more information, see xref:../authentication/bound-service-account-tokens.ad
 [id="ocp-4-10-39-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-40"]
 === RHBA-2022:7298 - {product-title} 4.10.40 bug fix update
@@ -3612,7 +3612,7 @@ $ oc adm release info 4.10.40 --pullspecs
 [id="ocp-4-10-40-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-41"]
 === RHBA-2022:7866 - {product-title} 4.10.41 bug fix and security update
@@ -3636,7 +3636,7 @@ $ oc adm release info 4.10.41 --pullspecs
 [id="ocp-4-10-41-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-42"]
 === RHBA-2022:8496 - {product-title} 4.10.42 bug fix update
@@ -3655,7 +3655,7 @@ $ oc adm release info 4.10.42 --pullspecs
 [id="ocp-4-10-42-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-43"]
 === RHBA-2022:8623 - {product-title} 4.10.43 bug fix update
@@ -3674,7 +3674,7 @@ $ oc adm release info 4.10.43 --pullspecs
 [id="ocp-4-10-43-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-45"]
 === RHBA-2022:8882 - {product-title} 4.10.45 bug fix update
@@ -3698,7 +3698,7 @@ $ oc adm release info 4.10.45 --pullspecs
 [id="ocp-4-10-45-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-46"]
 === RHBA-2022:9099 - {product-title} 4.10.46 bug fix and security update
@@ -3717,7 +3717,7 @@ $ oc adm release info 4.10.46 --pullspecs
 [id="ocp-4-10-46-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-47"]
 === RHSA-2023:0032 - {product-title} 4.10.47 bug fix and security update
@@ -3748,7 +3748,7 @@ $ oc adm release info 4.10.47 --pullspecs
 [id="ocp-4-10-47-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-50"]
 === RHSA-2023:0241 - {product-title} 4.10.50 bug fix and security update
@@ -3773,4 +3773,4 @@ $ oc adm release info 4.10.50 --pullspecs
 [id="ocp-4-10-50-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5037](https://issues.redhat.com//browse/OSDOCS-5037): this is a CI task that adds anchor ids to the xref to updating in RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5037
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview
](https://joealdinger.github.io/openshift-docs/OSDOCS-5037/release_notes/ocp-4-10-release-notes.html#ocp-4-10-3-ga)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
