### PR TITLE
BZ#2071184: Added eus channel info in the note in 'Updating a cluster using the CLI' section.

### DIFF
--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -56,7 +56,7 @@ $ oc get clusterversion -o json|jq ".items[0].spec"
 +
 [IMPORTANT]
 ====
-For production clusters, you must subscribe to a `stable-\*` or `fast-*` channel.
+For production clusters, you must subscribe to a `stable-\*`, `eus-*` or `fast-*` channel.
 ====
 
 . View the available updates and note the version number of the update that


### PR DESCRIPTION
Version: 4.9 only

Scope: Added eus channel info in the 'Updating a cluster using the CLI' section.

Issue: [BZ2071184](https://bugzilla.redhat.com/show_bug.cgi?id=2071184)


QE review: @yanyang ptal

