### PR TITLE
OCPBUGS#6828: Correct the RHEL versions

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -10,7 +10,7 @@ After you update your cluster, you must update the {op-system-base-full} compute
 
 [IMPORTANT]
 ====
-{op-system-base-full} version 7.9 and version 8.4 is supported for {op-system-base} worker (compute) machines.
+{op-system-base-full} version 8.4 and version 8.5 is supported for {op-system-base} worker (compute) machines.
 ====
 
 You can also update your compute machines to another minor version of {product-title} if you are using {op-system-base} as the operating system. You do not need to exclude any RPM packages from {op-system-base} when performing a minor version update.


### PR DESCRIPTION
Correct the supported RHEL versions

Version(s): 4.9 only

Issue: https://issues.redhat.com/browse/OCPBUGS-6828

Link to docs preview: https://56114--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-rhel-compute.html#rhel-compute-updating-minor_updating-cluster-rhel-compute

QE review: @gpei

  - [x]  QE has approved this change.

Additional information: