### PR TITLE
OCPBUGS 5829: Adding note about the upstream cert-manager version bein…

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-install.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-install.adoc
@@ -11,6 +11,11 @@ The {cert-manager-operator} is not installed in {product-title} by default. You 
 :FeatureName: The {cert-manager-operator}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
+[WARNING]
+====
+This Technology Preview version of the {cert-manager-operator} uses the upstream cert-manager version 1.7, which is no longer supported upstream. A future version of {product-title} is expected to release using a supported upstream cert-manager version. For more information, see link:https://cert-manager.io/docs/installation/supported-releases/#support-policy[Supported Releases] in the upstream cert-manager documentation.
+====
+
 // Installing the {cert-manager-operator} using the web console
 include::modules/cert-manager-install-console.adoc[leveloffset=+1]
 

--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -24,7 +24,12 @@ The following advisory is available for the {cert-manager-operator} 1.7.1-1:
 
 * link:https://access.redhat.com/errata/RHEA-2022:1273[RHEA-2022:1273]
 
-For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.7/#v1-7-1[cert-manager project release notes for v1.7.1].
+For more information, see the upstream link:https://cert-manager.io/docs/release-notes/release-notes-1.7/#v1-7-1[cert-manager project release notes for v1.7.1].
+
+[WARNING]
+====
+This Technology Preview version of the {cert-manager-operator} uses the upstream cert-manager version 1.7, which is no longer supported upstream. A future version of {product-title} is expected to release using a supported upstream cert-manager version. For more information, see link:https://cert-manager.io/docs/installation/supported-releases/#support-policy[Supported Releases] in the upstream cert-manager documentation.
+====
 
 [id="cert-manager-operator-1.7.1-1-new-features-and-enhancements"]
 === New features and enhancements


### PR DESCRIPTION
…g unsupported

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-5829

Link to docs preview:
* https://55659--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html#cert-manager-operator-release-notes-1.7.1-1
* https://55659--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-install.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
