### PR TITLE
[RHACS] Fixed `roxctl` installation gaps

### DIFF
--- a/installing/acs-installation-platforms.adoc
+++ b/installing/acs-installation-platforms.adoc
@@ -6,7 +6,7 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-{rh-rhacs-first} and {product-title-managed} ({product-title-managed-short}) are supported on{ocp} and Kubernetes platforms. 
+{rh-rhacs-first} and {product-title-managed} ({product-title-managed-short}) are supported on {ocp} and Kubernetes platforms.
 
 [id="install-platforms-methods_{context}"]
 == Installation methods for different platforms
@@ -80,41 +80,3 @@ Not all installation methods are supported for all platforms.
 include::modules/installation-methods-for-different-architectures.adoc[leveloffset=+1]
 
 include::modules/supported-browsers-for-rhacs.adoc[leveloffset=+1]
-
-
-//content without IBM support [old content]
-////
-[id="install-platforms-methods"]
-== Installation methods for different platforms
-
-You can perform different types of installations on different platforms.
-
-[NOTE]
-====
-Not all installation options are supported for all platforms, as shown in the following tables. Red Hat recommends that you do not use the `roxctl` install method unless you have a specific installation need that requires using this method.
-====
-
-.Recommended installation methods
-|===
-|Platform | Installation steps | Supported installation methods
-
-a| * Red Hat OpenShift Container Platform (OCP) 4.x 
-* Red Hat OpenShift Kubernetes Engine (OKE) 4.x
-* Red Hat OpenShift Dedicated (OSD) 
-* Azure Red Hat OpenShift (ARO) 
-* Red Hat OpenShift Service on Amazon Web Services (ROSA)
-a| * xref:../installing/installing_ocp/install-rhacs-ocp.adoc#install-rhacs-ocp[Installing {product-title-short} on {osp}] 
-*  xref:../installing/installing_cloud_ocp/install-rhacs-cloud-ocp.adoc#install-rhacs-cloud-ocp[Installing {product-title-managed-short} on {osp}]
-a|* Operator (recommended)
-* Helm charts
-* `roxctl` CLI
-a| * Amazon Elastic Kubernetes Service (EKS) 
-* Google Kubernetes Engine (GKE) 
-* Microsoft Azure Kubernetes Service (AKS) 
-a| * xref:../installing/installing_other/install-rhacs-other.adoc#install-rhacs-other[Installing {product-title-short} on other platforms]
-* xref:../installing/installing_cloud_other/install-rhacs-cloud-other.adoc#install-rhacs-cloud-other[Installing {product-title-managed-short} on other platforms]
-a| * Helm charts (recommended)
-* `roxctl` CLI
-
-|===
-////

--- a/installing/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
+++ b/installing/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
@@ -44,6 +44,10 @@ include::modules/adding-helm-repository.adoc[leveloffset=+2]
 
 include::modules/acs-quick-install-secured-cluster-using-helm.adoc[leveloffset=+3]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_cloud_ocp/init-bundle-cloud-ocp.adoc#generate-init-bundle[Generating and applying an init bundle for {product-title-short} Cloud Service on Red Hat OpenShift]
+
 [id="configure-secured-cluster-services-helm-chart-customizations-cloud-ocp"]
 === Configuring the secured-cluster-services Helm chart with customizations
 
@@ -62,6 +66,11 @@ When using the `secured-cluster-services` Helm chart, do not change the `values.
 
 include::modules/secured-cluster-services-config.adoc[leveloffset=+3]
 include::modules/install-secured-cluster-services-helm-chart.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_cloud_ocp/init-bundle-cloud-ocp.adoc#generate-init-bundle[Generating and applying an init bundle for {product-title-short} Cloud Service on Red Hat OpenShift]
+
 include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 
 [id="installing-sc-roxctl-cloud-ocp"]

--- a/installing/installing_cloud_other/install-secured-cluster-cloud-other.adoc
+++ b/installing/installing_cloud_other/install-secured-cluster-cloud-other.adoc
@@ -30,6 +30,10 @@ include::modules/adding-helm-repository.adoc[leveloffset=+2]
 
 include::modules/acs-quick-install-secured-cluster-using-helm.adoc[leveloffset=+3]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_cloud_other/init-bundle-cloud-other.adoc#generate-init-bundle[Generating and applying an init bundle for {product-title-short} Cloud Service on other platforms]
+
 [id="configure-secured-cluster-services-helm-chart-customizations-cloud-other"]
 === Configuring the secured-cluster-services Helm chart with customizations
 
@@ -49,6 +53,10 @@ While using the `secured-cluster-services` Helm chart, do not modify the `values
 include::modules/secured-cluster-services-config.adoc[leveloffset=+3]
 
 include::modules/install-secured-cluster-services-helm-chart.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_cloud_other/init-bundle-cloud-other.adoc#generate-init-bundle[Generating and applying an init bundle for {product-title-short} Cloud Service on other platforms]
 
 include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 

--- a/installing/installing_ocp/install-secured-cluster-ocp.adoc
+++ b/installing/installing_ocp/install-secured-cluster-ocp.adoc
@@ -33,6 +33,10 @@ include::modules/adding-helm-repository.adoc[leveloffset=+3]
 
 include::modules/acs-quick-install-secured-cluster-using-helm.adoc[leveloffset=+3]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_ocp/init-bundle-ocp.adoc#generate-init-bundle[Generating and applying an init bundle for {product-title-short} on Red Hat OpenShift]
+
 [id="configure-secured-cluster-services-helm-chart-customizations"]
 === Configuring the secured-cluster-services Helm chart with customizations
 
@@ -52,6 +56,10 @@ While using the `secured-cluster-services` Helm chart, do not modify the `values
 include::modules/secured-cluster-services-config.adoc[leveloffset=+3]
 
 include::modules/install-secured-cluster-services-helm-chart.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_ocp/init-bundle-ocp.adoc#generate-init-bundle[Generating and applying an init bundle for {product-title-short} on Red Hat OpenShift]
 
 include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 
@@ -74,7 +82,5 @@ You must first download the binary. You can install `roxctl` on Linux, Windows, 
 include::modules/install-roxctl-cli-linux.adoc[leveloffset=+3]
 include::modules/install-roxctl-cli-macos.adoc[leveloffset=+3]
 include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
-
-include::modules/install-scanner-roxctl.adoc[leveloffset=+2]
 
 include::modules/install-sensor-roxctl.adoc[leveloffset=+2]

--- a/installing/installing_other/install-secured-cluster-other.adoc
+++ b/installing/installing_other/install-secured-cluster-other.adoc
@@ -22,6 +22,10 @@ include::modules/adding-helm-repository.adoc[leveloffset=+3]
 
 include::modules/acs-quick-install-secured-cluster-using-helm.adoc[leveloffset=+3]
 
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_other/init-bundle-other.adoc#generate-init-bundle[Generating and applying an init bundle for {product-title-short} on other platforms]
+
 [id="configure-secured-cluster-services-helm-chart-customizations-other"]
 === Configuring the secured-cluster-services Helm chart with customizations
 
@@ -41,6 +45,10 @@ While using the `secured-cluster-services` Helm chart, do not modify the `values
 include::modules/secured-cluster-services-config.adoc[leveloffset=+3]
 
 include::modules/install-secured-cluster-services-helm-chart.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_other/init-bundle-other.adoc#generate-init-bundle[Generating and applying an init bundle for {product-title-short} on other platforms]
 
 include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 
@@ -63,7 +71,5 @@ You must first download the binary. You can install `roxctl` on Linux, Windows, 
 include::modules/install-roxctl-cli-linux.adoc[leveloffset=+3]
 include::modules/install-roxctl-cli-macos.adoc[leveloffset=+3]
 include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
-
-include::modules/install-scanner-roxctl.adoc[leveloffset=+2]
 
 include::modules/install-sensor-roxctl.adoc[leveloffset=+2]

--- a/installing/prerequisites.adoc
+++ b/installing/prerequisites.adoc
@@ -4,11 +4,13 @@
 include::modules/common-attributes.adoc[]
 :context: acs-prerequisites
 
-
-
 toc::[]
 
 include::modules/acs-requirements.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../installing/acs-installation-platforms.adoc#installation-methods-for-different-architectures_acs-installation-platforms[Installation methods for different architectures].
 
 include::modules/central-requirements.adoc[leveloffset=+1]
 

--- a/modules/acs-quick-install-secured-cluster-using-helm.adoc
+++ b/modules/acs-quick-install-secured-cluster-using-helm.adoc
@@ -22,6 +22,7 @@ To install Collector on systems that have Unified Extensible Firmware Interface 
 ====
 
 .Prerequisites
+* You must have generated {product-title-short} init bundle for your cluster.
 ifndef::cloud-svc[]
 * You must have the address and the port number that you are exposing the Central service on.
 endif::cloud-svc[]
@@ -40,7 +41,7 @@ $ helm install -n stackrox --create-namespace \
     --set clusterName=<name_of_the_secured_cluster> \
     --set centralEndpoint=<endpoint_of_central_service> <2>
 ifdef::cloud-svc[]
---set imagePullSecrets.username=<your redhat.com username> \ 
+--set imagePullSecrets.username=<your redhat.com username> \
 --set imagePullSecrets.password=<your redhat.com password>
 endif::[]
 ----

--- a/modules/acs-quick-install-using-helm.adoc
+++ b/modules/acs-quick-install-using-helm.adoc
@@ -8,6 +8,9 @@
 
 Use the following instructions to install the `central-services` Helm chart to deploy the centralized components (Central and Scanner).
 
+.Prerequisites
+* You must have access to the Red Hat Container Registry. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].
+
 .Procedure
 
 * Run the following command to install Central services and expose Central using a route:
@@ -16,7 +19,8 @@ Use the following instructions to install the `central-services` Helm chart to d
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.allowNone=true \
+  --set imagePullSecrets.username=<username> \
+  --set imagePullSecrets.password=<password> \
   --set central.exposure.route.enabled=true
 ----
 
@@ -26,7 +30,8 @@ $ helm install -n stackrox \
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.allowNone=true \
+  --set imagePullSecrets.username=<username> \
+  --set imagePullSecrets.password=<password> \
   --set central.exposure.loadBalancer.enabled=true
 ----
 
@@ -36,13 +41,14 @@ $ helm install -n stackrox \
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.allowNone=true
+    --set imagePullSecrets.username=<username> \
+  --set imagePullSecrets.password=<password>
 ----
 
 [IMPORTANT]
 ====
-If you are installing {product-title} in a cluster that requires a proxy to connect to external services, you must specify your proxy configuration by using the `proxyConfig` parameter. For example:
-
+* If you are installing {product-title} in a cluster that requires a proxy to connect to external services, you must specify your proxy configuration by using the `proxyConfig` parameter. For example:
++
 [source,yaml]
 ----
 env:
@@ -53,6 +59,11 @@ env:
     excludes:
     - some.domain
 ----
+* If you already created one or more image pull secrets in the namespace in which you are installing, instead of using a username and password, you can use `--set imagePullSecrets.useExisting="<pull-secret-1;pull-secret-2>"`.
+* Do not use image pull secrets:
+
+** If you are pulling your images from `quay.io/stackrox-io` or a registry in a private network that does not require authentication. Use use `--set imagePullSecrets.allowNone=true` instead of specifying a username and password.
+** If you already configured image pull secrets in the default service account in the namespace you are installing. Use `--set imagePullSecrets.useFromDefaultServiceAccount=true` instead of specifying a username and password.
 ====
 
 The output of the installation command includes:

--- a/modules/acs-requirements.adoc
+++ b/modules/acs-requirements.adoc
@@ -36,6 +36,13 @@ For more information, see the link:https://access.redhat.com/node/5822721[{produ
 ====
 For deploying Central, use a machine type with four or more cores and apply scheduling policies to launch Central on such nodes.
 ====
+** *Architectures*: AMD64 or ppc64le.
++
+[NOTE]
+====
+You can only install {product-title-short} Secured cluster services on {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} clusters.
+Central is not supported at this time.
+====
 
 * Persistent storage by using persistent volume claim (PVC).
 +

--- a/modules/install-secured-cluster-services-helm-chart.adoc
+++ b/modules/install-secured-cluster-services-helm-chart.adoc
@@ -12,6 +12,15 @@ After you configure the `values-public.yaml` and `values-private.yaml` files, in
 To install Collector on systems that have Unified Extensible Firmware Interface (UEFI) and that have Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. Collector identifies Secure Boot status at the start and switches to eBPF probes if required.
 ====
 
+.Prerequisites
+* You must have generated {product-title-short} init bundle for your cluster.
+ifndef::cloud-svc[]
+* You must have the address and the port number that you are exposing the Central service on.
+endif::cloud-svc[]
+ifdef::cloud-svc[]
+* You must have the *Central API Endpoint*, including the address and the port number. You can view this information by choosing *Advanced Cluster Security* -> *ACS Instances* from the cloud console navigation menu, then clicking the ACS instance you created.
+endif::[]
+
 .Procedure
 
 * Run the following command:

--- a/modules/install-sensor-roxctl.adoc
+++ b/modules/install-sensor-roxctl.adoc
@@ -17,6 +17,9 @@ To monitor a cluster, you must deploy Sensor.
 You must deploy Sensor into each cluster that you want to monitor.
 The following steps describe adding Sensor by using the RHACS portal.
 
+.Prerequisites
+* You must have already installed Central services, or you can access Central services on Red Hat Advanced Cluster Security Cloud Service (ACSCS).
+
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Clusters*.
 . Select *+ New Cluster*.
@@ -57,7 +60,7 @@ After Sensor is deployed, it contacts Central and provides cluster information.
 
 .Verification
 . Return to the {product-title-short} portal and check if the deployment is successful.
-If successful, when viewing your list of clusters in *Platform Configuration* -> *Clusters*, the cluster status displays a green checkmark and a *Healthy* status. 
+If successful, when viewing your list of clusters in *Platform Configuration* -> *Clusters*, the cluster status displays a green checkmark and a *Healthy* status.
 If you do not see a green checkmark, use the following command to check for problems:
 ifndef::kube[]
 * On {ocp}:

--- a/modules/installation-methods-for-different-architectures.adoc
+++ b/modules/installation-methods-for-different-architectures.adoc
@@ -6,7 +6,7 @@
 = Installation methods for different architectures
 
 [role="_abstract"]
-{rh-rhacs-first} and {product-title-managed} ({product-title-managed-short}) are supported on specific architectures.
+{rh-rhacs-first} and {product-title-managed} ({product-title-managed-short}) supports the following architectures.
 
 .Supported architectures and recommended installation methods
 [%autowidth]
@@ -18,12 +18,12 @@
 |Yes
 a|Operator (preferred), Helm charts, or roxctl CLI (not recommended)
 
-|IBM Power (ppc64le) 
+| ppc64le ({ibm-power})
 |No
 |Yes ({ocp} versions 4.10, 4.11, and 4.12 only)
 .2+a|Operator is the only supported install method.
 
-|IBM Z
+| ppc64le ({ibm-zsystems} and {ibm-linuxone})
 |No
 |Yes ({ocp} versions 4.10, 4.11, and 4.12 only)
 

