### PR TITLE
OCPBUGS-7592: adds clarification for IPv6 support

### DIFF
--- a/modules/installing-ocp-agent.adoc
+++ b/modules/installing-ocp-agent.adoc
@@ -128,6 +128,7 @@ platform:
     - 192.168.11.4
     - 2001:DB8::5
 ----
+IPv6 is supported only on bare metal platforms.
 ====
 
 . Create the `agent-config.yaml` file:
@@ -268,4 +269,5 @@ networking:
   - fd03::/112
   networkType: OVNKubernetes
 ----
+IPv6 is supported only on bare metal platforms.
 ====


### PR DESCRIPTION
- Applies to 4.12 and above versions
- [Jira](https://issues.redhat.com/browse/OCPBUGS-7592)
- [Preview](https://56268--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html)