### PR TITLE
OCP BUGS 1042: Adding caveat about LowNodeUtilization not honoring ex…

### DIFF
--- a/modules/nodes-descheduler-configuring-profiles.adoc
+++ b/modules/nodes-descheduler-configuring-profiles.adoc
@@ -48,12 +48,19 @@ spec:
   - EvictPodsWithLocalStorage
   - EvictPodsWithPVC
 ----
-<1> Optional: Set a list of user-created namespaces to include or exclude from descheduler operations. Use `excluded` to set a list of namespaces to exclude or use `included` to set a list of namespaces to include. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are always excluded.
+--
+<1> Optional: Set a list of user-created namespaces to include or exclude from descheduler operations. Use `excluded` to set a list of namespaces to exclude or use `included` to set a list of namespaces to include. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are excluded by default.
++
+[IMPORTANT]
+====
+The `LowNodeUtilization` strategy does not support namespace exclusion. If the `LifecycleAndUtilization` profile is set, which enables the `LowNodeUtilization` strategy, then no namespaces are excluded, even the protected namespaces. To avoid evictions from the protected namespaces while the `LowNodeUtilization` strategy is enabled, set the priority class name to `system-cluster-critical` or `system-node-critical`.
+====
 <2> Optional: Enable a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
 <3> Optional: Specify a priority threshold to consider pods for eviction only if their priority is lower than the specified level. Use the `thresholdPriority` field to set a numerical priority threshold (for example, `10000`) or use the `thresholdPriorityClassName` field to specify a certain priority class name (for example, `my-priority-class-name`). If you specify a priority class name, it must already exist or the descheduler will throw an error. Do not set both `thresholdPriority` and `thresholdPriorityClassName`.
 <4> Add one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, and `EvictPodsWithPVC`.
 <5> Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enabling both results in a conflict.
 +
 You can enable multiple profiles; the order that the profiles are specified in is not important.
+--
 
 . Save the file to apply the changes.

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -79,7 +79,12 @@ Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enab
 Do not specify both *thresholdPriority* and *thresholdPriorityClassName* for the descheduler.
 ====
 
-**** Set specific namespaces to exclude or include from descheduler operations. Expand the *namespaces* field and add namespaces to the *excluded* or *included* list. You can only either set a list of namespaces to exclude or a list of namespaces to include.
+**** Set specific namespaces to exclude or include from descheduler operations. Expand the *namespaces* field and add namespaces to the *excluded* or *included* list. You can only either set a list of namespaces to exclude or a list of namespaces to include. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are excluded by default.
++
+[IMPORTANT]
+====
+The `LowNodeUtilization` strategy does not support namespace exclusion. If the `LifecycleAndUtilization` profile is set, which enables the `LowNodeUtilization` strategy, then no namespaces are excluded, even the protected namespaces. To avoid evictions from the protected namespaces while the `LowNodeUtilization` strategy is enabled, set the priority class name to `system-cluster-critical` or `system-node-critical`.
+====
 
 **** Experimental: Set thresholds for underutilization and overutilization for the `LowNodeUtilization` strategy. Use the *devLowNodeUtilizationThresholds* field to set one of the following values:
 +


### PR DESCRIPTION
…cluded namespaces

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-1042

Link to docs preview:
https://55691--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-descheduler.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
