### PR TITLE
OCPBUGS#7553 Incorrect vSphere version requirements in update doc

### DIFF
--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -16,7 +16,7 @@ Multiple compute nodes can be updated in parallel given workloads are tolerant o
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -11,7 +11,7 @@ To reduce the risk of downtime, it is recommended that control plane nodes be up
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1606,7 +1606,7 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.10 |4.11 | 4.12
 
-|vSphere 6.7 Update 2 or earlier
+|vSphere 6.x or earlier
 |Deprecated
 |Removed
 |Removed
@@ -1616,7 +1616,7 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 
-|VMware ESXi 6.7 Update 2 or earlier
+|VMware ESXi 6.x or earlier
 |Deprecated
 |Removed
 |Removed

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -103,12 +103,12 @@ xref:../updating/updating-restricted-network-cluster/index.adoc#about-restricted
 [id="updating-clusters-overview-vsphere-updating-hardware"]
 == Updating hardware on nodes running in vSphere
 
-xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
+xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
 
 * xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-virtual-hardware-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Updating virtual hardware on vSphere]
 * xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#scheduling-virtual-hardware-update-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Scheduling an update for virtual hardware on vSphere]
 
 [IMPORTANT]
 ====
-Using hardware version 13 for your cluster nodes running on vSphere is now deprecated. This version is still fully supported, but support will be removed in a future version of {product-title}. Hardware version 15 is now the default for vSphere virtual machines in {product-title}.
+Version 4.12 of {product-title} requires VMware virtual hardware version 15 or later.
 ====

--- a/updating/updating-hardware-on-nodes-running-on-vsphere.adoc
+++ b/updating/updating-hardware-on-nodes-running-on-vsphere.adoc
@@ -6,9 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster.
+You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster.
 
 You can update your virtual hardware immediately or schedule an update in vCenter.
+
+[IMPORTANT]
+====
+Version 4.12 of {product-title} requires VMware virtual hardware version 15 or later.
+====
 
 [id="updating-virtual-hardware-on-vsphere_{context}"]
 == Updating virtual hardware on vSphere


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-7553

Link to docs preview:
https://55957--docspreview.netlify.app/openshift-enterprise/latest/updating/index.html#updating-clusters-overview-vsphere-updating-hardware
https://55957--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-hardware-on-nodes-running-on-vsphere.html
https://55957--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-deprecated-removed-features

QE review:
- [x] QE has approved this change.

