### PR TITLE
Update cluster-logging-manual-rollout-rolling.adoc

### DIFF
--- a/modules/cluster-logging-manual-rollout-rolling.adoc
+++ b/modules/cluster-logging-manual-rollout-rolling.adoc
@@ -28,7 +28,7 @@ $ oc project openshift-logging
 . Get the names of the Elasticsearch pods:
 +
 ----
-$ oc get pods -l component=elasticsearch-
+$ oc get pods -l component=elasticsearch
 ----
 
 . Scale down the collector pods so they stop sending new logs to Elasticsearch:


### PR DESCRIPTION
Fixing minor errors in doc.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-5299]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10.x, 4.11.x, 4.12.x

Issue:
Fixing minor errors in doc. 
Listing ES component with '-' generating error. 

$ oc get pods -l component=elasticsearch-
Error from server (BadRequest): Unable to find "/v1, Resource=pods" that match label selector "component=elasticsearch-", field selector "": unable to parse requirement: values[0][component]: Invalid value: "elasticsearch-": a valid label must be an empty string or consist of alphanumeric characters, '-', '_' or '.', and must start and end with an alphanumeric character (e.g. 'MyValue',  or 'my_value',  or '12345', regex used for validation is '(([A-Za-z0-9][-A-Za-z0-9_.]*)?[A-Za-z0-9])?') 

Removing '-' fix it. 

$ oc get pods -l component=elasticsearch
NAME                                            READY   STATUS    RESTARTS   AGE
elasticsearch-cdm-g559ha9u-1-659fd594bf-pcm2f   0/2     Pending   0          8d
elasticsearch-cdm-g559ha9u-2-66455f68db-v46n6   0/2     Pending   0          8d
elasticsearch-cdm-g559ha9u-3-85696bcf55-g7tf8   0/2     Pending   0          8d
$ 

https://issues.redhat.com/browse/OSDOCS-5299

Link to docs preview:

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
