### PR TITLE
OSDOCS-5032 GA for Custom Metric Autoscaler 

### DIFF
--- a/modules/nodes-pods-autoscaling-custom-about.adoc
+++ b/modules/nodes-pods-autoscaling-custom-about.adoc
@@ -6,16 +6,20 @@
 [id="nodes-pods-autoscaling-custom-about_{context}"]
 = Understanding the custom metrics autoscaler
 
-The custom metrics autoscaler uses the Kubernetes-based Event Driven Autoscaler (KEDA) and is built on top of the {product-title} horizontal pod autoscaler (HPA).
+The Custom Metrics Autoscaler Operator scales your pods up and down based on custom, external metrics from specific applications. Your other applications continue to use other scaling methods. You configure _triggers_, also known as scalers, which are the source of events and metrics that the custom metrics autoscaler uses to determine how to scale. The custom metrics autoscaler uses a metrics API to convert the external metrics to a form that {product-title} can use. The custom metrics autoscaler creates a horizontal pod autoscaler (HPA) that performs the actual scaling. 
 
-The Custom Metrics Autoscaler Operator scales your pods up and down based on custom, external metrics from specific applications. Your other applications continue to use other scaling methods. You configure _triggers_, also known as scalers, which are the source of events and metrics that the custom metrics autoscaler uses to determine how to scale. The custom metrics autoscaler uses a metrics API to convert the external metrics to a form that {product-title} can use. The custom metrics autoscaler creates a horizontal pod autoscaler (HPA) that performs the actual scaling. The custom metrics autoscaler currently supports only the Prometheus trigger, which can use the installed {product-title} monitoring or an external Prometheus server as the metrics source.  
-
-To use the custom metrics autoscaler, you create a `ScaledObject` or `ScaledJob` object, which defines the scaling metadata. You specify the deployment or job to scale, the source of the metrics to scale on (trigger), and other parameters such as the minimum and maximum replica counts allowed. 
+To use the custom metrics autoscaler, you create a `ScaledObject` or `ScaledJob` object, which is a custom resource (CR) that defines the scaling metadata. You specify the deployment or job to scale, the source of the metrics to scale on (trigger), and other parameters such as the minimum and maximum replica counts allowed. 
 
 [NOTE]
 ====
 You can create only one scaled object or scaled job for each workload that you want to scale. Also, you cannot use a scaled object or scaled job and the horizontal pod autoscaler (HPA) on the same workload.
 ==== 
+
+The custom metrics autoscaler, unlike the HPA, can scale to zero. If you set the `minReplicaCount` value in the custom metrics autoscaler CR to `0`, the custom metrics autoscaler scales the workload down from 1 to 0 replicas to or up from 0 replicas to 1. This is known as the _activation phase_. After scaling up to 1 replica, the HPA takes control of the scaling. This is known as the _scaling phase_. 
+
+Some triggers allow you to change the number of replicas that are scaled by the cluster metrics autoscaler.  In all cases, the parameter to configure the activation phase always uses the same phrase, prefixed with _activation_. For example, if the `threshold` parameter configures scaling, `activationThreshold` would configure activation. Configuring the activation and scaling phases allows you more flexibility with your scaling policies. For example, you could configure a higher activation phase to prevent scaling up or down if the metric is particularly low.  
+
+The activation value has more priority than the scaling value in case of different decisions for each. For example, if the `threshold` is set to `10`, and the `activationThreshold` is `50`, if the metric reports `40`, the scaler is not active and the pods are scaled to zero even if the HPA requires 4 instances.
 
 ////
 [NOTE]
@@ -35,3 +39,5 @@ Successfully set ScaleTarget replica count
 ----
 Successfully updated ScaleTarget
 ---- 
+
+You can temporarily pause the autoscaling of a workload object, if needed. For example, you could pause autoscaling before performing cluster maintenance.

