### PR TITLE
PR for review of RN for TELCODOCS 947

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3126,6 +3126,13 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.12.1 --pullspecs
 ----
 
+[id="ocp-4-12-1-assisted-installer-api-mixed-arch-clusters"]
+==== Deploy heterogeneous spoke clusters from a hub cluster
+
+With this update, you can create {product-title} mixed-architecture clusters, also known as heterogeneous clusters, that feature hosts with both AMD64 and AArch64 CPU architectures. You can deploy a heterogeneous spoke cluster from a hub cluster managed by Red Hat Advanced Cluster Management (RHACM). To create a heterogeneous spoke cluster, add an AArch64 worker node to a deployed AMD64 cluster. 
+
+To add an AArch64 worker node to a deployed AMD64 cluster, you can specify the AArch64 architecture, the multi-architecture release image, and the operating system required for the node by using an `InfraEnv` custom resource (CR). You can then provision the AArch64 worker node to the AMD64 cluster by using the {ai-full} API and the `InfraEnv` CR.
+
 [id="ocp-4-12-1-bug-fixes"]
 ==== Bug fixes
 


### PR DESCRIPTION
TELCODOCS 947: You can create mixed-architectures clusters by the using the Assisted Installer API to add Aarch64 architecture hosts to deployed AMD64 clusters.

Version(s):
TBD - need peer review only

Issue:
https://issues.redhat.com/browse/TELCODOCS-947

Link to docs preview:
https://55537--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-1-assisted-installer-api-mixed-arch-clusters

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Merging will be handled by different PR. Location in OCP docs may not be accurate, just need a peer review of RN content only. 