### PR TITLE
OSDOCS-5391: fix broken RHEL attribute

### DIFF
--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-You can install {product-title} from an RPM package on a machine with {op-system-first} {op-system-version}.
+You can install {product-title} from an RPM package on a machine with {op-system-base-full} {op-system-version}.
 
 [IMPORTANT]
 ====

--- a/modules/microshift-install-system-requirements.adoc
+++ b/modules/microshift-install-system-requirements.adoc
@@ -6,11 +6,9 @@
 [id="system-requirements-installing-microshift"]
 = System requirements for installing {product-title}
 
-{product-title} supports a 64-bit version of the x86 architecture and the {op-system-first} {op-system-version} operating system.
-
 The following conditions must be met prior to installing {product-title}:
 
-* {op-system-first} {op-system-version}
+* {op-system} {op-system-version}
 * 2 CPU cores
 * 2 GB of RAM
 * 10 GB of storage


### PR DESCRIPTION
MicroShift
Version(s):
4.12, 4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-7783

Link to docs preview:
https://56206--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#system-requirements-installing-microshift 

QE review:
N/A internal docs bug
Developer Preview docs

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
