### PR TITLE
Revert the etcd disk latency from 20ms to 10ms

### DIFF
--- a/modules/recommended-etcd-practices.adoc
+++ b/modules/recommended-etcd-practices.adoc
@@ -65,7 +65,7 @@ $ sudo docker run --volume /var/lib/etcd:/var/lib/etcd:Z quay.io/openshift-scale
 ----
 --
 
-The output reports whether the disk is fast enough to host etcd by comparing the 99th percentile of the fsync metric captured from the run to see if it is less than 20 ms. A few of the most important etcd metrics that might affected by I/O performance are as follow:
+The output reports whether the disk is fast enough to host etcd by comparing the 99th percentile of the fsync metric captured from the run to see if it is less than 10 ms. A few of the most important etcd metrics that might affected by I/O performance are as follow:
 
 * `etcd_disk_wal_fsync_duration_seconds_bucket` metric reports the etcd's WAL fsync duration
 * `etcd_disk_backend_commit_duration_seconds_bucket`  metric reports the etcd backend commit latency duration


### PR DESCRIPTION
After several discussions on slack, we wanted to revert the time to its original value of 10ms - but didn't seem like we did.