### PR TITLE
OCPBUGS-6886: Add Ironic provisioning service update release note

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1607,6 +1607,9 @@ After cleaning up resources manually, the `OrphanedCloudResource` condition pers
 
 * Previously, users had to enter a long form of an IPv6 address in the installation configuration file, for example `2001:0db8:85a3:0000:0000:8a2e:0370:7334`. Ironic could not find an interface matching this IP address causing the installation to fail. With this update, the IPv6 address supplied by the user is converted to a short form address, for example, `2001:db8:85a3::8a2e:370:7334`. As a result, installation is now successful. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2010698[*BZ#2010698*])
 
+* Before this update, when a Redfish system features a Settings URI, the Ironic provisioning service always attempts to use this URI to make changes to boot-related BIOS settings. However, bare-metal provisioning fails if the Baseboard Management Controller (BMC) features a Settings URI but does not support changing a particular BIOS setting by using this Settings URI. In {product-title} {product-version} and later, if a system features a Settings URI, Ironic verifies that it can change a particular BIOS setting by using the Settings URI before proceeding. Otherwise, Ironic implements the change by using the System URI. This additional logic ensures that Ironic can apply boot-related BIOS setting changes and bare-metal provisioning can succeed. (link:https://issues.redhat.com/browse/OCPBUGS-6886[*OCPBUGS-6886*])
+
+
 [discrete]
 [id="ocp-4-10-builds-bug-fixes"]
 ==== Builds


### PR DESCRIPTION
Version(s):
4.10

Issue:
[OCPBUGS-6886](https://issues.redhat.com/browse/OCPBUGS-6886)

Link to docs preview: [Bare Metal Hardware Provisioning: last listed bug](http://file.emea.redhat.com/dfitzmau/OCPBUGS-6886/release_notes/ocp-4-10-release-notes.html#ocp-4-10-bug-fixes)

Useful link: Note originally published in the [4.12 release notes](https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html#ocp-4-12-bug-fixes). OCPBUGS-6886 Jira request to backport the change to 4.10. 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

QE not required for this backporting release note update. 
