### PR TITLE
[OCPBUGS-6506] Note in IBM Power docs not resolving correctly on access.redhat.com

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -555,14 +555,14 @@ ifeval::["{context}" == "installing-ibm-z"]
 :!ibm-z:
 endif::[]
 ifeval::["{context}" == "installing-ibm-z-kvm"]
-:!ibm-z-kvm:
+:!ibm-z:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z"]
 :!ibm-z:
 :!restricted:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-ibm-z-kvm"]
-:!ibm-z-kvm:
+:!ibm-z:
 :!restricted:
 endif::[]
 ifeval::["{context}" == "installing-ibm-power"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9 + 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-6506

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- [IBM Power](https://55733--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html#installation-machine-requirements_installing-ibm-power) / [restricted](https://55733--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-restricted-networks-ibm-power.html#installation-machine-requirements_installing-restricted-networks-ibm-power)
- [IBM Z](https://55733--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-machine-requirements_installing-ibm-z)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
This PR hopefully fixes a Note that is not resolving correctly for Power on access.redhat.com and doesn't break anything on docs.openshift.com. The note itself is located in **modules\installation-machine-requirements.adoc**. However, the root case might be the unclosed defintions in **modules/installation-user-infra-generate-k8s-manifest-ignition.adoc** 
See thread: https://redhat-internal.slack.com/archives/C02KBD8A4UF/p1675948340979409?thread_ts=1675877521.764059&cid=C02KBD8A4UF
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
