### PR TITLE
[OSDOCS-5013]: CPMS for GCP: YAML samples

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-configuration.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-configuration.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-These example YAML file and snippets demonstrate the base structure for a control plane machine set custom resource (CR) and platform-specific samples for failure domain and provider specification configurations.
+These example YAML file and snippets demonstrate the base structure for a control plane machine set custom resource (CR) and platform-specific samples for provider specification and failure domain configurations.
 
 //Sample YAML for a control plane machine set custom resource
 include::modules/cpmso-yaml-sample-cr.adoc[leveloffset=+1]
@@ -25,36 +25,53 @@ The `<platform_failure_domains>` and `<platform_provider_spec>` sections of the 
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-aws_cpmso-configuration[Sample YAML snippets for configuring Amazon Web Services clusters]
 
+* xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-gcp_cpmso-configuration[Sample YAML snippets for configuring Google Cloud Platform clusters]
+
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Sample YAML snippets for configuring Microsoft Azure clusters]
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[Sample YAML snippets for configuring VMware vSphere clusters]
 
-
 [id="cpmso-sample-yaml-aws_{context}"]
 == Sample YAML for configuring Amazon Web Services clusters
 
-Some sections of the control plane machine set CR are provider-specific. The example YAML in this section show failure domain and provider specification configurations for an Amazon Web Services (AWS) cluster.
-
-//Sample AWS failure domain configuration
-include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+2]
+Some sections of the control plane machine set CR are provider-specific. The example YAML in this section show provider specification and failure domain configurations for an Amazon Web Services (AWS) cluster.
 
 //Sample AWS provider specification
 include::modules/cpmso-yaml-provider-spec-aws.adoc[leveloffset=+2]
+
+//Sample AWS failure domain configuration
+include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-supported-features-aws_cpmso-using[Enabling Amazon Web Services features for control plane machines]
 
+[id="cpmso-sample-yaml-gcp_{context}"]
+== Sample YAML for configuring Google Cloud Platform clusters
+
+Some sections of the control plane machine set CR are provider-specific. The example YAML in this section show provider specification and failure domain configurations for a Google Cloud Platform (GCP) cluster.
+
+//Sample GCP provider specification
+include::modules/cpmso-yaml-provider-spec-gcp.adoc[leveloffset=+2]
+
+//Sample GCP failure domain configuration
+include::modules/cpmso-yaml-failure-domain-gcp.adoc[leveloffset=+2]
+////
+//To be added in a later PR
+[role="_additional-resources"]
+.Additional resources
+* xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-supported-features-gcp_cpmso-using[Enabling Google Cloud Platform features for control plane machines]
+////
 [id="cpmso-sample-yaml-azure_{context}"]
 == Sample YAML for configuring Microsoft Azure clusters
 
-Some sections of the control plane machine set CR are provider-specific. The example YAML in this section show failure domain and provider specification configurations for an Azure cluster.
-
-//Sample Azure failure domain configuration
-include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+2]
+Some sections of the control plane machine set CR are provider-specific. The example YAML in this section show provider specification and failure domain configurations for an Azure cluster.
 
 //Sample Azure provider specification
 include::modules/cpmso-yaml-provider-spec-azure.adoc[leveloffset=+2]
+
+//Sample Azure failure domain configuration
+include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/cpmso-yaml-failure-domain-gcp.adoc
+++ b/modules/cpmso-yaml-failure-domain-gcp.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-configuration.adoc
+
+:_content-type: REFERENCE
+[id="cpmso-yaml-failure-domain-gcp_{context}"]
+= Sample GCP failure domain configuration
+
+The control plane machine set concept of a failure domain is analogous to the existing GCP concept of a link:https://cloud.google.com/compute/docs/regions-zones[_zone_]. The `ControlPlaneMachineSet` CR spreads control plane machines across multiple failure domains when possible.
+
+When configuring GCP failure domains in the control plane machine set, you must specify the zone name to use.
+
+.Sample GCP failure domain values
+[source,yaml]
+----
+failureDomains:
+  gcp:
+  - zone: <gcp_zone_a> <1>
+  - zone: <gcp_zone_b> <2>
+  - zone: <gcp_zone_c>
+  - zone: <gcp_zone_d>
+  platform: GCP <3>
+----
+<1> Specifies a GCP zone for the first failure domain.
+<2> Specifies an additional failure domain. Further failure domains are added the same way.
+<3> Specifies the cloud provider platform name. Do not change this value.

