### PR TITLE
modules/*etcd*: Use '-l k8s-app=etcd' to find etcd pods

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -266,7 +266,7 @@ $ sudo crictl ps | grep etcd | grep -v operator
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 [NOTE]
@@ -645,7 +645,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output

--- a/modules/etcd-defrag.adoc
+++ b/modules/etcd-defrag.adoc
@@ -87,7 +87,7 @@ Follow this procedure to defragment etcd data on each etcd member.
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd -o wide | grep -v guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd -o wide
 ----
 +
 .Example output

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -104,7 +104,7 @@ ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.25.0
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output

--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -70,7 +70,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -32,7 +32,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd -o wide | grep etcd | grep -v guard
+$ oc -n openshift-etcd get pods -l k8s-app=etcd -o wide
 ----
 +
 .Example output
@@ -570,7 +570,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd -o wide | grep etcd | grep -v guard
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -35,7 +35,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output
@@ -346,7 +346,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output


### PR DESCRIPTION
The selector a more idiomatic and structured way to avoid including the quorum-guard pods.