### PR TITLE
TELCODOCS:1103b - Update to kataconfig file in 4.11

### DIFF
--- a/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
+++ b/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
@@ -66,8 +66,9 @@ spec:
   kataMonitorImage: registry.redhat.io/openshift-sandboxed-containers/osc-monitor-rhel8:{sandboxed-containers-version}.0
   kataConfigPoolSelector:
     matchLabels:
-      <label_key>: '<label_value>'
+      <label_key>: '<label_value>' <1>
 ----
+<1> Labels in `kataConfigPoolSelector` only support single values; `nodeSelector` syntax is not supported.
 
 . Click *Create*.
 


### PR DESCRIPTION
Version(s): 4.11

Issue: [TELCODOCS-1103](https://issues.redhat.com/browse/TELCODOCS-1103)

[Link to docs preview](https://55840--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html#sandboxed-containers-create-kataconfig-resource-web-console_deploying-sandboxed-containers)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
