### PR TITLE
OSDOCS-4642: Updating procedure to include multi-arch (Update in heterogeneous clusters)

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
@@ -40,12 +40,14 @@ imageContentSources:
 $ OCP_RELEASE_NUMBER=<release_version>
 ----
 
-.. Specify the architecture of the server by running the following command:
+.. Specify the architecture of the cluster by running the following command:
 +
 [source,terminal]
 ----
-$ ARCHITECTURE=<server_architecture>
+$ ARCHITECTURE=<cluster_architecture> <1>
 ----
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
+
 
 .. Get the release image digest from Quay by running the following command
 +

--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -108,13 +108,14 @@ $ RELEASE_NAME="okd"
 endif::[]
 
 ifndef::openshift-origin[]
-.. Export the type of architecture for your server, such as `x86_64` 
-or `aarch64`:
+.. Export the type of architecture for your cluster:
 +
 [source,terminal]
 ----
-$ ARCHITECTURE=<server_architecture>
+$ ARCHITECTURE=<cluster_architecture> <1>
 ----
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
+
 endif::[]
 
 .. Export the path to the directory to host the mirrored images:

--- a/modules/ipi-install-mirroring-for-disconnected-registry.adoc
+++ b/modules/ipi-install-mirroring-for-disconnected-registry.adoc
@@ -103,12 +103,14 @@ $ RELEASE_NAME="okd"
 endif::[]
 
 ifndef::openshift-origin[]
-.. Export the type of architecture for your server, such as `x86_64`:
+.. Export the type of architecture for your cluster:
 +
 [source,terminal]
 ----
-$ ARCHITECTURE=<server_architecture>
+$ ARCHITECTURE=<cluster_architecture> <1>
 ----
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
+
 endif::[]
 
 .. Export the path to the directory to host the mirrored images:

--- a/modules/update-configuring-image-signature.adoc
+++ b/modules/update-configuring-image-signature.adoc
@@ -30,9 +30,9 @@ to update the cluster, such as `4.4.0`.
 +
 [source,terminal]
 ----
-$ ARCHITECTURE=<server_architecture> <1>
+$ ARCHITECTURE=<cluster_architecture> <1>
 ----
-<1> For `server_architecture`, specify the architecture of the server, such as `x86_64`.
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
 
 . Get the release image digest from link:https://quay.io/[Quay]:
 +

--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -73,12 +73,13 @@ $ RELEASE_NAME="ocp-release"
 +
 For a production release, you must specify `ocp-release`.
 
-.. Export the type of architecture for your server, such as `x86_64`.:
+.. Export the type of architecture for your cluster:
 +
 [source,terminal]
 ----
-$ ARCHITECTURE=<server_architecture>
+$ ARCHITECTURE=<cluster_architecture> <1>
 ----
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
 
 .. Export the path to the directory to host the mirrored images:
 +

--- a/modules/update-service-mirror-release.adoc
+++ b/modules/update-service-mirror-release.adoc
@@ -100,12 +100,13 @@ $ RELEASE_NAME="ocp-release"
 +
 For a production release, you must specify `ocp-release`.
 
-.. Export the type of architecture for your server, such as `x86_64`:
+.. Export the type of architecture for your cluster:
 +
 [source,terminal]
 ----
-$ ARCHITECTURE=<server_architecture>
+$ ARCHITECTURE=<cluster_architecture> <1>
 ----
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
 
 .. Export the path to the directory to host the mirrored images:
 +


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-4642

Link to docs preview:
https://55665--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster.html#update-mirror-repository_updating-restricted-network-cluster

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
