### PR TITLE
OCPBUGS 7544: Replacing instances of k8s.gcr.io with registry.k8s.io

### DIFF
--- a/modules/application-health-about.adoc
+++ b/modules/application-health-about.adoc
@@ -80,7 +80,7 @@ spec:
   containers:
   - name: goproxy-app <1>
     args:
-    image: k8s.gcr.io/goproxy:0.1 <2>
+    image: registry.k8s.io/goproxy:0.1 <2>
     readinessProbe: <3>
       exec: <4>
         command: <5>
@@ -109,7 +109,7 @@ spec:
   containers:
   - name: goproxy-app <1>
     args:
-    image: k8s.gcr.io/goproxy:0.1 <2>
+    image: registry.k8s.io/goproxy:0.1 <2>
     livenessProbe: <3>
       httpGet: <4>
         scheme: HTTPS <5>
@@ -153,7 +153,7 @@ spec:
   containers:
   - name: goproxy-app <1>
     args:
-    image: k8s.gcr.io/goproxy:0.1 <2>
+    image: registry.k8s.io/goproxy:0.1 <2>
     livenessProbe: <3>
       exec: <4>
         command: <5>

--- a/modules/application-health-configuring.adoc
+++ b/modules/application-health-configuring.adoc
@@ -31,7 +31,7 @@ spec:
   containers:
   - name: my-container <1>
     args:
-    image: k8s.gcr.io/goproxy:0.1 <2>
+    image: registry.k8s.io/goproxy:0.1 <2>
     livenessProbe: <3>
       tcpSocket:  <4>
         port: 8080 <5>
@@ -77,7 +77,7 @@ spec:
 ====
 If the `initialDelaySeconds` value is lower than the `periodSeconds` value, the first Readiness probe occurs at some point between the two periods due to an issue with timers.
 
-The `timeoutSeconds` value must be lower than the `periodSeconds` value. 
+The `timeoutSeconds` value must be lower than the `periodSeconds` value.
 ====
 
 . Create the `Pod` object:
@@ -101,8 +101,8 @@ Events:
   Type    Reason     Age   From                                  Message
   ----    ------     ----  ----                                  -------
   Normal  Scheduled  9s    default-scheduler                     Successfully assigned openshift-logging/liveness-exec to ip-10-0-143-40.ec2.internal
-  Normal  Pulling    2s    kubelet, ip-10-0-143-40.ec2.internal  pulling image "k8s.gcr.io/liveness"
-  Normal  Pulled     1s    kubelet, ip-10-0-143-40.ec2.internal  Successfully pulled image "k8s.gcr.io/liveness"
+  Normal  Pulling    2s    kubelet, ip-10-0-143-40.ec2.internal  pulling image "registry.k8s.io/liveness"
+  Normal  Pulled     1s    kubelet, ip-10-0-143-40.ec2.internal  Successfully pulled image "registry.k8s.io/liveness"
   Normal  Created    1s    kubelet, ip-10-0-143-40.ec2.internal  Created container
   Normal  Started    1s    kubelet, ip-10-0-143-40.ec2.internal  Started container
 ----
@@ -125,12 +125,12 @@ Events:
   ----     ------          ----               ----                                               -------
   Normal   Scheduled       <unknown>                                                             Successfully assigned aaa/liveness-http to ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj
   Normal   AddedInterface  47s                multus                                             Add eth0 [10.129.2.11/23]
-  Normal   Pulled          46s                kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Successfully pulled image "k8s.gcr.io/liveness" in 773.406244ms
-  Normal   Pulled          28s                kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Successfully pulled image "k8s.gcr.io/liveness" in 233.328564ms
+  Normal   Pulled          46s                kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Successfully pulled image "registry.k8s.io/liveness" in 773.406244ms
+  Normal   Pulled          28s                kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Successfully pulled image "registry.k8s.io/liveness" in 233.328564ms
   Normal   Created         10s (x3 over 46s)  kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Created container liveness
   Normal   Started         10s (x3 over 46s)  kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Started container liveness
   Warning  Unhealthy       10s (x6 over 34s)  kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Liveness probe failed: HTTP probe failed with statuscode: 500
   Normal   Killing         10s (x2 over 28s)  kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Container liveness failed liveness probe, will be restarted
-  Normal   Pulling         10s (x3 over 47s)  kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Pulling image "k8s.gcr.io/liveness"
-  Normal   Pulled          10s                kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Successfully pulled image "k8s.gcr.io/liveness" in 244.116568ms
+  Normal   Pulling         10s (x3 over 47s)  kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Pulling image "registry.k8s.io/liveness"
+  Normal   Pulled          10s                kubelet, ci-ln-37hz77b-f76d1-wdpjv-worker-b-snzrj  Successfully pulled image "registry.k8s.io/liveness" in 244.116568ms
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-7544

Link to docs preview:
https://55928--docspreview.netlify.app/openshift-enterprise/latest/applications/application-health.html#application-health-about_application-health

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
