### PR TITLE
OCPBUGS#7461: Correct grep command for cluster restore

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -69,7 +69,7 @@ $ sudo mv /etc/kubernetes/manifests/etcd-pod.yaml /tmp
 +
 [source,terminal]
 ----
-$ sudo crictl ps | grep etcd | grep -v operator
+$ sudo crictl ps | grep etcd | egrep -v "operator|etcd-guard"
 ----
 +
 The output of this command should be empty. If it is not empty, wait a few minutes and check again.
@@ -85,7 +85,7 @@ $ sudo mv /etc/kubernetes/manifests/kube-apiserver-pod.yaml /tmp
 +
 [source,terminal]
 ----
-$ sudo crictl ps | grep kube-apiserver | grep -v operator
+$ sudo crictl ps | grep kube-apiserver | egrep -v "operator|guard"
 ----
 +
 The output of this command should be empty. If it is not empty, wait a few minutes and check again.


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-7461

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Correct grep command to verify if etcd and kube-apiserver pods are stopped.
