### PR TITLE
OSDOCS-5350 Security Profiles Operator 0.5.2 release notes

### DIFF
--- a/security/security_profiles_operator/spo-release-notes.adoc
+++ b/security/security_profiles_operator/spo-release-notes.adoc
@@ -12,10 +12,25 @@ These release notes track the development of the Security Profiles Operator in {
 
 For an overview of the Security Profiles Operator, see xref:../security_profiles_operator/spo-overview.adoc#[Security Profiles Operator Overview].
 
+[id="spo-release-notes-0-5-2"]
+== Security Profiles Operator 0.5.2
+
+The following advisory is available for the Security Profiles Operator 0.5.2:
+
+* link:https://access.redhat.com/errata/RHBA-2023:0788[RHBA-2023:0788 - OpenShift Security Profiles Operator bug fix update]
+
+This update addresses a CVE in an underlying dependency.
+
+[discrete]
+[id="spo-0-5-2-known-issue"]
+=== Known issue
+
+* When uninstalling the Security Profiles Operator, the `MutatingWebhookConfiguration` object is not deleted and must be manually removed. As a workaround, delete the `MutatingWebhookConfiguration` object after uninstalling the Security Profiles Operator. These steps are defined in xref:../security_profiles_operator/spo-uninstalling.adoc#[Uninstalling the Security Profiles Operator]. (link:https://issues.redhat.com/browse/OCPBUGS-4687[*OCPBUGS-4687*])
+
 [id="spo-release-notes-0-5-0"]
 == Security Profiles Operator 0.5.0
 
-The following advisory is available for Security Profiles Operator 0.5.0:
+The following advisory is available for the Security Profiles Operator 0.5.0:
 
 * link:https://access.redhat.com/errata/RHBA-2022:8762[RHBA-2022:8762 - OpenShift Security Profiles Operator bug fix update]
 
@@ -23,4 +38,4 @@ The following advisory is available for Security Profiles Operator 0.5.0:
 [id="spo-0-5-0-known-issue"]
 === Known issue
 
-* When uninstalling the Security Profiles Operator, the `MutatingWebhookConfiguration` object is not deleted and must be manually removed. As a workaround, delete the `MutatingWebhookConfiguration` object after uninstalling the Security Profiles Operator. These steps are defined in xref:../security_profiles_operator/spo-uninstalling.adoc#[Uninstalling the Security Profiles Operator]. link:https://issues.redhat.com/browse/OCPBUGS-4687[OCPBUGS-4687]
+* When uninstalling the Security Profiles Operator, the `MutatingWebhookConfiguration` object is not deleted and must be manually removed. As a workaround, delete the `MutatingWebhookConfiguration` object after uninstalling the Security Profiles Operator. These steps are defined in xref:../security_profiles_operator/spo-uninstalling.adoc#[Uninstalling the Security Profiles Operator]. (link:https://issues.redhat.com/browse/OCPBUGS-4687[*OCPBUGS-4687*])


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-5350

Link to docs preview (VPN required):
[Security Profiles Operator 0.5.2](http://file.rdu.redhat.com/antaylor/OSDOCS-5350/security/security_profiles_operator/spo-release-notes.html#spo-release-notes-0-5-2)

Additional information:
This update addresses an underlying CVE, no bug fix-specific information required.
