### PR TITLE
OSDOCS-5323: Multi-arch AWS support

### DIFF
--- a/modules/multi-architecture-modify-machine-set-aws.adoc
+++ b/modules/multi-architecture-modify-machine-set-aws.adoc
@@ -1,0 +1,135 @@
+//Module included in the following assembly
+//
+//post_installation_configuration/cluster-tasks.adoc
+
+:_content-type: PROCEDURE
+[id="multi-architecture-modify-machine-set-aws_{context}"]
+
+= Adding an ARM64 compute machine set to your cluster 
+
+To configure a cluster with multi-architecture compute machines, you must create a AWS ARM64 compute machine set. This adds ARM64 compute nodes to your cluster so that your cluster has multi-architecture compute machines.
+
+.Prerequisites 
+
+* You installed the OpenShift CLI (`oc`). 
+* You used the installation program to create an AMD64 single-architecture AWS cluster with the multi-architecture installer binary.
+
+
+.Procedure
+* Create and modify a compute machine set, this will control the ARM64 compute nodes in your cluster. 
++
+--
+[source,terminal]
+----
+$ oc create -f aws-arm64-machine-set-0.yaml
+----
+.Sample YAML compute machine set to deploy an ARM64 compute node
+
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1> 
+  name: <infrastructure_id>-aws-arm64-machine-set-0 <1>
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
+  template:
+    metadata:
+      labels:
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id> 
+        machine.openshift.io/cluster-api-machine-role: <role> <3> 
+        machine.openshift.io/cluster-api-machine-type: <role> <3> 
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/<role>: "" 
+      providerSpec:
+        value:
+          ami:
+            id: ami-02a574449d4f4d280 <4>
+          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          blockDevices:
+            - ebs:
+                iops: 0
+                volumeSize: 120
+                volumeType: gp2
+          credentialsSecret:
+            name: aws-cloud-credentials
+          deviceIndex: 0
+          iamInstanceProfile:
+            id: <infrastructure_id>-worker-profile <1>
+          instanceType: m6g.xlarge <5> 
+          kind: AWSMachineProviderConfig
+          placement:
+            availabilityZone: us-east-1a <6>
+            region: <region> <7> 
+          securityGroups:
+            - filters:
+                - name: tag:Name
+                  values:
+                    - <infrastructure_id>-worker-sg <1>
+          subnet:
+            filters:
+              - name: tag:Name
+                values:
+                  - <infrastructure_id>-private-<zone>  
+          tags:
+            - name: kubernetes.io/cluster/<infrastructure_id> <1>
+              value: owned
+            - name: <custom_tag_name> 
+              value: <custom_tag_value> 
+          userDataSecret:
+            name: worker-user-data
+----
+<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath=‘{.status.infrastructureName}{“\n”}’ infrastructure cluster
+----
+<2> Specify the infrastructure ID, role node label, and zone.	
+<3> Specify the role node label to add.
+<4> Specify an ARM64 supported Red Hat Enterprise Linux CoreOS (RHCOS) Amazon Machine Image (AMI) for your AWS zone for your OpenShift Container Platform nodes. 
++
+[source,terminal]
+----
+$ oc get configmap/coreos-bootimages /
+	  -n openshift-machine-config-operator /
+	  -o jsonpath='{.data.stream}' | jq /
+	  -r '.architectures.<arch>.images.aws.regions."<region>".image'
+----
+<5> Specify an ARM64 supported machine type. For more information, refer to "Tested instance types for AWS 64-bit ARM"
+<6> Specify the zone, for example `us-east-1a`. Ensure that the zone you select offers 64-bit ARM machines. 
+<7> Specify the region, for example, `us-east-1`. Ensure that the zone you select offers 64-bit ARM machines.
+--
+
+.Verification 
+
+. View the list of compute machine sets by entering the following command:
++
+[source,terminal]
+----
+$ oc get machineset -n openshift-machine-api
+----
+You can then see your created ARM64 machine set. 
++
+.Example output
+[source,terminal]
+----
+NAME                                                DESIRED  CURRENT  READY  AVAILABLE  AGE
+<infrastructure_id>-aws-arm64-machine-set-0                   2        2      2          2  10m
+----
+. You can check that the nodes are ready and scheduable with the following command:
++
+[source,terminal]
+---- 
+$ oc get nodes
+----

--- a/post_installation_configuration/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/multi-architecture-configuration.adoc
@@ -22,6 +22,16 @@ include::modules/multi-architecture-modify-machine-set.adoc[leveloffset=+2]
 .Additional resources
 * xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc[Creating a compute machine set on Azure] 
 
+== Creating a cluster with multi-architecture compute machines on AWS
+
+To create an AWS cluster with multi-architecture compute machines, you must first create a single-architecture AWS installer-provisioned cluster with the multi-architecture installer binary. For more information on AWS installations, refer to xref:../installing/installing_aws/installing-aws-customizations.adoc[Installing a cluster on AWS with customizations]. You can then add a ARM64 compute machine set to your AWS cluster.
+
+include::modules/multi-architecture-modify-machine-set-aws.adoc[leveloffset=+2]
+
+[role="_additional-resources"] 
+.Additional resources
+* xref:../installing/installing_aws/installing-aws-customizations.adoc#installation-aws-arm-tested-machine-types_installing-aws-customizations[Tested instance types for AWS 64-bit ARM]
+
 include::modules/multi-architecture-upgrade-mirrors.adoc[leveloffset=+1]
 
 include::modules/multi-architecture-import-imagestreams.adoc[leveloffset=+1]


### PR DESCRIPTION
**Versions:** 4.13+ 
**Issue:** [OSDOCS-5323](https://issues.redhat.com//browse/OSDOCS-5323)

**Description:** Clusters with multi-architecture compute machines is going GA in 4.13, this PR adds documentation instructions on how to create one on AWS. 

**Preview:** 
Configuring multi-architecture compute machines on an OpenShift Container Platform cluster

- [Creating a cluster with multi-architecture compute machines on AWS](https://56234--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html#creating-a-cluster-with-multi-architecture-compute-machines-on-aws)
- [Adding an ARM64 compute machine set to your cluster](https://56234--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html#multi-architecture-modify-machine-set-aws_multi-architecture-configuration)



**QE review:** 
- [x] QE Approval