### PR TITLE
TELCODOCS-1043 - Adding partner agreed PTP config

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc
@@ -10,7 +10,10 @@ You can configure the `linuxptp` services (`ptp4l`, `phc2sys`) as boundary clock
 
 [NOTE]
 ====
-Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as the boundary clock for your particular hardware and environment. This example CR also configures PTP fast events by setting appropriate values for `ptp4lOpts`, `ptp4lConf`, and `ptpClockThreshold`. `ptpClockThreshold` is used only when events are enabled.
+Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as the boundary clock for your particular hardware and environment.
+This example CR does not configure PTP fast events. To configure PTP fast events, set appropriate values for `ptp4lOpts`, `ptp4lConf`, and `ptpClockThreshold`.
+`ptpClockThreshold` is used only when events are enabled.
+See "Configuring the PTP fast event notifications publisher" for more information.
 ====
 
 .Prerequisites
@@ -25,155 +28,201 @@ Use the following example `PtpConfig` CR as the basis to configure `linuxptp` se
 
 . Create the following `PtpConfig` CR, and then save the YAML in the `boundary-clock-ptp-config.yaml` file.
 +
+.Recommended PTP boundary clock configuration
 [source,yaml]
 ----
+---
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
-  name: boundary-clock-ptp-config                     <1>
+  name: boundary-clock-ptp-config
   namespace: openshift-ptp
 spec:
-  profile:                                            <2>
-  - name: "<profile_name>"                            <3>
-    ptp4lOpts: "-2 --summary_interval -4"             <4>
-    ptp4lConf: |                                      <5>
-      [ens1f0]                                        <6>
+  profile:
+  - name: boundary-clock
+    phc2sysOpts: "-a -r -n 24"
+    ptp4lOpts: "-2"
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    ptp4lConf: |
+      [<interface_1>]
       masterOnly 0
-      [ens1f3]                                        <7>
+      [<interface_2>]
+      masterOnly 1
+      [<interface_3>]
+      masterOnly 1
+      [<interface_4>]
       masterOnly 1
       [global]
       #
       # Default Data Set
       #
-      twoStepFlag                       1
-      #slaveOnly                        1
-      priority1                         128
-      priority2                         128
-      domainNumber                      24
-      #utc_offset                       37
-      clockClass                        248
-      clockAccuracy                     0xFE
-      offsetScaledLogVariance           0xFFFF
-      free_running                      0
-      freq_est_interval                 1
-      dscp_event                        0
-      dscp_general                      0
-      dataset_comparison                G.8275.x
-      G.8275.defaultDS.localPriority    128
+      twoStepFlag 1
+      slaveOnly 0
+      priority1 128
+      priority2 128
+      domainNumber 24
+      clockClass 248
+      clockAccuracy 0xFE
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
       #
       # Port Data Set
       #
-      logAnnounceInterval              -3
-      logSyncInterval                  -4
-      logMinDelayReqInterval           -4
-      logMinPdelayReqInterval          -4
-      announceReceiptTimeout            3
-      syncReceiptTimeout                0
-      delayAsymmetry                    0
-      fault_reset_interval              4
-      neighborPropDelayThresh           20000000
-      masterOnly                        0
-      G.8275.portDS.localPriority       128
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval -4
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval 4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
       #
-      # Runtime options
+      # Run time options
       #
-      assume_two_step                   0
-      logging_level                     6
-      path_trace_enabled                0
-      follow_up_info                    0
-      hybrid_e2e                        0
-      inhibit_multicast_service         0
-      net_sync_monitor                  0
-      tc_spanning_tree                  0
-      tx_timestamp_timeout              10            <8>
-      unicast_listen                    0
-      unicast_master_table              0
-      unicast_req_duration              3600
-      use_syslog                        1
-      verbose                           0
-      summary_interval                 -4
-      kernel_leap                       1
-      check_fup_sync                    0
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval 0
+      kernel_leap 1
+      check_fup_sync 0
       #
       # Servo Options
       #
-      pi_proportional_const             0.0
-      pi_integral_const                 0.0
-      pi_proportional_scale             0.0
-      pi_proportional_exponent         -0.3
-      pi_proportional_norm_max          0.7
-      pi_integral_scale                 0.0
-      pi_integral_exponent              0.4
-      pi_integral_norm_max              0.3
-      step_threshold                    2.0
-      first_step_threshold              0.00002
-      max_frequency                     900000000
-      clock_servo                       pi
-      sanity_freq_limit                 200000000
-      ntpshm_segment                    0
+      pi_proportional_const 0.0
+      pi_integral_const 0.0
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 2.0
+      first_step_threshold 0.00002
+      max_frequency 900000000
+      clock_servo pi
+      sanity_freq_limit 200000000
+      ntpshm_segment 0
       #
       # Transport options
       #
