### PR TITLE
RHDEVDOCS-4899-fix-oc-command-syntax-in-enable-query-logging

### DIFF
--- a/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
+++ b/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
@@ -71,7 +71,7 @@ $ oc -n openshift-monitoring get pods
 +
 [source,terminal]
 ----
-$ token=`oc sa get-token prometheus-k8s -n openshift-monitoring`
+$ token=`oc create token prometheus-k8s -n openshift-monitoring`
 $ oc -n openshift-monitoring exec -c prometheus prometheus-k8s-0 -- curl -k -H "Authorization: Bearer $token" 'https://thanos-querier.openshift-monitoring.svc:9091/api/v1/query?query=cluster_version'
 ----
 . Run the following command to read the query log:


### PR DESCRIPTION
Summary: This PR fixes some incorrect command syntax in a procedure for enabling query logging for Thanos Querier.

- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4899
- Direct link to doc preview: https://56075--docspreview.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#enabling-query-logging-for-thanos-querier_configuring-the-monitoring-stack
- SME review: @ tbd
- QE review: @juzhao 
- Peer review: @rh-tokeefe 