### PR TITLE
BZ1998132: Clarified image short name note in Image configuration res…

### DIFF
--- a/modules/images-configuration-shortname.adoc
+++ b/modules/images-configuration-shortname.adoc
@@ -17,9 +17,18 @@ When pulling or pushing images, the container runtime searches the registries li
 
 [WARNING]
 ====
-Using image short names with public registries is strongly discouraged. You should use image short names with only internal or private registries.
+Using image short names with public registries is strongly discouraged because the image might not deploy if the public registry requires authentication. Use fully-qualified image names with public registries.
 
-If you list public registries under the `containerRuntimeSearchRegistries` parameter, you expose your credentials to all the registries on the list and you risk network and registry attacks. You should always use fully-qualified image names with public registries.
+Red Hat internal or private registries typically support the use of image short names.
+
+If you list public registries under the `containerRuntimeSearchRegistries` parameter, you expose your credentials to all the registries on the list and you risk network and registry attacks. 
+
+You cannot list multiple public registries under the `containerRuntimeSearchRegistries` parameter if each public registry requires different credentials and a cluster does not list the public registry in the global pull secret. 
+ 
+For a public registry that requires authentication, you can use an image short name only if the registry has its credentials stored in the global pull secret.
+////
+Potentially add the last line to the Ignoring image registry repository mirroring section.
+////
 ====
 
 The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, if the `containerRuntimeSearchRegistries` parameter is added, the MCO creates a file in the `/etc/containers/registries.conf.d` directory on each node with the listed registries. The file overrides the default list of unqualified search registries in the `/host/etc/containers/registries.conf` file. There is no way to fall back to the default list of unqualified search registries.


### PR DESCRIPTION
Version(s):
4.9+

Issue:
[bz1998132](https://bugzilla.redhat.com/show_bug.cgi?id=1998132)

Link to docs preview: [Adding registries that allow image short names](https://55375--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/image-configuration.html#images-configuration-shortname_image-configuration)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->