### PR TITLE
RHDEVDOCS-4892-add-deprecated-alertmanager-key-names

### DIFF
--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -35,15 +35,15 @@ route:
   repeat_interval: 12h
   receiver: default
   routes:
-  - match:
-      alertname: Watchdog
+  - matchers:
+    - "alertname=Watchdog"
     repeat_interval: 5m
     receiver: watchdog
-  - match:
-      service: <your_service> <1>
+  - matchers:
+    - "service=<your_service>" <1>
     routes:
-    - match:
-        <your_matching_rules> <2>
+    - matchers:
+      - <your_matching_rules> <2>
       receiver: <receiver> <3>
 receivers:
 - name: default
@@ -54,6 +54,15 @@ receivers:
 <1> `service` specifies the service that fires the alerts.
 <2> `<your_matching_rules>` specifies the target alerts.
 <3> `receiver` specifies the receiver to use for the alert.
++
+[NOTE]
+====
+Use the `matchers` key name to indicate the matchers that an alert has to fulfill to match the node.
+Do not use the `match` or `match_re` key names, which are both deprecated and planned for removal in a future release.
+
+In addition, if you define inhibition rules, use the `target_matchers` key name to indicate the target matchers and the `source_matchers` key name to indicate the source matchers.
+Do not use the `target_match`, `target_match_re`, `source_match`, or `source_match_re` key names, which are deprecated and planned for removal in a future release.
+====
 +
 The following Alertmanager configuration example configures PagerDuty as an alert receiver:
 +
@@ -67,15 +76,15 @@ route:
   repeat_interval: 12h
   receiver: default
   routes:
-  - match:
-      alertname: Watchdog
+  - matchers:
+    - "alertname=Watchdog"
     repeat_interval: 5m
     receiver: watchdog
-  *- match:
-      service: example-app
+  *- matchers:
+    - "service=example-app"
     routes:
-    - match:
-        severity: critical
+    - matchers:
+      - "severity=critical"
       receiver: team-frontend-page*
 receivers:
 - name: default


### PR DESCRIPTION
Summary: This PR updates the custom Alertmanager config topic to add information about deprecated key names.

- Aligned team: DevTools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4892
- Direct link to doc preview: https://55499--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts.html#applying-custom-alertmanager-configuration_managing-alerts
- SME review: @simonpasquier 
- QE review: @juzhao 
- Peer review: @ tbd