### PR TITLE
OSDOCS-5293:adds RNs to 4.10 zstream

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3796,3 +3796,29 @@ $ oc adm release info 4.10.51 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-52"]
+=== RHSA-2023:0698 - {product-title} 4.10.52 bug fix and security update
+
+Issued: 2023-02-15
+
+{product-title} release 4.10.52, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:0698[RHSA-2023:0698] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0697[RHSA-2023:0697] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.52 --pullspecs
+----
+
+[id="ocp-4-10-52-bug-fixes"]
+==== Bug fixes
+
+* Previously, when a Redfish system features a Settings URI, the Ironic provisioning service always attempts to use this URI to make changes to boot related BIOS settings. However, bare-metal provisioning fails if the Baseboard Management Controller (BMC) features a Settings URI but does not support changing a particular BIOS setting by using this Settings URI. In {product-title} {product-version} and later, if a system features a Settings URI, Ironic verifies that it can change a particular BIOS setting by using the Settings URI before proceeding. Otherwise, Ironic implements the change by using the System URI. This additional logic ensures that Ironic can apply boot-related BIOS setting changes and bare-metal provisioning can succeed. (link:https://issues.redhat.com/browse/OCPBUGS-6886[*OCPBUGS-6886*])
+
+* Previously due to a missing definition for `spec.provider`, the *Operator details* page failed when trying to show `ClusterServiceVersion`. With this update, the user interface works without `spec.provider` and the *Operator details* page does not fail. (link:https://issues.redhat.com/browse/OCPBUGS-6690[*OCPBUGS-6690*])
+
+[id="ocp-4-10-52-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5293](https://issues.redhat.com//browse/OSDOCS-5293): adds zstream update to 4.10
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5293
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview](https://joealdinger.github.io/openshift-docs/OSDOCS-5293/release_notes/ocp-4-10-release-notes.html#ocp-4-10-52)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
