### PR TITLE
OSDOCS-5022:Added missing step for Selecting an AMI section

### DIFF
--- a/modules/installation-azure-marketplace-subscribe.adoc
+++ b/modules/installation-azure-marketplace-subscribe.adoc
@@ -129,7 +129,39 @@ ifdef::ipi[]
 . Record the image details of your offer. You must update the `compute` section in the `install-config.yaml` file with values for `publisher`, `offer`, `sku`, and `version` before deploying the cluster.
 endif::ipi[]
 ifdef::upi[]
-. Record the image details of your offer. If you use the Azure Resource Manager (ARM) template to deploy your worker nodes, you can update `storageProfile.imageReference` by deleting the `id` parameter and adding the `offer`, `publisher`, `sku`, and `version` parameters using the values from your offer.
+. Record the image details of your offer. If you use the Azure Resource Manager (ARM) template to deploy your worker nodes:
++
+.. Update `storageProfile.imageReference` by deleting the `id` parameter and adding the `offer`, `publisher`, `sku`, and `version` parameters by using the values from your offer.
+.. Specify a `plan` for the virtual machines (VMs). 
++
+.Example `06_workers.json` ARM template with an updated `storageProfile.imageReference` object and a specified `plan` 
++
+[source,json,subs="none"]
+----
+...
+  "plan" : {
+    "name": "rh-ocp-worker",
+    "product": "rh-ocp-worker",
+    "publisher": "redhat"
+  },
+  "dependsOn" : [
+    "[concat('Microsoft.Network/networkInterfaces/', concat(variables('vmNames')[copyIndex()], '-nic'))]"
+  ],
+  "properties" : {
+...
+  "storageProfile": {
+    "imageReference": {
+    "offer": "rh-ocp-worker",
+    "publisher": "redhat",
+    "sku": "rh-ocp-worker",
+    "version": "4.8.2021122100"
+    }
+    ...
+   }
+...
+  }
+----
+
 endif::upi[]
 ifdef::mapi[]
 . Record the image details of your offer, specifically the values for `publisher`, `offer`, `sku`, and `version`.


### PR DESCRIPTION
Version(s):
4.10+

Issue:
[OSDOCS-5022](https://issues.redhat.com/browse/OSDOCS-5022)

Link to docs preview:
[Selecting an Azure Marketplace image](https://56119--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-azure-marketplace-subscribe_installing-azure-user-infra)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
