### PR TITLE
[OSDOCS-5069]: VMware OoT provider is GA

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-This Operator is only fully supported for Microsoft Azure Stack Hub.
+This Operator is only fully supported for Microsoft Azure Stack Hub, {rh-openstack-first}, and VMware vSphere.
 
-It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud, IBM Cloud Power VS, Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
+It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud, IBM Cloud Power VS, and Microsoft Azure.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPCLOUD-1129](https://issues.redhat.com//browse/OCPCLOUD-1129) | [OSDOCS-5071](https://issues.redhat.com//browse/OSDOCS-5071)

Link to docs preview:
[Cluster Cloud Controller Manager Operator](https://55354--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information:
- Also moved OpenStack since it GAed in 4.12