### PR TITLE
OSDOCS-5255: Add temporary ROSA version snippet

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -142,7 +142,7 @@ $ rosa create cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 |The subnet prefix length (integer) to assign to each individual node. For example, if host prefix is set to `23`, then each node is assigned a `/23` subnet out of the given CIDR.
 
 |--machine-cidr
-|Block of IP addresses (ipNet) used by OpenShift Container Platform while installing the cluster. Example: `10.0.0.0/16`
+|Block of IP addresses (ipNet) used by {product-title} while installing the cluster. Example: `10.0.0.0/16`
 
 |--max-replicas
 |Specifies the maximum number of compute nodes when enabling autoscaling. Default: `2`
@@ -180,7 +180,7 @@ When using `--private-link`, the `--subnet-ids` argument is required and only on
 |The Amazon Resource Name (ARN) of the role used by Red Hat Site Reliabilty Engineers (SREs) to enable access to the cluster account to provide support.
 
 |--version
-|The version (string) of OpenShift Container Platform that will be used to install the cluster. Example: `4.3.10`
+|The version (string) of {product-title} that will be used to install the cluster or cluster resources, including `account-role`. Example: `4.12`
 
 |--worker-iam-role string
 |The Amazon Resource Name (ARN) of the IAM role that will be attached to compute instances.

--- a/modules/rosa-sts-account-wide-roles-and-policies.adoc
+++ b/modules/rosa-sts-account-wide-roles-and-policies.adoc
@@ -5,6 +5,8 @@
 [id="rosa-sts-account-wide-roles-and-policies_{context}"]
 = Account-wide IAM role and policy reference
 
+include::snippets/rosa-4-11-12-snippet.adoc[]
+
 This section provides details about the account-wide IAM roles and policies that are required for ROSA deployments that use STS, including the Operator policies. It also includes the JSON files that define the policies.
 
 The account-wide roles and policies are specific to an OpenShift minor release version, for example OpenShift 4.8, and are backward compatible. You can minimize the required STS resources by reusing the account-wide roles and policies for multiple clusters of the same minor version, regardless of their patch version.

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -23,7 +23,7 @@ The following table describes the interactive cluster creation mode options:
 |Create an OpenShift cluster that uses the AWS Security Token Service (STS) to allocate temporary, limited-privilege credentials for component-specific AWS Identity and Access Management (IAM) roles. The service enables cluster components to make AWS API calls using secure cloud resource management practices. The default is `Yes`.
 
 |`OpenShift version`
-|Select the version of OpenShift to install, for example `4.3.12`. The default is the latest version.
+|Select the version of OpenShift to install, for example `4.12`. The default is the latest version.
 
 |`Installer role ARN`
 |If you have more than one set of account roles in your AWS account for your cluster version, a list of installer role ARNs are provided. Select the ARN for the installer role that you want to use with your cluster. The cluster uses the account-wide roles and policies that relate to the selected installer role.

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -6,6 +6,8 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
+include::snippets/rosa-4-11-12-snippet.adoc[]
+
 Create a {product-title} (ROSA) cluster with the AWS Security Token Service (STS) using customizations. You can deploy your cluster by using {cluster-manager-first} or the ROSA CLI (`rosa`).
 
 With the procedures in this document, you can also choose between the `auto` and `manual` modes when creating the required AWS Identity and Access Management (IAM) resources.

--- a/snippets/rosa-4-11-12-snippet.adoc
+++ b/snippets/rosa-4-11-12-snippet.adoc
@@ -1,0 +1,6 @@
+[IMPORTANT]
+====
+{product-title} ROSA 4.12 cluster creation can take a long time or fail. The default version of ROSA is set to 4.11, which means that only 4.11 resources are created when you create account roles or ROSA clusters using the default settings. Account roles from 4.12 are backwards compatible, which is the case for `account-role` policy versions. You can use the `--version` flag to create 4.12 resources.
+
+For more information see the link:https://access.redhat.com/solutions/6996508[ROSA 4.12 cluster creation failure solution].
+====


### PR DESCRIPTION
Version(s):
4.12+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-5255

Link to docs preview:
https://55864--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-ocm-roles-and-permissions_rosa-sts-about-iam-resources

https://55864--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html

https://55864--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli.html#rosa-create-cluster-command_rosa-managing-objects-cli

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