--- a/modules/nodes-pods-autoscaling-custom-audit.adoc
+++ b/modules/nodes-pods-autoscaling-custom-audit.adoc
@@ -1,0 +1,177 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-pods-autoscaling-custom.adoc
+
+:_content-type: PROCEDURE
+[id="nodes-pods-autoscaling-custom-audit_{context}"]
+= Configuring audit logging
+
+// Text borrowed from gathering-cluster-data.adoc. Make into snippet?
+
+You can gather audit logs, which are a security-relevant chronological set of records documenting the sequence of activities that have affected the system by individual users, administrators, or other components of the system.
+
+For example, audit logs can help you understand where an autoscaling request is coming from. This is key information when backends are getting overloaded by autoscaling requests made by user applications and you need to determine which is the troublesome application. You can configure auditing for the Custom Metrics Autoscaler Operator by editing the `KedaController` custom resource. The logs are sent to an audit log file on a volume that is secured by using a persistent volume claim in the `KedaController` CR. 
+
+// You can view the audit log file directly or use the `oc adm must-gather` CLI. The `oc adm must-gather` CLI collects the log along with other information from your cluster that is most likely needed for debugging issues, such as resource definitions and service logs.
+
+.Prerequisites
+
+* The Custom Metrics Autoscaler Operator must be installed.
+
+.Procedure
+
+. Edit the `KedaController` custom resource to add the `auditConfig` stanza:
++
+[source,yaml]
+----
+kind: KedaController
+apiVersion: keda.sh/v1alpha1
+metadata:
+  name: keda
+  namespace: openshift-keda
+spec:
+ ...
+  metricsServer:
+ ...
+    auditConfig:
+      logFormat: "json" <1>
+      logOutputVolumeClaim: "pvc-audit-log" <2>
+      policy:
+        rules: <3>
+        - level: Metadata
+        omitStages: "RequestReceived" <4>
+        omitManagedFields: false <5>
+      lifetime: <6>
+        maxAge: "2"
+        maxBackup: "1"
+        maxSize: "50"
+----
+<1> Specifies the output format of the audit log, either `legacy` or `json`.
+<2> Specifies an existing persistent volume claim for storing the log data. All requests coming to the API server are logged to this persistent volume claim. If you leave this field empty, the log data is sent to stdout.
+<3> Specifies which events should be recorded and what data they should include:
++
+* `None`: Do not log events.
+* `Metadata`: Log only the metadata for the request, such as user, timestamp, and so forth. Do not log the request text and the response text. This is the default.
+* `Request`: Log only the metadata and the request text but not the response text. This option does not apply for non-resource requests.
+* `RequestResponse`: Log event metadata, request text, and response text. This option does not apply for non-resource requests.
++
+<4> Specifies stages for which no event is created.
+<5> Specifies whether to omit the managed fields of the request and response bodies from being written to the API audit log, either `true` to omit the fields or `false` to include the fields.
+<6> Specifies the size and lifespan of the audit logs.
++
+* `maxAge`: The maximum number of days to retain audit log files, based on the timestamp encoded in their filename.
+* `maxBackup`: The maximum number of audit log files to retain. Set to `0` to retain all audit log files.
+* `maxSize`: The maximum size in megabytes of an audit log file before it gets rotated.
+
+.Verification
+
+////
+. Use the `oc adm must-gather` CLI to collect the audit log file:
++
+[source,terminal]
+----
+oc adm must-gather -- /usr/bin/gather_audit_logs
+---- 
+////
+
+. View the audit log file directly:
+
+.. Obtain the name of the `keda-metrics-apiserver-*` pod:
++
+[source,terminal]
+----
+oc get pod -n openshift-keda
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                                                  READY   STATUS    RESTARTS   AGE
+custom-metrics-autoscaler-operator-5cb44cd75d-9v4lv   1/1     Running   0          8m20s
+keda-metrics-apiserver-65c7cc44fd-rrl4r               1/1     Running   0          2m55s
+keda-operator-776cbb6768-zpj5b                        1/1     Running   0          2m55s
+----
+
+.. View the log data by using a command similar to the following:
++
+[source,terminal]
+----
+$ oc logs keda-metrics-apiserver-<hash>|grep -i metadata <1>
+----
+<1> Optional: You can use the `grep` command to specify the log level to display: `Metadata`, `Request`, `RequestResponse`.
++
+For example:
++
+[source,terminal]
+----
+$ oc logs keda-metrics-apiserver-65c7cc44fd-rrl4r|grep -i metadata
+----
++
+.Example output
++
+[source,terminal]
+----
+ ...
+{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Metadata","auditID":"4c81d41b-3dab-4675-90ce-20b87ce24013","stage":"ResponseComplete","requestURI":"/healthz","verb":"get","user":{"username":"system:anonymous","groups":["system:unauthenticated"]},"sourceIPs":["10.131.0.1"],"userAgent":"kube-probe/1.26","responseStatus":{"metadata":{},"code":200},"requestReceivedTimestamp":"2023-02-16T13:00:03.554567Z","stageTimestamp":"2023-02-16T13:00:03.555032Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":""}}
+ ...
+----
+
+. Alternatively, you can view a specific log:
++
+.. Use a command similar to the following to log into the `keda-metrics-apiserver-*` pod:
++
+[source,terminal]
+----
+$ oc rsh pod/keda-metrics-apiserver-<hash> -n openshift-keda
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc rsh pod/keda-metrics-apiserver-65c7cc44fd-rrl4r -n openshift-keda
+----
+
+.. Change to the `/var/audit-policy/` directory: 
++
+[source,terminal]
+----
+sh-4.4$ cd /var/audit-policy/
+----
+
+.. List the available logs:
++
+[source,terminal]
+----
+sh-4.4$ ls
+----
++
+.Example output
++
+[source,terminal]
+----
+log-2023.02.17-14:50  policy.yaml
+----
+
+.. View the log, as needed:
++
+[source,terminal]
+----
+sh-4.4$ cat <log_name>/<pvc_name>|grep -i <log_level> <1>
+----
+<1> Optional: You can use the `grep` command to specify the log level to display: `Metadata`, `Request`, `RequestResponse`.
++
+For example:
++
+[source,terminal]
+----
+sh-4.4$ cat log-2023.02.17-14:50/pvc-audit-log|grep -i Request
+----
++
+.Example output
+----
+ ...
+{"kind":"Event","apiVersion":"audit.k8s.io/v1","level":"Request","auditID":"63e7f68c-04ec-4f4d-8749-bf1656572a41","stage":"ResponseComplete","requestURI":"/openapi/v2","verb":"get","user":{"username":"system:aggregator","groups":["system:authenticated"]},"sourceIPs":["10.128.0.1"],"responseStatus":{"metadata":{},"code":304},"requestReceivedTimestamp":"2023-02-17T13:12:55.035478Z","stageTimestamp":"2023-02-17T13:12:55.038346Z","annotations":{"authorization.k8s.io/decision":"allow","authorization.k8s.io/reason":"RBAC: allowed by ClusterRoleBinding \"system:discovery\" of ClusterRole \"system:discovery\" to Group \"system:authenticated\""}}
+ ...
+----

--- a/modules/nodes-pods-autoscaling-custom-creating-workload.adoc
+++ b/modules/nodes-pods-autoscaling-custom-creating-workload.adoc
@@ -6,12 +6,15 @@
 [id="nodes-pods-autoscaling-custom-creating-workload_{context}"]
 = Adding a custom metrics autoscaler to a workload
 
-You can create a custom metrics autoscaler for a workload created by a `Deployment`, `StatefulSet`, or custom resource` object.
+You can create a custom metrics autoscaler for a workload that is created by a `Deployment`, `StatefulSet`, or `custom resource` object.
 
 .Prerequisites
 
-////
-* If you use a custom metrics autoscaler for scaling based on CPU or memory, your cluster administrator must have properly configured cluster metrics. You can use the `oc describe PodMetrics <pod-name>` command to determine if metrics are configured. If metrics are configured, the output appears similar to the following, with CPU and Memory displayed under Usage.
+* The Custom Metrics Autoscaler Operator must be installed. 
+
+* If you use a custom metrics autoscaler for scaling based on CPU or memory: 
+
+** Your cluster administrator must have properly configured cluster metrics. You can use the `oc describe PodMetrics <pod-name>` command to determine if metrics are configured. If metrics are configured, the output appears similar to the following, with CPU and Memory displayed under Usage.
 +
 [source,terminal]
 ----
@@ -42,13 +45,28 @@ Timestamp:             2019-05-23T18:47:56Z
 Window:                1m0s
 Events:                <none>
 ----
-////
 
-* The Custom Metrics Autoscaler Operator must be installed. 
+** The pods associated with the object you want to scale must include specified memory and CPU limits. For example:
++
+.Example pod spec
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+ ...
+spec:
+  containers:
+  - name: app
+    image: images.my-company.example/app:v4
+    resources:
+      limits:
+        memory: "128Mi"
+        cpu: "500m"
+----
 
 .Procedure
 
-. Create a YAML file similar to the following:
+. Create a YAML file similar to the following. Only the name `<2>`, object name `<4>`, and object kind `<5>` are required:
 +
 .Example scaled object
 [source,yaml,options="nowrap"]
@@ -56,22 +74,41 @@ Events:                <none>
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: scaledobject
+  annotations:
+    autoscaling.keda.sh/paused-replicas: "0" <1>
+  name: scaledobject <2>
   namespace: my-namespace
 spec:
   scaleTargetRef:
-    api: apps/v1 <1>
-    name: example-deployment <2>
-    kind: Deployment <3>
-    envSourceContainerName: .spec.template.spec.containers[0] <4>
-  cooldownPeriod:  200 <5>
-  maxReplicaCount: 100 <6>
-  minReplicaCount: 0 <7>
-  pollingInterval: 30 <8>
+    api: apps/v1 <3>
+    name: example-deployment <4>
+    kind: Deployment <5>
+    envSourceContainerName: .spec.template.spec.containers[0] <6>
+  cooldownPeriod:  200 <7>
+  maxReplicaCount: 100 <8>
+  minReplicaCount: 0 <9>
+  metricsServer: <10>
+    auditConfig:
+      logFormat: "json" 
+      logOutputVolumeClaim: "persistentVolumeClaimName" 
+      policy:
+        rules: 
+        - level: Metadata
+        omitStages: "RequestReceived" 
+        omitManagedFields: false 
+      lifetime: 
+        maxAge: "2"
+        maxBackup: "1"
+        maxSize: "50"
+  fallback: <11>
+    failureThreshold: 3
+    replicas: 6
+  pollingInterval: 30 <12>
   advanced: 
-    restoreToOriginalReplicaCount: false <9>
+    restoreToOriginalReplicaCount: false <13>
     horizontalPodAutoscalerConfig: 
-      behavior: <10>
+      name: keda-hpa-scale-down <14>
+      behavior: <15>
         scaleDown:
           stabilizationWindowSeconds: 300
           policies:
@@ -79,7 +116,7 @@ spec:
             value: 100
             periodSeconds: 15
   triggers:
-  - type: prometheus <11>
+  - type: prometheus <16>
     metadata:
       serverAddress: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092
       namespace: kedatest 
@@ -87,30 +124,35 @@ spec:
       threshold: '5'
       query: sum(rate(http_requests_total{job="test-app"}[1m]))
       authModes: "basic"
-  - authenticationRef: <12>
+  - authenticationRef: <17>
       name: prom-triggerauthentication
     metadata:
       name: prom-triggerauthentication
     type: object
-  - authenticationRef: <13>
+  - authenticationRef: <18>
       name: prom-cluster-triggerauthentication
     metadata:
       name: prom-cluster-triggerauthentication
     type: object
 ----
-<1> Optional: Specifies the API version of the target resource. The default is `apps/v1`.
-<2> Specifies the name of the object that you want to scale. 
-<3> Specifies the `kind` as `Deployment`, `StatefulSet` or `CustomResource`.
-<4> Optional: Specifies the name of the container in the target resource, from which the custom autoscaler gets environment variables holding secrets and so forth. The default is `.spec.template.spec.containers[0]`.
-<5> Optional. Specifies the period in seconds to wait after the last trigger is reported before scaling the deployment back to `0` if the `minReplicaCount` is set to `0`. The default is `300`.
-<6> Optional: Specifies the maximum number of replicas when scaling up. The default is `100`.
-<7> Optional: Specifies the minimum number of replicas when scaling down.
-<8> Optional: Specifies the interval in seconds to check each trigger on. The default is `30`.
-<9> Optional: Specifies whether to scale back the target resource to the original replicas count after the scaled object is deleted. The default is `false`, which keeps the replica count as it is when the scaled object is deleted.
-<10> Optional: Specifies a scaling policy to use to control the rate to scale pods up or down. For more information, see the link in the "Additional resources" section that follows.
-<11> Specifies the trigger to use as the basis for scaling, as described in the "Understanding the custom metrics autoscaler triggers" section. This example uses {product-title} monitoring.
-<12> Optional: Specifies a trigger authentication, as described in the "Creating a custom metrics autoscaler trigger authentication" section.
-<13> Optional: Specifies a cluster trigger authentication, as described in the "Creating a custom metrics autoscaler trigger authentication" section.
+<1> Optional: Specifies that the Custom Metrics Autoscaler Operator is to scale the replicas to the specified value and stop autoscaling, as described in the "Pausing the custom metrics autoscaler for a workload" section.
+<2> Specifies a name for this custom metrics autoscaler. 
+<3> Optional: Specifies the API version of the target resource. The default is `apps/v1`.
+<4> Specifies the name of the object that you want to scale. 
+<5> Specifies the `kind` as `Deployment`, `StatefulSet` or `CustomResource`.
+<6> Optional: Specifies the name of the container in the target resource, from which the custom metrics autoscaler gets environment variables holding secrets and so forth. The default is `.spec.template.spec.containers[0]`.
+<7> Optional. Specifies the period in seconds to wait after the last trigger is reported before scaling the deployment back to `0` if the `minReplicaCount` is set to `0`. The default is `300`.
+<8> Optional: Specifies the maximum number of replicas when scaling up. The default is `100`.
+<9> Optional: Specifies the minimum number of replicas when scaling down.
+<10> Optional: Specifies the parameters for audit logs. as described in the "Configuring audit logging" section.  
+<11> Optional: Specifies the number of replicas to fall back to if a scaler fails to get metrics from the source for the number of times defined by the `failureThreshold` parameter. For more information on fallback behavior, see the link:https://keda.sh/docs/2.7/concepts/scaling-deployments/#fallback[KEDA documentation]. 
+<12> Optional: Specifies the interval in seconds to check each trigger on. The default is `30`.
+<13> Optional: Specifies whether to scale back the target resource to the original replica count after the scaled object is deleted. The default is `false`, which keeps the replica count as it is when the scaled object is deleted.
+<14> Optional: Specifies a name for the horizontal pod autoscaler. The default is `keda-hpa-{scaled-object-name}`.
+<15> Optional: Specifies a scaling policy to use to control the rate to scale pods up or down, as described in the "Scaling policies" section.
+<16> Specifies the trigger to use as the basis for scaling, as described in the "Understanding the custom metrics autoscaler triggers" section. This example uses {product-title} monitoring.
+<17> Optional: Specifies a trigger authentication, as described in the "Creating a custom metrics autoscaler trigger authentication" section.
+<18> Optional: Specifies a cluster trigger authentication, as described in the "Creating a custom metrics autoscaler trigger authentication" section.
 +
 [NOTE]
 ====
@@ -154,12 +196,4 @@ Note the following fields in the output:
 ** If `False`, the custom metrics autoscaler is getting metrics. 
 ** If `True`, the custom metrics autoscaler is getting metrics because there are no metrics or there is a problem in one or more of the objects you created.
 
-////
-For more information on fallback behavior, see the link:https://keda.sh/docs/2.7/concepts/scaling-deployments/#fallback[KEDA documentation]. 
 
-  fallback: <9>
-    failureThreshold: 3
-    replicas: 6
-
-<9> Optional: Specifies the number of replicas to fall back to if a scaler fails to get metrics from the source for the number of times defined by the `failureThreshold` parameter.
-////

--- a/modules/nodes-pods-autoscaling-custom-install.adoc
+++ b/modules/nodes-pods-autoscaling-custom-install.adoc
@@ -106,11 +106,24 @@ spec:
     logEncoder: console <3>
   metricsServer:
     logLevel: '0' <4>
+    auditConfig: <5>
+      logFormat: "json"
+      logOutputVolumeClaim: "persistentVolumeClaimName"
+      policy:
+        rules:
+        - level: Metadata
+        omitStages: "RequestReceived"
+        omitManagedFields: false
+      lifetime:
+        maxAge: "2"
+        maxBackup: "1"
+        maxSize: "50"
   serviceAccount: {}
 ----
 <1> Specifies the namespaces that the custom autoscaler should watch. Enter names in a comma-separated list. Omit or set empty to watch all namespaces. The default is empty.
 <2> Specifies the level of verbosity for the Custom Metrics Autoscaler Operator log messages. The allowed values are `debug`, `info`, `error`. The default is `info`.
 <3> Specifies the logging format for the Custom Metrics Autoscaler Operator log messages. The allowed values are `console` or `json`. The default is `console`.
 <4> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` or `debug`. The default is `0`.
+<5> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section. 
 
 .. Click *Create* to create the KEDAController.

--- a/modules/nodes-pods-autoscaling-custom-pausing.adoc
+++ b/modules/nodes-pods-autoscaling-custom-pausing.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-pods-autoscaling-custom.adoc
+
+:_content-type: PROCEDURE
+[id="nodes-pods-autoscaling-custom-pausing_{context}"]
+= Pausing the custom metrics autoscaler for a workload
+
+You can pause the autoscaling of a workload, as needed, by adding the `autoscaling.keda.sh/paused-replicas` annotation to the custom metrics autoscaler for that workload. The custom metrics autoscaler scales the replicas for that workload to the specified value and pauses autoscaling until the annotation is removed.
+
+[source,yaml]
+----
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  annotations:
+    autoscaling.keda.sh/paused-replicas: "4"
+...
+----
+
+To restart autoscaling, edit the `ScaledObject` CR to remove the annotation.
+
+For example, you might want to pause autoscaling before performing cluster maintenance or to avoid resource starvation by removing non-mission-critical workloads. 
+
+.Procedure
+
+. Use the following command to edit the `ScaledObject` CR for your workload:
++
+[source,terminal]
+----
+$ oc edit ScaledObject scaledobject 
+----
+
+. Add the `autoscaling.keda.sh/paused-replicas` annotation with any value:
++
+[source,yaml]
+----
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  annotations:
+    autoscaling.keda.sh/paused-replicas: "4" <1>
+  creationTimestamp: "2023-02-08T14:41:01Z"
+  generation: 1
+  name: scaledobject
+  namespace: my-project
+  resourceVersion: "65729"
+  uid: f5aec682-acdf-4232-a783-58b5b82f5dd0
+----
+<1> Specifies that the Custom Metrics Autoscaler Operator is to scale the replicas to the specified value and stop autoscaling.
+

--- a/modules/nodes-pods-autoscaling-custom-prometheus-config.adoc
+++ b/modules/nodes-pods-autoscaling-custom-prometheus-config.adoc
@@ -6,7 +6,7 @@
 [id="nodes-pods-autoscaling-custom-prometheus-config_{context}"]
 = Configuring the custom metrics autoscaler to use {product-title} monitoring
 
-You can use the installed {product-title} monitoring as a source for the metrics used by the custom metrics autoscaler. However, there are some additional configurations you must perform.
+You can use the installed {product-title} Prometheus monitoring as a source for the metrics used by the custom metrics autoscaler. However, there are some additional configurations you must perform.
 
 [NOTE]
 ====

--- a/modules/nodes-pods-autoscaling-custom-rn.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-pods-autoscaling-custom.adoc
+
+:_content-type: CONCEPT
+[id="nodes-pods-autoscaling-custom-rn_{context}"]
+= Custom Metrics Autoscaler Operator release notes
+
+The release notes for the Custom Metrics Autoscaler Operator for Red Hat Openshift describe new features and enhancements, deprecated features, and known issues.
+
+The Custom Metrics Autoscaler Operator uses the Kubernetes-based Event Driven Autoscaler (KEDA) and is built on top of the {product-title} horizontal pod autoscaler (HPA).
+
+[NOTE]
+====
+The Custom Metrics Autoscaler Operator for Red Hat OpenShift is provided as an installable component, with a distinct release cycle from the core {product-title}. The link:https://access.redhat.com/support/policy/updates/openshift#cma[Red Hat OpenShift Container Platform Life Cycle Policy] outlines release compatibility.
+====
+
+[id="nodes-pods-autoscaling-custom-rn-versions_{context}"]
+== Supported versions
+
+The following table defines the Custom Metrics Autoscaler Operator versions for each {product-title} version.
+
+[cols="3,7,3",options="header"]
+|===
+|Version
+|{product-title} version
+|General availability
+
+|2.8.2
+|4.13
+|Technology Preview
+
+|2.8.2
+|4.12
+|Technology Preview
+
+|2.8.2
+|4.11
+|Technology Preview
+
+|2.8.2
+|4.10
+|Technology Preview
+|===
+
+[id="nodes-pods-autoscaling-custom-rn-282_{context}"]
+== Custom Metrics Autoscaler Operator 2.8.2 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.8.2 provides new features and bug fixes for running the Operator in an {product-title} cluster. The components of the Custom Metrics Autoscaler Operator 2.8.2 were released in link:https://access.redhat.com/errata/RHSA-2023:1042[RHSA-2023:1042].
+
+[IMPORTANT]
+====
+The Custom Metrics Autoscaler Operator is currently a link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview] feature.
+====
+
+[id="nodes-pods-autoscaling-custom-rn-282-new_{context}"]
+New features and enhancements
+
+[id="autoscaling-custom-2-8-2-audit-log"]
+=== Audit Logging
+
+You can now gather and view audit logs for the Custom Metrics Autoscaler Operator and its associated components. Audit logs are security-relevant chronological sets of records that document the sequence of activities that have affected the system by individual users, administrators, or other components of the system.  
+
+[id="autoscaling-custom-2-8-2-kafka-metrics"]
+=== Scale applications based on Apache Kafka metrics
+
+You can now use the KEDA Apache kafka trigger/scaler to scale deployments based on an Apache Kafka topic.
+
+[id="autoscaling-custom-2-8-2-cpu-metrics"]
+=== Scale applications based on CPU metrics
+
+You can now use the KEDA CPU trigger/scaler to scale deployments based on CPU metrics.
+
+[id="autoscaling-custom-2-8-2-memory-metrics"]
+=== Scale applications based on memory metrics
+
+You can now use the KEDA memory trigger/scaler to scale deployments based on memory metrics.

