### PR TITLE
CNF-6351(TELCODOCS-1003) OVN-Kubernetes attached to SR-IOV single NIC dual port

### DIFF
--- a/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
+++ b/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
@@ -21,6 +21,17 @@ include::modules/virt-planning-bare-metal-cluster-for-ocp-virt.adoc[leveloffset=
 * xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[About Single Root I/O Virtualization (SR-IOV) hardware networks]
 * xref:../../virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.adoc#virt-attaching-vm-to-sriov-network[Connecting a virtual machine to an SR-IOV network]
 
+include::modules/nw-sriov-dual-nic-con.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-sample-config-bond-sriov_preparing-to-install-with-agent-based-installer[Example: Bonds and SR-IOV dual-nic node network configuration]
+
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow[Optional: Configuring host network interfaces for dual port NIC]
+
+* xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#bonding-multiple-sriov-network-interfaces-to-dual-port_installing-bare-metal[Bonding multiple SR-IOV network interfaces to a dual port NIC interface]
+
 [id="choosing-a-method-to-install-ocp-on-bare-metal"]
 == Choosing a method to install {product-title} on bare metal
 

--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -44,6 +44,13 @@ include::modules/ipi-install-modifying-install-config-for-dual-stack-network.ado
 
 include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
 
+include::modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/configuring-network-bonding_configuring-and-managing-networking[Configuring network bonding]
+
 include::modules/ipi-install-configure-multiple-cluster-nodes.adoc[leveloffset=+2]
 
 include::modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc[leveloffset=+2]

--- a/installing/installing_openstack/installing-openstack-nfv-preparing.adoc
+++ b/installing/installing_openstack/installing-openstack-nfv-preparing.adoc
@@ -15,14 +15,14 @@ include::modules/installation-openstack-ovs-dpdk-requirements.adoc[leveloffset=+
 [id="installing-openstack-nfv-preparing-tasks-sr-iov"]
 == Preparing to install a cluster that uses SR-IOV
 
-You must configure {rh-openstack} before you install a cluster that uses SR-IOV on it. 
+You must configure {rh-openstack} before you install a cluster that uses SR-IOV on it.
 
 include::modules/installation-osp-configuring-sr-iov.adoc[leveloffset=+2]
 
 [id="installing-openstack-nfv-preparing-tasks-ovs-dpdk"]
 == Preparing to install a cluster that uses OVS-DPDK
 
-You must configure {rh-openstack} before you install a cluster that uses SR-IOV on it. 
+You must configure {rh-openstack} before you install a cluster that uses SR-IOV on it.
 
 * Complete link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.2/html/network_functions_virtualization_planning_and_configuration_guide/part-dpdk-configure#p-ovs-dpdk-flavor-deploy-instance[Creating a flavor and deploying an instance for OVS-DPDK] before you install a cluster on {rh-openstack}.
 

--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -34,6 +34,13 @@ include::modules/agent-install-networking.adoc[leveloffset=+1]
 
 include::modules/agent-install-sample-config-bonds-vlans.adoc[leveloffset=+1]
 
+include::modules/agent-install-sample-config-bond-sriov.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/configuring-network-bonding_configuring-and-managing-networking[Configuring network bonding]
+
 include::modules/installation-bare-metal-agent-installer-config-yaml.adoc[leveloffset=+1]
 
 include::modules/validations-before-agent-iso-creation.adoc[leveloffset=+1]

--- a/modules/agent-install-sample-config-bond-sriov.adoc
+++ b/modules/agent-install-sample-config-bond-sriov.adoc
@@ -1,0 +1,119 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-with-agent-based-installer/preparing-to-install-with-agent-based-installer.adoc
+
+:_content-type: REFERENCE
+[id="agent-install-sample-config-bond-sriov_{context}"]
+= Example: Bonds and SR-IOV dual-nic node network configuration
+
+:FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+The following `agent-config.yaml` file is an example of a manifest for dual port NIC with a bond and SR-IOV interfaces:
+
+[source,yaml]
+----
+apiVersion: v1alpha1
+kind: AgentConfig
+rendezvousIP: 10.10.10.14
+hosts:
+  - hostname: worker-1
+    interfaces:
+      - name: eno1
+        macAddress: 0c:42:a1:55:f3:06
+      - name: eno2
+        macAddress: 0c:42:a1:55:f3:07
+    networkConfig: <1>
+      interfaces: <2>
+        - name: eno1 <3>
+          type: ethernet <4>
+          state: up
+          mac-address: 0c:42:a1:55:f3:06
+          ipv4:
+            enabled: true
+            dhcp: false <5>
+          ethernet:
+            sr-iov:
+              total-vfs: 2 <6>
+          ipv6:
+            enabled: false
+        - name: sriov:eno1:0
+          type: ethernet
+          state: up <7>
+          ipv4:
+            enabled: false <8>
+          ipv6:
+            enabled: false
+            dhcp: false
+        - name: sriov:eno1:1
+          type: ethernet
+          state: down
+        - name: eno2
+          type: ethernet
+          state: up
+          mac-address: 0c:42:a1:55:f3:07
+          ipv4:
+            enabled: true
+          ethernet:
+            sr-iov:
+              total-vfs: 2
+          ipv6:
+            enabled: false
+        - name: sriov:eno2:0
+          type: ethernet
+          state: up
+          ipv4:
+            enabled: false
+          ipv6:
+            enabled: false
+        - name: sriov:eno2:1
+          type: ethernet
+          state: down
+        - name: bond0
+          type: bond
+          state: up
+          min-tx-rate: 100 <9>
+          max-tx-rate: 200 <10>
+          link-aggregation:
+            mode: active-backup <11>
+            options:
+              primary: sriov:eno1:0 <12>
+            port:
+              - sriov:eno1:0
+              - sriov:eno2:0
+          ipv4:
+            address:
+              - ip: 10.19.16.57 <13>
+                prefix-length: 23
+            dhcp: false
+            enabled: true
+          ipv6:
+            enabled: false
+          dns-resolver:
+            config:
+              server:
+                - 10.11.5.160
+                - 10.2.70.215
+          routes:
+            config:
+              - destination: 0.0.0.0/0
+                next-hop-address: 10.19.17.254
+                next-hop-interface: bond0 <14>
+                table-id: 254
+----
+<1> The `networkConfig` field contains information about the network configuration of the host, with subfields including `interfaces`,`dns-resolver`, and `routes`.
+<2> The `interfaces` field is an array of network interfaces defined for the host.
+<3> The name of the interface.
+<4> The type of interface. This example creates an ethernet interface.
+<5> Set this to `false` to disable DHCP for the physical function (PF) if it is not strictly required.
+<6> Set this to the number of SR-IOV virtual functions (VFs) to instantiate.
+<7> Set this to `up`.
+<8> Set this to `false` to disable IPv4 addressing for the VF attached to the bond.
+<9> Sets a minimum transmission rate, in Mbps, for the VF. This sample value sets a rate of 100 Mbps.
+    * This value must be less than or equal to the maximum transmission rate.
+    * Intel NICs do not support the `min-tx-rate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[*BZ#1772847*].
+<10> Sets a maximum transmission rate, in Mbps, for the VF. This sample value sets a rate of 200 Mbps.
+<11> Sets the desired bond mode.
+<12> Sets the preferred port of the bonding interface. The primary device is the first of the bonding interfaces to be used and is not abandoned unless it fails. This setting is particularly useful when one NIC in the bonding interface is faster and, therefore, able to handle a bigger load. This setting is only valid when the bonding interface is in `active-backup` mode (mode 1) and `balance-tlb` (mode 5).
+<13> Sets a static IP address for the bond interface. This is the node IP address.
+<14> Sets `bond0` as the gateway for the default route.

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -212,16 +212,15 @@ ifndef::ibm-z-kvm[]
 
 Optional: You can bond multiple network interfaces to a single interface by using the `bond=` option. Refer to the following examples:
 
-* The syntax for configuring a bonded interface is: `bond=name[:network_interfaces][:options]`
+* The syntax for configuring a bonded interface is: `bond=<name>[:<network_interfaces>][:options]`
 +
-_name_ is the bonding device name (`bond0`), _network_interfaces_
-represents a comma-separated list of physical (ethernet) interfaces (`em1,em2`),
+`<name>` is the bonding device name (`bond0`), `<network_interfaces>` represents a comma-separated list of physical (ethernet) interfaces (`em1,em2`),
 and _options_ is a comma-separated list of bonding options. Enter `modinfo bonding` to see available options.
 
 * When you create a bonded interface using `bond=`, you must specify how the IP address is assigned and other
 information for the bonded interface.
 
-* To configure the bonded interface to use DHCP, set the bond's IP address to `dhcp`. For example:
+** To configure the bonded interface to use DHCP, set the bond's IP address to `dhcp`. For example:
 +
 [source,terminal]
 ----
@@ -229,8 +228,7 @@ bond=bond0:em1,em2:mode=active-backup
 ip=bond0:dhcp
 ----
 
-* To configure the bonded interface to use a static IP address,
-enter the specific IP address you want and related information. For example:
+** To configure the bonded interface to use a static IP address, enter the specific IP address you want and related information. For example:
 ifndef::ibm-z[]
 +
 [source,terminal]
@@ -247,7 +245,7 @@ bond=bond0:em1,em2:mode=active-backup,fail_over_mac=1
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 ----
 
-Always set option `fail_over_mac=1` in active-backup mode, to avoid problems when shared OSA/RoCE cards are used.
+Always set the `fail_over_mac=1` option in active-backup mode, to avoid problems when shared OSA/RoCE cards are used.
 endif::ibm-z[]
 
 [discrete]
@@ -270,6 +268,57 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0.100:none
 bond=bond0:em1,em2:mode=active-backup
 vlan=bond0.100:bond0
 ----
+
+[id="bonding-multiple-sriov-network-interfaces-to-dual-port_{context}"]
+[discrete]
+=== Bonding multiple SR-IOV network interfaces to a dual port NIC interface
+
+:FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+Optional: You can bond multiple SR-IOV network interfaces to a dual port NIC interface by using the `bond=` option.
+
+On each node, you must perform the following tasks:
+
+. Create the SR-IOV virtual functions (VFs) following the guidance in link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_virtualization/managing-virtual-devices_configuring-and-managing-virtualization#managing-sr-iov-devices_managing-virtual-devices[Managing SR-IOV devices]. Follow the procedure in the "Attaching SR-IOV networking devices to virtual machines" section.
+
+. Create the bond, attach the desired VFs to the bond and set the bond link state up following the guidance in link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/configuring_and_managing_networking/configuring-network-bonding_configuring-and-managing-networking[Configuring network bonding]. Follow any of the described procedures to create the bond.
+
+The following examples illustrate the syntax you must use:
+
+* The syntax for configuring a bonded interface is `bond=<name>[:<network_interfaces>][:options]`.
++
+`<name>` is the bonding device name (`bond0`), `<network_interfaces>` represents the virtual functions (VFs) by their known name in the kernel and shown in the output of the `ip link` command(`eno1f0`, `eno2f0`), and _options_ is a comma-separated list of bonding options. Enter `modinfo bonding` to see available options.
+
+* When you create a bonded interface using `bond=`, you must specify how the IP address is assigned and other information for the bonded interface.
+
+** To configure the bonded interface to use DHCP, set the bond's IP address to `dhcp`. For example:
++
+[source,terminal]
+----
+bond=bond0:eno1f0,eno2f0:mode=active-backup
+ip=bond0:dhcp
+----
+
+** To configure the bonded interface to use a static IP address, enter the specific IP address you want and related information. For example:
+ifndef::ibm-z[]
++
+[source,terminal]
+----
+bond=bond0:eno1f0,eno2f0:mode=active-backup
+ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
+----
+endif::ibm-z[]
+ifdef::ibm-z[]
+
+[source,terminal]
+----
+bond=bond0:eno1f0,eno2f0:mode=active-backup,fail_over_mac=1
+ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
+----
+
+Always set the `fail_over_mac=1` option in active-backup mode, to avoid problems when shared OSA/RoCE cards are used.
+endif::ibm-z[]
 
 [discrete]
 === Using network teaming

--- a/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -1,0 +1,135 @@
+// This is included in the following assemblies:
+//
+// installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_{context}"]
+= Optional: Configuring host network interfaces for dual port NIC
+
+:FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState to support dual port NIC.
+
+.Prequisites
+
+* Configure a `PTR` DNS record with a valid hostname for each node with a static IP address.
+* Install the NMState CLI (`nmstate`).
+
+[NOTE]
+====
+Errors in the YAML syntax might result in a failure to apply the network configuration. Additionally, maintaining the validated YAML syntax is useful when applying changes using Kubernetes NMState after deployment or when expanding the cluster.
+====
+
+.Procedure
+
+. Add the NMState configuration to the `networkConfig` field to hosts within the `install-config.yaml` file:
++
+[source,yaml]
+----
+hosts:
+  - hostname: worker-1
+    interfaces:
+      - name: eno1
+        macAddress: 0c:42:a1:55:f3:06
+      - name: eno2
+        macAddress: 0c:42:a1:55:f3:07
+    networkConfig: <1>
+      interfaces: <2>
+        - name: eno1 <3>
+          type: ethernet <4>
+          state: up
+          mac-address: 0c:42:a1:55:f3:06
+          ipv4:
+            enabled: true
+            dhcp: false <5>
+          ethernet:
+            sr-iov:
+              total-vfs: 2 <6>
+          ipv6:
+            enabled: false
+            dhcp: false
+        - name: sriov:eno1:0
+          type: ethernet
+          state: up <7>
+          ipv4:
+            enabled: false <8>
+          ipv6:
+            enabled: false
+        - name: sriov:eno1:1
+          type: ethernet
+          state: down
+        - name: eno2
+          type: ethernet
+          state: up
+          mac-address: 0c:42:a1:55:f3:07
+          ipv4:
+            enabled: true
+          ethernet:
+            sr-iov:
+              total-vfs: 2
+          ipv6:
+            enabled: false
+        - name: sriov:eno2:0
+          type: ethernet
+          state: up
+          ipv4:
+            enabled: false
+          ipv6:
+            enabled: false
+        - name: sriov:eno2:1
+          type: ethernet
+          state: down
+        - name: bond0
+          type: bond
+          state: up
+          min-tx-rate: 100 <9>
+          max-tx-rate: 200 <10>
+          link-aggregation:
+            mode: active-backup <11>
+            options:
+              primary: sriov:eno1:0 <12>
+            port:
+              - sriov:eno1:0
+              - sriov:eno2:0
+          ipv4:
+            address:
+              - ip: 10.19.16.57 <13>
+                prefix-length: 23
+            dhcp: false
+            enabled: true
+          ipv6:
+            enabled: false
+          dns-resolver:
+            config:
+              server:
+                - 10.11.5.160
+                - 10.2.70.215
+          routes:
+            config:
+              - destination: 0.0.0.0/0
+                next-hop-address: 10.19.17.254
+                next-hop-interface: bond0 <14>
+                table-id: 254
+----
+<1> The `networkConfig`` field contains information about the network configuration of the host, with subfields including `interfaces``,`dns-resolver`, and `routes`.
+<2> The `interfaces` field is an array of network interfaces defined for the host.
+<3> The name of the interface.
+<4> The type of interface. This example creates a ethernet interface.
+<5> Set this to `false to disable DHCP for the physical function (PF) if it is not strictly required.
+<6> Set to the number of SR-IOV virtual functions (VFs) to instantiate.
+<7> Set this to `up`.
+<8> Set this to `false` to disable IPv4 addressing for the VF attached to the bond.
+<9> Sets a minimum transmission rate, in Mbps, for the VF. This sample value sets a rate of 100 Mbps.
+    * This value must be less than or equal to the maximum transmission rate.
+    * Intel NICs do not support the `min-tx-rate` parameter. For more information, see link:https://bugzilla.redhat.com/show_bug.cgi?id=1772847[*BZ#1772847*].
+<10> Sets a maximum transmission rate, in Mbps, for the VF. This sample value sets a rate of 200 Mbps.
+<11> Sets the desired bond mode.
+<12> Sets the preferred port of the bonding interface. The primary device is the first of the bonding interfaces to be used and is not abandoned unless it fails. This setting is particularly useful when one NIC in the bonding interface is faster and, therefore, able to handle a bigger load. This setting is only valid when the bonding interface is in active-backup mode (mode 1) and balance-tlb (mode 5).
+<13> Sets a static IP address for the bond interface. This is the node IP address.
+<14> Sets `bond0` as the gateway for the default route.
++
+[IMPORTANT]
+====
+After deploying the cluster, you cannot modify the `networkConfig` configuration setting of `install-config.yaml` file to make changes to the host network interface. Use the Kubernetes NMState Operator to make changes to the host network interface after deployment.
+====

--- a/modules/nw-sriov-dual-nic-con.adoc
+++ b/modules/nw-sriov-dual-nic-con.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-sriov-device.adoc
+
+:_content-type: CONCEPT
+[id="nw-sriov-dual-nic-con_{context}"]
+= NIC partitioning for SR-IOV devices (Technology Preview)
+
+{product-title} can be deployed on a server with a dual port network interface card (NIC).
+You can partition a single, high-speed dual port NIC into multiple virtual functions (VFs) and enable SR-IOV.
+
+[NOTE]
+====
+Currently, it is not possible to assign virtual functions (VF) for system services such as OVN-Kubernetes and assign other VFs created from the same physical function (PF) to pods connected to the SR-IOV Network Operator.
+====
+
+This feature supports the use of bonds for high availability with the Link Aggregation Control Protocol (LACP).
+
+[NOTE]
+====
+Only one LACP can be declared by physical NIC.
+====
+
+An {product-title} cluster can be deployed on a bond interface with 2 VFs on 2 physical functions (PFs) using the following methods:
+
+* Agent based installer
+* Installer-provisioned infrastructure installation
+* User-provisioned infrastructure installation
+
+:FeatureName: Support for Day 1 operations associated with enabling NIC partitioning for SR-IOV devices
+include::snippets/technology-preview.adoc[leveloffset=+1]

--- a/networking/hardware_networks/configuring-sriov-device.adoc
+++ b/networking/hardware_networks/configuring-sriov-device.adoc
@@ -11,7 +11,9 @@ You can configure a Single Root I/O Virtualization (SR-IOV) device in your clust
 include::modules/nw-sriov-networknodepolicy-object.adoc[leveloffset=+1]
 
 // A direct companion to nw-sriov-networknodepolicy-object
+
 include::modules/nw-sriov-nic-partitioning.adoc[leveloffset=+2]
+
 
 include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-1003]: OVN-Kubernetes attached to SR-IOV VFs on day-1


Version(s):
4.13 and main

Issue:
https://issues.redhat.com/browse/TELCODOCS-1003

Link to docs preview:

https://55768--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/preparing-to-install-on-bare-metal.html#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal

I have added a draft diagram. 

https://55768--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#agent-install-sample-config-bond-sriov_preparing-to-install-with-agent-based-installer

https://55768--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-dual-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow

https://55768--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-routing-bonding_installing-bare-metal
Section: Bonding multiple SR-IOV network interfaces to a dual NIC interface

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
