### PR TITLE
OCPBUGS-7229: OpenStack: Add load balancer Services limitations

### DIFF
--- a/modules/nw-osp-loadbalancer-etp-local.adoc
+++ b/modules/nw-osp-loadbalancer-etp-local.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+// * networking/nw-osp-loadbalancer-limitations.adoc
+
+:_content-type: CONCEPT
+[id="nw-osp-loadbalancer-etp-local_{context}"]
+= Local external traffic policies
+
+You can set the external traffic policy (ETP) parameter, `.spec.externalTrafficPolicy`, on a load balancer service to preserve the source IP address of incoming traffic when it reaches service endpoint pods. However, if your cluster uses the Amphora Octavia provider, the source IP of the traffic is replaced with the IP address of the Amphora VM. This behavior does not occur if your cluster uses the OVN Octavia provider.
+
+Having the `ETP` option set to `Local` requires that health monitors be created for the load balancer. Without health monitors, traffic can be routed to a node that doesn't have a functional endpoint, which causes the connection to drop. To force Cloud Provider OpenStack to create health monitors, you must set the value of the `create-monitor` option in the cloud provider configuration to `true`.
+
+In {rh-openstack} 16.1 and 16.2, the OVN Octavia provider does not support health monitors. Therefore, setting the ETP to local is unsupported.
+
+In {rh-openstack} 16.1 and 16.2, the Amphora Octavia provider does not support HTTP monitors on UDP pools. As a result, UDP load balancer services have `UDP-CONNECT` monitors created instead. Due to implementation details, this configuration only functions properly with the OVN-Kubernetes CNI plugin. When the OpenShift SDN CNI plugin is used, the UDP services alive nodes are detected unreliably.

--- a/modules/nw-osp-loadbalancer-limitations.adoc
+++ b/modules/nw-osp-loadbalancer-limitations.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+// * networking/load-balancing-openstack.adoc
+// For thinking and reviewing, adding to networking/load-balancing-openstack.adoc
+
+:_content-type: CONCEPT
+[id="nw-osp-loadbalancer-limitations_{context}"]
+= Limitations of load balancer services
+
+{product-title} clusters on {rh-openstack-first} use Octavia to handle load balancer services. As a result of this choice, such clusters have a number of functional limitations.
+
+{rh-openstack} Octavia has two supported providers: Amphora and OVN. These providers differ in terms of available features as well as implementation details. These distinctions affect load balancer services that are created on your cluster.

--- a/modules/nw-osp-loadbalancer-source-ranges.adoc
+++ b/modules/nw-osp-loadbalancer-source-ranges.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+// * networking/nw-osp-loadbalancer-limitations.adoc
+
+:_content-type: CONCEPT
+[id="nw-osp-loadbalancer-source-ranges_{context}"]
+= Load balancer source ranges
+
+Use the `.spec.loadBalancerSourceRanges` property to restrict the traffic that can pass through the load balancer according to source IP. This property is supported for use with the Amphora Octavia provider only. If your cluster uses the OVN Octavia provider, the option is ignored and traffic is unrestricted.

--- a/networking/load-balancing-openstack.adoc
+++ b/networking/load-balancing-openstack.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+include::modules/nw-osp-loadbalancer-limitations.adoc[leveloffset=+1]
+include::modules/nw-osp-loadbalancer-etp-local.adoc[leveloffset=+2]
+include::modules/nw-osp-loadbalancer-source-ranges.adoc[leveloffset=+2]
 include::modules/installation-osp-kuryr-octavia-upgrade.adoc[leveloffset=+1]
 include::modules/installation-osp-api-octavia.adoc[leveloffset=+1]
 include::modules/installation-osp-api-scaling.adoc[leveloffset=+2]


### PR DESCRIPTION
This commit adds information about a bunch of limitations related to OpenStack Octavia in various versions and how these limitations affect the load balancer Services in OpenShift.

Version(s):
4.12, 4.13, 4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-7229

QE review:
- [x] QE has approved this change.
