### PR TITLE
Adds OMR Release Notes for 1.3.0

### DIFF
--- a/installing/disconnected_install/installing-mirroring-creating-registry.adoc
+++ b/installing/disconnected_install/installing-mirroring-creating-registry.adoc
@@ -35,6 +35,7 @@ include::modules/mirror-registry-remote-host-update.adoc[leveloffset=+1]
 include::modules/mirror-registry-uninstall.adoc[leveloffset=+1]
 include::modules/mirror-registry-flags.adoc[leveloffset=+1]
 include::modules/mirror-registry-release-notes.adoc[leveloffset=+1]
+include::modules/mirror-registry-troubleshooting.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/mirror-registry-flags.adoc
+++ b/modules/mirror-registry-flags.adoc
@@ -13,9 +13,11 @@ The following flags are available for the _mirror registry for Red Hat OpenShift
 | `--autoApprove` | A boolean value that disables interactive prompts. If set to `true`, the `quayRoot` directory is automatically deleted when uninstalling the mirror registry. Defaults to `false` if left unspecified.
 | `--initPassword` | The password of the init user created during Quay installation. Must be at least eight characters and contain no whitespace.
 |`--initUser string` | Shows the username of the initial user. Defaults to `init` if left unspecified.
-|`--no-color`, `-c` | Allows users to disable color sequences and propagate that to Ansible when running install, uninstall, and upgrade commands.
+| `--no-color`, `-c` | Allows users to disable color sequences and propagate that to Ansible when running install, uninstall, and upgrade commands.
+| `--pgStorage` | The folder where Postgres persistent storage data is saved. Defaults to the `pg-storage` Podman volume. Root privileges are required to uninstall. 
 | `--quayHostname` | The fully-qualified domain name of the mirror registry that clients will use to contact the registry. Equivalent to `SERVER_HOSTNAME` in the Quay `config.yaml`. Must resolve by DNS. Defaults to `<targetHostname>:8443` if left unspecified. ^[1]^
-| `--quayRoot`, `-r` | The directory where container image layer and configuration data is saved, including `rootCA.key`, `rootCA.pem`, and `rootCA.srl` certificates. Requires about 12 GB for {product-title} 4.10 Release images, or about 358 GB for {product-title} 4.10 Release images and {product-title} 4.10 Red Hat Operator images. Defaults to `/etc/quay-install` if left unspecified.
+| `--quayStorage` | The folder where Quay persistent storage data is saved. Defaults to the `quay-storage` Podman volume. Root privileges are required to uninstall.  
+| `--quayRoot`, `-r` | The directory where container image layer and configuration data is saved, including `rootCA.key`, `rootCA.pem`, and `rootCA.srl` certificates. Defaults to `$HOME/quay-install` if left unspecified.
 | `--ssh-key`, `-k` | The path of your SSH identity key. Defaults to `~/.ssh/quay_installer` if left unspecified.
 | `--sslCert` | The path to the SSL/TLS public key / certificate. Defaults to `{quayRoot}/quay-config` and is auto-generated if left unspecified.
 | `--sslCheckSkip` | Skips the check for the certificate hostname against the `SERVER_HOSTNAME` in the `config.yaml` file. ^[2]^
@@ -23,7 +25,7 @@ The following flags are available for the _mirror registry for Red Hat OpenShift
 | `--targetHostname`, `-H` | The hostname of the target you want to install Quay to. Defaults to `$HOST`, for example, a local host, if left unspecified.
 | `--targetUsername`, `-u` | The user on the target host which will be used for SSH. Defaults to `$USER`, for example, the current user if left unspecified.
 | `--verbose`, `-v` | Shows debug logs and Ansible playbook outputs.
-|`--version` | Shows the version for the _mirror registry for Red Hat OpenShift_.
+| `--version` | Shows the version for the _mirror registry for Red Hat OpenShift_.
 |===
 [.small]
 1. `--quayHostname` must be modified if the public DNS name of your system is different from the local hostname. Additionally, the `--quayHostname` flag does not support installation with an IP address. Installation with a hostname is required. 

--- a/modules/mirror-registry-localhost-update.adoc
+++ b/modules/mirror-registry-localhost-update.adoc
@@ -6,7 +6,7 @@
 [id="mirror-registry-localhost-update_{context}"]
 = Updating mirror registry for Red Hat OpenShift from a local host
 
-This procedure explains how to update the _mirror registry for Red Hat OpenShift_ from a local host using the `upgrade` command. Updating to the latest version ensures bug fixes and security vulnerability fixes.
+This procedure explains how to update the _mirror registry for Red Hat OpenShift_ from a local host using the `upgrade` command. Updating to the latest version ensures new features, bug fixes, and security vulnerability fixes.
 
 [IMPORTANT]
 ====
@@ -19,7 +19,7 @@ When updating, there is intermittent downtime of your mirror registry, as it is 
 
 .Procedure
 
-* To upgrade the _mirror registry for Red Hat OpenShift_ from localhost, enter the following command:
+* If you are upgrading the _mirror registry for Red Hat OpenShift_ from 1.2.z -> 1.3.0, and your installation directory is the default at `/etc/quay-install`, you can enter the following command:
 +
 [source,terminal]
 ----
@@ -28,5 +28,15 @@ $ sudo ./mirror-registry upgrade -v
 +
 [NOTE]
 ====
-Users who upgrade the _mirror registry for Red Hat OpenShift_ with the `./mirror-registry upgrade -v` flag must include the same credentials used when creating their mirror registry. For example, if you installed the _mirror registry for Red Hat OpenShift_ with `--quayHostname <host_example_com>` and `--quayRoot <example_directory_name>`, you must include that string to properly upgrade the mirror registry.
+* _mirror registry for Red Hat OpenShift_ migrates Podman volumes for Quay storage, Postgres data, and `/etc/quay-install` data to the new `$HOME/quay-install` location. This allows you to use _mirror registry for Red Hat OpenShift_ without the `--quayRoot` flag during future upgrades.
+
+* Users who upgrade _mirror registry for Red Hat OpenShift_ with the `./mirror-registry upgrade -v` flag must include the same credentials used when creating their mirror registry. For example, if you installed the _mirror registry for Red Hat OpenShift_ with `--quayHostname <host_example_com>` and `--quayRoot <example_directory_name>`, you must include that string to properly upgrade the mirror registry.
 ====
+
+* If you are upgrading the _mirror registry for Red Hat OpenShift_ from 1.2.z -> 1.3.0 and you used a specified directory in your 1.2.z deployment, you must pass in the new `--pgStorage`and `--quayStorage` flags. For example:
++
+[source,terminal]
+----
+$ sudo ./mirror-registry upgrade --quayHostname <host_example_com> --quayRoot <example_directory_name> --pgStorage <example_directory_name>/pg-data --quayStorage <example_directory_name>/quay-storage -v
+----
+

--- a/modules/mirror-registry-localhost.adoc
+++ b/modules/mirror-registry-localhost.adoc
@@ -10,7 +10,7 @@ This procedure explains how to install the _mirror registry for Red Hat OpenShif
 
 [NOTE]
 ====
-Installing the _mirror registry for Red Hat OpenShift_ using the `mirror-registry` CLI tool makes several changes to your machine. After installation, a `/etc/quay-install` directory is created, which has installation files, local storage, and the configuration bundle. Trusted SSH keys are generated in case the deployment target is the local host, and systemd files on the host machine are set up to ensure that container runtimes are persistent. Additionally, an initial user named `init` is created with an automatically generated password. All access credentials are printed at the end of the install routine.
+Installing the _mirror registry for Red Hat OpenShift_ using the `mirror-registry` CLI tool makes several changes to your machine. After installation, a `$HOME/quay-install` directory is created, which has installation files, local storage, and the configuration bundle. Trusted SSH keys are generated in case the deployment target is the local host, and systemd files on the host machine are set up to ensure that container runtimes are persistent. Additionally, an initial user named `init` is created with an automatically generated password. All access credentials are printed at the end of the install routine.
 ====
 
 .Procedure

--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -11,6 +11,39 @@ These release notes track the development of the _mirror registry for Red Hat Op
 
 For an overview of the _mirror registry for Red Hat OpenShift_, see xref:../../installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-flags_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift].
 
+[id="mirror-registry-for-openshift-1-3-0"]
+== Mirror registry for Red Hat OpenShift 1.3.0
+
+Issued: 2023-02-20
+
+_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.1.
+
+The following advisory is available for the _mirror registry for Red Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2023:0558[RHBA-2023:0558 - mirror registry for Red Hat OpenShift 1.3.0]
+
+=== New features
+
+* _Mirror registry for Red Hat OpenShift_ is now supported on {op-system-base-full} 9 installations.
+
+* IPv6 support is now available on _Mirror registry for Red Hat OpenShift_ local host installations.
++
+IPv6 is currently unsupported on _Mirror registry for Red Hat OpenShift_ remote host installations.
+
+* A new feature flag, `--quayStorage`, has been added. With this flag, users with root privileges can manually set the location of their Quay persistent storage.
+
+* A new feature flag, `--pgStorage`, has been added. With this flag, users with root privileges can manually set the location of their Postgres persistent storage.
+
+* Previously, users were required to have root privileges (`sudo`) to install _Mirror registry for Red Hat OpenShift_. With this update, `sudo` is no longer required to install _Mirror registry for Red Hat OpenShift_.
++
+When _Mirror registry for Red Hat OpenShift_ was installed with `sudo`, an `/etc/quay-install` directory that contained installation files, local storage, and the configuration bundle was created. With the removal of the `sudo` requirement, installation files and the configuration bundle are now installed to `$HOME/quay-install`. Local storage, for example Postgres and Quay, are now stored in named volumes automatically created by Podman.
++
+To override the default directories that these files are stored in, you can use the command line arguments for _Mirror registry for Red Hat OpenShift_. For more information about _Mirror registry for Red Hat OpenShift_ command line arguments, see "_Mirror registry for Red Hat OpenShift_ flags".
+
+=== Bug fixes
+
+* Previously, the following error could be returned when attempting to uninstall _Mirror registry for Red Hat OpenShift_: `["Error: no container with name or ID \"quay-postgres\" found: no such container"], "stdout": "", "stdout_lines": []***`. With this update, the order that _Mirror registry for Red Hat OpenShift_ services are stopped and uninstalled have been changed so that the error no longer occurs when uninstalling _Mirror registry for Red Hat OpenShift_. For more information, see link:https://issues.redhat.com/browse/PROJQUAY-4629[*PROJQUAY-4629*].
+
 
 [id="mirror-registry-for-openshift-1-2-9"]
 == Mirror registry for Red Hat OpenShift 1.2.9
@@ -54,9 +87,9 @@ The following advisory is available for the _mirror registry for Red Hat OpenShi
 
 * link:https://access.redhat.com/errata/RHBA-2022:6278[RHBA-2022:6278 - mirror registry for Red Hat OpenShift 1.2.6]
 
-=== New features 
+=== New features
 
-A new feature flag, `--no-color` (`-c`) has been added. This feature flag allows users to disable color sequences and propagate that to Ansible when running install, uninstall, and upgrade commands. 
+A new feature flag, `--no-color` (`-c`) has been added. This feature flag allows users to disable color sequences and propagate that to Ansible when running install, uninstall, and upgrade commands.
 
 [id="mirror-registry-for-openshift-1-2-5"]
 == Mirror registry for Red Hat OpenShift 1.2.5

--- a/modules/mirror-registry-remote.adoc
+++ b/modules/mirror-registry-remote.adoc
@@ -10,7 +10,7 @@ This procedure explains how to install the _mirror registry for Red Hat OpenShif
 
 [NOTE]
 ====
-Installing the _mirror registry for Red Hat OpenShift_ using the `mirror-registry` CLI tool makes several changes to your machine. After installation, a `/etc/quay-install` directory is created, which has installation files, local storage, and the configuration bundle. Trusted SSH keys are generated in case the deployment target is the local host, and systemd files on the host machine are set up to ensure that container runtimes are persistent. Additionally, an initial user named `init` is created with an automatically generated password. All access credentials are printed at the end of the install routine.
+Installing the _mirror registry for Red Hat OpenShift_ using the `mirror-registry` CLI tool makes several changes to your machine. After installation, a `$HOME/quay-install` directory is created, which has installation files, local storage, and the configuration bundle. Trusted SSH keys are generated in case the deployment target is the local host, and systemd files on the host machine are set up to ensure that container runtimes are persistent. Additionally, an initial user named `init` is created with an automatically generated password. All access credentials are printed at the end of the install routine.
 ====
 
 .Procedure

--- a/modules/mirror-registry-troubleshooting.adoc
+++ b/modules/mirror-registry-troubleshooting.adoc
@@ -1,0 +1,34 @@
+// module included in the following assembly:
+//
+// * installing-mirroring-creating-registry.adoc
+
+:_content-type: PROCEDURE
+[id="mirror-registry-troubleshooting_{context}"]
+= Troubleshooting mirror registry for Red Hat OpenShift
+
+To assist in troubleshooting _mirror registry for Red Hat OpenShift_, you can gather logs of systemd services installed by the mirror registry. The following services are installed:
+
+* quay-app.service
+* quay-postgres.service
+* quay-redis.service
+* quay-pod.service
+
+.Prerequisites
+
+* You have installed _mirror registry for Red Hat OpenShift_.
+
+.Procedure
+
+* If you installed _mirror registry for Red Hat OpenShift_ with root privileges, you can get the status information of its systemd services by entering the following command:
++
+[source,terminal]
+----
+$ sudo systemctl status <service>
+----
+
+* If you installed _mirror registry for Red Hat OpenShift_ as a standard user, you can get the status information of its systemd services by entering the following command:
++
+[source,terminal]
+----
+$ systemctl --user status <service>
+----


### PR DESCRIPTION
Adds OMR Release Notes for 1.3.0
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-5089

Link to docs preview:
https://55396--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-for-openshift-1-3-0

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
