### PR TITLE
OSDOCS-5265: Greenboot for MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -149,6 +149,8 @@ Topics:
   File: microshift-applications
 - Name: Operators
   File: microshift-operators
+- Name: Greenboot health check
+  File: microshift-greenboot
 # ---
 # Name: Networking
 # Dir: networking

--- a/microshift_running_apps/microshift-greenboot.adoc
+++ b/microshift_running_apps/microshift-greenboot.adoc
@@ -1,0 +1,35 @@
+:_content-type: ASSEMBLY
+[id="microshift-greenboot"]
+= The greenboot health check
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-greenboot
+
+toc::[]
+
+Greenboot is the generic health check framework for the `systemd` service on RPM-OSTree-based systems. The `microshift-greenboot` RPM and `greenboot-default-health-check` are optional RPM packages you can install. Greenboot is used to assess system health and automate a rollback to the last healthy state in the event of software trouble.
+
+This health check framework is especially useful when you need to check for software problems and perform system rollbacks on edge devices where direct serviceability is either limited or non-existent. When health check scripts are installed and configured, health checks run every time the system starts.
+
+Using greenboot can reduce your risk of being locked out of edge devices during updates and prevent a significant interruption of service if an update fails. When a failure is detected, the system boots into the last known working configuration using the `rpm-ostree` rollback capability.
+
+A {product-title} health check script is included in the `microshift-greenboot` RPM. The `greenboot-default-health-check` RPM includes health check scripts verifying that DNS and `ostree` services are accessible. You can also create your own health check scripts based on the workloads you are running. You can write one that verifies that an application has started, for example.
+
+[NOTE]
+====
+Health check scripts might run on a system not using an OSTree file system, but no rollback is possible in the case of an update failure.
+====
+
+include::modules/microshift-greenboot-dir-structure.adoc[leveloffset=+1]
+include::modules/microshift-greenboot-microshift-health-script.adoc[leveloffset=+1]
+include::modules/microshift-greenboot-systemd-journal-data.adoc[leveloffset=+1]
+//include::modules/microshift-greenboot-create-health-check-script.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../microshift_running_apps/microshift-applications.adoc#microshift-manifests-example_applications-microshift[Auto applying manifests]
+
+include::modules/microshift-greenboot-updates-workloads.adoc[leveloffset=+1]
+include::modules/microshift-greenboot-workloads-validation.adoc[leveloffset=+1]
+include::modules/microshift-greenboot-health-check-log.adoc[leveloffset=+1]
+include::modules/microshift-greenboot-prerollback-log.adoc[leveloffset=+1]
+include::modules/microshift-greenboot-check-update.adoc[leveloffset=+1]

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -10,7 +10,7 @@ Add the {product-title} RPM package to a blueprint and enable the {product-title
 
 .Image Builder blueprint example
 
-[source,toml]
+[source,text]
 ----
 name = "minimal-microshift"
 
@@ -21,8 +21,13 @@ groups = []
 
 [[packages]]
 name = "microshift"
-version = "4.12.0-1"
+version = "4.13.0-1"
+
+[[packages]]
+name = "microshift-greenboot" <1>
+version = "4.13.0-1"
 
 [customizations.services]
 enabled = ["microshift"]
 ----
+<1> Optional `microshift-greenboot` RPM. For more information, read the "Greenboot health check" guide in the "Running Applications" section.

--- a/modules/microshift-configuring-ovn.adoc
+++ b/modules/microshift-configuring-ovn.adoc
@@ -36,7 +36,7 @@ To customize your configuration, use the following table that lists the valid va
 |bool
 |false
 |Skip configuring OVS bridge `br-ex` in `microshift-ovs-init.service`
-|true ^1^
+|true ^[1]^
 
 |`ovsInit.gatewayInterface`
 |Alpha
@@ -56,7 +56,10 @@ To customize your configuration, use the following table that lists the valid va
 |MTU value used for the pods
 |1300
 |===
-^1^ The OVS bridge is required. When `disableOVSInit` is true, OVS bridge `br-ex` must be configured manually.
+[.small]
+--
+1. The OVS bridge is required. When `disableOVSInit` is true, OVS bridge `br-ex` must be configured manually.
+--
 
 .Example `ovn.yaml` config file:
 

--- a/modules/microshift-greenboot-check-update.adoc
+++ b/modules/microshift-greenboot-check-update.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * microshift_running applications/microshift-greenboot.adoc
+
+:_content-type: PROCEDURE
+[id="greenboot-check-updates_{context}"]
+= Checking updates with a health script
+
+Access the output of health check scripts in the system log after an update by using the following procedure.
+
+.Procedure
+
+* To access the result of update checks, run the following command:
++
+[source, terminal]
+----
+$ sudo grub2-editenv - list | grep ^boot_success
+----
+
+.Example output for a successful update
+
+[source, terminal]
+----
+boot_success=1
+----
+
+If your command returns `boot_success=0`, either the greenboot health check is still running, or the update is a failure.

--- a/modules/microshift-greenboot-create-health-check-script.adoc
+++ b/modules/microshift-greenboot-create-health-check-script.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * microshift_running applications/microshift-greenboot.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-greenboot-create-health-check-script_{context}"]
+= Creating a health check script
+
+You can create a health check script for installed workloads by placing them in the `/etc/greenboot/check/required.d` directory. The following procedure provides an example of installing the busybox application and creating a health check script for busybox. You can use this example as a general guide for creating health check scripts for your applications.
+
+.Prerequisite
+
+* You have installed a workload. For this example, the busybox application is used as a workload. The "Additional resources" section that follows this procedure has a link to instructions on deploying workloads using manifests.
+
+.Procedure
+
+. To create a health check script, run the following command:
++
+[source, terminal]
+----
+$ SCRIPT_FILE=/etc/greenboot/check/required.d/50_busybox_running_check.sh
+sudo curl -s https://raw.githubusercontent.com/openshift/microshift/3b7f6025cd77bd1bf827416fd026783ead82b7c8/docs/config/busybox_running_check.sh \
+  -o ${SCRIPT_FILE} && echo SUCCESS || echo ERROR
+sudo chmod 755 ${SCRIPT_FILE}
+----
++
+In this example, the script verifies that busybox is running as expected. You can replace `/etc/greenboot/check/required.d/50_busybox_running_check.sh` with your own workload details.
++
+[NOTE]
+====
+In this example, the {product-title} core service health checks run before the user workload health checks.
+====
+
+. To test that your script is running as expected:
+
+.. Restart the system.
+
+.. Once the system has restarted, run the following command:
++
+[source, terminal]
+----
+$ sudo journalctl -o cat -u greenboot-healthcheck.service
+----
++
+.Example output for the busybox health check script
++
+[source, terminal]
+----
+...
+...
+STARTED
+Waiting 300s for pod image(s) from the 'busybox' namespace to be downloaded
+Waiting 300s for 1 pod(s) from the 'busybox' namespace to be in 'Ready' state
+Checking pod restart count in the 'busybox' namespace
+FINISHED
+Script '50_busybox_running_check.sh' SUCCESS
+----

--- a/modules/microshift-greenboot-dir-structure.adoc
+++ b/modules/microshift-greenboot-dir-structure.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * microshift_running applications/microshift-greenboot.adoc
+
+:_content-type: CONCEPT
+[id="microshift-greenboot-dir-structure_{context}"]
+= How greenboot uses directories to run scripts
+
+Health check scripts run from four `/etc/greenboot` directories. These scripts run in alphabetical order. Keep this in mind when you configure the scripts for your workloads.
+
+When the system starts, greenboot runs the scripts in the `required.d` and `wanted.d` directories. Depending on the outcome of those scripts, greenboot continues the startup or attempts a rollback as follows:
+
+. System as expected: When all of the scripts in the `required.d` directory are successful, greenboot runs any scripts present in the `/etc/greenboot/green.d` directory.
+
+. System trouble: If any of the scripts in the `required.d` directory fail, greenboot runs any prerollback scripts present in the `red.d` directory, then restarts the system.
+
+[NOTE]
+====
+Greenboot redirects script and health check output to the system log. When you are logged in, a daily message provides the overall system health output.
+====
+
+[id="greenboot-directories-details_{context}"]
+== Greenboot directories details
+
+Returning a nonzero exit code from any script means that script has failed. Greenboot restarts the system a few times to retry the scripts before attempting to roll back to the previous version.
+
+* `/etc/greenboot/check/required.d` contains the health checks that must not fail.
+
+** If the scripts fail, greenboot retries them three times by default. You can configure the number of retries in the `/etc/greenboot/greenboot.conf` file by setting the `GREENBOOT_MAX_BOOTS` parameter to the desired number of retries.
+
+** After all retries fail, greenboot automatically initiates a rollback if one is available. If a rollback is not available, the system log output shows that manual intervention is required.
+
+** The `40_microshift_running_check.sh` health check script for {product-title} is installed into this directory.
+
+* `/etc/greenboot/check/wanted.d` contains health scripts that are allowed to fail without causing the system to be rolled back.
+
+** If any of these scripts fail, greenboot logs the failure but does not initiate a rollback.
+
+* `/etc/greenboot/green.d` contains scripts that run after greenboot has declared the start successful.
+
+* `/etc/greenboot/red.d` contains scripts that run after greenboot has declared the startup as failed, including the `40_microshift_pre_rollback.sh` prerollback script. This script is executed right before a system rollback. The script performs {product-title} pod and OVN-Kubernetes cleanup to avoid potential conflicts after the system is rolled back to a previous version.

--- a/modules/microshift-greenboot-health-check-log.adoc
+++ b/modules/microshift-greenboot-health-check-log.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * microshift_running applications/microshift-greenboot.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-greenboot-access-health-check_{context}"]
+= Accessing health check output in the system log
+
+You can manually access the output of health checks in the system log by using the following procedure.
+
+.Procedure
+
+* To access the results of a health check, run the following command:
++
+[source, terminal]
+----
+$ sudo journalctl -o cat -u greenboot-healthcheck.service
+----
+
+.Example output of a failed health check
+[source, terminal]
+----
+...
+...
+Running Required Health Check Scripts...
+STARTED
+GRUB boot variables:
+boot_success=0
+boot_indeterminate=0
+boot_counter=2
+...
+...
+Waiting 300s for MicroShift service to be active and not failed
+FAILURE
+...
+...
+----

--- a/modules/microshift-greenboot-microshift-health-script.adoc
+++ b/modules/microshift-greenboot-microshift-health-script.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * microshift_running applications/microshift-greenboot.adoc
+
+:_content-type: CONCEPT
+[id="microshift-health-script_{context}"]
+= The {product-title} health script
+
+The `40_microshift_running_check.sh` health check script only performs validation of core {product-title} services. Install your customized workload validation scripts in the greenboot directories to ensure successful application operations after system updates. Scripts run in alphabetical order.
+
+{product-title} health checks are listed in the following table:
+
+.Validation statuses and outcome for {product-title}
+
+[cols="3", options="header"]
+|===
+|Validation
+|Pass
+|Fail
+
+|Check that the script runs with `root` permissions
+|Next
+|`exit 0`
+
+|Check that the `microshift.service` is enabled
+|Next
+|`exit 0`
+
+|Wait for the `microshift.service` to be active (!failed)
+|Next
+|`exit 1`
+
+|Wait for Kubernetes API health endpoints to be working and receiving traffic
+|Next
+|`exit 1`
+
+|Wait for any pod to start
+|Next
+|`exit 1`
+
+|For each core namespace, wait for images to be pulled
+|Next
+|`exit 1`
+
+|For each core namespace, wait for pods to be ready
+|Next
+|`exit 1`
+
+|For each core namespace, check if pods are not restarting
+|`exit 0`
+|`exit 1`
+|===
+
+[id="validation-wait-period"]
+== Validation wait period
+The wait period in each validation is five minutes by default. After the wait period, if the validation has not succeeded, it is declared a failure. This wait period is incrementally increased by the base wait period after each boot in the verification loop.
+
+* You can override the base-time wait period by setting the `MICROSHIFT_WAIT_TIMEOUT_SEC` environment variable in the `/etc/greenboot/greenboot.conf` configuration file. For example, you can change the wait time to three minutes by resetting the value to 180 seconds, such as `MICROSHIFT_WAIT_TIMEOUT_SEC=180`.

--- a/modules/microshift-greenboot-prerollback-log.adoc
+++ b/modules/microshift-greenboot-prerollback-log.adoc
@@ -1,0 +1,49 @@
+
+// Module included in the following assemblies:
+//
+// * microshift_running applications/microshift-greenboot.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-greenboot-access-prerollback-check_{context}"]
+= Accessing prerollback health check output in the system log
+
+You can access the output of health check scripts in the system log. For example, to check the results of a prerollback script, use the following procedure.
+
+.Procedure
+
+* To access the results of a prerollback script, run the following command:
++
+[source, terminal]
+----
+$ sudo journalctl -o cat -u redboot-task-runner.service
+----
+
+.Example output of a prerollback script
+[source, terminal]
+----
+...
+...
+Running Red Scripts...
+STARTED
+GRUB boot variables:
+boot_success=0
+boot_indeterminate=0
+boot_counter=0
+The ostree status:
+* rhel c0baa75d9b585f3dd989a9cf05f647eb7ca27ee0dbd4b94fe8c93ed3a4b9e4a5.0
+    Version: 9.1
+    origin: <unknown origin type>
+  rhel 6869c1347b0e0ba1bbf0be750cdf32da5138a1fcbc5a4c6325ab9eb647b64663.0 (rollback)
+    Version: 9.1
+    origin refspec: edge:rhel/9/x86_64/edge
+System rollback imminent - preparing MicroShift for a clean start
+Stopping MicroShift services
+Removing MicroShift pods
+Killing conmon, pause and OVN processes
+Removing OVN configuration
+Finished greenboot Failure Scripts Runner.
+Cleanup succeeded
+Script '40_microshift_pre_rollback.sh' SUCCESS
+FINISHED
+redboot-task-runner.service: Deactivated successfully.
+----

--- a/modules/microshift-greenboot-systemd-journal-data.adoc
+++ b/modules/microshift-greenboot-systemd-journal-data.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * microshift_running applications/microshift-greenboot.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-greenboot-systemd-journal-data_{context}"]
+= Enabling systemd journal service data persistency
+
+The default configuration of the `systemd` journal service stores the data in the volatile `/run/log/journal` directory. To persist system logs across system starts and restarts, enable log persistence and set limits on the maximal journal data size. The following steps allow you to enable `systemd` journal service data persistency.
+
+.Procedure
+
+. Make the directory by running the following command:
++
+[source, terminal]
+----
+$ sudo mkdir -p /etc/systemd/journald.conf.d
+----
+
+. Create the configuration file by running the following command:
++
+[source, terminal]
+----
+cat <<EOF | sudo tee /etc/systemd/journald.conf.d/microshift.conf &>/dev/null
+[Journal]
+Storage=persistent
+SystemMaxUse=1G
+RuntimeMaxUse=1G
+EOF
+----
+
+. Edit the configuration file values for your size requirements.

--- a/modules/microshift-greenboot-updates-workloads.adoc
+++ b/modules/microshift-greenboot-updates-workloads.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * microshift_running applications/microshift-greenboot.adoc
+
+:_content-type: CONCEPT
+[id="microshift-greenboot-updates-workloads_{context}"]
+= Updates and third-party workloads
+
+Health checks are especially useful after an update. You can examine the output of greenboot health checks and determine whether the update was declared valid. This health check can help you determine if the system is working properly.
+
+Health check scripts for updates are installed into the `/etc/greenboot/check/required.d` directory and are automatically executed during each system start. Exiting scripts with a nonzero status means the system start is declared as failed.
+
+[IMPORTANT]
+====
+Wait until after an update is declared valid before starting third-party workloads. If a rollback is performed after workloads start, you can lose data. Some third-party workloads create or update data on a device before an update is complete. Upon rollback, the file system reverts to its state before the update.
+====

--- a/modules/microshift-greenboot-workloads-validation.adoc
+++ b/modules/microshift-greenboot-workloads-validation.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * microshift_running applications/microshift-greenboot.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-greenboot-workloads-validation_{context}"]
+= Checking the results of an update
+
+After a successful start, greenboot sets the variable `boot_success=` to `1` in GRUB. You can view the overall status of system health checks after an update in the system log by using the following procedure.
+
+.Procedure
+
+* To access the overall status of system health checks, run the following command:
++
+[source, terminal]
+----
+$ sudo grub2-editenv - list | grep ^boot_success
+----
+
+.Example output for a successful system start
+[source, terminal]
+----
+boot_success=1
+----

--- a/modules/microshift-installing-from-rpm.adoc
+++ b/modules/microshift-installing-from-rpm.adoc
@@ -31,6 +31,13 @@ $ sudo subscription-manager repos \
 $ sudo dnf install -y microshift
 ----
 
+. Optional: Install greenboot for {product-title} by running the following command:
++
+[source,terminal]
+----
+$ sudo dnf install -y microshift-greenboot
+----
+
 . Download your installation pull secret from the Red Hat Hybrid Cloud Console to a temporary folder, for example, `$HOME/openshift-pull-secret`. This pull secret allows you to authenticate with the container registries that serve the container images used by {product-title}.
 
 . To copy the pull secret to the `/etc/crio` folder of your {op-system} machine, run the following command:


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5265

Link to docs preview:
https://55833--docspreview.netlify.app/microshift/latest/microshift_running_apps/microshift-greenboot.html
https://55833--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#installing-microshift-from-rpm-package_microshift-install-rpm
https://55833--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#adding-MicroShift-service_microshift-embed-in-rpm-ostree

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
