### PR TITLE
[enterprise-4.10]: RHDEVDOCS-4988 | Updated the command in Step 1 and 3

### DIFF
--- a/modules/op-running-a-pipeline.adoc
+++ b/modules/op-running-a-pipeline.adoc
@@ -19,7 +19,7 @@ $ tkn pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=https://raw.githubusercontent.com/openshift/pipelines-tutorial/{pipelines-ver}/01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=pipelines-vote-api \
     -p git-url=https://github.com/openshift/pipelines-vote-api.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/pipelines-vote-api \
+    -p IMAGE='image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/pipelines-vote-api' \
     --use-param-defaults
 ----
 +
@@ -42,7 +42,7 @@ $ tkn pipeline start build-and-deploy \
     -w name=shared-workspace,volumeClaimTemplateFile=https://raw.githubusercontent.com/openshift/pipelines-tutorial/{pipelines-ver}/01_pipeline/03_persistent_volume_claim.yaml \
     -p deployment-name=pipelines-vote-ui \
     -p git-url=https://github.com/openshift/pipelines-vote-ui.git \
-    -p IMAGE=image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/pipelines-vote-ui \
+    -p IMAGE='image-registry.openshift-image-registry.svc:5000/$(context.pipelineRun.namespace)/pipelines-vote-ui' \
     --use-param-defaults
 ----
 


### PR DESCRIPTION
Manual CP from [56057](https://github.com/openshift/openshift-docs/pull/56057) to 4.10

Aligned team: Dev Tools

Purpose: To resolve [RHDEVDOCS-4988](https://issues.redhat.com/browse/RHDEVDOCS-4988)

OCP version this PR applies to: `enterprise 4.10`