### PR TITLE
OCPBUGS#7608: iPXE for ZTP not default behaviour

### DIFF
--- a/modules/ztp-installation-crs.adoc
+++ b/modules/ztp-installation-crs.adoc
@@ -22,7 +22,7 @@ The following table lists the installation CRs that are automatically applied by
 
 |`BareMetalHost`
 |Contains the connection information for the Baseboard Management Controller (BMC) of the target bare-metal host.
-|Provides access to the BMC to load and boot the discovery image on the target server by using the Redfish protocol. ZTP supports iPXE and virtual media network booting.
+|Provides access to the BMC to load and start the discovery image on the target server by using the Redfish protocol.
 
 |`InfraEnv`
 |Contains information for installing {product-title} on the target bare-metal host.

--- a/snippets/ztp-example-siteconfig.adoc
+++ b/snippets/ztp-example-siteconfig.adoc
@@ -78,7 +78,7 @@ spec:
 <4> Cluster labels must correspond to the `bindingRules` field in the `PolicyGenTemplate` CRs that you define. For example, `policygentemplates/common-ranGen.yaml` applies to all clusters with `common: true` set, `policygentemplates/group-du-sno-ranGen.yaml` applies to all clusters with `group-du-sno: ""` set.
 <5> Optional. The CR specifed under `KlusterletAddonConfig` is used to override the default `KlusterletAddonConfig` that is created for the cluster.
 <6> For single-node deployments, define a single host. For three-node deployments, define three hosts. For standard deployments, define three hosts with `role: master` and two or more hosts defined with `role: worker`.
-<7> BMC address that you use to access the host. Applies to all cluster types. ZTP supports iPXE and virtual media booting by using Redfish or IPMI protocols.
+<7> BMC address that you use to access the host. Applies to all cluster types.
 <8> Name of the `bmh-secret` CR that you separately create with the host BMC credentials. When creating the `bmh-secret` CR, use the same namespace as the `SiteConfig` CR that provisions the host.
 <9> Configures the boot mode for the host. The default value is `UEFI`. Use `UEFISecureBoot` to enable secure boot on the host.
 <10> `cpuset` must match the value set in the cluster `PerformanceProfile` CR `spec.cpu.reserved` field for workload partitioning.


### PR DESCRIPTION
OCPBUGS#7608: Removing two lines as iPXE network booting for ZTP is not the default behaviour currently. 

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-7608

Link to docs preview:
- https://56323--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-manual-install.html#ztp-installation-crs_ztp-manual-install
- https://56323--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-manual-install.html#ztp-generating-install-and-config-crs-manually_ztp-manual-install
(removed reference from callout 7 of step 4.)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
