### PR TITLE
OSDOCS-481 Pt2: Additional Fixes

### DIFF
--- a/modules/rosa-aws-scp.adoc
+++ b/modules/rosa-aws-scp.adoc
@@ -6,9 +6,9 @@
 //
 
 [id="rosa-minimum-scp_{context}"]
-= Minimum required service control policy (SCP)
+= Minimum set of effective permissions for service control policies (SCP)
 
-Service control policies (SCP) are a type of organization policy that manages permissions within your organization. SCPs ensure that accounts within your organization stay within your defined access control guidelines. These polices are maintained in the AWS Organizations and control the services that are available within the attached AWS accounts. SCP management is the responsibility of the customer.
+Service control policies (SCP) are a type of organization policy that manages permissions within your organization. SCPs ensure that accounts within your organization stay within your defined access control guidelines. These polices are maintained in AWS Organizations and control the services that are available within the attached AWS accounts. SCP management is the responsibility of the customer.
 
 ifeval::["{context}" == "rosa-sts-about-iam-resources"]
 :aws-sts:
@@ -32,7 +32,7 @@ endif::aws-sts[]
 ifdef::aws-non-sts[]
 [NOTE]
 ====
-The minimum SCP requirement does not apply when using AWS security token service (STS). For more information about STS, see link:https://docs.openshift.com/rosa/rosa_getting_started_sts/rosa-sts-aws-prereqs.html[AWS prerequisites for ROSA with STS].
+The minimum SCP requirement does not apply when using AWS Security Token Service (STS). For more information about STS, see link:https://docs.openshift.com/rosa/rosa_getting_started_sts/rosa-sts-aws-prereqs.html[AWS prerequisites for ROSA with STS].
 ====
 endif::aws-non-sts[]
 
@@ -102,3 +102,4 @@ ViewUsage
 .Additional resources
 
 * link:https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html[Service control policies]
+* link:https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html#scp-effects-on-permissions[SCP effects on permissions]


### PR DESCRIPTION
Version(s):
`enterprise-4.12+`

Issue:
[OSDOCS-4813](https://issues.redhat.com/browse/OSDOCS-4813)

Link to docs preview:
* STS
* Non-STS

Additional information:
Cleaned up some typos and added a new link to AWS.