### PR TITLE
OSDOCS#4822 Updated ROSA getting started content to reflect current AWS experience

### DIFF
--- a/modules/rosa-getting-started-enable-rosa.adoc
+++ b/modules/rosa-getting-started-enable-rosa.adoc
@@ -4,14 +4,15 @@
 // * rosa_getting_started/rosa-getting-started.adoc
 
 :_content-type: PROCEDURE
-[id="rosa-getting-started-enable-rosa_{context}"]
-= Enabling ROSA in your AWS account
+[id="rosa-getting-started-verifying-rosa-prerequisites_{context}"]
+= Verifying ROSA prerequisites
 
 Use the steps in this procedure to enable {product-title} (ROSA) in your AWS account.
 
 .Prerequisites
 
-* You created an AWS account.
+* You have a Red Hat account.
+* You have an AWS account.
 +
 [NOTE]
 ====
@@ -22,4 +23,31 @@ Consider using a dedicated AWS account to run production clusters. If you are us
 
 . Sign in to the https://console.aws.amazon.com/rosa/home[AWS Management Console].
 
-. Activate ROSA in your AWS account by navigating to the link:https://console.aws.amazon.com/rosa/home[ROSA service] and selecting *Enable OpenShift*.
+. Navigate to the link:https://console.aws.amazon.com/rosa/home[ROSA service].
+
+. Click *Get started*.
++
+The *Verify ROSA prerequisites* page opens.
+
+. Under *ROSA enablement*, ensure that a green check mark and `You previously enabled ROSA` are displayed.
++
+If not, follow these steps:
+
+.. Select the checkbox beside `I agree to share my contact information with Red Hat`.
+.. Click *Enable ROSA*.
++
+After a short wait, a green check mark and `You enabled ROSA` message are displayed.
+
+. Under *Service Quotas*, ensure that a green check and `Your quotas meet the requirements for ROSA` are displayed.
++
+If you see `Your quotas don't meet the minimum requirements`, take note of the quota type and the minimum listed in the error message. See Amazon's documentation on link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[requesting a quota increase] for guidance. It may take several hours for Amazon to approve your quota request.
+
+. Under *ELB service-linked role*, ensure that a green check mark and `AWSServiceRoleForElasticLoadBalancing already exists` are displayed.
+
+. Click *Continue to Red Hat*.
++
+The *Get started with {product-title} (ROSA)* page opens in a new tab. You have already completed Step 1 on this page, and can now continue with Step 2.
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.aws.amazon.com/ROSA/latest/userguide/troubleshoot-rosa-enablement.html#error-aws-orgs-scp-denies-permissions[Troubleshoot ROSA enablement errors]

--- a/modules/rosa-getting-started-environment-setup.adoc
+++ b/modules/rosa-getting-started-environment-setup.adoc
@@ -8,10 +8,8 @@
 
 Before you create a {product-title} (ROSA) cluster, you must set up your environment by completing the following tasks:
 
-* Enable ROSA in your AWS account.
+* Verify ROSA prerequisites against your AWS and Red Hat accounts.
 * Install and configure the required command line interface (CLI) tools.
 * Verify the configuration of the CLI tools.
-* Verify that the AWS Elastic Load Balancing (ELB) service role exists.
-* Verify that the required AWS resource quotas are available.
 
 You can follow the procedures in this section to complete these setup requirements.

--- a/rosa_getting_started/rosa-getting-started.adoc
+++ b/rosa_getting_started/rosa-getting-started.adoc
@@ -29,17 +29,15 @@ You can create a ROSA cluster either with or without the AWS Security Token Serv
 include::modules/rosa-getting-started-environment-setup.adoc[leveloffset=+1]
 include::modules/rosa-getting-started-enable-rosa.adoc[leveloffset=+2]
 include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffset=+2]
-include::modules/rosa-getting-started-verify-elb-role.adoc[leveloffset=+2]
-include::modules/rosa-getting-started-verify-aws-quota.adoc[leveloffset=+2]
 
 [id="rosa-getting-started-creating-a-cluster"]
 == Creating a ROSA cluster with STS
 
-Choose from one of the following methods to deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS). In both scenarios, you can deploy your cluster by using {cluster-manager-first} or the ROSA CLI (`rosa`):
+Choose from one of the following methods to deploy a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS). In each scenario, you can deploy your cluster by using {cluster-manager-first} or the ROSA CLI (`rosa`):
 
-* *xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[Creating a ROSA cluster with STS using the default options]*: You can create a ROSA cluster with STS quickly by using the default options and automatic STS resource creation.
+* xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc#rosa-sts-creating-a-cluster-quickly[*Creating a ROSA cluster with STS using the default options*]: You can create a ROSA cluster with STS quickly by using the default options and automatic STS resource creation.
 
-* *xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-a-cluster-with-customizations[Creating a ROSA cluster with STS using customizations]*: You can create a ROSA cluster with STS using customizations. You can also choose between the `auto` and `manual` modes when creating the required STS resources.
+* xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-a-cluster-with-customizations[*Creating a ROSA cluster with STS using customizations*]: You can create a ROSA cluster with STS using customizations. You can also choose between the `auto` and `manual` modes when creating the required STS resources.
 
 .Additional resources
 

--- a/rosa_getting_started/rosa-quickstart-guide-ui.adoc
+++ b/rosa_getting_started/rosa-quickstart-guide-ui.adoc
@@ -43,16 +43,6 @@ include::modules/rosa-getting-started-enable-rosa.adoc[leveloffset=+2]
 include::modules/rosa-getting-started-install-configure-cli-tools.adoc[leveloffset=+2]
 
 
-//This content is pulled from rosa-getting-started-verify-elb-role.adoc
-[discrete]
-include::modules/rosa-getting-started-verify-elb-role.adoc[leveloffset=+2]
-
-
-//This content is pulled from rosa-getting-started-verify-aws-quota.adoc
-[discrete]
-include::modules/rosa-getting-started-verify-aws-quota.adoc[leveloffset=+2]
-
-
 //This content is pulled from rosa-sts-creating-a-cluster-quickly.adoc
 [id="rosa-quickstart-creating-a-cluster"]
 == Creating a ROSA cluster with AWS STS using the default auto mode


### PR DESCRIPTION
Following on from https://github.com/openshift/openshift-docs/pull/56263 (raised against wrong branch).

Version(s): main

Issue: https://issues.redhat.com/browse/OSDOCS-4822

Link to docs preview:

- https://56360--docspreview.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart-guide-ui.html#rosa-getting-started-environment-setup_rosa-quickstart-guide-ui
- https://56360--docspreview.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-getting-started.html#rosa-getting-started-verifying-rosa-prerequisites_rosa-getting-started

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

Additional information: N/A
