### PR TITLE
OCPBUGS-7538 - updates fast events notifications REST API URI >  ocloudNotifications

### DIFF
--- a/modules/cnf-fast-event-notifications-api-refererence.adoc
+++ b/modules/cnf-fast-event-notifications-api-refererence.adoc
@@ -11,25 +11,25 @@ Subscribe applications to PTP events by using the resource address `/cluster/nod
 
 Deploy your `cloud-event-consumer` DU application container and `cloud-event-proxy` sidecar container in a separate DU application pod. The `cloud-event-consumer` DU application subscribes to the `cloud-event-proxy` container in the application pod.
 
-Use the following API endpoints to subscribe the `cloud-event-consumer` DU application to PTP events posted by the `cloud-event-proxy` container at [x-]`http://localhost:8089/api/cloudNotifications/v1/` in the DU application pod:
+Use the following API endpoints to subscribe the `cloud-event-consumer` DU application to PTP events posted by the `cloud-event-proxy` container at [x-]`http://localhost:8089/api/ocloudNotifications/v1/` in the DU application pod:
 
-* `/api/cloudNotifications/v1/subscriptions`
+* `/api/ocloudNotifications/v1/subscriptions`
 - `POST`: Creates a new subscription
 - `GET`: Retrieves a list of subscriptions
 
-* `/api/cloudNotifications/v1/subscriptions/<subscription_id>`
+* `/api/ocloudNotifications/v1/subscriptions/<subscription_id>`
 - `GET`: Returns details for the specified subscription ID
 
-* `api/cloudNotifications/v1/subscriptions/status/<subscription_id>`
+* `api/ocloudNotifications/v1/subscriptions/status/<subscription_id>`
 - `PUT`: Creates a new status ping request for the specified subscription ID
 
-* `/api/cloudNotifications/v1/health`
-- `GET`: Returns the health status of `cloudNotifications` API
+* `/api/ocloudNotifications/v1/health`
+- `GET`: Returns the health status of `ocloudNotifications` API
 
-* `api/cloudNotifications/v1/publishers`
+* `api/ocloudNotifications/v1/publishers`
 - `GET`: Returns an array of `os-clock-sync-state`, `ptp-clock-class-change`, and `lock-state` messages for the cluster node
 
-* `/api/cloudnotifications/v1/<resource_address>/CurrentState`
+* `/api/ocloudnotifications/v1/<resource_address>/CurrentState`
 -  `GET`: Returns the current state of one the following event types: `os-clock-sync-state`, `ptp-clock-class-change`, or `lock-state` events
 
 [NOTE]
@@ -37,12 +37,12 @@ Use the following API endpoints to subscribe the `cloud-event-consumer` DU appli
 `9089` is the default port for the `cloud-event-consumer` container deployed in the application pod. You can configure a different port for your DU application as required.
 ====
 
-== api/cloudNotifications/v1/subscriptions
+== api/ocloudNotifications/v1/subscriptions
 
 [discrete]
 === HTTP method
 
-`GET api/cloudNotifications/v1/subscriptions`
+`GET api/ocloudNotifications/v1/subscriptions`
 
 [discrete]
 ==== Description
@@ -56,7 +56,7 @@ Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code 
  {
   "id": "75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
   "endpointUri": "http://localhost:9089/event",
-  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions/75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
+  "uriLocation": "http://localhost:8089/api/ocloudNotifications/v1/subscriptions/75b1ad8f-c807-4c23-acf5-56f4b7ee3826",
   "resource": "/cluster/node/compute-1.example.com/ptp"
  }
 ]
@@ -65,7 +65,7 @@ Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code 
 [discrete]
 === HTTP method
 
-`POST api/cloudNotifications/v1/subscriptions`
+`POST api/ocloudNotifications/v1/subscriptions`
 
 [discrete]
 ==== Description
@@ -84,17 +84,17 @@ Creates a new subscription. If a subscription is successfully created, or if it 
 [source,json]
 ----
 {
-  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions",
+  "uriLocation": "http://localhost:8089/api/ocloudNotifications/v1/subscriptions",
   "resource": "/cluster/node/compute-1.example.com/ptp"
 }
 ----
 
