### PR TITLE
TELCODOCS-1142: MGMT-10209 assisted-service ICSP support

### DIFF
--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -6,7 +6,7 @@
 [id="ztp-configuring-the-cluster-for-a-disconnected-environment_{context}"]
 = Configuring the hub cluster to use a disconnected mirror registry
 
-You can configure the hub cluster to use a disconnected mirror registry for a disconnected environment.
+You can configure the hub cluster to use a disconnected mirror registry for a disconnected environment. 
 
 .Prerequisites
 
@@ -43,7 +43,7 @@ data:
       mirror-by-digest-only = true
 ----
 <1> The mirror registry’s certificate used when creating the mirror registry.
-<2> The configuration for the mirror registry.
+<2> The configuration file for the mirror registry. The mirror registry configuration adds mirror information to `/etc/containers/registries.conf` in the Discovery image. The mirror information is stored in the `imageContentSources` section of the `install-config.yaml` file when passed to the installation program. The Assisted Service pod running on the HUB cluster fetches the container images from the configured mirror registry.  
 <3> The URL of the mirror registry.
 +
 This updates `mirrorRegistryRef` in the `AgentServiceConfig` custom resource, as shown below:


### PR DESCRIPTION
Summary of Change:
Enhancing call-out 2 of the diagram, in the 'Configuring the hub cluster to use a disconnected mirror registry' section. 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Main, 4.12, 4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-1142?filter=-1

Link to docs preview:
https://55836--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
