### PR TITLE
TELCODOCS-1188 adding config parameters to control when SR-IOV starts up and manages VFs

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -49,10 +49,6 @@ Do not set a different value.
 |Specifies the node selection to control scheduling the SR-IOV Network Config Daemon on selected nodes.
 By default, this field is not set and the Operator deploys the SR-IOV Network Config daemon set on worker nodes.
 
-|`spec.configurationMode`
-|`string`
-|Specifies when to start the SR-IOV Network Operator in the boot process. Set to `systemd` to start the SR-IOV Network Operator before the network manager. The default mode is `daemon`. When the `configurationMode` is set to `deamon` the SR-IOV daemon needs to be up before the SR-IOV Network Operator can start.
-
 |`spec.disableDrain`
 |`boolean`
 |Specifies whether to disable the node draining process or enable the node draining process when you apply a new policy to configure the NIC on a node.

--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -49,6 +49,10 @@ Do not set a different value.
 |Specifies the node selection to control scheduling the SR-IOV Network Config Daemon on selected nodes.
 By default, this field is not set and the Operator deploys the SR-IOV Network Config daemon set on worker nodes.
 
+|`spec.configurationMode`
+|`string`
+|Specifies when to start the SR-IOV Network Operator in the boot process. Set to `systemd` to start the SR-IOV Network Operator before the network manager. The default mode is `daemon`. When the `configurationMode` is set to `deamon` the SR-IOV daemon needs to be up before the SR-IOV Network Operator can start.
+
 |`spec.disableDrain`
 |`boolean`
 |Specifies whether to disable the node draining process or enable the node draining process when you apply a new policy to configure the NIC on a node.

--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -25,17 +25,17 @@ spec:
   mtu: <mtu> <6>
   needVhostNet: false <7>
   numVfs: <num> <8>
-  nicSelector: <9>
-    vendor: "<vendor_code>" <10>
-    deviceID: "<device_id>" <11>
-    pfNames: ["<pf_name>", ...] <12>
-    rootDevices: ["<pci_bus_id>", ...] <13>
-    netFilter: "<filter_string>" <14>
-  deviceType: <device_type> <15>
-  isRdma: false <16>
-  linkType: <link_type> <17>
-  eSwitchMode: "switchdev" <18>
-  excludeTopology: false <19>
+  externallyManaged: false <9>
+  nicSelector: <10>
+    vendor: "<vendor_code>" <11>
+    deviceID: "<device_id>" <12>
+    pfNames: ["<pf_name>", ...] <13>
+    rootDevices: ["<pci_bus_id>", ...] <14>
+    netFilter: "<filter_string>" <15>
+  deviceType: <device_type> <16>
+  isRdma: false <17>
+    linkType: <link_type> <18>
+  eSwitchMode: "switchdev" <19>
 ----
 <1> The name for the custom resource object.
 
