### PR TITLE
TELCODOCS-1039 - Westport channel NIC PTP grandmaster clock

### DIFF
--- a/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock.adoc
+++ b/modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * networking/using-ptp.adoc
+
+:_content-type: PROCEDURE
+[id="configuring-linuxptp-services-as-grandmaster-clock_{context}"]
+= Configuring linuxptp services as a grandmaster clock
+
+You can configure the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as grandmaster clock by creating a `PtpConfig` custom resource (CR) that configures the host NIC.
+
+The `ts2phc` utility allows you to synchronize the system clock with the PTP grandmaster clock so that the node can stream precision clock signal to downstream PTP ordinary clocks and boundary clocks.
+
+[NOTE]
+====
+Use the following example `PtpConfig` CR as the basis to configure `linuxptp` services as the grandmaster clock for your particular hardware and environment.
+This example CR does not configure PTP fast events. To configure PTP fast events, set appropriate values for `ptp4lOpts`, `ptp4lConf`, and `ptpClockThreshold`.
+`ptpClockThreshold` is used only when events are enabled.
+See "Configuring the PTP fast event notifications publisher" for more information.
+====
+
+.Prerequisites
+
+* Install an Intel Westport Channel network interface in the bare-metal cluster host.
+
+* Install the OpenShift CLI (`oc`).
+
+* Log in as a user with `cluster-admin` privileges.
+
+* Install the PTP Operator.
+
+.Procedure
+
+. Create the `PtpConfig` resource. For example:
+
+.. Save the following YAML in the `grandmaster-clock-ptp-config.yaml` file:
++
+include::snippets/grandmaster-clock-ptp-config.adoc[]
+
+.. Create the CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f grandmaster-clock-ptp-config.yaml
+----
+
+.Verification
+
+. Check that the `PtpConfig` profile is applied to the node.
+
+.. Get the list of pods in the `openshift-ptp` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-ptp -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          READY   STATUS    RESTARTS   AGE     IP             NODE
+linuxptp-daemon-74m2g         3/3     Running   3          4d15h   10.16.230.7    compute-1.example.com
+ptp-operator-5f4f48d7c-x7zkf  1/1     Running   1          4d15h   10.128.1.145   compute-1.example.com
+----
+
+.. Check that the profile is correct. Examine the logs of the `linuxptp` daemon that corresponds to the node you specified in the `PtpConfig` profile.
+Run the following command:
++
+[source,terminal]
+----
+$ oc logs linuxptp-daemon-74m2g -n openshift-ptp -c linuxptp-daemon-container
+----
++
+.Example output
+[source,terminal]
+----
+ts2phc[94980.334]: [ts2phc.0.config] nmea delay: 98690975 ns
+ts2phc[94980.334]: [ts2phc.0.config] ens3f0 extts index 0 at 1676577329.999999999 corr 0 src 1676577330.901342528 diff -1
+ts2phc[94980.334]: [ts2phc.0.config] ens3f0 master offset         -1 s2 freq      -1
+ts2phc[94980.441]: [ts2phc.0.config] nmea sentence: GNRMC,195453.00,A,4233.24427,N,07126.64420,W,0.008,,160223,,,A,V
+phc2sys[94980.450]: [ptp4l.0.config] CLOCK_REALTIME phc offset       943 s2 freq  -89604 delay    504
+phc2sys[94980.512]: [ptp4l.0.config] CLOCK_REALTIME phc offset      1000 s2 freq  -89264 delay    474
+----

