### PR TITLE
OSDOCS-5410: Adds a step that console supports Operator to specify where to run with CSV suggested namespace

### DIFF
--- a/modules/osdk-suggested-namespace.adoc
+++ b/modules/osdk-suggested-namespace.adoc
@@ -6,9 +6,11 @@
 [id="osdk-suggested-namespace_{context}"]
 = Setting a suggested namespace
 
-Some Operators must be deployed in a specific namespace, or with ancillary resources in specific namespaces, to work properly. If resolved from a subscription, Operator Lifecycle Manager (OLM) defaults the namespaced resources of an Operator to the namespace of its subscription.
+Some Operators must be deployed in a specific namespace, or with ancillary resources in specific namespaces, to work properly. If resolved from a subscription, Operator Lifecycle Manager (OLM) defaults the namespaced resources of an Operator to the namespace of its subscription. In general, Operators should be able to run on any node and namespace in the cluster. Some Operators only run on primary nodes, which is currently done by setting a `nodeSelector` to the pod spec by the Operator itself.
 
-As an Operator author, you can instead express a desired target namespace as part of your cluster service version (CSV) to maintain control over the final namespaces of the resources installed for their Operators. When adding the Operator to a cluster using OperatorHub, this enables the web console to autopopulate the suggested namespace for the cluster administrator during the installation process.
+As an Operator author, you can express a desired target namespace with a namespace default node selector specified in the namespace manifest in YAML as part of your cluster service version (CSV). Adding an Operator to a cluster using OperatorHub enables the web console to autopopulate the suggested namespace for the cluster administrator during the installation process, and the suggested namespace is created directly using the namespace manifest in YAML included as part of your CSV.
+
+To avoid getting duplicate and potentially conflicting cluster-wide `nodeSelector`, you can set a default node selector on the namespace where the Operator runs. The namespace default node selector will take precedence over the cluster default, and the cluster default will not be applied to the pods in the Operator's namespace.
 
 .Procedure
 
@@ -18,6 +20,16 @@ As an Operator author, you can instead express a desired target namespace as par
 ----
 metadata:
   annotations:
-    operatorframework.io/suggested-namespace: <namespace> <1>
+    operatorframework.io/suggested-namespace-template: <namespace> <1>
+      {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+          "name": "vertical-pod-autoscaler-suggested-template",
+          "annotations": {
+            "openshift.io/node-selector": ""
+          }
+        }
+      }
 ----
 <1> Set your suggested namespace.


### PR DESCRIPTION
[OSDOCS-5410](https://issues.redhat.com//browse/OSDOCS-5410): Adds a step that console supports Operator to specify where to run with CSV suggested namespace

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5410
https://issues.redhat.com/browse/OSDOCS-5163

Link to docs preview:
https://56317--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html#osdk-suggested-namespace_osdk-generating-csvs

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
