### PR TITLE
[OCPBUGS-6849]: Update commands to find etcd pods for OCP 4.9

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -261,7 +261,7 @@ $ sudo crictl ps | grep etcd | grep -v operator
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 [NOTE]
@@ -635,7 +635,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output

--- a/modules/etcd-defrag.adoc
+++ b/modules/etcd-defrag.adoc
@@ -78,7 +78,7 @@ Follow this procedure to defragment etcd data on each etcd member.
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd -o wide | grep -v quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd -o wide 
 ----
 +
 .Example output

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -104,7 +104,7 @@ ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.22.1
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output

--- a/modules/restore-replace-crashlooping-etcd-member.adoc
+++ b/modules/restore-replace-crashlooping-etcd-member.adoc
@@ -70,7 +70,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -570,7 +570,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc -n openshift-etcd get pods -l k8s-app=etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd -o wide
 ----
 +
 .Example output

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -32,7 +32,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd -o wide | grep etcd | grep -v guard
+$ oc -n openshift-etcd get pods -l k8s-app=etcd -o wide
 ----
 +
 .Example output
@@ -570,7 +570,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd -o wide | grep etcd | grep -v guard
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output
@@ -648,3 +648,4 @@ $ oc get etcd -o=jsonpath='{range.items[0].status.conditions[?(@.type=="NodeInst
 ----
 AllNodesAtLatestRevision
 ----
+

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -30,7 +30,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output
@@ -341,7 +341,7 @@ In a terminal that has access to the cluster as a `cluster-admin` user, run the 
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-etcd | grep -v etcd-quorum-guard | grep etcd
+$ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
 +
 .Example output
@@ -396,3 +396,4 @@ If the output from the previous command lists more than three etcd members, you 
 ====
 Be sure to remove the correct etcd member; removing a good etcd member might lead to quorum loss.
 ====
+


### PR DESCRIPTION
[OCPBUGS-6849](https://issues.redhat.com/browse/OCPBUGS-6849)
** Reviewers: This PR is to CP this update to the 4.9 branch. The original Jira applied to releases 4.9+, but this update was completed separately.

Version(s): 4.9

Links to docs preview:
- Restoring to a previous cluster stats (Steps 11b and 18): http://file.rdu.redhat.com/tlove/etcd-ocpbugs-6849-cp49-tlove/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state 
- Manual defragmentation (step 1a): http://file.rdu.redhat.com/tlove/etcd-ocpbugs-6849-cp49-tlove/scalability_and_performance/recommended-host-practices.html#manual-defrag-etcd-data_recommended-host-practices
- Determining the state of the unhealthy etcd member (step 3b): http://file.rdu.redhat.com/tlove/etcd-ocpbugs-6849-cp49-tlove/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-determine-state-etcd-member_replacing-unhealthy-etcd-member
- Replacing an unhealthy etcd member whose etcd pod is crashlooping (step 2a): http://file.rdu.redhat.com/tlove/etcd-ocpbugs-6849-cp49-tlove/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-crashlooping-etcd-member_replacing-unhealthy-etcd-member
- Replacing an unhealthy  bare metal etcd member whose machine is not running or whose node is not ready (step 1a): http://file.rdu.redhat.com/tlove/etcd-ocpbugs-6849-cp49-tlove/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member
- Replacing an unhealthy etcd member whose machine is not running or whose node is not ready (step 1a and verification, step 1): http://file.rdu.redhat.com/tlove/etcd-ocpbugs-6849-cp49-tlove/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member

QE review:
- [x ] QE has approved this change (Ge Liu).

