### PR TITLE
[enterprise-4.10] [OSDOCS-4833]: Document private S3 bucket for OIDC in AWS STS

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -104,18 +104,17 @@ ifdef::aws-sts[]
 [source,terminal]
 ----
 $ ccoctl aws create-all \
---name=<name> \
---region=<aws_region> \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
+  --name=<name> \// <1>
+  --region=<aws_region> \// <2>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <3>
+  --output-dir=<path_to_ccoctl_output_dir> \// <4>
+  --create-private-s3-bucket <5>
 ----
-+
-where:
-+
---
-** `<name>` is the name used to tag any cloud resources that are created for tracking.
-** `<aws_region>` is the AWS region in which cloud resources will be created.
-** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
---
+<1> Specify the name used to tag any cloud resources that are created for tracking.
+<2> Specify the AWS region in which cloud resources will be created.
+<3> Specify the directory containing the files for the component `CredentialsRequest` objects.
+<4> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<5> Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Cherrypicked from dee49c09f76ec80b16fca9aa37b1c28f531a9319 xref: #54882