### PR TITLE
OSDOCS-5333: RNs for AES-GCM etcd encryption

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -152,6 +152,16 @@ With {product-title} {product-version}, running `oc describe` on an image now re
 [id="ocp-4-13-images"]
 === Images
 
+[id="ocp-4-13-security"]
+=== Security and compliance
+
+[id="ocp-4-13-aesgcm-encryption"]
+==== AES-GCM encryption is now supported
+
+The AES-GCM encryption type is now supported when enabling etcd encryption for {product-title}. Encryption keys for the AES-GCM encryption type are rotated weekly.
+
+For more information, see xref:../security/encrypting-etcd.adoc#etcd-encryption-types_encrypting-etcd[Supported encryption types].
+
 [id="ocp-4-13-auth"]
 === Authentication and authorization
 
@@ -301,14 +311,14 @@ For more information, see xref:../machine_management/control_plane_machine_manag
 [id="ocp-4-13-machine-config-operator-layering"]
 ==== Support for adding third party and custom content to {op-system}
 
-You can now use {op-system-first} image layering to add {op-system-base-full} and third-party packages to cluster nodes. 
+You can now use {op-system-first} image layering to add {op-system-base-full} and third-party packages to cluster nodes.
 
 For more information, see  xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[{op-system-first} image layering].
 
 [id="ocp-4-13-machine-config-operator-core"]
 ==== Support for setting the `core` user password
 
-You can now create a password for the {op-system} `core` user. In the event that you cannot use SSH or the `oc debug node` command to access a node, this password allows you to use the `core` user to access the node through a cloud provider serial console or a bare metal baseboard controller manager (BMC). 
+You can now create a password for the {op-system} `core` user. In the event that you cannot use SSH or the `oc debug node` command to access a node, this password allows you to use the `core` user to access the node through a cloud provider serial console or a bare metal baseboard controller manager (BMC).
 
 For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#core-user-password_post-install-machine-configuration-tasks[Changing the core user password for node access].
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13 only

Issue:
https://issues.redhat.com/browse/OSDOCS-5333

Link to docs preview:
https://56167--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-aesgcm-encryption
(note that the supported encryption types page won't exist in this preview - that relies on #56166 being merged first)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
