### PR TITLE
BZ1998450: Updated procedure related to Accessing Registry Metrics.

### DIFF
--- a/modules/registry-accessing-metrics.adoc
+++ b/modules/registry-accessing-metrics.adoc
@@ -18,45 +18,7 @@ endpoint.
 
 .Procedure
 
-There are two ways in which you can access the metrics, running a metrics query
-or using the cluster role.
-
-*Metrics query*
-
-. Run a metrics query, for example:
-+
-[source,terminal]
-----
-$ curl --insecure -s -u <user>:<secret> \ <1>
-    https://image-registry.openshift-image-registry.svc:5000/extensions/v2/metrics | grep imageregistry | head -n 20
-----
-+
-.Example output
-[source,terminal]
-----
-# HELP imageregistry_build_info A metric with a constant '1' value labeled by major, minor, git commit & git version from which the image registry was built.
-# TYPE imageregistry_build_info gauge
-imageregistry_build_info{gitCommit="9f72191",gitVersion="v3.11.0+9f72191-135-dirty",major="3",minor="11+"} 1
-# HELP imageregistry_digest_cache_requests_total Total number of requests without scope to the digest cache.
-# TYPE imageregistry_digest_cache_requests_total counter
-imageregistry_digest_cache_requests_total{type="Hit"} 5
-imageregistry_digest_cache_requests_total{type="Miss"} 24
-# HELP imageregistry_digest_cache_scoped_requests_total Total number of scoped requests to the digest cache.
-# TYPE imageregistry_digest_cache_scoped_requests_total counter
-imageregistry_digest_cache_scoped_requests_total{type="Hit"} 33
-imageregistry_digest_cache_scoped_requests_total{type="Miss"} 44
-# HELP imageregistry_http_in_flight_requests A gauge of requests currently being served by the registry.
-# TYPE imageregistry_http_in_flight_requests gauge
-imageregistry_http_in_flight_requests 1
-# HELP imageregistry_http_request_duration_seconds A histogram of latencies for requests to the registry.
-# TYPE imageregistry_http_request_duration_seconds summary
-imageregistry_http_request_duration_seconds{method="get",quantile="0.5"} 0.01296087
-imageregistry_http_request_duration_seconds{method="get",quantile="0.9"} 0.014847248
-imageregistry_http_request_duration_seconds{method="get",quantile="0.99"} 0.015981195
-imageregistry_http_request_duration_seconds_sum{method="get"} 12.260727916000022
-----
-<1> `<user>` can be arbitrary, but `<secret>` must match the value specified in the
-registry configuration.
+There are two ways in which you can access the metrics, using the cluster role or running a metrics query.
 
 *Cluster role*
 
@@ -99,3 +61,40 @@ $ oc adm policy add-cluster-role-to-user prometheus-scraper <username>
 ----
 $ curl --insecure -s -u <user>:<token> \
 ----
+
+*Metrics query*
+
+. Run a metrics query, for example:
++
+[source,terminal]
+----
+$ curl --insecure -s -u <user>:<secret> \ <1>
+    https://image-registry.openshift-image-registry.svc:5000/extensions/v2/metrics | grep imageregistry | head -n 20
+----
++
+.Example output
+[source,terminal]
+----
+# HELP imageregistry_build_info A metric with a constant '1' value labeled by major, minor, git commit & git version from which the image registry was built.
+# TYPE imageregistry_build_info gauge
+imageregistry_build_info{gitCommit="9f72191",gitVersion="v3.11.0+9f72191-135-dirty",major="3",minor="11+"} 1
+# HELP imageregistry_digest_cache_requests_total Total number of requests without scope to the digest cache.
+# TYPE imageregistry_digest_cache_requests_total counter
+imageregistry_digest_cache_requests_total{type="Hit"} 5
+imageregistry_digest_cache_requests_total{type="Miss"} 24
+# HELP imageregistry_digest_cache_scoped_requests_total Total number of scoped requests to the digest cache.
+# TYPE imageregistry_digest_cache_scoped_requests_total counter
+imageregistry_digest_cache_scoped_requests_total{type="Hit"} 33
+imageregistry_digest_cache_scoped_requests_total{type="Miss"} 44
+# HELP imageregistry_http_in_flight_requests A gauge of requests currently being served by the registry.
+# TYPE imageregistry_http_in_flight_requests gauge
+imageregistry_http_in_flight_requests 1
+# HELP imageregistry_http_request_duration_seconds A histogram of latencies for requests to the registry.
+# TYPE imageregistry_http_request_duration_seconds summary
+imageregistry_http_request_duration_seconds{method="get",quantile="0.5"} 0.01296087
+imageregistry_http_request_duration_seconds{method="get",quantile="0.9"} 0.014847248
+imageregistry_http_request_duration_seconds{method="get",quantile="0.99"} 0.015981195
+imageregistry_http_request_duration_seconds_sum{method="get"} 12.260727916000022
+----
+<1> `<user>` can be arbitrary, but `<secret>` must match the value specified in the
+registry configuration.

--- a/modules/registry-accessing-metrics.adoc
+++ b/modules/registry-accessing-metrics.adoc
@@ -86,14 +86,16 @@ EOF
 $ oc adm policy add-cluster-role-to-user prometheus-scraper <username>
 ----
 
-. Access the metrics using cluster role. The part of
-the configuration file responsible for metrics should look like this:
+. Get user token 
 +
-[source,yaml]
+[source,terminal]
 ----
-openshift:
-  version: 1.0
-  metrics:
-    enabled: true
-...
+ $ oc whoami -t
+----
+
+. Run a metrics query in node or inside a pod, for example:
++
+[source,terminal]
+----
+$ curl --insecure -s -u <user>:<token> \
 ----


### PR DESCRIPTION
Version(s): 4.8+

Scope: Added steps related to registry-accessing metrics for a cluster role.

[BZ1998450](https://bugzilla.redhat.com/show_bug.cgi?id=1998450)

Link to docs preview:
Preview not generating

QE Review: 
@wewang58 @xiuwang ptal

Additional Information:
[Accessing Registry Metrics](https://docs.google.com/document/d/1_FQFoKCn9IU0zBhxnZlTtd-44D31TfzLjce5iW3CuE0/edit)

