### PR TITLE
OSDOCS#4348: Installing an IBM Cloud VPC cluster in restricted env

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -297,6 +297,8 @@ Topics:
     File: installing-ibm-cloud-vpc
   - Name: Installing a private cluster on IBM Cloud
     File: installing-ibm-cloud-private
+  - Name: Installing a cluster on IBM Cloud in a restricted network
+    File: installing-ibm-cloud-restricted
   - Name: Installation configuration parameters for IBM Cloud
     File: installation-config-parameters-ibm-cloud-vpc
   - Name: Uninstalling a cluster on IBM Cloud

--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -77,7 +77,7 @@ If you use a user-provisioned installation method, you can configure a proxy for
 
 If you want to prevent your cluster on a public cloud from exposing endpoints externally, you can deploy a private cluster with installer-provisioned infrastructure on xref:../installing/installing_aws/installing-aws-private.adoc#installing-aws-private[AWS], xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[Azure], or xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[GCP].
 
-If you need to install your cluster that has limited access to the internet, such as a disconnected or restricted network cluster, you can xref:../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[mirror the installation packages] and install the cluster from them. Follow detailed instructions for user provisioned infrastructure installations into restricted networks for xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[AWS], xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[GCP], xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[{ibm-z-name} or {ibm-linuxone-name}], xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[{ibm-z-name} or {ibm-linuxone-name} with {op-system-base} KVM], xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[{ibm-power-name}], xref:../installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[vSphere], or xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[bare metal]. You can also install a cluster into a restricted network using installer-provisioned infrastructure by following detailed instructions for xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[AWS], xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[GCP], xref:../installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc#installing-restricted-networks-nutanix-installer-provisioned[Nutanix], xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[{rh-openstack}], and xref:../installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[vSphere].
+If you need to install your cluster that has limited access to the internet, such as a disconnected or restricted network cluster, you can xref:../installing/disconnected_install/installing-mirroring-installation-images.adoc#installing-mirroring-installation-images[mirror the installation packages] and install the cluster from them. Follow detailed instructions for user provisioned infrastructure installations into restricted networks for xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[AWS], xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[GCP], xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[{ibm-z-name} or {ibm-linuxone-name}], xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc#installing-restricted-networks-ibm-z-kvm[{ibm-z-name} or {ibm-linuxone-name} with {op-system-base} KVM], xref:../installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc#installing-restricted-networks-ibm-power[{ibm-power-name}], xref:../installing/installing_vsphere/upi/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[vSphere], or xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[bare metal]. You can also install a cluster into a restricted network using installer-provisioned infrastructure by following detailed instructions for xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[AWS], xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[GCP], xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc#installing-ibm-cloud-restricted[{ibm-cloud-name}], xref:../installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc#installing-restricted-networks-nutanix-installer-provisioned[Nutanix], xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[{rh-openstack}], and xref:../installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[vSphere].
 
 
 If you need to deploy your cluster to an xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[AWS GovCloud region], xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[AWS China region], or xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[Azure government region], you can configure those custom regions during an installer-provisioned infrastructure installation.
