### PR TITLE
OSDOCS-5307: Add release note that customers should change channel to stable for updates

### DIFF
--- a/networking/network_observability/network-observability-operator-release-notes.adoc
+++ b/networking/network_observability/network-observability-operator-release-notes.adoc
@@ -27,3 +27,18 @@ The Network Observability Operator is now stable and the release channel is upgr
 
 * Previously, unless the Loki `authToken` configuration was set to `FORWARD` mode, authentication was no longer enforced, allowing any user who could connect to the {product-title} console in an {product-title} cluster to retrieve flows without authentication.
 Now, regardless of the Loki `authToken` mode, only cluster administrators can retrieve flows. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2169468[*BZ#2169468*])
+
+
+[id="network-observability-operator-release-notes-1-2"]
+== Network Observability Operator 1.2.0
+
+The following advisory is available for the Network Observability Operator 1.1.0:
+
+* <errata link here>
+
+[id="network-observability-operator-preparing-to-update]
+=== Preparing to update to 1.3
+The subscription of an installed Operator specifies an update channel that tracks and receives updates for the Operator. Until the 1.2 release of the Network Observability Operator, the only channel available was `v1.0.x`. The 1.2 release of the Network Observability Operator introduces the `stable` update channel for tracking and receiving updates. You must switch your channel from the default `v1.0.x` to `stable` to recieve future Operator updates, 
+
+The names of update channels in a subscription can differ between Operators, but the naming scheme typically follows a common convention within a given Operator. For example, Network Observability Operator channel names might follow a minor release update stream for the application provided by the Operator, such as `v1.0.x` or a release frequency, such as `stable` or `fast`.
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Operator release 1.2 (4.12)
Not to be merged until 2/27/23 at Operator 1.2 GA. 
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5307
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://55857--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/network-observability-operator-release-notes.html
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
