### PR TITLE
Revert "[OSDOCS-5346] : Fix Broken Links"

### DIFF
--- a/ocm/ocm-overview.adoc
+++ b/ocm/ocm-overview.adoc
@@ -61,6 +61,6 @@ include::modules/ocm-settings-tab.adoc[leveloffset=+2]
 
 * For the complete documentation for {cluster-manager}, see link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2022/html-single/managing_clusters/index[{cluster-manager} documentation].
 ifdef::openshift-dedicated,openshift-rosa[]
-* For steps to add cluster notification contacts, see xref:../logging/sd-accessing-the-service-logs.adoc#adding-cluster-notification-contacts[Adding cluster notification contacts].
+* For steps to add cluster notification contacts, see xref:../logging/sd-accessing-the-service-logs.adoc#adding-cluster-notification-contacts_sd-accessing-the-service-logs[Adding cluster notification contacts].
 endif::[]
 


### PR DESCRIPTION
Reverts openshift/openshift-docs#56076

Mistakenly merged, thinking it would fix a broken link in Customer Portal. I did not cherry-pick it to Enterprise 4.12 and 4.13, so this just needs to be fixed for `main` 