### PR TITLE
[OCPBUGS-4561]: Small update to revised instance type proc

### DIFF
--- a/modules/aws-console-changing-aws-instance-type.adoc
+++ b/modules/aws-console-changing-aws-instance-type.adoc
@@ -11,6 +11,7 @@ You can change the Amazon Web Services (AWS) instance type that your control pla
 .Prerequisites
 
 * You have access to the AWS console with the permissions required to modify the EC2 Instance for your cluster.
+* You have access to the {product-title} cluster as a user with the `cluster-admin` role.
 
 .Procedure
 
@@ -27,5 +28,7 @@ You can change the Amazon Web Services (AWS) instance type that your control pla
 .. Change the instance to a larger type, ensuring that the type is the same base as the previous selection, and apply changes. For example, you can change `m6i.xlarge` to `m6i.2xlarge` or `m6i.4xlarge`.
 
 .. Start the instance.
+
+.. If your {product-title} cluster has a corresponding `Machine` object for the instance, update the instance type of the object to match the instance type set in the AWS console.
 
 . Repeat this process for each control plane machine.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OCPBUGS-4561](https://issues.redhat.com/browse/OCPBUGS-4561)

Link to docs preview:
[Changing the Amazon Web Services instance type by using the AWS console](https://55485--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#aws-console-changing-aws-instance-type_recommended-host-practices)

QE review:
- [ ] QE has approved this change.

Additional information:
Based on [feedback](https://github.com/openshift/openshift-docs/pull/55123#pullrequestreview-1281149153) for #55123, which adds this proc for OCP 4.8-4.11