### PR TITLE
OSDOCS-5246: RN for backporting Network Observability Operator to 4.11

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -657,6 +657,16 @@ These changes are reflected in simplified post-installation and network configur
 
 For {product-title} installer-provisioned installations on {rh-openstack-first}, VMware vSphere, or oVirt, keepalived is now configured with unicast as the default instead of multicast. You no longer need to allow multicast traffic. The unicast migration occurs a few minutes after the cluster finishes upgrading because all of the nodes must migrate at the same time. Having both multicast and unicast clusters at the same time should not result in any issues because keepalived treats unicast and multicast as completely separate.
 
+[id="ocp-4-11-network-observability-operator"]
+==== Network Observability Operator to observe network traffic flow
+
+As an administrator, you can now install the Network Observability Operator to observe the network traffic for your {product-title} cluster in the console. You can view and monitor the network traffic data in different graphical representations. The Network Observability Operator uses eBPF technology to create the network flows. The network flows are enriched with OpenShift Container Platform information, and stored in Loki. You can use the network traffic information for detailed troubleshooting and analysis.
+
+The Network Observability Operator is General Availability (GA) status in the 4.12 release of {product-title} and is also supported in the 4.10 and 4.11 versions. 
+
+For more information, see xref:../networking/network_observability/network-observability-overview.adoc#network-observability-overview[Network Observability].
+
+
 [id="ocp-4-11-storage"]
 === Storage
 
@@ -1130,6 +1140,12 @@ For more information, see xref:../authentication/understanding-and-managing-pod-
 {product-title} {product-version} introduces the following notable technical changes.
 
 // Note: use [discrete] for these sub-headings.
+[discrete]
+[id="ocp-4-11-4-12-network-observability-operator"]
+==== Network Observability operator for observing network flows
+The Network Observability Operator is General Availability (GA) status in the 4.12 release of {product-title} and is also supported in {product-title} 4.11. 
+
+For more information, see xref:../networking/network_observability/network-observability-overview.adoc#network-observability-overview[Network Observability].
 
 [discrete]
 [id="ocp-4-11-router-load-balancing-algorithm-default-update"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
RN for 4.11 backport of the Network Observability operator. 
* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5246
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
This build will be broken until https://github.com/openshift/openshift-docs/pull/55720 is merged.
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
