### PR TITLE
Cherrypick-RN-4.8: Added 1.7.0 RN and resolved merge conflicts

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -22,6 +22,7 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-7-0.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-6-2.adoc[leveloffset=+1]
 
@@ -49,6 +50,10 @@ include::modules/gitops-release-notes-1-4-13.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-12.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-4-11.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-4-6.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-4-5.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-4-3.adoc[leveloffset=+1]
@@ -62,6 +67,8 @@ include::modules/gitops-release-notes-1-4-0.adoc[leveloffset=+1]
 include::modules/gitops-release-notes-1-3-7.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-6.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-3-3.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-3-2.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-4-11.adoc
+++ b/modules/gitops-release-notes-1-4-11.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-4-11_{context}"]
+= Release notes for {gitops-title} 1.4.11
+
+{gitops-title} 1.4.11 is now available on {product-title} 4.8, 4.9, and 4.10.
+
+[id="new-features-1-4-11_{context}"]
+== New features
+
+The current release adds the following improvements:
+
+* With this update, the bundled Argo CD has been updated to version 2.2.12.
+
+[id="fixed-issues-1-4-11_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, the `redis-ha-haproxy` pods of an ArgoCD instance failed when more restrictive SCCs were present in the cluster. This update fixes the issue by updating the security context in workloads. link:https://issues.redhat.com/browse/GITOPS-2034[GITOPS-2034]
+
+[id="known-issues-1-4-11_{context}"]
+== Known issues
+
+*  {gitops-title} Operator can use RHSSO (KeyCloak) with OIDC and Dex. However, with a recent security fix applied, the Operator cannot validate the RHSSO certificate in some scenarios. link:https://issues.redhat.com/browse/GITOPS-2214[GITOPS-2214]
++
+As a workaround, disable TLS validation for the OIDC (Keycloak/RHSSO) endpoint in the ArgoCD specification. 
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  extraConfig:
+    "admin.enabled": "true"
+...
+----

--- a/modules/gitops-release-notes-1-4-6.adoc
+++ b/modules/gitops-release-notes-1-4-6.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+[id="gitops-release-notes-1-4-6_{context}"]
+= Release notes for {gitops-title} 1.4.6
+
+[role="_abstract"]
+{gitops-title} 1.4.6 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
+
+[id="fixed-issues-1-4-6_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* The base images are updated to the latest version to avoid OpenSSL flaw link: https://access.redhat.com/security/cve/CVE-2022-0778[(CVE-2022-0778)].
+
+[NOTE]
+====
+To install the current release of {gitops-title} 1.4 and receive further updates during its product life cycle, switch to the **GitOps-1.4** channel.  
+====

--- a/modules/gitops-release-notes-1-7-0.adoc
+++ b/modules/gitops-release-notes-1-7-0.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-7-0_{context}"]
+= Release notes for {gitops-title} 1.7.0
+
+{gitops-title} 1.7.0 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
+
+[id="new-features-1-7-0_{context}"]
+== New features
+
+The current release adds the following improvements:
+
+* With this update, you can add environment variables to the Notifications controller. link:https://issues.redhat.com/browse/GITOPS-2313[GITOPS-2313]
+
+* With this update, the default nodeSelector `"kubernetes.io/os": "linux"` key-value pair is added to all workloads such that they only schedule on Linux nodes. In addition, any custom node selectors are added to the default and take precedence if they have the same key. link:https://issues.redhat.com/browse/GITOPS-2215[GITOPS-2215]
+
+* With this update, you can set custom node selectors in the Operator workloads by editing their `GitopsService` custom resource. link:https://issues.redhat.com/browse/GITOPS-2164[GITOPS-2164]
+
+* With this update, you can use the RBAC policy matcher mode to select from the following options: `glob` (default) and `regex`.link:https://issues.redhat.com/browse/GITOPS-1975[GITOPS-1975]
+
+* With this update, you can customize resource behavior using the following additional subkeys:
++
+[options=header]
+|===
+| Subkey | Key form | Mapped field in argocd-cm
+| resourceHealthChecks | resource.customizations.health.<group_kind> | resource.customizations.health
+| resourceIgnoreDifferences | resource.customizations.ignoreDifferences.<group_kind> | resource.customizations.ignoreDifferences
+| resourceActions | resource.customizations.actions.<group_kind> | resource.customizations.actions
+|===
++
+link:https://issues.redhat.com/browse/GITOPS-1561[GITOPS-1561]
++
+[NOTE]
+====
+In future releases, there is a possibility to deprecate the old method of customizing resource behavior by using only resourceCustomization and not subkeys.
+====
+
+* With this update, to use the *Environments* feature on the *Developer* tab you must upgrade if you are using a {gitops-title} version prior to 1.7 and {product-title} 4.15 or above. link:https://issues.redhat.com/browse/GITOPS-2415[GITOPS-2415] 
+
+* With this update, applications can be created in any namespace in the same cluster and still managed by the same control-plane’s ArgoCD instance. This is done by adding a new label `argocd.argoproj.io/managed-by-cluster-argocd` to the namespace added in `spec.sourceNamespaces` of the Argo CD custom resource. link:https://issues.redhat.com/browse/GITOPS-2341[GITOPS-2341]
+
+:FeatureName: Argo CD Applications controller
+include::snippets/technology-preview.adoc[]
+
+[id="fixed-issues-1-7-0_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, {gitops-title} releases were affected by an issue of Dex pods failing with `CreateContainerConfigError` error when the `anyuid` SCC was assigned to the Dex service account. This update fixes the issue by assigning a default user id to the Dex container. link:https://issues.redhat.com/browse/GITOPS-2235[GITOPS-2235]
+
+* Before this update, {gitops-title} used the RHSSO (Keycloak) through OIDC in addition to Dex. However, with a recent security fix, the certificate of RHSSO could not be validated when configured with a certificate not signed by one of the well-known certificate authorities. This update fixes the issue; you can now provide a custom certificate to verify the KeyCloak's TLS certificate while communicating with it. In addition, you can add `rootCA` to the Argo CD custom resource `.spec.keycloak.rootCA` field. The Operator reconciles such changes and updates the `oidc.config in argocd-cm` config map with the PEM encoded root certificate. link:https://issues.redhat.com/browse/GITOPS-2214[GITOPS-2214]
+
+Example Argo CD with Keycloak configuration:
+
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  sso:
+    keycloak:
+      rootCA: '<PEM encoded root certificate>' 
+    provider: keycloak
+.......
+.......
+----
+
+* Before this update, the application controllers restarted multiple times due to the unresponsiveness of liveness probes. This update fixes the issue by removing the liveness probe in the `statefulset` application controller. link:https://issues.redhat.com/browse/GITOPS-2153[GITOPS-2153]
+
+[id="known-issues-1-7-0_{context}"]
+== Known issues
+
+* Before this update, the Operator did not reconcile the `mountsatoken` and `ServiceAccount` settings for the repository server. While this has been fixed, deletion of the service account does not revert to the default. link:https://issues.redhat.com/browse/GITOPS-1873[GITOPS-1873]
+
+* Workaround: Manually set the `spec.repo.serviceaccountfield to thedefault` service account. link:https://issues.redhat.com/browse/GITOPS-2452[GITOPS-2452]

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -12,18 +12,19 @@ In the table, features are marked with the following statuses:
 * *GA*: _General Availability_
 
 |===
-|*OpenShift GitOps* 6+|*Component Versions*|*OpenShift Versions*|*Support status*
+|*OpenShift GitOps* 8+|*Component Versions*|*OpenShift Versions*
 
-|*Version*|*kam*|*Helm*|*Kustomize*|*Argo CD*|*ApplicationSet*|*Dex*||
-|1.6.0 |0.0.46 TP |3.8.1 GA |4.4.1 GA |2.4.5 GA |2.4.5 GA |2.30.3 GA |4.8-4.11 |GA
-|1.5.0 |0.0.42 TP |3.8.0 GA |4.4.1 GA |2.3.3 GA |0.4.1 TP |2.30.3 GA |4.8-4.11 |GA
-|1.4.0 |0.0.41 TP |3.7.1 GA |4.2.0 GA |2.2.2 GA |0.2.0 TP |2.30.0 GA |4.7-4.11 |GA
-|1.3.0|0.0.40|3.6.0|4.2.0|2.1.2|0.2.0|2.28.0|4.7-4.9|GA
-|1.2.0|0.0.38|3.5.0|3.9.4|2.0.5|0.1.0|N/A|4.8|GA
-|1.1.0|0.0.32|3.5.0|3.9.4|2.0.0|N/A|N/A|4.7|GA
+|*Version* |*kam*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |*Notifications Controller*|
+|1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |2.4.5 GA       |2.35.1 GA |7.5.1 GA |2.4.5 TP|4.8-4.11
+|1.6.0    |0.0.46 TP |3.8.1 GA|4.4.1 GA   |2.4.5 GA |2.4.5 GA       |2.30.3 GA |7.5.1 GA |2.4.5 TP|4.8-4.10
+|1.5.0    |0.0.42 TP|3.8.0 GA|4.4.1 GA   |2.3.3 GA |0.4.1 TP        |2.30.3 GA |7.5.1 GA ||4.8-4.10
+|1.4.0    |0.0.41 TP|3.7.1 GA|4.2.0 GA   |2.2.2 GA |0.2.0 TP        |2.30.0 GA |7.4.0 GA ||4.7-4.9
+|1.3.0    |0.0.40 TP|3.6.0 GA|4.2.0 GA   |2.1.2 GA |0.2.0 TP        |2.28.0 GA |7.4.0 GA ||4.7-4.9
+
 |===
 
-[NOTE]
-====
-To use {gitops-title} v1.3 on {product-title} 4.6, do a fresh installation of {gitops-title}. There is no upgrade path from {gitops-title} 1.0 (TP) on OpenShift 4.6.
-====
+* "kam" is an abbreviation for {gitops-title} Application Manager (kam).
+* "RH SSO" is an abbreviation for Red Hat SSO.
+* The *Environments* page in the *Developer* perspective of the {product-title} web console is also in Technology Preview.
+
+// Writer, to update this support matrix, refer to https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix


### PR DESCRIPTION
Aligned team: Dev Tools

Purpose: Cherrypick 1.7.0 RN to enterprise 4.8 to resolve conflicts in context of this issue: https://issues.redhat.com/browse/RHDEVDOCS-4940

OCP version this PR applies to: enterprise 4.8 