--- a/modules/nw-ptp-grandmaster-clock-configuration-reference.adoc
+++ b/modules/nw-ptp-grandmaster-clock-configuration-reference.adoc
@@ -1,0 +1,102 @@
+// Module included in the following assemblies:
+//
+// * networking/using-ptp.adoc
+
+:_content-type: REFERENCE
+[id="nw-ptp-grandmaster-clock-configuration-reference_{context}"]
+= Grandmaster clock PtpConfig configuration reference
+
+The following reference information describes the configuration options for the `PtpConfig` custom resource (CR) that configures the `linuxptp` services (`ptp4l`, `phc2sys`, `ts2phc`) as grandmaster clock.
+
+.PtpConfig configuration options for PTP Grandmaster clock
+[cols="1,3" options="header"]
+|====
+|PtpConfig CR field
+|Description
+
+|`plugins`
+|Specify an array of `.exec.cmdline` options that configure the NIC for grandmaster clock operation. Grandmaster clock configuration requires certain PTP pins to be disabled.
+
+The plugin mechanism allows the PTP Operator to do automated hardware configuration.
+For the Intel Westport Channel NIC, when `enableDefaultConfig` is true, The PTP Operator runs a hard-coded script to do the required configuration for the NIC.
+
+|`ptp4lOpts`
+|Specify system configuration options for the `ptp4l` service.
+The options should not include the network interface name `-i <interface>` and service config file `-f /etc/ptp4l.conf` because the network interface name and the service config file are automatically appended.
+
+|`ptp4lConf`
+|Specify the required configuration to start `ptp4l` as grandmaster clock.
+For example, the `ens2f1` interface synchronizes downstream connected devices.
+For grandmaster clocks, set `clockClass` to `6` and set `clockAccuracy` to `0x27`.
+Set `timeSource` to `0x20` for when receiving the timing signal from a Global navigation satellite system (GNSS).
+
+|`tx_timestamp_timeout`
+|Specify the maximum amount of time to wait for the transmit (TX) timestamp from the sender before discarding the data.
+
+|`boundary_clock_jbod`
+|Specify the JBOD boundary clock time delay value.
+This value is used to correct the time values that are passed between the network time devices.
+
+|`phc2sysOpts`
+a|Specify system config options for the `phc2sys` service.
+If this field is empty the PTP Operator does not start the `phc2sys` service.
+[NOTE]
+====
+Ensure that the network interface listed here is configured as grandmaster and is referenced as required in the `ts2phcConf` and `ptp4lConf` fields.
+====
+
+|`ptpSchedulingPolicy`
+|Configure the scheduling policy for `ptp4l` and `phc2sys` processes.
+Default value is `SCHED_OTHER`.
+Use `SCHED_FIFO` on systems that support FIFO scheduling.
+
+|`ptpSchedulingPriority`
+|Set an integer value from 1-65 to configure FIFO priority for `ptp4l` and `phc2sys` processes when `ptpSchedulingPolicy` is set to `SCHED_FIFO`.
+The `ptpSchedulingPriority` field is not used when `ptpSchedulingPolicy` is set to `SCHED_OTHER`.
+
+|`ptpClockThreshold`
+|Optional.
+If `ptpClockThreshold` stanza is not present, default values are used for `ptpClockThreshold` fields.
+Stanza shows default `ptpClockThreshold` values. `ptpClockThreshold` values configure how long after the PTP master clock is disconnected before PTP events are triggered.
+`holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected.
+The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`).
+When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.
+
+|`ts2phcConf`
+a|Sets the configuration for the `ts2phc` command.
+
+`leapfile` is the default path to the current leap seconds definition file in the PTP Operator container image.
+
+`ts2phc.nmea_serialport` is the serial port device that is connected to the NMEA GPS clock source.
+When configured, the GNSS receiver is accessible on `/dev/gnss<id>`.
+If the host has multiple GNSS receivers, you can find the correct device by enumerating either of the following devices:
+
+* `/sys/class/net/<eth_port>/device/gnss/`
+* `/sys/class/gnss/gnss<id>/device/`
+
+|`ts2phcOpts`
+|Set options for the `ts2phc` command.
+
+|`recommend`
+|Specify an array of one or more `recommend` objects that define rules on how the `profile` should be applied to nodes.
+
+|`.recommend.profile`
+|Specify the `.recommend.profile` object name that is defined in the `profile` section.
+
+|`.recommend.priority`
+|Specify the `priority` with an integer value between `0` and `99`.
+A larger number gets lower priority, so a priority of `99` is lower than a priority of `10`.
+If a node can be matched with multiple profiles according to rules defined in the `match` field, the profile with the higher priority is applied to that node.
+
+|`.recommend.match`
+|Specify `.recommend.match` rules with `nodeLabel` or `nodeName`.
+
+|`.recommend.match.nodeLabel`
+|Set `nodeLabel` with the `key` of `node.Labels` from the node object by using the `oc
+get nodes --show-labels` command.
+For example: `node-role.kubernetes.io/worker`.
+
+|`.recommend.match.nodeName`
+|Set `nodeName` with value of `node.Name` from the node object by using the `oc get nodes` command.
+For example: `compute-1.example.com`.
+|====

