### PR TITLE
RHDEVDOCS-4940-firstPR: Covers CVE update for GitOps 1.7.1, 1.6.4, and 1.5.9

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,13 +23,19 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-7-1.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-7-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-6-4.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-6-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-6-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-6-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-5-9.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-5-7.adoc[leveloffset=+1]
 
@@ -69,13 +75,13 @@ include::modules/gitops-release-notes-1-3-7.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-6.adoc[leveloffset=+1]
 
-include::modules/gitops-release-notes-1-3-3.adoc[leveloffset=+1]
-
 include::modules/gitops-release-notes-1-3-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-2-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-2-1.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-2-2.adoc
+++ b/modules/gitops-release-notes-1-2-2.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-2-2_{context}"]
+= Release notes for {gitops-title} 1.2.2
+
+{gitops-title} 1.2.2 is now available on {product-title} 4.8.
+
+[id="fixed-issues-1-2-2_{context}"]
+== Fixed issues
+The following issue was resolved in the current release:
+
+* All versions of Argo CD are vulnerable to a path traversal bug that allows to pass arbitrary values to be consumed by Helm charts. This update fixes the CVE-2022-24348 gitops error, path traversal and dereference of symlinks when passing Helm value files.
+link:https://issues.redhat.com/browse/GITOPS-1756[GITOPS-1756]

--- a/modules/gitops-release-notes-1-4-12.adoc
+++ b/modules/gitops-release-notes-1-4-12.adoc
@@ -47,7 +47,7 @@ spec:
       enabled: true
 ----
 
-* Before this update, a terminating namespace that was managed by Argo CD would block the creation of roles and other configuration of other managed namespaces. This update fixes this issue. link:https://issues.redhat.com/browse/GITOPS-2277[GITOPS-2277]
+* Before this update, a terminating namespace that was managed by Argo CD would block the creation of roles and other configuration of other managed namespaces. This update fixes this issue. link:https://issues.redhat.com/browse/GITOPS-2276[GITOPS-2276]
 
 * Before this update, the Dex pods failed to start with `CreateContainerConfigError` when an SCC of `anyuid` was assigned to the Dex `ServiceAccount` resource. This update fixes this issue by assigning a default user id to the Dex container. link:https://issues.redhat.com/browse/GITOPS-2235[GITOPS-2235]  
 

--- a/modules/gitops-release-notes-1-4-2.adoc
+++ b/modules/gitops-release-notes-1-4-2.adoc
@@ -13,6 +13,4 @@
 
 The following issue has been resolved in the current release:
 
-* All versions of Argo CD are vulnerable to a path traversal bug that allows to pass arbitrary values to be consumed by Helm charts. This update fixes the `CVE-2022-24348 gitops` error, path traversal and dereference of symlinks when passing Helm value files. link:https://issues.redhat.com/browse/GITOPS-1756[GITOPS-1756]
-
 * Before this update, the *Route* resources got stuck in `Progressing` Health status if more than one `Ingress` were attached to the route.  This update fixes the health check and reports the correct health status of the *Route* resources. link:https://issues.redhat.com/browse/GITOPS-1751[GITOPS-1751]

--- a/modules/gitops-release-notes-1-5-6.adoc
+++ b/modules/gitops-release-notes-1-5-6.adoc
@@ -47,7 +47,7 @@ spec:
       enabled: true
 ----
 
-* Before this update, a terminating namespace that was managed by Argo CD would block the creation of roles and other configuration of other managed namespaces. This update fixes this issue. link:https://issues.redhat.com/browse/GITOPS-2277[GITOPS-2277]
+* Before this update, a terminating namespace that was managed by Argo CD would block the creation of roles and other configuration of other managed namespaces. This update fixes this issue. link:https://issues.redhat.com/browse/GITOPS-2278[GITOPS-2278]
 
 * Before this update, the Dex pods failed to start with `CreateContainerConfigError` when an SCC of `anyuid` was assigned to the Dex `ServiceAccount` resource. This update fixes this issue by assigning a default user id to the Dex container. link:https://issues.redhat.com/browse/GITOPS-2235[GITOPS-2235]  
 

