### PR TITLE
RHDEVDOCS-4861: Updated GitOps1.7 RN for an inaccuracy

### DIFF
--- a/modules/gitops-release-notes-1-7-0.adoc
+++ b/modules/gitops-release-notes-1-7-0.adoc
@@ -40,9 +40,13 @@ In future releases, there is a possibility to deprecate the old method of custom
 
 * With this update, to use the *Environments* feature on the *Developer* tab you must upgrade if you are using a {gitops-title} version prior to 1.7 and {product-title} 4.15 or above. link:https://issues.redhat.com/browse/GITOPS-2415[GITOPS-2415] 
 
-* With this update, applications can be created in any namespace in the same cluster and still managed by the same control-plane’s ArgoCD instance. This is done by adding a new label `argocd.argoproj.io/managed-by-cluster-argocd` to the namespace added in `spec.sourceNamespaces` of the Argo CD custom resource. link:https://issues.redhat.com/browse/GITOPS-2341[GITOPS-2341]
+* With this update, you can create applications, which are managed by the same control plane Argo CD instance, in any namespace in the same cluster. As an administrator, perform the following actions to enable this update: 
+** Add the namespace to the `.spec.sourceNamespaces` attribute for a cluster-scoped Argo CD instance that manages the application.
+** Add the namespace to the `.spec.sourceNamespaces` attribute in the `AppProject` custom resource that is associated with the application. 
++
+link:https://issues.redhat.com/browse/GITOPS-2341[GITOPS-2341]
 
-:FeatureName: Argo CD Applications controller
+:FeatureName: Argo CD applications in non-control plane namespaces
 include::snippets/technology-preview.adoc[]
 
 * With this update, Argo CD supports the Server-Side Apply feature, which helps users to perform the following tasks:


### PR DESCRIPTION
**Aligned team**: Dev Tools

**Purpose**: To resolve the following issue: 
https://issues.redhat.com/browse/RHDEVDOCS-4861

**OCP version this PR applies to**:  enterprise 4.9 and later

**Link to docs preview**:  https://55985--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#new-features-1-7-0_gitops-release-notes

**Change Management**
Need an ACK from Eng:  @jaideepr97
Need an ACK from PM: @harrietgrace @wtam2018 
Need an ACK from Product experience: @RickJWagner 
Need an ACK from QE: @varshab1210 
Need an ACK from DPM: @pmkovar 
Need an ACK from CS: @Preeticp 

Peer review: @Srivaralakshmi 