### PR TITLE
OSDOCS-4923:fixes typo in value

### DIFF
--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -113,7 +113,7 @@ Wired connection 1  46da4a6a-xxxx-xxxx-xxxx-ac0ca900f213  ethernet  ens3
 .Example output for OVN-Kubernetes without an original connection configuration
 [source,text]
 ----
-ovs-if-phys0        353774d3-0d3d-4ada-b14e-cd4d8824e2a8  ethernet       ens4   
+ovs-if-phys0        353774d3-0d3d-4ada-b14e-cd4d8824e2a8  ethernet       ens4
 ovs-port-phys0      332ef950-b2e5-4991-a0dc-3158977c35ca  ovs-port       ens4
 ----
 +
@@ -229,7 +229,7 @@ storage:
     - path: /etc/NetworkManager/system-connections/<connection_name> <1>
       contents:
         local: config.nmconnection <2>
-      mode: 0644
+      mode: 0600
 ----
 <1> Specify the NetworkManager connection name for the primary network interface.
 <2> Specify the local filename for the updated NetworkManager configuration file from the previous step.


### PR DESCRIPTION
[OSDOCS-4923](https://issues.redhat.com//browse/OSDOCS-4923): fixes a typo in the MTU value
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-4923
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://55943--docspreview.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
@lihongan PTAL
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
