### PR TITLE
BZ#2071184: Added eus channel info in updating a cluster using the web console se…

### DIFF
--- a/modules/update-upgrading-web.adoc
+++ b/modules/update-upgrading-web.adoc
@@ -28,7 +28,7 @@ link:https://access.redhat.com/downloads/content/290[in the errata section] of t
 +
 [IMPORTANT]
 ====
-For production clusters, you must subscribe to a `stable-\*` or `fast-*` channel.
+For production clusters, you must subscribe to a `stable-\*`, `eus-*` or `fast-*` channel.
 ====
 ifdef::openshift-origin[]
 such as `stable-4`.
@@ -51,7 +51,7 @@ If you are upgrading your cluster to the next minor version, like version 4.y to
 --
 ** If updates are available, continue to perform updates in the current channel until you can no longer update.
 ifndef::openshift-origin[]
-** If no updates are available, change the *Channel* to the `stable-\*` or `fast-*` channel for the next minor version, and update to the version that you want in that channel.
+** If no updates are available, change the *Channel* to the `stable-\*`, `eus-*` or `fast-*` channel for the next minor version, and update to the version that you want in that channel.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 ** If no updates are available, change the *Channel* to the `stable-*` channel for the next minor version, and update to the version that you want in that channel.


### PR DESCRIPTION
Version(s): 4.9+

Scope: Added eus channel info in the 'Updating a cluster using the web console' section.

Issue: [BZ2071184](https://bugzilla.redhat.com/show_bug.cgi?id=2071184)

Link to docs preview:
[Preview](https://56354--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-within-minor.html#update-upgrading-web_updating-cluster-within-minor)

QE review: @yanyang ptal