### PR TITLE
OSDOCS-4802: Clarifying life cycle language

### DIFF
--- a/modules/life-cycle-mandatory-upgrades.adoc
+++ b/modules/life-cycle-mandatory-upgrades.adoc
@@ -10,7 +10,4 @@ impacts the security or stability of the cluster, the customer must upgrade to t
 patch release within two link:https://access.redhat.com/articles/2623321[business days].
 
 In extreme circumstances and based on Red Hat's assessment of the CVE criticality to the
-environment, if the upgrade to the next supported patch release has not been performed within
-two link:https://access.redhat.com/articles/2623321[business days] of notification, the cluster
-will be automatically updated to the latest patch release to mitigate potential security breach
-or instability.
+environment, Red Hat will notify customers that they have two link:https://access.redhat.com/articles/2623321[business days] to schedule or manually update their cluster to the latest, secure patch release. In the case that an update has not been performed, Red Hat will automatically update the cluster to the latest, secure patch release to mitigate potential security breach(es) or instability. Red Hat may, at its own discretion, temporarily delay an automated update if requested by a customer through a link:https://access.redhat.com/support[support case].


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-4802](https://issues.redhat.com/browse/OSDOCS-4802)

Link to docs preview:

- [ROSA Mandatory upgrades](https://55405--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html#rosa-mandatory-upgrades_rosa-life-cycle)
- [OSD Mandatory upgrades](https://55405--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle.html#rosa-mandatory-upgrades_osd-life-cycle)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