-      transportSpecific                 0x0
-      ptp_dst_mac                       01:1B:19:00:00:00
-      p2p_dst_mac                       01:80:C2:00:00:0E
-      udp_ttl                           1
-      udp6_scope                        0x0E
-      uds_address                       /var/run/ptp4l
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
       #
       # Default interface options
       #
-      clock_type                        BC
-      network_transport                 L2
-      delay_mechanism                   E2E
-      time_stamping                     hardware
-      tsproc_mode                       filter
-      delay_filter                      moving_median
-      delay_filter_length               10
-      egressLatency                     0
-      ingressLatency                    0
-      boundary_clock_jbod               0             <9>
+      clock_type BC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 0
       #
       # Clock description
       #
-      productDescription                ;;
-      revisionData                      ;;
-      manufacturerIdentity              00:00:00
-      userDescription                   ;
-      timeSource                        0xA0
-    phc2sysOpts:                        "-a -r -n 24" <10>
-    ptpSchedulingPolicy:                SCHED_OTHER   <11>
-    ptpSchedulingPriority:              10            <12>
-  ptpClockThreshold:                                  <13>
-    holdOverTimeout:                    5
-    maxOffsetThreshold:                 100
-    minOffsetThreshold:                -100
-  recommend:                                          <14>
-  - profile: "<profile_name>"                         <15>
-    priority: 10                                      <16>
-    match:                                            <17>
-    - nodeLabel: "<node_label>"                       <18>
-      nodeName: "<node_name>"                         <19>
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0xA0
+  recommend:
+  - profile: boundary-clock
+    priority: 4
+    match:
+    - nodeLabel: node-role.kubernetes.io/master
+      nodeName: <nodename>
 ----
-<1> The name of the `PtpConfig` CR.
-<2> Specify an array of one or more `profile` objects.
-<3> Specify the name of a profile object which uniquely identifies a profile object.
-<4> Specify system config options for the `ptp4l` service. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
-<5> Specify the needed configuration to start `ptp4l` as boundary clock. For example, `ens1f0` synchronizes from a grandmaster clock and `ens1f3` synchronizes connected devices.
-<6> The interface that receives the synchronization clock.
-<7> The interface that sends the synchronization clock.
-<8> For Intel Columbiaville 800 Series NICs, set `tx_timestamp_timeout` to `50`.
-<9> For Intel Columbiaville 800 Series NICs, ensure `boundary_clock_jbod` is set to `0`. For Intel Fortville X710 Series NICs, ensure `boundary_clock_jbod` is set to `1`.
-<10> Specify system config options for the `phc2sys` service. If this field is empty the PTP Operator does not start the `phc2sys` service.
-<11> Scheduling policy for ptp4l and phc2sys processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
-<12> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
-<13> Optional. If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields. Stanza shows default `ptpClockThreshold` values. `ptpClockThreshold` values configure how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.
-<14> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
-<15> Specify the `profile` object name defined in the `profile` section.
-<16> Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
-<17> Specify `match` rules with `nodeLabel` or `nodeName`.
-<18> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command. For example: `node-role.kubernetes.io/worker`.
-<19> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command. For example: `node-role.kubernetes.io/worker`. For example: `compute-0.example.com`.
++
+.PTP boundary clock CR configuration options
+[cols="1,3" options="header"]
+|====
+|Custom resource field
+|Description
+
+|`name`
+|The name of the `PtpConfig` CR.
+
+|`profile`
+|Specify an array of one or more `profile` objects.
+
+|`name`
+|Specify the name of a profile object which uniquely identifies a profile object.
+
+|`ptp4lOpts`
+|Specify system config options for the `ptp4l` service. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
+
+|`ptp4lConf`
+|Specify the required configuration to start `ptp4l` as boundary clock. For example, `ens1f0` synchronizes from a grandmaster clock and `ens1f3` synchronizes connected devices.
+
+|`<interface_1>`
+|The interface that receives the synchronization clock.
+
+|`<interface_2>`
+|The interface that sends the synchronization clock.
+
+|`tx_timestamp_timeout`
+|For Intel Columbiaville 800 Series NICs, set `tx_timestamp_timeout` to `50`.
+
+|`boundary_clock_jbod`
+|For Intel Columbiaville 800 Series NICs, ensure `boundary_clock_jbod` is set to `0`. For Intel Fortville X710 Series NICs, ensure `boundary_clock_jbod` is set to `1`.
+
+|`phc2sysOpts`
+|Specify system config options for the `phc2sys` service. If this field is empty, the PTP Operator does not start the `phc2sys` service.
+
+|`ptpSchedulingPolicy`
+|Scheduling policy for ptp4l and phc2sys processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
+
+|`ptpSchedulingPriority`
+|Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
+
+|`ptpClockThreshold`
+|Optional. If `ptpClockThreshold` is not present, default values are used for the `ptpClockThreshold` fields. `ptpClockThreshold` configures how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.
+
+|`recommend`
+|Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
+
+|`.recommend.profile`
+|Specify the `.recommend.profile` object name defined in the `profile` section.
+
+|`.recommend.priority`
+|Specify the `priority` with an integer value between `0` and `99`. A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`. If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
+
+|`.recommend.match`
+|Specify `.recommend.match` rules with `nodeLabel` or `nodeName`.
+
+|`.recommend.match.nodeLabel`
+|Update `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command. For example: `node-role.kubernetes.io/worker`.
+
+|`.recommend.match.nodeLabel`
+|Update `nodeName` with value of `node.Name` from the node object by using the `oc get nodes` command. For example: `compute-0.example.com`.
+|====
 
 . Create the CR by running the following command:
 +
