### PR TITLE
OSDOCS-4824_PT2: Additional AWS Quota Updates

### DIFF
--- a/modules/rosa-required-aws-service-quotas.adoc
+++ b/modules/rosa-required-aws-service-quotas.adoc
@@ -1,7 +1,7 @@
 
 // Module included in the following assemblies:
 //
-// getting_started_rosa/rosa-required-aws-service-quotas.adoc
+// rosa_planning/rosa-required-aws-service-quotas.adoc
 
 
 [id="rosa-required-aws-service-quotas_{context}"]
@@ -16,16 +16,17 @@ The AWS SDK allows ROSA to check quotas, but the AWS SDK calculation does not in
 
 If you need to modify or increase a specific quota, see Amazon's documentation on link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[requesting a quota increase].
 
+[IMPORTANT]
+====
+For On-Demand Standard (A, C, D, H, I, M, R, T, Z) Amazon EC2 instances, creating a ROSA cluster requires 100 vCPUs or greater. To request for your quota to be increased, open the Service Quotas console within the AWS console.
+====
+
+
+.ROSA-required service quota
+
 [options="header"]
 |===
-|Quota name |Service code |Quota code| Default | Recommended value | Description
-
-|EC2-VPC Elastic IPs
-|ec2
-|L-0263D0A3
-|5
-|5
-| The maximum number of Elastic IP addresses that you can allocate for EC2-VPC in this Region.
+|Quota name |Service code |Quota code| Default | Minimum required | Description
 
 |Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances
 |ec2
@@ -35,6 +36,46 @@ If you need to modify or increase a specific quota, see Amazon's documentation o
 | Maximum number of vCPUs assigned to the Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances.
 
 The default value of 5 vCPUs is not sufficient to create ROSA clusters. ROSA has a minimum requirement of 100 vCPUs for cluster creation.
+
+|Storage for General Purpose SSD (gp2) volume storage in TiB
+|ebs
+|L-D18FCD1D
+|50
+|300
+| The maximum aggregated amount of storage, in TiB, that can be provisioned across General Purpose SSD (gp2) volumes in this Region.
+
+|Storage for General Purpose SSD (gp3) volume storage in TiB
+|ebs
+|L-7A658B76
+|50
+|300
+| The maximum aggregated amount of storage, in TiB, that can be provisioned across General Purpose SSD (gp3) volumes in this Region.
+
+300 TiB of storage is the required minimum for optimal performance.
+
+|Storage for Provisioned IOPS SSD (io1) volumes in TiB
+|ebs
+|L-FD252861
+|50
+|300
+| The maximum aggregated amount of storage, in TiB, that can be provisioned across Provisioned IOPS SSD (io1) volumes in this Region.
+
+300 TiB of storage is the required minimum for optimal performance.
+
+|===
+
+.General AWS service quotas
+
+[options="header"]
+|===
+|Quota name |Service code |Quota code| Default | Minimum required | Description
+
+|EC2-VPC Elastic IPs
+|ec2
+|L-0263D0A3
+|5
+|5
+| The maximum number of Elastic IP addresses that you can allocate for EC2-VPC in this Region.
 
 |VPCs per Region
 |vpc
@@ -57,15 +98,6 @@ The default value of 5 vCPUs is not sufficient to create ROSA clusters. ROSA has
 |5,000
 | The maximum number of network interfaces per Region.
 
-|Storage for General Purpose SSD (gp3) volume storage in TiB
-|ebs
-|L-7A658B76
-|50
-|300
-| The maximum aggregated amount of storage, in TiB, that can be provisioned across General Purpose SSD (gp2) volumes in this Region.
-
-300 TiB of storage is the required minimum for optimal performance.
-
 |Snapshots per Region
 |ebs
 |L-309BACF6
@@ -79,15 +111,6 @@ The default value of 5 vCPUs is not sufficient to create ROSA clusters. ROSA has
 |300,000
 |300,000
 | The maximum aggregated number of IOPS that can be provisioned across Provisioned IOPS SDD (io1) volumes in this Region.
-
-|Storage for Provisioned IOPS SSD (io1) volumes in TiB
-|ebs
-|L-FD252861
-|50
-|300
-| The maximum aggregated amount of storage, in TiB, that can be provisioned across Provisioned IOPS SSD (io1) volumes in this Region.
-
-300 TiB of storage is the required minimum for optimal performance.
 
 |Application Load Balancers per Region
 |elasticloadbalancing
@@ -103,3 +126,7 @@ The default value of 5 vCPUs is not sufficient to create ROSA clusters. ROSA has
 |20
 |
 |===
+
+[role="_additional-resources"]
+== Additional resources
+* See link:https://docs.aws.amazon.com/ROSA/latest/userguide/service-quotas-rosa.html[ROSA service quotas]


### PR DESCRIPTION
Version(s):
Enterprise-4.12+ 

Issue:
[OSDOCS-4824](https://issues.redhat.com/browse/OSDOCS-4824)

Link to docs preview:

- [ROSA Quota](https://55495--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-required-aws-service-quotas.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR captures some additional changes in the AWS quota section.