### PR TITLE
OCPBUGS-411: Amend `oc` prerequisite to adhere to glossary usage.

### DIFF
--- a/modules/getting-started-cli-deploying-first-image.adoc
+++ b/modules/getting-started-cli-deploying-first-image.adoc
@@ -11,7 +11,7 @@ The simplest way to deploy an application in {product-title} is to run an existi
 .Prerequisites
 
 * You must have access to an {product-title} cluster.
-* You must have installed the OpenShift CLI (`oc`).
+* Install the OpenShift CLI (`oc`).
 
 .Procedure
 


### PR DESCRIPTION
The preferred usage is documented in the [OpenShift glossary of terms](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/term_glossary.adoc#openshift-cli).

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-411

Link to docs preview:
https://55858--docspreview.netlify.app/openshift-enterprise/latest/getting_started/openshift-cli.html#getting-started-cli-deploying-first-image_openshift-cli

QE review:
- N/A. The meaning of the prerequisite remains the same.

Additional information:
I could only find references to this section of the documentation going back to version 4.10. Please let me know if this construction existed in another location for previous versions of the documentation.