### PR TITLE
R ns 4.99.55 date

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -3359,3 +3359,27 @@ $ oc adm release info 4.9.54 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-55"]
+=== RHSA-2023:0574 - {product-title} 4.9.55 bug fix and security update
+
+Issued: 2023-02-10
+
+{product-title} release 4.9.55, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:0574[RHSA-2023:0574] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0573[RHSA-2023:0573] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.9.55 --pullspecs
+----
+
+[id="ocp-4-9-55-bug-fixes"]
+==== Bug fixes
+
+* Previously, some OpenStack object storage instances responded with `204 No Content` when listing requests with no containers or objects. In these cases, {product-title} did not correctly handle listing responses. With this update, the installation program works around the issue of zero items to list. (link:https://issues.redhat.com/browse/OCPBUGS-6086[*OCPBUGS-6086*])
+
+[id="ocp-4-9-55-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-4914](https://issues.redhat.com/browse/OSDOCS-4914): Updates RNs for 4.9.55

Version(s):
4.9

Issue:
https://issues.redhat.com/browse/OSDOCS-4914

Link to docs preview: [4.9.55](http://file.emea.redhat.com/dfitzmau/RNs-4.99.55-date/release_notes/ocp-4-9-release-notes.html#ocp-4-9-55)

QE review:

 QE has approved this change.

Additional comments:
Because of a power outage, the 4.9.55 release is a day late. PR #55804 PR expands upon https://github.com/openshift/openshift-docs/pull/55607 by changing the date from 2023-02-09 to 2023-02-10.