### PR TITLE
Add Compliance Operator info to RHACS docs

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -163,6 +163,11 @@ Topics:
   File: view-dashboard
 - Name: Managing compliance
   File: manage-compliance
+- Name: Using the Compliance Operator
+  Dir: manage-compliance-operator
+  Topics:
+  - Name: Using Compliance Operator with RHACS
+    File: compliance-operator-rhacs
 - Name: Evaluating security risks
   File: evaluate-security-risks
 - Name: Using admission controller enforcement

--- a/modules/compliance-operator-configure-scanning.adoc
+++ b/modules/compliance-operator-configure-scanning.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-compliance-operator/compliance-operator-rhacs.adoc
+:_content-type: PROCEDURE
+[id="compliance-operator-configure-scanning_{context}"]
+= Configuring the ScanSettingBinding object
+
+[role="_abstract"]
+Create a `ScanSettingBinding` object in the `openshift-compliance` namespace to scan the cluster using the `cis` and `cis-node` profiles. 
+
+[NOTE]
+====
+This example uses `cis` and `cis-node` profiles, but {ocp} provides additional profiles. See "Understanding the Compliance Operator" in the "Additional resources" section for more information.
+====
+
+.Procedure
+
+Select one of the following options:
+
+* Use the CLI to create the YAML file and object. For example:
+
+.. Create a file called `sscan.yaml` using the following text:
++
+[source,yaml]
+----
+
+apiVersion: compliance.openshift.io/v1alpha1
+kind: ScanSettingBinding
+metadata:
+  name: cis-compliance
+profiles:
+  - name: ocp4-cis-node
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+  - name: ocp4-cis
+    kind: Profile
+    apiGroup: compliance.openshift.io/v1alpha1
+settingsRef:
+  name: default
+  kind: ScanSetting
+  apiGroup: compliance.openshift.io/v1alpha1
+----
+.. Create the `ScanSettingBinding` object by running the following command:
++
+[source, terminal]
+----
+$ oc create -f sscan.yaml -n openshift-compliance
+----
+If successful, the following message is displayed:
++
+[source, terminal]
+----
+$ scansettingbinding.compliance.openshift.io/cis-compliance created
+----
+* Use the web console to create the object by performing the following steps:
+
+.. Change the active project to `openshift-compliance`.
+.. Click *+* to open the *Import YAML* window.
+.. Paste the YAML from the previous example and then click *Create*.
+
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/security_and_compliance/compliance-operator#understanding-compliance-operator[Understanding the Compliance Operator]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/security_and_compliance/compliance-operator#compliance-operator-scans[Compliance Operator scans] in {ocp}

--- a/modules/compliance-operator-install.adoc
+++ b/modules/compliance-operator-install.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-compliance-operator/compliance-operator-rhacs.adoc
+:_content-type: PROCEDURE
+[id="compliance-operator-install_{context}"]
+= Installing the Compliance Operator
+
+[role="_abstract"]
+Install the Compliance Operator using Operator Hub.
+
+.Procedure
+
+Install the Operator by performing the following steps:
+
+. Navigate in the web console to the *Operators* -> *OperatorHub* page.
+
+. Enter *compliance operator* into the *Filter by keyword* box to find the Compliance Operator.
+
+. Select the *Compliance Operator* to view the details page.
+
+. Read the information about the Operator and click *Install*.

--- a/modules/view-compliance-status-for-standard.adoc
+++ b/modules/view-compliance-status-for-standard.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-compliance.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="view-compliance-status-for-standard_{context}"]
 = Viewing compliance status for a specific standard
 
@@ -10,6 +10,16 @@
 You can view all the compliance controls for a single compliance standard.
 
 .Procedure
-. Navigate to the RHACS portal and open the compliance dashboard by selecting *Compliance* from the navigation menu.
-. On the compliance dashboard, look for the *Passing standards by cluster* widget.
+. Navigate to the {product-title-short} portal and open the compliance dashboard by selecting *Compliance* from the navigation menu.
+. On the compliance dashboard, look for the *Passing standards across clusters cluster* widget.
 . In this widget, click on a standard to view information about all the controls associated with that standard.
+
+[NOTE]
+====
+Many of the controls in CIS Docker refer to the configuration of the Docker engine on each Kubernetes node. Many CIS Docker controls are also best practices for building and using containers, and {product-title-short} has policies to enforce their use. See "Managing security policies" in "Additional resources" for more information.
+====
+
+.Additional resources
+xref:../operating/manage-security-policies.adoc#manage-security-policies[Managing security policies]
+
+

