### PR TITLE
CNV-22128: Fix for bandwidthPerMigration default value

### DIFF
--- a/modules/virt-live-migration-limits-reftable.adoc
+++ b/modules/virt-live-migration-limits-reftable.adoc
@@ -22,7 +22,7 @@
 
 |`bandwidthPerMigration`
 |Bandwidth limit of each migration, in MiB/s.
-|64Mi
+|0 ^[1]^
 
 |`completionTimeoutPerGiB`
 |The migration is canceled if it has not completed in this time, in seconds
@@ -36,3 +36,7 @@ not completed migration in 4800 seconds. If the `Migration Method` is
 time, in seconds.
 |150
 |===
+[.small]
+--
+1. The default value of `0` is unlimited.
+--


### PR DESCRIPTION
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/CNV-22128

Link to docs preview:
https://55608--docspreview.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration-limits.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
As noted in this [PR](https://github.com/kubevirt/kubevirt/pull/6007), it was discovered the default `bandwidthPerMigration` value of 64Mi was not actually being enforced properly. That behavior was fixed and the default value is now "0" or "unlimited"