### PR TITLE
OSDOCS#5035 Updates anchor IDs for updating in 4.9 branch

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -2329,7 +2329,7 @@ A new conditional gatherer has been implemented for the `SamplesImagestreamImpor
 [id="ocp-4-9-4-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-5"]
 === RHBA-2021:4005 - {product-title} 4.9.5 bug fix update
@@ -2359,7 +2359,7 @@ $ oc adm release info 4.9.5 --pullspecs
 [id="ocp-4-9-5-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-6"]
 === RHBA-2021:4119 - {product-title} 4.9.6 bug fix and security update
@@ -2394,7 +2394,7 @@ $ oc adm release info 4.9.6 --pullspecs
 [id="ocp-4-9-6-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-7"]
 === RHBA-2021:4579 - {product-title} 4.9.7 bug fix update
@@ -2421,7 +2421,7 @@ This update contains changes from Kubernetes 1.22.2. More information can be fou
 [id="ocp-4-9-7-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-8"]
 === RHBA-2021:4712 - {product-title} 4.9.8 bug fix update
@@ -2445,7 +2445,7 @@ $ oc adm release info 4.9.8 --pullspecs
 [id="ocp-4-9-8-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-9"]
 === RHBA-2021:4834 - {product-title} 4.9.9 bug fix and security update
@@ -2477,7 +2477,7 @@ This update contains changes from Kubernetes 1.22.3. More information can be fou
 [id="ocp-4-9-9-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-10"]
 === RHBA-2021:4889 - {product-title} 4.9.10 bug fix update
@@ -2496,7 +2496,7 @@ $ oc adm release info 4.9.10 --pullspecs
 [id="ocp-4-9-10-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-11"]
 === RHBA-2021:5003 - {product-title} 4.9.11 bug fix and security update
@@ -2515,7 +2515,7 @@ $ oc adm release info 4.9.11 --pullspecs
 [id="ocp-4-9-11-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-12"]
 === RHBA-2021:5214 - {product-title} 4.9.12 bug fix update
@@ -2534,7 +2534,7 @@ $ oc adm release info 4.9.12 --pullspecs
 [id="ocp-4-9-12-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-15"]
 === RHBA-2022:0110 - {product-title} 4.9.15 bug fix update
@@ -2553,7 +2553,7 @@ $ oc adm release info 4.9.15 --pullspecs
 [id="ocp-4-9-15-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-17"]
 === RHBA-2022:0195 - {product-title} 4.9.17 bug fix update
@@ -2580,7 +2580,7 @@ $ oc adm release info 4.9.17 --pullspecs
 [id="ocp-4-9-17-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-18"]
 === RHBA-2022:0279 - {product-title} 4.9.18 bug fix update
@@ -2606,7 +2606,7 @@ $ oc adm release info 4.9.18 --pullspecs
 [id="ocp-4-9-18-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-19"]
 === RHBA-2022:0340 - {product-title} 4.9.19 bug fix and security update
@@ -2630,7 +2630,7 @@ Due to the removal of the scheduler Policy API, {product-title} 4.9.19 introduce
 [id="ocp-4-9-19-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-21"]
 === RHBA-2022:0488 - {product-title} 4.9.21 bug fix update
@@ -2660,7 +2660,7 @@ $ oc adm release info 4.9.21 --pullspecs
 [id="ocp-4-9-21-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-22"]
 === RHSA-2022:0561 - {product-title} 4.9.22 bug fix and security update
@@ -2684,7 +2684,7 @@ $ oc adm release info 4.9.22 --pullspecs
 [id="ocp-4-9-22-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-23"]
 === RHSA-2022:0655 - {product-title} 4.9.23 bug fix and security update
@@ -2715,7 +2715,7 @@ $ oc adm release info 4.9.23 --pullspecs
 [id="ocp-4-9-23-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-24"]
 === RHBA-2022:0798 - {product-title} 4.9.24 bug fix update
@@ -2751,7 +2751,7 @@ Starting with {product-title} 4.9.24, support for using the Cloud Credential Ope
 [id="ocp-4-9-24-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-25"]
 === RHBA-2022:0861 - {product-title} 4.9.25 bug fix and security update
@@ -2770,7 +2770,7 @@ $ oc adm release info 4.9.25 --pullspecs
 [id="ocp-4-9-25-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-26"]
 === RHBA-2022:1022 - {product-title} 4.9.26 bug fix and security update
@@ -2803,7 +2803,7 @@ $ oc adm release info 4.9.26 --pullspecs
 [id="ocp-4-9-26-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-27"]
 === RHSA-2022:1158 - {product-title} 4.9.27 bug fix and security update
@@ -2826,7 +2826,7 @@ $ oc adm release info 4.9.27 --pullspecs
 [id="ocp-4-9-27-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-28"]
 === RHBA-2022:1245 - {product-title} 4.9.28 bug fix update
@@ -2852,7 +2852,7 @@ $ oc adm release info 4.9.28 --pullspecs
 [id="ocp-4-9-28-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-29"]
 === RHSA-2022:1363 - {product-title} 4.9.29 bug fix and security update
@@ -2879,7 +2879,7 @@ $ oc adm release info 4.9.29 --pullspecs
 [id="ocp-4-9-29-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-31"]
 === RHBA-2022:1605 - {product-title} 4.9.31 bug fix update
@@ -2911,7 +2911,7 @@ This update contains changes from Kubernetes 1.22.6 up to 1.22.8. More informati
 [id="ocp-4-9-31-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-32"]
 === RHBA-2022:1694 - {product-title} 4.9.32 bug fix update
@@ -2930,7 +2930,7 @@ $ oc adm release info 4.9.32 --pullspecs
 [id="ocp-4-9-32-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-9-33"]
 === RHBA-2022:2206 - {product-title} 4.9.33 bug fix and security update
@@ -2956,7 +2956,7 @@ $ oc adm release info 4.9.33 --pullspecs
 [id="ocp-4-9-33-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-35"]
 === RHSA-2022:2283 - {product-title} 4.9.35 bug fix and security update
@@ -2975,7 +2975,7 @@ $ oc adm release info 4.9.35 --pullspecs
 [id="ocp-4-9-35-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-36"]
 === RHBA-2022:4741 - {product-title} 4.9.36 bug fix update
@@ -2994,7 +2994,7 @@ $ oc adm release info 4.9.36 --pullspecs
 [id="ocp-4-9-36-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-37"]
 === RHBA-2022:4906 - {product-title} 4.9.37 bug fix update
@@ -3013,7 +3013,7 @@ $ oc adm release info 4.9.37 --pullspecs
 [id="ocp-4-9-37-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-38"]
 === RHBA-2022:2283 - {product-title} 4.9.38 bug fix and security update
@@ -3037,7 +3037,7 @@ $ oc adm release info 4.9.38 --pullspecs
 [id="ocp-4-9-38-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-40"]
 === RHBA-2022:5180 - {product-title} 4.9.40 bug fix update
@@ -3056,7 +3056,7 @@ $ oc adm release info 4.9.40 --pullspecs
 [id="ocp-4-9-40-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-41"]
 === RHBA-2022:5434 - {product-title} 4.9.41 bug fix update
@@ -3082,7 +3082,7 @@ $ oc adm release info 4.9.41 --pullspecs
 [id="ocp-4-9-41-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-42"]
 === RHBA-2022:5509 - {product-title} 4.9.42 bug fix update
@@ -3101,7 +3101,7 @@ $ oc adm release info 4.9.42 --pullspecs
 [id="ocp-4-9-42-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-43"]
 === RHBA-2022:5561 - {product-title} 4.9.43 bug fix update
@@ -3127,7 +3127,7 @@ $ oc adm release info 4.9.43 --pullspecs
 [id="ocp-4-9-43-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-45"]
 === RHSA-2022:5879 - {product-title} 4.9.45 bug fix update and security update
@@ -3151,7 +3151,7 @@ $ oc adm release info 4.9.45 --pullspecs
 [id="ocp-4-9-45-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-46"]
 === RHSA-2022:6033 - {product-title} 4.9.46 bug fix update
@@ -3170,7 +3170,7 @@ $ oc adm release info 4.9.46 --pullspecs
 [id="ocp-4-9-46-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-47"]
 === RHSA-2022:6147 - {product-title} 4.9.47 bug fix update and security update
@@ -3199,7 +3199,7 @@ This is a new AWS permission and you must update credentials for manual mode clu
 [id="ocp-4-9-47-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-48"]
 === RHSA-2022:6317 - {product-title} 4.9.48 bug fix update and security update
@@ -3218,7 +3218,7 @@ $ oc adm release info 4.9.48 --pullspecs
 [id="ocp-4-9-48-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-49"]
 === RHBA-2022:6678 - {product-title} 4.9.49 bug fix update
@@ -3242,7 +3242,7 @@ $ oc adm release info 4.9.49 --pullspecs
 [id="ocp-4-9-49-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-50"]
 === RHSA-2022:6905 - {product-title} 4.9.50 bug fix and security update
@@ -3270,7 +3270,7 @@ $ oc adm release info 4.9.50 --pullspecs
 [id="ocp-4-9-50-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-51"]
 === RHSA-2022:7216 - {product-title} 4.9.51 bug fix and security update
@@ -3296,7 +3296,7 @@ For more information, see xref:../authentication/bound-service-account-tokens.ad
 [id="ocp-4-9-51-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-52"]
 === RHBA-2022:8485 - {product-title} 4.9.52 bug fix update
@@ -3315,7 +3315,7 @@ $ oc adm release info 4.9.52 --pullspecs
 [id="ocp-4-9-52-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-53"]
 === RHBA-2022:8714 - {product-title} 4.9.53 bug fix update
@@ -3339,7 +3339,7 @@ $ oc adm release info 4.9.53 --pullspecs
 [id="ocp-4-9-53-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-9-54"]
 === RHSA-2022:9111 - {product-title} 4.9.54 bug fix and security update
@@ -3358,4 +3358,4 @@ $ oc adm release info 4.9.54 --pullspecs
 [id="ocp-4-9-54-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.9

Issue:
https://issues.redhat.com/browse/OSDOCS-5035

Link to docs preview
[preview](https://joealdinger.github.io/openshift-docs/OSDOCS-5035-RN/release_notes/ocp-4-9-release-notes.html#ocp-4-9-0-ga)
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[OSDOCS-5035](https://issues.redhat.com/browse/OSDOCS-5035): this is a CI task that adds anchor ids to the xref to updating in RNs
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
