### PR TITLE
OSDOCS-5273-R: Documented 4.11.27 z-stream release

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3255,3 +3255,27 @@ $ oc adm release info 4.11.26 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-27"]
+=== RHSA-2023:0651 - {product-title} 4.11.27 bug fix and security update
+
+Issued: 2023-02-15
+
+{product-title} release 4.11.27, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0651[RHSA-2023:0651] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0650[RHBA-2023:0650] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.27 --pullspecs
+----
+
+[id="ocp-4-11-27-bug-fixes"]
+==== Bug fixes
+
+* Previously, the topology sidebar did not display updated information. When you updated the resources directly from the topology sidebar, you had to reopen the sidebar to see the changes. With this fix, the updated resources are displayed correctly. (link:https://issues.redhat.com/browse/OCPBUGS-5459[*OCPBUGS-5459*])
+
+[id="ocp-4-11-27-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5273-R](https://issues.redhat.com/browse/OSDOCS-5273)

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-5273

Link to docs preview:
[Release notes 4.11.27](https://55867--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-27)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
