### PR TITLE
OCPBUGS#7164: Fix typo in quorum guard instruction

### DIFF
--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -212,7 +212,7 @@ When the etcd cluster Operator performs a redeployment, it ensures that all cont
 +
 [source,terminal]
 ----
-$ oc patch etcd/cluster --type=merge -p '\{"spec": {"unsupportedConfigOverrides": null}}
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
 . You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -544,7 +544,7 @@ openshift-compute-1       Ready worker 3h58m v1.25.0
 +
 [source,terminal]
 ----
-$ oc patch etcd/cluster --type=merge -p '\{"spec": {"unsupportedConfigOverrides": null}}
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
 . You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -320,7 +320,7 @@ It might take a few minutes for the new machine to be created. The etcd cluster 
 +
 [source,terminal]
 ----
-$ oc patch etcd/cluster --type=merge -p '\{"spec": {"unsupportedConfigOverrides": null}}
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides": null}}'
 ----
 
 . You can verify that the `unsupportedConfigOverrides` section is removed from the object by entering this command:


### PR DESCRIPTION


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/OCPBUGS-7164



QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Fix typo in quorum guard instruction to the etcd docs for version 4.8+

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
