### PR TITLE
OSDOCS#5227: RN for three-node cluster support on public cloud and vSphere

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -56,7 +56,7 @@ This release adds improvements related to the following components and concepts.
 === Installation and upgrade
 
 [id="ocp-4-13-installation-vsphere-8-support"]
-==== Support for VMware vSphere version 8.0 
+==== Support for VMware vSphere version 8.0
 {product-title} {product-version} supports VMware vSphere version 8.0. You can continue to install an {product-title} cluster on VMware vSphere version 7.0 Update 2.
 
 [id="ocp-4-13-installation-vsphere-region-zone"]
@@ -68,6 +68,13 @@ You can also specify multiple regions and zones on a cluster after installation.
 [id="ocp-4-13-installation-vsphere-default-config-yaml"]
 ==== Changes to the default `install-config.yaml` file
 After you run the installation program for {product-title} on vSphere, the default `install-config.yaml` file now includes `vcenters` and `failureDomains` fields, so that you can choose to specify multiple datacenters, region, and zone information for your cluster. You can leave these fields blank if you want to install an {product-title} cluster in a vSphere environment that consists of single datacenter running in a VMware vCenter.
+
+[id="ocp-4-13-installation-and-upgrade-three-node"]
+==== Three-node cluster support
+
+Beginning with {product-title} {product-version}, deploying a three-node cluster is supported on Amazon Web Services (AWS), Microsoft Azure, Google Cloud Platform (GCP), and VMware vSphere. This type of {product-title} cluster is a smaller, more resource efficient cluster, as it consists of only three control plane machines, which also act as compute machines.
+
+For more information, see xref:../installing/installing_aws/installing-aws-three-node.adoc#installing-aws-three-node[Installing a three-node cluster on AWS], xref:../installing/installing_azure/installing-azure-three-node.adoc#installing-azure-three-node[Installing a three-node cluster on Azure], xref:../installing/installing_gcp/installing-gcp-three-node.adoc#installing-gcp-three-node[Installing a three-node cluster on GCP], and xref:../installing/installing_vsphere/installing-vsphere-three-node.adoc#installing-vsphere-three-node[Installing a three-node cluster on vSphere].
 
 [id="ocp-4-13-post-installation"]
 === Post-installation configuration
@@ -216,9 +223,9 @@ For more information, see xref:../machine_management/control_plane_machine_manag
 [id="ocp-4-13-NUMA-scheduler-ga"]
 ==== NUMA-aware scheduling with the NUMA Resources Operator is generally available
 
-NUMA-aware scheduling with the NUMA Resources Operator was previously introduced as a Technology Preview in {product-title} 4.10 and is now generally available in {product-title} {product-version}. 
+NUMA-aware scheduling with the NUMA Resources Operator was previously introduced as a Technology Preview in {product-title} 4.10 and is now generally available in {product-title} {product-version}.
 
-The NUMA Resources Operator deploys a NUMA-aware secondary scheduler that makes scheduling decisions for workloads based on a complete picture of available NUMA zones in clusters. This enhanced NUMA-aware scheduling ensures that latency-sensitive workloads are processed in a single NUMA zone for maximum efficiency and performance. 
+The NUMA Resources Operator deploys a NUMA-aware secondary scheduler that makes scheduling decisions for workloads based on a complete picture of available NUMA zones in clusters. This enhanced NUMA-aware scheduling ensures that latency-sensitive workloads are processed in a single NUMA zone for maximum efficiency and performance.
 
 This update adds the following features:
 


### PR DESCRIPTION
Version(s):
4.13

Issue:
This PR address [osdocs-5227](https://issues.redhat.com/browse/OSDOCS-5227). This Jira issue represents the collective docs work for three-node support on AWS, Azure, GCP, and vSphere.

Link to docs preview:

[Three-node cluster support](https://56307--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-installation-and-upgrade-three-node)

QE review:
- [ ] QE has approved this change.