### PR TITLE
Testing mixed caps in anchor ID

### DIFF
--- a/modules/virt-runbook-kubevirtcomponentexceedsrequestedcpu.adoc
+++ b/modules/virt-runbook-kubevirtcomponentexceedsrequestedcpu.adoc
@@ -4,7 +4,7 @@
 // * virt/logging_events_monitoring/virt-runbooks.adoc
 
 :_content-type: REFERENCE
-[id="virt-runbook-kubevirtcomponentexceedsrequestedcpu_{context}"]
+[id="virt-runbook-KubeVirtComponentExceedsRequestedCPU"]
 = KubeVirtComponentExceedsRequestedCPU
 
 [discrete]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56009--docspreview.netlify.app/openshift-enterprise/latest/virt/logging_events_monitoring/virt-runbooks.html#virt-runbook-KubeVirtComponentExceedsRequestedCPU
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA

Additional information: This is a test to see whether runbook modules can have uppercase letters in the main anchor ID and no context tag. 

The reason is so that the CNV monitoring team does not have to rename all their runbooks, since they use a simple string substitution (runbook name -> path) when creating URLs to downstream docs in the web console.
