### PR TITLE
[enterprise-4.11] OCPBUGS-6886-12: Fix typo in Ironic provisioning service update release note

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1423,6 +1423,8 @@ As a result to these workarounds, virtual media based provisioning will succeed 
 
 * Previously, Ironic failed to match `wwn` serial numbers to multi-path devices. Consequently, `wwn` serial numbers for device mapper devices could not be used in the `rootDeviceHint` parameter in the `install-config.yaml` configuration file. With this update, Ironic now recognizes `wwn` serial numbers as unique identifiers for multi-path devices. As a result, it is now possible to use `wwn` serial numbers for device mapper devices for the `install-config.yaml` file. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2098392[*BZ#2098392*])
 
+* Before this update, when a Redfish system features a Settings URI, the Ironic provisioning service always attempts to use this URI to make changes to boot-related BIOS settings. However, bare-metal provisioning fails if the Baseboard Management Controller (BMC) features a Settings URI but does not support changing a particular BIOS setting by using this Settings URI. In {product-title} {product-version} and later, if a system features a Settings URI, Ironic verifies that it can change a particular BIOS setting by using the Settings URI before proceeding. Otherwise, Ironic implements the change by using the System URI. This additional logic ensures that Ironic can apply boot-related BIOS setting changes and bare-metal provisioning can succeed. (link:https://issues.redhat.com/browse/OCPBUGS-2052[*OCPBUGS-2052*])
+
 [discrete]
 [id="ocp-4-11-builds-bug-fixes"]
 ==== Builds


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/55458

Preview: [Last bullet in Bare-metal hardware provisioning bug fix section](https://55473--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-bug-fixes)