### PR TITLE
OSDOCS-4968: updating graph data image source

### DIFF
--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -15,9 +15,9 @@ The OpenShift Update Service requires a graph-data container image, from which t
 ----
 FROM registry.access.redhat.com/ubi8/ubi:8.1
 
-RUN curl -L -o cincinnati-graph-data.tar.gz https://github.com/openshift/cincinnati-graph-data/archive/master.tar.gz
+RUN curl -L -o cincinnati-graph-data.tar.gz https://api.openshift.com/api/upgrades_info/graph-data
 
-CMD exec /bin/bash -c "tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati/graph-data/ --strip-components=1"
+CMD exec /bin/bash -c "tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati/graph-data/"
 ----
 
 . Use the docker file created in the above step to build a graph-data container image, for example, `registry.example.com/openshift/graph-data:latest`:


### PR DESCRIPTION
[OSDOCS-4968](https://issues.redhat.com/browse/OSDOCS-4968)

Versions 4.9+

This PR changes the documentation to direct users to retrieve their graph data container images from a new API endpoint on the OpenShift domain, rather than from github.

QE review:
- [ ] QE has approved this change.

**Current documentation**: https://docs.openshift.com/container-platform/4.12/updating/updating-restricted-network-cluster/restricted-network-update-osus.html#update-service-graph-data_updating-restricted-network-cluster-osus

**Preview**: https://56022--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/restricted-network-update-osus.html#update-service-graph-data_updating-restricted-network-cluster-osus