### PR TITLE
logging: Add note about picking a storage class

### DIFF
--- a/modules/cluster-logging-loki-deploy.adoc
+++ b/modules/cluster-logging-loki-deploy.adoc
@@ -92,12 +92,12 @@ spec:
     secret:
       name: logging-loki-s3
       type: s3
-  storageClassName: gp3-csi <1>
+  storageClassName: <storage_class_name> <1>
   tenants:
     mode: openshift-logging
 ----
-<1> Or `gp2-csi`. 
-+
+<1> Enter the name of an existing storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed using `oc get storageclasses`.
+
 .. Apply the configuration:
 +
 [source,terminal]

--- a/modules/logging-deploy-loki-console.adoc
+++ b/modules/logging-deploy-loki-console.adoc
@@ -92,7 +92,7 @@ stringData:
 <3> Define the secret used for your log storage.
 <4> Define corresponding storage type.
 <5> Enter the name of an existing storage class for temporary storage. For best performance, specify a storage class that allocates block storage. Available storage classes for your cluster can be listed using `oc get storageclasses`.
-+
+
 .. Apply the configuration:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s): 4.10+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

I noticed that the 4.12 release of OpenShift no longer contains the `gp2` storage class we reference in our docs. Apart from this specific storage class going away, this configuration value has already been a source of confusion before.
I've added a note to the example resource, to better explain, that this value should be set based on what the cluster offers.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

cc @libander 