### PR TITLE
OSDOCS-5088: Added Alibabacloud to install FIPS mode list

### DIFF
--- a/installing/installing-fips.adoc
+++ b/installing/installing-fips.adoc
@@ -71,6 +71,7 @@ To ensure that containers know that they are running on a host that is using FIP
 To install a cluster in FIPS mode, follow the instructions to install a customized cluster on your preferred infrastructure. Ensure that you set `fips: true` in the `install-config.yaml` file before you deploy your cluster.
 
 * xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Amazon Web Services]
+* xref:../installing/installing_alibaba/installing-alibaba-customizations.adoc#installing-alibaba-customizations[Alibaba Cloud]
 * xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[Microsoft Azure]
 * xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Bare metal]
 * xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Google Cloud Platform]


### PR DESCRIPTION
[OSDOCS-5088](https://issues.redhat.com/browse/OSDOCS-5088)

Version(s):
4.10, 4.11, 4.12 +

Issue:
https://issues.redhat.com/browse/OSDOCS-5088

Link to docs preview: [Installing a cluster in FIPS mode](https://55636--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-fips.html#installation-about-fips-components_installing-fips)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