-== api/cloudNotifications/v1/subscriptions/<subscription_id>
+== api/ocloudNotifications/v1/subscriptions/<subscription_id>
 
 [discrete]
 === HTTP method
 
-`GET api/cloudNotifications/v1/subscriptions/<subscription_id>`
+`GET api/ocloudNotifications/v1/subscriptions/<subscription_id>`
 
 [discrete]
 ==== Description
@@ -115,17 +115,17 @@ Returns details for the subscription with ID `<subscription_id>`
 {
   "id":"48210fb3-45be-4ce0-aa9b-41a0e58730ab",
   "endpointUri": "http://localhost:9089/event",
-  "uriLocation":"http://localhost:8089/api/cloudNotifications/v1/subscriptions/48210fb3-45be-4ce0-aa9b-41a0e58730ab",
+  "uriLocation":"http://localhost:8089/api/ocloudNotifications/v1/subscriptions/48210fb3-45be-4ce0-aa9b-41a0e58730ab",
   "resource":"/cluster/node/compute-1.example.com/ptp"
 }
 ----
 
-== api/cloudNotifications/v1/subscriptions/status/<subscription_id>
+== api/ocloudNotifications/v1/subscriptions/status/<subscription_id>
 
 [discrete]
 === HTTP method
 
-`PUT api/cloudNotifications/v1/subscriptions/status/<subscription_id>`
+`PUT api/ocloudNotifications/v1/subscriptions/status/<subscription_id>`
 
 [discrete]
 ==== Description
@@ -146,17 +146,17 @@ Creates a new status ping request for subscription with ID `<subscription_id>`. 
 {"status":"ping sent"}
 ----
 
-== api/cloudNotifications/v1/health/
+== api/ocloudNotifications/v1/health/
 
 [discrete]
 === HTTP method
 
-`GET api/cloudNotifications/v1/health/`
+`GET api/ocloudNotifications/v1/health/`
 
 [discrete]
 ==== Description
 
-Returns the health status for the `cloudNotifications` REST API.
+Returns the health status for the `ocloudNotifications` REST API.
 
 .Example API response
 [source,terminal]
@@ -164,12 +164,12 @@ Returns the health status for the `cloudNotifications` REST API.
 OK
 ----
 
-== api/cloudNotifications/v1/publishers
+== api/ocloudNotifications/v1/publishers
 
 [discrete]
 === HTTP method
 
-`GET api/cloudNotifications/v1/publishers`
+`GET api/ocloudNotifications/v1/publishers`
 
 [discrete]
 ==== Description
