### PR TITLE
Fixing upgrade section in multi-arch docs

### DIFF
--- a/modules/multi-architecture-upgrade-mirrors.adoc
+++ b/modules/multi-architecture-upgrade-mirrors.adoc
@@ -7,17 +7,19 @@
 
 = Upgrading a cluster with multi-architecture compute machines
 
-You must perform an explicit upgrade command to upgrade your existing cluster to a cluster that supports multi-architecture compute machines.
+To upgrade your cluster with multi-architecture compute machines, you must use the `candidate-{product-version}` update channel. For more information, see "Understanding upgrade channels".
 
-.Prerequisites
+// You must perform an explicit upgrade command to upgrade your existing cluster to a cluster that supports multi-architecture compute machines.
 
-* You installed the OpenShift CLI (`oc`). 
+// .Prerequisites
 
-.Procedure
-* To manually upgrade your cluster, use the following command: 
-[source, terminal]
-+
-----
-$ oc adm upgrade --allow-explicit-upgrade --to-image <image-pullspec> <1>
-----
-<1> You can access the `image-pullspec` object from the link:https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/latest[mixed-arch mirrors page] in the `release.txt` file.
+// * You installed the OpenShift CLI (`oc`). 
+
+// .Procedure
+// * To manually upgrade your cluster, use the following command: 
+// [source, terminal]
+// +
+// ----
+// $ oc adm upgrade --allow-explicit-upgrade --to-image <image-pullspec> <1>
+// ----
+// <1> You can access the `image-pullspec` object from the link:https://mirror.openshift.com/pub/openshift-v4/multi/clients/ocp/latest[mixed-arch mirrors page] in the `release.txt` file.

--- a/post_installation_configuration/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/multi-architecture-configuration.adoc
@@ -28,4 +28,8 @@ include::modules/multi-architecture-modify-machine-set.adoc[leveloffset=+1]
 
 include::modules/multi-architecture-upgrade-mirrors.adoc[leveloffset=+1]
 
+[role="_additional-resources"] 
+.Additional resources
+* xref:../updating/understanding-upgrade-channels-release.adoc[Understanding upgrade channels]
+
 include::modules/multi-architecture-import-imagestreams.adoc[leveloffset=+1]


### PR DESCRIPTION
For versions 4.11+ 
Per discussion on Slack 

Preview: [Configuring multi-architecture compute machines on an OpenShift Container Platform cluster -> Upgrading a cluster with multi-architecture compute machines ](https://55851--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html#multi-architecture-upgrade-mirrors_multi-architecture-configuration)