### PR TITLE
OCPBUGS-6709-main: adding note

### DIFF
--- a/modules/psap-driver-toolkit-pulling.adoc
+++ b/modules/psap-driver-toolkit-pulling.adoc
@@ -31,18 +31,21 @@ The driver-toolkit image for the latest minor release are tagged with the minor 
 # For x86 image:
 $ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version}.z-x86_64 --image-for=driver-toolkit
 
-# For ARM image:
+# For ARM image: 
 $ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version}.z-aarch64 --image-for=driver-toolkit
 ----
 +
 .Example output
+
+The output for the `ocp-release:4.12.0-x86_64` image is as follows:
++ 
 [source,terminal]
 ----
-quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0fd84aee79606178b6561ac71f8540f404d518ae5deff45f6d6ac8f02636c7f4
+quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b53883ca2bac5925857148c4a1abc300ced96c222498e3bc134fe7ce3a1dd404
 ----
 
 . This image can be obtained using a valid pull secret, such as the pull secret required to install {product-title}.
-
++
 [source,terminal]
 ----
 $ podman pull --authfile=path/to/pullsecret.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:<SHA>


### PR DESCRIPTION
Complimentary PR to OCPBUGS-6709-main to address issue of SHA in example.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
Summary of changes:
Update to step 1 of the 'Finding the Driver Toolkit image URL in the payload' section.

Version(s):
main, 4.13

Issue:
OCPBUGS-6709 (second related PR)

Link to docs preview:
https://55835--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-driver-toolkit.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
