### PR TITLE
CNV-22364: Add note to "Expose port as service" section

### DIFF
--- a/modules/virt-about-services.adoc
+++ b/modules/virt-about-services.adoc
@@ -6,14 +6,16 @@
 [id="virt-about-services_{context}"]
 = About services
 
-A Kubernetes _service_ is an abstract way to expose an application running on a set of pods as a network service. Services allow your applications to receive traffic. Services can be exposed in different ways by specifying a `spec.type` in the `Service` object:
+A Kubernetes _service_ exposes network access for clients to an application running on a set of pods. Services offer abstraction, load balancing, and, in the case of NodePort and LoadBalancer, exposure to the outside world. 
 
-ClusterIP:: Exposes the service on an internal IP address within the cluster. `ClusterIP` is the default service `type`.
+Services can be exposed in different ways by specifying a `spec.type` in the `Service` object:
+
+ClusterIP:: Exposes the service on an internal IP address and as a DNS name to other applications within the cluster. A single service can map to multiple virtual machines. When a client tries to connect to the service, the client's request is load balanced among available backends. `ClusterIP` is the default service `type`.
 
 NodePort:: Exposes the service on the same port of each selected node in the cluster. `NodePort` makes a service accessible from outside the cluster.
 
 LoadBalancer:: Creates an external load balancer in the current cloud (if supported) and assigns a fixed, external IP address to the service.
-+
+
 [NOTE]
 ====
 For on-premise clusters, you can configure a load balancing service by using the MetalLB Operator in layer 2 mode. The BGP mode is not supported. The MetalLB Operator is installed in the `metallb-system` namespace.


### PR DESCRIPTION
Version(s): 4.13


Issue:  [CNV-22364](https://issues.redhat.com/browse/CNV-22364)


Link to docs preview: https://56089--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-creating-service-vm.html


QE review:
- [x] QE has approved this change.
