### PR TITLE
enterprise-4.10 OSDOCS-3969c Alibaba-VPC cherrypick to 4.10

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -136,6 +136,8 @@ Topics:
       File: installing-alibaba-customizations
     - Name: Installing a cluster on Alibaba Cloud with network customizations
       File: installing-alibaba-network-customizations
+    - Name: Installing a cluster on Alibaba Cloud into a shared VPC
+      File: installing-alibaba-vpc
     - Name: Uninstalling a cluster on Alibaba Cloud
       File: uninstall-cluster-alibaba
 - Name: Installing on AWS

--- a/installing/installing_alibaba/installing-alibaba-vpc.adoc
+++ b/installing/installing_alibaba/installing-alibaba-vpc.adoc
@@ -1,0 +1,72 @@
+:_content-type: ASSEMBLY
+[id="installing-alibaba-vpc"]
+= Installing a cluster on Alibaba Cloud into an existing VPC
+include::_attributes/common-attributes.adoc[]
+:context: installing-alibaba-vpc
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a cluster into an existing Alibaba Virtual Private Cloud (VPC) on Alibaba Cloud Services. The installation program provisions the required infrastructure, which can then be customized. To customize the VPC installation, modify the parameters in the 'install-config.yaml' file before you install the cluster.
+
+[NOTE]
+====
+The scope of the {product-title} installation configurations is intentionally narrow. It is designed for simplicity and ensured success. You can complete many more {product-title} configuration tasks after an installation completes.
+====
+
+:FeatureName: Alibaba Cloud on {product-title}
+include::snippets/technology-preview.adoc[]
+
+[id="prerequisites_installing-alibaba-vpc"]
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+* You read the documentation on xref:../../installing/installing-preparing.adoc#installing-preparing[selecting a cluster installation method and preparing it for users].
+* You xref:../../installing/installing_alibaba/preparing-to-install-on-alibaba.adoc#installation-alibaba-dns_preparing-to-install-on-alibaba[registered your domain].
+* If you use a firewall, you xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[configured it to allow the sites] that your cluster requires access to.
+* If the cloud Resource Access Management (RAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_alibaba/manually-creating-alibaba-ram.adoc#manually-creating-alibaba-ram[manually create and maintain Resource Access Management (RAM) credentials].
+
+include::modules/installation-custom-alibaba-vpc.adoc[leveloffset=+1]
+
+include::modules/cluster-entitlements.adoc[leveloffset=+1]
+
+include::modules/ssh-agent-using.adoc[leveloffset=+1]
+
+include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
+
+include::modules/installation-initializing.adoc[leveloffset=+2]
+
+include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+
+include::modules/installation-alibaba-config-yaml.adoc[leveloffset=+2]
+
+include::modules/manually-creating-alibaba-manifests.adoc[leveloffset=+2]
+
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
+
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
+
+include::modules/installation-launching-installer.adoc[leveloffset=+1]
+
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
+include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]
+
+include::modules/logging-in-by-using-the-web-console.adoc[leveloffset=+1]
+
+include::modules/cluster-telemetry.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
+* See xref:../../web_console/web-console.adoc#web-console[Accessing the web console] for more details about accessing and understanding the {product-title} web console
+
+[id="next-steps_installing-alibaba-vpc"]
+== Next steps
+
+* xref:../../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation].
+* xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
+* If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
+//Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
+//* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].
+

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -4,6 +4,7 @@
 // * authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc
 // * installing/installing_alibaba/manually-creating-alibaba-ram.adoc
 // * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
 
 ifeval::["{context}" == "cco-mode-sts"]
 :aws-sts:
@@ -16,6 +17,9 @@ ifeval::["{context}" == "installing-alibaba-default"]
 endif::[]
 ifeval::["{context}" == "installing-alibaba-customizations"]
 :alibabacloud-customizations:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-vpc"]
+:alibabacloud-vpc:
 endif::[]
 
 :_content-type: PROCEDURE
@@ -34,12 +38,12 @@ ifdef::google-cloud-platform[]
 
 You can use the `ccoctl gcp create-all` command to automate the creation of GCP resources.
 endif::google-cloud-platform[]