--- a/modules/nw-ptp-introduction.adoc
+++ b/modules/nw-ptp-introduction.adoc
@@ -8,14 +8,14 @@
 
 Precision Time Protocol (PTP) is used to synchronize clocks in a network. When used in conjunction with hardware support, PTP is capable of sub-microsecond accuracy, and is more accurate than Network Time Protocol (NTP).
 
-The `linuxptp` package includes the `ptp4l` and `phc2sys` programs for clock synchronization. `ptp4l` implements the PTP boundary clock and ordinary clock. `ptp4l` synchronizes the PTP hardware clock to the source clock with hardware time stamping and synchronizes the system clock to the source clock with software time stamping. `phc2sys` is used for hardware time stamping to synchronize the system clock to the PTP hardware clock on the network interface controller (NIC).
-
 [id="ptp-elements_{context}"]
 == Elements of a PTP domain
 
-PTP is used to synchronize multiple nodes connected in a network, with clocks for each node. The clocks synchronized by PTP are organized in a source-destination hierarchy. The hierarchy is created and updated automatically by the best master clock (BMC) algorithm, which runs on every clock. Destination clocks are synchronized to source clocks, and destination clocks can themselves be the source for other downstream clocks. The following types of clocks can be included in configurations:
+PTP is used to synchronize multiple nodes connected in a network, with clocks for each node. The clocks synchronized by PTP are organized in a source-destination hierarchy.
+The hierarchy is created and updated automatically by the best master clock (BMC) algorithm, which runs on every clock. Destination clocks are synchronized to source clocks, and destination clocks can themselves be the source for other downstream clocks.
+The three primary types of PTP clocks are described below.
 
-Grandmaster clock:: The grandmaster clock provides standard time information to other clocks across the network and ensures accurate and stable synchronisation. It writes time stamps and responds to time requests from other clocks. Grandmaster clocks can be synchronized to a Global Positioning System (GPS) time source.
+Grandmaster clock:: The grandmaster clock provides standard time information to other clocks across the network and ensures accurate and stable synchronisation. It writes time stamps and responds to time requests from other clocks. Grandmaster clocks synchronize to a Global Navigation Satellite System (GNSS) time source. The Grandmaster clock is the authoritative source of time in the network and is responsible for providing time synchronization to all other devices.
 
 Ordinary clock:: The ordinary clock has a single port connection that can play the role of source or destination clock, depending on its position in the network. The ordinary clock can read and write time stamps.
 

