### PR TITLE
OSDOCS-5196: Updated 7.0 version in VSphere docs

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -45,7 +45,12 @@ endif::[]
 [id="installation-vsphere-infrastructure_{context}"]
 = VMware vSphere infrastructure requirements
 
-You must install the {product-title} cluster on a VMware vSphere version 7 instance that meets the requirements for the components that you use.
+You must install the {product-title} cluster on a VMware vSphere version 7.0 Update 2 or later instance that meets the requirements for the components that you use.
+
+[NOTE]
+====
+{product-title} version 4.13 supports VMware vSphere version 8.0.
+====
 
 You can host the VMware vSphere infrastructure on-premise or on a VMware Cloud Verified provider that meets the requirements outlined in the following table:
 
@@ -54,31 +59,26 @@ You can host the VMware vSphere infrastructure on-premise or on a VMware Cloud V
 |===
 |Virtual environment product |Required version
 |VMware virtual hardware | 15 or later
-|vSphere ESXi hosts | 7.0.2 or later
-|vCenter host   | 7.0.2 or later
+|vSphere ESXi hosts | 7.0 Update 2 or later
+|vCenter host   | 7.0 Update 2 or later
 |===
-
-[IMPORTANT]
-====
-Installing a cluster on VMware vSphere versions 7.0.0 and 7.0.1 is deprecated. These versions are still fully supported, but all vSphere 6.x versions are no longer supported. Version 4.12 of {product-title} requires VMware virtual hardware version 15 or later. To update the hardware version for your vSphere virtual machines, see the "Updating hardware on nodes running in vSphere" article in the _Updating clusters_ section.
-====
 
 .Minimum supported vSphere version for VMware components
 |===
 |Component | Minimum supported versions |Description
 
 |Hypervisor
-|vSphere 7.0.2 and later with virtual hardware version 15
+|vSphere 7.0 Update 2 and later with virtual hardware version 15
 |This version is the minimum version that {op-system-first} supports. See the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux?sort=sortTitle%20asc&vendors=VMware&category=Server[Red Hat Enterprise Linux 8 supported hypervisors list].
 
 |Storage with in-tree drivers
-|vSphere 7.0.2 and later
+|vSphere 7.0 Update 2 and later
 |This plugin creates vSphere storage by using the in-tree storage drivers for vSphere included in {product-title}.
 
 ifndef::vmc[]
 |Optional: Networking (NSX-T)
-|vSphere 7.0.2 and later
-|vSphere 7.0.2 is required for {product-title}. VMware's NSX Container Plugin (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
+|vSphere 7.0 Update 2 and later
+|vSphere 7.0 Update 2 is required for {product-title}. VMware's NSX Container Plugin (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
 endif::vmc[]
 |===
 

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -24,8 +24,8 @@
 
 To install the CSI Driver Operator, the following requirements must be met:
 
-* VMware vSphere version 7.0.2 or later
-* vCenter 7.0.2 or later
+* VMware vSphere version 7.0 Update 2 or later
+* vCenter 7.0 Update 2 or later
 * Virtual machines of hardware version 15 or later
 * No third-party CSI driver already installed in the cluster
 


### PR DESCRIPTION
Issue:
[OSDOCS-5196](https://issues.redhat.com/browse/OSDOCS-5197)

Version(s):
4.13

Link to docs preview:
* [Preparing to install on vSphere](https://55872--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/preparing-to-install-on-vsphere.html)
* [Installing a cluster on vSphere](https://55872--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

