### PR TITLE
[OCPBUGS-5808] Recreate k8s cloud.conf docs for ShiftStack - 4.9

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -302,6 +302,8 @@ Topics:
     File: installing-openstack-installer-restricted
   # - Name: Load balancing deployments on OpenStack
   #   File: installing-openstack-load-balancing
+  - Name: OpenStack cloud configuration reference guide
+    File: installing-openstack-cloud-config-reference
   - Name: Uninstalling a cluster on OpenStack
     File: uninstalling-cluster-openstack
   - Name: Uninstalling a cluster on OpenStack from your own infrastructure

--- a/installing/installing_openstack/installing-openstack-cloud-config-reference.adoc
+++ b/installing/installing_openstack/installing-openstack-cloud-config-reference.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="installing-openstack-cloud-config-reference"]
+= OpenStack cloud configuration reference guide
+include::_attributes/common-attributes.adoc[]
+:context: installing-openstack-cloud-config-reference
+
+toc::[]
+
+A cloud provider configuration controls how {product-title} interacts with {rh-openstack-first}. Use the following parameters in a cloud-provider configuration manifest file to configure your cluster.
+
+include::modules/cloud-conf-shiftstack-reference.adoc[leveloffset=+1]

--- a/installing/installing_openstack/installing-openstack-installer-custom.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-custom.adoc
@@ -26,6 +26,11 @@ include::modules/installation-registry-osp-creating-custom-pvc.adoc[leveloffset=
 include::modules/installation-osp-verifying-external-network.adoc[leveloffset=+1]
 include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+1]
 include::modules/installation-osp-setting-cloud-provider-options.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* For more information about cloud provider configuration, see xref:../../installing/installing_openstack/installing-openstack-cloud-config-reference.adoc#cloud-conf-shiftstack-reference_installing-openstack-cloud-config-reference[OpenStack cloud provider options].
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 include::modules/installation-initializing.adoc[leveloffset=+1]
 

--- a/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-kuryr.adoc
@@ -32,6 +32,11 @@ include::modules/installation-osp-enabling-swift.adoc[leveloffset=+1]
 include::modules/installation-osp-verifying-external-network.adoc[leveloffset=+1]
 include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+1]
 include::modules/installation-osp-setting-cloud-provider-options.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* For more information about cloud provider configuration, see xref:../../installing/installing_openstack/installing-openstack-cloud-config-reference.adoc#cloud-conf-shiftstack-reference_installing-openstack-cloud-config-reference[OpenStack cloud provider options].
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 include::modules/installation-initializing.adoc[leveloffset=+1]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -30,6 +30,11 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 include::modules/installation-osp-enabling-swift.adoc[leveloffset=+1]
 include::modules/installation-osp-describing-cloud-parameters.adoc[leveloffset=+1]
 include::modules/installation-osp-setting-cloud-provider-options.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* For more information about cloud provider configuration, see xref:../../installing/installing_openstack/installing-openstack-cloud-config-reference.adoc#cloud-conf-shiftstack-reference_installing-openstack-cloud-config-reference[OpenStack cloud provider options].
+
 include::modules/installation-creating-image-restricted.adoc[leveloffset=+1]
 include::modules/installation-initializing.adoc[leveloffset=+1]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/modules/cloud-conf-shiftstack-reference.adoc
+++ b/modules/cloud-conf-shiftstack-reference.adoc
@@ -19,7 +19,7 @@ The following options are used for {rh-openstack} CCM authentication with the {r
 | Option | Description
 
 | `auth-url`
-| The {rh-openstack} Identity service URL. For example, `http://128.110.154.166/identity`.
+| The {rh-openstack} Identity service URL. For example, `\http://128.110.154.166/identity`.
 
 | `ca-file`
 | Optional. The CA certificate bundle file for communication with the {rh-openstack} Identity service. If you use the HTTPS protocol with The Identity service URL, this option is required.

--- a/modules/cloud-conf-shiftstack-reference.adoc
+++ b/modules/cloud-conf-shiftstack-reference.adoc
@@ -113,7 +113,8 @@ This option is unsupported if you use {rh-openstack} earlier than version 17 wit
 | Option | Description
 
 | `search-order`
-| This configuration key affects the way that the provider retrieves metadata that relates to the instances in which it runs. The default value of `configDrive,metadataService` results in the provider retrieving instance metadata from the configuration drive first if available, and then the metadata service. Alternative values are:
+a| This configuration key affects the way that the provider retrieves metadata that relates to the instances in which it runs. The default value of `configDrive,metadataService` results in the provider retrieving instance metadata from the configuration drive first if available, and then the metadata service. Alternative values are:
+
  * `configDrive`: Only retrieve instance metadata from the configuration drive.
  * `metadataService`: Only retrieve instance metadata from the metadata service.
  * `metadataService,configDrive`: Retrieve instance metadata from the metadata service first if available, and then retrieve instance metadata from the configuration drive.

--- a/modules/cloud-conf-shiftstack-reference.adoc
+++ b/modules/cloud-conf-shiftstack-reference.adoc
@@ -1,0 +1,120 @@
+//  Module included in the following assemblies:
+
+//  * installing/installing_openstack/installing-openstack-cloud-config-reference.adoc
+
+:_content-type: REFERENCE
+[id="cloud-conf-shiftstack-reference_{context}"]
+= OpenStack cloud provider options 
+
+The cloud provider configuration, typically stored as a file named `cloud.conf`, controls how {product-title} interacts with Red Hat OpenStack Platform (RHOSP).
+
+You can create a valid `cloud.conf` file by specifying the following options in it.
+
+[id="ccm-config-global-options"]
+== Global options
+
+The following options are used for {rh-openstack} CCM authentication with the {rh-openstack} Identity service, also known as Keystone. They are similiar to the global options that you can set by using the `openstack` CLI.
+
+|===
+| Option | Description
+
+| `auth-url`
+| The {rh-openstack} Identity service URL. For example, `http://128.110.154.166/identity`.
+
+| `ca-file`
+| Optional. The CA certificate bundle file for communication with the {rh-openstack} Identity service. If you use the HTTPS protocol with The Identity service URL, this option is required.
+
+| `domain-id`
+| The Identity service user domain ID. 
+
+ Leave this option unset if you are using Identity service application credentials.
+
+| `domain-name`
+| The Identity service user domain name. 
+
+ This option is not required if you set `domain-id`.
+
+| `tenant-id`
+| The Identity service project ID. Leave this option unset if you are using Identity service application credentials.
+
+In version 3 of the Identity API, which changed the identifier `tenant` to `project`, the value of `tenant-id` is automatically mapped to the project construct in the API. 
+
+| `tenant-name`
+| The Identity service project name. 
+
+| `username`
+| The Identity service user name. 
+
+Leave this option unset if you are using Identity service application credentials.
+
+| `password`
+| The Identity service user password. 
+
+ Leave this option unset if you are using Identity service application credentials.
+
+| `region`
+| The Identity service region name.
+
+| `trust-id`
+| The Identity service trust ID. A trust represents the authorization of a user, or trustor, to delegate roles to another user, or trustee. Optionally, a trust authorizes the trustee to impersonate the trustor. You can find available trusts by querying the `/v3/OS-TRUST/trusts` endpoint of the Identity service API.
+|===
+
+[id="ccm-config-lb-options"]
+== Load balancer options
+
+The cloud provider supports several load balancer options for deployments that use Octavia. 
+
+|===
+| Option | Description
+
+| `use-octavia`
+| Whether or not to use Octavia for the `LoadBalancer` type of the service implementation rather than Neutron-LBaaS. The default value is `true`.
+
+| `floating-network-id`
+| Optional. The external network used to create floating IP addresses for load balancer virtual IP addresses (VIPs). If there are multiple external networks in the cloud, this option must be set or the user must specify `loadbalancer.openstack.org/floating-network-id` in the service annotation.
+
+| `lb-method`
+| The load balancing algorithm used to create the load balancer pool.
+For the Amphora provider the value can be `ROUND_ROBIN`, `LEAST_CONNECTIONS`, or `SOURCE_IP`. The default value is `ROUND_ROBIN`.
+
+For the OVN provider, only the `SOURCE_IP_PORT` algorithm is supported.
+
+For the Amphora provider, if using the `LEAST_CONNECTIONS` or `SOURCE_IP` methods, configure the `create-monitor` option as `true`  in the `cloud-provider-config` config map on the `openshift-config` namespace and `ETP:Local` on the load-balancer type service to allow balancing algorithm enforcement in the client to service endpoint connections.
+
+| `lb-provider`
+| Optional. Used to specify the provider of the load balancer, for example, `amphora` or `octavia`. Only the Amphora and Octavia providers are supported.
+
+| `lb-version`
+| Optional. The load balancer API version. Only `"v2"` is supported.
+
+| `subnet-id`
+| The ID of the Networking service subnet on which load balancer VIPs are created. 
+
+| `create-monitor`
+| Whether or not to create a health monitor for the service load balancer. A health monitor is required for services that declare `externalTrafficPolicy: Local`. The default value is `false`.
+
+This option is unsupported if you use {rh-openstack} earlier than version 17 with the `ovn` provider.
+
+| `monitor-delay`
+| The interval in seconds by which probes are sent to members of the load balancer. The default value is `5`.
+
+| `monitor-max-retries`
+| The number of successful checks that are required to change the operating status of a load balancer member to `ONLINE`. The valid range is `1` to `10`, and the default value is `1`.
+
+| `monitor-timeout`
+| The time in seconds that a monitor waits to connect to the back end before it times out. The default value is `3`.
+
+|===
+
+[id="ccm-config-metadata-options"]
+== Metadata options
+
+|===
+| Option | Description
+
+| `search-order`
+| This configuration key affects the way that the provider retrieves metadata that relates to the instances in which it runs. The default value of `configDrive,metadataService` results in the provider retrieving instance metadata from the configuration drive first if available, and then the metadata service. Alternative values are:
+ * `configDrive`: Only retrieve instance metadata from the configuration drive.
+ * `metadataService`: Only retrieve instance metadata from the metadata service.
+ * `metadataService,configDrive`: Retrieve instance metadata from the metadata service first if available, and then retrieve instance metadata from the configuration drive.
+|===

--- a/modules/installation-osp-setting-cloud-provider-options.adoc
+++ b/modules/installation-osp-setting-cloud-provider-options.adoc
@@ -11,7 +11,7 @@
 
 Optionally, you can edit the cloud provider configuration for your cluster. The cloud provider configuration controls how {product-title} interacts with {rh-openstack-first}.
 
-For a complete list of cloud provider configuration parameters, see link:https://v1-18.docs.kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#cloud-conf[the `cloud.conf` specification].
+For a complete list of cloud provider configuration parameters, see the "OpenStack cloud configuration reference guide" page in the "Installing on OpenStack" documentation.
 
 .Procedure
 
@@ -29,7 +29,7 @@ $ openshift-install --dir <destination_directory> create manifests
 $ vi openshift/manifests/cloud-provider-config.yaml
 ----
 
-. Modify the options based on link:https://v1-18.docs.kubernetes.io/docs/concepts/cluster-administration/cloud-providers/#cloud-conf[the `cloud.conf` specification].
+. Modify the options based on the cloud configuration specification.
 +
 Configuring Octavia for load balancing is a common case for clusters that do not use Kuryr. For example:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9. 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-5808](https://issues.redhat.com/browse/OCPBUGS-5808)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://tubular-rolypoly-8496eb.netlify.app/installing/installing_openstack/installing-openstack-cloud-config-reference.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 4.10 and 4.11 elsewhere due to irrelevance to main branch. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