--- a/modules/ptp-linuxptp-introduction.adoc
+++ b/modules/ptp-linuxptp-introduction.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * networking/using-ptp.adoc
+
+:_content-type: CONCEPT
+[id="ptp-linuxptp-introduction_{context}"]
+= Overview of linuxptp in {product-title} nodes
+
+{product-title} uses PTP and `linuxptp` for high precision system timing in bare-metal infrastructure.
+The `linuxptp` package includes the `ts2phc`, `pmc`, `ptp4l`, and `phc2sys` programs for system clock synchronization.
+
+ts2phc:: `ts2phc` synchronizes the PTP hardware clock (PHC) across PTP devices with a high degree of precision.
+`ts2phc` is used in grandmaster clock configurations.
+It receives the precision timing signal a high precision clock source such as Global Navigation Satellite System (GNSS).
+GNSS provides an accurate and reliable source of synchronized time for use in large distributed networks.
+GNSS clocks typically provide time information with a precision of a few nanoseconds.
++
+The `ts2phc` system daemon sends timing information from the grandmaster clock to other PTP devices in the network by reading time information from the grandmaster clock and converting it to PHC format.
+PHC time is used by other devices in the network to synchronize their clocks with the grandmaster clock.
+
+pmc:: `pmc` implements a PTP management client (`pmc`) according to IEEE standard 1588.1588.
+`pmc` provides basic management access for the `ptp4l` system daemon.
+`pmc` reads from standard input and sends the output over the selected transport, printing any replies it receives.
+
+ptp4l:: `ptp4l` implements the PTP boundary clock and ordinary clock and runs as a system daemon.
+`ptp4l` does the following:
+
+* Synchronizes the PHC to the source clock with hardware time stamping
+* Synchronizes the system clock to the source clock with software time stamping
+
+phc2sys:: `phc2sys` synchronizes the system clock to the PHC on the network interface controller (NIC).
+The `phc2sys` system daemon continuously monitors the PHC for timing information.
+When it detects a timing error, the PHC corrects the system clock.

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -33,6 +33,8 @@ Before enabling PTP, ensure that NTP is disabled for the required nodes. You can
 
 include::modules/ptp-dual-nics.adoc[leveloffset=+2]
 
+include::modules/ptp-linuxptp-introduction.adoc[leveloffset=+1]
+
 include::modules/nw-ptp-installing-operator-cli.adoc[leveloffset=+1]
 
 include::modules/nw-ptp-installing-operator-web-console.adoc[leveloffset=+1]
@@ -44,6 +46,15 @@ The PTP Operator adds the `NodePtpDevice.ptp.openshift.io` custom resource defin
 When installed, the PTP Operator searches your cluster for PTP-capable network devices on each node. It creates and updates a `NodePtpDevice` custom resource (CR) object for each node that provides a compatible PTP-capable network device.
 
 include::modules/nw-ptp-device-discovery.adoc[leveloffset=+2]
+
+include::modules/nw-ptp-configuring-linuxptp-services-as-grandmaster-clock.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../networking/using-ptp.adoc#cnf-configuring-the-ptp-fast-event-publisher_using-ptp[Configuring the PTP fast event notifications publisher]
+
+include::modules/nw-ptp-grandmaster-clock-configuration-reference.adoc[leveloffset=+3]
 
 include::modules/nw-ptp-configuring-linuxptp-services-as-ordinary-clock.adoc[leveloffset=+2]
 

