### PR TITLE
OCPBUGS#7196: Add correct access points limit

### DIFF
--- a/modules/persistent-storage-csi-dynamic-provisioning-aws-efs.adoc
+++ b/modules/persistent-storage-csi-dynamic-provisioning-aws-efs.adoc
@@ -10,7 +10,7 @@
 
 [role="_abstract"]
 The AWS EFS CSI Driver supports a different form of dynamic provisioning than other CSI drivers. It provisions new PVs as subdirectories of a pre-existing EFS volume. The PVs are independent of each other. However, they all share the same EFS volume. When the volume is deleted, all PVs provisioned out of it are deleted too.
-The EFS CSI driver creates an AWS Access Point for each such subdirectory. Due to AWS AccessPoint limits, you can only dynamically provision 120 PVs from a single `StorageClass`/EFS volume.
+The EFS CSI driver creates an AWS Access Point for each such subdirectory. Due to AWS AccessPoint limits, you can only dynamically provision 1000 PVs from a single `StorageClass`/EFS volume.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> ---> On January 17th 2023, Amazon Elastic File System (Amazon EFS) has increased the maximum number of Access Points per file system from 120 to 1,000. This PR updates the correct access points limit

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-7196
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56067--docspreview.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs#csi-dynamic-provisioning-aws-efs_persistent-storage-csi-aws-efs
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