@@ -186,20 +186,20 @@ Returns an array of `os-clock-sync-state`, `ptp-clock-class-change`, and `lock-s
 [
   {
     "id": "0fa415ae-a3cf-4299-876a-589438bacf75",
-    "endpointUri": "http://localhost:9085/api/cloudNotifications/v1/dummy",
-    "uriLocation": "http://localhost:9085/api/cloudNotifications/v1/publishers/0fa415ae-a3cf-4299-876a-589438bacf75",
+    "endpointUri": "http://localhost:9085/api/ocloudNotifications/v1/dummy",
+    "uriLocation": "http://localhost:9085/api/ocloudNotifications/v1/publishers/0fa415ae-a3cf-4299-876a-589438bacf75",
     "resource": "/cluster/node/compute-1.example.com/sync/sync-status/os-clock-sync-state"
   },
   {
     "id": "28cd82df-8436-4f50-bbd9-7a9742828a71",
-    "endpointUri": "http://localhost:9085/api/cloudNotifications/v1/dummy",
-    "uriLocation": "http://localhost:9085/api/cloudNotifications/v1/publishers/28cd82df-8436-4f50-bbd9-7a9742828a71",
+    "endpointUri": "http://localhost:9085/api/ocloudNotifications/v1/dummy",
+    "uriLocation": "http://localhost:9085/api/ocloudNotifications/v1/publishers/28cd82df-8436-4f50-bbd9-7a9742828a71",
     "resource": "/cluster/node/compute-1.example.com/sync/ptp-status/ptp-clock-class-change"
   },
   {
     "id": "44aa480d-7347-48b0-a5b0-e0af01fa9677",
-    "endpointUri": "http://localhost:9085/api/cloudNotifications/v1/dummy",
-    "uriLocation": "http://localhost:9085/api/cloudNotifications/v1/publishers/44aa480d-7347-48b0-a5b0-e0af01fa9677",
+    "endpointUri": "http://localhost:9085/api/ocloudNotifications/v1/dummy",
+    "uriLocation": "http://localhost:9085/api/ocloudNotifications/v1/publishers/44aa480d-7347-48b0-a5b0-e0af01fa9677",
     "resource": "/cluster/node/compute-1.example.com/sync/ptp-status/lock-state"
   }
 ]
@@ -293,16 +293,16 @@ $ oc logs -f linuxptp-daemon-cvgr6 -n openshift-ptp -c cloud-event-proxy
 }
 ----
 
-== /api/cloudnotifications/v1/<resource_address>/CurrentState
+== /api/ocloudnotifications/v1/<resource_address>/CurrentState
 
 [discrete]
 === HTTP method
 
-`GET api/cloudNotifications/v1/cluster/node/<node_name>/sync/ptp-status/lock-state/CurrentState`
+`GET api/ocloudNotifications/v1/cluster/node/<node_name>/sync/ptp-status/lock-state/CurrentState`
 
-`GET api/cloudNotifications/v1/cluster/node/<node_name>/sync/sync-status/os-clock-sync-state/CurrentState`
+`GET api/ocloudNotifications/v1/cluster/node/<node_name>/sync/sync-status/os-clock-sync-state/CurrentState`
 
-`GET api/cloudNotifications/v1/cluster/node/<node_name>/sync/ptp-status/ptp-clock-class-change/CurrentState`
+`GET api/ocloudNotifications/v1/cluster/node/<node_name>/sync/ptp-status/ptp-clock-class-change/CurrentState`
 
 [discrete]
 ==== Description

--- a/modules/cnf-rfhe-notifications-api-refererence.adoc
+++ b/modules/cnf-rfhe-notifications-api-refererence.adoc
@@ -12,17 +12,17 @@ Subscribe applications to Redfish events by using the resource address `/cluster
 
 Deploy your `cloud-event-consumer` application container and `cloud-event-proxy` sidecar container in a separate application pod. The `cloud-event-consumer` application subscribes to the `cloud-event-proxy` container in the application pod.
 
-Use the following API endpoints to subscribe the `cloud-event-consumer` application to Redfish events posted by the `cloud-event-proxy` container at [x-]`http://localhost:8089/api/cloudNotifications/v1/` in the application pod:
+Use the following API endpoints to subscribe the `cloud-event-consumer` application to Redfish events posted by the `cloud-event-proxy` container at [x-]`http://localhost:8089/api/ocloudNotifications/v1/` in the application pod:
 
-* `/api/cloudNotifications/v1/subscriptions`
+* `/api/ocloudNotifications/v1/subscriptions`
 - `POST`: Creates a new subscription
 - `GET`: Retrieves a list of subscriptions
-* `/api/cloudNotifications/v1/subscriptions/<subscription_id>`
+* `/api/ocloudNotifications/v1/subscriptions/<subscription_id>`
 - `GET`: Returns details for the specified subscription ID
-* `api/cloudNotifications/v1/subscriptions/status/<subscription_id>`
+* `api/ocloudNotifications/v1/subscriptions/status/<subscription_id>`
 - `PUT`: Creates a new status ping request for the specified subscription ID
-* `/api/cloudNotifications/v1/health`
-- `GET`: Returns the health status of `cloudNotifications` API
+* `/api/ocloudNotifications/v1/health`
+- `GET`: Returns the health status of `ocloudNotifications` API
 
 [NOTE]
 ====
@@ -30,12 +30,12 @@ Use the following API endpoints to subscribe the `cloud-event-consumer` applicat
 ====
 
 [discrete]
-== api/cloudNotifications/v1/subscriptions
+== api/ocloudNotifications/v1/subscriptions
 
 [discrete]
 === HTTP method
 
-`GET api/cloudNotifications/v1/subscriptions`
+`GET api/ocloudNotifications/v1/subscriptions`
 
 [discrete]
 ==== Description
@@ -48,8 +48,8 @@ Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code 
 [
  {
   "id": "ca11ab76-86f9-428c-8d3a-666c24e34d32",
-  "endpointUri": "http://localhost:9089/api/cloudNotifications/v1/dummy",
-  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions/ca11ab76-86f9-428c-8d3a-666c24e34d32",
+  "endpointUri": "http://localhost:9089/api/ocloudNotifications/v1/dummy",
+  "uriLocation": "http://localhost:8089/api/ocloudNotifications/v1/subscriptions/ca11ab76-86f9-428c-8d3a-666c24e34d32",
   "resource": "/cluster/node/openshift-worker-0.openshift.example.com/redfish/event"
  }
 ]
@@ -58,7 +58,7 @@ Returns a list of subscriptions. If subscriptions exist, a `200 OK` status code 
 [discrete]
 === HTTP method
 
-`POST api/cloudNotifications/v1/subscriptions`
+`POST api/ocloudNotifications/v1/subscriptions`
 
 [discrete]
 ==== Description
@@ -77,18 +77,18 @@ Creates a new subscription. If a subscription is successfully created, or if it 
 [source,json]
 ----
 {
-  "uriLocation": "http://localhost:8089/api/cloudNotifications/v1/subscriptions",
+  "uriLocation": "http://localhost:8089/api/ocloudNotifications/v1/subscriptions",
   "resource": "/cluster/node/openshift-worker-0.openshift.example.com/redfish/event"
 }
 ----
 
 [discrete]
-== api/cloudNotifications/v1/subscriptions/<subscription_id>
+== api/ocloudNotifications/v1/subscriptions/<subscription_id>
 
 [discrete]
 === HTTP method
 
-`GET api/cloudNotifications/v1/subscriptions/<subscription_id>`
+`GET api/ocloudNotifications/v1/subscriptions/<subscription_id>`
 
 [discrete]
 ==== Description
@@ -108,19 +108,19 @@ Returns details for the subscription with ID `<subscription_id>`
 ----
 {
   "id":"ca11ab76-86f9-428c-8d3a-666c24e34d32",
-  "endpointUri":"http://localhost:9089/api/cloudNotifications/v1/dummy",
-  "uriLocation":"http://localhost:8089/api/cloudNotifications/v1/subscriptions/ca11ab76-86f9-428c-8d3a-666c24e34d32",
+  "endpointUri":"http://localhost:9089/api/ocloudNotifications/v1/dummy",
+  "uriLocation":"http://localhost:8089/api/ocloudNotifications/v1/subscriptions/ca11ab76-86f9-428c-8d3a-666c24e34d32",
   "resource":"/cluster/node/openshift-worker-0.openshift.example.com/redfish/event"
 }
 ----
 
 [discrete]
-== api/cloudNotifications/v1/subscriptions/status/<subscription_id>
+== api/ocloudNotifications/v1/subscriptions/status/<subscription_id>
 
 [discrete]
 === HTTP method
 
-`PUT api/cloudNotifications/v1/subscriptions/status/<subscription_id>`
+`PUT api/ocloudNotifications/v1/subscriptions/status/<subscription_id>`
 
 [discrete]
 ==== Description
@@ -142,17 +142,17 @@ Creates a new status ping request for subscription with ID `<subscription_id>`. 
 ----
 
 [discrete]
-== api/cloudNotifications/v1/health/
+== api/ocloudNotifications/v1/health/
 
 [discrete]
 === HTTP method
 
-`GET api/cloudNotifications/v1/health/`
+`GET api/ocloudNotifications/v1/health/`
 
 [discrete]
 ==== Description
 
-Returns the health status for the `cloudNotifications` REST API.
+Returns the health status for the `ocloudNotifications` REST API.
 
 .Example API response
 [source,terminal]


### PR DESCRIPTION
Fixes REST API URI for bare metal and PTP fast events, `cloudNotifications` > `ocloudNotifications`.

Version(s):
enterprise-4.13, enterprise-4.12, enterprise-4.11, enterprise-4.10, ~enterprise-4.9~

**EDIT: 4.9 NOT REQUIRED**

Issue:
https://issues.redhat.com/browse/OCPBUGS-7538

Link to docs preview:
* https://56192--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-fast-event-notifications-api-refererence_using-ptp
* https://56192--docspreview.netlify.app/openshift-enterprise/latest/monitoring/using-rfhe.html#cnf-rfhe-notifications-api-refererence_using-rfhe


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->