-ifdef::alibabacloud-default,alibabacloud-customizations[]
+ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 [id="cco-ccoctl-creating-at-once_{context}"]
 = Creating credentials for {product-title} components with the ccoctl tool
 
 You can use the {product-title} Cloud Credential Operator (CCO) utility to automate the creation of Alibaba Cloud RAM users and policies for each in-cluster component.
-endif::alibabacloud-default,alibabacloud-customizations[]
+endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 
 [NOTE]
 ====
@@ -51,14 +55,23 @@ By default, `ccoctl` creates objects in the directory in which the commands are 
 You must have:
 
 * Extracted and prepared the `ccoctl` binary.
-ifdef::alibabacloud-default,alibabacloud-customizations[]
+ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 * Created a RAM user with sufficient permission to create the {product-title} cluster.
 * Added the AccessKeyID (`access_key_id`) and AccessKeySecret (`access_key_secret`) of that RAM user into the link:https://www.alibabacloud.com/help/en/doc-detail/311667.htm#h2-sls-mfm-3p3[`~/.alibabacloud/credentials` file] on your local computer.
-endif::alibabacloud-default,alibabacloud-customizations[]
+endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 
 .Procedure
 
-. Extract the list of `CredentialsRequest` objects from the {product-title} release image:
+ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
+. Set the `$RELEASE_IMAGE` variable by running the following command:
++
+[source,terminal] 
+----
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
+----
+endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
+
+. Extract the list of `CredentialsRequest` objects from the {product-title} release image by running the following command:
 +
 [source,terminal]
 ifdef::aws-sts[]
@@ -79,15 +92,15 @@ $ oc adm release extract \
 --quay.io/<path_to>/ocp-release:<version>
 ----
 endif::google-cloud-platform[]
-ifdef::alibabacloud-default,alibabacloud-customizations[]
+ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 ----
 $ oc adm release extract \
 --credentials-requests \
 --cloud=alibabacloud \
 --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
---quay.io/<path_to>/ocp-release:<version>
+$RELEASE_IMAGE
 ----
-endif::alibabacloud-default,alibabacloud-customizations[]
+endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 +
 <1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
 +
@@ -95,6 +108,71 @@ endif::alibabacloud-default,alibabacloud-customizations[]
 ====
 This command can take a few moments to run.
 ====
+
+ifdef::aws-sts[]
+. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.12 on AWS
++
+[source,terminal]
+----
+0000_30_machine-api-operator_00_credentials-request.yaml <1>
+0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <2>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <3>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
+0000_50_cluster-network-operator_02-cncc-credentials.yaml <5>
+0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <6>
+----
++
+<1> The Machine API Operator CR is required.
+<2> The Cloud Credential Operator CR is required.
+<3> The Image Registry Operator CR is required.
+<4> The Ingress Operator CR is required.
+<5> The Network Operator CR is required.
+<6> The Storage Operator CR is an optional component and might be disabled in your cluster.
+endif::aws-sts[]
+ifdef::google-cloud-platform[]
+. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.12 on GCP
++
+[source,terminal]
+----
+0000_26_cloud-controller-manager-operator_16_credentialsrequest-gcp.yaml <1>
+0000_30_machine-api-operator_00_credentials-request.yaml <2>
+0000_50_cloud-credential-operator_05-gcp-ro-credentialsrequest.yaml <3>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request-gcs.yaml <4>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <5>
+0000_50_cluster-network-operator_02-cncc-credentials.yaml <6>
+0000_50_cluster-storage-operator_03_credentials_request_gcp.yaml <7>
+----
++
+<1> The Cloud Controller Manager Operator CR is required.
+<2> The Machine API Operator CR is required.
+<3> The Cloud Credential Operator CR is required.
+<4> The Image Registry Operator CR is required.
+<5> The Ingress Operator CR is required.
+<6> The Network Operator CR is required.
+<7> The Storage Operator CR is an optional component and might be disabled in your cluster.
+endif::google-cloud-platform[]
+ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
+. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
++
+.Example `credrequests` directory contents for {product-title} 4.12 on Alibaba Cloud
++
+[source,terminal]
+----
+0000_30_machine-api-operator_00_credentials-request.yaml <1>
+0000_50_cluster-image-registry-operator_01-registry-credentials-request-alibaba.yaml <2>
+0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <3>
+0000_50_cluster-storage-operator_03_credentials_request_alibaba.yaml <4>
+----
++
+<1> The Machine API Operator CR is required.
+<2> The Image Registry Operator CR is required.
+<3> The Ingress Operator CR is required.
+<4> The Storage Operator CR is an optional component and might be disabled in your cluster.
+endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 
 ifdef::aws-sts,google-cloud-platform[]
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
@@ -146,7 +224,7 @@ If your cluster uses Technology Preview features that are enabled by the `TechPr
 ====
 endif::google-cloud-platform[]
 
-ifdef::alibabacloud-default,alibabacloud-customizations[]
+ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
 
 .. Run the following command to use the tool:
@@ -222,8 +300,8 @@ $ cp ./<path_to_ccoctl_output_dir>/manifests/*credentials.yaml ./<path_to_instal
 where:
 
 `<path_to_ccoctl_output_dir>`:: Specifies the directory created by the `ccoctl alibabacloud create-ram-users` command.
-`<path_to_installation>dir>`:: Specifies the directory in which the installation program creates files.
-endif::alibabacloud-default,alibabacloud-customizations[]
+`<path_to_installation_dir>`:: Specifies the directory in which the installation program creates files.
+endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 
 ifdef::aws-sts,google-cloud-platform[]
 .Verification
@@ -267,4 +345,7 @@ ifeval::["{context}" == "installing-alibaba-default"]
 endif::[]
 ifeval::["{context}" == "installing-alibaba-customizations"]
 :!alibabacloud-customizations:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-vpc"]
+:!alibabacloud-vpc:
 endif::[]

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
 // * cli_reference/openshift_cli/getting-started.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc

--- a/modules/cli-logging-in-kubeadmin.adoc
+++ b/modules/cli-logging-in-kubeadmin.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-default.adoc

--- a/modules/cluster-entitlements.adoc
+++ b/modules/cluster-entitlements.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
 // * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc

--- a/modules/cluster-telemetry.adoc
+++ b/modules/cluster-telemetry.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
 // * installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
 // * installing/installing_bare_metal/installing-bare-metal.adoc
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc

--- a/modules/installation-alibaba-config-yaml.adoc
+++ b/modules/installation-alibaba-config-yaml.adoc
@@ -46,16 +46,22 @@ platform:
       instanceType: ecs.g6.xlarge
       systemDiskCategory: cloud_efficiency
       systemDiskSize: 200
-    region: ap-southeast-1 <3>
-    resourceGroupID: rg-acfnw6j3hyai <4>
+    region: ap-southeast-1 <4>
+    resourceGroupID: rg-acfnw6j3hyai <5>
+    vpcID: vpc-0xifdjerdibmaqvtjob2b <8>
+    vswitchIDs: <8>
+    - vsw-0xi8ycgwc8wv5rhviwdq5
+    - vsw-0xiy6v3z2tedv009b4pz2
 publish: External
 pullSecret: '{"auths": {"cloud.openshift.com": {"auth": ... }' <5>
 sshKey: |
   ssh-rsa AAAA... <6>
 ----
 <1> Required. The installation program prompts you for a cluster name.
-<2> Optional. Specify parameters for machine pools that do not define their own platform configuration.
-<3> Required. The installation program prompts you for the region to deploy the cluster to.
-<4> Optional. Specify an existing resource group where the cluster should be installed.
-<5> Required. The installation program prompts you for the pull secret.
-<6> Optional. The installation program prompts you for the SSH key value that you use to access the machines in your cluster.
+<2> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
+<3> Optional. Specify parameters for machine pools that do not define their own platform configuration.
+<4> Required. The installation program prompts you for the region to deploy the cluster to.
+<5> Optional. Specify an existing resource group where the cluster should be installed.
+<6> Required. The installation program prompts you for the pull secret.
+<7> Optional. The installation program prompts you for the SSH key value that you use to access the machines in your cluster.
+<8> Optional. These are example vswitchID values.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1,8 +1,9 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_alibaba//installing-alibaba-default.adoc
+// * installing/installing_alibaba/installing-alibaba-default.adoc
 // * installing/installing_aws/installing-alibaba-customizations.adoc
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba_installing-alibaba-vpc.adoc
 // * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
@@ -51,6 +52,9 @@
 // * installing/installing_azure_stack_hub/installing-azure-stack-hub-customizations.adoc
 
 ifeval::["{context}" == "installing-alibaba-customizations"]
+:alibabacloud:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-vpc"]
 :alibabacloud:
 endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]
@@ -549,7 +553,7 @@ accounts for the dramatically decreased machine performance.
 
 |`compute.platform`
 |Required if you use `compute`. Use this parameter to specify the cloud provider to host the worker machines. This parameter value must match the `controlPlane.platform` parameter value.
-|`alibaba`, `aws`, `azure`, `gcp`, `ibmcloud`, `openstack`, `ovirt`, `vsphere`, or `{}`
+|`alibabacloud`, `aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `ovirt`, `vsphere`, or `{}`
 
 |`compute.replicas`
 |The number of compute machines, which are also known as worker machines, to provision.
@@ -618,7 +622,7 @@ accounts for the dramatically decreased machine performance.
 
 |`controlPlane.platform`
 |Required if you use `controlPlane`. Use this parameter to specify the cloud provider that hosts the control plane machines. This parameter value must match the `compute.platform` parameter value.
-|`alibaba`, `aws`, `azure`, `gcp`, `ibmcloud`, `openstack`, `ovirt`, `vsphere`, or `{}`
+|`alibabacloud`, `aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `ovirt`, `vsphere`, or `{}`
 
 |`controlPlane.replicas`
 |The number of control plane machines to provision.
@@ -1509,10 +1513,57 @@ ifdef::alibabacloud[]
 
 Additional Alibaba Cloud configuration parameters are described in the following table. The `alibabacloud` parameters are the configuration used when installing on Alibaba Cloud. The `defaultMachinePlatform` parameters are the default configuration used when installing on Alibaba Cloud for machine pools that do not define their own platform configuration.
 
+These parameters apply to both compute machines and control plane machines where specified.
+
+[NOTE]
+====
+If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.platform.alibabacloud` will overwrite `platform.alibabacloud.defaultMachinePlatform` settings for compute machines and control plane machines respectively.
+====
+
 .Optional {alibaba} parameters
 [cols=".^2,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
+
+|`compute.platform.alibabacloud.imageID`
+|The imageID used to create the ECS instance. ImageID must belong to the same region as the cluster.
+|String.
+
+|`compute.platform.alibabacloud.instanceType`
+|InstanceType defines the ECS instance type. Example: `ecs.g6.large`
+|String.
+
+|`compute.platform.alibabacloud.systemDiskCategory`
+|Defines the category of the system disk. Examples: `cloud_efficiency`,`cloud_essd`
+|String.
+
+|`compute.platform.alibabacloud.systemDisksize`
+|Defines the size of the system disk in gibibytes (GiB).
+|Integer.
+
+|`compute.platform.alibabacloud.zones`
+|The list of availability zones that can be used. Examples: `cn-hangzhou-h`, `cn-hangzhou-j`
+|String list.
+
+|`controlPlane.platform.alibabacloud.imageID`
+|The imageID used to create the ECS instance. ImageID must belong to the same region as the cluster.
+|String.
+
+|`controlPlane.platform.alibabacloud.instanceType`
+|InstanceType defines the ECS instance type. Example: `ecs.g6.xlarge`
+|String.
+
+|`controlPlane.platform.alibabacloud.systemDiskCategory`
+|Defines the category of the system disk. Examples: `cloud_efficiency`,`cloud_essd`
+|String.
+
+|`controlPlane.platform.alibabacloud.systemDisksize`
+|Defines the size of the system disk in gibibytes (GiB).
+|Integer.
+
+|`controlPlane.platform.alibabacloud.zones`
+|The list of availability zones that can be used. Examples: `cn-hangzhou-h`, `cn-hangzhou-j`
+|String list.
 
 |`platform.alibabacloud.region`
 |Required.The Alibaba Cloud region where the cluster will be created.
@@ -1535,24 +1586,24 @@ Additional Alibaba Cloud configuration parameters are described in the following
 |String list.
 
 |`platform.alibabacloud.defaultMachinePlatform.imageID`
-|For compute machines, the image ID that should be used to create ECS instance. If set, the image ID should belong to the same region as the cluster
+|For both compute machines and control plane machines, the image ID that should be used to create ECS instance. If set, the image ID should belong to the same region as the cluster.
 |String.
 
 |`platform.alibabacloud.defaultMachinePlatform.instanceType`
-|For compute machines, the configuration used when installing on Alibaba Cloud.
-|String. For example `ecs.g6.large`.
+|For both compute machines and control plane machines, the ECS instance type used to create the ECS instance. Example: `ecs.g6.xlarge` 
+|String.
 
 |`platform.alibabacloud.defaultMachinePlatform.systemDiskCategory`
-|For compute machines, the category of the system disk.
+|For both compute machines and control plane machines, the category of the system disk. Examples: `cloud_efficiency`, `cloud_essd`.
 |String, for example "", `cloud_efficiency`, `cloud_essd`.
 
 |`platform.alibabacloud.defaultMachinePlatform.systemDiskSize`
-|For compute machine, the size of the system disk in gibibytes (GiB). The minimum is `120`.
+|For both compute machines and control plane machines, the size of the system disk in gibibytes (GiB). The minimum is `120`.
 |Integer.
 
 |`platform.alibabacloud.defaultMachinePlatform.zones`
-|For compute machine, list of availability zones that can be used.
-|String.
+|For both compute machines and control plane machines, the list of availability zones that can be used. Examples: `cn-hangzhou-h`, `cn-hangzhou-j`
+|String list.
 
 |`platform.alibabacloud.privateZoneID`
 |The ID of an existing private zone into which to add DNS records for the cluster's internal API. An existing private zone can only be used when also using existing VPC. The private zone must be associated with the VPC containing the subnets. Leave the private zone unset to have the installer create the private zone on your behalf.
@@ -1566,6 +1617,9 @@ ifdef::bare[]
 :!bare:
 endif::bare[]
 ifeval::["{context}" == "installing-alibaba-customizations"]
+:!alibabacloud:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-vpc"]
 :!alibabacloud:
 endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]

