### PR TITLE
CNV-21088: updates to descheduler spec

### DIFF
--- a/modules/nodes-descheduler-configuring-profiles.adoc
+++ b/modules/nodes-descheduler-configuring-profiles.adoc
@@ -35,32 +35,35 @@ spec:
   logLevel: Normal
   managementState: Managed
   operatorLogLevel: Normal
+  mode: Predictive                                     <1>
   profileCustomizations:
-    namespaces:                                        <1>
+    namespaces:                                        <2>
       excluded:
       - my-namespace
-    podLifetime: 48h                                   <2>
-    thresholdPriorityClassName: my-priority-class-name <3>
-  profiles:                                            <4>
+    podLifetime: 48h                                   <3>
+    thresholdPriorityClassName: my-priority-class-name <4>
+  profiles:                                            <5>
   - AffinityAndTaints
-  - TopologyAndDuplicates                              <5>
+  - TopologyAndDuplicates                              <6>
   - LifecycleAndUtilization
   - EvictPodsWithLocalStorage
   - EvictPodsWithPVC
 ----
++
 --
-<1> Optional: Set a list of user-created namespaces to include or exclude from descheduler operations. Use `excluded` to set a list of namespaces to exclude or use `included` to set a list of namespaces to include. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are excluded by default.
+<1> Optional: By default, the descheduler does not evict pods. To evict pods, set `mode` to `Automatic`.
+<2> Optional: Set a list of user-created namespaces to include or exclude from descheduler operations. Use `excluded` to set a list of namespaces to exclude or use `included` to set a list of namespaces to include. Note that protected namespaces (`openshift-*`, `kube-system`, `hypershift`) are excluded by default.
 +
 [IMPORTANT]
 ====
 The `LowNodeUtilization` strategy does not support namespace exclusion. If the `LifecycleAndUtilization` profile is set, which enables the `LowNodeUtilization` strategy, then no namespaces are excluded, even the protected namespaces. To avoid evictions from the protected namespaces while the `LowNodeUtilization` strategy is enabled, set the priority class name to `system-cluster-critical` or `system-node-critical`.
 ====
-<2> Optional: Enable a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
-<3> Optional: Specify a priority threshold to consider pods for eviction only if their priority is lower than the specified level. Use the `thresholdPriority` field to set a numerical priority threshold (for example, `10000`) or use the `thresholdPriorityClassName` field to specify a certain priority class name (for example, `my-priority-class-name`). If you specify a priority class name, it must already exist or the descheduler will throw an error. Do not set both `thresholdPriority` and `thresholdPriorityClassName`.
-<4> Add one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, and `EvictPodsWithPVC`.
-<5> Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enabling both results in a conflict.
-+
+<3> Optional: Enable a custom pod lifetime value for the `LifecycleAndUtilization` profile. Valid units are `s`, `m`, or `h`. The default pod lifetime is 24 hours.
+<4> Optional: Specify a priority threshold to consider pods for eviction only if their priority is lower than the specified level. Use the `thresholdPriority` field to set a numerical priority threshold (for example, `10000`) or use the `thresholdPriorityClassName` field to specify a certain priority class name (for example, `my-priority-class-name`). If you specify a priority class name, it must already exist or the descheduler will throw an error. Do not set both `thresholdPriority` and `thresholdPriorityClassName`.
+<5> Add one or more profiles to enable. Available profiles: `AffinityAndTaints`, `TopologyAndDuplicates`, `LifecycleAndUtilization`, `SoftTopologyAndDuplicates`, `EvictPodsWithLocalStorage`, and `EvictPodsWithPVC`.
+<6> Do not enable both `TopologyAndDuplicates` and `SoftTopologyAndDuplicates`. Enabling both results in a conflict.
+
 You can enable multiple profiles; the order that the profiles are specified in is not important.
 --
-
++
 . Save the file to apply the changes.

--- a/modules/virt-enabling-descheduler-evictions.adoc
+++ b/modules/virt-enabling-descheduler-evictions.adoc
@@ -41,6 +41,8 @@ spec:
   deschedulingIntervalSeconds: 3600
   profiles:
   - DevPreviewLongLifecycle
+  mode: Predictive <1>
 ----
+<1> By default, the descheduler does not evict pods. To evict pods, set `mode` to `Automatic`.
 
 The descheduler is now enabled on the VM.


### PR DESCRIPTION
Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-21088](https://issues.redhat.com//browse/CNV-21088)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
http://file.rdu.redhat.com/sjess/CNV21088/virt/virtual_machines/advanced_vm_management/virt-enabling-descheduler-evictions.html
http://file.rdu.redhat.com/sjess/CNV21088/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-configuring-profiles_nodes-descheduler
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @geetikakay @RoniKishner 
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
