### PR TITLE
OSDOCS-5180-followup: Replaced refer to entries with see entries

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -80,13 +80,13 @@ Issued: 2023-01-30
 
 {product-title} release 4.12.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0452[RHBA-2023:0452] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0449[RHSA-2023:0449] advisory.
 
-For the `TopoLVM image` refer to link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
 
 [id="microshift-4-12-2-dp"]
-=== RHBA-2023:0452 - {product-title} 4.12.2 bug fix
+=== RHBA-2023:0572 - {product-title} 4.12.2 bug fix
 
 Issued: 2023-02-07
 
 {product-title} release 4.12.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0572[RHBA-2023:0572] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0569[RHSA-2023:0569] advisory.
 
-For the `TopoLVM image` refer to link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]


### PR DESCRIPTION
**This is a follow-up Jira from the comment on [OSDOCS-5180](https://github.com/openshift/openshift-docs/pull/55514#issuecomment-1422657032)**

[OSDOCS-5180](https://issues.redhat.com//browse/OSDOCS-5180):adds z-stream update 4.12.2
 
Version(s): 4.12

Issue: https://issues.redhat.com/browse/OSDOCS-5180

Link to docs preview: [OCP RNs](https://55694--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html) [MicroShift RN]

QE review:

* [ ]  QE has approved this change.

Additional information:

