### PR TITLE
RHDEVDOCS-4336-fix-incorrect-info-for-UWM-labels

### DIFF
--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -6,7 +6,10 @@
 [id="attaching-additional-labels-to-your-time-series-and-alerts_{context}"]
 = Attaching additional labels to your time series and alerts
 
-Using the external labels feature of Prometheus, you can attach custom labels to all time series and alerts leaving Prometheus.
+You can use the external labels feature of Prometheus to attach custom labels to all time series and alerts leaving the Prometheus instance used for core {product-title} monitoring.
+
+If you enable monitoring for user-defined projects, Prometheus manages metrics and Thanos Ruler manages alerting and recording rules.
+Therefore, you can only attach external labels for metrics and not for alerting and recording rules when you configure the `prometheus` component in the `user-workload-monitoring-config` `ConfigMap` object.
 
 .Prerequisites
 
@@ -52,7 +55,7 @@ data:
 Do not use `prometheus` or `prometheus_replica` as key names, because they are reserved and will be overwritten.
 ====
 +
-For example, to add metadata about the region and environment to all time series and alerts, use:
+For example, to add metadata about the region and environment to metrics, use:
 +
 [source,yaml]
 ----
@@ -69,7 +72,7 @@ data:
         environment: prod
 ----
 
-** *To attach custom labels to all time series and alerts leaving the Prometheus instance that monitors user-defined projects*:
+** *To attach custom labels to metrics leaving the Prometheus instance that monitors user-defined projects*:
 .. Edit the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project:
 +
 [source,terminal]
@@ -100,12 +103,7 @@ data:
 Do not use `prometheus` or `prometheus_replica` as key names, because they are reserved and will be overwritten.
 ====
 +
-[NOTE]
-====
-In the `openshift-user-workload-monitoring` project, Prometheus handles metrics and Thanos Ruler handles alerting and recording rules. Setting `externalLabels` for `prometheus` in the `user-workload-monitoring-config` `ConfigMap` object will only configure external labels for metrics and not for any rules.
-====
-+
-For example, to add metadata about the region and environment to all time series and alerts related to user-defined projects, use:
+For example, to add metadata about the region and environment to metrics related to user-defined projects, use:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Summary: This PR fixes incorrect and unclear information about attaching external labels for time series data in core platform monitoring versus user workload monitoring (user-defined projects).

- Aligned team: DevTools
- For branches: 4.9+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4336
- Direct link to doc preview: https://55812--docspreview.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#attaching-additional-labels-to-your-time-series-and-alerts_configuring-the-monitoring-stack
- SME review: @jan--f 
- QE review: @juzhao 
- Peer review: @ tbd