### PR TITLE
OCPBUGS-7152: adds more detail for the agent create command

### DIFF
--- a/modules/installing-ocp-agent.adoc
+++ b/modules/installing-ocp-agent.adoc
@@ -178,6 +178,11 @@ You must provide the rendezvous IP address when you do not specify at least one 
 $ openshift-install --dir <install_directory> agent create image
 ----
 +
+[IMPORTANT]
+====
+The `dir` parameter specifies the assets directory, which stores the manifest files, the ISO image, and ** auth ** directory. The ** auth ** directory stores the ** kubeadmin-password ** and ** kubeconfig ** files. As a `kubeadmin` user, you can use `kubeconfig` to access the cluster with the following setting: `export KUBECONFIG=<install_directory>/auth/kubeconfig`. Note that the `kubeconfig` is specific to the generated ISO image, so if the `kubeconfig` is set and the `oc` command fails, it is possible that the system did not boot with the generated ISO image. You can use the contents of ** kubeadmin-password ** file to log into the console during the bootstrap as the `core` user to perform debugging. 
+====
++
 NOTE: Red Hat Enterprise Linux CoreOS (RHCOS) supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Multipathing is enabled by default in the agent ISO image, with a default `/etc/multipath.conf` configuration.
 
 . Boot the `agent.x86_64.iso` image on the bare metal machines.


### PR DESCRIPTION
- Applies to main, 4.13 and 4.12
- [Jira](https://issues.redhat.com/browse/OCPBUGS-7152)
- [Preveiw](https://55668--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html)
@bfournie ptal