### PR TITLE
OSDOCS-4038: Multi-arch on Azure GA docs updates

### DIFF
--- a/modules/multi-architecture-creating-arm64-bootimage.adoc
+++ b/modules/multi-architecture-creating-arm64-bootimage.adoc
@@ -7,7 +7,7 @@
 
 = Creating an arm64 boot image using the Azure image gallery
  
-To configure your cluster with multi-architecture compute machines, you must create an `arm64` boot image and add it to your Azure compute machine set. The following procedure describes how to manually generate an `arm64` boot image. 
+The following procedure describes how to manually generate an `arm64` boot image. 
  
 .Prerequisites
 

--- a/post_installation_configuration/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/multi-architecture-configuration.adoc
@@ -6,21 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. You can deploy a cluster with multi-architecture compute machines by creating an Azure installer-provisioned cluster using the multi-architecture installer binary. For Azure installation, see xref:../installing/installing_azure/installing-azure-customizations.adoc[Installing a cluster on Azure with customizations].
+An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. Clusters with multi-architecture compute machines are available only on AWS or Azure installer-provisioned infrastructures and bare metal user-provisioned infrastructures with `x86_64` control plane machines. 
 
-[WARNING]
-====
-The multi-architecture compute machines Technology Preview feature has limited usability with installing, upgrading, and running payloads. 
-====
+== Creating a cluster with multi-architecture compute machine on Azure 
 
-The following procedures explain how to generate an `arm64` boot image and create an Azure compute machine set with the `arm64` boot image. This adds `arm64` compute nodes to your cluster and deploys the desired amount of `arm64` virtual machines (VM). This section also shows how to upgrade your existing cluster to a cluster that supports multi-architecture compute machines. Clusters with multi-architecture compute machines are only available on Azure installer-provisioned infrastructures with `x86_64` control plane machines. 
+To deploy an Azure cluster with multi-architecture compute machines, you must first create a single-architecture Azure installer-provisioned cluster that uses the multi-architecture installer binary. For more information on Azure installations, see xref:../installing/installing_azure/installing-azure-customizations.adoc[Installing a cluster on Azure with customizations]. You can then add an `arm64` compute machine set to your cluster to create a cluster with multi-architecture compute machines. 
 
-:FeatureName: {product-title} clusters with multi-architecture compute machines on Azure installer-provisioned infrastructure installations
-include::snippets/technology-preview.adoc[leveloffset=+1]
+The following procedures explain how to generate an `arm64` boot image and create an Azure compute machine set that uses the `arm64` boot image. This adds `arm64` compute nodes to your cluster and deploys the amount of `arm64` virtual machines (VM) that you need. 
 
-include::modules/multi-architecture-creating-arm64-bootimage.adoc[leveloffset=+1]
+include::modules/multi-architecture-creating-arm64-bootimage.adoc[leveloffset=+2]
 
-include::modules/multi-architecture-modify-machine-set.adoc[leveloffset=+1]
+include::modules/multi-architecture-modify-machine-set.adoc[leveloffset=+2]
 
 [role="_additional-resources"] 
 .Additional resources


### PR DESCRIPTION
**For version** 4.13+ 
**Issue:** [OSDOCS-4038](https://issues.redhat.com//browse/OSDOCS-4038) 

**Description:** Clusters with multi-architecture compute machines are going GA on Azure in 4.13. This PR updates the documentation to show full support. 

**Preview:** 

 Configuring multi-architecture compute machines on a OpenShift Container platform cluster

- [Creating a cluster with multi-architecture compute machines on Azure ](https://56306--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html)

**QE review:** 
- [x] QE Approval
