### PR TITLE
reformatting OSDOCS issue format in template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,4 +1,4 @@
-<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
+<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
 
 <!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
 


### PR DESCRIPTION
This should keep the bot from issuing multiple comments about valid issues.