### PR TITLE
remove cluster-logging-systemd.adoc per ticket request

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -95,7 +95,7 @@ Topics:
   File: creating-a-gcp-cluster
 - Name: Configuring your identity providers
   File: config-identity-providers
-- Name: Revoking privileges and access to an OpenShift Dedicated cluster  
+- Name: Revoking privileges and access to an OpenShift Dedicated cluster
   File: osd-revoking-cluster-privileges
 - Name: Deleting an OpenShift Dedicated cluster
   File: osd-deleting-a-cluster
@@ -282,8 +282,8 @@ Topics:
     File: cluster-logging-tolerations
   - Name: Moving the Logging resources with node selectors
     File: cluster-logging-moving-nodes
-  - Name: Configuring systemd-journald and Fluentd
-    File: cluster-logging-systemd
+  #- Name: Configuring systemd-journald and Fluentd
+  #  File: cluster-logging-systemd
   - Name: Maintenance and support
     File: cluster-logging-maintenance-support
 - Name: Logging with the LokiStack
@@ -316,7 +316,7 @@ Topics:
   - Name: Understanding Logging alerts
     File: cluster-logging-alerts
   - Name: Collecting logging data for Red Hat Support
-    File: cluster-logging-must-gather    
+    File: cluster-logging-must-gather
   - Name: Troubleshooting for Critical Alerts
     File: cluster-logging-troubleshooting-for-critical-alerts
 - Name: Uninstalling Logging
@@ -403,7 +403,7 @@ Topics:
       File: restrictive-network-policies
   - Name: Traffic splitting
     Dir: traffic-splitting
-    Topics:    
+    Topics:
     - Name: Traffic splitting overview
       File: traffic-splitting-overview
     - Name: Traffic spec examples
@@ -418,7 +418,7 @@ Topics:
       File: traffic-splitting-blue-green
   - Name: External and Ingress routing
     Dir: external-ingress-routing
-    Topics:    
+    Topics:
     - Name: Routing overview
       File: routing-overview
     - Name: Customizing labels and annotations
@@ -591,7 +591,9 @@ Topics:
       Distros: openshift-enterprise
     - Name: Using Jaeger distributed tracing
       File: serverless-tracing-jaeger
-# Removing  
+# Removing
+=======
+# Removing
 - Name: Removing Serverless
   Dir: removing
   Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -395,8 +395,8 @@ Topics:
     File: cluster-logging-tolerations
   - Name: Moving the Logging resources with node selectors
     File: cluster-logging-moving-nodes
-  - Name: Configuring systemd-journald and Fluentd
-    File: cluster-logging-systemd
+  #- Name: Configuring systemd-journald and Fluentd
+    #File: cluster-logging-systemd
   - Name: Maintenance and support
     File: cluster-logging-maintenance-support
 - Name: Logging with the LokiStack
@@ -556,7 +556,7 @@ Topics:
   - Name: Installing the Serverless Operator
     File: install-serverless-operator
   - Name: Installing the Knative CLI
-    File: installing-kn    
+    File: installing-kn
   - Name: Installing Knative Serving
     File: installing-knative-serving
   - Name: Installing Knative Eventing
@@ -601,7 +601,7 @@ Topics:
       File: restrictive-network-policies
   - Name: Traffic splitting
     Dir: traffic-splitting
-    Topics:    
+    Topics:
     - Name: Traffic splitting overview
       File: traffic-splitting-overview
     - Name: Traffic spec examples
@@ -616,7 +616,7 @@ Topics:
       File: traffic-splitting-blue-green
   - Name: External and Ingress routing
     Dir: external-ingress-routing
-    Topics:    
+    Topics:
     - Name: Routing overview
       File: routing-overview
     - Name: Customizing labels and annotations
@@ -794,12 +794,14 @@ Topics:
   Dir: integrations
   Topics:
   - Name: Integrating Service Mesh with OpenShift Serverless
-    File: serverless-ossm-setup  
+    File: serverless-ossm-setup
   - Name: Integrating Serverless with the cost management service
     File: serverless-cost-management-integration
   - Name: Using NVIDIA GPU resources with serverless applications
     File: gpu-resources
-# Removing  
+# Removing
+=======
+# Removing
 - Name: Removing Serverless
   Dir: removing
   Topics:
@@ -816,6 +818,17 @@ Topics:
 # Support
 - Name: Serverless support
   File: serverless-support
+=======
+# Integrations
+- Name: Integrations
+  Dir: integrations
+  Topics:
+  - Name: Integrating Service Mesh with OpenShift Serverless
+    File: serverless-ossm-setup
+  - Name: Integrating Serverless with the cost management service
+    File: serverless-cost-management-integration
+  - Name: Using NVIDIA GPU resources with serverless applications
+    File: gpu-resources
 ---
 Name: Troubleshooting
 Dir: rosa_support


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
[OSDOCS-5388]: Removing a section from the OSD/ROSA documentation for the Logging stack
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5388
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Because I only commented out (removed) title from topic maps, there is not Netlify preview. However, changes can be seen in local build. Title "Configuring systemd-journald and Fluentd" is no longer present as seen in attached image. 
![image](https://user-images.githubusercontent.com/122639474/220634145-c53ed3c3-fc5f-4821-b98f-96fefd548493.png)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
