### PR TITLE
OSDOCS-5246: RN for backporting Network Observability Operator to 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -685,6 +685,15 @@ For more information, see xref:../networking/using-ptp.adoc#configuring-ptp-devi
 
 SR-IOV support is now available for xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Mellanox MT2892 cards].
 
+[id="ocp-4-10-network-observability-operator"]
+==== Network Observability Operator to observe network traffic flow
+
+As an administrator, you can now install the Network Observability Operator to observe the network traffic for your {product-title} cluster in the console. You can view and monitor the network traffic data in different graphical representations. The Network Observability Operator uses eBPF technology to create the network flows. The network flows are enriched with OpenShift Container Platform information, and stored in Loki. You can use the network traffic information for detailed troubleshooting and analysis.
+
+The Network Observability Operator is General Availability (GA) status in the 4.12 release of {product-title} and is also supported in {product-title} 4.10. 
+
+For more information, see xref:../networking/network_observability/network-observability-overview.adoc#network-observability-overview[Network Observability].
+
 [id="ocp-4-10-hardware"]
 === Hardware
 
@@ -1311,6 +1320,13 @@ If you have any Operator projects that were previously created or maintained wit
 ==== Changed Cluster Autoscaler alert severity
 
 Previously, the `ClusterAutoscalerUnschedulablePods` alert showed a severity of `warning`, which suggested it required developer intervention. This alert is informational and does not describe a problematic condition that requires intervention. With this release, the `ClusterAutoscalerUnschedulablePods` alert is reduced in severity from `warning` to `info`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2025230[*BZ#2025230*])
+
+[discrete]
+[id="ocp-4-10-4-12-network-observability-operator"]
+==== Network Observability operator for observing network flows
+The Network Observability Operator is General Availability (GA) status in the 4.12 release of {product-title} and is also supported in {product-title} 4.10. 
+
+For more information, see xref:../networking/network_observability/network-observability-overview.adoc#network-observability-overview[Network Observability].
 
 [id="ocp-4-10-deprecated-removed-features"]
 == Deprecated and removed features


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.10
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5246
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
This build will be broken until https://github.com/openshift/openshift-docs/pull/55720 is merged. 
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