--- a/modules/nodes-pods-autoscaling-custom-trigger.adoc
+++ b/modules/nodes-pods-autoscaling-custom-trigger.adoc
@@ -10,17 +10,17 @@ Triggers, also known as scalers, provide the metrics that the Custom Metrics Aut
 
 [NOTE]
 ====
-The custom metrics autoscaler currently supports only the Prometheus trigger, which can use the installed {product-title} monitoring or an external Prometheus server as the metrics source.  
+The custom metrics autoscaler currently supports only the  Prometheus, CPU, memory, and Apache Kafka triggers.  
 ====
 
-//You can specify a single trigger or multiple triggers. When using multiple triggers, the scaling is based on the greatest value from all the triggers. This section contains examples of the triggers suported for use with {product-title}. 
+//You can specify a single trigger or multiple triggers. When using multiple triggers, the scaling is based on the greatest value from all the triggers. This section contains examples of the triggers supported for use with {product-title}. 
 
 You use a `ScaledObject` or `ScaledJob` custom resource to configure triggers for specific objects, as described in the sections that follow. 
 
 [id="nodes-pods-autoscaling-custom-trigger-prom_{context}"]
 == Understanding the Prometheus trigger
 
-Scale applications based on Prometheus metrics. See _Additional resources_ for information on the configurations required to use the {product-title} monitoring as a source for metrics. 
+You can scale pods based on Prometheus metrics, which can use the installed {product-title} monitoring or an external Prometheus server as the metrics source. See _Additional resources_ for information on the configurations required to use the {product-title} monitoring as a source for metrics. 
 
 [NOTE]
 ====
