### PR TITLE
TELCODOCS:1103 - Update note in kataconfig file about label values

### DIFF
--- a/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
+++ b/modules/sandboxed-containers-create-kata-config-resource-cli.adoc
@@ -64,8 +64,9 @@ spec:
   logLevel: info
   kataConfigPoolSelector:
     matchLabels:
-      <label_key>: '<label_value>'
+      <label_key>: '<label_value>' <1>
 ----
+<1> Labels in `kataConfigPoolSelector` only support single values; `nodeSelector` syntax is not supported.
 
 . Create the `KataConfig` resource:
 +


### PR DESCRIPTION
Version(s): Main, 4.13, 4.12, 4.11, 4.10, 4.9

Issue: [TELCODOCS-1103](https://issues.redhat.com/browse/TELCODOCS-1103)

[Link to docs preview](https://55632--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html#sandboxed-containers-create-kataconfig-rsource-cli_deploying-sandboxed-containers)

QE review:
- [x] QE has approved this change.
