### PR TITLE
[enterprise-4.11] OSDOCS#5365: Fixed incorrect platform parameter

### DIFF
--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -29,7 +29,7 @@ controlPlane: <2> <3>
   hyperthreading: Enabled <4>
   name: master
   platform:
-    ibm-cloud: {}
+    ibmcloud: {}
   replicas: 3
 compute: <2> <3>
 - hyperthreading: Enabled <4>


### PR DESCRIPTION
This is a manual cherry pick for https://github.com/openshift/openshift-docs/pull/55978.

Cherry picked from commit id a7cd8752f507b4998a22b72853c91959e8a780f0.
