### PR TITLE
Correct the incorrect version for ServiceMeshControlPlane CR.

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -134,7 +134,7 @@ endif::[]
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
 :SMProductVersion: 2.3.1
-:MaistraVersion: 2.3.1
+:MaistraVersion: 2.3
 //Service Mesh v1
 :SMProductVersion1x: 1.1.18.2
 //Windows containers


### PR DESCRIPTION
Resolves #55442. The version in the SMCP is incorrect which causes problems in the installation. This change should
help to improve the documentation.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12
4.11
4.10

<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://github.com/openshift/openshift-docs/issues/55442

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
