### PR TITLE
OSDOCS-5196-4-12: Updated vSphere versioning format for 4.12 docs

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -53,13 +53,13 @@ You must install the {product-title} cluster on a VMware vSphere version 7 insta
 |===
 |Virtual environment product |Required version
 |VMware virtual hardware | 15 or later
-|vSphere ESXi hosts | 7.0.2 or later
-|vCenter host   | 7.0.2 or later
+|vSphere ESXi hosts | 7.0 Update 2 or later
+|vCenter host   | 7.0 Update 2 or later
 |===
 
 [IMPORTANT]
 ====
-Installing a cluster on VMware vSphere versions 7.0.0 and 7.0.1 is deprecated. These versions are still fully supported, but all vSphere 6.x versions are no longer supported. Version 4.12 of {product-title} requires VMware virtual hardware version 15 or later. To update the hardware version for your vSphere virtual machines, see the "Updating hardware on nodes running in vSphere" article in the _Updating clusters_ section.
+Installing a cluster on VMware vSphere versions 7.0 and 7.0 Update 1 is deprecated. These versions are still fully supported, but all vSphere 6.x versions are no longer supported. Version 4.12 of {product-title} requires VMware virtual hardware version 15 or later. To update the hardware version for your vSphere virtual machines, see the "Updating hardware on nodes running in vSphere" article in the _Updating clusters_ section.
 ====
 
 .Minimum supported vSphere version for VMware components
@@ -67,17 +67,17 @@ Installing a cluster on VMware vSphere versions 7.0.0 and 7.0.1 is deprecated. T
 |Component | Minimum supported versions |Description
 
 |Hypervisor
-|vSphere 7.0.2 and later with virtual hardware version 15
+|vSphere 7.0 Update 2 and later with virtual hardware version 15
 |This version is the minimum version that {op-system-first} supports. See the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux?sort=sortTitle%20asc&vendors=VMware&category=Server[Red Hat Enterprise Linux 8 supported hypervisors list].
 
 |Storage with in-tree drivers
-|vSphere 7.0.2 and later
+|vSphere 7.0 Update 2 and later
 |This plugin creates vSphere storage by using the in-tree storage drivers for vSphere included in {product-title}.
 
 ifndef::vmc[]
 |Optional: Networking (NSX-T)
-|vSphere 7.0.2 and later
-|vSphere 7.0.2 is required for {product-title}. VMware's NSX Container Plugin (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
+|vSphere 7.0 Update 2 and later
+|vSphere 7.0 Update 2 is required for {product-title}. VMware's NSX Container Plugin (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
 endif::vmc[]
 |===
 

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -24,8 +24,8 @@
 
 To install the CSI Driver Operator, the following requirements must be met:
 
-* VMware vSphere version 7.0.2 or later
-* vCenter 7.0.2 or later
+* VMware vSphere version 7.0 Update 2 or later
+* vCenter 7.0 Update 2 or later
 * Virtual machines of hardware version 15 or later
 * No third-party CSI driver already installed in the cluster
 

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -263,9 +263,9 @@ To install a CSI driver on a cluster running on vSphere, the following requireme
 
 * Virtual machines of hardware version 15 or later
 
-* VMware vSphere version 7.0.2 or later, up to but not including version 8. vSphere 8 is not supported.
+* VMware vSphere version 7.0 Update 2 or later, up to but not including version 8. vSphere 8 is not supported.
 
-* vCenter 7.0.2 or later, up to but not including version 8. vCenter 8 is not supported.
+* vCenter 7.0 Update 2 or later, up to but not including version 8. vCenter 8 is not supported.
 
 * No third-party CSI driver already installed in the cluster
 +
@@ -948,8 +948,8 @@ For more information, see xref:../storage/container_storage_interface/persistent
 ==== VMware vSphere CSI Driver Operator requirements
 For {product-title} 4.12, VMWare vSphere Container Storage Interface (CSI) Driver Operator requires the following minimum components installed:
 
-* VMware vSphere version 7.0.2 or later, up to but not including version 8. vSphere 8 is not supported.
-* vCenter 7.0.2 or later, up to but not including version 8. vCenter 8 is not supported.
+* VMware vSphere version 7.0 Update 2 or later, up to but not including version 8. vSphere 8 is not supported.
+* vCenter 7.0 Update 2 or later, up to but not including version 8. vCenter 8 is not supported.
 * Virtual machines of hardware version 15 or later
 * No third-party CSI driver already installed in the cluster
 


### PR DESCRIPTION
Issue:
[OSDOCS-5196](https://issues.redhat.com/browse/OSDOCS-5197)

Version(s):
4.12

Link to docs preview:
* [VMware vSphere infrastructure requirements](http://file.emea.redhat.com/dfitzmau/OCDOCS-5196-4-12/installing/installing_vsphere/preparing-to-install-on-vsphere.html#installation-vsphere-infrastructure_preparing-to-install-on-vsphere)
* [VMware vSphere CSI Driver Operator requirements](http://file.emea.redhat.com/dfitzmau/OCDOCS-5196-4-12/installing/installing_vsphere/installing-vsphere-installer-provisioned.html#vsphere-csi-driver-reqs_installing-vsphere-installer-provisioned)
* [Post-installation configuration](http://file.emea.redhat.com/dfitzmau/OCDOCS-5196-4-12/release_notes/ocp-4-12-release-notes.html#ocp-4-12-post-installation)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

