### PR TITLE
[OCPBUGS-6728]: Delete node objects during etcd restore to prevent OVN-Kubernetes from starting its DBs as clustered

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -295,6 +295,12 @@ If the status is `Pending`, or the output lists more than one running etcd pod, 
 Perform the following step only if you are using `OVNKubernetes` network plugin.
 ====
 +
+. Delete the node objects that are associated with control plane hosts that are not the recovery control plane host.
++
+[source,terminal]
+----
+$ oc delete node <non-recovery-controlplane-host-1> <non-recovery-controlplane-host-2>
+----
 . Restart the Open Virtual Network (OVN) Kubernetes pods on all the hosts.
 +
 [NOTE]


### PR DESCRIPTION
[OCPBUGS-6728](https://issues.redhat.com/browse/OCPBUGS-6728)

Version(s): 4.11+

Link to docs preview: http://file.rdu.redhat.com/tlove/etcd-ocpbugs-6728-tlove/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state  (Step 12)

QE review:
- [ x] QE has approved this change.