### PR TITLE
[RHACS] ROX13809 Adding 3 missing roles to System Role documentation

### DIFF
--- a/modules/rbac-system-roles-3630.adoc
+++ b/modules/rbac-system-roles-3630.adoc
@@ -1,12 +1,12 @@
 // Module included in the following assemblies:
 //
 // * operating/manage-role-based-access-control.adoc
-:_module-type: CONCEPT
+:_content-type: CONCEPT
 [id="rbac-system-roles-3630_{context}"]
 = System roles
 
 [role="_abstract"]
-{product-title} includes some default system roles that you can apply to users when you create rules.
+{rh-rhacs-first} includes some default system roles that you can apply to users when you create rules.
 You can also create custom roles as required.
 
 [cols="1,3"]
@@ -27,8 +27,18 @@ You can also create custom roles as required.
 You can set this role as the minimum access role for all users.
 
 | *Sensor Creator*
-| {product-title} uses this role to automate new cluster setups. It includes the permission set to create Sensors in secured clusters.
+| {product-title-short} uses this role to automate new cluster setups. It includes the permission set to create Sensors in secured clusters.
 
 | *Scope Manager*
 | This role includes the minimum permissions required to create and modify access scopes.
+
+| *Vulnerability Management Approver* 
+| This role allows you to provide access to approve vulnerability deferrals or false positive requests.
+
+| *Vulnerability Management Requester* 
+| This role allows you to provide access to request vulnerability deferrals or false positives.
+
+| *Vulnerability Report Creator* 
+| This role allows you to create and manage vulnerability reporting configurations for scheduled vulnerability reports.
+
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
3.72+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-13809
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://56062--docspreview.netlify.app/openshift-acs/latest/operating/manage-user-access/manage-role-based-access-control-3630.html#rbac-system-roles-3630_manage-role-based-access-control
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Merge into `rhacs-docs` and cherry-pick into:
- `rhacs-docs-3.74`
- `rhacs-docs-3.73`
- `rhacs-docs-3.72`
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
