### PR TITLE
OSDOCS-5412: fixing broken links in install guide

### DIFF
--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-You can embed {product-title} into a {op-system-ostree-first} {op-system-version} image. Use the content within this section to build a {op-system-ostree-first} {op-system-version} image containing {product-title}.
+You can embed {product-title} into a {op-system-ostree-first} {op-system-version} image. Use the content within this section to build a {op-system} image containing {product-title}.
 
 [IMPORTANT]
 ====
@@ -51,9 +51,9 @@ include::modules/microshift-provisioning-ostree.adoc[leveloffset=+1]
 .Additional resources
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/composing_installing_and_managing_rhel_for_edge_images/index[{op-system-ostree} documentation].
-* xref:../microshift_install/microshift-install-rpm.adoc#system-requirements-installing-microshift[System requirements for installing {product-title}].
+* xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-system-requirements_microshift-install-rpm[System requirements for installing MicroShift].
 * Red Hat Hybrid Cloud Console link:https://console.redhat.com/openshift/install/pull-secret[pull secret].
-* xref:../microshift_networking/microshift-firewall.adoc#microshift-firewall-req-settings_microshift-networking[Required firewall settings].
+* xref:../microshift_networking/microshift-firewall.adoc#microshift-firewall-req-settings_microshift-firewall[Required firewall settings].
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/creating-kickstart-files_installing-rhel-as-an-experienced-user[Creating a Kickstart file].
 * link:https://access.redhat.com/solutions/60959[How to embed a Kickstart file into an ISO image].
 

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -16,10 +16,9 @@ Red Hat does not support an update path from Developer Preview and Technology Pr
 include::modules/microshift-install-system-requirements.adoc[leveloffset=+1]
 include::modules/microshift-install-rpm-preparing.adoc[leveloffset=+1]
 
-[role="_additional-resources_microshift-install-rpm"]
+[role="_additional-resources"]
+[id="_additional-resources_microshift-install-rpm"]
 .Additional resources
-
-* xref:../microshift_install/microshift-install-rpm.adoc#system-requirements-installing-microshift[System Requirements for Installing MicroShift] have been met.
 
 * Download the link:https://console.redhat.com/openshift/install/pull-secret[pull secret] from the Red Hat Hybrid Cloud Console.
 
@@ -27,16 +26,17 @@ include::modules/microshift-install-rpm-preparing.adoc[leveloffset=+1]
 
 * For more options on partition configuration, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_a_standard_rhel_8_installation/index#manual-partitioning_graphical-installation[Configuring Manual Partitioning].
 
-* For more information about resizing your existing LVs to free up capacity in your VGs, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_logical_volumes/index#managing-lvm-volume-groups_configuring-and-managing-logical-volumes[Managing LVM Volume Groups]
+* For more information about resizing your existing LVs to free up capacity in your VGs, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_logical_volumes/index#managing-lvm-volume-groups_configuring-and-managing-logical-volumes[Managing LVM Volume Groups].
 
 include::modules/microshift-installing-from-rpm.adoc[leveloffset=+1]
 
-[role="_additional-resources_microshift-install-rpm"]
+[role="_additional-resources"]
+[id="_additional-resources_microshift-install-rpm-section-two"]
 .Additional resources
 
-* xref:../microshift_install/microshift-install-rpm.adoc#system-requirements-installing-microshift[System requirements for installing MicroShift] have been met.
+* xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-system-requirements_microshift-install-rpm[System requirements for installing MicroShift].
 
-* xref:../microshift_install/microshift-install-rpm.adoc#preparing-install-microshift-from-rpm-package_microshift-install-rpm[Preparing to install MicroShift from an RPM package].
+* xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm-preparing_microshift-install-rpm[Preparing to install MicroShift from an RPM package].
 
 include::modules/microshift-service-starting.adoc[leveloffset=+1]
 include::modules/microshift-service-stopping.adoc[leveloffset=+1]

--- a/modules/microshift-install-rpm-preparing.adoc
+++ b/modules/microshift-install-rpm-preparing.adoc
@@ -3,7 +3,7 @@
 // microshift/microshift-install-rpm.adoc
 
 :_content-type: PROCEDURE
-[id="preparing-install-microshift-from-rpm-package_{context}"]
+[id="microshift-install-rpm-preparing_{context}"]
 = Preparing to install {product-title} from an RPM package
 
 Before installing {product-title} from an RPM package, you must configure your {op-system} machine to have a logical volume manager (LVM) volume group (VG) with sufficient capacity for the persistent volumes (PVs) of your workload.

--- a/modules/microshift-install-system-requirements.adoc
+++ b/modules/microshift-install-system-requirements.adoc
@@ -3,7 +3,7 @@
 // microshift/microshift-install-rpm.adoc
 
 :_content-type: REFERENCE
-[id="system-requirements-installing-microshift"]
+[id="microshift-install-system-requirements_{context}"]
 = System requirements for installing {product-title}
 
 The following conditions must be met prior to installing {product-title}:

--- a/modules/microshift-oc-by-example-content.adoc
+++ b/modules/microshift-oc-by-example-content.adoc
@@ -3,7 +3,7 @@
 //* microshift-oc-cli-commands-list/microshift-oc-by-example-content.adoc
 
 :_content-type: REFERENCE
-[id="microshift-oc-by-example-content"_{context}]
+[id="microshift-oc-by-example-content_{context}"]
 = oc commands list for {product-title}
 
 The following lists a few examples of `oc` commands you can use to administer, deploy, and observe a {product-title} node.

--- a/modules/microshift-provisioning-ostree.adoc
+++ b/modules/microshift-provisioning-ostree.adoc
@@ -3,7 +3,7 @@
 // microshift/microshift-embed-into-rpm-ostree.adoc
 
 :_content-type: PROCEDURE
-[id="provisioning-{product-title}_{context}"]
+[id="provisioning-a-machine_{context}"]
 = Provisioning for {product-title}
 
 Provision a machine with your {op-system-ostree} image by using the procedures from the {op-system-ostree} documentation.
@@ -24,7 +24,7 @@ If you are using a Kickstart such as the {op-system-ostree} Installer (iso) imag
 
 . You have created an {op-system-ostree} Installer (ISO) image containing your {op-system-ostree} commit with {product-title}.
 . Create a Kickstart file or use an existing one. In the Kickstart file, you must include:
-.. The details about how to create a user.
+.. Detailed instructions about how to create a user.
 .. How to fetch and deploy the {op-system-ostree} image.
 
 For more information, see "Additional resources."


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5412

Link to docs preview:
https://56319--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#installing-microshift-from-rpm-package_microshift-install-rpm
scroll up a little from
https://56319--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#accessing-microshift-cluster_microshift-embed-in-rpm-ostree

QE review:
N/A internal docs bug

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
