### PR TITLE
OSDOCS#3906: Guidance on uninstalling with the EOL of the Azure AD Graph API

### DIFF
--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -19,6 +19,12 @@ endif::[]
 ifeval::["{context}" == "uninstalling-cluster-ibm-cloud"]
 :ibm-cloud:
 endif::[]
+ifeval::["{context}" == "uninstall-cluster-azure"]
+:azure:
+endif::[]
+ifeval::["{context}" == "uninstall-cluster-azure-stack-hub"]
+:ash:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-uninstall-clouds_{context}"]
@@ -50,6 +56,12 @@ ifdef::ibm-cloud[]
 * You have configured the `ccoctl` binary.
 * You have installed the IBM Cloud CLI and installed or updated the VPC infrastructure service plugin. For more information see "Prerequisites" in the link:https://cloud.ibm.com/docs/vpc?topic=vpc-infrastructure-cli-plugin-vpc-reference&interface=ui#cli-ref-prereqs[IBM Cloud VPC CLI documentation].
 endif::ibm-cloud[]
+
+ifdef::azure,ash[]
+While you can uninstall the cluster using the copy of the installation program that was used to deploy it, using {product-title} version 4.13 or later is recommended.
+
+The removal of service principals is dependent on the Microsoft Azure AD Graph API. Using version 4.13 or later of the installation program ensures that service principals are removed without the need for manual intervention, if and when Microsoft decides to link:https://learn.microsoft.com/en-us/answers/questions/768833/(updated-info)-when-are-adal-and-azure-ad-graph-re.html[retire] the Azure AD Graph API.
+endif::azure,ash[]
 
 .Procedure
 ifdef::ibm-cloud[]
@@ -139,4 +151,10 @@ ifeval::["{context}" == "uninstalling-cluster-gcp"]
 endif::[]
 ifeval::["{context}" == "uninstalling-cluster-ibm-cloud"]
 :!ibm-cloud:
+endif::[]
+ifeval::["{context}" == "uninstall-cluster-azure"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "uninstall-cluster-azure-stack-hub"]
+:!ash:
 endif::[]


### PR DESCRIPTION
Version(s):
4.10

Issue:
This PR addresses [osdocs-3906](https://issues.redhat.com/browse/OSDOCS-3906). Given the nature of this doc update, the changes do not apply to main and 4.13 Separate PRs are required for 4.12,4.11, 4.10, and 4.9. This PR is for the 4.10 doc set.

Link to docs preview:

- [Uninstalling a cluster on Azure](http://file.rdu.redhat.com/mpytlak/osdocs-3906-410/installing/installing_azure/uninstalling-cluster-azure.html)
- [Uninstalling a cluster on Azure Stack Hub](http://file.rdu.redhat.com/mpytlak/osdocs-3906-410/installing/installing_azure_stack_hub/uninstalling-cluster-azure-stack-hub.html)

Note: Public Netlify docs preview builds are enabled on this branch. This preview is available on a file share, which requires you to be on the VPN.

QE review:
- [ ] QE has approved this change.

Additional information:
Doc PR for 4.12 updates is https://github.com/openshift/openshift-docs/pull/56029
Doc PR for 4.11 updates is https://github.com/openshift/openshift-docs/pull/56146
Doc PR for 4.9 updates is https://github.com/openshift/openshift-docs/pull/56164