### PR TITLE
TELCODOCS:1103d - Update to kataconfig file in 4.9

### DIFF
--- a/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
+++ b/modules/sandboxed-containers-create-kataconfig-resource-web-console.adoc
@@ -52,8 +52,9 @@ If you want to install `kata` as a `RuntimeClass` only on selected nodes, includ
  spec:
    kataConfigPoolSelector:
      matchLabels:
-     <label_key>: '<label_value>'
+      <label_key>: '<label_value>' <1>
 ----
+<1> Labels in `kataConfigPoolSelector` only support single values; `nodeSelector` syntax is not supported.
 
 . Click *Create*.
 


### PR DESCRIPTION
Version(s): 4.9

Issue: [TELCODOCS-1103](https://issues.redhat.com/browse/TELCODOCS-1103)

[Link to docs preview](https://55842--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads.html#sandboxed-containers-create-kataconfig-resource-web-console_deploying-sandboxed-containers)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
