### PR TITLE
OSDOCS-5142 and OSDOCS-5143: Use RHEL major version instead of full version

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,11 +4,13 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
+:ocp-version: 4.12
 :rhel-major: rhel-8
 :op-system-first: Red Hat Enterprise Linux (RHEL)
 :op-system: RHEL
 :op-system-ostree-first: Red Hat Enterprise Linux (RHEL) for Edge
 :op-system-ostree: RHEL for Edge
 :op-system-version: 8.7
+:op-system-version-major: 8
 :op-system-ram: 2GB RAM
 :op-system-chip: two-core AMD64 1.5GHz processor

--- a/modules/microshift-adding-repos-to-image-builder.adoc
+++ b/modules/microshift-adding-repos-to-image-builder.adoc
@@ -20,8 +20,8 @@ Use the following procedure to add the {product-title} repositories to Image Bui
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos
-    --enable rhocp-{ocp-version}-for-rhel-{op-system-version}-$(uname -i)-rpms
-    --enable fast-datapath-for-rhel-{op-system-version}-$(uname -i)-rpms
+    --enable rhocp-{ocp-version}-for-rhel-{op-system-version-major}-$(uname -i)-rpms
+    --enable fast-datapath-for-rhel-{op-system-version-major}-$(uname -i)-rpms
 ----
 
 . Install the `reposync` and `createrepo` tools by running the following command:
@@ -37,8 +37,8 @@ $ sudo yum install -y yum-utils
 ----
 $ sudo reposync --arch=$(uname -i) --arch=noarch --gpgcheck \
     --download-path REPO_PATH=/var/repos/microshift-local \
-    --repo=rhocp-{ocp-version}-for-rhel-{op-system-version}-$(uname -i)-rpms \
-    --repo=fast-datapath-for-rhel-{op-system-version}-$(uname -i)-rpms
+    --repo=rhocp-{ocp-version}-for-rhel-{op-system-version-major}-$(uname -i)-rpms \
+    --repo=fast-datapath-for-rhel-{op-system-version-major}-$(uname -i)-rpms
 ----
 
 . Remove `coreos` packages to avoid conflicts by running the following command:


### PR DESCRIPTION
The current variable substitution results in "8.7" but only the major version part "8" is correct in these locations. Introduced a new variable {op-system-version-major} to capture this. Also, {ocp-version} did not get substituted due to a missing variable definition.

Signed-off-by: Frank A. Zdarsky <fzdarsky@redhat.com>