### PR TITLE
RHDEVDOCS-4940-secondPR: Added a CVE update for 1.5.9 and 1.6.4 releases

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -25,11 +25,15 @@ include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 // Modules included, most to least recent
 include::modules/gitops-release-notes-1-7-0.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-6-4.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-6-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-6-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-6-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-5-9.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-5-7.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-5-9.adoc
+++ b/modules/gitops-release-notes-1-5-9.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-5-9_{context}"]
+= Release notes for {gitops-title} 1.5.9
+
+{gitops-title} 1.5.9 is now available on {product-title} 4.8, 4.9, 4.10, 4.11, and 4.12.
+
+[id="fixed-issues-1-5-9_{context}"]
+== Fixed issues
+
+* Before this update, all versions of Argo CD v1.8.2 and later were vulnerable to an improper authorization bug. As a result, Argo CD would accept tokens for audiences who might not be intended to access the cluster. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2160492[CVE-2023-22482]

--- a/modules/gitops-release-notes-1-6-4.adoc
+++ b/modules/gitops-release-notes-1-6-4.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-6-4_{context}"]
+= Release notes for {gitops-title} 1.6.4
+
+{gitops-title} 1.6.4 is now available on {product-title} 4.8, 4.9, 4.10, 4.11, and 4.12.
+
+[id="fixed-issues-1-6-4_{context}"]
+== Fixed issues
+
+* Before this update, all versions of Argo CD v1.8.2 and later were vulnerable to an improper authorization bug. As a result, Argo CD would accept tokens for audiences who might not be intended to access the cluster. This issue is now fixed. link:https://bugzilla.redhat.com/show_bug.cgi?id=2160492[CVE-2023-22482]


### PR DESCRIPTION
**Aligned team**: Dev Tools

**Purpose**: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-4940

**OCP version this PR applies to**:  enterprise 4.8 and later 

**Link to docs preview**: 
For 1.6.4: https://55529--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-6-4_gitops-release-notes
For 1.5.9: https://55529--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-5-9_gitops-release-notes

**Change Management**
Need an ACK from Eng: @iam-veeramalla 
Need an ACK from PM: @harrietgrace @wtam2018 
Need an ACK from Product experience: @RickJWagner 
Need an ACK from QE: @varshab1210 
Need an ACK from DPM: @pmkovar 
Need an ACK from CS: @Preeticp 

Peer review: 