### PR TITLE
SD Broken Link Cleanup: Fixed some broken links for Customer Portal

### DIFF
--- a/osd_architecture/osd_policy/osd-life-cycle.adoc
+++ b/osd_architecture/osd_policy/osd-life-cycle.adoc
@@ -11,7 +11,7 @@ include::modules/life-cycle-overview.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../osd_policy/osd-service-definition.adoc#osd-service-definition[{product-title} service definition]
+* xref:../../osd_architecture/osd_policy/osd-service-definition.adoc#osd-service-definition[{product-title} service definition]
 
 include::modules/life-cycle-definitions.adoc[leveloffset=+1]
 include::modules/life-cycle-major-versions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
`enterprise-4.12+`

Issue:
[Broken Link Tracker
](https://docs.google.com/spreadsheets/d/14JB9qPyvztA2LiHTzpOvHHUvnq5ieSVKghD9SxNPIGs/edit#gid=0)

Link to docs preview:
1. [OSD life cycle](https://56243--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle.html)

Link to CP where the link is broken - https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html-single/introduction_to_openshift_dedicated/index#osd-life-cycle

Additional information:
This PR _hopes_ to fix the broken links in Customer Portal.