### PR TITLE
OCPBUGS-6615: OSP: Add note about rgw_max_attr_size in OSP17

### DIFF
--- a/modules/installation-osp-enabling-swift.adoc
+++ b/modules/installation-osp-enabling-swift.adoc
@@ -17,6 +17,13 @@ If link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform
 If Swift is present and you want to use it, you must enable access to it. If it is not present, or if you do not want to use it, skip this section.
 ====
 
+[IMPORTANT]
+====
+{rh-openstack} 17 sets the `rgw_max_attr_size` parameter of Ceph RGW to 256 characters. This setting causes issues with uploading container images to the {product-title} registry. You must set the value of `rgw_max_attr_size` to at least 1024 characters.
+
+Before installation, check if your {rh-openstack} deployment is affected by this problem. If it is, reconfigure Ceph RGW.
+====
+
 .Prerequisites
 
 * You have a {rh-openstack} administrator account on the target environment.


### PR DESCRIPTION
Due to bug [1] Ceph RGW setting `rgw_max_attr_size` is set to 256 by default in OSP17. This causes problems hen uploading container images by the internal registry. This commit adds a note that in OSP 17.0 it is important to check and reconfigure that parameter before installation.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2167161

Version(s):
4.11, 4.12, 4.13, 4.14

Issue:
* https://issues.redhat.com/browse/OCPBUGS-6615
* https://bugzilla.redhat.com/show_bug.cgi?id=2167161

Link to docs preview:


QE review:
- [ ] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
