### PR TITLE
OSDOCS-5196-4-11: Updated vSphere versioning format for 4.11 docs

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -53,13 +53,13 @@ You must install the {product-title} cluster on a VMware vSphere version 7 insta
 |===
 |Virtual environment product |Required version
 |VM hardware version | 15 or later
-|vSphere ESXi hosts | 7.0.2 or later
-|vCenter host   | 7.0.2 or later
+|vSphere ESXi hosts | 7.0 Update 2 or later
+|vCenter host   | 7.0 Update 2 or later
 |===
 
 [IMPORTANT]
 ====
-Installing a cluster on VMware vSphere version 7.0.1 or earlier is now deprecated. These versions are still fully supported, but version 4.11 of {product-title} requires vSphere virtual hardware version 15 or later. Hardware version 15 is now the default for vSphere virtual machines in {product-title}. To update the hardware version for your vSphere nodes, see the "Updating hardware on nodes running in vSphere" article.
+Installing a cluster on VMware vSphere version 7.0 Update 1 or earlier is now deprecated. These versions are still fully supported, but version 4.11 of {product-title} requires vSphere virtual hardware version 15 or later. Hardware version 15 is now the default for vSphere virtual machines in {product-title}. To update the hardware version for your vSphere nodes, see the "Updating hardware on nodes running in vSphere" article.
 
 If your vSphere nodes are below hardware version 15 or your VMware vSphere version is earlier than 6.7.3, upgrading from {product-title} 4.10 to {product-title} 4.11 is not available.
 ====
@@ -78,8 +78,8 @@ If your vSphere nodes are below hardware version 15 or your VMware vSphere versi
 
 ifndef::vmc[]
 |Optional: Networking (NSX-T)
-|vSphere 7.0.1 and later
-|vSphere 7.0.1 is required for {product-title}. VMware's NSX Container Plugin (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
+|vSphere 7.0 Update 1 and later
+|vSphere 7.0 Update 1 is required for {product-title}. VMware's NSX Container Plugin (NCP) is certified with {product-title} 4.6 and NSX-T 3.x+.
 endif::vmc[]
 |===
 

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -24,7 +24,7 @@
 
 The following requirements must be met in order to install the CSI Driver Operator:
 
-* VMware vSphere version 7.0.1 or later
+* VMware vSphere version 7.0 Update 1 or later
 * Virtual machines of hardware version 15 or later
 * No third-party CSI driver already installed in the cluster
 


### PR DESCRIPTION
Issue:
[OSDOCS-5196](https://issues.redhat.com/browse/OSDOCS-5197)

Version(s):
4.11

Link to docs preview:
* [VMware vSphere infrastructure requirements](http://file.emea.redhat.com/dfitzmau/OSDOCS-5196-4-11/installing/installing_vsphere/installing-vsphere-installer-provisioned.html#installation-vsphere-infrastructure_installing-vsphere-installer-provisioned)
* [VMware vSphere CSI Driver Operator requirements](http://file.emea.redhat.com/dfitzmau/OSDOCS-5196-4-11/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#vsphere-csi-driver-reqs_installing-vsphere-installer-provisioned-customizations)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

