### PR TITLE
RHDEVDOCS-4788

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -762,19 +762,20 @@ Topics:
     File: administrator-cli-commands
     Distros: openshift-enterprise,openshift-origin
 - Name: Developer CLI (odo)
-  Dir: developer_cli_odo
+  File: odo-important-update
+  # Dir: developer_cli_odo
   Distros: openshift-enterprise,openshift-origin,openshift-online
-  Topics:
-  - Name: odo release notes
-    File: odo-release-notes
-  - Name: Understanding odo
-    File: understanding-odo
-  - Name: Installing odo
-    File: installing-odo
-  - Name: Configuring the odo CLI
-    File: configuring-the-odo-cli
-  - Name: odo CLI reference
-    File: odo-cli-reference
+  # Topics:
+  # - Name: odo release notes
+  #  File: odo-release-notes
+  # - Name: Understanding odo
+  #  File: understanding-odo
+  # - Name: Installing odo
+  #  File: installing-odo
+  # - Name: Configuring the odo CLI
+  #  File: configuring-the-odo-cli
+  # - Name: odo CLI reference
+  #  File: odo-cli-reference
 - Name: Knative CLI (kn) for use with OpenShift Serverless
   File: kn-cli-tools
   Distros: openshift-enterprise,openshift-origin

--- a/cli_reference/developer_cli_odo/configuring-the-odo-cli.adoc
+++ b/cli_reference/developer_cli_odo/configuring-the-odo-cli.adoc
@@ -1,3 +1,4 @@
+////
 :_content-type: ASSEMBLY
 [id='configuring-the-odo-cli']
 = Configuring the odo CLI
@@ -23,3 +24,4 @@ include::modules/developer-cli-odo-unset-config.adoc[leveloffset=+1]
 include::modules/developer-cli-odo-preference-table.adoc[leveloffset=+1]
 
 include::modules/developer-cli-odo-ignoring-files-or-patterns.adoc[leveloffset=+1]
+////

--- a/cli_reference/developer_cli_odo/installing-odo.adoc
+++ b/cli_reference/developer_cli_odo/installing-odo.adoc
@@ -1,3 +1,4 @@
+////
 :_content-type: ASSEMBLY
 [id='installing-odo']
 = Installing odo
@@ -26,3 +27,4 @@ include::modules/developer-cli-odo-installing-odo-on-macos.adoc[leveloffset=+1]
 include::modules/developer-cli-odo-installing-odo-on-vs-code.adoc[leveloffset=+1]
 
 include::modules/developer-cli-odo-installing-odo-on-linux-rpm.adoc[leveloffset=+1]
+////

--- a/cli_reference/developer_cli_odo/odo-cli-reference.adoc
+++ b/cli_reference/developer_cli_odo/odo-cli-reference.adoc
@@ -1,3 +1,4 @@
+////
 :_content-type: ASSEMBLY
 [id='odo-cli-reference']
 = odo CLI reference
@@ -17,4 +18,4 @@ include::modules/developer-cli-odo-ref-service.adoc[leveloffset=+1]
 include::modules/developer-cli-odo-ref-storage.adoc[leveloffset=+1]
 include::modules/developer-cli-odo-ref-flags.adoc[leveloffset=+1]
 include::modules/developer-cli-odo-ref-json-output.adoc[leveloffset=+1]
-
+////

--- a/cli_reference/developer_cli_odo/odo-release-notes.adoc
+++ b/cli_reference/developer_cli_odo/odo-release-notes.adoc
@@ -1,3 +1,4 @@
+////
 :_content-type: ASSEMBLY
 [id='odo-release-notes']
 = `{odo-title}` release notes
@@ -64,11 +65,10 @@ If you find an error or have suggestions for improving the documentation, file a
 
 
 
-////
-[id="odo-known-issues_{context}"]
+////[id="odo-known-issues_{context}"]
 == Known issues
-
 ////
 
 //[id="odo-technology-preview_{context}"]
 //== Technology Preview features `{odo-title}`
+////

--- a/cli_reference/developer_cli_odo/understanding-odo.adoc
+++ b/cli_reference/developer_cli_odo/understanding-odo.adoc
@@ -1,3 +1,4 @@
+////
 :_content-type: ASSEMBLY
 [id="understanding-odo"]
 = Understanding odo
