### PR TITLE
OADP-1223: Fix callouts in example Backup CR

### DIFF
--- a/modules/oadp-creating-backup-cr.adoc
+++ b/modules/oadp-creating-backup-cr.adoc
@@ -57,14 +57,14 @@ spec:
   excludedResources: [] <3>
   storageLocation: <velero-sample-1> <4>
   ttl: 720h0m0s
-  labelSelector: <3>
+  labelSelector: <5>
   - matchLabels:
       app=<label_1>
   - matchLabels:
       app=<label_2>
   - matchLabels:
       app=<label_3>
-  orlabelSelectors: <4>
+  orlabelSelectors: <6>
   - matchLabels:
       app=<label_1>
   - matchLabels:
@@ -76,6 +76,8 @@ spec:
 <2> Optional: Specify an array of resources to include in the backup. Resources might be shortcuts (for example, 'po' for 'pods') or fully-qualified. If unspecified, all resources are included.
 <3> Optional: Specify an array of resources to exclude from the backup. Resources might be shortcuts (for example, 'po' for 'pods') or fully-qualified.
 <4> Specify the name of the `backupStorageLocations` CR.
+<5> Backup resources that have all of the specified labels.
+<6> Backup resources that have one or more of the specified labels.
 
 . Verify that the status of the `Backup` CR is `Completed`:
 +


### PR DESCRIPTION
OADP 1.x.x; OCP 4.9+

Dev and QE approved. 

Resolves https://issues.redhat.com/browse/OADP-1223 by fixing the callouts in the example `Backup CR` and adding information that was inadvertently omitted. 

Preview: https://55589--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-creating-backup-cr_backing-up-applications [See the YAML file in step 2 of the procedure]. 