### PR TITLE
OCPBUGS 6674 410 the ifname parameter is now obsolete, it will not be used. The name will be taken from the pod annotation

### DIFF
--- a/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
+++ b/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
@@ -35,13 +35,12 @@ apiVersion: "k8s.cni.cncf.io/v1"
       "type": "bond", <1>
       "cniVersion": "0.3.1",
       "name": "bond-net1",
-      "ifname": "bond0", <2>
-      "mode": "active-backup", <3>
-      "failOverMac": 1, <4>
-      "linksInContainer": true, <5>
+      "mode": "active-backup", <2>
+      "failOverMac": 1, <3>
+      "linksInContainer": true, <4>
       "miimon": "100",
       "mtu": 1500,
-      "links": [ <6>
+      "links": [ <5>
             {"name": "net1"},
             {"name": "net2"}
         ],
@@ -55,29 +54,28 @@ apiVersion: "k8s.cni.cncf.io/v1"
         }
       }'
 ----
-<1> The type is `bond`.
-<2> The `ifname` attribute specifies the name of the bond interface.
-<3> The `mode` attribute specifies the bonding mode. 
+<1> The cni-type is always set to `bond`.
+<2> The `mode` attribute specifies the bonding mode.
 +
 [NOTE]
 ====
 The bonding modes supported are:
 
-* `balance-rr` - 0 
+* `balance-rr` - 0
 * `active-backup` - 1
 * `balance-xor` - 2
 
 For `balance-rr` or `balance-xor` modes, you must set the `trust` mode to `on` for the SR-IOV virtual function.
 ====
-<4> The `failover` attribute is mandatory for active-backup mode.
-<5> The `linksInContainer=true` flag informs the Bond CNI that the interfaces required are to be found inside the container. By default Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV and Multus.
-<6> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
+<3> The `failover` attribute is mandatory for active-backup mode and must be set to 1.
+<4> The `linksInContainer=true` flag informs the Bond CNI that the required interfaces are to be found inside the container. By default, Bond CNI looks for these interfaces on the host which does not work for integration with SRIOV and Multus.
+<5> The `links` section defines which interfaces will be used to create the bond. By default, Multus names the attached interfaces as: "net", plus a consecutive number, starting with one.
 
 [id="nw-sriov-cfg-creating-pod-using-interface_{context}"]
 == Creating a pod using a bond interface
 
-You can now test the setup by creating a pod using a bond interface.
-
+. Test the setup by creating a pod with a YAML file named for example `podbonding.yaml` with content similar to the following:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -95,7 +93,15 @@ apiVersion: v1
 ----
 <1> Note the network annotation: it contains two SR-IOV network attachments, and one bond network attachment. The bond attachment uses the two SR-IOV interfaces as bonded port interfaces.
 
-You can inspect the pod interfaces with the following command:
+. Apply the yaml by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f podbonding.yaml
+----
+
+. Inspect the pod interfaces with the following command:
++
 [source,yaml]
 ----
 $ oc rsh -n demo bondpod1
@@ -109,14 +115,28 @@ valid_lft forever preferred_lft forever
 link/ether 62:b1:b5:c8:fb:7a brd ff:ff:ff:ff:ff:ff
 inet 10.244.1.122/24 brd 10.244.1.255 scope global eth0
 valid_lft forever preferred_lft forever
-4: bond0: <BROADCAST,MULTICAST,UP,LOWER_UP400> mtu 1500 qdisc noqueue state UP qlen 1000
-link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff
+4: net3: <BROADCAST,MULTICAST,UP,LOWER_UP400> mtu 1500 qdisc noqueue state UP qlen 1000
+link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <1>
 inet 10.56.217.66/24 scope global bond0
 valid_lft forever preferred_lft forever
 43: net1: <BROADCAST,MULTICAST,UP,LOWER_UP800> mtu 1500 qdisc mq master bond0 state UP qlen 1000
-link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <1>
-44: net2: <BROADCAST,MULTICAST,UP,LOWER_UP800> mtu 1500 qdisc mq master bond0 state UP qlen 1000
 link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <2>
+44: net2: <BROADCAST,MULTICAST,UP,LOWER_UP800> mtu 1500 qdisc mq master bond0 state UP qlen 1000
+link/ether 9e:23:69:42:fb:8a brd ff:ff:ff:ff:ff:ff <3>
 ----
-<1> The `net1` interface is based on an SR-IOV virtual function.
-<2> The `net2` interface is based on an SR-IOV virtual function.
+<1> The bond interface is automatically named `net3`. To set a specific interface name add `@name` suffix to the pod’s `k8s.v1.cni.cncf.io/networks` annotation.
+<2> The `net1` interface is based on an SR-IOV virtual function.
+<3> The `net2` interface is based on an SR-IOV virtual function.
++
+[NOTE]
+====
+If no interface names are configured in the pod annotation, interface names are assigned automatically as `net<n>`, with `<n>` starting at `1`.
+====
+
+. Optional: If you want to set a specific interface name for example `bond0`, edit the `k8s.v1.cni.cncf.io/networks` annotation and set `bond0` as the interface name as follows:
++
+[source,terminal]
+----
+annotations:
+        k8s.v1.cni.cncf.io/networks: demo/sriovnet1, demo/sriovnet2, demo/bond-net1@bond0
+----


### PR DESCRIPTION
OCPBUGS-6674]: the ifname parameter is now obsolete

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OCPBUGS-6674

Link to docs preview:

http://file.emea.redhat.com/kquinn/OCPBUGS-6674/networking/hardware_networks/using-pod-level-bonding.html#nw-sriov-cfg-creating-bond-network-attachment-definition_using-pod-level-bonding

QE review:

 QE has approved this change.