### PR TITLE
OCPBUGS#7176: Add toleration value as reserved

### DIFF
--- a/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
+++ b/modules/binding-infra-node-workloads-using-taints-tolerations.adoc
@@ -46,14 +46,14 @@ This example shows that the node has a taint. You can proceed with adding a tole
 + 
 [source,terminal]
 ----
-$ oc adm taint nodes <node_name> <key>:<effect>
+$ oc adm taint nodes <node_name> <key>=<value>:<effect>
 ----
 +
 For example:
 +
 [source,terminal]
 ----
-$ oc adm taint nodes node1 node-role.kubernetes.io/infra:NoSchedule
+$ oc adm taint nodes node1 node-role.kubernetes.io/infra=reserved:NoExecute
 ----
 +
 [TIP]
@@ -71,7 +71,8 @@ metadata:
 spec:
   taints:
     - key: node-role.kubernetes.io/infra
-      effect: NoSchedule
+      effect: NoExecute
+      value: reserved
   ...
 ----
 ====
@@ -88,13 +89,15 @@ If a descheduler is used, pods violating node taints could be evicted from the c
 [source,yaml]
 ----
 tolerations:
-  - effect: NoSchedule <1>
+  - effect: NoExecute <1>
     key: node-role.kubernetes.io/infra <2>
     operator: Exists <3>
+    value: reserved <4>
 ----
 <1> Specify the effect that you added to the node.
 <2> Specify the key that you added to the node.
 <3> Specify the `Exists` Operator to require a taint with the key `node-role.kubernetes.io/infra` to be present on the node.
+<4> Specify the value of the key-value pair taint that you added to the node.
 +
 This toleration matches the taint created by the `oc adm taint` command. A pod with this toleration can be scheduled onto the infra node.
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> ---> Add toleration value as `reserved`

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-7176
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56055--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#binding-infra-node-workloads-using-taints-tolerations_creating-infrastructure-machinesets
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
