### PR TITLE
OCPBUGS-7083: Updated Prism Central link

### DIFF
--- a/modules/nutanix-entitlements.adoc
+++ b/modules/nutanix-entitlements.adoc
@@ -5,4 +5,5 @@
 [id="nutanix-entitlements_{context}"]
 = Internet access for Prism Central
 
-Prism Central requires internet access to obtain the {op-system-first} image that is required to install the cluster. The {op-system} image for Nutanix is available at `rhcosredirector.apps.art.xq1c.p1.openshiftapps.com`.
+Prism Central requires internet access to obtain the {op-system-first} image that is required to install the cluster. The {op-system} image for Nutanix is available at `rhcos.mirror.openshift.com`.
+


### PR DESCRIPTION
[OCPBUGS-7083](https://issues.redhat.com/browse/OCPBUGS-7083)

Version(s):
4.12 & 4.11
(mpytlak: This work also applies to 4.13. See last comment).

Issue:
(https://issues.redhat.com/browse/OCPBUGS-7083)

Link to docs preview: [Internet access for Prism Central](https://55631--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#cluster-entitlements_installing-nutanix-installer-provisioned)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
