### PR TITLE
OCPBUGS-7798 ensuring text description of command output match up

### DIFF
--- a/modules/nw-ovn-kubernetes-list-resources.adoc
+++ b/modules/nw-ovn-kubernetes-list-resources.adoc
@@ -61,7 +61,7 @@ configmap/signer-ca                  1      57m
 +
 There are three `ovnkube-masters` that run on the control plane nodes, and two daemon sets used to deploy the `ovnkube-master` and `ovnkube-node` pods.
 There is one `ovnkube-node` pod for each node in the cluster.
-In this example, there are 6, and since there is one `ovnkube-node` per node in the cluster, there are six nodes in the cluster.
+In this example, there are 5, and since there is one `ovnkube-node` per node in the cluster, there are five nodes in the cluster.
 The `ovnkube-config` `ConfigMap` has the {product-title} OVN-Kubernetes configurations started by online-master and `ovnkube-node`.
 The `ovn-kubernetes-master` `ConfigMap` has the information of the current online master leader.
 


### PR DESCRIPTION
[OCPBUGS-7798]: The command output does not match the description underneath. So this updates 6 to 5 as that is accurate. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.13 and main

Issue: https://issues.redhat.com/browse/OCPBUGS-7798


Link to docs preview:
https://56303--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly.html#nw-ovn-kubernetes-list-resources_ovn-kubernetes-architecture

Doc has gone through extensive review in PR https://github.com/openshift/openshift-docs/pull/54155. This PR is really fixing a typo where it should read 5 instead of 6. I updated the command-line output in the previous PR late in the cycle, but I neglected to revise the description underneath. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
