### PR TITLE
OSDOCS-4967:adds OVN health monitoring to RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -87,6 +87,60 @@ With {product-title} {product-version}, running `oc describe` on an image now re
 [id="ocp-4-13-networking"]
 === Networking
 
+[id="ocp-4-13-networking-metrics"]
+==== Enhancements to networking metrics
+===== egress_ips_rebalance_total
+* Metric name: `ovnkube_master_egress_ips_rebalance_total`
+* *Help message:* `The total number of times assigned egress IP(s) needed to be moved to a different node.`
+
+===== egress_ips_node_unreachable_total
+* Metric name: `ovnkube_master_egress_ips_node_unreachable_total`
+* *Help message*: `The total number of times assigned egress IP(s) were unreachable.`
+
+===== egress_ips_unassign_latency_seconds
+* Metric name: `ovnkube_master_egress_ips_unassign_latency_seconds`
+* *Help message*: `The latency of egress IP unassignment from OVN northbound database.`
+
+===== interfaces_total
+* Metric name: `ovs_vswitchd_interfaces_total`
+* *Help message*: `The total number of Open vSwitch interface(s) created for pods` and  `Open vSwitch interface until its available.`
+
+===== interface_up_wait_seconds_total
+* Metric name: `ovs_vswitchd_interface_up_wait_seconds_total`
+* *Help message*: `The total number of seconds that is required to wait for pod.` and `Open vSwitch interface until its available.`
+
+===== ovnkube_resource_retry_failures_total
+* Metric name: `ovnkube_resource_retry_failures_total`
+* *Help message*: `The total number of times processing a Kubernetes resource reached the maximum retry limit and was no longer processed.`
+
+[id="ocp-4-13-networking-alerts"]
+==== Enhancements to networking alerts
+* OVN Kubernetes retries a claim up to 15 times before dropping it. With this update, if this failure happens, {product-title} alerts the cluster administrator. A description of each alert can be viewed in the console.
+
+===== NoOvnMasterLeader
+* Summary: There is no ovn-kubernetes master leader.
+* Description in console:
+[source,text]
+----
+Networking control plane is degraded. Networking configuration updates applied to the cluster will not be implemented while there is no OVN Kubernetes leader. Existing workloads should continue to have connectivity. OVN-Kubernetes control plane is not functional.
+----
+
+===== OVNKubernetesNodeOVSOverflowUserspace
+* Summary: OVS vSwitch daemon drops packets due to buffer overflow.
+* Description in console:
+[source,text]
+----
+Netlink messages dropped by OVS vSwitch daemon due to netlink socket buffer overflow. This will result in packet loss.
+----
+
+===== OVNKubernetesNodeOVSOverflowKernel
+* Summary: OVS kernel module drops packets due to buffer overflow.
+* Description in console:
+[source,text]
+----
+Netlink messages dropped by OVS kernel module due to netlink socket buffer overflow. This will result in packet loss.
+----
+
 [id="ocp-4-13-storage"]
 === Storage
 


### PR DESCRIPTION
[OSDOCS-4697](https://issues.redhat.com//browse/OSDOCS-4697):adds enhancements and alert updates for OVN health monitoring to networking 4.13 RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-4967
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://56345--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-networking
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