--- a/snippets/grandmaster-clock-ptp-config.adoc
+++ b/snippets/grandmaster-clock-ptp-config.adoc
@@ -1,0 +1,146 @@
+.Recommended PTP grandmaster clock configuration
+[source,yaml]
+----
+apiVersion: ptp.openshift.io/v1
+kind: PtpConfig
+metadata:
+  name: grandmaster
+  namespace: openshift-ptp
+spec:
+  profile:
+  - name: "grandmaster"
+    ptp4lOpts: "-2 --summary_interval -4"
+    phc2sysOpts: -r -u 0 -m -O -37 -N 8 -R 16 -s ens2f1 -n 24
+    ptpSchedulingPolicy: SCHED_FIFO
+    ptpSchedulingPriority: 10
+    plugins:
+      e810:
+        enableDefaultConfig: true
+    ts2phcOpts: " "
+    ts2phcConf: |
+      [nmea]
+      ts2phc.master 1
+      [global]
+      use_syslog  0
+      verbose 1
+      logging_level 7
+      ts2phc.pulsewidth 100000000
+      #GNSS module - ls /dev/gnss* -al
+      ts2phc.nmea_serialport /dev/gnss0
+      leapfile  /usr/share/zoneinfo/leap-seconds.list
+      [ens2f1]
+      ts2phc.extts_polarity rising
+      ts2phc.extts_correction 0
+    ptp4lConf: |
+      [ens2f1]
+      masterOnly 1
+      [ens2f2]
+      masterOnly 1
+      [ens2f3]
+      masterOnly 1
+      [ens2f4]
+      masterOnly 1
+      [global]
+      #
+      # Default Data Set
+      #
+      twoStepFlag 1
+      priority1 128
+      priority2 128
+      domainNumber 24
+      #utc_offset 37
+      clockClass 6
+      clockAccuracy 0x27
+      offsetScaledLogVariance 0xFFFF
+      free_running 0
+      freq_est_interval 1
+      dscp_event 0
+      dscp_general 0
+      dataset_comparison G.8275.x
+      G.8275.defaultDS.localPriority 128
+      #
+      # Port Data Set
+      #
+      logAnnounceInterval -3
+      logSyncInterval -4
+      logMinDelayReqInterval -4
+      logMinPdelayReqInterval 0
+      announceReceiptTimeout 3
+      syncReceiptTimeout 0
+      delayAsymmetry 0
+      fault_reset_interval 4
+      neighborPropDelayThresh 20000000
+      masterOnly 0
+      G.8275.portDS.localPriority 128
+      #
+      # Run time options
+      #
+      assume_two_step 0
+      logging_level 6
+      path_trace_enabled 0
+      follow_up_info 0
+      hybrid_e2e 0
+      inhibit_multicast_service 0
+      net_sync_monitor 0
+      tc_spanning_tree 0
+      tx_timestamp_timeout 50
+      unicast_listen 0
+      unicast_master_table 0
+      unicast_req_duration 3600
+      use_syslog 1
+      verbose 0
+      summary_interval -4
+      kernel_leap 1
+      check_fup_sync 0
+      #
+      # Servo Options
+      #
+      pi_proportional_const 0.0
+      pi_integral_const 0.0
+      pi_proportional_scale 0.0
+      pi_proportional_exponent -0.3
+      pi_proportional_norm_max 0.7
+      pi_integral_scale 0.0
+      pi_integral_exponent 0.4
+      pi_integral_norm_max 0.3
+      step_threshold 0.0
+      first_step_threshold 0.00002
+      clock_servo pi
+      sanity_freq_limit  200000000
+      ntpshm_segment 0
+      #
+      # Transport options
+      #
+      transportSpecific 0x0
+      ptp_dst_mac 01:1B:19:00:00:00
+      p2p_dst_mac 01:80:C2:00:00:0E
+      udp_ttl 1
+      udp6_scope 0x0E
+      uds_address /var/run/ptp4l
+      #
+      # Default interface options
+      #
+      clock_type BC
+      network_transport L2
+      delay_mechanism E2E
+      time_stamping hardware
+      tsproc_mode filter
+      delay_filter moving_median
+      delay_filter_length 10
+      egressLatency 0
+      ingressLatency 0
+      boundary_clock_jbod 0
+      #
+      # Clock description
+      #
+      productDescription ;;
+      revisionData ;;
+      manufacturerIdentity 00:00:00
+      userDescription ;
+      timeSource 0x20
+  recommend:
+  - profile: "grandmaster"
+    priority: 4
+    match:
+    - nodeLabel: "node-role.kubernetes.io/worker"
+----


### PR DESCRIPTION
Adds Grandmaster clock and PTP events to the Westport channel NIC
Westport channel adds ts2phc (time stamp 2 physical clock) configuration for clock synchronization

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-1039

Link to docs preview:
* [Configuring linuxptp services as a grandmaster clock](https://55704--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#configuring-linuxptp-services-as-grandmaster-clock_using-ptp)
* [Overview of linuxptp in cluster nodes](https://55704--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#ptp-linuxptp-introduction_using-ptp) 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->