--- a/modules/vulnerability-management-scheduled-report.adoc
+++ b/modules/vulnerability-management-scheduled-report.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-vulnerabilities.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="vulnerability-management-scheduled-report_{context}"]
 = Scheduling vulnerability management reports
 
@@ -9,7 +9,7 @@
 The following procedure creates a scheduled vulnerability report.
 
 .Procedure
-. On the RHACS portal, navigate to *Vulnerability Management* -> *Reporting*.
+. On the {product-title-short} portal, navigate to *Vulnerability Management* -> *Reporting*.
 . Click *Create report*.
 . Enter a name for your report in the *Report name* field.
 . Select a weekly or monthly cadence for your report under *Repeat report...*

--- a/operating/manage-compliance-operator/compliance-operator-rhacs.adoc
+++ b/operating/manage-compliance-operator/compliance-operator-rhacs.adoc
@@ -1,0 +1,35 @@
+:_content-type: ASSEMBLY
+[id="compliance-operator-rhacs"]
+= Using the Compliance Operator with {product-title}
+include::modules/common-attributes.adoc[]
+:context: compliance-operator-rhacs
+
+toc::[]
+
+[role="_abstract"]
+You can configure {product-title-short} to use the Compliance Operator for compliance reporting and remediation with {ocp} clusters. Results from the Compliance Operator can be reported in the {product-title-short} Compliance Dashboard.
+
+include::modules/compliance-operator-install.adoc[leveloffset=+1]
+
+include::modules/compliance-operator-configure-scanning.adoc[leveloffset=+1]
+
+// See https://docs.openshift.com/container-platform/4.12/security/compliance_operator/compliance-scans.html#running-compliance-scans_compliance-operator-scans. 
+
+Optional: If you installed the Compliance Operator _after_ installing {product-title-short}, restart Sensor in the secured cluster by performing one of the following options:
+
+* Run the following command:
++
+[source, terminal]
+----
+$ oc -n stackrox delete pod -lapp=sensor
+----
+* In the {ocp} web console, perform the following steps:
+.. Change the active project to `stackrox`.
+.. Navigate to *Workloads* -> *Pods*.
+.. Locate the pod with the name starting with `sensor-`, and then click *Actions* -> *Delete Pod.* 
+
+.Verification
+After performing these steps, run a compliance scan in {product-title-short} and ensure that `ocp4-cis` and `ocp4-cis-node` results are displayed. See "Running a compliance scan" in the "Additional resources" section for more information.
+
+.Additional resources
+* xref:../../operating/manage-compliance.adoc#run-compliance-scan_manage-compliance[Running a compliance scan in {product-title-short}]

--- a/operating/manage-compliance.adoc
+++ b/operating/manage-compliance.adoc
@@ -14,6 +14,7 @@ You can run out-of-the-box compliance scans based on industry standards includin
 * *HIPAA* (Health Insurance Portability and Accountability Act)
 * *NIST Special Publication 800-190* and *800-53* (National Institute of Standards and Technology)
 * *PCI DSS* (Payment Card Industry Data Security Standard)
+* *OpenSCAP* (Open Security Content Automation Protocol): Available in {product-title-short} for {ocp} clusters when the Compliance Operator is installed and configured to provide results to {product-title-short} 
 
 By scanning your environment based on these standards you can:
 
@@ -27,6 +28,7 @@ By scanning your environment based on these standards you can:
 include::modules/compliance-dashboard.adoc[leveloffset=+1]
 
 include::modules/run-compliance-scan.adoc[leveloffset=+1]
+
 
 [id="view-compliance-scan-results"]
 == Viewing compliance scan results


### PR DESCRIPTION
Version(s):

Merge to `rhacs-docs`
Cherry pick to:
- `rhacs-docs-3.74`
- `rhacs-docs-3.73`
- `rhacs-docs-3.72`

[Issue](https://issues.redhat.com/browse/ROX-10741)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- [Managing compliance](https://55353--docspreview.netlify.app/openshift-acs/latest/operating/manage-compliance.html)
- [Using Compliance Operator with RHACS](https://55353--docspreview.netlify.app/openshift-acs/latest/operating/manage-compliance-operator/compliance-operator-rhacs.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

