### PR TITLE
[OSDOCS-5194] Correct command typo in replace etcd member module

### DIFF
--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -212,7 +212,7 @@ When the etcd cluster Operator performs a redeployment, it ensures that all cont
 +
 [source,terminal]
 ----
-$ oc patch etcd/cluster --type=merge -p '\{"spec": {"unsupportedConfigOverrides": null}}
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
 . You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -544,7 +544,7 @@ openshift-compute-1       Ready worker 3h58m v1.25.0
 +
 [source,terminal]
 ----
-$ oc patch etcd/cluster --type=merge -p '\{"spec": {"unsupportedConfigOverrides": null}}
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
 . You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -320,7 +320,7 @@ It might take a few minutes for the new machine to be created. The etcd cluster 
 +
 [source,terminal]
 ----
-$ oc patch etcd/cluster --type=merge -p '\{"spec": {"unsupportedConfigOverrides": null}}
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
 . You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:


### PR DESCRIPTION
Version(s):
4.11, 4.12, latest

Issue:
https://issues.redhat.com/browse/OSDOCS-5194

Link to docs preview:
https://github.com/feichashao/openshift-docs/blob/replace_etcd_typo/modules/restore-replace-crashlooping-etcd-member.adoc
https://github.com/feichashao/openshift-docs/blob/replace_etcd_typo/modules/restore-replace-stopped-etcd-member.adoc
https://github.com/feichashao/openshift-docs/blob/replace_etcd_typo/modules/restore-replace-stopped-baremetal-etcd-member.adoc

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
