### PR TITLE
OSDOCS-5148: adding update procedure for disconnected OSUS page

### DIFF
--- a/modules/update-service-perform-update.adoc
+++ b/modules/update-service-perform-update.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+
+:_content-type: PROCEDURE
+[id="update-service-perform-update"]
+= Updating the disconnected cluster with the OpenShift Update Service
+
+Once you have configured your cluster to use your locally installed Update Service and local mirror registry, you can then perform any of the available update methods as you would with a connected cluster.
+
+.Prerequisites
+
+* You have configured the Cluster Version Operator (CVO) to use your locally installed OpenShift Update Service application.
+* You have applied the release image signature ConfigMap for the new release to your cluster.
+* You have mirrored the target release images onto your local registry.
+* You have recently mirrored a graph data container image onto your local registry.
+
+.Procedure
+
+. Perform any of the following procedures for updating your cluster:
+
+** Updating a cluster using the web console
+** Updating a cluster using the CLI
+** Preparing to perform an EUS-to-EUS update
+** Performing a canary rollout update
+** Updating a cluster that includes RHEL compute machines

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -79,6 +79,7 @@ xref:../updating/updating-restricted-network-cluster/index.adoc#about-restricted
 * xref:../updating/updating-restricted-network-cluster/restricted-network-update.adoc#generating-icsp-object-scoped-to-a-registry_updating-restricted-network-cluster[Widening the scope of the mirror image catalog to reduce the frequency of cluster node reboots]
 * xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-install[Installing the OpenShift Update Service Operator]
 * xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-create-service[Creating an OpenShift Update Service application]
+* xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-perform-update[Updating the disconnected cluster with the OpenShift Update Service]
 * xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-delete-service[Deleting an OpenShift Update Service application]
 * xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-uninstall[Uninstalling the OpenShift Update Service Operator]
 

--- a/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
@@ -119,6 +119,17 @@ include::modules/update-service-configure-cvo.adoc[leveloffset=+3]
 See xref:../../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object[Enabling the cluster-wide proxy] to configure the CA to trust the update server.
 ====
 
+include::modules/update-service-perform-update.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster using the web console]
+* xref:../../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]
+* xref:../../updating/preparing-eus-eus-upgrade.adoc#preparing-eus-eus-upgrade[Preparing to perform an EUS-to-EUS update]
+* xref:../../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update]
+* xref:../../updating/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-compute[Updating a cluster that includes RHEL compute machines]
+
 [id="update-service-delete-service"]
 == Deleting an OpenShift Update Service application
 


### PR DESCRIPTION
[OSDOCS-5148](https://issues.redhat.com/browse/OSDOCS-5148)

Version(s): 4.9+

This PR adds a section to the "Updating disconnected environments using the OpenShift Update Service" page that explicitly instructs users how to update their cluster once they have completed all of the prior preparation/configuration.

QE review:
- [x] QE has approved this change.

Current documentation: https://docs.openshift.com/container-platform/4.12/updating/updating-restricted-network-cluster/restricted-network-update-osus.html

Preview: https://55829--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/restricted-network-update-osus.html#update-service-perform-update