### PR TITLE
Adds Network Observability 1.2 release notes

### DIFF
--- a/networking/network_observability/network-observability-operator-release-notes.adoc
+++ b/networking/network_observability/network-observability-operator-release-notes.adoc
@@ -18,12 +18,49 @@ For an overview of the Network Observability Operator, see xref:../../networking
 
 The following advisory is available for the Network Observability Operator 1.2.0:
 
-* https://access.redhat.com/errata/RHSA-2023:110096[RHSA-2023:110096-03 Network Observability Operator 1.2.0]
+* https://access.redhat.com/errata/RHSA-2023:1817[RHSA-2023:1817 Network Observability Operator 1.2.0]
 
 [id="network-observability-operator-preparing-to-update"]
 === Preparing for the next update 
 
 The subscription of an installed Operator specifies an update channel that tracks and receives updates for the Operator. Until the 1.2 release of the Network Observability Operator, the only channel available was `v1.0.x`. The 1.2 release of the Network Observability Operator introduces the `stable` update channel for tracking and receiving updates. You must switch your channel from `v1.0.x` to `stable` to receive future Operator updates. The `v1.0.x` channel is deprecated and planned for removal in a following release.
+
+[id="network-observability-operator-1.2.0-features-enhancements"]
+=== New features and enhancements
+
+[id="histogram-feature-1.2"]
+==== Histogram in Traffic Flows view
+* You can now choose to show a histogram bar chart of flows over time. The histogram enables you to visualize the history of flows without hitting the Loki query limit. For more information, see xref:../../networking/network_observability/observing-network-traffic.adoc#network-observability-histogram-trafficflow_nw-observe-network-traffic[Using the histogram].
+
+[id="conversation-tracking-feature-1.2"]
+==== Conversation tracking
+* You can now query flows by *Log Type*, which enables grouping network flows that are part of the same conversation. For more information, see xref:../../networking/network_observability/observing-network-traffic.adoc#network-observability-working-with-conversations_nw-observe-network-traffic[Working with conversations].
+
+[id="health-alerts-feature-1.2"]
+==== Network Observability health alerts
+* The Network Observability Operator now creates automatic alerts if the `flowlogs-pipeline` is dropping flows because of errors at the write stage or if the Loki ingestion rate limit has been reached. For more information, see xref:../../networking/network_observability/network-observability-operator-monitoring.adoc#network-observability-alert-dashboard_network_observability[Viewing health information]. 
+
+[id="network-observability-operator-1.2.0-bug-fixes"]
+=== Bug fixes
+
+* Previously, after changing the `namespace` value in the FlowCollector spec, eBPF Agent pods running in the previous namespace were not appropriately deleted. Now, the pods running in the previous namespace are appropriately deleted. (link:https://issues.redhat.com/browse/NETOBSERV-774[*NETOBSERV-774*])
+
+* Previously, after changing the `caCert.name` value in the FlowCollector spec (such as in Loki section), FlowLogs-Pipeline pods and Console plug-in pods were not restarted, therefore they were unaware of the configuration change. Now, the pods are restarted, so they get the configuration change. (link:https://issues.redhat.com/browse/NETOBSERV-772[*NETOBSERV-772*])
+
+* Previously, network flows between pods running on different nodes were sometimes not correctly identified as being duplicates because they are captured by different network interfaces. This resulted in over-estimated metrics displayed in the console plug-in. Now, flows are correctly identified as duplicates, and the console plug-in displays accurate metrics. (link:https://issues.redhat.com/browse/NETOBSERV-755[*NETOBSERV-755*])
+
+* The "reporter" option in the console plug-in is used to filter flows based on the observation point of either source node or destination node. Previously, this option mixed the flows regardless of the node observation point. This was due to network flows being incorrectly reported as Ingress or Egress at the node level.  Now, the network flow direction reporting is correct. The "reporter" option filters for source observation point, or destination observation point, as expected. (link:https://issues.redhat.com/browse/NETOBSERV-696[*NETOBSERV-696*])
+
+* Previously, for agents configured to send flows directly to the processor as gRPC+protobuf requests, the submitted payload could be too large and is rejected by the processors' GRPC server. This occured under  very-high-load scenarios and with only some configurations of the agent. The agent logged an error message, such as: _grpc: received message larger than max_. As a consequence, there was information loss about those flows.
+Now, the gRPC payload is split into several messages when the size exceeds a threshold. As a result, the server maintains connectivity. (link:https://issues.redhat.com/browse/NETOBSERV-617[*NETOBSERV-617*])
+
+[id="network-observability-operator-1.2.0-known-issues"]
+=== Known issue
+* In the 1.2.0 release of the Network Observability Operator, using Loki Operator 5.6, a Loki certificate transition periodically affects the `flowlogs-pipeline` pods and results in dropped flows rather than flows written to Loki. The problem self-corrects after some time, but it still causes temporary flow data loss during the Loki certificate transition. (link:https://issues.redhat.com/browse/NETOBSERV-980[*NETOBSERV-980*])
+
+[id="network-observability-operator-1.2.0-notable-technical-changes"]
+=== Notable technical changes
+* Previously, you could install the Network Observability Operator using a custom namespace. This release introduces the `conversion webhook` which changes the `ClusterServiceVersion`. Because of this change, all the available namespaces are no longer listed. Additionally, to enable Operator metrics collection, namespaces that are shared with other Operators, like the `openshift-operators` namespace, cannot be used. Now, the Operator must be installed in the `openshift-netobserv-operator` namespace. You cannot automatically upgrade to the new Operator version if you previously installed the Network Observability Operator using a custom namespace. If you previously installed the Operator using a custom namespace, you must delete the instance of the Operator that was installed and re-install your operator in the `openshift-netobserv-operator` namespace. It is important to note that custom namespaces, such as the commonly used `netobserv` namespace, are still possible for the `FlowCollector`, Loki, Kafka, and other plug-ins. (link:https://issues.redhat.com/browse/NETOBSERV-907[*NETOBSERV-907*])(link:https://https://issues.redhat.com/browse/NETOBSERV-956[*NETOBSERV-956*])
 
 [id="network-observability-operator-release-notes-1-1"]
 == Network Observability Operator 1.1.0


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
IMPORTANT: The build for this will be broken until Network Observability GA day (April 18) when I can merge all the feature docs that this PR links to.
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
ocp 4.10+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://56244--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/network-observability-operator-release-notes.html

I have another PR open for release note addition, and stable release info that adds the 1.2 intro header (which is missing from this PR). 
UPDATE: Previously, this PR was only going to be for 1.2 bug fixes. Since our 1.2 release is now bug fixes and features, I'm going to lump all the release notes into one PR. 
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
