### PR TITLE
OCPBUGS#6273: Fix 'aggregate' typo in PO

### DIFF
--- a/modules/olm-installing-po-after.adoc
+++ b/modules/olm-installing-po-after.adoc
@@ -54,7 +54,7 @@ status:
     message: Successfully applied the cert-manager BundleDeployment resource
     reason: InstallSuccessful
     status: "True" <1>
-    type: Installed 
+    type: Installed
 ----
 <1> Wait until the `Installed` status condition reports `True`.
 
@@ -62,7 +62,7 @@ status:
 +
 [source,terminal]
 ----
-$ oc get clusteroperator platform-operators-aggregate -o yaml
+$ oc get clusteroperator platform-operators-aggregated -o yaml
 ----
 +
 .Example output

--- a/modules/olm-installing-po-during.adoc
+++ b/modules/olm-installing-po-during.adoc
@@ -84,7 +84,7 @@ status:
     message: Successfully applied the cert-manager BundleDeployment resource
     reason: InstallSuccessful
     status: "True" <1>
-    type: Installed 
+    type: Installed
 ----
 <1> Wait until the `Installed` status condition reports `True`.
 
@@ -92,7 +92,7 @@ status:
 +
 [source,terminal]
 ----
-$ oc get clusteroperator platform-operators-aggregate -o yaml
+$ oc get clusteroperator platform-operators-aggregated -o yaml
 ----
 +
 .Example output


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-6273

Fix `aggregate` typo in two commands.

Preview:

* [Installing platform Operators during cluster creation](https://55924--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-po.html#olm-installing-po-during_olm-managing-po)
* [Installing platform Operators after cluster creation](https://55924--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-po.html#olm-installing-po-after_olm-managing-po)