### PR TITLE
Updating the Compliance Operator uninstallation procedure

### DIFF
--- a/modules/compliance-operator-cli-uninstall.adoc
+++ b/modules/compliance-operator-cli-uninstall.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// security/compliance_operator/compliance-operator-uninstallation.adoc
+
+:_content-type: PROCEDURE
+[id="compliance-operator-uninstall-cli_{context}"]
+= Uninstalling the OpenShift Compliance Operator from {product-title} using the CLI
+
+To remove the Compliance Operator, you must first delete the objects in the namespace. After the objects are removed, you can remove the Operator and its namespace by deleting the *openshift-compliance* project.
+
+.Prerequisites
+
+* Access to an {product-title} cluster using an account with `cluster-admin` permissions.
+* The OpenShift Compliance Operator must be installed.
+
+.Procedure
+
+. Delete all objects in the namespace.
+
+.. Delete the `ScanSettingBinding` objects:
++
+[source,terminal]
+----
+$ oc delete ssb <ScanSettingBinding-name> -n openshift-compliance
+----
+
+.. Delete the `ScanSetting` objects:
++
+[source,terminal]
+----
+$ oc delete ss <ScanSetting-name> -n openshift-compliance
+----
+
+.. Delete the `ComplianceSuite` objects:
++
+[source,terminal]
+----
+$ oc delete suite <compliancesuite-name> -n openshift-compliance
+----
+
+.. Delete the `ComplianceScan` objects:
++
+[source,terminal]
+----
+$ oc delete scan <compliancescan-name> -n openshift-compliance
+----
+
+.. Obtain the `ProfileBundle` objects:
++
+[source,terminal]
+----
+$ oc get profilebundle.compliance -n openshift-compliance
+----
++
+.Example output
+[source,terminal]
+----
+NAME     CONTENTIMAGE                                                                     CONTENTFILE         STATUS
+ocp4     registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:<hash>   ssg-ocp4-ds.xml     VALID
+rhcos4   registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:<hash>   ssg-rhcos4-ds.xml   VALID
+----
+
+.. Delete the `ProfileBundle` objects:
++
+[source,terminal]
+----
+$ oc delete profilebundle.compliance ocp4 rhcos4 -n openshift-compliance
+----
++
+.Example output
+[source,terminal]
+----
+profilebundle.compliance.openshift.io "ocp4" deleted
+profilebundle.compliance.openshift.io "rhcos4" deleted
+----
+
+. Delete the Subscription object:
++
+[source,terminal]
+----
+$ oc delete sub <Subscription-Name> -n openshift-compliance
+----
+
+. Delete the CSV object:
++
+[source,terminal]
+----
+$ oc delete CSV -n openshift-compliance
+----
+
+. Delete the project:
++
+[source,terminal]
+----
+$ oc delete project -n openshift-compliance
+----
++
+.Example output
+[source,terminal]
+----
+project.project.openshift.io "openshift-compliance" deleted
+----
+
+.Verification
+
+. Confirm the namespace is deleted:
++
+[source,terminal]
+----
+$ oc get project/openshift-compliance
+----
++
+.Example output
+[source,terminal]
+----
+Error from server (NotFound): namespaces "openshift-compliance" not found
+----

--- a/modules/compliance-operator-uninstall.adoc
+++ b/modules/compliance-operator-uninstall.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="compliance-operator-uninstall_{context}"]
-= Uninstalling the OpenShift Compliance Operator from {product-title}
+= Uninstalling the OpenShift Compliance Operator from {product-title} using the web console
 
-To remove the Compliance Operator, you must first delete the Compliance Operator custom resource definitions (CRDs). After the CRDs are removed, you can then remove the Operator and its namespace by deleting the *openshift-compliance* project.
+To remove the Compliance Operator, you must first delete the objects in the namespace. After the objects are removed, you can remove the Operator and its namespace by deleting the *openshift-compliance* project.
 
 .Prerequisites
 
@@ -17,9 +17,11 @@ To remove the Compliance Operator, you must first delete the Compliance Operator
 
 To remove the Compliance Operator by using the {product-title} web console:
 
-. Navigate to the *Operators* -> *Installed Operators* page.
+. Go to the *Operators* -> *Installed Operators* -> *Compliance Operator* page.
 
-. Delete all ScanSettingBinding, ComplainceSuite, ComplianceScan, and ProfileBundle objects.
+.. Click *All instances*.
+
+.. In *All namespaces*, click the Options menu {kebab} and delete all ScanSettingBinding, ComplainceSuite, ComplianceScan, and ProfileBundle objects.
 
 . Switch to the *Administration* -> *Operators* -> *Installed Operators* page.
 

--- a/security/compliance_operator/compliance-operator-uninstallation.adoc
+++ b/security/compliance_operator/compliance-operator-uninstallation.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can remove the OpenShift Compliance Operator from your cluster by using the {product-title} web console.
+You can remove the OpenShift Compliance Operator from your cluster by using the {product-title} web console or the CLI.
 
 include::modules/compliance-operator-uninstall.adoc[leveloffset=+1]
+
+include::modules/compliance-operator-cli-uninstall.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/OCPBUGS-7363

Link to docs preview (VPN required) :
[Uninstalling the OpenShift Compliance Operator](http://file.rdu.redhat.com/antaylor/OCPBUGS-7363/security/compliance_operator/compliance-operator-uninstallation.html#compliance-operator-uninstall_compliance-operator-uninstallation)

QE review:
- [x] QE has approved this change.

Additional information:
Addresses feedback from support provided in the issue linked above.
