### PR TITLE
[enterprise-4.9] BZ1990455: Added importing of image stream tags

### DIFF
--- a/modules/images-cluster-sample-imagestream-import.adoc
+++ b/modules/images-cluster-sample-imagestream-import.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+// * openshift_images/cluster-tasks.adoc
+
+:_content-type: PROCEDURE
+[id="images-cluster-sample-imagestream-import_{context}"]
+= Configuring periodic importing of Cluster Sample Operator image stream tags
+
+You can ensure that you always have access to the latest versions of the Cluster Sample Operator images by periodically importing the image stream tags when new versions become available.
+
+.Procedure
+
+. Fetch all the imagestreams in the `openshift` namespace by running the following command:
++
+[source,terminal]
+----
+oc get imagestreams -nopenshift
+----
+
+. Fetch the tags for every imagestream in the `openshift` namespace by running the following command:
++
+[source, terminal]
+----
+$ oc get is <image-stream-name> -o jsonpath="{range .spec.tags[*]}{.name}{'\t'}{.from.name}{'\n'}{end}" -nopenshift
+----
++
+For example:
++
+[source, terminal]
+----
+$ oc get is ubi8-openjdk-17 -o jsonpath="{range .spec.tags[*]}{.name}{'\t'}{.from.name}{'\n'}{end}" -nopenshift
+----
++
+.Example output
+[source, terminal]
+----
+1.11	registry.access.redhat.com/ubi8/openjdk-17:1.11
+1.12	registry.access.redhat.com/ubi8/openjdk-17:1.12
+----
+
+. Schedule periodic importing of images for each tag present in the image stream by running the following command:
++
+[source,terminal]
+----
+$ oc tag <repository/image> <image-stream-name:tag> --scheduled -nopenshift
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc tag registry.access.redhat.com/ubi8/openjdk-17:1.11 ubi8-openjdk-17:1.11 --scheduled -nopenshift
+$ oc tag registry.access.redhat.com/ubi8/openjdk-17:1.12 ubi8-openjdk-17:1.12 --scheduled -nopenshift
+----
++
+This command causes {product-title} to periodically update this particular image stream tag. This period is a cluster-wide setting set to 15 minutes by default.
+
+. Verify the scheduling status of the periodic import by running the following command:
++
+[source,terminal]
+----
+oc get imagestream <image-stream-name> -o jsonpath="{range .spec.tags[*]}Tag: {.name}{'\t'}Scheduled: {.importPolicy.scheduled}{'\n'}{end}" -nopenshift
+----
++
+For example:
++
+[source,terminal]
+----
+oc get imagestream ubi8-openjdk-17 -o jsonpath="{range .spec.tags[*]}Tag: {.name}{'\t'}Scheduled: {.importPolicy.scheduled}{'\n'}{end}" -nopenshift
+----
++
+.Example output
+[source,terminal]
+----
+Tag: 1.11	Scheduled: true
+Tag: 1.12	Scheduled: true
+----

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -667,3 +667,5 @@ include::modules/installation-images-samples-disconnected-mirroring-assist.adoc[
 include::modules/installation-restricted-network-samples.adoc[leveloffset=+2]
 
 include::modules/installation-preparing-restricted-cluster-to-gather-support-data.adoc[leveloffset=+2]
+
+include::modules/images-cluster-sample-imagestream-import.adoc[leveloffset=+1]


### PR DESCRIPTION
Original PR: #55039 

Version(s): 4.9

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=1990455