### PR TITLE
Fix attr block that causes vale to barf

### DIFF
--- a/modules/ipi-install-preparing-the-bare-metal-node.adoc
+++ b/modules/ipi-install-preparing-the-bare-metal-node.adoc
@@ -117,7 +117,7 @@ spec:
 <3> Add the NMState YAML syntax to configure the host interfaces.
 <4> Optional: If you have configured the network interface with `nmstate`, and you want to disable an interface, set `state: up` with the IP addresses set to `enabled: false` as shown:
 +
-[source,yaml,]
+[source,yaml]
 ----
 ---
    interfaces:


### PR DESCRIPTION
Fixes asciidoc error that causes https://github.com/errata-ai/vale/issues/573

Version(s):
main, enterprise-4.12, enterprise-4.13 

Issue:
No BZ/OCPBUGS

Link to docs preview:
https://docs.openshift.com/container-platform/4.11/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#preparing-the-bare-metal-node_ipi-install-expanding

QE review:
Not required, typo fix