@@ -46,6 +46,9 @@ spec:
       threshold: '5' <5>
       query: sum(rate(http_requests_total{job="test-app"}[1m])) <6>
       authModes: "basic" <7>
+      cortexOrgID: my-org <8>
+      ignoreNullValues: false <9>
+      unsafeSsl: "false" <10>
 ----
 <1> Specifies Prometheus as the scaler/trigger type.
 <2> Specifies the address of the Prometheus server. This example uses  {product-title} monitoring.
@@ -54,57 +57,25 @@ spec:
 <5> Specifies the value to start scaling for.
 <6> Specifies the Prometheus query to use.
 <7> Specifies the authentication method to use. Prometheus scalers support bearer authentication, basic authentication, or TLS authentication. You configure the specific authentication parameters in a trigger authentication, as discussed in a following section. As needed, you can also use a secret.
-
-////
-[id="nodes-pods-autoscaling-custom-trigger-kafka_{context}"]
-== Understanding the Kafka trigger
-
-Scale applications based on an Apache Kafka topic or other services that support Kafka protocol. The custom metrics autoscaler does not scale higher than the number of Kafka partitions, unless you set the `allowIdleConsumers` parameter to `true` in the scaled object or scaled job.
-
-.Example scaled object with a Kafka target
-[source,yaml,options="nowrap"]
-----
-apiVersion: keda.sh/v1alpha1
-kind: ScaledObject
-metadata:
-  name: kafka-scaledobject
-  namespace: my-namespace
-spec:
- ...
-  triggers:
-  - type: kafka <1>
-    metadata:
-      topic: my-topic <2>
-      bootstrapServers: my-cluster-kafka-bootstrap.openshift-operators.svc:9092 <3>
-      consumerGroup: my-group <4>
-      lagThreshold: '10' <5>
-      offsetResetPolicy: 'latest' <6>
-      allowIdleConsumers: true <7>
-      scaleToZeroOnInvalidOffset: false <8>
-      version: 1.0.0 <9>
-----
-<1> Specifies Kafka as the scaler/trigger type.
-<2> Specifies the name of the Kafka topic on which Kafka is processing the offset lag.
-<3> Specifies a comma-separated list of Kafka brokers to connect to.
-<4> Specifies the name of the Kafka consumer group used for checking the offset on the topic and processing the related lag.
-<5> Optional: Specifies the average target value to trigger scaling actions. The default is `5`.
-<6> Optional: Specifies the Kafka offset reset policy for the Kafka consumer. The available values are: `latest` and `earliest`. The default is `latest`.
-<7> Optional: Specifies whether the number of Kafka replicas can exceed the number of partitions on a topic.  The default is `false`.
-     * If `true`, the number of Kafka replicas can exceed the number of partitions on a topic. This allows for idle Kafka consumers.
-     * If `false`, the number of Kafka replicas can exceed the number of partitions on a topic.
-<8> Specifies how the trigger behaves when a Kafka partition does not have a valid offset. The default is `false`.
-     * If `false`, the scaler keeps a single consumer for that partition.
-     * If `true`, the consumers is scaled to zero for that partition.
-<9> Optional: Specifies the version of your Kafka brokers. The default is `1.0.0`.
+<8> Optional: Passes the `X-Scope-OrgID` header to multi-tenant link:https://cortexmetrics.io/[Cortex] or link:https://grafana.com/oss/mimir/[Mimir] storage for Prometheus. This parameter is required only with multi-tenant Prometheus storage, to indicate which data Prometheus should return. 
+<9> Optional: Specifies how the trigger should proceed if the Prometheus target is lost.
+     * If `true`, the trigger continues to operate if the Prometheus target is lost. This is the default.
+     * If `false`, the trigger returns an error if the Prometheus target is lost.
+<10> Optional: Specifies whether the certificate check should be skipped. For example, you might skip the check if you use self-signed certificates at the Prometheus endpoint.
+     * If `true`, the certificate check is performed.
+     * If `false`, the certificate check is not performed. This is the default.
 
 [id="nodes-pods-autoscaling-custom-trigger-cpu_{context}"]
 == Understanding the CPU trigger
 
