### PR TITLE
[enterprise-4.10]: RHDEVDOCS-2634 Pipelines 1.8.2 Release Notes

### DIFF
--- a/modules/op-release-notes-1-8.adoc
+++ b/modules/op-release-notes-1-8.adoc
@@ -5,7 +5,7 @@
 [id="op-release-notes-1-8_{context}"]
 = Release notes for {pipelines-title} General Availability 1.8
 
-With this update, {pipelines-title} General Availability (GA) 1.8 is available on {product-title} 4.10, and is planned to be available on {product-title} 4.11 and 4.12.
+With this update, {pipelines-title} General Availability (GA) 1.8 is available on {product-title} 4.10, 4.11 and 4.12.
 
 [id="new-features-1-8_{context}"]
 == New features
@@ -313,6 +313,13 @@ $ oc get route -n openshift-pipelines pipelines-as-code-controller \
 [id="deprecated-features-1-8_{context}"]
 == Deprecated and removed features
 
+* Starting with {product-title} 4.11, the `preview` and `stable` channels for installing and upgrading the {pipelines-title} Operator are removed. To install and upgrade the Operator, use the appropriate `pipelines-<version>` channel, or the `latest` channel for the most recent stable version. For example, to install the {pipelines-shortname} Operator version `1.8.x`, use the `pipelines-1.8` channel. 
++
+[NOTE]
+====
+In {product-title} 4.10 and earlier versions, you can use the `preview` and `stable` channels for installing and upgrading the Operator.
+====
+
 * Support for the `tekton.dev/v1alpha1` API version, which was deprecated in {pipelines-title} GA 1.6, is planned to be removed in the upcoming {pipelines-title} GA 1.9 release.
 +
 This change affects the pipeline component, which includes the `TaskRun`, `PipelineRun`, `Task`, `Pipeline`, and similar `tekton.dev/v1alpha1` resources. As an alternative, update existing resources to use `apiVersion: tekton.dev/v1beta1` as described in link:https://tekton.dev/docs/pipelines/migrating-v1alpha1-to-v1beta1/[Migrating From Tekton v1alpha1 to Tekton v1beta1].
@@ -543,6 +550,10 @@ With this update, {pipelines-title} General Availability (GA) 1.8.1 is available
 [id="known-issues-1-8-1_{context}"]
 === Known issues
 
+* By default, the containers have restricted permissions for enhanced security. The restricted permissions apply to all controller pods in the {pipelines-title} Operator, and to some cluster tasks. Due to restricted permissions, the `git-clone` cluster task fails under certain configurations. 
++
+Workaround: None. You can track the issue link:https://issues.redhat.com/browse/SRVKP-2634[SRVKP-2634].
+
 * When installer sets are in a failed state, the status of the `TektonConfig` custom resource is incorrectly displayed as `True` instead of `False`.
 +
 .Example: Failed installer sets
@@ -599,3 +610,15 @@ config   1.8.1     True
 
 * Before this update, cluster administrators could not provide a `config.json` file to the `Buildah` cluster task for accessing a container registry. With this update, cluster administrators can provide the `Buildah` cluster task with a `config.json` file by using the `dockerconfig` workspace.
 // https://issues.redhat.com/browse/SRVKP-2424
+
+[id="release-notes-1-8-2_{context}"]
+== Release notes for {pipelines-title} General Availability 1.8.2
+
+With this update, {pipelines-title} General Availability (GA) 1.8.2 is available on {product-title} 4.10 and 4.11.
+
+[id="fixed-issues-1-8-2_{context}"]
+=== Fixed issues
+
+* Before this update, the `git-clone` task failed when cloning a repository using SSH keys. With this update, the role of the non-root user in the `git-init` task is removed, and the SSH program looks in the `$HOME/.ssh/` directory for the correct keys.
+// https://issues.redhat.com/browse/SRVKP-2634
+


### PR DESCRIPTION
Manual CP from #53178 to 4.10

Aligned team: Dev Tools

Purpose: To resolve the following issue:
https://issues.redhat.com/browse/RHDEVDOCS-4985

OCP version this PR applies to: enterprise 4.10