### PR TITLE
OSDOCS-5058: Azure UPI support on 64-bit ARM systems

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -459,12 +459,13 @@ endif::openshift-origin[]
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |Nutanix |{rh-openstack} |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |{ibmzProductName} |{ibmzProductName} with {op-system-base} KVM |{ibmpowerProductName} |Platform agnostic
+||Alibaba |AWS (x86_64) |AWS (arm64) |Azure (x86_64) |Azure (arm64) |Azure Stack Hub |GCP |Nutanix |{rh-openstack} |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |{ibmzProductName} |{ibmzProductName} with {op-system-base} KVM |{ibmpowerProductName} |Platform agnostic
 
 |Custom
 |
 |xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[&#10003;]
 |xref:../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[&#10003;]
+|xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[&#10003;]
 |xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[&#10003;]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[&#10003;]
 |xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[&#10003;]
@@ -492,6 +493,7 @@ ifndef::openshift-origin[]
 |
 |
 |
+|
 |xref:../installing/installing_openstack/installing-openstack-user-kuryr.adoc#installing-openstack-user-kuryr[&#10003;]
 |
 |xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installing-bare-metal-network-customizations[&#10003;]
@@ -510,6 +512,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_aws/installing-restricted-networks-aws.adoc#installing-restricted-networks-aws[&#10003;]
 |
 |
+|
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[&#10003;]
 |
 |
@@ -525,6 +528,7 @@ ifndef::openshift-origin[]
 |
 
 |Shared VPC hosted outside of cluster project
+|
 |
 |
 |

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -71,6 +71,7 @@ This section describes the requirements for deploying {product-title} on user-pr
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
+include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]
 

--- a/modules/installation-azure-user-infra-deploying-rhcos.adoc
+++ b/modules/installation-azure-user-infra-deploying-rhcos.adoc
@@ -49,10 +49,14 @@ $ export VHD_BLOB_URL=`az storage blob url --account-name ${CLUSTER_NAME}sa --ac
 $ az deployment group create -g ${RESOURCE_GROUP} \
   --template-file "<installation_directory>/02_storage.json" \
   --parameters vhdBlobURL="${VHD_BLOB_URL}" \ <1>
-  --parameters baseName="${INFRA_ID}"<2>
+  --parameters baseName="${INFRA_ID}" \ <2>
+  --parameters storageAccount="${CLUSTER_NAME}sa" \ <3> 
+  --parameters architecture="<architecture>" <4>
 ----
 <1> The blob URL of the {op-system} VHD to be used to create master and worker machines.
 <2> The base name to be used in resource names; this is usually the cluster's infrastructure ID.
+<3> The name of your Azure storage account. 
+<4> Specify the system architecture. Valid values are `x64` (default) or `Arm64`. 
 
 ifeval::["{context}" == "installing-azure-user-infra"]
 :!azure:

--- a/modules/installation-azure-user-infra-uploading-rhcos.adoc
+++ b/modules/installation-azure-user-infra-uploading-rhcos.adoc
@@ -74,7 +74,7 @@ $ export ACCOUNT_KEY=`az storage account keys list -g ${RESOURCE_GROUP} --accoun
 ifdef::azure[]
 [source,terminal]
 ----
-$ export VHD_URL=`openshift-install coreos print-stream-json | jq -r '.architectures.x86_64."rhel-coreos-extensions"."azure-disk".url'`
+$ export VHD_URL=`openshift-install coreos print-stream-json | jq -r '.architectures.<architecture>."rhel-coreos-extensions"."azure-disk".url'`
 ----
 endif::azure[]
 ifdef::ash[]


### PR DESCRIPTION
**Version:** 4.13+
**Issue:** [OSDOCS-5058](https://issues.redhat.com//browse/OSDOCS-5058)

**Description:** Azure UPI installs is supported on ARM platforms in 4.13

**Previews:** 

- Installing a cluster on Azure using ARM templates

1. [Tested instance types for Azure ARM](https://55861--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-azure-arm-tested-machine-types_installing-azure-user-infra)
2. [Uploading the RHCOS cluster image and bootstrap Ignition config file](https://55861--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-azure-user-infra-uploading-rhcos_installing-azure-user-infra)  
3. [Deploying the RHCOS clyster image for the Azure infrastructure ](https://55861--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-azure-user-infra-deploying-rhcos_installing-azure-user-infra)

- [Selecting an installation method and preparing a cluster -> Supported installation methods for different platforms](https://55861--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms) 

QE review

- [x] QE approved