### PR TITLE
Fix versioning that was changed in 55005

### DIFF
--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -59,18 +59,18 @@ For details and information on how to perform an `EUS-to-EUS` channel upgrade, p
 _Preparing to perform an EUS-to-EUS upgrade_ page, listed in the Additional resources section.
 ====
 
-. Based on your organization requirements, set the appropriate upgrade channel. For example, you can set your channel to `stable-4.10`, `fast-4.10`, or `eus-4.10`. For more information about channels, refer to _Understanding update channels and releases_ listed in the Additional resources section.
+. Based on your organization requirements, set the appropriate upgrade channel. For example, you can set your channel to `stable-4.12`, `fast-4.12`, or `eus-4.12`. For more information about channels, refer to _Understanding update channels and releases_ listed in the Additional resources section.
 +
 [source,terminal]
 ----
 $ oc adm upgrade channel <channel>
 ----
 +
-For example, to set the channel to `stable-4.10`:
+For example, to set the channel to `stable-{product-version}`:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc adm upgrade channel stable-4.10
+$ oc adm upgrade channel stable-{product-version}
 ----
 +
 [IMPORTANT]
@@ -133,10 +133,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.23.12+8a6bfe4
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.23.12+8a6bfe4
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.23.12+8a6bfe4
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.23.12+8a6bfe4
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.23.12+8a6bfe4
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.23.12+8a6bfe4
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.25.0
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.25.0
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.25.0
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.25.0
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.25.0
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.25.0
 ----


### PR DESCRIPTION
When merging #55005 we accidentally changed some `product-version` variables to `enterprise-4.10` and set the version of an example output to `v1.23.12+8a6bfe4`, a version appropriate only to 4.10. This PR fixes those errors in main and 4.13. See separate PRs for [4.10](https://github.com/openshift/openshift-docs/pull/55645), [4.11](https://github.com/openshift/openshift-docs/pull/55648). and [4.12](https://github.com/openshift/openshift-docs/pull/55647).