@@ -217,7 +266,7 @@ I1115 09:41:17.117604 4143292 daemon.go:109] updating NodePTPProfile to:
 I1115 09:41:17.117607 4143292 daemon.go:110] ------------------------------------
 I1115 09:41:17.117612 4143292 daemon.go:102] Profile Name: profile1
 I1115 09:41:17.117616 4143292 daemon.go:102] Interface:
-I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -2 --summary_interval -4
+I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -2
 I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r -n 24
 I1115 09:41:17.117626 4143292 daemon.go:116] ------------------------------------
 ----

--- a/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc
@@ -10,7 +10,10 @@ You can configure `linuxptp` services (`ptp4l`, `phc2sys`) as ordinary clock by 
 
 [NOTE]
 ====
-Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as ordinary clock for your particular hardware and environment. This example CR also configures PTP fast events by setting appropriate values for `ptp4lOpts`, `ptp4lConf` and `ptpClockThreshold`. `ptpClockThreshold` is used only when events are enabled.
+Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as an ordinary clock for your particular hardware and environment.
+This example CR does not configure PTP fast events.
+To configure PTP fast events, set appropriate values for `ptp4lOpts`, `ptp4lConf`, and `ptpClockThreshold`. `ptpClockThreshold` is required only when events are enabled.
+See "Configuring the PTP fast event notifications publisher" for more information.
 ====
 
 .Prerequisites
@@ -23,151 +26,188 @@ Use the following example `PtpConfig` CR as the basis to configure `linuxptp` se
 
 . Create the following `PtpConfig` CR, and then save the YAML in the `ordinary-clock-ptp-config.yaml` file.
 +
+[[ptp-ordinary-clock]]
+.Recommended PTP ordinary clock configuration
 [source,yaml]
 ----
 apiVersion: ptp.openshift.io/v1
 kind: PtpConfig
 metadata:
-  name: ordinary-clock-ptp-config                       <1>
+  name: ordinary-clock-ptp-config
   namespace: openshift-ptp
