### PR TITLE
OSDOCS-1585: Changing query and fixing example output

### DIFF
--- a/modules/security-context-constraints-psa-alert-eval.adoc
+++ b/modules/security-context-constraints-psa-alert-eval.adoc
@@ -26,17 +26,15 @@ $ oc adm must-gather -- /usr/bin/gather_audit_logs
 +
 [source,terminal]
 ----
-$ zgrep -h pod-security.kubernetes.io/audit-violations must-gather.local.<archive_id>/quay*/audit_logs/kube-apiserver/*log.gz \
-  | jq -r 'select((.annotations["pod-security.kubernetes.io/audit-violations"] != null) and (.objectRef.resource=="pods")) | .objectRef.namespace + " " + .objectRef.name + " " + .objectRef.resource' \
+$ zgrep -h pod-security.kubernetes.io/audit-violations must-gather.local.<archive_id>/<image_digest_id>/audit_logs/kube-apiserver/*log.gz \
+  | jq -r 'select((.annotations["pod-security.kubernetes.io/audit-violations"] != null) and (.objectRef.resource=="pods")) | .objectRef.namespace + " " + .objectRef.name' \
   | sort | uniq -c
 ----
 +
-Replace `must-gather.local.<archive_id>` with the actual directory name.
+Replace `<archive_id>` and `<image_digest_id>` with the actual path names.
 +
 .Example output
 [source,text]
 ----
-15 ci namespace-ttl-controller deployments
- 1 ci-op-k5whzrsh rpm-repo-546f98d8b replicasets
- 1 ci-op-k5whzrsh rpm-repo deployments
+1 test-namespace my-pod
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-1585

Link to docs preview:
https://55766--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/understanding-and-managing-pod-security-admission#security-context-constraints-psa-alert-eval_understanding-and-managing-pod-security-admission

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
