### PR TITLE
TELCODOCS-1174-412: Update the TALM versions for 4.12

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -27,5 +27,5 @@ The Red Hat Telco Radio Access Network (RAN) version {product-version} solution 
 |1.6
 
 |{cgu-operator-first}
-|4.11 or 4.12
+|4.10, 4.11, or 4.12
 |====


### PR DESCRIPTION
Additional Information: 
Cherry-picking [TELCODOCS-1174](https://issues.redhat.com//browse/TELCODOCS-1174) to versions 4.12 and 4.13 following request by Shikha Jhala.

Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-1174?filter=-1

Link to docs preview:
https://55956--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

 