### PR TITLE
OSDOCS#4894: Installing a three-node AWS cluster

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -182,6 +182,8 @@ Topics:
     File: installing-restricted-networks-aws
   - Name: Installing a cluster on AWS with remote workers on AWS Outposts
     File: installing-aws-outposts-remote-workers
+  - Name: Installing a three-node cluster on AWS
+    File: installing-aws-three-node
   - Name: Uninstalling a cluster on AWS
     File: uninstalling-cluster-aws
 - Name: Installing on Azure
@@ -3754,7 +3756,7 @@ Topics:
   - Name: Installing the Serverless Operator
     File: install-serverless-operator
   - Name: Installing the Knative CLI
-    File: installing-kn    
+    File: installing-kn
   - Name: Installing Knative Serving
     File: installing-knative-serving
   - Name: Installing Knative Eventing
@@ -4094,7 +4096,7 @@ Topics:
     File: serverless-cost-management-integration
   - Name: Using NVIDIA GPU resources with serverless applications
     File: gpu-resources
-# Removing  
+# Removing
 - Name: Removing Serverless
   Dir: removing
   Topics:

--- a/installing/installing_aws/installing-aws-three-node.adoc
+++ b/installing/installing_aws/installing-aws-three-node.adoc
@@ -1,0 +1,22 @@
+:_content-type: ASSEMBLY
+[id="installing-aws-three-node"]
+= Installing a three-node AWS cluster
+include::_attributes/common-attributes.adoc[]
+:context: installing-aws-three-node
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a three-node cluster on Amazon Web Services (AWS). A three-node cluster consists of three control plane machines, which also act as compute machines. This type of cluster provides a smaller, more resource efficient cluster, for cluster administrators and developers to use for testing, development, and production.
+
+You can install a three-node cluster using either installer-provisioned or user-provisioned infrastructure.
+
+[NOTE]
+====
+Deploying a three-node cluster using an AWS Marketplace image is not supported.
+====
+
+include::modules/installation-three-node-cluster-cloud-provider.adoc[leveloffset=+1]
+
+== Next steps
+* xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Installing a cluster on AWS with customizations]
+* xref:../../installing/installing_aws/installing-aws-user-infra.adoc#installing-aws-user-infra[Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates]

--- a/modules/installation-creating-aws-worker.adoc
+++ b/modules/installation-creating-aws-worker.adoc
@@ -3,6 +3,10 @@
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-restricted-networks-aws.adoc
 
+ifeval::["{context}" == "installing-aws-user-infra"]
+:three-node-cluster:
+endif::[]
+
 :_content-type: PROCEDURE
 [id="installation-creating-aws-worker_{context}"]
 = Creating the worker nodes in AWS
@@ -12,6 +16,13 @@ If you do not plan to automatically create worker nodes by using a MachineSet,
 ////
 
 You can create worker nodes in Amazon Web Services (AWS) for your cluster to use.
+
+ifdef::three-node-cluster[]
+[NOTE]
+====
+If you are installing a three-node cluster, skip this step. A three-node cluster consists of three control plane machines, which also act as compute machines.
+====
+endif::three-node-cluster[]
 
 You can use the provided CloudFormation template and a custom parameter file to create a stack of AWS resources that represent a worker node.
 
@@ -39,6 +50,8 @@ have to contact Red Hat support with your installation logs.
 * You created the security groups and roles required for your cluster in AWS.
 * You created the bootstrap machine.
 * You created the control plane machines.
+
+
 
 .Procedure
 
@@ -163,3 +176,7 @@ $ aws cloudformation describe-stacks --stack-name <name>
 You must create at least two worker machines, so you must create at least
 two stacks that use this CloudFormation template.
 ====
+
+ifeval::["{context}" == "installing-aws-user-infra"]
+:!three-node-cluster:
+endif::[]

--- a/modules/installation-generate-aws-user-infra-install-config.adoc
+++ b/modules/installation-generate-aws-user-infra-install-config.adoc
@@ -4,6 +4,9 @@
 // * installing/installing_aws/installing-aws-user-infra.adoc
 // * installing/installing_aws/installing-restricted-networks-aws.adoc
 
+ifeval::["{context}" == "installing-aws-user-infra"]
+:three-node-cluster:
+endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws"]
 :restricted:
 endif::[]
@@ -145,6 +148,10 @@ platform:
 <1> Add the `subnets` section and specify the `PrivateSubnetIds` and `PublicSubnetIds` values from the outputs of the CloudFormation template for the VPC. Do not include the Local Zone subnets here.
 endif::localzone[]
 
+ifdef::three-node-cluster[]
+. If you are installing a three-node cluster, modify the `install.config.yaml` file by setting the `compute.replicas` parameter to `0`. This ensures that the cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on AWS".
+endif::three-node-cluster[]
+
 . Optional: Back up the `install-config.yaml` file.
 +
 [IMPORTANT]
@@ -153,6 +160,9 @@ The `install-config.yaml` file is consumed during the installation process. If
 you want to reuse the file, you must back it up now.
 ====
 
+ifeval::["{context}" == "installing-aws-user-infra"]
+:!three-node-cluster:
+endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws"]
 :!restricted:
 endif::[]

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -54,6 +54,7 @@ ifeval::["{context}" == "installing-alibaba-vpc"]
 endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :aws:
@@ -472,6 +473,13 @@ ifndef::restricted,alibabacloud-default,alibabacloud-custom,alibabacloud-vpc,nut
 . Modify the `install-config.yaml` file. You can find more information about
 the available parameters in the "Installation configuration parameters" section.
 endif::restricted,alibabacloud-default,alibabacloud-custom,alibabacloud-vpc,nutanix,aws-outposts[]
+ifdef::three-node-cluster[]
++
+[NOTE]
+====
+If you are installing a three-node cluster, be sure to set the `compute.replicas` parameter to `0`. This ensures that cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on AWS".
+====
+endif::three-node-cluster[]
 
 ifdef::alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
 . Installing the cluster into Alibaba Cloud requires that the Cloud Credential Operator (CCO) operate in manual mode. Modify the `install-config.yaml` file to set the `credentialsMode` parameter to `Manual`:
@@ -666,6 +674,7 @@ ifeval::["{context}" == "installing-alibaba-vpc"]
 endif::[]
 ifeval::["{context}" == "installing-aws-customizations"]
 :!aws:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :!aws:

--- a/modules/installation-three-node-cluster-cloud-provider.adoc
+++ b/modules/installation-three-node-cluster-cloud-provider.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+// * installing/installing_aws/installing-aws-three-node.adoc
+// *
+// *
+
+:_content-type: PROCEDURE
+[id="installation-three-node-cluster_{context}"]
+= Configuring a three-node cluster
+
+You configure a three-node cluster by setting the number of worker nodes to `0` in the `install-config.yaml` file before deploying the cluster. Setting the number of worker nodes to `0` ensures that the control plane machines are schedulable. This allows application workloads to be scheduled to run from the control plane nodes.
+
+[NOTE]
+====
+Because application workloads run from control plane nodes, additional subscriptions are required, as the control plane nodes are considered to be compute nodes.
+====
+
+.Prerequisites
+
+* You have an existing `install-config.yaml` file.
+
+.Procedure
+
+. Set the number of compute replicas to `0` in your `install-config.yaml` file, as shown in the following `compute` stanza:
++
+[source,yaml]
+----
+compute:
+- name: worker
+  platform: {}
+  replicas: 0
+----
+. If you are deploying a cluster with user-provisioned infrastructure, do not create additional worker nodes.
+
+.Verification
+
+To verify that the control plane nodes are schedulable, open the `cluster-scheduler-02-config.yml` Kubernetes manifest file and confirm that the `spec.mastersSchedulable` parameter is set to `true`. You can locate this file in `<installation_directory>/manifests`.
+
+* If you install a cluster on infrastructure that the installation program provisions, you can complete this verification step after the cluster is deployed.
+* If you install a cluster on infrastructure that you provision, you can complete this verification step after creating the Kubernetes manifest and Ignition configuration files.
+
+.Example `cluster-scheduler-02-config.yml` file for a three-node cluster
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  creationTimestamp: null
+  name: cluster
+spec:
+  mastersSchedulable: true
+  policy:
+    name: ""
+status: {}
+----

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -24,6 +24,7 @@
 
 ifeval::["{context}" == "installing-aws-user-infra"]
 :aws:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-aws"]
 :aws:
@@ -207,7 +208,7 @@ to initialize them.
 +
 * You can preserve the compute machine set files to create compute machines by using the machine API, but you must update references to them to match your environment.
 endif::osp,vsphere,vmc[]
-ifdef::baremetal,baremetal-restricted,ibm-z,ibm-power[]
+ifdef::baremetal,baremetal-restricted,ibm-z,ibm-power,three-node-cluster[]
 +
 [WARNING]
 ====
@@ -218,7 +219,7 @@ If you are installing a three-node cluster, skip the following step to allow the
 ====
 When you configure control plane nodes from the default unschedulable to schedulable, additional subscriptions are required. This is because control plane nodes then become compute nodes.
 ====
-endif::baremetal,baremetal-restricted,ibm-z,ibm-power[]
+endif::baremetal,baremetal-restricted,ibm-z,ibm-power,three-node-cluster[]
 
 . Check that the `mastersSchedulable` parameter in the `<installation_directory>/manifests/cluster-scheduler-02-config.yml` Kubernetes manifest file is set to `false`. This setting prevents pods from being scheduled on the control plane machines:
 +
@@ -496,6 +497,7 @@ ifeval::["{context}" == "installing-restricted-networks-aws"]
 endif::[]
 ifeval::["{context}" == "installing-aws-user-infra"]
 :!aws:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :!azure:


### PR DESCRIPTION
Version(s):
4.13+

Issue:
This PR addresses [osdocs-4894](https://issues.redhat.com/browse/OSDOCS-4894)

Link to docs preview:

- [Installing a three-node AWS cluster](https://56253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-three-node.html)
- Installing a cluster on AWS with customizations > [Creating the installation configuration file](https://56253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-initializing_installing-aws-customizations) (note under step 2)
- Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates > [Creating the installation configuration file](https://56253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-generate-aws-user-infra-install-config_installing-aws-user-infra) (step 2)
- Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates > [Creating the Kubernetes manifest and Ignition config files](https://56253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-aws-user-infra) (warning before step 5)
- Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates > [Creating the worker nodes in AWS](https://56253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra.html#installation-creating-aws-worker_installing-aws-user-infra) (first note)

QE review:
- [ ] QE has approved this change.

Additional information:
Per the engineering installer [plan](https://docs.google.com/spreadsheets/d/1yl7p0IGQh0itLnoN1eJQWWtBq9zFdjGrM6mSyZVU-Ck/edit#gid=2101423022) this work is QE and docs only. SME approval is not required.