### PR TITLE
[RHACS] Updated integration docs for the new Clair v4 integration

### DIFF
--- a/integration/integrate-with-image-vulnerability-scanners.adoc
+++ b/integration/integrate-with-image-vulnerability-scanners.adoc
@@ -6,14 +6,14 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{product-title} (RHACS) integrates with various vulnerability scanners to enable you to import your container images and monitor them for vulnerabilities.
-You can set up {product-title} to obtain image vulnerability data from many open-source and commercial container image vulnerability scanners, including:
+{product-title} (RHACS) integrates with various vulnerability scanners to enable you to import your container images and watch them for vulnerabilities.
+You can set up {product-title} to obtain image vulnerability data from many open source and commercial container image vulnerability scanners, including:
 
 * link:https://github.com/quay/clair[Clair]
 * link:https://cloud.google.com/container-registry/docs/container-analysis[Google Container Analysis]
 * link:https://quay.io[Red Hat Quay]
 
-If you are using one of these products in your DevOps workflow, you can use the {product-title-short} portal to configure a connection with {product-title-short}. Once integrated, your image vulnerabilities are surfaced in the {product-title-short} portal and you can triage them easily.
+If you use one of these products in your DevOps workflow, you can use the {product-title-short} portal to configure an integration with your vulnerability scanner. After the integration, the {product-title-short} portal shows the image vulnerabilities and you can triage them easily.
 
 include::modules/integrate-with-clair.adoc[leveloffset=+1]
 

--- a/modules/integrate-with-clair.adoc
+++ b/modules/integrate-with-clair.adoc
@@ -3,17 +3,24 @@
 // * integration/integrate-with-image-vulnerability-scanners.adoc
 :_module-type: PROCEDURE
 [id="integrate-with-clair_{context}"]
-= Integrating with CoreOS Clair
+= Integrating with Clair
 
-You can integrate {product-title} with CoreOS Clair for the static analysis of vulnerabilities in your images.
+You can integrate {product-title} with Clair for the static analysis of vulnerabilities in your images.
+
+[NOTE]
+====
+* With {product-title-short} 3.74, you can integrate with Clair V4 Scanner.
+Red Hat has deprecated the previous CoreOS Clair integration in favor of Clair v4 integration.
+* There is no planned support for the link:https://quay.github.io/clair/concepts/authentication.html[JWT-based authentication] option for Clair V4 integration in the next {product-title-short} 4.0 release.
+====
 
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Integrations*.
-. Under the *Image Integrations* section, select *CoreOS Clair*.
-. Click *New integration*. 
+. Under the *Image Integrations* section, select *Clair v4*.
+. Click *New integration*.
 . Enter the details for the following fields:
 .. *Integration name*: The name of the integration.
 .. *Endpoint*: The address of the scanner.
 . (Optional) If you are not using a TLS certificate when connecting to the registry, select *Disable TLS certificate validation (insecure)*.
-. (Optional) Select *Test* to test that the integration with the selected registry is working.
-. Select *Save*.
+. (Optional) Click *Test* to test that the integration with the selected registry is working.
+. Click *Save*.


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-14257

Updated the steps to integrate with Clair V4.

- Merge into `rhacs-docs` and cherry-pick into `rhacs-docs-3.74`.

Preview: https://55587--docspreview.netlify.app/openshift-acs/latest/integration/integrate-with-image-vulnerability-scanners.html#integrate-with-clair_integrate-with-image-vulnerability-scanners