### PR TITLE
OSDOCS#3906: Guidance on uninstalling with the EOL of the Azure AD Graph API

### DIFF
--- a/modules/installation-uninstall-clouds.adoc
+++ b/modules/installation-uninstall-clouds.adoc
@@ -14,6 +14,9 @@ endif::[]
 ifeval::["{context}" == "uninstalling-cluster-gcp"]
 :gcp:
 endif::[]
+ifeval::["{context}" == "uninstall-cluster-azure"]
+:azure:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-uninstall-clouds_{context}"]
@@ -43,6 +46,12 @@ endif::gcp[]
 * Have the files that the installation program generated when you created your
 cluster.
 
+ifdef::azure[]
+While you can uninstall the cluster using the copy of the installation program that was used to deploy it, using {product-title} version 4.13 or later is recommended.
+
+The removal of service principals is dependent on the Microsoft Azure AD Graph API. Using version 4.13 or later of the installation program ensures that service principals are removed without the need for manual intervention, if and when Microsoft decides to link:https://learn.microsoft.com/en-us/answers/questions/768833/(updated-info)-when-are-adal-and-azure-ad-graph-re.html[retire] the Azure AD Graph API.
+endif::azure[]
+
 .Procedure
 
 . From the directory that contains the installation program on the computer that you used to install the cluster, run the following command:
@@ -71,4 +80,7 @@ ifeval::["{context}" == "uninstalling-cluster-aws"]
 endif::[]
 ifeval::["{context}" == "uninstalling-cluster-gcp"]
 :!gcp:
+endif::[]
+ifeval::["{context}" == "uninstall-cluster-azure"]
+:!azure:
 endif::[]


### PR DESCRIPTION
Version(s):
4.9

Issue:
This PR addresses osdocs-3906. Given the nature of this doc update, the changes do not apply to main and 4.13 Separate PRs are required for 4.12,4.11, 4.10, and 4.9. This PR is for the 4.9 doc set.

Link to docs preview:

[Uninstalling a cluster on Azure](http://file.rdu.redhat.com/mpytlak/osdocs-3906-49/installing/installing_azure/uninstalling-cluster-azure.html)

Note: Public Netlify docs preview builds are enabled on this branch. This preview is available on a file share, which requires you to be on the VPN.

QE review:
- [ ] QE has approved this change.

Additional information:
Doc PR for 4.12 updates is https://github.com/openshift/openshift-docs/pull/56029
Doc PR for 4.11 updates is https://github.com/openshift/openshift-docs/pull/56146
Doc PR for 4.10 updates is https://github.com/openshift/openshift-docs/pull/56160