--- a/modules/installation-custom-alibaba-vpc.adoc
+++ b/modules/installation-custom-alibaba-vpc.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
+
+:_content-type: CONCEPT
+[id="installation-custom-alibaba-vpc_{context}"]
+= Using a custom VPC
+
+In {product-title} {product-version}, you can deploy a cluster into existing subnets in an existing Virtual Private Cloud (VPC) in the Alibaba Cloud Platform. By deploying {product-title} into an existing Alibaba VPC, you can avoid limit constraints in new accounts and more easily adhere to your organization's operational constraints. If you cannot obtain the infrastructure creation permissions that are required to create the VPC yourself, use this installation option. You must configure networking using vSwitches.
+
+[id="installation-custom-alibaba-vpc-requirements_{context}"]
+== Requirements for using your VPC
+
+The union of the VPC CIDR block and the machine network CIDR must be non-empty. The vSwitches must be within the machine network.
+
+The installation program does not create the following components:
+
+* VPC
+* vSwitches
+* Route table
+* NAT gateway
+
+include::snippets/custom-dns-server.adoc[]
+
+[id="installation-custom-alibaba-vpc-validation_{context}"]
+== VPC validation
+
+To ensure that the vSwitches you provide are suitable, the installation program confirms the following data:
+
+* All the vSwitches that you specify must exist.
+* You have provided one or more vSwitches for control plane machines and compute machines.
+* The vSwitches' CIDRs belong to the machine CIDR that you specified.
+
+[id="installation-about-custom-alibaba-permissions_{context}"]
+== Division of permissions
+
+Some individuals can create different resources in your cloud than others. For example, you might be able to create application-specific items, like instances, buckets, and load balancers, but not networking-related components, such as VPCs or vSwitches.
+
+[id="installation-custom-alibaba-vpc-isolation_{context}"]
+== Isolation between clusters
+
+If you deploy {product-title} into an existing network, the isolation of cluster services is reduced in the following ways:
+
+* You can install multiple {product-title} clusters in the same VPC.
+
+* ICMP ingress is allowed to the entire network.
+
+* TCP 22 ingress (SSH) is allowed to the entire network.
+
+* Control plane TCP 6443 ingress (Kubernetes API) is allowed to the entire network.
+
+* Control plane TCP 22623 ingress (MCS) is allowed to the entire network.

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -2,7 +2,8 @@
 //
 // * installing/installing_aws/installing-alibaba-default.adoc
 // * installing/installing_aws/installing-alibaba-customizations.adoc
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_aws/installing-alibaba-vpc.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-network-customizations.adoc
 // * installing/installing_aws/installing-aws-vpc.adoc
