### PR TITLE
Minor formatting fixes to doc_guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -36,7 +36,7 @@ toc::[]                                                         <7>
 
 <1> The content type for the file. For assemblies, always use `:_content-type: ASSEMBLY`. Place this attribute before the anchor ID or, if present, the conditional that contains the anchor ID.
 <2> A unique (within OpenShift docs) anchor ID for this assembly. Use lowercase. Example: cli-developer-commands
-<3> Human readable title (notice the '=' top-level header)
+<3> Human readable title (notice the `=` top-level header)
 <4> Includes attributes common to OpenShift docs.
 +
 [NOTE]
@@ -345,7 +345,7 @@ link:https://redhat-documentation.github.io/modular-docs/#forming-assemblies[Red
 ====
 When using the "Prerequisites", "Next steps", or "Additional resources" headings in an assembly, use `==` formatting, such as `== Prerequisites` or `== Additional resources`. Use of this heading syntax at the assembly level indicates that the sections relate to the whole assembly.
 
-Only use `.` formatting (.Additional resources`) to follow a module in an assembly. Because you cannot use the xrefs in modules, this functions as a _trailing include_ at the assembly level, where the `.` formatting of the `include` statement indicates that the resource applies specifically to the module and not to the assembly.
+Only use `.` formatting (`.Additional resources`) to follow a module in an assembly. Because you cannot use the xrefs in modules, this functions as a _trailing include_ at the assembly level, where the `.` formatting of the `include` statement indicates that the resource applies specifically to the module and not to the assembly.
 ====
 
 == Writing concepts
@@ -1035,7 +1035,7 @@ syntax highlighting. For example:
 be split up into three separate code blocks:
 +
 ....
-To create templates you can modify, run the following commands :
+To create templates you can modify, run the following commands:
 
 [source,terminal]
 ----


### PR DESCRIPTION
`main` branch only.

No full build preview, as it only affects the repo guidelines:

https://github.com/adellape/openshift-docs/blob/guidelines_backtick/contributing_to_docs/doc_guidelines.adoc