### PR TITLE
[enterprise-4.11] Fixing upgrade section in 4.11 multi-arch docs

### DIFF
--- a/modules/multi-architecture-upgrade-mirrors.adoc
+++ b/modules/multi-architecture-upgrade-mirrors.adoc
@@ -7,7 +7,9 @@
 
 = Upgrading a cluster with multi-architecture compute machines
 
-You must perform an explicit upgrade command to upgrade your existing cluster to a cluster that supports multi-architecture compute machines.
+To upgrade your cluster with multi-architecture compute machines from {product-title} version {product-version} to a version 4.12 cluster, you must use the `candidate-4.12` update channel. For more information, see "Understanding upgrade channels". 
+
+If you want to  upgrade your cluster to a specific {product-version} z-stream version, you can perform the following explicit upgrade command. 
 
 .Prerequisites
 

--- a/post_installation_configuration/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/multi-architecture-configuration.adoc
@@ -27,3 +27,7 @@ include::modules/multi-architecture-modify-machine-set.adoc[leveloffset=+1]
 * xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc[Creating a compute machine set on Azure] 
 
 include::modules/multi-architecture-upgrade-mirrors.adoc[leveloffset=+1]
+
+[role="_additional-resources"] 
+.Additional resources
+* xref:../updating/understanding-upgrade-channels-release.adoc[Understanding upgrade channels]


### PR DESCRIPTION
Version: 4.11
Issue brought up in slack thread

Preview: 

- [Configuring multi-architecture compute machines on an OpenShift Container Platform cluster -> Upgrading a cluster with multi-architecture compute machines](https://55863--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html#multi-architecture-upgrade-mirrors_multi-architecture-configuration)