### PR TITLE
RHDEVDOCS-3436 | Updated OCP>Support and OKD>Support pages for missing link to pipelines must-gather

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -65,6 +65,10 @@ endif::openshift-dedicated[]
 
 |`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v<installed-version-NMO>`
 |Data collection for the Node Maintenance Operator (NMO).
+
+
+|`quay.io/openshift-pipeline/must-gather`
+|Data collection for Red Hat OpenShift Pipelines
 |===
 
 endif::openshift-origin[]
@@ -99,6 +103,8 @@ ifndef::openshift-dedicated[]
 |Data collection for Local Storage Operator.
 endif::openshift-dedicated[]
 
+|`quay.io/openshift-pipeline/must-gather`
+|Data collection for Red Hat OpenShift Pipelines
 |===
 
 endif::openshift-origin[]


### PR DESCRIPTION
- Aligned team: Dev Tools
- OCP version for cherry-picking: `enterprise-4.10`, `enterprise-4.11`, and `enterprise-4.12`
- JIRA issue: [RHDEVDOCS-3436](https://issues.redhat.com/browse/RHDEVDOCS-3436)
- Preview pages: [Click to preview the docs in your browser](https://56361--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html)
- SME review: @vdemeester  
- QE review: @ppitonak @VeereshAradhya 
- Peer review: