### PR TITLE
OSDOCS-5339-okd: fix dedead links OKD oc install

### DIFF
--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -77,7 +77,7 @@ You can install the OpenShift CLI (`oc`) binary on Linux by using the following 
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/[https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/] and choose the folder for your operating system and architecture.
 . Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]
@@ -116,7 +116,7 @@ You can install the OpenShift CLI (`oc`) binary on Windows by using the followin
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/[https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/] and choose the folder for your operating system and architecture.
 . Download `oc.zip`.
 endif::[]
 ifndef::openshift-origin[]
@@ -149,7 +149,7 @@ You can install the OpenShift CLI (`oc`) binary on macOS by using the following 
 .Procedure
 
 ifdef::openshift-origin[]
-. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ and choose the folder for your operating system and architecture.
+. Navigate to link:https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/[https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/] and choose the folder for your operating system and architecture.
 . Download `oc.tar.gz`.
 endif::[]
 ifndef::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.11 only

Issue:
https://issues.redhat.com/browse/OSDOCS-5339

Link to docs preview:
[Installing the OpenShift CLI on Linux](http://file.rdu.redhat.com/mburke/55894/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli)
[Installing the OpenShift CLI on Windows](http://file.rdu.redhat.com/mburke/55894/cli_reference/openshift_cli/getting-started-cli.html#installing-openshift-cli)

Additional information:
Completes fixes need as noted in https://github.com/openshift/openshift-docs/pull/55521

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
