### PR TITLE
[OSDOCS-5012]: Full Azure CPMS support (rel notes)

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -157,6 +157,17 @@ Netlink messages dropped by OVS kernel module due to netlink socket buffer overf
 [id="ocp-4-13-machine-api"]
 === Machine API
 
+[id="ocp-4-13-mapi-cpms-platform-support"]
+==== Additional platform support for control plane machine sets
+
+This release includes an enhancement to the user experience for the control plane machine set on Microsoft Azure clusters. For Azure clusters that are installed with or upgraded to {product-title} version 4.13, you are no longer required to create a control plane machine set custom resource (CR).
+
+* Clusters that are installed with version 4.13 have a control plane machine set that is active by default.
+
+* For clusters that are upgraded to version 4.13, an inactive CR is generated for the cluster and can be activated after you verify that the values in the CR are correct for your control plane machines.
+
+For more information, see xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with the Control Plane Machine Set Operator].
+
 [id="ocp-4-13-machine-config-operator"]
 === Machine Config Operator
 


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OCPCLOUD-1764](https://issues.redhat.com//browse/OCPCLOUD-1764) | [OSDOCS-5012](https://issues.redhat.com//browse/OSDOCS-5012)

Link to docs preview:
[Additional platform support for control plane machine sets](https://55409--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-mapi-cpms-platform-support)

QE review:
- [x] QE has approved this change.

Additional information:
* Main docs: #55407 