### PR TITLE
[OSDOCS-5069]: VMware OoT provider is GA (rel notes)

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -130,6 +130,23 @@ With {product-title} {product-version}, running `oc describe` on an image now re
 
 // Note: use [discrete] for these sub-headings.
 
+[discrete]
+[id="ocp-4-13-cluster-cloud-controller-manager-operator"]
+==== Cloud controller managers for additional cloud providers
+
+The Kubernetes community plans to deprecate the use of the Kubernetes controller manager to interact with underlying cloud platforms in favor of using cloud controller managers. As a result, there is no plan to add Kubernetes controller manager support for any new cloud platforms.
+//Can reuse this for Nutanix in 4.13:
+//The Alibaba Cloud and IBM Cloud implementations that are added in this release of {product-title} use cloud controller managers.
+
+//In addition, this
+This release introduces the General Availability of using cloud controller managers for VMware vSphere.
+
+To learn more about the cloud controller manager, see the link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Kubernetes Cloud Controller Manager documentation].
+
+To manage the cloud controller manager and cloud node manager deployments and lifecycles, use the Cluster Cloud Controller Manager Operator.
+
+For more information, see the xref:../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_cluster-operators-ref[Cluster Cloud Controller Manager Operator] entry in the _Platform Operators reference_.
+
 [id="ocp-4-13-deprecated-removed-features"]
 == Deprecated and removed features
 
@@ -149,7 +166,7 @@ In the following tables, features are marked with the following statuses:
 .Operator deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |SQLite database format for Operator catalogs
 |Deprecated
@@ -164,7 +181,7 @@ In the following tables, features are marked with the following statuses:
 .Images deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |`ImageChangesInProgress` condition for Cluster Samples Operator
 |Deprecated
@@ -184,7 +201,7 @@ In the following tables, features are marked with the following statuses:
 .Monitoring deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |====
 
@@ -194,7 +211,7 @@ In the following tables, features are marked with the following statuses:
 .Installation deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |vSphere 7.0 Update 1 or earlier
 |General Availability
@@ -224,7 +241,7 @@ In the following tables, features are marked with the following statuses:
 .Updating clusters deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |====
 
@@ -234,7 +251,7 @@ In the following tables, features are marked with the following statuses:
 .Storage deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Persistent storage using FlexVolume
 |Deprecated
@@ -249,7 +266,7 @@ In the following tables, features are marked with the following statuses:
 .Authentication and authorization deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |====
 
@@ -259,7 +276,7 @@ In the following tables, features are marked with the following statuses:
 .Specialized hardware and driver enablement deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Special Resource Operator (SRO)
 |Technology Preview
@@ -274,7 +291,7 @@ In the following tables, features are marked with the following statuses:
 .Multi-architecture deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |IBM POWER8 all models (`ppc64le`)
 |General Availability
@@ -324,7 +341,7 @@ In the following tables, features are marked with the following statuses:
 .Networking deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Kuryr on {rh-openstack}
 |General Availability
@@ -490,7 +507,7 @@ In the following tables, features are marked with the following statuses:
 .Networking Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |PTP single NIC hardware configured as boundary clock
 |Technology Preview
@@ -519,11 +536,6 @@ In the following tables, features are marked with the following statuses:
 
 |AWS Load Balancer Operator
 |Not Available
-|Technology Preview
-|Technology Preview
-
-|Cloud controller manager for VMware vSphere
-|Technology Preview
 |Technology Preview
 |Technology Preview
 
@@ -595,7 +607,7 @@ In the following tables, features are marked with the following statuses:
 .Storage Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds
 |Technology Preview
@@ -668,7 +680,7 @@ In the following tables, features are marked with the following statuses:
 .Installation Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Adding kernel modules to nodes with kvc
 |Technology Preview
@@ -708,7 +720,7 @@ In the following tables, features are marked with the following statuses:
 .Nodes Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Non-preempting priority classes
 |Technology Preview
@@ -733,7 +745,7 @@ In the following tables, features are marked with the following statuses:
 .Multi-Architecture Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |`kdump` on `arm64` architecture
 |Not Available
@@ -763,7 +775,7 @@ In the following tables, features are marked with the following statuses:
 .Serverless Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Serverless functions
 |Technology Preview
@@ -778,7 +790,7 @@ In the following tables, features are marked with the following statuses:
 .Specialized hardware and driver enablement Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Driver Toolkit
 |Technology Preview
@@ -803,7 +815,7 @@ In the following tables, features are marked with the following statuses:
 .Web console Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Multicluster console
 |Technology Preview
@@ -823,7 +835,7 @@ In the following tables, features are marked with the following statuses:
 .Scalability and performance Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Hyperthreading-aware CPU manager policy
 |Technology Preview
@@ -863,7 +875,7 @@ In the following tables, features are marked with the following statuses:
 .Operator Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Hybrid Helm Operator
 |Technology Preview
@@ -913,7 +925,7 @@ In the following tables, features are marked with the following statuses:
 .Monitoring Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Alert routing for user-defined projects monitoring
 |Technology Preview
@@ -933,7 +945,7 @@ In the following tables, features are marked with the following statuses:
 .{rh-openstack} Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Support for {rh-openstack} DCN
 |Technology Preview
@@ -953,7 +965,7 @@ In the following tables, features are marked with the following statuses:
 .Architecture Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Hosted control planes for {product-title} on bare metal
 |Not Available
@@ -973,7 +985,7 @@ In the following tables, features are marked with the following statuses:
 .Machine management Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
-|Feature |4.11 |4.12 | 4.13
+|Feature |4.11 |4.12 |4.13
 
 |Managing machines with the Cluster API
 |Not Available
@@ -1006,6 +1018,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Cloud controller manager for {rh-openstack-first}
+|Technology Preview
+|General Availability
+|General Availability
+
+|Cloud controller manager for VMware vSphere
 |Technology Preview
 |Technology Preview
 |General Availability


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OCPCLOUD-1129](https://issues.redhat.com//browse/OCPCLOUD-1129) | [OSDOCS-5070](https://issues.redhat.com//browse/OSDOCS-5070)

Link to docs preview:
- [Cloud controller managers for additional cloud providers](https://55358--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-cluster-cloud-controller-manager-operator) in _Notable technical changes_
- [Technology Preview tracker](https://55358--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#machine-management-technology-preview-features) table

QE review:
- [x] QE has approved this change.

Additional information:
- Left some text commented out that I plan to use for another related feature when I get to that (Nutanix CCMs)
- Also fixed a few things in the rel notes