### PR TITLE
[SRVOCF-508] Update Tekton task links for 1.27

### DIFF
--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -24,14 +24,14 @@ You can use the Knative (`kn`) CLI to initiate a function project build and then
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.26.0/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.27.0/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
 ----
 
 .. Create the `kn func` deploy Tekton task to be able to deploy the function in the pipeline:
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.26.0/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.27.0/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
 ----
 
 . Create a function:


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/SRVOCF-508

Link to docs preview:
https://55595--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-on-cluster-builds.html

QE review:
- [ x] QE has approved this change.