### PR TITLE
Network Observability v1.1.0 Release Notes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1380,6 +1380,8 @@ Topics:
 - Name: Network Observability
   Dir: network_observability
   Topics:
+  - Name: Network Observability release notes
+    File: network-observability-operator-release-notes
   - Name: Network Observability overview
     File: network-observability-overview
   - Name: Installing the Network Observability Operator

--- a/networking/network_observability/network-observability-operator-release-notes.adoc
+++ b/networking/network_observability/network-observability-operator-release-notes.adoc
@@ -1,0 +1,29 @@
+//Network Observability Operator Release Notes
+:_content-type: ASSEMBLY
+[id="network-observability-operator-release-notes"]
+= Network Observability Operator release notes
+:context: network-observability-operator-release-notes-v0
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+The Network Observability Operator enables administrators to observe and analyze network traffic flows for {product-title} clusters.
+
+These release notes track the development of the Network Observability Operator in the {product-title}.
+
+For an overview of the Network Observability Operator, see xref:../../networking/network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
+
+[id="network-observability-operator-release-notes-1-1"]
+== Network Observability Operator 1.1.0
+
+The following advisory is available for the Network Observability Operator 1.1.0:
+
+* link:https://access.redhat.com/errata/RHSA-2023:0786[RHSA-2023:0786 Network Observability Operator Security Advisory Update]
+
+The Network Observability Operator is now stable and the release channel is upgraded to `v1.1.0`.
+
+[id="network-observability-operator-1.1.0-bug-fixes"]
+=== Bug fix
+
+* Previously, unless the Loki `authToken` configuration was set to `FORWARD` mode, authentication was no longer enforced, allowing any user who could connect to the {product-title} console in an {product-title} cluster to retrieve flows without authentication.
+Now, regardless of the Loki `authToken` mode, only cluster administrators can retrieve flows. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2169468[*BZ#2169468*])


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
I am adding a stub for Network Observability Operator release notes and information about the 1.1 release.

Version(s):
4.10+
Issue:
https://issues.redhat.com/browse/OSDOCS-5366
Link to docs preview:
https://55951--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/network-observability-operator-release-notes.html
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
