### PR TITLE
CNV19923: updates to reserving PVC space

### DIFF
--- a/modules/virt-how-fs-overhead-affects-space-vm-disks.adoc
+++ b/modules/virt-how-fs-overhead-affects-space-vm-disks.adoc
@@ -8,8 +8,8 @@
 When you add a virtual machine disk to a persistent volume claim (PVC) that uses the `Filesystem` volume mode, you must ensure that there is enough space on the PVC for:
 
 * The virtual machine disk.
-* The space that the Containerized Data Importer (CDI) reserves for file system overhead, such as metadata.
+* The space reserved for file system overhead, such as metadata
 
-By default, CDI reserves 5.5% of the PVC space for overhead, reducing the space available for virtual machine disks by that amount.
+By default, {VirtProductName} reserves 5.5% of the PVC space for overhead, reducing the space available for virtual machine disks by that amount.
 
-If a different value works better for your use case, you can configure the overhead value by editing the `CDI` object. You can change the value globally and you can specify values for specific storage classes.
+You can configure a different overhead value by editing the `HCO` object. You can change the value globally and you can specify values for specific storage classes.

--- a/modules/virt-overriding-default-fs-overhead-value.adoc
+++ b/modules/virt-overriding-default-fs-overhead-value.adoc
@@ -6,7 +6,7 @@
 [id="virt-overriding-default-fs-overhead-value_{context}"]
 = Overriding the default file system overhead value
 
-Change the amount of persistent volume claim (PVC) space that the Containerized Data Importer (CDI) reserves for file system overhead by editing the `spec.config.filesystemOverhead` attribute of the `CDI` object.
+Change the amount of persistent volume claim (PVC) space that the {VirtProductName} reserves for file system overhead by editing the `spec.config.filesystemOverhead` attribute of the `HCO` object.
 
 .Prerequisites
 
@@ -14,11 +14,11 @@ Change the amount of persistent volume claim (PVC) space that the Containerized 
 
 .Procedure
 
-. Open the `CDI` object for editing by running the following command:
+. Open the `HCO` object for editing by running the following command:
 +
 [source,terminal]
 ----
-$ oc edit cdi
+$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
 ----
 
 . Edit the `spec.config.filesystemOverhead` fields, populating them with your chosen values:
@@ -33,16 +33,25 @@ spec:
       storageClass:
         <storage_class_name>: "<new_value_for_this_storage_class>" <2>
 ----
-<1> The file system overhead percentage that CDI uses across the cluster. For example, `global: "0.07"` reserves 7% of the PVC for file system overhead.
+<1> The default file system overhead percentage used for any storage classes that do not already have a set value. For example, `global: "0.07"` reserves 7% of the PVC for file system overhead.
 <2> The file system overhead percentage for the specified storage class. For example, `mystorageclass: "0.04"` changes the default overhead value for PVCs in the `mystorageclass` storage class to 4%.
 
-. Save and exit the editor to update the `CDI` object.
+. Save and exit the editor to update the `HCO` object.
 
 .Verification
 
-* View the `CDI` status and verify your changes by running the following command:
+* View the `CDIConfig` status and verify your changes by running one of the following commands:
++
+To generally verify changes to `CDIConfig`:
 +
 [source,terminal]
 ----
-$ oc get cdi -o yaml
+$ oc get cdiconfig -o yaml
+----
++
+To view your specific changes to `CDIConfig`:
++
+[source,terminal]
+----
+$ oc get cdiconfig -o jsonpath='{.items..status.filesystemOverhead}'
 ----

--- a/virt/virtual_machines/virtual_disks/virt-reserving-pvc-space-fs-overhead.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-reserving-pvc-space-fs-overhead.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-By default, the Containerized Data Importer (CDI) reserves space for file system overhead data in persistent volume claims (PVCs) that use the `Filesystem` volume mode. You can set the percentage that CDI reserves for this purpose globally and for specific storage classes.
+By default, the {VirtProductName} reserves space for file system overhead data in persistent volume claims (PVCs) that use the `Filesystem` volume mode. You can set the percentage to reserve space for this purpose globally and for specific storage classes.
 
 include::modules/virt-how-fs-overhead-affects-space-vm-disks.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-19923](https://issues.redhat.com//browse/CNV-19923)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/sjess/CNV19923-3/virt/virtual_machines/virtual_disks/virt-reserving-pvc-space-fs-overhead.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Kevin Goldblatt
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Recreation of wonky https://github.com/openshift/openshift-docs/pull/54363 . Peer review complete. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
