### PR TITLE
MIG-1300: fix error in MTC workflow sample use case

### DIFF
--- a/modules/migration-mtc-workflow.adoc
+++ b/modules/migration-mtc-workflow.adoc
@@ -15,7 +15,7 @@ You can migrate Kubernetes resources, persistent volume data, and internal conta
 * A namespace specified in a migration plan.
 * Namespace-scoped resources: When the {mtc-short} migrates a namespace, it migrates all the objects and resources associated with that namespace, such as services or pods. Additionally, if a resource that exists in the namespace but not at the cluster level depends on a resource that exists at the cluster level, the {mtc-short} migrates both resources.
 +
-For example, a security context constraint (SCC) is a resource that exists at the cluster level and a service account (SA) is a resource that exists at the namespace level. If an SA exists in a namespace that the {mtc-short} migrates, the {mtc-short} automatically locates any SCCs that are linked to the SA and also migrates those SCCs. Similarly, the {mtc-short} migrates persistent volume claims that are linked to the persistent volumes of the namespace.
+For example, a security context constraint (SCC) is a resource that exists at the cluster level and a service account (SA) is a resource that exists at the namespace level. If an SA exists in a namespace that the {mtc-short} migrates, the {mtc-short} automatically locates any SCCs that are linked to the SA and also migrates those SCCs. Similarly, the {mtc-short} migrates persistent volumes that are linked to the persistent volume claims of the namespace.
 +
 [NOTE]
 ====


### PR DESCRIPTION
MTC 1.7.7 , OCP 4.9+

Resolves https://issues.redhat.com/browse/MIG-1300 by correcting the text in a sample user case.

Preview: https://55466--docspreview.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/about-mtc.html#migration-mtc-workflow_about-mtc  Paragraph beginning "For example..."
