### PR TITLE
OSDOCS-5268: Updated the Custom Domain sample

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -248,7 +248,7 @@ Topics:
   Dir: deployments
   Distros: openshift-dedicated
   Topics:
-    - Name: Configuring custom domains for applications
+    - Name: Custom domains for applications
       File: osd-config-custom-domains-applications
 ---
 Name: Logging

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -340,7 +340,7 @@ Topics:
   Dir: deployments
   Distros: openshift-rosa
   Topics:
-    - Name: Configuring custom domains for applications
+    - Name: Custom domains for applications
       File: osd-config-custom-domains-applications
 # - Name: Application GitOps workflows
 #   File: rosa-app-gitops-workflows

--- a/applications/deployments/osd-config-custom-domains-applications.adoc
+++ b/applications/deployments/osd-config-custom-domains-applications.adoc
@@ -1,9 +1,11 @@
 :_content-type: ASSEMBLY
 [id="osd-config-custom-domains-applications"]
-= Configuring custom domains for applications
+= Custom domains for applications
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: osd-config-custom-domains-applications
 
 toc::[]
+
+You can configure a custom domain for your applications. Custom domains are specific wildcard domains that can be used with {product-title} applications. 
 
 include::modules/osd-applications-config-custom-domains.adoc[leveloffset=+1]

--- a/modules/osd-applications-config-custom-domains.adoc
+++ b/modules/osd-applications-config-custom-domains.adoc
@@ -6,7 +6,7 @@
 [id="osd-applications-config-custom-domains_{context}"]
 = Configuring custom domains for applications
 
-Custom domains are specific wildcard domains that can be used with {product-title} applications. The top-level domains (TLDs) are owned by the customer that is operating the {product-title} cluster. The Custom Domains Operator sets up a new `ingresscontroller` with a custom certificate as a second day operation. The public DNS record for this `ingresscontroller` can then be used by an external DNS to create a wildcard CNAME record for use with a custom domain.
+The top-level domains (TLDs) are owned by the customer that is operating the {product-title} cluster. The Custom Domains Operator sets up a new ingress controller with a custom certificate as a second day operation. The public DNS record for this ingress controller can then be used by an external DNS to create a wildcard CNAME record for use with a custom domain.
 
 [NOTE]
 ====
@@ -45,12 +45,14 @@ metadata:
 spec:
   domain: apps.companyname.io <1>
   scope: External
+  loadBalancerType: Classic <2>
   certificate:
-    name: <name>-tls <2>
+    name: <name>-tls <3>
     namespace: <my_project>
 ----
 <1> The custom domain.
-<2> The secret created in the previous step.
+<2> The type of load balancer for your custom domain. This type can be the default `classic` or `NLB` if you use a network load balancer.
+<3> The secret created in the previous step.
 
 . Apply the CR:
 +


### PR DESCRIPTION
Version(s):
`enterprise-4.12+`

Issue:
[OSDOC-5268](https://issues.redhat.com/browse/OSDOCS-5268)

Link to docs preview:

![image](https://user-images.githubusercontent.com/16167833/218873221-71551e47-ff2b-4e35-932a-e2c9757dc877.png)

![image](https://user-images.githubusercontent.com/16167833/218873021-4cc51638-e8e5-44f0-930d-546906bf7de5.png)

- [Custom Domains for ROSA](https://55904--docspreview.netlify.app/openshift-rosa/latest/applications/deployments/osd-config-custom-domains-applications.html)
- [Custom Domains for OSD](https://55904--docspreview.netlify.app/openshift-dedicated/latest/applications/deployments/osd-config-custom-domains-applications.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updated the YAML sample to include the Load Balancer type. I also added an intro since the topic previously had an H1 followed by an H2. The ROSA and OSD versions are identical.