### PR TITLE
OSDOCS-4032: Agent based installer on ARM

### DIFF
--- a/modules/installing-ocp-agent.adoc
+++ b/modules/installing-ocp-agent.adoc
@@ -51,38 +51,39 @@ cat << EOF > ./my-cluster/install-config.yaml
 apiVersion: v1
 baseDomain: test.example.com
 compute:
-- architecture: amd64
+  architecture: amd64 <1>
   hyperthreading: Enabled
   name: worker
   replicas: 0
 controlPlane:
-  architecture: amd64
+  architecture: amd64  
   hyperthreading: Enabled
   name: master
   replicas: 1
 metadata:
-  name: sno-cluster <1>
+  name: sno-cluster <2>
 networking:
   clusterNetwork:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.111.0/16
-  networkType: OVNKubernetes <2>
+  networkType: OVNKubernetes <3>
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   none: {}
-pullSecret: '<pull_secret>' <3>
+pullSecret: '<pull_secret>' <4>
 sshKey: |
-  '<ssh_pub_key>' <4>
+  '<ssh_pub_key>' <5>
   EOF
 ----
 +
-<1> Required.
-<2> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
-<3> Enter your pull secret.
-<4> Enter your ssh public key.
+<1> Specify the system architecture, valid values are `amd64` and `arm64`.
+<2> Required. Specify your cluster name. 
+<3> State the cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
+<4> Specify your pull secret.
+<5> Specify your ssh public key.
 
 +
 [NOTE]
@@ -180,7 +181,7 @@ $ openshift-install --dir <install_directory> agent create image
 +
 NOTE: Red Hat Enterprise Linux CoreOS (RHCOS) supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Multipathing is enabled by default in the agent ISO image, with a default `/etc/multipath.conf` configuration.
 
-. Boot the `agent.x86_64.iso` image on the bare metal machines.
+. Boot the `agent.x86_64.iso` or `agent.aarch64.iso` image on the bare metal machines.
 
 . Optional: To know when the bootstrap host (which is the rendezvous host) reboots, run the following command:
 

--- a/modules/sample-ztp-custom-resources.adoc
+++ b/modules/sample-ztp-custom-resources.adoc
@@ -89,6 +89,7 @@ spec:
   clusterRef:
     name: ostest
     namespace: cluster0
+  cpuArchitecture: aarch64
   pullSecretRef:
     name: pull-secret
   sshAuthorizedKey: <YOUR_SSH_PUBLIC_KEY>


### PR DESCRIPTION
**For Version:** 4.13+
**Issue:** [OSDOCS-4032](https://issues.redhat.com//browse/OSDOCS-4032)

**Description:** Documents updates to agent install for ARM64 support

**Preview:** 
- [Installing OpenShift Container Platform with Agent based installer](https://56007--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#installing-ocp-agent_installing-with-agent-based-installer)

**QE review:** 
- [x] QE approval  