### PR TITLE
TELCODOCS-868: AWS Outposts documentation links added to the 4.12 Rel…

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -180,8 +180,8 @@ In {product-title} 4.12, cluster deployments to {rh-openstack-first} clouds that
 For a brief overview of this type of deployment, see the blog post link:https://cloud.redhat.com/blog/deploying-your-cluster-at-the-edge-with-openstack[Deploying Your Cluster at the Edge With OpenStack].
 
 [id="ocp-4-12-aws-outposts"]
-==== {product-title} on AWS Outposts
-{product-title} {product-version} is now supported on the AWS Outposts platform. With AWS Outposts you can deploy edge-based worker nodes, while using AWS Regions for the control plane nodes. The documentation for this feature is currently unavailable and is targeted for release at a later date.
+==== {product-title} on AWS Outposts (Technology Preview)
+{product-title} {product-version} is now supported on the AWS Outposts platform as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. With AWS Outposts you can deploy edge-based worker nodes, while using AWS Regions for the control plane nodes. For more information, see xref:../installing/installing_aws/installing-aws-outposts-remote-workers.adoc[Installing a cluster on AWS with remote workers on AWS Outposts].
 
 ==== Agent-based installation supports two input modes
 The Agent-based installation supports two input modes:
@@ -2472,6 +2472,11 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Not Available
 |General Availability
+
+|AWS Outposts platform
+|Not Available
+|Not Available
+|Technology Preview
 
 |====
 


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-868 Document new features

Applies to OpenShift version : 4.12

Preview: [OpenShift Container Platform on AWS Outposts](https://56185--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-aws-outposts)
Preview: [Technology Preview features](https://56185--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview)

QE review completed by @amalykhi 
Peer review completed by @stevsmit 

Thank you.