### PR TITLE
[OSDOCS-5093]: GCP Shielded VM options

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -29,6 +29,15 @@ include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
 //Creating preemptible VM instances by using compute machine sets
 include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+2]
 
+//Configuring Shielded VM options by using machine sets
+include::modules/machineset-gcp-shielded-vms.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm[What is Shielded VM?]
+** link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#secure-boot[Secure Boot]
+** link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#vtpm[Virtual Trusted Platform Module (vTPM)]
+** link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm#integrity-monitoring[Integrity monitoring]
+
 //Enabling customer-managed encryption keys for a compute machine set
 include::modules/machineset-enabling-customer-managed-encryption.adoc[leveloffset=+1]
 //TODO break out procedure as a L2

--- a/modules/machineset-gcp-pd-disk-types.adoc
+++ b/modules/machineset-gcp-pd-disk-types.adoc
@@ -6,7 +6,7 @@
 [id="machineset-gcp-pd-disk-types_{context}"]
 = Configuring persistent disk types by using compute machine sets
 
-You can configure the type of persistent disk that a compute machine set deploys machines on by editing the compute machine set YAML file. 
+You can configure the type of persistent disk that a compute machine set deploys machines on by editing the compute machine set YAML file.
 
 For more information about persistent disk types, compatibility, regional availability, and limitations, see the GCP Compute Engine documentation about link:https://cloud.google.com/compute/docs/disks#pdspecs[persistent disks].
 
@@ -27,4 +27,4 @@ providerSpec:
 
 .Verification
 
-* On the Google Cloud console, review the details for a machine deployed by the compute machine set and verify that the `Type` field matches the configured disk type.
+* Using the Google Cloud console, review the details for a machine deployed by the compute machine set and verify that the `Type` field matches the configured disk type.

--- a/modules/machineset-gcp-shielded-vms.adoc
+++ b/modules/machineset-gcp-shielded-vms.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-gcp.adoc
+
+ifeval::["{context}" == "cpmso-using"]
+:cpmso:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="machineset-gcp-shielded-vms_{context}"]
+= Configuring Shielded VM options by using machine sets
+
+By editing the machine set YAML file, you can configure the Shielded VM options that a machine set uses for machines that it deploys.
+
+For more information about Shielded VM features and functionality, see the GCP Compute Engine documentation about link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm[Shielded VM].
+
+.Procedure
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Edit the following section under the `providerSpec` field:
++
+[source,yaml]
+----
+ifndef::cpmso[]
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+endif::cpmso[]
+ifdef::cpmso[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+endif::cpmso[]
+...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          shieldedInstanceConfig: <1>
+            integrityMonitoring: Enabled <2>
+            secureBoot: Disabled <3>
+            virtualizedTrustedPlatformModule: Enabled <4>
+...
+----
+<1> In this section, specify any Shielded VM options that you want.
+<2> Specify whether UEFI Secure Boot is enabled. Valid values are `Disabled` or `Enabled`.
+<3> Specify whether integrity monitoring is enabled. Valid values are `Disabled` or `Enabled`.
+<4> Specify whether virtual trusted platform module (vTPM) is enabled. Valid values are `Disabled` or `Enabled`.
+
+.Verification
+
+* Using the Google Cloud console, review the details for a machine deployed by the machine set and verify that the Shielded VM options match the values that you configured.
+
+ifeval::["{context}" == "cpmso-using"]
+:!cpmso:
+endif::[]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPCLOUD-1828](https://issues.redhat.com//browse/OCPCLOUD-1828) | [OSDOCS-5093](https://issues.redhat.com//browse/OSDOCS-5093)

Link to docs preview:
[Configuring Shielded VM options by using machine sets](https://56252--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-gcp-shielded-vms_creating-machineset-gcp)

QE review:
- [x] QE has approved this change.

Additional information:
* Control plane machine set assembly that will use the `cpmso` condition version does not exist yet.
* Not sure if I really should include all those GCP links in additional resources, will consult with other writers.