### PR TITLE
OSDOCS#5038 Updates anchor IDs for updating in 4.11 branch

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2542,7 +2542,7 @@ $ oc adm release info 4.11.1 --pullspecs
 [id="ocp-4-11-1-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-2"]
 === RHBA-2022:6143 - {product-title} 4.11.2 bug fix update
@@ -2561,7 +2561,7 @@ $ oc adm release info 4.11.2 --pullspecs
 [id="ocp-4-11-2-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-3"]
 === RHSA-2022:6287 - {product-title} 4.11.3 bug fix update and security update
@@ -2588,7 +2588,7 @@ Beginning with {product-title} 4.11.3, users no longer need to set the Root FS i
 [id="ocp-4-11-3-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-4"]
 === RHBA-2022:6376 - {product-title} 4.11.4 bug fix update
@@ -2607,7 +2607,7 @@ $ oc adm release info 4.11.4 --pullspecs
 [id="ocp-4-11-4-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-5"]
 === RHSA-2022:6536 - {product-title} 4.11.5 bug fix and security update
@@ -2636,7 +2636,7 @@ $ oc adm release info 4.11.5 --pullspecs
 [id="ocp-4-11-5-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-6"]
 === RHBA-2022:6659 - {product-title} 4.11.6 bug fix update
@@ -2867,7 +2867,7 @@ $ oc annotate pod dns-default target.workload.openshift.io/management='{"effect"
 [id="ocp-4-11-6-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-7"]
 === RHSA-2022:6732 - {product-title} 4.11.7 bug fix update
@@ -2886,7 +2886,7 @@ $ oc adm release info 4.11.7 --pullspecs
 [id="ocp-4-11-7-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-8"]
 === RHBA-2022:6809 - {product-title} 4.11.8 bug fix update
@@ -2910,7 +2910,7 @@ $ oc adm release info 4.11.8 --pullspecs
 [id="ocp-4-11-8-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-9"]
 === RHBA-2022:6897 - {product-title} 4.11.9 bug fix update
@@ -2929,7 +2929,7 @@ $ oc adm release info 4.11.9 --pullspecs
 [id="ocp-4-11-9-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-12"]
 === RHSA-2022:7201 - {product-title} 4.11.12 bug fix and security update
@@ -2960,7 +2960,7 @@ For more information, see xref:../authentication/bound-service-account-tokens.ad
 [id="ocp-4-11-12-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-13"]
 === RHBA-2022:7201 - {product-title} 4.11.13 bug fix update
@@ -2984,7 +2984,7 @@ $ oc adm release info 4.11.13 --pullspecs
 [id="ocp-4-11-13-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-16"]
 === RHSA-2022:8535 - {product-title} 4.11.16 bug fix and security update
@@ -3012,7 +3012,7 @@ $ oc adm release info 4.11.16 --pullspecs
 [id="ocp-4-11-16-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-17"]
 === RHBA-2022:8627 - {product-title} 4.11.17 bug fix and security update
@@ -3031,7 +3031,7 @@ $ oc adm release info 4.11.17 --pullspecs
 [id="ocp-4-11-17-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-18"]
 === RHBA-2022:8698 - {product-title} 4.11.18 bug fix update
@@ -3067,7 +3067,7 @@ $ oc adm release info 4.11.18 --pullspecs
 [id="ocp-4-11-18-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-20"]
 === RHSA-2022:8893 - {product-title} 4.11.20 bug fix and security update
@@ -3096,7 +3096,7 @@ $ oc adm release info 4.11.20 --pullspecs
 [id="ocp-4-11-20-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-21"]
 === RHSA-2022:9107 - {product-title} 4.11.21 bug fix and security update
@@ -3124,7 +3124,7 @@ $ oc adm release info 4.11.21 --pullspecs
 [id="ocp-4-11-21-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-22"]
 === RHBA-2023:0027 - {product-title} 4.11.22 bug fix update
@@ -3164,7 +3164,7 @@ This is due to a CoreOS limitation in the number of seccomp profiles that can be
 [id="ocp-4-11-22-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-24"]
 === RHSA-2023:0069 - {product-title} 4.11.24 bug fix and security update
@@ -3183,7 +3183,7 @@ $ oc adm release info 4.11.24 --pullspecs
 [id="ocp-4-11-24-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-25"]
 === RHSA-2023:0245 - {product-title} 4.11.25 bug fix and security update
@@ -3202,4 +3202,4 @@ $ oc adm release info 4.11.25 --pullspecs
 [id="ocp-4-11-25-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-5038

Link to docs preview:
https://55435--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-asynchronous-errata-updates

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[OSDOCS-5038](https://issues.redhat.com/browse/OSDOCS-5038): this is a CI task that adds anchor ids to the xref to updating in RNs

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
