### PR TITLE
TELCODOCS-1174: Update the TALM versions

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -6,7 +6,7 @@
 [id="ztp-telco-ran-software-versions_{context}"]
 = Telco RAN {product-version} validated solution software versions
 
-The Red Hat Telco Radio Access Network (RAN) version {product-version} solution has been validated using the following Red Hat software products versions.
+The Red Hat Telco Radio Access Network (RAN) version {product-version} solution has been validated using the following Red Hat software products.
 
 .Telco RAN {product-version} validated solution software
 [cols=2*, width="80%", options="header"]
@@ -14,15 +14,18 @@ The Red Hat Telco Radio Access Network (RAN) version {product-version} solution 
 |Product
 |Software version
 
-|ZTP GitOps plugin
-|4.11
+|Hub cluster {product-title} version
+|4.12
+
+|GitOps ZTP plugin
+|4.10, 4.11, or 4.12
 
 |{rh-rhacm-first}
-|{rh-rhacm-version}
+|2.6
 
 |{gitops-title}
-|1.6.0
+|1.6
 
 |{cgu-operator-first}
-|4.10 (Technology Preview)
+|4.10, 4.11, or 4.12
 |====


### PR DESCRIPTION
Summary of Changes:
- Copied the 4.12 table into main
- Updated the KALM versions

Version(s):
main

Issue:
(https://issues.redhat.com/browse/TELCODOCS-1174?filter=-1)

Link to docs preview:
https://55735--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
