### PR TITLE
RHDEVDOCS-4928 - Logging 5.6.2 Release Notes

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -11,6 +11,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/cluster-logging-rn-5.6.2.adoc[leveloffset=+1]
+
 include::modules/cluster-logging-rn-5.6.1.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-rn-5.6.adoc[leveloffset=+1]

--- a/modules/cluster-logging-rn-5.6.2.adoc
+++ b/modules/cluster-logging-rn-5.6.2.adoc
@@ -1,0 +1,29 @@
+//module included in cluster-logging-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-6-2_{context}"]
+= Logging 5.6.2
+This release includes link:https://access.redhat.com/errata/RHBA-2023:0793[OpenShift Logging Bug Fix Release 5.6.2].
+
+[id="openshift-logging-5-6-2-bug-fixes"]
+== Bug fixes
+* Before this update, the collector did not set `level` fields correctly based on priority for systemd logs. With this update, `level` fields are set correctly. (link:https://issues.redhat.com/browse/LOG-3429[LOG-3429])
+
+* Before this update, the Operator incorrectly generated incompatibility warnings on  {product-title} 4.12 or later. With this update, the Operator max {product-title} version value has been corrected, resolving the issue. (link:https://issues.redhat.com/browse/LOG-3584[LOG-3584])
+
+* Before this update, creating a `ClusterLogForwarder` custom resource (CR) with an output value of `default` did not generate any errors. With this update, an error warning that this value is invalid generates appropriately. (link:https://issues.redhat.com/browse/LOG-3437[LOG-3437])
+
+* Before this update, when the `ClusterLogForwarder` custom resource (CR) had multiple pipelines configured with one output set as `default`, the collector pods restarted. With this update, the logic for output validation has been corrected, resolving the issue. (link:https://issues.redhat.com/browse/LOG-3559[LOG-3559])
+
+* Before this update, collector pods restarted after being created. With this update, the deployed collector does not restart on its own. (link:https://issues.redhat.com/browse/LOG-3608[LOG-3608])
+
+* Before this update, patch releases removed previous versions of the Operators from the catalog. This made installing the old versions impossible. This update changes bundle configurations so that previous releases of the same minor version stay in the catalog. (link:https://issues.redhat.com/browse/LOG-3635[LOG-3635])
+
+[id="openshift-logging-5-6-2-CVEs"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2022-23521[CVE-2022-23521]
+* link:https://access.redhat.com/security/cve/CVE-2022-40303[CVE-2022-40303]
+* link:https://access.redhat.com/security/cve/CVE-2022-40304[CVE-2022-40304]
+* link:https://access.redhat.com/security/cve/CVE-2022-41903[CVE-2022-41903]
+* link:https://access.redhat.com/security/cve/CVE-2022-47629[CVE-2022-47629]
+* link:https://access.redhat.com/security/cve/CVE-2023-21835[CVE-2023-21835]
+* link:https://access.redhat.com/security/cve/CVE-2023-21843[CVE-2023-21843]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [RHDEVDOCS-4928](https://issues.redhat.com//browse/RHDEVDOCS-4928)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://55965--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-release-notes.html#cluster-logging-release-notes-5-6-2_cluster-logging-release-notes-v5x
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
