### PR TITLE
[enterprise-4.12] Fixing upgrade section in 4.12 multi-arch docs

### DIFF
--- a/modules/multi-architecture-upgrade-mirrors.adoc
+++ b/modules/multi-architecture-upgrade-mirrors.adoc
@@ -7,7 +7,14 @@
 
 = Upgrading a cluster with multi-architecture compute machines
 
-You must perform an explicit upgrade command to upgrade your existing cluster to a cluster that supports multi-architecture compute machines.
+To upgrade your cluster with multi-architecture compute machines, use the `candidate-{product-version}` update channel. For more information, see "Understanding upgrade channels".
+
+[NOTE]
+==== 
+Only {product-title} clusters that are already using a multi-architecture payload can update with the `candidate-{product-version}` channel.
+====
+
+If you want to upgrade an existing cluster to support multi-architecture compute machines, you can perform an explicit upgrade command, as shown in the following procedure. This updates your current single-architecture cluster to a cluster that uses the multi-architecture payload.
 
 .Prerequisites
 

--- a/post_installation_configuration/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/multi-architecture-configuration.adoc
@@ -28,4 +28,8 @@ include::modules/multi-architecture-modify-machine-set.adoc[leveloffset=+1]
 
 include::modules/multi-architecture-upgrade-mirrors.adoc[leveloffset=+1]
 
+[role="_additional-resources"] 
+.Additional resources
+* xref:../updating/understanding-upgrade-channels-release.adoc[Understanding upgrade channels]
+
 include::modules/multi-architecture-import-imagestreams.adoc[leveloffset=+1]


### PR DESCRIPTION
Version: 4.12
Issue brought up in slack thread 

Preview: 

- [Configuring multi-architecture compute machines on an OpenShift Container Platform cluster -> Upgrading a cluster with multi-architecture compute machines](https://55865--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html#multi-architecture-upgrade-mirrors_multi-architecture-configuration)

- [x] QE approval