### PR TITLE
CNV-18461: Replace v1alpha1 API calls

### DIFF
--- a/modules/oadp-installing-dpa.adoc
+++ b/modules/oadp-installing-dpa.adoc
@@ -43,7 +43,7 @@ ifdef::installing-oadp-aws[]
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: oadp.openshift.io/v1alpha1
+apiVersion: oadp.openshift.io/v1beta1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
@@ -93,7 +93,7 @@ ifdef::installing-oadp-azure[]
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: oadp.openshift.io/v1alpha1
+apiVersion: oadp.openshift.io/v1beta1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
@@ -147,7 +147,7 @@ ifdef::installing-oadp-gcp[]
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: oadp.openshift.io/v1alpha1
+apiVersion: oadp.openshift.io/v1beta1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
@@ -193,7 +193,7 @@ ifdef::installing-oadp-mcg[]
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: oadp.openshift.io/v1alpha1
+apiVersion: oadp.openshift.io/v1beta1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
@@ -237,7 +237,7 @@ ifdef::installing-oadp-ocs[]
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: oadp.openshift.io/v1alpha1
+apiVersion: oadp.openshift.io/v1beta1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>
@@ -280,7 +280,7 @@ ifdef::virt-installing-configuring-oadp[]
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: oadp.openshift.io/v1alpha1
+apiVersion: oadp.openshift.io/v1beta1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>

--- a/modules/oadp-self-signed-certificate.adoc
+++ b/modules/oadp-self-signed-certificate.adoc
@@ -18,7 +18,7 @@ You must enable a self-signed CA certificate for object storage by editing the `
 +
 [source,yaml]
 ----
-apiVersion: oadp.openshift.io/v1alpha1
+apiVersion: oadp.openshift.io/v1beta1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>

--- a/modules/oadp-setting-resource-limits-and-requests.adoc
+++ b/modules/oadp-setting-resource-limits-and-requests.adoc
@@ -19,7 +19,7 @@ You set the CPU and memory resource allocations for the `Velero` pod by editing 
 +
 [source,yaml]
 ----
-apiVersion: oadp.openshift.io/v1alpha1
+apiVersion: oadp.openshift.io/v1beta1
 kind: DataProtectionApplication
 metadata:
   name: <dpa_sample>

--- a/modules/virt-about-node-placement-virtualization-components.adoc
+++ b/modules/virt-about-node-placement-virtualization-components.adoc
@@ -39,7 +39,7 @@ To specify the nodes where OLM deploys the {VirtProductName} Operators, edit the
 
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1beta1
 kind: Subscription
 metadata:
   name: hco-operatorhub

--- a/modules/virt-configuring-a-live-migration-policy.adoc
+++ b/modules/virt-configuring-a-live-migration-policy.adoc
@@ -28,7 +28,7 @@ If multiple live migration policies apply to a VMI, the policy with the highest 
 +
 [source,yaml]
 ----
-apiVersion: migrations.kubevirt.io/v1alpha1
+apiVersion: migrations.kubevirt.io/v1beta1
 kind: MigrationPolicy
 metadata:
   name: my-awesome-policy

--- a/modules/virt-creating-vm-snapshot-cli.adoc
+++ b/modules/virt-creating-vm-snapshot-cli.adoc
@@ -29,7 +29,7 @@ For example:
 +
 [source,yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1alpha1
+apiVersion: snapshot.kubevirt.io/v1beta1
 kind: VirtualMachineSnapshot
 metadata:
   name: my-vmsnapshot <1>
@@ -86,7 +86,7 @@ $ oc describe vmsnapshot <my-vmsnapshot>
 
 [source,yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1alpha1
+apiVersion: snapshot.kubevirt.io/v1beta1
 kind: VirtualMachineSnapshot
 metadata:
   creationTimestamp: "2020-09-30T14:41:51Z"
@@ -96,7 +96,7 @@ metadata:
   name: mysnap
   namespace: default
   resourceVersion: "3897"
-  selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinesnapshots/my-vmsnapshot
+  selfLink: /apis/snapshot.kubevirt.io/v1beta1/namespaces/default/virtualmachinesnapshots/my-vmsnapshot
   uid: 28eedf08-5d6a-42c1-969c-2eda58e2a78d
 spec:
   source:

--- a/modules/virt-example-node-placement-node-selector-olm-subscription.adoc
+++ b/modules/virt-example-node-placement-node-selector-olm-subscription.adoc
@@ -9,7 +9,7 @@ In this example, `nodeSelector` is configured so that OLM places the {VirtProduc
 
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1beta1
 kind: Subscription
 metadata:
   name: hco-operatorhub

--- a/modules/virt-example-node-placement-tolerations-olm-subscription.adoc
+++ b/modules/virt-example-node-placement-tolerations-olm-subscription.adoc
@@ -9,7 +9,7 @@ In this example, nodes that are reserved for OLM to deploy {VirtProductName} Ope
 
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1beta1
 kind: Subscription
 metadata:
   name: hco-operatorhub

--- a/modules/virt-restoring-vm-from-snapshot-cli.adoc
+++ b/modules/virt-restoring-vm-from-snapshot-cli.adoc
@@ -21,7 +21,7 @@ For example:
 +
 [source,yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1alpha1
+apiVersion: snapshot.kubevirt.io/v1beta1
 kind: VirtualMachineRestore
 metadata:
   name: my-vmrestore <1>
@@ -56,7 +56,7 @@ $ oc get vmrestore <my-vmrestore>
 +
 [source, yaml]
 ----
-apiVersion: snapshot.kubevirt.io/v1alpha1
+apiVersion: snapshot.kubevirt.io/v1beta1
 kind: VirtualMachineRestore
 metadata:
 creationTimestamp: "2020-09-30T14:46:27Z"
@@ -71,7 +71,7 @@ ownerReferences:
   name: my-vm
   uid: 355897f3-73a0-4ec4-83d3-3c2df9486f4f
   resourceVersion: "5512"
-  selfLink: /apis/snapshot.kubevirt.io/v1alpha1/namespaces/default/virtualmachinerestores/my-vmrestore
+  selfLink: /apis/snapshot.kubevirt.io/v1beta1/namespaces/default/virtualmachinerestores/my-vmrestore
   uid: 71c679a8-136e-46b0-b9b5-f57175a6a041
   spec:
     target:

--- a/modules/virt-subscribing-cli.adoc
+++ b/modules/virt-subscribing-cli.adoc
@@ -30,7 +30,7 @@ spec:
   targetNamespaces:
     - openshift-cnv
 ---
-apiVersion: operators.coreos.com/v1alpha1
+apiVersion: operators.coreos.com/v1beta1
 kind: Subscription
 metadata:
   name: hco-operatorhub


### PR DESCRIPTION
**Version(s):**
4.13 only

**Issue:**
https://issues.redhat.com/browse/CNV-18461

**Link to docs preview:**
https://56123--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-installing-dpa_installing-oadp-aws

**QE review:**
- [x] QE has approved this change.

**Additional information:**
Same changes as https://github.com/openshift/openshift-docs/pull/52793 after it being closed and push to 4.13.