### PR TITLE
TELCODOCS-1050 RN: Configuring the hub cluster to use unauthenticated registries

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1279,6 +1279,15 @@ The Assisted Installer currently supports the following {product-title} platform
 * `None`
 
 {sno-caps} does not support `VSphere`.
+[id="ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries"]
+==== Configuring the hub cluster to use unauthenticated registries
+
+This release supports the use of unauthenticated registries when configuring the hub cluster.
+Registries that do not require authentication are listed under `spec.unauthenticatedRegistries` in the `AgentServiceConfig` resource.
+Any registry on this list is not required to have an entry in the pull secret used for the spoke cluster installation.
+`assisted-service` validates the pull secret by making sure it contains the authentication information for every image registry used for installation.
+
+For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries_ztp-preparing-the-hub-cluster[Configuring the hub cluster to use unauthenticated registries].
 
 [id="ocp-4-12-insights-operator"]
 === Insights Operator


### PR DESCRIPTION
Fixes: [TELCODOCS-1050](https://issues.redhat.com/browse/TELCODOCS-1050)

For: Version 4.12+ 

Doc Preview [here](https://55899--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries)

Signed-off-by: Katie Tothill ktothill@redhat.com