### PR TITLE
fix typo on firewall entry for observatorium

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -104,7 +104,7 @@ CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard ent
 |443
 |Required for telemetry and Red Hat Insights.
 
-|`observatorium.api.openshift.comm`
+|`observatorium.api.openshift.com`
 |443
 |Required for managed OpenShift-specific telemetry.
 |===


### PR DESCRIPTION
4.12+
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Small typo fix


Link to docs:
https://docs.openshift.com/rosa/rosa_planning/rosa-sts-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs


