### PR TITLE
Adds oc describe enhancement release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -73,6 +73,11 @@ With this enhancement, users can set the `--import-mode` flag to `Legacy` or `Pr
 
 //Insert reference for feature procedure
 
+[id="ocp-4-13-oc-describe-enhancement"]
+==== Returning os/arch and digests of an image
+
+With {product-title} {product-version}, running `oc describe` on an image now returns os/arch and digests of each manifest.
+
 [id="ocp-4-13-ibm-z"]
 === IBM Z and LinuxONE
 


### PR DESCRIPTION
Adds `oc describe` enhancement to 4.13 release notes. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5397

Link to docs preview:
https://56108--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-oc

QE not needed. 

x2 SME acks received in DMs (Flavian Carlette and Dominik Werle) 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
