### PR TITLE
Document GitOps v1.8 RN

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-8-0.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-7-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-7-0.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-1.adoc
+++ b/modules/gitops-release-notes-1-1.adoc
@@ -30,7 +30,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 | GA
 | Argo CD ApplicationSet
 | TP
-| {gitops-title} Application Manager (kam)
+| {gitops-title} Application Manager CLI (`kam`)
 | TP
 |===
 

--- a/modules/gitops-release-notes-1-2-1.adoc
+++ b/modules/gitops-release-notes-1-2-1.adoc
@@ -30,7 +30,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 | GA
 | Argo CD ApplicationSet
 | TP
-| {gitops-title} Application Manager (kam)
+| {gitops-title} Application Manager CLI (`kam`)
 | TP
 |===
 

--- a/modules/gitops-release-notes-1-2.adoc
+++ b/modules/gitops-release-notes-1-2.adoc
@@ -30,7 +30,7 @@ Note the following scope of support on the Red Hat Customer Portal for these fea
 | GA
 | Argo CD ApplicationSet
 | TP
-| {gitops-title} Application Manager (kam)
+| {gitops-title} Application Manager CLI (`kam`)
 | TP
 |===
 

--- a/modules/gitops-release-notes-1-4-0.adoc
+++ b/modules/gitops-release-notes-1-4-0.adoc
@@ -12,7 +12,7 @@
 
 The current release adds the following improvements.
 
-* This enhancement upgrades {gitops-title} Application Manager (kam) to version *0.0.41*. link:https://issues.redhat.com/browse/GITOPS-1669[GITOPS-1669]
+* This enhancement upgrades the {gitops-title} Application Manager CLI (`kam`) to version *0.0.41*. link:https://issues.redhat.com/browse/GITOPS-1669[GITOPS-1669]
 
 * This enhancement upgrades Argo CD to version *2.2.2*. link:https://issues.redhat.com/browse/GITOPS-1532[GITOPS-1532]
 
@@ -33,7 +33,7 @@ With this update, administrators can configure a common cluster role for all the
 
 The following issues have been resolved in the current release:
 
-* Before this update, when the Route to the {gitops-title} Application Manager (kam) was accessed without specifying a path in the URL, a default page without any helpful information was displayed to the user. This update fixes the issue so that the default page displays download links for kam. link:https://issues.redhat.com/browse/GITOPS-923[GITOPS-923]
+* Before this update, when the Route to the {gitops-title} Application Manager CLI (`kam`) was accessed without specifying a path in the URL, a default page without any helpful information was displayed to the user. This update fixes the issue so that the default page displays download links for the `kam` CLI. link:https://issues.redhat.com/browse/GITOPS-923[GITOPS-923]
 
 * Before this update, setting a resource quota in the namespace of the Argo CD custom resource might cause the setup of the Red Hat SSO (RH SSO) instance to fail. This update fixes this issue by setting a minimum resource request for the RH SSO deployment pods. link:https://issues.redhat.com/browse/GITOPS-1297[GITOPS-1297]
 

--- a/modules/gitops-release-notes-1-8-0.adoc
+++ b/modules/gitops-release-notes-1-8-0.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="gitops-release-notes-1-8-0_{context}"]
+= Release notes for {gitops-title} 1.8.0
+
+{gitops-title} 1.8.0 is now available on {product-title} 4.10, 4.11, and 4.12.
+
+[id="errata-updates-1-8-0_{context}"]
+== New features
+
+The current release adds the following improvements:
+
+* With this update,  you can add support for the ApplicationSet Progressive Rollout Strategy feature. Using this feature, you can enhance the ArgoCD ApplicationSet resource to embed a rollout strategy for a progressive application resource update after you modify the ApplicationSet spec or Application templates. When you enable this feature, applications are updated in a declarative order instead of simultaneously. link:https://issues.redhat.com/browse/GITOPS-956[GITOPS-956]
++
+[IMPORTANT]
+====
+ApplicationSet Progressive Rollout Strategy is a Technology Preview feature.
+====
+//https://github.com/argoproj/argo-cd/pull/12103
+
+* With this update, the *Application environments* page in the *Developer* perspective of the {product-title} web console is decoupled from the {gitops-title} Application Manager command-line interface (CLI), `kam`. You do not have to use the `kam` CLI to generate Application Environment manifests for the environments to show up in the *Developer* perspective of the {product-title} web console. You can use your own manifests, but the environments must still be represented by namespaces. In addition, specific labels and annotations are still needed. link:https://issues.redhat.com/browse/GITOPS-1785[GITOPS-1785]
+
+* With this update, the {gitops-title} Operator and the `kam` CLI are now available to use on ARM architecture on {product-title}. link:https://issues.redhat.com/browse/GITOPS-1688[GITOPS-1688]
++
+[IMPORTANT]
+====
+`spec.sso.provider: keycloak` is not yet supported on ARM.
+====
+
+* With this update, you can enable workload monitoring for specific Argo CD instances by setting the `.spec.monitoring.enabled` flag value to `true`. As a result, the Operator creates a `PrometheusRule` object that contains alert rules for each Argo CD component. These alert rules trigger an alert when the replica count of the corresponding component has drifted from the desired state for a certain amount of time. The Operator will not overwrite the changes made to the `PrometheusRule` object by the users. link:https://issues.redhat.com/browse/GITOPS-2459[GITOPS-2459]
+
+* With this update, you can pass command arguments to the repo server deployment using the Argo CD CR. link:https://issues.redhat.com/browse/GITOPS-2445[GITOPS-2445]
++
+For example:
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+spec:
+  repo:
+    extraRepoCommandArgs:
+      - --max.combined.directory.manifests.size
+      - 10M
+----
+
+[id="fixed-issues-1-8-0_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, you could set the `ARGOCD_GIT_MODULES_ENABLED` environment variable only on the `openshift-gitops-repo-server` pod and not on the `ApplicationSet Controller` pod. As a result, when using the Git generator, Git submodules were cloned during the generation of child applications because the variable was missing from the `ApplicationSet Controller` environment. In addition, if the credentials required to clone these submodules were not configured in ArgoCD, the application generation failed. This update fixes the issue; you can now add any environment variables such as `ArgoCD_GIT_MODULES_ENABLED` to the `ApplicationSet Controller` pod using the Argo CD CR. The `ApplicationSet Controller` pod then successfully generates child applications from the cloned repository and no submodule is cloned in the process. link:https://issues.redhat.com/browse/GITOPS-2399[GITOPS-2399]
++
+For example:
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  applicationSet:
+    env:
+     - name: ARGOCD_GIT_MODULES_ENABLED
+       value: "true"
+----
+
+* Before this update, while installing the {gitops-title} Operator v1.7.0, the default `argocd-cm.yml` config map file created for authenticating Dex contained the base64-encoded client secret in the format of a `key:value` pair. This update fixes this issue by not storing the client secret in the default `argocd-cm.yml` config map file. Instead, the client secret is inside an `argocd-secret` object now, and you can reference it inside the configuration map as a secret name. link:https://issues.redhat.com/browse/GITOPS-2570[GITOPS-2570] 
+
+[id="known-issues-1-8-0_{context}"]
+== Known issues
+
+* When you deploy applications using your manifests without using the `kam` CLI and view the applications in the *Application environments* page in the *Developer* perspective of the {product-title} web console, the Argo CD URL to the corresponding application does not load the page as expected from the Argo CD icon in the card. link:https://issues.redhat.com/browse/GITOPS-2736[GITOPS-2736]

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -17,7 +17,8 @@ In the table, features are marked with the following statuses:
 |===
 |*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
 
-|*Version* |*kam*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |
+|*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |
+|1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
 |1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
 |1.6.0    |0.0.46 TP |3.8.1 GA|4.4.1 GA   |2.4.5 GA |GA and included in ArgoCD component    |2.30.3 GA |7.5.1 GA |4.8-4.11
 |1.5.0    |0.0.42 TP|3.8.0 GA|4.4.1 GA   |2.3.3 GA |0.4.1 TP       |2.30.3 GA |7.5.1 GA |4.8-4.11
@@ -27,8 +28,8 @@ In the table, features are marked with the following statuses:
 |1.1.0    |0.0.32 TP |3.5.0 GA |3.9.4 GA  |2.0.0 GA |NA            |NA |NA |4.7
 |===
 
-* "kam" is an abbreviation for {gitops-title} Application Manager (kam).
-* "RH SSO" is an abbreviation for Red Hat SSO.
+* `kam` is the {gitops-title} Application Manager command-line interface (CLI).
+* RH SSO is an abbreviation for Red Hat SSO.
 
 // Writer, to update this support matrix, refer to https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
 
@@ -40,18 +41,25 @@ Some features in this release are currently in Technology Preview (TP). These ex
 .Technology Preview tracker
 [cols="4,1,1",options="header"]
 |====
-|Feature |TP in OCP versions|GA in OCP versions
+|Feature |TP in {gitops-title} versions|GA in {gitops-title} versions
+
+|ApplicationSet Progressive Rollout Strategy
+|1.8.0
+|NA
+
+|Multiple sources for an application
+|1.8.0
+|NA
 
 |Argo CD applications in non-control plane namespaces
-|4.8, 4.9, 4.10, 4.11, 4.12
+|1.7.0
+|NA
+
+|Argo CD Notifications controller
+|1.6.0
 |NA
 
 |The {gitops-title} *Environments* page in the *Developer* perspective of the {product-title} web console 
-|4.7, 4.8, 4.9, 4.10, 4.11, 4.12
-|NA
-
-
-|Argo CD Notifications controller
-|4.8, 4.9, 4.10, 4.11, 4.12
+|1.1.0
 |NA
 |====


### PR DESCRIPTION
[RHDEVDOCS-4961](https://issues.redhat.com/browse/RHDEVDOCS-4961): GitOps 1.8 release notes
[RHDEVDOCS-5030](https://issues.redhat.com/browse/RHDEVDOCS-5030): Update instances of kam to reflect the correct usage

- **Aligned team**: Dev Tools
- **OCP version for cherry-picking**: enterprise-`4.10` and later
- **JIRA issues**: [RHDEVDOCS-4961](https://issues.redhat.com/browse/RHDEVDOCS-4961)
- **Preview pages**: [Red Hat OpenShift GitOps release notes](https://55921--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html)
- **SME Review**: Completed by @iam-veeramalla, @jaideepr97, @reginapizza, @ciiay, @harrietgrace 
- **QE review**: Completed by @varshab1210
- **Peer-review**: Completed by @rolfedh , @deerskindoll, @shipsing 