--- a/modules/cpmso-yaml-provider-spec-gcp.adoc
+++ b/modules/cpmso-yaml-provider-spec-gcp.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-configuration.adoc
+
+:_content-type: REFERENCE
+[id="cpmso-yaml-provider-spec-gcp_{context}"]
+= Sample GCP provider specification
+
+When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane machine custom resource (CR) that is created by the installation program. You can omit any field that is set in the failure domain section of the CR.
+
+[discrete]
+[id="cpmso-yaml-provider-spec-gcp-oc_{context}"]
+== Values obtained by using the  OpenShift CLI
+
+In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
+
+Infrastructure ID:: The `<cluster_id>` string is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+
+Image path:: The `<path_to_image>` string is the path to the image that was used to create the disk. If you have the OpenShift CLI installed, you can obtain the path to the image by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-machine-api \
+  -o jsonpath='{.spec.template.machines_v1beta1_machine_openshift_io.spec.providerSpec.value.disks[0].image}{"\n"}' \
+  get ControlPlaneMachineSet/cluster
+----
+
+.Sample GCP `providerSpec` values
+[source,yaml]
+----
+providerSpec:
+  value:
+    apiVersion: machine.openshift.io/v1beta1
+    canIPForward: false
+    credentialsSecret:
+      name: gcp-cloud-credentials <1>
+    deletionProtection: false
+    disks:
+    - autoDelete: true
+      boot: true
+      image: <path_to_image> <2>
+      labels: null
+      sizeGb: 200
+      type: pd-ssd
+    kind: GCPMachineProviderSpec <3>
+    machineType: e2-standard-4
+    metadata:
+      creationTimestamp: null
+    metadataServiceOptions: {}
+    networkInterfaces:
+    - network: <cluster_id>-network
+      subnetwork: <cluster_id>-master-subnet
+    projectID: <project_name> <4>
+    region: <region> <5>
+    serviceAccounts:
+    - email: <cluster_id>-m@<project_name>.iam.gserviceaccount.com
+      scopes:
+      - https://www.googleapis.com/auth/cloud-platform
+    shieldedInstanceConfig: {}
+    tags:
+    - <cluster_id>-master
+    targetPools:
+    - <cluster_id>-api
+    userDataSecret:
+      name: master-user-data <6>
+    zone: "" <7>
+----
+<1> Specifies the secret name for the cluster. Do not change this value.
+<2> Specifies the path to the image that was used to create the disk.
++
+To use a GCP Marketplace image, specify the offer to use:
++
+--
+* {product-title}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`
+* {opp}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-opp-48-x86-64-202206140145`
+* {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-48-x86-64-202206140145`
+--
+<3> Specifies the cloud provider platform type. Do not change this value.
+<4> Specifies the name of the GCP project that you use for your cluster.
+<5> Specifies the GCP region for the cluster.
+<6> Specifies the control plane user data secret. Do not change this value.
+<7> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -12,14 +12,36 @@ endif::[]
 =  Sample YAML for a compute machine set custom resource on GCP
 
 This sample YAML defines a compute machine set that runs in Google Cloud Platform (GCP) and creates nodes that are labeled with
-ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
-ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
-
-In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
+ifndef::infra[`node-role.kubernetes.io/<role>: ""`,]
+ifdef::infra[`node-role.kubernetes.io/infra: ""`,]
+where
 ifndef::infra[`<role>`]
-ifdef::infra[`<infra>`]
+ifdef::infra[`infra`]
 is the node label to add.
 
+[discrete]
+[id="cpmso-yaml-provider-spec-gcp-oc_{context}"]
+== Values obtained by using the  OpenShift CLI
+
+In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
+
+Infrastructure ID:: The `<infrastructure_id>` string is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+
+Image path:: The `<path_to_image>` string is the path to the image that was used to create the disk. If you have the OpenShift CLI installed, you can obtain the path to the image by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-machine-api \
+  -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}{"\n"}' \
+  get machineset/<infrastructure_id>-worker-a
+----
+
+.Sample GCP `MachineSet` values
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
@@ -99,26 +121,14 @@ ifdef::infra[]
         effect: NoSchedule
 endif::infra[]
 ----
-<1> For `<infrastructure_id>`, specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
-+
-[source,terminal]
-----
-$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
-----
+<1> For `<infrastructure_id>`, specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster.
 ifndef::infra[]
 <2> For `<node>`, specify the node label to add.
 endif::infra[]
 ifdef::infra[]
 <2> For `<infra>`, specify the `<infra>` node label.
 endif::infra[]
-<3> Specify the path to the image that is used in current compute machine sets. If you have the OpenShift CLI installed, you can obtain the path to the image by running the following command:
-+
-[source,terminal]
-----
-$ oc -n openshift-machine-api \
-    -o jsonpath='{.spec.template.spec.providerSpec.value.disks[0].image}{"\n"}' \
-    get machineset/<infrastructure_id>-worker-a
-----
+<3> Specify the path to the image that is used in current compute machine sets.
 +
 To use a GCP Marketplace image, specify the offer to use:
 +


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPCLOUD-1774](https://issues.redhat.com//browse/OCPCLOUD-1774) | [OSDOCS-5013](https://issues.redhat.com//browse/OSDOCS-5013)

Link to docs preview:
* [Sample YAML for configuring Google Cloud Platform clusters](https://55443--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration.html#cpmso-sample-yaml-gcp_cpmso-configuration)
* [Sample YAML for a compute machine set custom resource on GCP](https://55443--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-yaml-gcp_creating-machineset-gcp)

QE review:
- [x] QE has approved this change.

Additional information:
Will squash commits after all reviews are in.