-You can scale based on CPU metrics. This trigger uses cluster metrics as the source for metrics.
+You can scale pods based on CPU metrics. This trigger uses cluster metrics as the source for metrics.
+
+The custom metrics autoscaler scales the pods associated with an object to maintain the CPU usage that you specify. The autoscaler increases or decreases the number of replicas between the minimum and maximum numbers to maintain the specified CPU utilization across all pods. The memory trigger considers the memory utilization of the entire pod. If the pod has multiple containers, the memory utilization is the sum of all of the containers.
 
 [NOTE]
 ====
-This trigger cannot be used with the `ScaledJob` custom resource.
+* This trigger cannot be used with the `ScaledJob` custom resource.
+* When using a memory trigger to scale an object, the object does not scale to `0`, even if you are using multiple triggers.
 ====
 
 .Example scaled object with a CPU target
@@ -124,21 +95,27 @@ spec:
     metricType: Utilization <2>
     metadata:
       value: "60" <3>
+      containerName: "api" <4>
+
 ----
 <1> Specifies CPU as the scaler/trigger type.
 <2> Specifies the type of metric to use, either `Utilization` or `AverageValue`.
 <3> Specifies the value to trigger scaling actions upon:
 * When using `Utilization`, the target value is the average of the resource metrics across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 * When using `AverageValue`, the target value is the average of the metrics across all relevant pods.
