### PR TITLE
OSDOCS-3790:CSI driver vol detach w/ non-graceful node shutdown

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1502,6 +1502,8 @@ Topics:
     File: persistent-storage-csi-cloning
   - Name: CSI automatic migration
     File: persistent-storage-csi-migration
+  - Name: Detach CSI volumes after non-graceful node shutdown
+    File: persistent-storage-csi-vol-detach-non-graceful-shutdown
   - Name: AliCloud Disk CSI Driver Operator
     File: persistent-storage-csi-alicloud-disk
   - Name: AWS Elastic Block Store CSI Driver Operator

--- a/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-overview.adoc
+++ b/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-overview.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
+//
+
+:_content-type: CONCEPT
+[id="persistent-storage-csi-vol-detach-non-graceful-overview_{context}"]
+= Overview
+
+A graceful node shutdown occurs when the kubelet's node shutdown manager detects the upcoming node shutdown action. Non-graceful shutdowns occur when the kubelet does not detect a node shutdown action, which can occur because of system or hardware failures. Also, the kubelet may not detect a node shutdown action when the shutdown command does not trigger the Inhibitor Locks mechanism used by the kubelet on Linux, or because of a user error, for example, if the shutdownGracePeriod and shutdownGracePeriodCriticalPods details are not configured correctly for that node.
+
+With this feature, when a non-graceful node shutdown occurs, you can manually add an `out-of-service` taint on the node to allow volumes to automatically detach from the node. 

--- a/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
+++ b/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * storage/container_storage_interface/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
+//
+
+:_content-type: PROCEDURE
+[id="persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure_{context}"]
+= Adding an out-of-service taint manually for automatic volume detachment
+
+.Prerequisites
+
+* Access to the cluster with cluster-admin privileges.
+
+.Procedure
+
+To allow volumes to detach automatically from a node after a non-graceful node shutdown:
+
+. After a node is detected as unhealthy, shut down the worker node.
+
+. Ensure that the node is shutdown by running the following command and checking the status:
++
+[source, terminal]
+----
+oc get node <node name> <1>
+----
+<1> <node name> = name of the non-gracefully shutdown node
+
+. Taint the corresponding node object by running the following command:
++
+[source, terminal]
+----
+oc adm taint node <node name> node.kubernetes.io/out-of-service=nodeshutdown:NoExecute <1>
+----
+<1> <node name> = name of the non-gracefully shutdown node
++
+After the taint is applied, the volumes detach from the shutdown node allowing their disks to be attached to a different node.
++
+.Example
++
+The resulting YAML file resembles the following:
++
+[source, yaml]
+----
+spec:
+  taints:
+  - effect: NoExecute
+    key: node.kubernetes.io/out-of-service
+    value: nodeshutdown
+----
+
+. Restart the node.
+
+. Remove the taint.

--- a/storage/container_storage_interface/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vol-detach-non-graceful-shutdown.adoc
@@ -1,0 +1,16 @@
+:_content-type: ASSEMBLY
+[id="ephemeral-storage-csi-vol-detach-non-graceful-shutdown"]
+= Detach CSI volumes after non-graceful node shutdown
+include::_attributes/common-attributes.adoc[]
+:context: ephemeral-storage-csi-vol-detach-non-graceful-shutdown
+
+toc::[]
+
+This feature allows Container Storage Interface (CSI) drivers to automatically detach volumes when a node goes down non-gracefully.
+
+:FeatureName: Detach CSI volumes after non-graceful node shutdown
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-overview.adoc[leveloffset=+1]
+
+include::modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/STOR-744
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56093--docspreview.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-vol-detach-non-graceful-shutdown.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**PTAL**: @jsafrane, @radeore, @gcharot
