### PR TITLE
[GH#52915] clarified single-az cluster minimum infra nodes

### DIFF
--- a/modules/rosa-policy-failure-points.adoc
+++ b/modules/rosa-policy-failure-points.adoc
@@ -35,7 +35,9 @@ When accounting for possible node failures, it is also important to understand h
 
 [id="rosa-policy-container-cluster-failure_{context}"]
 == Cluster failure
-ROSA clusters have at least three control plane nodes and three infrastructure nodes that are preconfigured for high availability, either in a single zone or across multiple zones, depending on the type of cluster you have selected. Control plane and infrastructure nodes have the same resiliency as worker nodes, with the added benefit of being managed completely by Red Hat.
+Single-AZ ROSA clusters have at least three control plane and two infrastructure nodes in the same availability zone (AZ) in the private subnet.
+
+Multi-AZ ROSA clusters have at least three control plane nodes and three infrastructure nodes that are preconfigured for high availability, either in a single zone or across multiple zones, depending on the type of cluster you have selected. Control plane and infrastructure nodes have the same resiliency as worker nodes, with the added benefit of being managed completely by Red Hat.
 
 In the event of a complete control plane outage, the OpenShift APIs will not function, and existing worker node pods are unaffected. However, if there is also a pod or node outage at the same time, the control planes must recover before new pods or nodes can be added or scheduled.
 


### PR DESCRIPTION
Version(s):
ROSA

Issue:
[#52915](https://github.com/openshift/openshift-docs/issues/52915)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[About availability for Red Hat OpenShift Service on AWS](https://56277--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-understand-availability.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
[Source](https://catalog.workshops.aws/aws-openshift-workshop/en-US/2-networking/2-rosa-az) for Single-AZ Cluster setup.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