+<4> Optional. Specifies an individual container to scale, based on the memory utilization of only that container, rather than the entire pod. Here, only the container named `api` is to be scaled.
 
 [id="nodes-pods-autoscaling-custom-trigger-memory_{context}"]
 == Understanding the memory trigger
 
-You can scale based on memory metrics. This trigger uses cluster metrics as the source for metrics.
+You can scale pods based on memory metrics. This trigger uses cluster metrics as the source for metrics.
+
+The custom metrics autoscaler scales the pods associated with an object to maintain the average memory usage that you specify. The autoscaler increases and decreases the number of replicas between the minimum and maximum numbers to maintain the specified memory utilization across all pods. The memory trigger considers the memory utilization of entire pod. If the pod has multiple containers, the memory utilization is the sum of all of the containers.
 
 [NOTE]
 ====
-This trigger cannot be used with the `ScaledJob` custom resource.
+* This trigger cannot be used with the `ScaledJob` custom resource.
+* When using a memory trigger to scale an object, the object does not scale to `0`, even if you are using multiple triggers.
 ====
 
 .Example scaled object with a memory target
@@ -158,11 +135,74 @@ spec:
     metricType: Utilization <2>
     metadata:
       value: "60" <3>
+      containerName: "api" <4>
 ----
 <1> Specifies memory as the scaler/trigger type.
 <2> Specifies the type of metric to use, either `Utilization` or `AverageValue`.
 <3> Specifies the value to trigger scaling actions for:
 * When using `Utilization`, the target value is the average of the resource metrics across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 * When using `AverageValue`, the target value is the average of the metrics across all relevant pods.
