### PR TITLE
RHDEVDOCS-5014: Release Notes updates for Pipelines 1.9.1

### DIFF
--- a/modules/op-release-notes-1-9.adoc
+++ b/modules/op-release-notes-1-9.adoc
@@ -358,7 +358,7 @@ spec:
 
 // .PAC	
 
-* Before this update, {pac} did not get updated values from the {pac} ConfigMap object. With this update, this issue is fixed and {pac} ConfigMap object looks for any new changes.	
+* Before this update, {pac} did not get updated values from the {pac} `ConfigMap` object. With this update, this issue is fixed and the {pac} `ConfigMap` object looks for any new changes.
 // Savita Ashture	
 
 * Before this update, {pac} controller did not wait for the `tekton.dev/pipeline` label to be updated and added the `checkrun id` label, which would cause race conditions. With this update, the {pac} controller waits for the `tekton.dev/pipeline` label to be updated and then adds the `checkrun id` label, which helps to avoid race conditions.	
@@ -373,3 +373,49 @@ spec:
 * Before this update, a pull request failed if the user in the annotation provided values by using a regex form, for example, `refs/head/rel-*`. The pull request failed because it was missing `refs/heads` in its base branch. With this update, the prefix is added and checked that it matches. This resolves the issue and the pull request is successful.	
 // Savita Ashture
 
+[id="release-notes-1-9-1_{context}"]
+== Release notes for {pipelines-title} General Availability 1.9.1
+
+With this update, {pipelines-title} General Availability (GA) 1.9.1 is available on {product-title} 4.11 and later.
+
+[id="fixed-issues-1-9-1_{context}"]	
+== Fixed issues	
+
+* Before this update, the `tkn pac repo list` command did not run on Microsoft Windows. This update fixes the issue, and now you can run the `tkn pac repo list` command on Microsoft Windows.
+
+* Before this update, {pac} watcher did not receive all the configuration change events. With this update, the {pac} watcher is updated, and now the {pac} watcher does not miss the configuration change events.
+
+* Before this update, the pods created by {pac}, such as `TaskRuns` or `PipelineRuns` could not access custom certificates exposed by the user in the cluster. This update fixes the issue, and you can now access custom certificates from the `TaskRuns` or `PipelineRuns` pods in the cluster.
+
+* Before this update, on a cluster enabled with FIPS, the `tekton-triggers-core-interceptors` core interceptor used in the `Trigger` resource did not function after the Pipelines Operator was upgraded to version 1.9. This update resolves the issue. Now, OpenShift uses MInTLS 1.2 for all its components. As a result, the `tekton-triggers-core-interceptors` core interceptor updates to TLS version 1.2and its functionality runs accurately.
+
+* Before this update, when using a pipeline run with an internal OpenShift image registry, the URL to the image had to be hardcoded in the pipeline run definition. For example:
++
+[source,yaml]
+----
+...
+  - name: IMAGE_NAME
+    value: 'image-registry.openshift-image-registry.svc:5000/<test_namespace>/<test_pipelinerun>'
+...
+----
++
+When using a pipeline run in the context of {pac}, such hardcoded values prevented the pipeline run definitions from being used in different clusters and namespaces.
++
+With this update, you can use the dynamic template variables instead of hardcoding the values for namespaces and pipeline run names to generalize pipeline run definitions. For example:
++
+[source,yaml]
+----
+...
+  - name: IMAGE_NAME
+    value: 'image-registry.openshift-image-registry.svc:5000/{{ target_namespace }}/$(context.pipelineRun.name)'
+...
+----
+
+* Before this update, {pac} used the same GitHub token to fetch a remote task available in the same host only on the default GitHub branch. This update resolves the issue. Now {pac} uses the same GitHub token to fetch a remote task from any GitHub branch.
+
+[id="known-issues-1-9-1_{context}"]
+== Known issues
+
+* The value for `CATALOG_REFRESH_INTERVAL`, a field in the Hub API `ConfigMap` object used in the Tekton Hub CR, is not getting updated with a custom value provided by the user.
++
+Workaround: None. You can track the issue link:https://issues.redhat.com/browse/SRVKP-2854[SRVKP-2854].

--- a/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
+++ b/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
@@ -19,7 +19,7 @@ GA:: General Availability
 
 | Operator | Pipelines | Triggers | CLI | Catalog | Chains | Hub | {pac} | |
 
-|1.9 | 0.41.x | 0.22.x | 0.28.x | NA | 0.13.x (TP) | 1.11.x | 0.15.x (GA) | 4.11, 4.12, 4.13 (planned) | GA
+|1.9 | 0.41.x | 0.22.x | 0.28.x | NA | 0.13.x (TP) | 1.11.x (TP) | 0.15.x (GA) | 4.11, 4.12, 4.13 (planned) | GA
 
 |1.8 | 0.37.x | 0.20.x | 0.24.x | NA | 0.9.0 (TP) | 1.8.x (TP) | 0.10.x (TP) | 4.10, 4.11, 4.12 | GA
 


### PR DESCRIPTION
Purpose: To resolve the following issue:

https://issues.redhat.com/browse/RHDEVDOCS-5014

Aligned team: DevTools

OCP version this PR applies to (cherrypicking): enterprise 4.11 and later

Content for preview: https://56267--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#release-notes-1-9-1_op-release-notes

SME review : @savitaashture 

QE review: @chmouel @VeereshAradhya @ppitonak 

PM review: @siamaksade

Peer review: @Srivaralakshmi 