### PR TITLE
OCPBUGS-6674 the ifname parameter is now obsolete, it will not be used. The name will be taken from the pod annotation

### DIFF
--- a/modules/nw-configure-sysctl-interface-sriov-network-bonded.adoc
+++ b/modules/nw-configure-sysctl-interface-sriov-network-bonded.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="configuring-sysctl-on-bonded-sriov-network_{context}"]
-= Configuring sysctl on a bonded SR-IOV network 
+= Configuring sysctl on a bonded SR-IOV network
 
 You can set interface specific `sysctl` settings on a bonded interface created from two SR-IOV interfaces. Do this by adding the tuning configuration to the optional `Plugins` parameter of the bond network attachment definition.
 
@@ -22,16 +22,16 @@ To change specific interface-level network `sysctl` settings create the `SriovNe
 
 .Procedure
 
-. Create the `SriovNetwork` custom resource (CR) for the bonded interface as in the following example CR. Save the YAML as the file `sriov-network-attachment.yaml`. 
+. Create the `SriovNetwork` custom resource (CR) for the bonded interface as in the following example CR. Save the YAML as the file `sriov-network-attachment.yaml`.
 +
 [source,yaml]
 ----
-apiVersion: sriovnetwork.openshift.io/v1 
-kind: SriovNetwork 
-metadata: 
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetwork
+metadata:
   name: allvalidflags <1>
   namespace: openshift-sriov-network-operator <2>
-spec: 
+spec:
   resourceName: policyallflags <3>
   networkNamespace: sysctl-tuning-test <4>
   capabilities: '{ "mac": true, "ips": true }' <5>
@@ -65,21 +65,20 @@ spec:
   "plugins":[
     {
       "type":"bond", <1>
-      "ifname":"bond0", <2>
-      "mode": "active-backup", <3>
-      "failOverMac": 1, <4>
-      "linksInContainer": true, <5>
+      "mode": "active-backup", <2>
+      "failOverMac": 1, <3>
+      "linksInContainer": true, <4>
       "miimon": "100",
-      "links": [ <6>
+      "links": [ <5>
         {"name": "net1"},
         {"name": "net2"}
       ],
-      "ipam":{ <7>
+      "ipam":{ <6>
         "type":"static"
       }
     },
     {
-      "type":"tuning", <8>
+      "type":"tuning", <7>
       "capabilities":{
         "mac":true
       },
@@ -99,19 +98,18 @@ spec:
 }'
 ----
 <1> The type is `bond`.
-<2> The `ifname` attribute specifies the name of the bond interface.
-<3> The `mode` attribute specifies the bonding mode. The bonding modes supported are:
+<2> The `mode` attribute specifies the bonding mode. The bonding modes supported are:
 
- * `balance-rr` - 0 
+ * `balance-rr` - 0
  * `active-backup` - 1
  * `balance-xor` - 2
 +
 For `balance-rr` or `balance-xor` modes, you must set the `trust` mode to `on` for the SR-IOV virtual function.
-<4> The `failover` attribute is mandatory for active-backup mode.
-<5> The `linksInContainer=true` flag informs the Bond CNI that the interfaces required are to be found inside the container. By default Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV and Multus.
-<6> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one. 
-<7> A configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition. In this pod example IP addresses are configured manually, so in this case `ipam` is set to static. 
-<8> Add additional capabilities to the device. For example, set the `type` field to `tuning`. Specify the interface-level network `sysctl` you want to set in the sysctl field. This example sets all interface-level network `sysctl` settings that can be set. 
+<3> The `failover` attribute is mandatory for active-backup mode.
+<4> The `linksInContainer=true` flag informs the Bond CNI that the required interfaces are to be found inside the container. By default, Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV and Multus.
+<5> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
+<6> A configuration object for the IPAM CNI plugin as a YAML block scalar. The plugin manages IP address assignment for the attachment definition. In this pod example IP addresses are configured manually, so in this case,`ipam` is set to static.
+<7> Add additional capabilities to the device. For example, set the `type` field to `tuning`. Specify the interface-level network `sysctl` you want to set in the sysctl field. This example sets all interface-level network `sysctl` settings that can be set.
 
 . Create the bond network attachment resource:
 +
@@ -133,8 +131,8 @@ $ oc get network-attachment-definitions -n <namespace> <1>
 .Example output
 [source,terminal]
 ----
-NAME                          AGE 
-bond-sysctl-network           22m 
+NAME                          AGE
+bond-sysctl-network           22m
 allvalidflags                 47m
 ----
 +
@@ -188,7 +186,7 @@ spec:
 <2> Optional: The MAC address for the SR-IOV device that is allocated from the resource type defined in the SR-IOV network attachment definition CR. To use this feature, you also must specify `{ "mac": true }` in the SriovNetwork object.
 <3> Optional: IP addresses for the SR-IOV device that are allocated from the resource type defined in the SR-IOV network attachment definition CR. Both IPv4 and IPv6 addresses are supported. To use this feature, you also must specify `{ "ips": true }` in the `SriovNetwork` object.
 
-. Apply the YAML: 
+. Apply the YAML:
 +
 [source,terminal]
 ----
@@ -214,7 +212,7 @@ tunepod   1/1     Running   0          47s
 +
 [source,terminal]
 ----
-$ oc rsh -n sysctl-tuning-test tunepod 
+$ oc rsh -n sysctl-tuning-test tunepod
 ----
 
 . Verify the values of the configured `sysctl` flag. Find the value  `net.ipv6.neigh.IFNAME.base_reachable_time_ms` by running the following command::

--- a/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
+++ b/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
@@ -35,13 +35,12 @@ apiVersion: "k8s.cni.cncf.io/v1"
       "type": "bond", <1>
       "cniVersion": "0.3.1",
       "name": "bond-net1",
-      "ifname": "bond0", <2>
-      "mode": "active-backup", <3>
-      "failOverMac": 1, <4>
-      "linksInContainer": true, <5>
+      "mode": "active-backup", <2>
+      "failOverMac": 1, <3>
+      "linksInContainer": true, <4>
       "miimon": "100",
       "mtu": 1500,
-      "links": [ <6>
+      "links": [ <5>
             {"name": "net1"},
             {"name": "net2"}
         ],
@@ -55,9 +54,8 @@ apiVersion: "k8s.cni.cncf.io/v1"
         }
       }'
 ----
-<1> The type is `bond`.
-<2> The `ifname` attribute specifies the name of the bond interface.
-<3> The `mode` attribute specifies the bonding mode.
+<1> The cni-type is always set to `bond`.
+<2> The `mode` attribute specifies the bonding mode.
 +
 [NOTE]
 ====
@@ -69,16 +67,16 @@ The bonding modes supported are:
 
 For `balance-rr` or `balance-xor` modes, you must set the `trust` mode to `on` for the SR-IOV virtual function.
 ====
-<4> The `failover` attribute is mandatory for active-backup mode.
-<5> The `linksInContainer=true` flag informs the Bond CNI that the interfaces required are to be found inside the container. By default Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV and Multus.
-<6> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
+<3> The `failover` attribute is mandatory for active-backup mode and must be set to 1.
+<4> The `linksInContainer=true` flag informs the Bond CNI that the required interfaces are to be found inside the container. By default, Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV and Multus.
+<5> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
 
 [id="nw-sriov-cfg-creating-pod-using-interface_{context}"]
 == Creating a pod using a bond interface
 
-You can now test the setup by creating a pod using a bond interface.
-
-[source,yaml,subs="attributes+"]
+. Test the setup by creating a pod with a YAML file named for example `podbonding.yaml` with content similar to the following:
++
+[source,yaml]
 ----
 apiVersion: v1
     kind: Pod
@@ -90,12 +88,20 @@ apiVersion: v1
     spec:
       containers:
       - name: podexample
-        image: quay.io/openshift/origin-network-interface-bond-cni:{product-version}.0
+        image: quay.io/openshift/origin-network-interface-bond-cni:4.11.0
         command: ["/bin/bash", "-c", "sleep INF"]
 ----
 <1> Note the network annotation: it contains two SR-IOV network attachments, and one bond network attachment. The bond attachment uses the two SR-IOV interfaces as bonded port interfaces.
 
-You can inspect the pod interfaces with the following command:
+. Apply the yaml by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f podbonding.yaml
+----
+
+. Inspect the pod interfaces with the following command:
++
 [source,yaml]
 ----
 $ oc rsh -n demo bondpod1
@@ -109,14 +115,28 @@ valid_lft forever preferred_lft forever
 link/ether 62:b1:b5:c8:fb:7a brd ff:ff:ff:ff:ff:ff
 inet 10.244.1.122/24 brd 10.244.1.255 scope global eth0
 valid_lft forever preferred_lft forever
-4: bond0: <BROADCAST,MULTICAST,UP,LOWER_UP400> mtu 1500 qdisc noqueue state UP qlen 1000
-link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff
+4: net3: <BROADCAST,MULTICAST,UP,LOWER_UP400> mtu 1500 qdisc noqueue state UP qlen 1000
+link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <1>
 inet 10.56.217.66/24 scope global bond0
 valid_lft forever preferred_lft forever
 43: net1: <BROADCAST,MULTICAST,UP,LOWER_UP800> mtu 1500 qdisc mq master bond0 state UP qlen 1000
-link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <1>
-44: net2: <BROADCAST,MULTICAST,UP,LOWER_UP800> mtu 1500 qdisc mq master bond0 state UP qlen 1000
 link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <2>
+44: net2: <BROADCAST,MULTICAST,UP,LOWER_UP800> mtu 1500 qdisc mq master bond0 state UP qlen 1000
+link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <3>
 ----
-<1> The `net1` interface is based on an SR-IOV virtual function.
-<2> The `net2` interface is based on an SR-IOV virtual function.
+<1> The bond interface is automatically named `net3`. To set a specific interface name add `@name` suffix to the pod’s `k8s.v1.cni.cncf.io/networks` annotation.
+<2> The `net1` interface is based on an SR-IOV virtual function.
+<3> The `net2` interface is based on an SR-IOV virtual function.
++
+[NOTE]
+====
+If no interface names are configured in the pod annotation, interface names are assigned automatically as `net<n>`, with `<n>` starting at `1`.
+====
+
+. Optional: If you want to set a specific interface name for example `bond0`, edit the `k8s.v1.cni.cncf.io/networks` annotation and set `bond0` as the interface name as follows:
++
+[source,terminal]
+----
+annotations:
+        k8s.v1.cni.cncf.io/networks: demo/sriovnet1, demo/sriovnet2, demo/bond-net1@bond0
+----


### PR DESCRIPTION
[OCPBUGS-6674]: the ifname parameter is now obsolete

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Main, 4.13, 4.12, 4.11

Issue:
https://issues.redhat.com/browse/OCPBUGS-6674

Link to docs preview:
* https://55552--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/using-pod-level-bonding.html#nw-sriov-cfg-creating-pod-using-interface_using-pod-level-bonding
* https://55552--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-interface-sysctl-sriov-device.html#configuring-sysctl-on-bonded-sriov-network_configuring-sysctl-interface-sriov-device

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