-////
+<4> Optional. Specifies an individual container to scale, based on the memory utilization of only that container, rather than the entire pod. Here, only the container named `api` is to be scaled.
+
+[id="nodes-pods-autoscaling-custom-trigger-kafka_{context}"]
+== Understanding the Kafka trigger
+
+You can scale pods based on an Apache Kafka topic or other services that support the Kafka protocol. The custom metrics autoscaler does not scale higher than the number of Kafka partitions, unless you set the `allowIdleConsumers` parameter to `true` in the scaled object or scaled job.
+
+[NOTE]
+====
+If the number of consumer groups exceeds the number of partitions in a topic, the extra consumer groups sit idle.
+
+To avoid this, by default the number of replicas does not exceed:
+
+* The number of partitions on a topic, if a topic is specified.
+* The number of partitions of all topics in the consumer group, if no topic is specified.
+* The `maxReplicaCount` specified in scaled object or scaled job CR.
+
+You can use the `allowIdleConsumers` parameter to disable these default behaviors.
+====
+
+.Example scaled object with a Kafka target
+[source,yaml,options="nowrap"]
+----
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: kafka-scaledobject
+  namespace: my-namespace
+spec:
+ ...
+  triggers:
+  - type: kafka <1>
+    metadata:
+      topic: my-topic <2>
+      bootstrapServers: my-cluster-kafka-bootstrap.openshift-operators.svc:9092 <3>
+      consumerGroup: my-group <4>
+      lagThreshold: '10' <5>
+      activationLagThreshold <6>
+      offsetResetPolicy: 'latest' <7>
+      allowIdleConsumers: true <8>
+      scaleToZeroOnInvalidOffset: false <9>
+      excludePersistentLag: false <10>
+      version: 1.0.0 <11>
+      partitionLimitation: '1,2,10-20,31' <12>
+----
+<1> Specifies Kafka as the scaler/trigger type.
+<2> Specifies the name of the Kafka topic on which Kafka is processing the offset lag.
+<3> Specifies a comma-separated list of Kafka brokers to connect to.
+<4> Specifies the name of the Kafka consumer group used for checking the offset on the topic and processing the related lag.
+<5> Optional: Specifies the average target value to trigger scaling actions. The default is `5`.
+<6> Optional: Specifies the target value for the activation phase.
+<7> Optional: Specifies the Kafka offset reset policy for the Kafka consumer. The available values are: `latest` and `earliest`. The default is `latest`.
+<8> Optional: Specifies whether the number of Kafka replicas can exceed the number of partitions on a topic.
+     * If `true`, the number of Kafka replicas can exceed the number of partitions on a topic. This allows for idle Kafka consumers.
+     * If `false`, the number of Kafka replicas cannot exceed the number of partitions on a topic. This is the default.
+<9> Specifies how the trigger behaves when a Kafka partition does not have a valid offset.
+     * If `true`, the consumers are scaled to zero for that partition.
+     * If `false`, the scaler keeps a single consumer for that partition. This is the default.
+<10> Optional: Specifies whether the trigger includes or excludes partition lag for partitions whose current offset is the same as the current offset of the previous polling cycle.
+      * If `true`, the scaler excludes partition lag in these partitions.
+      * If `false`, the trigger includes all consumer lag in all partitions. This is the default.
+<11> Optional: Specifies the version of your Kafka brokers. The default is `1.0.0`.
+<12> Optional: Specifies a comma-separated list of partition IDs to scope the scaling on. If set, only the listed IDs are considered when calculating lag. The default is to consider all partitions.
 

