### PR TITLE
TELCODOCS-1179 fixing BGP communities doc bugs

### DIFF
--- a/modules/nw-metallb-community-cr.adoc
+++ b/modules/nw-metallb-community-cr.adoc
@@ -10,7 +10,7 @@ The `community` custom resource is a collection of aliases for communities. User
 
 [NOTE]
 ====
-The `community` CRD applies only to BGPAdvertisement. 
+The `community` CRD applies only to BGPAdvertisement.
 ====
 
 
@@ -33,9 +33,7 @@ Specify the same namespace that the MetalLB Operator uses.
 
 |`spec.communities`
 |`string`
-|Specifies a list of IP addresses for MetalLB to assign to services.
-You can specify multiple ranges in a single pool, they will all share the same settings.
-Specify each range in CIDR notation or as starting and ending IP addresses separated with a hyphen.
+|Specifies a list of BGP community aliases that can be used in BGPAdvertisements. A community alias consists of a pair of name (alias) and value (number:number). Link the BGPAdvertisement to a community alias by referring to the alias name in its `spec.communities` field.
 
 |===
 

--- a/modules/nw-metallb-configure-community-bgp-advertisement.adoc
+++ b/modules/nw-metallb-configure-community-bgp-advertisement.adoc
@@ -43,7 +43,7 @@ spec:
 $ oc apply -f ipaddresspool.yaml
 ----
 
-. Create a community alias named `community1`. 
+. Create a community alias named `community1`.
 +
 [source,yaml]
 ----
@@ -55,10 +55,10 @@ metadata:
 spec:
   communities:
     - name: NO_ADVERTISE
-    - value: '65535:65282'
+      value: '65535:65282'
 ----
 
-. Create a BGP peer named `doc-example-bgp-peer`. 
+. Create a BGP peer named `doc-example-bgp-peer`.
 
 .. Create a file, such as `bgppeer.yaml`, with content like the following example:
 +
@@ -98,12 +98,14 @@ spec:
   aggregationLength: 32
   aggregationLengthV6: 128
   communities:
-    - community1
+    - NO_ADVERTISE <1>
   ipAddressPools:
     - doc-example-bgp-community
   peers:
     - doc-example-peer
 ----
++
+<1> Specify the `CommunityAlias.name` here and not the community custom resource (CR) name.
 
 .. Apply the configuration:
 +


### PR DESCRIPTION
[TELCODOCS-1179 ]: Various documentation issues with BGP communities

Version(s):
4.13, 4.12 and main
Issue:
https://issues.redhat.com/browse/TELCODOCS-1179
Link to docs preview:
* https://56005--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-community-alias.html#nw-metallb-community-cr_configure-community-alias
* https://56005--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-community-alias.html#nw-metallb-configure-BGP-advertisement-community-alias_configure-community-alias

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