@@ -15,4 +16,5 @@ Red Hat OpenShift Developer CLI (`odo`) is a tool for creating applications on {
 include::modules/odo-key-features.adoc[leveloffset=+1]
 include::modules/odo-core-concepts.adoc[leveloffset=+1]
 include::modules/odo-listing-components.adoc[leveloffset=+1]
-include::modules/odo-telemetry.adoc[leveloffset=+1]
+include::modules/odo-telemetry.adoc[leveloffset=+1]   
+////

--- a/cli_reference/odo-important-update.adoc
+++ b/cli_reference/odo-important-update.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+// 
+// * cli_reference/developer_cli_odo/odo-important-update.adoc
+
+:_content-type: CONCEPT
+[id="odo-important_update_{context}"]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+include::_attributes/common-attributes.adoc[]
+= Important update on `{odo-title}`
+:context: odo-important-update
+
+toc::[]
+
+Red Hat does not provide information about `{odo-title}` on the {OCP} documentation site. See the link:https://odo.dev/docs/introduction[documentation] maintained by Red Hat and the upstream community for documentation information related to `{odo-title}`.
+
+[IMPORTANT]
+====
+For the materials maintained by the upstream community, Red Hat provides support under link:https://access.redhat.com/solutions/5893251[Cooperative Community Support]. 
+====
+

--- a/getting_started/openshift-overview.adoc
+++ b/getting_started/openshift-overview.adoc
@@ -51,7 +51,7 @@ Use the
 xref:../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[*Topology* view]
 to see your applications, monitor status, connect and group components, and modify your code base.
 
-* ** xref:../cli_reference/developer_cli_odo/understanding-odo.adoc#understanding-odo[Use the developer CLI tool (`odo`)]**:
+* ** xref:../cli_reference/odo-important-update.adoc#odo-important_update[Use the developer CLI tool (`odo`)]**:
 The `odo` CLI tool lets developers create single or multi-component applications and automates deployment, build, and service route configurations. It abstracts complex Kubernetes and {product-title} concepts, allowing you to focus on developing your applications.
 
 * **xref:../cicd/pipelines/understanding-openshift-pipelines.adoc#op-key-features[Create CI/CD Pipelines]**: Pipelines are serverless, cloud-native, continuous integration, and continuous deployment systems that run in isolated containers.

--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -216,9 +216,9 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must allowl
 |443, 80
 |Required for your cluster token.
 
-|`registry.access.redhat.com`
-|443, 80
-|Required for `odo` CLI.
+// |`registry.access.redhat.com`
+// |443, 80
+// |Required for `odo` CLI.
 
 |`sso.redhat.com`
 |443, 80

--- a/modules/windows-containers-release-notes-limitations.adoc
+++ b/modules/windows-containers-release-notes-limitations.adoc
@@ -8,7 +8,7 @@
 Note the following limitations when working with Windows nodes managed by the WMCO (Windows nodes):
 
 * The following {product-title} features are not supported on Windows nodes:
-** Red Hat OpenShift Developer CLI (odo)
+// ** Red Hat OpenShift Developer CLI (odo)
 ** Image builds
 ** OpenShift Pipelines
 ** OpenShift Service Mesh

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -208,7 +208,7 @@ to see your applications, monitor status, connect and group components, and modi
 
 - **xref:../applications/connecting_applications_to_services/understanding-service-binding-operator.adoc#understanding-service-binding-operator[Connect your workloads to backing services]**: The Service Binding Operator enables application developers to easily bind workloads with Operator-managed backing services by automatically collecting and sharing binding data with the workloads. The Service Binding Operator improves the development lifecycle with a consistent and declarative service binding method that prevents discrepancies in cluster environments.
 
-- ** xref:../cli_reference/developer_cli_odo/understanding-odo.adoc#understanding-odo[Use the developer CLI tool (`odo`)]**:
+- ** xref:../cli_reference/odo-important-update.adoc#odo-important_update[Use the developer CLI tool (`odo`)] **: 
 The `odo` CLI tool lets developers create single or multi-component applications easily and automates deployment, build, and service route configurations. It abstracts complex Kubernetes and {product-title} concepts, allowing you to focus on developing your applications.
 
 - **xref:../cicd/pipelines/understanding-openshift-pipelines.adoc#op-key-features[Create CI/CD Pipelines]**: Pipelines are serverless, cloud-native, continuous integration and continuous deployment systems that run in isolated containers.

--- a/welcome/learn_more_about_openshift.adoc
+++ b/welcome/learn_more_about_openshift.adoc
@@ -122,7 +122,7 @@ Use the following sections to find content to help you learn about and use {prod
 | xref:../openshift_images/index.adoc#overview-of-images[Images]
 
 |
-| xref:../cli_reference/developer_cli_odo/understanding-odo.adoc#understanding-odo[Developer-focused CLI]
+| xref:../cli_reference/odo-important-update.adoc#odo-important_update[Developer-focused CLI]
 
 |
 |===


### PR DESCRIPTION
[RHDEVDOCS-4788](https://issues.redhat.com//browse/RHDEVDOCS-4788): Unpublish odo docs; link to upstream

Aligned team: Dev Tools
OCP version for cherry-picking: From enterprise-4.10 and later.
JIRA issues: [RHDEVDOCS-4788](https://issues.redhat.com//browse/RHDEVDOCS-4788)
Preview pages: [Click to see the build preview in your browser](https://55456--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/odo-important-update.html)
SME Review: @valaparthvi 
QE review: @anandrkskd 
CS review: @rkratky 
DPM review: @pmkovar 
PM review: @mohitsuman
Product experience review: @RickJWagner 
Peer-review: @deerskindoll 