@@ -41,6 +42,9 @@ ifeval::["{context}" == "installing-alibaba-default"]
 endif::[]
 ifeval::["{context}" == "installing-alibaba-customizations"]
 :alibabacloud-custom:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-vpc"]
+:alibabacloud-vpc:
 endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
@@ -156,9 +160,9 @@ endif::[]
 = Creating the installation configuration file
 
 You can customize the {product-title} cluster you install on
-ifdef::alibabacloud-default,alibabacloud-custom[]
+ifdef::alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
 Alibaba Cloud.
-endif::alibabacloud-default,alibabacloud-custom[]
+endif::alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
 ifdef::aws[]
 Amazon Web Services (AWS).
 endif::aws[]
@@ -225,12 +229,12 @@ ifndef::rhv[]
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 endif::rhv[]
-ifdef::alibabacloud-default,alibabacloud-custom[]
-... Specify *alibabacloud* as the platform to target.
-... Specify the region to deploy the cluster to.
-... Specify the base domain to deploy the cluster to.  All DNS records will be sub-domains of this base and will also include the cluster name.
-... Specify a descriptive name for your cluster.
-endif::alibabacloud-default,alibabacloud-custom[]
+ifdef::alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
+... Select *alibabacloud* as the platform to target.
+... Select the region to deploy the cluster to.
+... Select the base domain to deploy the cluster to. The base domain corresponds to the public DNS zone that you created for your cluster.
+... Provide a descriptive name for your cluster.
+endif::alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
 ifdef::aws[]
 ... Select *AWS* as the platform to target.
 ... If you do not have an Amazon Web Services (AWS) profile stored on your computer, enter the AWS
@@ -296,12 +300,12 @@ The installation program connects to your vCenter instance.
 ... Enter the base domain. This base domain must be the same one that you used in the DNS records that you configured.
 endif::vsphere,vmc[]
 ifndef::osp[]
-ifndef::rhv,alibabacloud-default,alibabacloud-custom[]
+ifndef::rhv,alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
 ... Enter a descriptive name for your cluster.
-ifdef::vsphere,vmc[]
-The cluster name must be the same one that you used in the DNS records that you configured.
-endif::vsphere,vmc[]
-endif::rhv,alibabacloud-default,alibabacloud-custom[]
+ifdef::vsphere,vmc,nutanix[]
+The cluster name you enter must match the cluster name you specified when configuring the DNS records.
+endif::vsphere,vmc,nutanix[]
+endif::rhv,alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
 endif::osp[]
 ifdef::osp[]
 ... Enter a name for your cluster. The name must be 14 or fewer characters long.
@@ -407,12 +411,12 @@ compute:
 <1> Set to `0`.
 endif::[]
 
-ifndef::restricted,alibabacloud-default,alibabacloud-custom[]
+ifndef::restricted,alibabacloud-default,alibabacloud-custom,alibabacloud-vpc,nutanix[]
 . Modify the `install-config.yaml` file. You can find more information about
 the available parameters in the "Installation configuration parameters" section.
-endif::restricted,alibabacloud-default,alibabacloud-custom[]
+endif::restricted,alibabacloud-default,alibabacloud-custom,alibabacloud-vpc,nutanix[]
 
-ifdef::alibabacloud-default,alibabacloud-custom[]
+ifdef::alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
 . Installing the cluster into Alibaba Cloud requires that the Cloud Credential Operator (CCO) operate in manual mode. Modify the `install-config.yaml` file to set the `credentialsMode` parameter to `Manual`:
 +
 .Example install-config.yaml configuration file with `credentialsMode` set to `Manual`
@@ -427,11 +431,12 @@ compute:
  ...
 ----
 <1> Add this line to set the `credentialsMode` to `Manual`.
-endif::alibabacloud-default,alibabacloud-custom[]
+endif::alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
 
