### PR TITLE
OCPBUGS-6180: Clarify statement for restoring a snapshot regarding pvc size

### DIFF
--- a/modules/lvms-restoring-volume-snapshots-in-single-node-openshift.adoc
+++ b/modules/lvms-restoring-volume-snapshots-in-single-node-openshift.adoc
@@ -13,6 +13,11 @@ The restored PVC is independent of the volume snapshot and the source PVC.
 
 * The storage class must be the same as that of the source PVC.
 * The size of the requested PVC must be the same as that of the source volume of the snapshot.
++
+[IMPORTANT]
+====
+A snapshot must be restored to a PVC of the same size as the source volume of the snapshot. If a larger PVC is required, you can resize the PVC after the snapshot is restored successfully.
+====
 
 .Procedure
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12, 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-6180
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://55911--docspreview.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-restoring-volume-snapshots-in-single-node-openshift_logical-volume-manager-storage
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
