### PR TITLE
OSDOCS-5333: Adding AES-GCM encryption option

### DIFF
--- a/modules/about-etcd-encryption.adoc
+++ b/modules/about-etcd-encryption.adoc
@@ -17,7 +17,7 @@ When you enable etcd encryption, the following OpenShift API server and Kubernet
 * OAuth access tokens
 * OAuth authorize tokens
 
-When you enable etcd encryption, encryption keys are created. These keys are rotated on a weekly basis. You must have these keys to restore from an etcd backup.
+When you enable etcd encryption, encryption keys are created. You must have these keys to restore from an etcd backup.
 
 [NOTE]
 ====

--- a/modules/enabling-etcd-encryption.adoc
+++ b/modules/enabling-etcd-encryption.adoc
@@ -27,7 +27,7 @@ It is not recommended to take a backup of etcd until the initial encryption proc
 $ oc edit apiserver
 ----
 
-. Set the `encryption` field type to `aescbc`:
+. Set the `encryption` field to `aescbc` or `aesgcm`:
 +
 [source,yaml]
 ----
@@ -35,7 +35,7 @@ spec:
   encryption:
     type: aescbc <1>
 ----
-<1> The `aescbc` type means that AES-CBC with PKCS#7 padding and a 32 byte key is used to perform the encryption.
+<1> Set to `aescbc` for AES-CBC encryption or `aesgcm` for AES-GCM encryption.
 
 . Save the file to apply the changes.
 +

--- a/modules/etcd-encryption-types.adoc
+++ b/modules/etcd-encryption-types.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * security/encrypting-etcd.adoc
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_content-type: CONCEPT
+[id="etcd-encryption-types_{context}"]
+= Supported encryption types
+
+The following encryption types are supported for encrypting etcd data in {product-title}:
+
+AES-CBC:: Uses AES-CBC with PKCS#7 padding and a 32 byte key to perform the encryption. The encryption keys are rotated weekly.
+
+AES-GCM:: Uses AES-GCM with a random nonce and a 32 byte key to perform the encryption. The encryption keys are rotated weekly.

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -654,6 +654,7 @@ include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+2]
 Back up etcd, enable or disable etcd encryption, or defragment etcd data.
 
 include::modules/about-etcd-encryption.adoc[leveloffset=+2]
+include::modules/etcd-encryption-types.adoc[leveloffset=+2]
 include::modules/enabling-etcd-encryption.adoc[leveloffset=+2]
 include::modules/disabling-etcd-encryption.adoc[leveloffset=+2]
 include::modules/backup-etcd.adoc[leveloffset=+2]

--- a/security/encrypting-etcd.adoc
+++ b/security/encrypting-etcd.adoc
@@ -9,6 +9,9 @@ toc::[]
 // About etcd encryption
 include::modules/about-etcd-encryption.adoc[leveloffset=+1]
 
+// Supported encryption types
+include::modules/etcd-encryption-types.adoc[leveloffset=+1]
+
 // Enabling etcd encryption
 include::modules/enabling-etcd-encryption.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5333

Link to docs preview:
https://56166--docspreview.netlify.app/openshift-enterprise/latest/security/encrypting-etcd.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
