### PR TITLE
OSDOCS-4504 changing mentions of gp2 storage to gp3

### DIFF
--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -35,13 +35,18 @@ Volume requirements for each EC2 instance:
 
 - Infrastructure Volume
 * Size: 300GB
-* Type: gp2
+* Type: gp3
 * Input/Output Operations Per Second: 900
 
 - Worker Volume
 * Size: 300GB
-* Type: gp2
+* Type: gp3
 * Input/Output Operations Per Second: 900
+
+[NOTE]
+====
+Clusters deployed before the release of {OCP} 4.11 use gp2 type storage by default.
+====
 
 [id="rosa-elastic-load-balancers_{context}"]
 == Elastic load balancers

--- a/modules/sd-planning-cluster-maximums-environment.adoc
+++ b/modules/sd-planning-cluster-maximums-environment.adoc
@@ -12,7 +12,7 @@ The following table lists the OpenShift Container Platform environment and confi
 
 [options="header",cols="8*"]
 |===
-| Node |Type |vCPU |RAM(GiB) |Disk type|Disk size(GiB)/IOS |Count |Region
+| Node |Type |vCPU |RAM(GiB) |Disk type|Disk size(GiB)/IOPS |Count |Region
 
 |Control plane/etcd ^[1]^
 |m5.4xlarge
@@ -27,7 +27,7 @@ The following table lists the OpenShift Container Platform environment and confi
 |r5.2xlarge
 |8
 |64
-|gp2
+|gp3
 |300 / 900
 |3
 |us-west-2
@@ -36,7 +36,7 @@ The following table lists the OpenShift Container Platform environment and confi
 |m5.2xlarge
 |8
 |32
-|gp2
+|gp3
 |350 / 900
 |3
 |us-west-2
@@ -45,7 +45,7 @@ The following table lists the OpenShift Container Platform environment and confi
 |m5.2xlarge
 |8
 |32
-|gp2
+|gp3
 |350 / 900
 |102
 |us-west-2

--- a/storage/persistent_storage/rosa-persistent-storage-aws-ebs.adoc
+++ b/storage/persistent_storage/rosa-persistent-storage-aws-ebs.adoc
@@ -15,12 +15,12 @@ Following are the two prebuilt storage classes:
 
 | Name | Provisioner
 
-| gp2 | kubernetes.io/aws-ebs
+| gp3 | kubernetes.io/aws-ebs
 
-| gp2-csi | ebs.csi.aws.com
+| gp3-csi | ebs.csi.aws.com
 
 |===
-The gp2 storage class is set as default; however, you can select either one as the default storage class.
+The gp3 storage class is set as default; however, you can select either one as the default storage class.
 
 The Kubernetes persistent volume framework enables administrators to provision a cluster with persistent storage and gives users a way to request those resources without having any knowledge of the underlying infrastructure. You can dynamically provision AWS EBS volumes. Persistent volumes are not bound to a single project or namespace; therefore, the volumes can be shared across ROSA clusters. Persistent volume claims are specific to a project or namespace and can be requested by users.
 


### PR DESCRIPTION
[OSDOCS-4504] changing mentions of gp2 storage to gp3

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-4504

Link to docs preview:
https://55900--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-limits-scalability.html#planning-cluster-maximums-environment-sd_rosa-limits-scalability

https://55900--docspreview.netlify.app/openshift-rosa/latest/storage/persistent_storage/rosa-persistent-storage-aws-ebs.html

https://55900--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#rosa-ebs-storage_prerequisites

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
