### PR TITLE
BZ1996674: Removed status entry from Removing the cluster-wide proxy

### DIFF
--- a/modules/nw-proxy-remove.adoc
+++ b/modules/nw-proxy-remove.adoc
@@ -31,7 +31,6 @@ kind: Proxy
 metadata:
   name: cluster
 spec: {}
-status: {}
 ----
 
 . Save the file to apply the changes.


### PR DESCRIPTION
Version(s):
4.9 +

Issue:
[BZ1996674](https://bugzilla.redhat.com/show_bug.cgi?id=1996674)

Link to docs preview:
[Removing the cluster-wide proxy](https://55700--docspreview.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy.html#nw-proxy-remove_config-cluster-wide-proxy)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