-ifdef::alibabacloud-custom[]
-. Set the available parameters in the "Installation configuration parameters" section, as needed.
-endif::alibabacloud-custom[]
+ifdef::alibabacloud-custom,alibabacloud-vpc[]
+. Modify the `install-config.yaml` file. You can find more information about
+the available parameters in the "Installation configuration parameters" section.
+endif::alibabacloud-custom,alibabacloud-vpc[]
 
 ifndef::restricted[]
 
@@ -575,6 +580,9 @@ ifeval::["{context}" == "installing-alibaba-default"]
 endif::[]
 ifeval::["{context}" == "installing-alibaba-customizations"]
 :!alibabacloud-custom:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-vpc"]
+:!alibabacloud-vpc:
 endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]
 :!aws:

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -3,6 +3,7 @@
 // installing/installing_alibaba/installing-alibaba-network-customizations.adoc
 // * installing/installing_alibaba/installing-alibaba-customizations.adoc
 // * installing/installing_alibaba/installing-alibaba-default.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-default.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc
@@ -45,6 +46,19 @@ ifeval::["{context}" == "installing-alibaba-customizations"]
 endif::[]
 ifeval::["{context}" == "installing-alibaba-default"]
 :custom-config:
+:single-step:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-network-customizations"]
+:custom-config:
+:single-step:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-vpc"]
+:custom-config:
+:single-step:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:custom-config:
+:aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]
 :custom-config:
@@ -488,6 +502,19 @@ ifeval::["{context}" == "installing-alibaba-customizations"]
 endif::[]
 ifeval::["{context}" == "installing-alibaba-default"]
 :!custom-config:
+:!single-step:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-network-customizations"]
+:!custom-config:
+:!single-step:
+endif::[]
+ifeval::["{context}" == "installing-alibaba-vpc"]
+:!custom-config:
+:!single-step:
+endif::[]
+ifeval::["{context}" == "installing-aws-private"]
+:!custom-config:
+:!aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]
 :!custom-config:

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-default.adoc

--- a/modules/logging-in-by-using-the-web-console.adoc
+++ b/modules/logging-in-by-using-the-web-console.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 //
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
-// *installing/installing_aws/installing-aws-china.adoc.
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
+// * installing/installing_aws/installing-aws-china.adoc.
 // * installing/installing_aws/installing-aws-secret-region.adoc
 // *installing/validating-an-installation.adoc
 // *installing/installing_aws/installing-aws-user-infra.adoc

--- a/modules/manually-creating-alibaba-manifests.adoc
+++ b/modules/manually-creating-alibaba-manifests.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_alibaba/installing-alibaba-default.adoc
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
 
 :_content-type: PROCEDURE
 [id="manually-creating-alibaba-manifests_{context}"]
@@ -21,4 +22,3 @@ $ openshift-install create manifests --dir <installation_directory>
 where:
 
 `<installation_directory>`:: Specifies the directory in which the installation program creates files.
-

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+// * installing/installing_alibaba/installing-alibaba-vpc.adoc
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-aws-china.adoc
 // * installing/installing_aws/installing-aws-customizations.adoc

--- a/snippets/custom-dns-server.adoc
+++ b/snippets/custom-dns-server.adoc
@@ -3,6 +3,7 @@
 // * modules/installation-custom-aws-vpc.adoc
 // * modules/installation-about-custom-azure-vnet.adoc
 // * modules/installation-custom-gcp-vpc.adoc
+// * modules/installation-custom-alibaba-vpc.adoc
 
 :_content-type: SNIPPET
 


### PR DESCRIPTION
This PR is opened for cherrypick to 4.10:  original PR merged already by Sara Thomas. Requesting merge review here for the cherrypick PR.

LGTM received from QE. I have SME and QE LGTM. Commits are squashed. Peer review and two merge reviews complete. 

Problem: This PR adds a new section documenting Alibaba VPC installation

Version(s): This is a cherrypick to 4.11. Original branch was from "main" before 4.12 freeze.

Issue:
How to install OpenShift into an Alibaba VPC https://issues.redhat.com/browse/OSDOCS-3969

FORMER PR for this issue:
https://github.com/openshift/openshift-docs/pull/44593

Link to docs preview:
https://55223--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-vpc.html

Additional information:
Gaurav Singh, PM. QE: Jianli Wei, SME: Thomas Wiest (Thomas has left the company but provided LGTM before departure.)