### PR TITLE
OCPBUGS#6709: Misleading information in Driver Toolkit doc in 4.11

### DIFF
--- a/hardware_enablement/psap-driver-toolkit.adoc
+++ b/hardware_enablement/psap-driver-toolkit.adoc
@@ -15,6 +15,11 @@ include::modules/psap-driver-toolkit.adoc[leveloffset=+1]
 
 include::modules/psap-driver-toolkit-pulling.adoc[leveloffset=+1]
 
+[IMPORTANT]
+====
+ARM images are built for 64-bit Arm (AArch64) only, and are currently a Technology Preview feature. For more information about {product-title} on ARM, see xref:../release_notes/ocp-4-11-release-notes.html#ocp-4-11-release-notes[Release Notes]. For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope]. 
+====
+
 include::modules/psap-driver-toolkit-using.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/psap-driver-toolkit-pulling.adoc
+++ b/modules/psap-driver-toolkit-pulling.adoc
@@ -26,19 +26,33 @@ The driver-toolkit image for the latest minor release will be tagged with the mi
 
 . The image URL of the `driver-toolkit` corresponding to a certain release can be extracted from the release image using the `oc adm` command:
 +
+--
+* For an x86 image, the command is as follows:
++
 [source,terminal]
 ----
-$ oc adm release info 4.11.0 --image-for=driver-toolkit
+$ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version}.z-x86_64 --image-for=driver-toolkit
 ----
+
+* For an ARM image, the command is as follows:
++
+[source,terminal]
+----
+$ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version}.z-aarch64 --image-for=driver-toolkit
+----
+--
 +
 .Example output
+
+The output for the `ocp-release:4.11.0-x86_64` image is as follows:
++
 [source,terminal]
 ----
-quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0fd84aee79606178b6561ac71f8540f404d518ae5deff45f6d6ac8f02636c7f4
+quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:514e256367e8707e2c30f18a4f06fbd6c821ab9776602d2488e861f577a357d0
 ----
 
 . This image can be pulled using a valid pull secret, such as the pull secret required to install {product-title}.
-
++
 [source,terminal]
 ----
 $ podman pull --authfile=path/to/pullsecret.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:<SHA>


### PR DESCRIPTION
**Title:**
Misleading information in Driver Toolkit doc in 4.11

Summary of changes:
Updates to step 1 of the 'Finding the Driver Toolkit image URL in the payload' section.

Versions:
Enterprise 4.11

Issue:
(https://issues.redhat.com/browse/OCPBUGS-6709?filter=-1)

Link to docs preview:
http://file.emea.redhat.com/tshwartz/OCPBUGS-6709/hardware_enablement/psap-driver-toolkit.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
