### PR TITLE
OCPBUGS#7748: Replace deprecated 'sa get-token' w/ 'create token'

### DIFF
--- a/modules/osdk-ansible-metrics.adoc
+++ b/modules/osdk-ansible-metrics.adoc
@@ -185,11 +185,11 @@ NAME                                                ENDPOINTS          AGE
 ansiblemetrics-controller-manager-metrics-service   10.129.2.70:8443   150m
 ----
 
-. Get the custom metrics token:
+. Request a custom metrics token:
 +
 [source,terminal]
 ----
-$ token=`oc sa get-token prometheus-k8s -n openshift-monitoring`
+$ token=`oc create token prometheus-k8s -n openshift-monitoring`
 ----
 
 . Check the metrics values:


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-7748

Command changed in 4.11+.

Preview:

* [Exposing custom metrics for Ansible-based Operators](https://56148--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-monitoring-prometheus.html#osdk-ansible-metrics_osdk-monitoring-prometheus)