-spec:
-  profile:                                              <2>
-  - name: "<profile_name>"                              <3>
-    interface: ""<interface_name>"                      <4>
-    ptp4lOpts: "-2 -s --summary_interval -4"            <5>
-    phc2sysOpts: "-a -r -n 24"                          <6>
-    ptp4lConf: |                                        <7>
-     [global]
-      #
-      # Default Data Set
-      #
-      twoStepFlag                        1
-      slaveOnly                          0
-      priority1                          128
-      priority2                          128
-      domainNumber                       24
-      #utc_offset                        37
-      clockClass                         248
-      clockAccuracy                      0xFE
-      offsetScaledLogVariance            0xFFFF
-      free_running                       0
-      freq_est_interval                  1
-      dscp_event                         0
-      dscp_general                       0
-      dataset_comparison                 G.8275.x
-      G.8275.defaultDS.localPriority     128
-      #
-      # Port Data Set
-      #
-      logAnnounceInterval               -3
-      logSyncInterval                   -4
-      logMinDelayReqInterval            -4
-      logMinPdelayReqInterval           -4
-      announceReceiptTimeout             3
-      syncReceiptTimeout                 0
-      delayAsymmetry                     0
-      fault_reset_interval               4
-      neighborPropDelayThresh            20000000
-      masterOnly                         0
-      G.8275.portDS.localPriority        128
-      #
-      # Run time options
-      #
-      assume_two_step                    0
-      logging_level                      6
-      path_trace_enabled                 0
-      follow_up_info                     0
-      hybrid_e2e                         0
-      inhibit_multicast_service          0
-      net_sync_monitor                   0
-      tc_spanning_tree                   0
-      tx_timestamp_timeout               10             <8>
-      unicast_listen                     0
-      unicast_master_table               0
-      unicast_req_duration               3600
-      use_syslog                         1
-      verbose                            0
-      summary_interval                   0
-      kernel_leap                        1
-      check_fup_sync                     0
-      #
-      # Servo Options
-      #
-      pi_proportional_const              0.0
-      pi_integral_const                  0.0
-      pi_proportional_scale              0.0
-      pi_proportional_exponent          -0.3
-      pi_proportional_norm_max           0.7
-      pi_integral_scale                  0.0
-      pi_integral_exponent               0.4
-      pi_integral_norm_max               0.3
-      step_threshold                     2.0
-      first_step_threshold               0.00002
-      max_frequency                      900000000
-      clock_servo                        pi
-      sanity_freq_limit                  200000000
-      ntpshm_segment                     0
-      #
-      # Transport options
-      #
-      transportSpecific                  0x0
-      ptp_dst_mac                        01:1B:19:00:00:00
-      p2p_dst_mac                        01:80:C2:00:00:0E
-      udp_ttl                            1
-      udp6_scope                         0x0E
-      uds_address                        /var/run/ptp4l
-      #
-      # Default interface options
-      #
-      clock_type                         OC
-      network_transport                  L2
-      delay_mechanism                    E2E
-      time_stamping                      hardware
-      tsproc_mode                        filter
-      delay_filter                       moving_median
-      delay_filter_length                10
-      egressLatency                      0
-      ingressLatency                     0
-      boundary_clock_jbod                0              <9>
-      #
-      # Clock description
-      #
-      productDescription                 ;;
-      revisionData                       ;;
-      manufacturerIdentity               00:00:00
-      userDescription                    ;
-      timeSource                         0xA0
-    ptpSchedulingPolicy:                 SCHED_OTHER    <10>
-    ptpSchedulingPriority:               10             <11>
-  ptpClockThreshold:                                    <12>
-    holdOverTimeout:                     5
-    maxOffsetThreshold:                  100
-    minOffsetThreshold:                 -100
-  recommend:                                            <13>
-  - profile: "profile1"                                 <14>
-    priority: 0                                         <15>
-    match:                                              <16>
-    - nodeLabel: "node-role.kubernetes.io/worker"       <17>
-      nodeName: "compute-0.example.com"                 <18>
+  spec:
+    profile:
+      - name: ordinary-clock
+        interface: "<interface_name>"
+        phc2sysOpts: "-a -r -n 24"
+        ptp4lOpts: "-2 -s"
+        ptpSchedulingPolicy: SCHED_FIFO
+        ptpSchedulingPriority: 10
+        ptp4lConf: |
+          [global]
+          #
+          # Default Data Set
+          #
+          twoStepFlag 1
+          slaveOnly 1
+          priority1 128
+          priority2 128
+          domainNumber 24
+          clockClass 255
+          clockAccuracy 0xFE
+          offsetScaledLogVariance 0xFFFF
+          free_running 0
+          freq_est_interval 1
+          dscp_event 0
+          dscp_general 0
+          dataset_comparison G.8275.x
+          G.8275.defaultDS.localPriority 128
+          #
+          # Port Data Set
+          #
+          logAnnounceInterval -3
+          logSyncInterval -4
+          logMinDelayReqInterval -4
+          logMinPdelayReqInterval -4
+          announceReceiptTimeout 3
+          syncReceiptTimeout 0
+          delayAsymmetry 0
+          fault_reset_interval 4
+          neighborPropDelayThresh 20000000
+          masterOnly 0
+          G.8275.portDS.localPriority 128
+          #
+          # Run time options
+          #
+          assume_two_step 0
+          logging_level 6
+          path_trace_enabled 0
+          follow_up_info 0
+          hybrid_e2e 0
+          inhibit_multicast_service 0
+          net_sync_monitor 0
+          tc_spanning_tree 0
+          tx_timestamp_timeout 50
+          unicast_listen 0
+          unicast_master_table 0
+          unicast_req_duration 3600
+          use_syslog 1
+          verbose 0
+          summary_interval 0
+          kernel_leap 1
+          check_fup_sync 0
+          #
+          # Servo Options
+          #
+          pi_proportional_const 0.0
+          pi_integral_const 0.0
+          pi_proportional_scale 0.0
+          pi_proportional_exponent -0.3
+          pi_proportional_norm_max 0.7
+          pi_integral_scale 0.0
+          pi_integral_exponent 0.4
+          pi_integral_norm_max 0.3
+          step_threshold 2.0
+          first_step_threshold 0.00002
+          max_frequency 900000000
+          clock_servo pi
+          sanity_freq_limit 200000000
+          ntpshm_segment 0
+          #
+          # Transport options
+          #
+          transportSpecific 0x0
+          ptp_dst_mac 01:1B:19:00:00:00
+          p2p_dst_mac 01:80:C2:00:00:0E
+          udp_ttl 1
+          udp6_scope 0x0E
+          uds_address /var/run/ptp4l
+          #
+          # Default interface options
+          #
+          clock_type OC
+          network_transport L2
+          delay_mechanism E2E
+          time_stamping hardware
+          tsproc_mode filter
+          delay_filter moving_median
+          delay_filter_length 10
+          egressLatency 0
+          ingressLatency 0
+          boundary_clock_jbod 0
+          #
+          # Clock description
+          #
+          productDescription ;;
+          revisionData ;;
+          manufacturerIdentity 00:00:00
+          userDescription ;
+          timeSource 0xA0
+      recommend:
+      - profile: ordinary-clock
+        priority: 4
+        match:
+        - nodeLabel: "node-role.kubernetes.io/worker"
+          nodeName: "<node_name>"
 ----