@@ -205,7 +205,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-installation-workflow[&#10003;]
 |xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-installation-workflow[&#10003;]
 |xref:../installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[&#10003;]
-|
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc#installing-ibm-cloud-restricted[&#10003;]
 |
 |
 |xref:../installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc#installing-restricted-networks-ibm-power-vs[&#10003;]
@@ -310,7 +310,7 @@ endif::openshift-origin[]
 //This table is for OKD only. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifdef::openshift-origin[]
 |===
-||Alibaba |AWS |Azure |Azure Stack Hub |GCP |Nutanix |{rh-openstack} |Bare metal |vSphere |VMC |{ibm-cloud-name} |{ibm-z-name} |{ibm-power-name}
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |Nutanix |{rh-openstack} |Bare metal |vSphere |{ibm-cloud-name} |{ibm-z-name} |{ibm-power-name}
 
 
 |Default
@@ -365,7 +365,7 @@ ifdef::openshift-origin[]
 |xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[&#10003;]
 |
 |xref:../installing/installing_vsphere/ipi/installing-restricted-networks-installer-provisioned-vsphere.adoc#installing-restricted-networks-installer-provisioned-vsphere[&#10003;]
-|
+|xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc#installing-ibm-cloud-restricted[&#10003;]
 |
 |
 
@@ -375,7 +375,6 @@ ifdef::openshift-origin[]
 |xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[&#10003;]
 |
 |xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[&#10003;]
-|
 |
 |
 |
@@ -394,7 +393,6 @@ ifdef::openshift-origin[]
 |
 |
 |
-|
 |xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc#installing-ibm-cloud-vpc[&#10003;]
 |
 |
@@ -403,7 +401,6 @@ ifdef::openshift-origin[]
 |
 |xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[&#10003;]
 |xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
-|
 |
 |
 |
@@ -427,12 +424,10 @@ ifdef::openshift-origin[]
 |
 |
 |
-|
 
 |China regions
 |
 |xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[&#10003;]
-|
 |
 |
 |
@@ -540,7 +535,7 @@ endif::openshift-origin[]
 //This table is for OKD only. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifdef::openshift-origin[]
 |===
-||Alibaba |AWS |Azure |Azure Stack Hub |GCP |Nutanix |{rh-openstack}|Bare metal |vSphere |VMC |{ibm-cloud-name} |{ibm-z-name} |{ibm-z-name} with {op-system-base} KVM |{ibm-power-name} |Platform agnostic
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |Nutanix |{rh-openstack}|Bare metal |vSphere |{ibm-cloud-name} |{ibm-z-name} |{ibm-z-name} with {op-system-base} KVM |{ibm-power-name} |Platform agnostic
 
 
 |Custom
@@ -598,7 +593,6 @@ ifdef::openshift-origin[]
 |
 |
 |xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[&#10003;]
-|
 |
 |
 |

--- a/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
+++ b/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
@@ -1,0 +1,84 @@
+:_content-type: ASSEMBLY
+[id="installing-ibm-cloud-restricted"]
+= Installing a cluster on IBM Cloud in a restricted network
+include::_attributes/common-attributes.adoc[]
+:context: installing-ibm-cloud-restricted
+
+toc::[]
+
+In {product-title} {product-version}, you can install a cluster in a restricted network by creating an internal mirror of the installation release content that is accessible to an existing Virtual Private Cloud (VPC) on {ibm-cloud-name}.
+
+[id="prerequisites_installing-ibm-cloud-restricted"]
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[configured an IBM Cloud account] to host the cluster.
+* You have a container image registry that is accessible to the internet and your restricted network. The container image registry should mirror the contents of the {product-registry} and contain the installation media. For more information, see xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+* You have an existing VPC on {ibm-cloud-name} that meets the following requirements:
+** The VPC contains the mirror registry or has firewall rules or a peering connection to access the mirror registry that is hosted elsewhere.
+** The VPC can access {ibm-cloud-name} service endpoints using a public endpoint. If network restrictions limit access to public service endpoints, evaluate those services for alternate endpoints that might be available. For more information see xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc#access-to-ibm-service-endpoints_installing-ibm-cloud-restricted[Access to IBM service endpoints].
+
++
+You cannot use the VPC that the installation program provisions by default.
+* If you plan on configuring endpoint gateways to use {ibm-cloud-name} Virtual Private Endpoints, consider the following requirements:
+** Endpoint gateway support is currently limited to the `us-east` and `us-south` regions.
+** The VPC must allow traffic to and from the endpoint gateways. You can use the VPC’s default security group, or a new security group, to allow traffic on port 443. For more information, see xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc#installation-ibm-cloud-configure-vpc-for-endpoint-gateways_installing-ibm-cloud-restricted[Allowing endpoint gateway traffic].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* You configured the `ccoctl` utility before you installed the cluster. For more information, see xref:../../installing/installing_ibm_cloud_public/configuring-iam-ibm-cloud.adoc#configuring-iam-ibm-cloud[Configuring IAM for IBM Cloud VPC].
+
+include::modules/installation-about-restricted-network.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin]
+* xref:../../installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vpc.adoc#installation-configuration-parameters-additional-ibm-cloud_installation-config-parameters-ibm-cloud-vpc[Additional IBM Cloud configuration parameters]
+
+include::modules/installation-custom-ibm-cloud-vpc.adoc[leveloffset=+1]
+include::modules/installation-ibm-cloud-configure-vpc-for-endpoint-gateways.adoc[leveloffset=+2]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-ibm-cloud-export-variables.adoc[leveloffset=+1]
+
+include::modules/installation-ibm-cloud-download-rhcos.adoc[leveloffset=+1]
+
+include::modules/installation-initializing-manual.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vpc.adoc#installation-config-parameters-ibm-cloud-vpc[Installation configuration parameters for {ibm-cloud-name}]
+
+include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-ibm-cloud-config-yaml.adoc[leveloffset=+2]
+include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/manually-create-iam-ibm-cloud.adoc[leveloffset=+1]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_installing-ibm-cloud-restricted-console"]
+.Additional resources
+* xref:../../web_console/web-console.adoc#web-console[Accessing the web console]
+
+== Post installation
+Complete the following steps to complete the configuration of your cluster.
+
+include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+2]
+include::modules/oc-mirror-updating-restricted-cluster-manifests.adoc[leveloffset=+2]
+
+include::modules/cluster-telemetry.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_installing-ibm-cloud-restricted-telemetry"]
+.Additional resources
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+
+[id="next-steps_installing-ibm-cloud-restricted"]
+== Next steps
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
+* Optional: xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[Opt out of remote health reporting].

--- a/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
+++ b/installing/installing_ibm_cloud_public/preparing-to-install-on-ibm-cloud.adoc
@@ -42,6 +42,8 @@ You can install a cluster on {ibm-cloud-name} infrastructure that is provisioned
 
 * **xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc#installing-ibm-cloud-private[Installing a private cluster on an existing VPC]**: You can install a private cluster on an existing Virtual Private Cloud (VPC). You can use this method to deploy {product-title} on an internal network that is not visible to the internet.
 
+* **xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc#installing-ibm-cloud-restricted[Installing a cluster on IBM Cloud VPC in a restricted network]**: You can install {product-title} on IBM Cloud VPC on installer-provisioned infrastructure by using an internal mirror of the installation release content. You can use this method to install a cluster that does not require an active internet connection to obtain the software components.
+
 [id="next-steps_preparing-to-install-on-ibm-cloud"]
 == Next steps
 * xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-account.adoc#installing-ibm-cloud-account[Configuring an {ibm-cloud-name} account]

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -33,6 +33,7 @@
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/install_config/installing-restricted-networks-preparations.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * openshift_images/samples-operator-alt-registry.adoc

--- a/modules/cli-logging-in-kubeadmin.adoc
+++ b/modules/cli-logging-in-kubeadmin.adoc
@@ -37,6 +37,7 @@
 // * installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
 // * installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
 // * installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc
 // * installing/installing_aws/installing-restricted-networks-aws.adoc

--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -17,6 +17,7 @@
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
 // * installing/installing_ibm_z/installing-ibm-z-kvm.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -107,6 +108,9 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
 :restricted:
 endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:restricted:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="cluster-entitlements_{context}"]
@@ -176,5 +180,8 @@ ifeval::["{context}" == "installing-restricted-networks-gcp"]
 :!restricted:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
+:!restricted:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
 :!restricted:
 endif::[]

--- a/modules/cluster-telemetry.adoc
+++ b/modules/cluster-telemetry.adoc
@@ -56,6 +56,7 @@
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/installing_ibm_power/installing-ibm-power.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc

--- a/modules/installation-about-restricted-network.adoc
+++ b/modules/installation-about-restricted-network.adoc
@@ -12,12 +12,17 @@
 // * installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
 // * installing/installing-restricted-networks-nutanix-installer-provisioned.adoc
 // * installing/installing-restricted-networks-azure-installer-provisioned.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 
 ifeval::["{context}" == "installing-ibm-power"]
 :ibm-power:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:ibm-cloud:
+:ipi:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power-vs"]
 :ipi:
@@ -48,20 +53,22 @@ endif::[]
 In {product-title} {product-version}, you can perform an installation that does not
 require an active connection to the internet to obtain software components. Restricted network installations can be completed using installer-provisioned infrastructure or user-provisioned infrastructure, depending on the cloud platform to which you are installing the cluster.
 
-ifndef::ibm-power[]
+ifndef::ibm-power,ibm-cloud[]
 If you choose to perform a restricted network installation on a cloud platform, you
 still require access to its cloud APIs. Some cloud functions, like
 Amazon Web Service's Route 53 DNS and IAM services, require internet access.
 //behind a proxy
 Depending on your network, you might require less internet
 access for an installation on bare metal hardware, Nutanix, or on VMware vSphere.
-endif::ibm-power[]
+endif::ibm-power,ibm-cloud[]
 
+ifndef::ibm-cloud[]
 To complete a restricted network installation, you must create a registry that
 mirrors the contents of the {product-registry} and contains the
 installation media. You can create this registry on a mirror host, which can
 access both the internet and your closed network, or by using other methods
 that meet your restrictions.
+endif::ibm-cloud[]
 
 ifndef::ipi[]
 [IMPORTANT]
@@ -69,6 +76,51 @@ ifndef::ipi[]
 Because of the complexity of the configuration for user-provisioned installations, consider completing a standard user-provisioned infrastructure installation before you attempt a restricted network installation using user-provisioned infrastructure. Completing this test installation might make it easier to isolate and troubleshoot any issues that might arise during your installation in a restricted network.
 ====
 endif::ipi[]
+
+ifdef::ibm-cloud[]
+[id="required-internet-access-and-an-installation-host_{context}"]
+== Required internet access and an installation host
+
+You complete the installation using a bastion host or portable device that can access both the internet and your closed network. You must use a host with internet access to:
+
+* Download the installation program, the OpenShift CLI (`oc`), and the CCO utility (`ccoctl`).
+* Use the installation program to locate the {op-system-first} image and create the installation configuration file.
+* Use `oc` to extract `ccoctl` from the CCO container image.
+* Use `oc` and `ccoctl` to configure IAM for {ibm-cloud-name}.
+
+[id="access-to-a-mirror-registry_{context}"]
+== Access to a mirror registry
+
+To complete a restricted network installation, you must create a registry that
+mirrors the contents of the {product-registry} and contains the installation media.
+
+You can create this registry on a mirror host, which can access both the internet and your restricted network, or by using other methods that meet your organization's security restrictions.
+
+For more information on mirroring images for a disconnected installation, see "Additional resources".
+
+[id="access-to-ibm-service-endpoints_{context}"]
+== Access to IBM service endpoints
+
+The installation program requires access to the following {ibm-cloud-name} service endpoints:
+
+* Cloud Object Storage
+* DNS Services
+* Global Search
+* Global Tagging
+* Identity Services
+* Resource Controller
+* Resource Manager
+* VPC
+
+[NOTE]
+====
+If you are specifying an {ibm-name} Key Protect for {ibm-cloud-name} root key as part of the installation process, the service endpoint for Key Protect is also required.
+====
+
+By default, the public endpoint is used to access the service. If network restrictions limit access to public service endpoints, you can override the default behavior.
+
+Before deploying the cluster, you can update the installation configuration file (`install-config.yaml`) to specify the URI of an alternate service endpoint. For more information on usage, see "Additional resources".
+endif::ibm-cloud[]
 
 [id="installation-restricted-network-limits_{context}"]
 == Additional limits
@@ -87,6 +139,10 @@ ifeval::["{context}" == "installing-ibm-power"]
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power"]
 :!ibm-power:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:!ibm-cloud:
+:!ipi:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-power-vs"]
 :!ipi:

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2516,6 +2516,43 @@ In either case, this resource group must only be used for a single cluster insta
 
 |platform:
   ibmcloud:
+    serviceEndpoints:
+      - name:
+        url:
+a|A list of service endpoint names and URIs.
+
+By default, the installation program and cluster components use public service endpoints to access the required {ibm-cloud-name} services.
+
+If network restrictions limit access to public service endpoints, you can specify an alternate service endpoint to override the default behavior.
+
+You can specify only one alternate service endpoint for each of the following services:
+
+* Cloud Object Storage
+* DNS Services
+* Global Search
+* Global Tagging
+* Identity Services
+* Key Protect
+* Resource Controller
+* Resource Manager
+* VPC
+
+a|A valid service endpoint name and fully qualified URI.
+
+Valid names include:
+
+* `COS`
+* `DNSServices`
+* `GlobalServices`
+* `GlobalTagging`
+* `IAM`
+* `KeyProtect`
+* `ResourceController`
+* `ResourceManager`
+* `VPC`
+
+|platform:
+  ibmcloud:
     networkResourceGroupName:
 |The name of an existing resource group. This resource contains the existing VPC and subnets to which the cluster will be deployed. This parameter is required when deploying the cluster to a VPC that you have provisioned.
 |String, for example `existing_network_resource_group`.

--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -30,6 +30,7 @@
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc

--- a/modules/installation-custom-ibm-cloud-vpc.adoc
+++ b/modules/installation-custom-ibm-cloud-vpc.adoc
@@ -1,7 +1,19 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_gcp/installing-ibm-cloud-vpc.adoc
+// * installing/installing_ibm_cloud/installing-ibm-cloud-vpc.adoc
 // * installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
+
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:ibm-cloud:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:ibm-cloud:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-private"]
+:ibm-cloud:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="installation-custom-ibm-cloud-vpc_{context}"]
@@ -32,13 +44,35 @@ include::snippets/custom-dns-server.adoc[]
 [id="installation-custom-ibm-cloud-vpc-validation_{context}"]
 == VPC validation
 
-The VPC and all of the subnets must be in an existing resource group. The cluster is deployed to this resource group.
+The VPC and all of the subnets must be in an existing resource group. The cluster is deployed to the existing VPC.
 
 As part of the installation, specify the following in the `install-config.yaml` file:
 
-* The name of the resource group
-* The name of VPC
-* The subnets for control plane machines and compute machines
+ifndef::ibm-cloud[]
+* The name of the existing resource group that contains the VPC and subnets
+endif::ibm-cloud[]
+ifdef::ibm-cloud[]
+* The name of the existing resource group that contains the VPC and subnets (`networkResourceGroupName`)
+endif::ibm-cloud[]
+ifndef::ibm-cloud[]
+* The name of the existing VPC
+endif::ibm-cloud[]
+ifdef::ibm-cloud[]
+* The name of the existing VPC (`vpcName`)
+endif::ibm-cloud[]
+ifndef::ibm-cloud[]
+* The subnets that were created for control plane machines and compute machines
+endif::ibm-cloud[]
+ifdef::ibm-cloud[]
+* The subnets that were created for control plane machines and compute machines (`controlPlaneSubnets` and `computeSubnets`)
+endif::ibm-cloud[]
+
+ifdef::ibm-cloud[]
+[NOTE]
+====
+Additional installer-provisioned cluster resources are deployed to a separate resource group (`resourceGroupName`). You can specify this resource group before installing the cluster. If undefined, a new resource group is created for the cluster.
+====
+endif::ibm-cloud[]
 
 To ensure that the subnets that you provide are suitable, the installation program confirms the following:
 
@@ -67,3 +101,13 @@ If you deploy {product-title} to an existing network, the isolation of cluster s
 * Control plane TCP 6443 ingress (Kubernetes API) is allowed to the entire network.
 
 * Control plane TCP 22623 ingress (MCS) is allowed to the entire network.
+
+ifeval::["{context}" == "installing-ibm-cloud-vpc"]
+:!ibm-cloud:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:!ibm-cloud:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-private"]
+:!ibm-cloud:
+endif::[]

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
 :with-networking:
@@ -16,6 +17,9 @@ ifeval::["{context}" == "installing-ibm-cloud-vpc"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :private:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:restricted:
 endif::[]
 
 :_mod-docs-content-type: REFERENCE
@@ -136,7 +140,7 @@ networking:
 platform:
   ibmcloud:
     region: eu-gb <1>
-    resourceGroupName: eu-gb-example-network-rg <7>
+    resourceGroupName: eu-gb-example-cluster-rg <7>
     networkResourceGroupName: eu-gb-example-existing-network-rg <8>
     vpcName: eu-gb-example-network-1 <9>
     controlPlaneSubnets: <10>
@@ -224,7 +228,7 @@ networking:
 platform:
   ibmcloud:
     region: eu-gb <1>
-    resourceGroupName: eu-gb-example-network-rg <8>
+    resourceGroupName: eu-gb-example-cluster-rg <8>
     networkResourceGroupName: eu-gb-example-existing-network-rg <9>
     vpcName: eu-gb-example-network-1 <10>
     controlPlaneSubnets: <11>
@@ -283,6 +287,143 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 endif::private[]
 
+ifdef::restricted[]
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com <1>
+controlPlane: <2> <3>
+  hyperthreading: Enabled <4>
+  name: master
+  platform:
+    ibm-cloud: {}
+  replicas: 3
+compute: <2> <3>
+- hyperthreading: Enabled <4>
+  name: worker
+  platform:
+    ibmcloud: {}
+  replicas: 3
+metadata:
+  name: test-cluster <1>
+networking:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14 <5>
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16 <6>
+  networkType: OVNKubernetes <7>
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  ibmcloud:
+    region: us-east <1>
+    resourceGroupName: us-east-example-cluster-rg <8>
+    serviceEndpoints: <9>
+      - name: IAM
+        url: https://private.us-east.iam.cloud.ibm.com
+      - name: VPC
+        url: https://us-east.private.iaas.cloud.ibm.com/v1
+      - name: ResourceController
+        url: https://private.us-east.resource-controller.cloud.ibm.com
+      - name: ResourceManager
+        url: https://private.us-east.resource-controller.cloud.ibm.com
+      - name: DNSServices
+        url: https://api.private.dns-svcs.cloud.ibm.com/v1
+      - name: COS
+        url: https://s3.direct.us-east.cloud-object-storage.appdomain.cloud
+      - name: GlobalSearch
+        url: https://api.private.global-search-tagging.cloud.ibm.com
+      - name: GlobalTagging
+        url: https://tags.private.global-search-tagging.cloud.ibm.com
+    networkResourceGroupName: us-east-example-existing-network-rg <10>
+    vpcName: us-east-example-network-1 <11>
+    controlPlaneSubnets: <12>
+      - us-east-example-network-1-cp-us-east-1
+      - us-east-example-network-1-cp-us-east-2
+      - us-east-example-network-1-cp-us-east-3
+    computeSubnets: <13>
+      - us-east-example-network-1-compute-us-east-1
+      - us-east-example-network-1-compute-us-east-2
+      - us-east-example-network-1-compute-us-east-3
+credentialsMode: Manual
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <14>
+ifndef::openshift-origin[]
+fips: false <15>
+sshKey: ssh-ed25519 AAAA... <16>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+sshKey: ssh-ed25519 AAAA... <15>
+endif::openshift-origin[]
+ifndef::openshift-origin[]
+additionalTrustBundle: | <17>
+    -----BEGIN CERTIFICATE-----
+    <MY_TRUSTED_CA_CERT>
+    -----END CERTIFICATE-----
+imageContentSources: <18>
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+additionalTrustBundle: | <16>
+  -----BEGIN CERTIFICATE-----
+  <MY_TRUSTED_CA_CERT>
+  -----END CERTIFICATE-----
+imageContentSources: <17>
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - <local_registry>/<local_repository_name>/release
+  source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
+endif::openshift-origin[]
+----
+<1> Required.
+<2> If you do not provide these parameters and values, the installation program provides the default value.
+<3> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
+<4> Enables or disables simultaneous multithreading, also known as Hyper-Threading. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
++
+[IMPORTANT]
+====
+If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
+====
+<5> The machine CIDR must contain the subnets for the compute machines and control plane machines.
+<6> The CIDR must contain the subnets defined in `platform.ibmcloud.controlPlaneSubnets` and `platform.ibmcloud.computeSubnets`.
+<7> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
+<8> The name of an existing resource group. All installer-provisioned cluster resources are deployed to this resource group. If undefined, a new resource group is created for the cluster.
+<9> Based on the network restrictions of the VPC, specify alternate service endpoints as needed. This overrides the default public endpoint for the service.
+<10> Specify the name of the resource group that contains the existing virtual private cloud (VPC). The existing VPC and subnets should be in this resource group. The cluster will be installed to this VPC.
+<11> Specify the name of an existing VPC.
+<12> Specify the name of the existing subnets to which to deploy the control plane machines. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
+<13> Specify the name of the existing subnets to which to deploy the compute machines. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
+<14> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, registry.example.com or registry.example.com:5000. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+ifndef::openshift-origin[]
+<15> Enables or disables FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+<16> Optional: provide the `sshKey` value that you use to access the machines in your cluster.
+<17> Provide the contents of the certificate file that you used for your mirror registry.
+<18> Provide these values from the `metadata.name: release-0` section of the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<15> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<16> Provide the contents of the certificate file that you used for your mirror registry.
+<17> Provide these values from the `metadata.name: release-0` section of the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
+endif::openshift-origin[]
++
+[NOTE]
+====
+For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
+====
+endif::restricted[]
+
 
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]
 :!with-networking:
@@ -295,4 +436,7 @@ ifeval::["{context}" == "installing-ibm-cloud-vpc"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :!private:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:!restricted:
 endif::[]

--- a/modules/installation-ibm-cloud-configure-vpc-for-endpoint-gateways.adoc
+++ b/modules/installation-ibm-cloud-configure-vpc-for-endpoint-gateways.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-ibm-cloud-configure-vpc-for-endpoint-gateways_{context}"]
+= Allowing endpoint gateway traffic
+
+If you are using {ibm-cloud-name} Virtual Private endpoints, your Virtual Private Cloud (VPC) must be configured to allow traffic to and from the endpoint gateways.
+
+A VPC's default security group is configured to allow all outbound traffic to endpoint gateways. Therefore, the simplest way to allow traffic between your VPC and endpoint gateways is to modify the default security group to allow inbound traffic on port 443.
+
+[NOTE]
+====
+If you choose to configure a new security group, the security group must be configured to allow both inbound and outbound traffic.
+====
+
+.Prerequisites
+
+* You have installed the {ibm-cloud-name} Command Line Interface utility (`ibmcloud`).
+
+.Procedure
+
+. Obtain the identifier for the default security group by running the following command:
++
+[source,terminal]
+----
+$ DEFAULT_SG=$(ibmcloud is vpc <your_vpc_name> --output JSON | jq -r '.default_security_group.id')
+----
+. Add a rule that allows inbound traffic on port 443 by running the following command:
++
+[source,terminal]
+----
+$ ibmcloud is security-group-rule-add $DEFAULT_SG inbound tcp --remote 0.0.0.0/0 --port-min 443 --port-max 443
+----
+
+[NOTE]
+====
+Be sure that your endpoint gateways are configured to use this security group.
+====

--- a/modules/installation-ibm-cloud-download-rhcos.adoc
+++ b/modules/installation-ibm-cloud-download-rhcos.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+// * installing/installing_installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="installation-ibm-cloud-download-rhcos_{context}"]
+= Downloading the RHCOS cluster image
+
+The installation program requires the {op-system-first} image to install the cluster. While optional, downloading the {op-system-first} before deploying removes the need for internet access when creating the cluster.
+
+Use the installation program to locate and download the {op-system-first} image.
+
+.Prerequisites
+
+* The host running the installation program has internet access.
+
+.Procedure
+
+. Change to the directory that contains the installation program and run the following command:
++
+[source,terminal]
+----
+$ ./openshift-install coreos print-stream-json
+----
+
+. Use the output of the command to find the location of the {ibm-cloud-name} image.
+[source,terminal]
++
+.Example output
+----
+  "release": "415.92.202311241643-0",
+  "formats": {
+    "qcow2.gz": {
+      "disk": {
+        "location": "https://rhcos.mirror.openshift.com/art/storage/prod/streams/4.15-9.2/builds/415.92.202311241643-0/x86_64/rhcos-415.92.202311241643-0-ibmcloud.x86_64.qcow2.gz",
+        "sha256": "6b562dee8431bec3b93adeac1cfefcd5e812d41e3b7d78d3e28319870ffc9eae",
+        "uncompressed-sha256": "5a0f9479505e525a30367b6a6a6547c86a8f03136f453c1da035f3aa5daa8bc9"
+----
+. Download and extract the image archive. Make the image available on the host that the installation program uses to create the cluster.

--- a/modules/installation-ibm-cloud-export-variables.adoc
+++ b/modules/installation-ibm-cloud-export-variables.adoc
@@ -8,6 +8,7 @@
 // * installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
 // * installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
 // * installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 
 ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 :ibm-vpc:
@@ -32,6 +33,9 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-power-vs"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-powervs-vpc"]
 :ibm-power-vs:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:ibm-vpc:
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE
@@ -90,4 +94,7 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-power-vs"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-powervs-vpc"]
 :!ibm-power-vs:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:!ibm-vpc:
 endif::[]

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -70,6 +70,10 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-power-vs-private-cluster"]
 :ibm-power-vs-private:
 endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:ibm-cloud-restricted:
+endif::[]
+
 
 :_mod-docs-content-type: PROCEDURE
 [id="installation-initializing-manual_{context}"]
@@ -86,10 +90,10 @@ For user-provisioned installations of {product-title}, you manually generate you
 The Cluster Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
 ====
 endif::vsphere-upi,restricted-upi[]
-ifdef::aws-china,aws-gov,aws-secret[]
-Installing the cluster requires that you manually generate the installation configuration file.
+ifdef::aws-china,aws-gov,aws-secret,ibm-cloud-restricted[]
+Installing the cluster requires that you manually create the installation configuration file.
 //Made this update as part of feedback in PR3961. tl;dr Simply state you have to create the config file, instead of creating a number of conditions to explain why.
-endif::aws-china,aws-gov,aws-secret[]
+endif::aws-china,aws-gov,aws-secret,ibm-cloud-restricted[]
 ifdef::azure-gov[]
 When installing {product-title} on Microsoft Azure into a government region, you
 must manually generate your installation configuration file.
@@ -109,7 +113,9 @@ endif::gcp-shared[]
 ifdef::aws-china,aws-secret[]
 * You have uploaded a custom RHCOS AMI.
 endif::aws-china,aws-secret[]
+ifndef::ibm-cloud-restricted[]
 * You have an SSH public key on your local machine to provide to the installation program. The key will be used for SSH authentication onto your cluster nodes for debugging and disaster recovery.
+endif::ibm-cloud-restricted[]
 * You have obtained the {product-title} installation program and the pull secret for your
 cluster.
 ifdef::restricted,restricted-upi[]
@@ -117,6 +123,10 @@ ifdef::restricted,restricted-upi[]
 mirror the repository.
 * Obtain the contents of the certificate for your mirror registry.
 endif::restricted,restricted-upi[]
+ifdef::ibm-cloud-restricted[]
+* You have the `imageContentSourcePolicy.yaml` file that was created when you mirrored your registry.
+* You have obtained the contents of the certificate for your mirror registry.
+endif::ibm-cloud-restricted[]
 
 .Procedure
 
@@ -139,11 +149,113 @@ when copying installation files from an earlier {product-title} version.
 
 . Customize the sample `install-config.yaml` file template that is provided and save
 it in the `<installation_directory>`.
+ifdef::ibm-cloud-restricted[]
 +
 [NOTE]
 ====
 You must name this configuration file `install-config.yaml`.
 ====
++
+When customizing the sample template, be sure to provide the information that is required for an installation in a restricted network:
+
+.. Update the `pullSecret` value to contain the authentication information for your registry:
++
+[source,yaml]
+----
+pullSecret: '{"auths":{"<mirror_host_name>:5000": {"auth": "<credentials>","email": "you@example.com"}}}'
+----
++
+For `<mirror_host_name>`, specify the registry domain name
+that you specified in the certificate for your mirror registry, and for
+`<credentials>`, specify the base64-encoded user name and password for
+your mirror registry.
+.. Add the `additionalTrustBundle` parameter and value.
++
+[source,yaml]
+----
+additionalTrustBundle: |
+  -----BEGIN CERTIFICATE-----
+  ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
+  -----END CERTIFICATE-----
+----
++
+The value must be the contents of the certificate file that you used for your mirror registry. The certificate file can be an existing, trusted certificate authority, or the self-signed certificate that you generated for the mirror registry.
+.. Define the network and subnets for the VPC to install the cluster in under the parent `platform.ibmcloud` field:
++
+[source,yaml]
+----
+vpcName: <existing_vpc>
+controlPlaneSubnets: <control_plane_subnet>
+computeSubnets: <compute_subnet>
+----
++
+For `platform.ibmcloud.vpcName`, specify the name for the existing IBM Cloud VPC. For `platform.ibmcloud.controlPlaneSubnets` and `platform.ibmcloud.computeSubnets`, specify the existing subnets to deploy the control plane machines and compute machines, respectively.
+.. Add the image content resources, which resemble the following YAML excerpt:
++
+[source,yaml]
+----
+imageContentSources:
+- mirrors:
+  - <mirror_host_name>:5000/<repo_name>/release
+  source: quay.io/openshift-release-dev/ocp-release
+- mirrors:
+  - <mirror_host_name>:5000/<repo_name>/release
+  source: registry.redhat.io/ocp/release
+----
++
+For these values, use the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
+.. If network restrictions limit the use of public endpoints to access the required {ibm-cloud-name} services, add the `serviceEndpoints` stanza to `platform.ibmcloud` to specify an alternate service endpoint.
++
+[NOTE]
+====
+You can specify only one alternate service endpoint for each service.
+====
++
+.Example of using alternate services endpoints
+[source,yaml]
+----
+# ...
+serviceEndpoints:
+  - name: IAM
+    url: <iam_alternate_endpoint_url>
+  - name: VPC
+    url: <vpc_alternate_endpoint_url>
+  - name: ResourceController
+    url: <resource_controller_alternate_endpoint_url>
+  - name: ResourceManager
+    url: <resource_manager_alternate_endpoint_url>
+  - name: DNSServices
+    url: <dns_services_alternate_endpoint_url>
+  - name: COS
+    url: <cos_alternate_endpoint_url>
+  - name: GlobalSearch
+    url: <global_search_alternate_endpoint_url>
+  - name: GlobalTagging
+    url: <global_tagging_alternate_endpoint_url>
+# ...
+----
+.. Optional: Set the publishing strategy to `Internal`:
++
+[source,yaml]
+----
+publish: Internal
+----
++
+By setting this option, you create an internal Ingress Controller and a private load balancer.
++
+[NOTE]
+====
+If you use the default value of `External`, your network must be able to access the public endpoint for {ibm-cloud-name} Internet Services (CIS). CIS is not enabled for Virtual Private Endpoints.
+====
+endif::ibm-cloud-restricted[]
+
+ifndef::ibm-cloud-restricted[]
++
+[NOTE]
+====
+You must name this configuration file `install-config.yaml`.
+====
+endif::ibm-cloud-restricted[]
 
 ifdef::restricted,restricted-upi[]
 
@@ -166,13 +278,13 @@ Because of this behavior, you must always keep a backup of these files in case y
 
 endif::restricted,restricted-upi[]
 
-ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default,ash-network,gcp-shared,ibm-cloud-private,ibm-power-vs-private[]
+ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default,ash-network,gcp-shared,ibm-cloud-private,ibm-power-vs-private,ibm-cloud-restricted[]
 +
 [NOTE]
 ====
 For some platform types, you can alternatively run `./openshift-install create install-config --dir <installation_directory>` to generate an `install-config.yaml` file. You can provide details about your cluster configuration at the prompts.
 ====
-endif::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default,ash-network,gcp-shared,ibm-cloud-private,ibm-power-vs-private[]
+endif::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default,ash-network,gcp-shared,ibm-cloud-private,ibm-power-vs-private,ibm-cloud-restricted[]
 ifdef::ash[]
 +
 Make the following modifications for Azure Stack Hub:
@@ -225,13 +337,11 @@ ifdef::vsphere-upi-vsphere[]
 . If you are installing a three-node cluster, modify the `install-config.yaml` file by setting the `compute.replicas` parameter to `0`. This ensures that the cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on {platform}".
 endif::vsphere-upi-vsphere[]
 
-. Back up the `install-config.yaml` file so that you can use it to install
-multiple clusters.
+. Back up the `install-config.yaml` file so that you can use it to install multiple clusters.
 +
 [IMPORTANT]
 ====
-The `install-config.yaml` file is consumed during the next step of the
-installation process. You must back it up now.
+The `install-config.yaml` file is consumed during the next step of the installation process. You must back it up now.
 ====
 
 ifeval::["{context}" == "installing-azure-government-region"]
@@ -284,5 +394,8 @@ ifeval::["{context}" == "installing-ibm-cloud-private"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-power-vs-private-cluster"]
 :!ibm-power-vs-private:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:!ibm-cloud-restricted:
 endif::[]
 :!platform:

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -27,6 +27,7 @@
 // * installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
 // * installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
 // * installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
 // * installing/installing_openstack/installing-openstack-user.adoc
@@ -39,7 +40,6 @@
 // * installing/installing_nutanix/configuring-iam-nutanix.adoc
 // * installing/installing-restricted-networks-nutanix-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
-
 // * installing/installing_gcp/installing-openstack-installer-restricted.adoc
 // Consider also adding the installation-configuration-parameters.adoc module.
 //YOU MUST SET AN IFEVAL FOR EACH NEW MODULE
@@ -132,6 +132,10 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :ibm-cloud:
 endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:ibm-cloud:
+:restricted:
+endif::[]
 ifeval::["{context}" == "installing-openstack-installer-custom"]
 :osp:
 endif::[]
@@ -209,17 +213,20 @@ endif::nutanix[]
 * You have the {product-title} installation program and the pull secret for your cluster.
 ifdef::restricted[]
 For a restricted network installation, these files are on your mirror host.
-ifndef::nutanix[]
+ifndef::nutanix,ibm-cloud[]
 * You have the `imageContentSources` values that were generated during mirror registry creation.
-endif::nutanix[]
+endif::nutanix,ibm-cloud[]
 ifdef::nutanix+restricted[]
 * You have the `imageContentSourcePolicy.yaml` file that was created when you mirrored your registry.
 * You have the location of the {op-system-first} image you download.
 endif::nutanix+restricted[]
+ifdef::ibm-cloud+restricted[]
+* You have the `imageContentSourcePolicy.yaml` file that was created when you mirrored your registry.
+endif::ibm-cloud+restricted[]
 * You have obtained the contents of the certificate for your mirror registry.
-ifndef::aws,gcp[]
+ifndef::aws,gcp,ibm-cloud[]
 * You have retrieved a {op-system-first} image and uploaded it to an accessible location.
-endif::aws,gcp[]
+endif::aws,gcp,ibm-cloud[]
 endif::restricted[]
 ifdef::azure[]
 * You have an Azure subscription ID and tenant ID.
@@ -254,6 +261,7 @@ files that the installation program creates.
 When specifying the directory:
 * Verify that the directory has the `execute` permission. This permission is required to run Terraform binaries under the installation directory.
 * Use an empty directory. Some installation assets, such as bootstrap X.509 certificates, have short expiration intervals, therefore you must not reuse an installation directory. If you want to reuse individual files from another cluster installation, you can copy them into your directory. However, the file names for the installation assets might change between releases. Use caution when copying installation files from an earlier {product-title} version.
+ifdef::ibm-power-vs[]
 +
 [NOTE]
 =====
@@ -263,6 +271,7 @@ Always delete the `~/.powervs` directory to avoid reusing a stale configuration.
 $ rm -rf ~/.powervs
 ----
 =====
+endif::ibm-power-vs[]
 .. At the prompts, provide the configuration details for your cloud:
 ... Optional: Select an SSH key to use to access your cluster machines.
 +
@@ -537,6 +546,7 @@ computeSubnet: <compute_subnet>
 +
 For `platform.gcp.network`, specify the name for the existing Google VPC. For `platform.gcp.controlPlaneSubnet` and `platform.gcp.computeSubnet`, specify the existing subnets to deploy the control plane machines and compute machines, respectively.
 endif::gcp+restricted[]
+
 ifdef::ibm-power-vs+restricted[]
 .. Define the network and subnets for the VPC to install the cluster in under the parent `platform.ibmcloud` field:
 +
@@ -548,6 +558,18 @@ vpcSubnets: <vpcSubnet>
 +
 For `platform.powervs.vpcName`, specify the name for the existing {ibm-cloud-name}. For `platform.powervs.vpcSubnets`, specify the existing subnets.
 endif::ibm-power-vs+restricted[]
+ifdef::ibm-cloud+restricted[]
+.. Define the network and subnets for the VPC to install the cluster in under the parent `platform.ibmcloud` field:
++
+[source,yaml]
+----
+vpcName: <existing_vpc>
+controlPlaneSubnets: <control_plane_subnet>
+computeSubnets: <compute_subnet>
+----
++
+For `platform.ibmcloud.vpcName`, specify the name for the existing IBM Cloud VPC. For `platform.ibmcloud.controlPlaneSubnets` and `platform.ibmcloud.computeSubnets`, specify the existing subnets to deploy the control plane machines and compute machines, respectively.
+endif::ibm-cloud+restricted[]
 
 .. Add the image content resources, which resemble the following YAML excerpt:
 +
@@ -562,8 +584,43 @@ imageContentSources:
   source: registry.redhat.io/ocp/release
 ----
 +
-ifndef::nutanix[]
+ifndef::nutanix,ibm-cloud[]
 For these values, use the `imageContentSources` that you recorded during mirror registry creation.
+endif::nutanix,ibm-cloud[]
+ifdef::nutanix,ibm-cloud[]
+For these values, use the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
+endif::nutanix,ibm-cloud[]
+ifdef::ibm-cloud[]
+.. If your Virtual Private Cloud (VPC) network is unable to access the public endpoints for the required {ibm-cloud-name} service endpoints, add the following stanza to `platform.ibmcloud` to override them using {ibm-cloud-name} Virtual Private Endpoints (VPE).
++
+[source,yaml]
+----
+# ...
+serviceEndpoints:
+  - name: IAM
+    url: <iam_private_endpoint_url>
+  - name: VPC
+    url: <vpc_private_endpoint_url>
+  - name: ResourceController
+    url: <resource_controller_private_endpoint_url>
+  - name: ResourceManager
+    url: <resource_manager_private_endpoint_url>
+  - name: DNSServices
+    url: <dns_services_private_endpoint_url>
+  - name: COS
+    url: <cos_private_endpoint_url>
+  - name: GlobalSearch
+    url: <global_search_private_endpoint_url>
+  - name: GlobalTagging
+    url: <global_tagging_private_endpoint_url>
+# ...
+----
++
+[NOTE]
+====
+Only one VPE can be specified per service.
+====
+endif::ibm-cloud[]
 ifdef::restricted[]
 .. Optional: Set the publishing strategy to `Internal`:
 +
@@ -573,20 +630,26 @@ publish: Internal
 ----
 +
 By setting this option, you create an internal Ingress Controller and a private load balancer.
+ifdef::azure[]
 +
 [IMPORTANT]
 ====
 Azure Firewall link:https://learn.microsoft.com/en-us/azure/firewall/integrate-lb[does not work seamlessly] with Azure Public Load balancers. Thus, when using Azure Firewall for restricting internet access, the `publish` field in `install-config.yaml` should be set to `Internal`.
 ====
+endif::azure[]
+ifdef::ibm-cloud[]
++
+[NOTE]
+====
+If you use the default value of `External`, your network must be able to access the public endpoint for {ibm-cloud-name} Internet Services (CIS). CIS is not enabled for Virtual Private Endpoints.
+====
+endif::ibm-cloud[]
 endif::restricted[]
-endif::nutanix[]
-ifdef::nutanix[]
-For these values, use the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
-endif::nutanix[]
 
 ifndef::nutanix[]
-. Make any other modifications to the `install-config.yaml` file that you require. You can find more information about
-the available parameters in the *Installation configuration parameters* section.
+. Make any other modifications to the `install-config.yaml` file that you require.
++
+For more information about the parameters, see "Installation configuration parameters".
 endif::nutanix[]
 endif::restricted[]
 
@@ -703,6 +766,10 @@ ifeval::["{context}" == "installing-ibm-cloud-vpc"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :!ibm-cloud:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:!ibm-cloud:
+:!restricted:
 endif::[]
 ifeval::["{context}" == "installing-openstack-installer-custom"]
 :!osp:

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -26,6 +26,11 @@
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
 // * installing/installing_gcp/installing-ibm-cloud-customizations.adoc
 // * installing/installing_gcp/installing-ibm-cloud-vpc.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc
@@ -223,6 +228,10 @@ ifeval::["{context}" == "installing-ibm-cloud-private"]
 :ibm-cloud:
 :single-step:
 endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:custom-config:
+:ibm-cloud-restricted:
+endif::[]
 ifeval::["{context}" == "installing-nutanix-installer-provisioned"]
 :custom-config:
 :nutanix:
@@ -271,6 +280,10 @@ You can run the `create cluster` command of the installation program only once, 
 ifndef::osp,vsphere,nutanix[* You have configured an account with the cloud platform that hosts your cluster.]
 
 * You have the {product-title} installation program and the pull secret for your cluster.
+ifdef::ibm-cloud-restricted[]
++
+If the {op-system-first} image is available locally, the host running the installation program does not require internet access.
+endif::ibm-cloud-restricted[]
 ifdef::azure[]
 * You have an Azure subscription ID and tenant ID.
 endif::azure[]
@@ -307,7 +320,7 @@ environment variables
 ** The `gcloud cli` default credentials
 endif::gcp[]
 
-ifdef::aws,azure-gov,azure-private,gcp,no-config[]
+ifdef::aws,azure-gov,azure-private,gcp,ibm-cloud-restricted,no-config[]
 ifdef::azure-default[]
 . Optional: If you have run the installation program on this computer before, and want to use an alternative service principal, go to the `~/.azure/` directory and delete the `osServicePrincipal.json` configuration file.
 +
@@ -318,8 +331,16 @@ ifdef::azure-gov,azure-private[]
 +
 Deleting this file prevents the installation program from automatically reusing subscription and authentication values from a previous installation.
 endif::azure-gov,azure-private[]
+ifdef::ibm-cloud-restricted[]
+. Export the `OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE` variable to specify the location of the {op-system-first} image by running the following command:
++
+[source,terminal]
+----
+$ export OPENSHIFT_INSTALL_OS_IMAGE_OVERRIDE="<path_to_image>/rhcos-<image_version>-ibmcloud.x86_64.qcow2.gz"
+----
+endif::ibm-cloud-restricted[]
 . Change to the directory that contains the installation program and initialize the cluster deployment:
-endif::aws,azure-gov,azure-private,gcp,no-config[]
+endif::aws,azure-gov,azure-private,gcp,ibm-cloud-restricted,no-config[]
 ifdef::single-step,azure-restricted[]
 * Change to the directory that contains the installation program and initialize the cluster deployment:
 endif::single-step,azure-restricted[]
@@ -707,6 +728,10 @@ ifeval::["{context}" == "installing-ibm-cloud-private"]
 :!custom-config:
 :!ibm-cloud:
 :!single-step:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:!custom-config:
+:!ibm-cloud-restricted:
 endif::[]
 ifeval::["{context}" == "installing-nutanix-installer-provisioned"]
 :!custom-config:

--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -39,6 +39,7 @@
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc
 // * installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/installing-restricted-networks-azure-installer-provisioned.adoc
 // * installing/installing_azure/installing-restricted-networks-azure-user-provisioned.adoc
 // * installing/installing_vsphere/upi/upi-vsphere-installation-reqs.adoc
@@ -108,6 +109,9 @@ ifeval::["{context}" == "installing-ibm-cloud-private"]
 endif::[]
 ifeval::["{context}" == "upi-vsphere-installation-reqs"]
 :vsphere:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:ibm-cloud-vpc:
 endif::[]
 
 :_mod-docs-content-type: CONCEPT
@@ -301,4 +305,7 @@ ifeval::["{context}" == "installing-ibm-cloud-private"]
 endif::[]
 ifeval::["{context}" == "upi-vsphere-installation-reqs"]
 :!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:!ibm-cloud-vpc:
 endif::[]

--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -8,6 +8,7 @@
 // * installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
 // * installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
 // * installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 
 ifeval::["{context}" == "installing-ibm-cloud-customizations"]
 :ibm-vpc:
@@ -32,6 +33,9 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-power-vs"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-powervs-vpc"]
 :ibm-power-vs:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:ibm-vpc:
 endif::[]
 
 :_mod-docs-content-type: PROCEDURE
@@ -198,4 +202,7 @@ ifeval::["{context}" == "installing-restricted-networks-ibm-power-vs"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-powervs-vpc"]
 :!ibm-power-vs:
+endif::[]
+ifeval::["{context}" == "installing-ibm-cloud-restricted"]
+:!ibm-vpc:
 endif::[]

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -5,6 +5,7 @@
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
 // * installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
 // * installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -35,6 +35,7 @@
 // * installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
 // * installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
 // * installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
+// * installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc
 // * installing/installing_aws/installing-restricted-networks-aws.adoc


### PR DESCRIPTION
Version(s):
4.15+

Issue:
This issue addresses [osdocs-4348](https://issues.redhat.com/browse/OSDOCS-4348).

Link to docs preview:
[Installing a cluster on IBM Cloud VPC in a restricted network](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html)

A significant amount of the content in this topic is reused from existing approved IBM Cloud VPC doc. The following preview links are for areas where notable new content was added in support of a restricted installation:

- [Supported installation methods for different platforms](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing-preparing#supported-installation-methods-for-different-platforms) (Updated support matrix to include a restricted installation)
- [Prerequisites](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html#prerequisites_installing-ibm-cloud-restricted) (updated to list using oc-mirror to mirror install media as a prereq)
- [Required internet access and an installation host](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html#required-internet-access-and-an-installation-host_installing-ibm-cloud-restricted)
- [Access to IBM service endpoints](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html#access-to-ibm-service-endpoints_installing-ibm-cloud-restricted)
- [Allowing endpoint gateway traffic](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html#installation-ibm-cloud-configure-vpc-for-endpoint-gateways_installing-ibm-cloud-restricted)
- [Downloading the RHCOS cluster image](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html#installation-ibm-cloud-download-rhcos_installing-ibm-cloud-restricted)
- [Manually creating the installation configuration file](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html#installation-initializing-manual_installing-ibm-cloud-restricted)
- [Sample customized install-config.yaml file for IBM Cloud VPC](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html#installation-ibm-cloud-config-yaml_installing-ibm-cloud-restricted) (added private endpoints as 9th annotation)
- [Disabling the default OperatorHub catalog sources](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html#olm-restricted-networks-operatorhub_installing-ibm-cloud-restricted)
- [Installing the policy resources into the cluster](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-restricted.html#oc-mirror-updating-cluster-manifests_installing-ibm-cloud-restricted)
- [Additional IBM Cloud configuration parameters](https://55526--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vpc#installation-configuration-parameters-additional-ibm-cloud_installation-config-parameters-ibm-cloud-vpc) (added serviceEndpoints)


QE review:
- [x] QE has approved this change.