### PR TITLE
RHDEVDOCS-4340-document-scrape-profiles-in-CMO

### DIFF
--- a/modules/monitoring-choosing-a-metrics-collection-profile.adoc
+++ b/modules/monitoring-choosing-a-metrics-collection-profile.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: PROCEDURE
+[id="choosing-a-metrics-collection-profile_{context}"]
+= Choosing a metrics collection profile
+
+To choose a metrics collection profile for core {product-title} monitoring components, edit the `cluster-monitoring-config` `ConfigMap` object.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have enabled Technology Preview features by using the `FeatureGate` custom resource (CR).
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+[WARNING]
+====
+Saving changes to a monitoring config map might restart monitoring processes and redeploy the pods and other resources in the related project.
+The running monitoring processes in that project might also restart.
+====
+
+.Procedure
+
+. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+----
+
+. Add the metrics collection profile setting under `data/config.yaml/prometheusK8s`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      collectionProfile: <metrics_collection_profile_name> <1>
+----
++
+<1> The name of the metrics collection profile.
+The available values are `full` or `minimal`. 
+If you do not specify a value or if the `collectionProfile` key name does not exist in the config map, the default setting of `full` is used.
++
+The following example sets the metrics collection profile to `minimal` for the core platform instance of Prometheus:
++
+[source,yaml,subs=quotes]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    prometheusK8s:
+      collectionProfile: *minimal*
+----
+
+. Save the file to apply the changes. The pods affected by the new configuration restart automatically.

--- a/modules/monitoring-configuring-metrics-collection-profiles.adoc
+++ b/modules/monitoring-configuring-metrics-collection-profiles.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: CONCEPT
+[id="configuring-metrics-collection-profiles_{context}"]
+= Configuring metrics collection profiles
+ 
+[IMPORTANT]
+====
+[subs="attributes+"]
+Using a metrics collection profile is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+Red Hat does not recommend using them in production. 
+These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview[https://access.redhat.com/support/offerings/techpreview].
+====
+
+By default, Prometheus collects metrics exposed by all default metrics targets in {product-title} components. 
+However, you might want Prometheus to collect fewer metrics from a cluster in certain scenarios:
+
+* If cluster administrators require only alert, telemetry, and console metrics and do not require other metrics to be available.
+* If a cluster increases in size, and the increased size of the default metrics data collected now requires a significant increase in CPU and memory resources. 
+
+You can use a metrics collection profile to collect either the default amount of metrics data or a minimal amount of metrics data. 
+When you collect minimal metrics data, basic monitoring features such as alerting continue to work.
+At the same time, the CPU and memory resources required by Prometheus decrease.
+
+[id="about-metrics-collection-profiles_{context}"]
+== About metrics collection profiles
+
+You can enable one of two metrics collection profiles:
+
+* *full*: Prometheus collects metrics data exposed by all platform components. This setting is the default.
+* *minimal*: Prometheus collects only the metrics data required for platform alerts, recording rules, telemetry, and console dashboards.

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -116,6 +116,16 @@ include::modules/monitoring-creating-cluster-id-labels-for-metrics.adoc[leveloff
 
 * For details about write relabel configuration, see xref:../monitoring/configuring-the-monitoring-stack.adoc#configuring_remote_write_storage_configuring-the-monitoring-stack[Configuring remote write storage].
 
+// Configuring metrics collection profiles
+include::modules/monitoring-configuring-metrics-collection-profiles.adoc[leveloffset=+1]
+include::modules/monitoring-choosing-a-metrics-collection-profile.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../monitoring/managing-metrics.adoc#viewing-a-list-of-available-metrics_managing-metrics[Viewing a list of available metrics] for steps to view a list of metrics being collected for a cluster.
+* See xref:../nodes/clusters/nodes-cluster-enabling-features.adoc[Enabling features using feature gates] for steps to enable Technology Preview features. 
+
 // Managing scrape sample limits for user-defined projects
 include::modules/monitoring-limiting-scrape-samples-in-user-defined-projects.adoc[leveloffset=+1]
 include::modules/monitoring-setting-scrape-sample-and-label-limits-for-user-defined-projects.adoc[leveloffset=+2]


### PR DESCRIPTION
Summary: This PR documents the TP feature that enables users to enable metrics collection profiles (aka "scrape profiles") for the OCP monitoring stack.

- Aligned team: DevTools
- For branches: 4.13+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4340
- Direct link to doc preview: https://56073--docspreview.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#configuring-metrics-collection-profiles_configuring-the-monitoring-stack
- SME review: @JoaoBraveCoding 
- QE review: @juzhao 
- Peer review: @Srivaralakshmi 