-<1> The name of the `PtpConfig` CR.
-<2> Specify an array of one or more `profile` objects.
-<3> Specify a unique name for the profile object.
-<4> Specify the network interface to be used by the `ptp4l` service, for example `ens787f1`.
-<5> Specify system config options for the `ptp4l` service, for example `-2` to select the IEEE 802.3 network transport. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended. Append `--summary_interval -4` to use PTP fast events with this interface.
-<6> Specify system config options for the `phc2sys` service. If this field is empty the PTP Operator does not start the `phc2sys` service. For Intel Columbiaville 800 Series NICs, set `phc2sysOpts` options to `-a -r -m -n 24 -N 8 -R 16`. `-m` prints messages to `stdout`. The `linuxptp-daemon` `DaemonSet` parses the logs and generates Prometheus metrics.
-<7> Specify a string that contains the configuration to replace the default `/etc/ptp4l.conf` file. To use the default configuration, leave the field empty.
-<8> For Intel Columbiaville 800 Series NICs, set `tx_timestamp_timeout` to `50`.
-<9> For Intel Columbiaville 800 Series NICs, set `boundary_clock_jbod` to `0`.
-<10> Scheduling policy for `ptp4l` and `phc2sys` processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
-<11> Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
-<12> Optional. If the `ptpClockThreshold` stanza is not present, default values are used for the `ptpClockThreshold` fields. The stanza shows default `ptpClockThreshold` values. The `ptpClockThreshold` values configure how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.
-<13> Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
-<14> Specify the `profile` object name defined in the `profile` section.
-<15> Set `priority` to `0` for ordinary clock.
-<16> Specify `match` rules with `nodeLabel` or `nodeName`.
-<17> Specify `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command.
-<18> Specify `nodeName` with `node.Name` from the node object by using the `oc get nodes` command.
++
+.PTP ordinary clock CR configuration options
+[cols="1,3" options="header"]
+|====
+|Custom resource field
+|Description
+
+|`name`
+|The name of the `PtpConfig` CR.
+
+|`profile`
+|Specify an array of one or more `profile` objects. Each profile must be uniquely named.
+
+|`interface`
+|Specify the network interface to be used by the `ptp4l` service, for example `ens787f1`.
+
+|`ptp4lOpts`
+|Specify system config options for the `ptp4l` service, for example `-2` to select the IEEE 802.3 network transport. The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended. Append `--summary_interval -4` to use PTP fast events with this interface.
+
+|`phc2sysOpts`
+|Specify system config options for the `phc2sys` service. If this field is empty, the PTP Operator does not start the `phc2sys` service. For Intel Columbiaville 800 Series NICs, set `phc2sysOpts` options to `-a -r -m -n 24 -N 8 -R 16`. `-m` prints messages to `stdout`. The `linuxptp-daemon` `DaemonSet` parses the logs and generates Prometheus metrics.
+
+|`ptp4lConf`
+|Specify a string that contains the configuration to replace the default `/etc/ptp4l.conf` file. To use the default configuration, leave the field empty.
+
+|`tx_timestamp_timeout`
+|For Intel Columbiaville 800 Series NICs, set `tx_timestamp_timeout` to `50`.
+
+|`boundary_clock_jbod`
+|For Intel Columbiaville 800 Series NICs, set `boundary_clock_jbod` to `0`.
+
+|`ptpSchedulingPolicy`
+|Scheduling policy for `ptp4l` and `phc2sys` processes. Default value is `SCHED_OTHER`. Use `SCHED_FIFO` on systems that support FIFO scheduling.
+
+|`ptpSchedulingPriority`
+|Integer value from 1-65 used to set FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`. The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
+
+|`ptpClockThreshold`
+|Optional. If `ptpClockThreshold` is not present, default values are used for the `ptpClockThreshold` fields. `ptpClockThreshold` configures how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.
+
+|`recommend`
+|Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
+
+|`.recommend.profile`
+|Specify the `.recommend.profile` object name defined in the `profile` section.
+
+|`.recommend.priority`
+|Set `.recommend.priority` to `0` for ordinary clock.
+
+|`.recommend.match`
+|Specify `.recommend.match` rules with `nodeLabel` or `nodeName`.
+
+|`.recommend.match.nodeLabel`
+|Update `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc get nodes --show-labels` command. For example: `node-role.kubernetes.io/worker`.
+
+|`.recommend.match.nodeLabel`
+|Update `nodeName` with value of `node.Name` from the node object by using the `oc get nodes` command. For example: `compute-0.example.com`.
+|====
 
 . Create the `PtpConfig` CR by running the following command:
 +
@@ -211,7 +251,7 @@ I1115 09:41:17.117604 4143292 daemon.go:109] updating NodePTPProfile to:
 I1115 09:41:17.117607 4143292 daemon.go:110] ------------------------------------
 I1115 09:41:17.117612 4143292 daemon.go:102] Profile Name: profile1
 I1115 09:41:17.117616 4143292 daemon.go:102] Interface: ens787f1
-I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -2 -s --summary_interval -4
+I1115 09:41:17.117620 4143292 daemon.go:102] Ptp4lOpts: -2 -s
 I1115 09:41:17.117623 4143292 daemon.go:102] Phc2sysOpts: -a -r -n 24
 I1115 09:41:17.117626 4143292 daemon.go:116] ------------------------------------
 ----

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -63,12 +63,16 @@ include::modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc[lev
 
 * For more information about FIFO priority scheduling on PTP hardware, see xref:../networking/using-ptp.adoc#cnf-configuring-fifo-priority-scheduling-for-ptp_using-ptp[Configuring FIFO priority scheduling for PTP hardware].
 
+* For more information about configuring PTP fast events, see xref:../networking/using-ptp.adoc#cnf-configuring-the-ptp-fast-event-publisher_using-ptp[Configuring the PTP fast event notifications publisher].
+
 include::modules/nw-ptp-configuring-linuxptp-services-as-boundary-clock.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
 * For more information about FIFO priority scheduling on PTP hardware, see xref:../networking/using-ptp.adoc#cnf-configuring-fifo-priority-scheduling-for-ptp_using-ptp[Configuring FIFO priority scheduling for PTP hardware].
+
+* For more information about configuring PTP fast events, see xref:../networking/using-ptp.adoc#cnf-configuring-the-ptp-fast-event-publisher_using-ptp[Configuring the PTP fast event notifications publisher].
 
 include::modules/ptp-configuring-linuxptp-services-as-boundary-clock-dual-nic.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Updates recommended PTP boundary and ordinary clock config CRs based on joint agreement with Ericsson, Verizon, Red Hat and Intel. 

Version(s):
4.10, 4.11, 4.12, 4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-1043

Link to docs preview:
* [Configuring linuxptp services as an ordinary clock](https://55553--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-ordinary-clock_using-ptp)
* [Configuring linuxptp services as an boundary clock](https://55553--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-boundary-clock_using-ptp)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->