--- a/modules/gitops-release-notes-1-5-9.adoc
+++ b/modules/gitops-release-notes-1-5-9.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-5-9_{context}"]
+= Release notes for {gitops-title} 1.5.9
+
+{gitops-title} 1.5.9 is now available on {product-title} 4.8, 4.9, 4.10, 4.11, and 4.12.
+
+[id="fixed-issues-1-5-9_{context}"]
+== Fixed issues
+
+* Before this update, all versions of Argo CD v1.8.2 and later were vulnerable to an improper authorization bug. As a result, Argo CD would accept tokens for users who might not be authorized to access the cluster. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2160492[CVE-2023-22482]

--- a/modules/gitops-release-notes-1-6-2.adoc
+++ b/modules/gitops-release-notes-1-6-2.adoc
@@ -9,6 +9,11 @@
 
 {gitops-title} 1.6.2 is now available on {product-title} 4.8, 4.9, 4.10 and 4.11.
 
+[id="new-features-1-6-2_{context}"]
+== New features
+
+* This release removes the `DISABLE_DEX` environment variable from the `openshift-gitops-operator` CSV file. As a result, this environment variable is no longer set when you perform a fresh installation of {gitops-title}. link:https://issues.redhat.com/browse/GITOPS-2360[GITOPS-2360]
+
 [id="fixed-issues-1-6-2_{context}"]
 == Fixed issues
 

--- a/modules/gitops-release-notes-1-6-4.adoc
+++ b/modules/gitops-release-notes-1-6-4.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-6-4_{context}"]
+= Release notes for {gitops-title} 1.6.4
+
+{gitops-title} 1.6.4 is now available on {product-title} 4.8, 4.9, 4.10, 4.11, and 4.12.
+
+[id="fixed-issues-1-6-4_{context}"]
+== Fixed issues
+
+* Before this update, all versions of Argo CD v1.8.2 and later were vulnerable to an improper authorization bug. As a result, Argo CD would accept tokens for audiences who might not be intended to access the cluster. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2160492[CVE-2023-22482]

--- a/modules/gitops-release-notes-1-7-0.adoc
+++ b/modules/gitops-release-notes-1-7-0.adoc
@@ -45,6 +45,12 @@ In future releases, there is a possibility to deprecate the old method of custom
 :FeatureName: Argo CD Applications controller
 include::snippets/technology-preview.adoc[]
 
+* With this update, Argo CD supports the Server-Side Apply feature, which helps users to perform the following tasks:
+** Manage large resources which are too big for the allowed annotation size of 262144 bytes.
+** Patch an existing resource that is not managed or deployed by Argo CD.
++
+You can configure this feature at application or resource level. link:https://issues.redhat.com/browse/GITOPS-2340[GITOPS-2340]
+
 [id="fixed-issues-1-7-0_{context}"]
 == Fixed issues
 

--- a/modules/gitops-release-notes-1-7-1.adoc
+++ b/modules/gitops-release-notes-1-7-1.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-7-1_{context}"]
+= Release notes for {gitops-title} 1.7.1
+
+{gitops-title} 1.7.1 is now available on {product-title} 4.8, 4.9, 4.10, 4.11, and 4.12.
+
+[id="errata-updates-1-7-1_{context}"]
+== Errata updates
+
+=== RHSA-2023:0467 - {gitops-title} 1.7.1 security update advisory 
+
+Issued: 2023-01-25
+
+The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2023:0467[RHSA-2023:0467] advisory. 
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----


### PR DESCRIPTION
**NOTE**: From GitOps 1.7.0 onwards, we will be documenting security issues in a new advisory format as part of errata updates. 

**Aligned team**: Dev Tools

**Purpose**: To resolve the following issues: 
https://issues.redhat.com/browse/RHDEVDOCS-4907
https://issues.redhat.com/browse/RHDEVDOCS-4940

**OCP version this PR applies to**:  enterprise 4.9 and later

**Link to docs preview**:  https://55464--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-7-1_gitops-release-notes

**Change Management**
Need an ACK from Eng: @iam-veeramalla 
Need an ACK from PM: @harrietgrace @wtam2018 
Need an ACK from Product experience: @RickJWagner 
Need an ACK from QE: @varshab1210 
Need an ACK from DPM: @pmkovar 
Need an ACK from CS: @Preeticp 

Peer review: @gabriel-rh 