@@ -55,37 +55,39 @@ When specifying a name, be sure to use the accepted syntax expression `^[a-zA-Z0
 
 <8> The number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
 
-<9> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
+<9> What is the definition of this parameter?
+
+<10> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
 +
 If you specify `rootDevices`, you must also specify a value for `vendor`, `deviceID`, or `pfNames`. If you specify both `pfNames` and `rootDevices` at the same time, ensure that they refer to the same device. If you specify a value for `netFilter`, then you do not need to specify any other parameter because a network ID is unique.
 
-<10> Optional: The vendor hexadecimal code of the SR-IOV network device. The only allowed values are `8086` and `15b3`.
+<11> Optional: The vendor hexadecimal code of the SR-IOV network device. The only allowed values are `8086` and `15b3`.
 
-<11> Optional: The device hexadecimal code of the SR-IOV network device. For example, `101b` is the device ID for a Mellanox ConnectX-6 device.
+<12> Optional: The device hexadecimal code of the SR-IOV network device. For example, `101b` is the device ID for a Mellanox ConnectX-6 device.
 
-<12> Optional: An array of one or more physical function (PF) names for the device.
+<13> Optional: An array of one or more physical function (PF) names for the device.
 
-<13> Optional: An array of one or more PCI bus addresses for the PF of the device. Provide the address in the following format: `0000:02:00.1`.
+<14> Optional: An array of one or more PCI bus addresses for the PF of the device. Provide the address in the following format: `0000:02:00.1`.
 
-<14> Optional: The platform-specific network filter. The only supported platform is {rh-openstack-first}. Acceptable values use the following format: `openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Replace `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with the value from the `/var/config/openstack/latest/network_data.json` metadata file.
+<15> Optional: The platform-specific network filter. The only supported platform is {rh-openstack-first}. Acceptable values use the following format: `openstack/NetworkID:xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx`. Replace `xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx` with the value from the `/var/config/openstack/latest/network_data.json` metadata file.
 
-<15> Optional: The driver type for the virtual functions. The only allowed values are `netdevice` and `vfio-pci`. The default value is `netdevice`.
+<16> Optional: The driver type for the virtual functions. The only allowed values are `netdevice` and `vfio-pci`. The default value is `netdevice`.
 +
 For a Mellanox NIC to work in DPDK mode on bare metal nodes, use the `netdevice` driver type and set `isRdma` to `true`.
 
-<16> Optional: Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
+<17> Optional: Configures whether to enable remote direct memory access (RDMA) mode. The default value is `false`.
 +
 If the `isRdma` parameter is set to `true`, you can continue to use the RDMA-enabled VF as a normal network device. A device can be used in either mode.
 +
 Set `isRdma` to `true` and additionally set `needVhostNet` to `true` to configure a Mellanox NIC for use with Fast Datapath DPDK applications.
 
-<17> Optional: The link type for the VFs. The default value is `eth` for Ethernet. Change this value to 'ib' for InfiniBand.
+<18> Optional: The link type for the VFs. The default value is `eth` for Ethernet. Change this value to 'ib' for InfiniBand.
 +
 When `linkType` is set to `ib`, `isRdma` is automatically set to `true` by the SR-IOV Network Operator webhook. When `linkType` is set to `ib`, `deviceType` should not be set to `vfio-pci`.
 +
 Do not set linkType to 'eth' for SriovNetworkNodePolicy, because this can lead to an incorrect number of available devices reported by the device plugin.
 
-<18> Optional: To enable hardware offloading, the 'eSwitchMode' field must be set to `"switchdev"`.
+<19> Optional: To enable hardware offloading, the 'eSwitchMode' field must be set to `"switchdev"`.
 
 <19> Optional: To exclude advertising an SR-IOV network resource's NUMA node to the Topology Manager, set the value to `true`. The default value is `false`.
 

--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -55,7 +55,7 @@ When specifying a name, be sure to use the accepted syntax expression `^[a-zA-Z0
 
 <8> The number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
 
-<9> What is the definition of this parameter?
+<9> Set `externallyManaged` to `true` to ensure some VFs are reserved for host managed systems. With the value set to `false` the SR-IOV Network Operator manages and configures all allocated VFs.
 
 <10> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
 +

--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -25,7 +25,7 @@ spec:
   mtu: <mtu> <6>
   needVhostNet: false <7>
   numVfs: <num> <8>
-  externallyManaged: false <9>
+  externallyManage: false <9>
   nicSelector: <10>
     vendor: "<vendor_code>" <11>
     deviceID: "<device_id>" <12>
@@ -34,7 +34,7 @@ spec:
     netFilter: "<filter_string>" <15>
   deviceType: <device_type> <16>
   isRdma: false <17>
-    linkType: <link_type> <18>
+  linkType: <link_type> <18>
   eSwitchMode: "switchdev" <19>
 ----
 <1> The name for the custom resource object.
@@ -55,7 +55,13 @@ When specifying a name, be sure to use the accepted syntax expression `^[a-zA-Z0
 
 <8> The number of the virtual functions (VF) to create for the SR-IOV physical network device. For an Intel network interface controller (NIC), the number of VFs cannot be larger than the total VFs supported by the device. For a Mellanox NIC, the number of VFs cannot be larger than `128`.
 
-<9> Set `externallyManaged` to `true` to ensure some VFs are reserved for host managed systems. With the value set to `false` the SR-IOV Network Operator manages and configures all allocated VFs.
+<9> Set `externallyManage` to `true` to ensure some virtual functions (VFs) are reserved for host managed systems. With the value set to `false` the SR-IOV Network Operator manages and configures all allocated VFs.
++
+[NOTE]
+====
+Before applying the policy, it is necessary to create the VFs first; otherwise, the webhook will obstruct the request.
+When the value is set to `false` the Operator creates and even resets the virtual functions if needed. Therefore to use VFs on the host system they must be created manually and `externallyManage` must be set to `true` so the Operator will not take any actions on the created VFs.
+====
 
 <10> The NIC selector identifies the device for the Operator to configure. You do not have to specify values for all the parameters. It is recommended to identify the network device with enough precision to avoid selecting a device unintentionally.
 +


### PR DESCRIPTION
[TELCODOCS-1002]:  [CNF-6356](https://issues.redhat.com//browse/CNF-6356) SR-IOV Network Operator alongside with host-reserved SR-IOV VFs

Version(s):
4.13 and main

Issue:
https://issues.redhat.com/browse/TELCODOCS-1188

Link to docs preview:
* https://55999--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html
* https://55999--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device.html#nw-sriov-networknodepolicy-object_configuring-sriov-device

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
