### PR TITLE
BZ2094492: Added removing backup section to Backup & restore docs

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -33,3 +33,8 @@ include::modules/oadp-using-data-mover-for-csi-snapshots.adoc[leveloffset=+1]
 
 include::modules/oadp-creating-backup-hooks.adoc[leveloffset=+1]
 include::modules/oadp-scheduling-backups.adoc[leveloffset=+1]
+include::modules/oadp-deleting-backups.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../backup_and_restore/application_backup_and_restore/troubleshooting.adoc#velero-obtaining-by-downloading_oadp-troubleshooting[Downloading the Velero CLI tool]

--- a/modules/oadp-deleting-backups.adoc
+++ b/modules/oadp-deleting-backups.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+:_content-type: PROCEDURE
+[id="oadp-deleting-backups_{context}"]
+= Deleting backups
+
+You can remove backup files by deleting the `Backup` custom resource (CR).
+
+[WARNING]
+====
+After you delete the `Backup` CR and the associated object storage data, you cannot recover the deleted data. 
+====
+
+.Prerequisites
+
+* You created a `Backup` CR.
+* You know the name of the `Backup` CR and the namespace that contains it. 
+* You downloaded the Velero CLI tool.
+* You can access the Velero binary in your cluster.
+
+.Procedure
+
+* Choose one of the following actions to delete the `Backup` CR:
+
+** To delete the `Backup` CR and keep the associated object storage data, issue the following command:
++
+[source,terminal]
+----
+$ oc delete backup <backup_CR_name> -n <velero_namespace>
+----
+
+** To delete the `Backup` CR and delete the associated object storage data, issue the following command:
++
+[source,terminal]
+----
+$ velero backup delete <backup_CR_name> -n <velero_namespace>
+----
++
+Where:
++
+<backup_CR_name>:: Specifies the name of the `Backup` custom resource.
+<velero_namespace>:: Specifies the namespace that contains the `Backup` custom resource.


### PR DESCRIPTION
Version(s):
4.9+

Issue:
[BZ2094492](https://bugzilla.redhat.com/show_bug.cgi?id=2094492)

Link to docs preview:
[Deleting backups](https://55737--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-deleting-backups_backing-up-applications)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
