### PR TITLE
OCPBUGS-7592: adds clarification for IPv6 support

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -214,6 +214,8 @@ You can create the agent ISO image with the following IP address configurations:
 * IPv6
 * IPv4 and IPv6 in parallel (dual-stack)
 
+NOTE: IPv6 is supported only on bare metal platforms.
+
 For more information, see xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent_installing-with-agent-based-installer[Dual and single IP stack clusters].
 
 [id="ocp-4-12-agent-based-install-mce"]
@@ -235,6 +237,8 @@ For more information, see xref:../installing/installing_with_agent_based_install
 ==== Configure static networking in a Agent-based installation
 With the Agent-based {product-title} Installer, you can configure static IP addresses for IPv4, IPv6, or dual-stack (both IPv4 and IPv6) for all the hosts prior to creating the agent ISO image. You can add the static addresses to the `hosts` section of the `agent-config.yaml` file or in the `NMStateConfig.yaml` file if you are using the ZTP manifests.
 Note that the configuration of the addresses must follow the syntax rules for NMState as described in link:https://nmstate.io/examples.html[NMState state examples].
+
+NOTE: IPv6 is supported only on bare metal platforms.
 
 For more information, see xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-networking_preparing-to-install-with-agent-based-installer[About networking].
 


### PR DESCRIPTION
- Applies to 4.12  only
- [Jira](https://issues.redhat.com/browse/OCPBUGS-7592)
- [Preview](https://56270--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-installation-and-upgrade)