### PR TITLE
TELCODOCS-903-RN: Release note for Graceful Node Shutdown 

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -86,6 +86,18 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-13-nodes"]
 === Nodes
 
+==== Graceful Node Shutdown
+
+Graceful Node Shutdown (GNS) enables kubelet to delay forcible eviction of pods in the event of a node shutdown.
+This is important for users who want to ensure that workloads that execute critical operations cannot be interrupted.
+For example, if an operator that flashes network card firmware is shut in a disorderly fashion, hardware can be damaged.
+
+GNS gives admins the ability to specify a termination grace period for protected workloads.
+This ensures time for the pod to shut down in an orderly manner, including operations that are monitoring the activity of sensitive workloads.
+Admins can also tag workloads to specify the order of shut down.
+
+For further information see <link>[topic_title]
+
 [id="ocp-4-13-monitoring"]
 === Monitoring
 


### PR DESCRIPTION
Version(s): 4.13 only

Issue: https://issues.redhat.com/browse/TELCODOCS-903

Link to docs preview: https://55869--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-nodes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
