### PR TITLE
Release note peer review

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3126,6 +3126,17 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.12.1 --pullspecs
 ----
 
+[id="ocp-4-12-1-configuring-kernel-arguments-discovery-ztp"]
+==== Configuring kernel arguments for the Discovery ISO by using GitOps ZTP
+
+{product-title} now supports specifying kernel arguments for the Discovery ISO in GitOps ZTP deployments. In both manual and automated GitOps ZTP deployments, the Discovery ISO is part of the {product-title} installation process on managed bare-metal hosts. You can now edit the `InfraEnv` resource to specify kernel arguments for the Discovery ISO. This is useful for cluster installations with specific environmental requirements. For example, you can define the **rd.net.timeout.carrier** kernel argument to help configure the cluster for static networking.
+
+For more information about how to specify kernel arguments see the following documentation:
+
+xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#setting-managed-bare-metal-host-kernel-arguments_ztp-deploying-far-edge-sites[Configuring kernel arguments for the Discovery ISO by using GitOps ZTP].
+
+xref:../scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc#setting-managed-bare-metal-host-kernel-arguments_ztp-manual-install[Configuring kernel arguments for the Discovery ISO for manual installations by using GitOps ZTP].
+
 [id="ocp-4-12-1-bug-fixes"]
 ==== Bug fixes
 


### PR DESCRIPTION
TELCODOCS 964: In ZTP, you can configure kernel parameters for the Dicovery ISO to satisfy specific installation environments.

Version(s):
Peer review only please. The z-stream version will be handled separately.

Issue:
https://issues.redhat.com//browse/TELCODOCS-964

Link to docs preview:
https://55532--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-1-configuring-kernel-arguments-discovery-ztp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The merging of this RN is handled separately by the owner of the RHACM 2.7 release checklist https://issues.redhat.com/browse/TELCODOCS-929?src=confmacro

The location of the RN in the release notes will probably change. There will be a separate merge review PR handled by another writer who is managing the RHACM 2.7 release checklist. This is really just a PR to enable peer review so I can add to the release-notes field in JIRA.