--- a/nodes/pods/nodes-pods-autoscaling-custom.adoc
+++ b/nodes/pods/nodes-pods-autoscaling-custom.adoc
@@ -6,11 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a developer, you can use the custom metrics autoscaler to specify how {product-title} should automatically increase or decrease the number of pods for a deployment, stateful set, custom resource, or job based on custom metrics that are not just based on CPU or memory.
+As a developer, you can use the custom metrics autoscaler to specify how {product-title} should automatically increase or decrease the number of pods for a deployment, stateful set, custom resource, or job based on custom metrics that are not based only on CPU or memory.
+
+The Custom Metrics Autoscaler Operator for Red Hat OpenShift is an optional operator, based on the Kubernetes Event Driven Autoscaler (KEDA), that allows workloads to be scaled using additional metrics sources other than pod metrics.
 
 [NOTE]
 ====
-The custom metrics autoscaler currently supports only the Prometheus trigger, which can use the installed {product-title} monitoring or an external Prometheus server as the metrics source.
+The custom metrics autoscaler currently supports only the Prometheus, CPU, memory, and Apache Kafka metrics.
 ====
 
 // For example, you can scale a database application based on the number of tables in the database, scale another application based on the number of messages in a Kafka topic, or scale based on incoming HTTP requests collected by {product-title} monitoring.
@@ -18,11 +20,19 @@ The custom metrics autoscaler currently supports only the Prometheus trigger, wh
 :FeatureName: The custom metrics autoscaler
 include::snippets/technology-preview.adoc[leveloffset=+0]
 
-
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other
 // assemblies.
+
+include::modules/nodes-pods-autoscaling-custom-rn.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-audit_nodes-pods-autoscaling-custom[Configuring audit logging]
+* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-trigger-cpu_nodes-pods-autoscaling-custom[Understanding the CPU trigger]
+* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-trigger-memory_nodes-pods-autoscaling-custom[Understanding the memory trigger]
+* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-trigger-kafka_nodes-pods-autoscaling-custom[Understanding the Kafka trigger]
 
 include::modules/nodes-pods-autoscaling-custom-about.adoc[leveloffset=+1]
 
@@ -51,6 +61,16 @@ include::modules/nodes-pods-autoscaling-custom-prometheus-config.adoc[leveloffse
 
 * For information on enabing monitoring of user-defined workloads, see xref:../../monitoring/configuring-the-monitoring-stack.html#creating-user-defined-workload-monitoring-configmap_configuring-the-monitoring-stack[Creating a user-defined workload monitoring config map].
 
+include::modules/nodes-pods-autoscaling-custom-pausing.adoc[leveloffset=+1]
+
+include::modules/nodes-pods-autoscaling-custom-audit.adoc[leveloffset=+1]
+
+////
+.Additional resources
+
+* For information on the `oc adm must-gather` command, see xref:../../support/gathering-cluster-data.adoc#gathering-cluster-data[Gathering data about your cluster].
+////
+
 include::modules/nodes-pods-autoscaling-custom-adding.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-autoscaling-custom-creating-workload.adoc[leveloffset=+2]
@@ -60,6 +80,7 @@ include::modules/nodes-pods-autoscaling-custom-creating-workload.adoc[leveloffse
 * xref:../../nodes/pods/nodes-pods-autoscaling.adoc#nodes-pods-autoscaling-policies_nodes-pods-autoscaling[Scaling policies]
 * xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-trigger_nodes-pods-autoscaling-custom[Understanding the custom metrics autoscaler triggers]
 * xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-trigger-auth_nodes-pods-autoscaling-custom[Understanding custom metrics autoscaler trigger authentications]
+* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-audit_nodes-pods-autoscaling-custom[Configuring audit logging]
 
 include::modules/nodes-pods-autoscaling-custom-creating-job.adoc[leveloffset=+2]
 
@@ -70,3 +91,4 @@ include::modules/nodes-pods-autoscaling-custom-creating-job.adoc[leveloffset=+2]
 * xref:../../nodes/jobs/nodes-nodes-jobs.adoc#nodes-nodes-jobs[Running tasks in pods using jobs]
 
 include::modules/nodes-pods-autoscaling-custom-uninstalling.adoc[leveloffset=+1]
+


### PR DESCRIPTION
Despite the title, **this PR is for the TP 2.8.2 release, slated for Mar 6.** The title matches the related Jira doc and dev issues.

https://issues.redhat.com/browse/OSDOCS-5032

[Advanced features](https://issues.redhat.com/browse/OCPNODE-1252): 
* pausing replicas:  [Preview of New module](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-pausing_nodes-pods-autoscaling-custom)
* fallback Preview: [Step 1 code block, callout 11](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-creating-workload_nodes-pods-autoscaling-custom)
* customizable HPA name [Step 1 code block, callout 14](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-creating-workload_nodes-pods-autoscaling-custom)
* activation threshold Preview: [New third, fourth, and fifth paragraphs](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-about_nodes-pods-autoscaling-custom)

[audit logging ](https://issues.redhat.com/browse/OCPNODE-1394)  
* [Preview of new module](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-audit_nodes-pods-autoscaling-custom)

[CPU/Memory scaler](https://issues.redhat.com/browse/OCPNODE-1452)  

* [CPU Scaler preview new section](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-trigger-cpu_nodes-pods-autoscaling-custom)  
* [Memory Scaler preview new section](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-trigger-memory_nodes-pods-autoscaling-custom)

[Kafka Scaler](https://issues.redhat.com/browse/OCPNODE-1451) 
* [New section preview](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-trigger-kafka_nodes-pods-autoscaling-custom)

[Update the Prometheus scaler](https://keda.sh/docs/2.9/scalers/prometheus/#trigger-specification) 
* [Understanding the Prometheus trigger callout 8, 9, 10](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-trigger-prom_nodes-pods-autoscaling-custom)

[Release notes preview](https://55731--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-rn_nodes-pods-autoscaling-custom)