--- a/modules/run-roxctl-from-container.adoc
+++ b/modules/run-roxctl-from-container.adoc
@@ -8,6 +8,9 @@
 The `roxctl` client is the default entry point in {product-title} `roxctl` image.
 To run the `roxctl` client in a container image:
 
+.Prerequisites
+* You must first generate an authentication token from the {product-title-short} portal.
+
 .Procedure
 
 . Log in to the `registry.redhat.io` registry.

--- a/modules/using-cli.adoc
+++ b/modules/using-cli.adoc
@@ -63,7 +63,7 @@ To secure a Kubernetes or an {ocp} cluster, you must deploy {product-title} serv
 You can generate deployment files in the RHACS portal by navigating to the *Platform Configuration* -> *Clusters* view, or you can use the `roxctl` CLI.
 
 [discrete]
-=== Generating Sensor deployment YAML file
+=== Generating Sensor deployment files
 
 .Kubernetes
 
@@ -76,8 +76,9 @@ $ roxctl -e "$ROX_CENTRAL_ADDRESS" sensor generate k8s --name <cluster_name> --c
 
 [source,terminal]
 ----
-$ roxctl -e "$ROX_CENTRAL_ADDRESS" sensor generate openshift --name <cluster_name> --central "$ROX_CENTRAL_ADDRESS"
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" sensor generate openshift --openshift-version <ocp-version> --name <cluster_name> --central "$ROX_CENTRAL_ADDRESS" <1>
 ----
+<1> For the `--openshift-version` option specify the major {ocp} version number for your cluster. For example, specify `3` for {ocp} version `3.x` and specify `4` for {ocp} version `4.x`.
 
 Read the `--help` output to see other options that you might need to use depending on your system architecture.
 
@@ -96,6 +97,17 @@ To use `wss`, prefix the address with *`wss://`*, and
 $ roxctl sensor generate k8s --central wss://stackrox-central.example.com:443
 ----
 ====
+
+[discrete]
+=== Installing Sensor by using the generate YAML files
+When you generate the Sensor deployment files, `roxctl` creates a directory called `sensor-<cluster_name>` in your working directory. The script to install Sensor is present in this directory. Run the sensor installation script to install Sensor.
+
+[source,terminal]
+----
+$ ./sensor-<cluster_name>/sensor.sh
+----
+
+If you get a warning that you do not have the required permissions to install Sensor, follow the on-screen instructions, or contact your cluster administrator for help.
 
 [discrete]
 === Downloading Sensor bundle for existing clusters

--- a/modules/using-the-interactive-installer.adoc
+++ b/modules/using-the-interactive-installer.adoc
@@ -15,6 +15,11 @@ Use the interactive installer to generate the required secrets, deployment confi
 ----
 $ roxctl central generate interactive
 ----
++
+[IMPORTANT]
+====
+Installing {product-title} using `roxctl` CLI creates PodSecurityPolicy (PSP) objects by default for backward compatibility. If you install {product-title-short} on Kubernetes versions 1.25 and newer or {ocp} version 4.12 and newer, you must disable the PSP object creation. To do this, specify `--enable-pod-security-policies` option as `false` for the `roxctl central generate` and `roxctl sensor generate` commands.
+====
 . Press *Enter* to accept the default value for a prompt or enter custom values as required.
 +
 [source,terminal]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-15094 
Updates to the existing docs based on internal technical review.

Cherrypick into:
- `rhacs-docs-3.74`

Preview: 
- Site: https://55791--docspreview.netlify.app/openshift-acs/latest/welcome/index.html
- General requirements: https://55791--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/prerequisites-other.html#acs-general-requirements_prerequisites-other
- Installing Sensor by using the generate YAML files: https://55791--docspreview.netlify.app/openshift-acs/latest/cli/getting-started-cli.html#installing-sensor-by-using-the-generate-yaml-files
- Installing the central-services Helm chart without customizations: https://55791--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/install-central-other.html#installing-quickly_install-central-other