### PR TITLE
OSDOCS-5145: comment out invalid module in install

### DIFF
--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -10,7 +10,7 @@ You can embed {product-title} into a {op-system-ostree-first} {op-system-version
 
 [IMPORTANT]
 ====
-Red Hat does not support an update path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation will be necessary.
+Red Hat does not support an update path from Developer Preview and Technology Preview versions to later versions of {product-title}. A new installation is necessary.
 ====
 
 [id="preparing-for-image-building_{context}"]
@@ -44,7 +44,7 @@ include::modules/microshift-adding-service-to-blueprint.adoc[leveloffset=+2]
 
 * For further customizations such as adding users, firewall rules, or kernel arguments to a blueprint, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images#image-customizations_composing-a-rhel-for-edge-image-using-image-builder-command-line[supported image customizations].
 
-include::modules/microshift-adding-containers-to-blueprint.adoc[leveloffset=+2]
+//include::modules/microshift-adding-containers-to-blueprint.adoc[leveloffset=+2]
 include::modules/microshift-provisioning-ostree.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5145

Link to docs preview:
https://55428--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html

QE review:
Developer Preview, QE not needed
SME approval needed

Additional information:
Removing
https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.12/html/installing/microshift-embed-in-rpm-ostree#adding-MicroShift-container-images_microshift-embed-in-rpm-ostree 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
