### PR TITLE
Adding additional feedback to netobserv release note

### DIFF
--- a/networking/network_observability/network-observability-operator-release-notes.adoc
+++ b/networking/network_observability/network-observability-operator-release-notes.adoc
@@ -25,5 +25,4 @@ The Network Observability Operator is now stable and the release channel is upgr
 [id="network-observability-operator-1.1.0-bug-fixes"]
 === Bug fix
 
-* Previously, unless the Loki `authToken` configuration was set to `FORWARD` mode, authentication was no longer enforced, allowing any user who could connect to the {product-title} console in an {product-title} cluster to retrieve flows without authentication.
-Now, regardless of the Loki `authToken` mode, only cluster administrators can retrieve flows. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2169468[*BZ#2169468*])
+* Previously, when the Loki `authToken` configuration was set to `HOST` mode, user authentication was not enforced. This allowed anyone who could connect to the {product-title} console in an {product-title} cluster to retrieve flows. User authentication was only enforced if the `authToken` configuration was set to `FORWARD`. Now, if Loki `authToken` mode is set to `FORWARD` or `HOST`, only cluster administrators can retrieve flows. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2169468[*BZ#2169468*])


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
Incorporating post-merge feedback about the release note. These are minor but important details:
 
* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.10+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5366
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
There was a [comment](https://github.com/openshift/openshift-docs/pull/55951#issuecomment-1433601429) from @stleerh that came in right at time of merge that had some minor yet important details that need addressing. His Slack message to me with context about his comment:
- Previously, HOST was doing only host authentication and not user authentication.
- "allowing any user" to "allowing anyone" because you don't even have to be logged in as a user.  It may still not be that obvious when we speak of a "user".
- "Now, regardless of the Loki authToken mode," -> There's a third choice which is DISABLED (default value) that will prevent even a cluster admin from getting flows because it's not providing a token.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
