### PR TITLE
TELCODOCS-1050: Configuring the hub cluster to use unauthenticated registries

### DIFF
--- a/modules/ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries.adoc
+++ b/modules/ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries_{context}"]
+= Configuring the hub cluster to use unauthenticated registries
+
+You can configure the hub cluster to use unauthenticated registries.
+Unauthenticated registries does not require authentication to access and download images.
+
+.Prerequisites
+
+* You have installed and configured a hub cluster and installed {rh-rhacm-first} on the hub cluster.
+
+* You have installed the OpenShift Container Platform CLI (oc).
+
+* You have logged in as a user with `cluster-admin` privileges.
+
+* You have configured an unauthenticated registry for use with the hub cluster.
+
+.Procedure
+
+. Update the `AgentServiceConfig` custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc edit AgentServiceConfig agent
+----
+
+. Add the `unauthenticatedRegistries` field in the CR:
++
+[source,yaml]
+----
+apiVersion: agent-install.openshift.io/v1beta1
+kind: AgentServiceConfig
+metadata:
+  name: agent
+spec:
+  unauthenticatedRegistries:
+  - example.registry.com
+  - example.registry2.com
+  ...
+----
++
+Unauthenticated registries are listed under `spec.unauthenticatedRegistries` in the `AgentServiceConfig` resource.
+Any registry on this list is not required to have an entry in the pull secret used for the spoke cluster installation.
+`assisted-service` validates the pull secret by making sure it contains the authentication information for every image registry used for installation.
+
+[NOTE]
+====
+Mirror registries are automatically added to the ignore list and do not need to be added under `spec.unauthenticatedRegistries`.
+Specifying the `PUBLIC_CONTAINER_REGISTRIES` environment variable in the `ConfigMap` overrides the default values with the specified value.
+The `PUBLIC_CONTAINER_REGISTRIES` defaults are https://quay.io[quay.io] and https://registry.svc.ci.openshift.org[registry.svc.ci.openshift.org].
+====
+
+.Verification
+
+Verify that you can access the newly added registry from the hub cluster by running the following commands:
+
+. Open a debug shell prompt to the hub cluster:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+. Test access to the unauthenticated registry by running the following command:
++
+[source,terminal]
+----
+sh-4.4# podman login -u kubeadmin -p $(oc whoami -t) <unauthenticated_registry>
+----
++
+where:
++
+--
+<unauthenticated_registry>:: Is the new registry, for example, `unauthenticated-image-registry.openshift-image-registry.svc:5000`.
+--
++
+.Example output
+[source,terminal]
+----
+Login Succeeded!
+----

--- a/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
@@ -34,12 +34,8 @@ include::modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc[leve
 
 include::modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc[leveloffset=+1]
 
+include::modules/ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries.adoc[leveloffset=+1]
 
 include::modules/ztp-preparing-the-hub-cluster-for-ztp.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster[Preparing the GitOps ZTP site configuration repository]
 
 include::modules/ztp-preparing-the-ztp-git-repository.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes: [TELCODOCS-1050](https://issues.redhat.com/browse/TELCODOCS-1050)

For: Version 4.12+

Doc Preview [here](https://55352--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries_ztp-preparing-the-hub-cluster)


Signed-off-by: Katie Tothill ktothill@redhat.com