### PR TITLE
OSDOCS-5379: Defining cv condition types/updating condition type doc (4.9)

### DIFF
--- a/modules/determining-upgrade-viability-conditiontype.adoc
+++ b/modules/determining-upgrade-viability-conditiontype.adoc
@@ -3,10 +3,10 @@
 // * updating/index.adoc
 
 :_content-type: CONCEPT
-[id="Understanding_clusteroperator_conditiontypes_{context}"]
+[id="understanding-clusteroperator-conditiontypes_{context}"]
 = Understanding cluster Operator condition types
 
-The status of cluster Operators includes their condition type, informing you of the current state of your Operator's health. The following definitions cover a list of some common ClusterOperator condition types. Operators that have additional condition types and use Operator-specific language have been omitted. 
+The status of cluster Operators includes their condition type, which informs you of the current state of your Operator's health. The following definitions cover a list of some common ClusterOperator condition types. Operators that have additional condition types and use Operator-specific language have been omitted. 
 
 The Cluster Version Operator (CVO) is responsible for collecting the status conditions from cluster Operators so that cluster administrators can better understand the state of the {product-title} cluster.
 
@@ -19,18 +19,18 @@ The Cluster Version Operator (CVO) is responsible for collecting the status cond
 
 
 * Available: 
-An Operator with the condition type `Available` is functional and available in the cluster. If the status is `False`, at least one part of the operand is non-functional and the condition requires an administrator to intervene.
+The condition type `Available` indicates that an Operator is functional and available in the cluster. If the status is `False`, at least one part of the operand is non-functional and the condition requires an administrator to intervene.
 
 * Progressing:
-An Operator with the condition type `Progressing` is actively rolling out new code, propagating configuration changes, or otherwise moving from one steady state to another. 
+The condition type `Progressing` indicates that an Operator is actively rolling out new code, propagating configuration changes, or otherwise moving from one steady state to another. 
 +
-Operators do not report the condition type `Progressing` as `True` when they are reconciling a previous known state. If the observed cluster state has changed and the Operator is reacting to it, then the status will report back as `True`, since it is moving from one steady state to another.
+Operators do not report the condition type `Progressing` as `True` when they are reconciling a previous known state. If the observed cluster state has changed and the Operator is reacting to it, then the status reports back as `True`, since it is moving from one steady state to another.
 +
 * Degraded:
-An Operator with the condition type `Degraded` has a current state that does not match the required state over a period of time. The period of time can vary by component, but a `Degraded` state represents persistent observation of an Operator's condition.  As a result, an Operator will not fluctuate in and out of the `Degraded` state.  
+The condition type `Degraded` indicates that an Operator has a current state that does not match its required state over a period of time. The period of time can vary by component, but a `Degraded` status represents persistent observation of an Operator's condition.  As a result, an Operator does not fluctuate in and out of the `Degraded` state.  
 +
 There might be a different condition type if the transition from one state to another does not persist over a long enough period to report `Degraded`.  
-An Operator will not report `Degraded` during the course of a normal upgrade.  An Operator may report `Degraded` in response to a persistent infrastructure failure that requires eventual administrator intervention.
+An Operator does not report `Degraded` during the course of a normal upgrade.  An Operator may report `Degraded` in response to a persistent infrastructure failure that requires eventual administrator intervention.
 +
 [NOTE]
 ====

--- a/modules/determining-upgrade-viability-cv-conditiontype.adoc
+++ b/modules/determining-upgrade-viability-cv-conditiontype.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * updating/index.adoc
+
+:_content-type: CONCEPT
+[id="understanding-clusterversion-conditiontypes_{context}"]
+= Understanding cluster version condition types
+ 
+The Cluster Version Operator (CVO) monitors cluster Operators and other components, and is responsible for collecting the status of both the cluster version and its Operators. This status includes the condition type, which informs you of the health and current state of the {product-title} cluster.
+
+In addition to `Available`, `Progressing`, and `Upgradeable`, there are condition types that affect cluster versions and Operators.
+
+* Failing: 
+The cluster version condition type `Failing` indicates that a cluster cannot reach its desired state, is unhealthy, and requires an administrator to intervene.
+* Invalid:
+The cluster version condition type `Invalid` indicates that the cluster version has an error that prevents the server from taking action. The CVO only reconciles the current state as long as this condition is set.
+* RetrievedUpdates:
+The cluster version condition type `RetrievedUpdates` indicates whether or not available updates have been retrieved from the upstream update server. The condition is `Unknown` before retrieval, `False` if the updates either recently failed or could not be retrieved, or `True` if the `availableUpdates` field is both recent and accurate.
+
+
+
+

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -23,6 +23,8 @@ xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgra
 
 include::modules/determining-upgrade-viability-conditiontype.adoc[leveloffset=+1]
 
+include::modules/determining-upgrade-viability-cv-conditiontype.adoc[leveloffset=+1]
+
 [id="updating-clusters-overview-prepare-eus-to-eus-update"]
 == Preparing to perform an EUS-to-EUS update
 xref:../updating/preparing-eus-eus-upgrade.adoc#preparing-eus-eus-upgrade[Preparing to perform an EUS-to-EUS update]: Due to fundamental Kubernetes design, all {product-title} updates between minor versions must be serialized. You must update from {product-title} 4.8 to 4.9, and then to 4.10. You cannot update from {product-title} 4.8 to 4.10 directly. However, if you want to update between two Extended Update Support (EUS) versions, you can do so by incurring only a single reboot of non-control plane hosts. For more information, see the following:


### PR DESCRIPTION
Adding additional content based on https://github.com/openshift/openshift-docs/pull/54165#discussion_r1090890526. Covering cluster version condition types and modifying cluster operator condition types. New condition types include Failing, Invalid, and RetrievedUpdates.

Version(s):
4.9 only

Issue:
https://issues.redhat.com/browse/OSDOCS-5379

Link to docs preview:
https://56042--docspreview.netlify.app/openshift-enterprise/latest/updating/index.html#Understanding_clusterversion_conditiontypes_updating-clusters-overview

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
