### PR TITLE
BZ2112254: corrects the CR

### DIFF
--- a/modules/ephemeral-storage-sharing-configmaps-across-namespaces.adoc
+++ b/modules/ephemeral-storage-sharing-configmaps-across-namespaces.adoc
@@ -27,7 +27,7 @@ kind: SharedConfigMap
 metadata:
   name: my-share
 spec:
-  secretRef:
+  configMapRef:
     name: <name of configmap>
     namespace: <namespace of configmap>
 EOF


### PR DESCRIPTION
- Applies to 4.10 and above versions( this content is not there in 4.9)
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2112254)
- [Preview](https://56054--docspreview.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/ephemeral-storage-shared-resource-csi-driver-operator.html#ephemeral-storage-sharing-configmaps-across-namespaces_ephemeral-storage-shared-resource-csi-driver-operator)
- @skeeey ptal