### PR TITLE
CNV-24897: Doc: Wrong text on the page Virtualization\Node maintenance\About node maintenance

### DIFF
--- a/modules/virt-about-node-maintenance.adoc
+++ b/modules/virt-about-node-maintenance.adoc
@@ -21,7 +21,7 @@ Virtual machine instances without an eviction strategy are shut down. Virtual ma
 Virtual machines must have a persistent volume claim (PVC) with a shared `ReadWriteMany` (RWX) access mode to be live migrated.
 ====
 
-When installed as part of {VirtProductName}, Node Maintenance Operator watches for new or deleted `NodeMaintenance` CRs. When a new `NodeMaintenance` CR is detected, no new workloads are scheduled and the node is cordoned off from the rest of the cluster. All pods that can be evicted are evicted from the node. When a `NodeMaintenance` CR is deleted, the node that is referenced in the CR is made available for new workloads.
+The Node Maintenance Operator watches for new or deleted `NodeMaintenance` CRs. When a new `NodeMaintenance` CR is detected, no new workloads are scheduled and the node is cordoned off from the rest of the cluster. All pods that can be evicted are evicted from the node. When a `NodeMaintenance` CR is deleted, the node that is referenced in the CR is made available for new workloads.
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s): 4.13, 4.12, 4.11

Issue: [CNV-24897](https://issues.redhat.com/browse/CNV-24897)


Link to docs preview:
https://55927--docspreview.netlify.app/openshift-enterprise/latest/virt/node_maintenance/virt-about-node-maintenance.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
