### PR TITLE
OSDOCS-4877 Availability Zones Switzerland

### DIFF
--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -23,6 +23,7 @@ The following AWS regions are supported by Red Hat OpenShift 4 and are supported
 * ap-southeast-4 (Melbourne, AWS opt-in required)
 * ca-central-1 (Central Canada)
 * eu-central-1 (Frankfurt)
+* eu-central-2 (Zurich, AWS opt-in required)
 * eu-north-1 (Stockholm)
 * eu-south-1 (Milan, AWS opt-in required)
 * eu-west-1 (Ireland)

--- a/modules/sdpolicy-am-regions-availability-zones.adoc
+++ b/modules/sdpolicy-am-regions-availability-zones.adoc
@@ -19,6 +19,7 @@ The following AWS regions are supported by {OCP} 4 and are supported for {produc
 * ap-southeast-4 (Melbourne, AWS opt-in required)
 * ca-central-1 (Central Canada)
 * eu-central-1 (Frankfurt)
+* eu-central-2 (Zurich, AWS opt-in required)
 * eu-north-1 (Stockholm)
 * eu-south-1 (Milan, AWS opt-in required)
 * eu-west-1 (Ireland)


### PR DESCRIPTION
OSDOCS 4877

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-4877

Link to docs preview:
OSD: https://56176--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#regions-availability-zones_osd-service-definition
ROSA: https://56176--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-regions-az_rosa-service-definition

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
