### PR TITLE
OCPBUGS-7065 bare-metal network config with STP

### DIFF
--- a/modules/ipi-install-configuring-networking.adoc
+++ b/modules/ipi-install-configuring-networking.adoc
@@ -26,6 +26,11 @@ $ export PUB_CONN=<baremetal_nic_name>
 
 . Configure the `baremetal` network:
 +
+[NOTE]
+====
+The SSH connection might disconnect after executing these steps.
+====
++
 [source,terminal]
 ----
 $ sudo nohup bash -c "
@@ -34,16 +39,11 @@ $ sudo nohup bash -c "
     # RHEL 8.1 appends the word \"System\" in front of the connection, delete in case it exists
     nmcli con down \"System $PUB_CONN\"
     nmcli con delete \"System $PUB_CONN\"
-    nmcli connection add ifname baremetal type bridge con-name baremetal
+    nmcli connection add ifname baremetal type bridge con-name baremetal bridge.stp no
     nmcli con add type bridge-slave ifname \"$PUB_CONN\" master baremetal
     pkill dhclient;dhclient baremetal
 "
 ----
-+
-[NOTE]
-====
-The ssh connection might disconnect after executing these steps.
-====
 
 . Optional: If you are deploying with a `provisioning` network, export the `provisioning` network NIC name:
 +


### PR DESCRIPTION
OCPBUGS-7065: If your interface is connected to a switch, need to check that there is no BPDU guard on the switch interface or disable stp on baremetal bridge.

Version(s):
4.9+
Will probably need to manually CP to older branches as module structure changed.

Issue:
https://issues.redhat.com/browse/OCPBUGS-7065

Link to docs preview:
https://55686--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-networking_ipi-install-installation-workflow

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
