### PR TITLE
[OSDOCS-5090]: GCP Confidential VM options

### DIFF
--- a/machine_management/creating_machinesets/creating-machineset-gcp.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-gcp.adoc
@@ -23,6 +23,11 @@ include::modules/machineset-creating.adoc[leveloffset=+1]
 //Configuring persistent disk types by using compute machine sets
 include::modules/machineset-gcp-pd-disk-types.adoc[leveloffset=+1]
 
+//Configuring Shielded VM options by using machine sets [PR#56252]
+
+//Configuring Confidential Computing by using machine sets
+include::modules/machineset-gcp-confidential-vm.adoc[leveloffset=+1]
+
 //Machine sets that deploy machines as preemptible VM instances
 include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
 

--- a/modules/machineset-gcp-confidential-vm.adoc
+++ b/modules/machineset-gcp-confidential-vm.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-gcp.adoc
+// * machine_management/control_plane_machine_management/cpmso-using.adoc
+
+ifeval::["{context}" == "cpmso-using"]
+:cpmso:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="machineset-gcp-confidential-vm_{context}"]
+= Configuring Confidential VM by using machine sets
+
+By editing the machine set YAML file, you can configure the Confidential VM options that a machine set uses for machines that it deploys.
+
+For more information about Confidential Compute features, functionality, and compatibility, see the GCP Compute Engine documentation about link:https://cloud.google.com/compute/confidential-vm/docs/about-cvm[Confidential VM].
+
+.Procedure
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Edit the following section under the `providerSpec` field:
++
+[source,yaml]
+----
+ifndef::cpmso[]
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+endif::cpmso[]
+ifdef::cpmso[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+endif::cpmso[]
+...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          confidentialCompute: Enabled <1>
+          onHostMaintenance: Terminate <2>
+          machineType: n2d-standard-8 <3>
+...
+----
+<1> Specify whether Confidential VM is enabled. Valid values are `Disabled` or `Enabled`.
+<2> Specify the behavior of the VM during a host maintenance event, such as a hardware or software update. For a machine that uses Confidential VM, this value must be set to `Terminate`, which stops the VM. Confidential VM does not support live VM migration.
+<3> Specify a machine type that supports Confidential VM. Confidential VM supports the N2D and C2D series of machine types.
+
+.Verification
+
+* On the Google Cloud console, review the details for a machine deployed by the machine set and verify that the Confidential VM options match the values that you configured.
+
+ifeval::["{context}" == "cpmso-using"]
+:!cpmso:
+endif::[]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPCLOUD-1889](https://issues.redhat.com//browse/OCPCLOUD-1889) | [OSDOCS-5090](https://issues.redhat.com//browse/OSDOCS-5090)

Link to docs preview:
[Configuring Confidential VM options by using machine sets](https://56348--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-gcp-confidential-vm_creating-machineset-gcp)

QE review:
- [x] QE has approved this change.

Additional information:
* Control plane machine set context that will use the `cpmso` condition version is not merged yet.
* This covers the machineset side, Installer docs team will cover install-config setup.
* Will squash commits after all reviews are in.