### PR TITLE
Draft RN for TELCODOCS-941

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3111,6 +3111,19 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.12.0 --pullspecs
 ----
+
+[id="ocp-4-12-0-ironic-agent-image-ztp"]
+==== Ironic agent mirroring in disconnected GitOps ZTP installations
+
+For disconnected installations using GitOps ZTP, if you are deploying {product-title} version 4.11 or earlier to a spoke cluster with converged flow enabled, you must mirror the default Ironic agent image to the local image repository. The default Ironic agent images are the following:
+
+* AMD64 Ironic agent image: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:d3f1d4d3cd5fbcf1b9249dd71d01be4b901d337fdc5f8f66569eb71df4d9d446`
+  
+* AArch64 Ironic agent image: `quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:cb0edf19fffc17f542a7efae76939b1e9757dc75782d4727fb0aa77ed5809b43`
+
+For more information about mirroring images, see xref:../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the OpenShift Container Platform image repository]
+
+
 //replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.
 [id="ocp-4-12-1"]
 === RHSA-2023:0449 - {product-title} 4.12.1 bug fix and security update


### PR DESCRIPTION
TELCODOCS 941: Need to mirror default Ironic agent image for spoke cluster deployment using OCP 4.11 or less.


Version(s):
Peer review only please

Issue:
https://issues.redhat.com/browse/TELCODOCS-941

Link to docs preview:
https://55610--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-0-ironic-agent-image-ztp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is for RHACM 2.7 release. The merging/organization of the RHACM 2.7 RNs is handled by https://issues.redhat.com/browse/TELCODOCS-930. I just need a peer review of the RN text, then I can add the approved text in a RN Jira field. Another writer will handle merging all the RHACM 2.7 RNs to the correct location, thanks.
