### PR TITLE
BZ2061349: cautions webhook disabling

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -109,6 +109,10 @@ Admission Controller application. It provides the following capabilities:
 * Mutation of the `SriovNetworkNodePolicy` CR by setting the default value for the `priority` and `deviceType` fields when the CR is created or updated.
 
 By default the SR-IOV Network Operator Admission Controller webhook is enabled by the Operator and runs as a daemon set on all control plane nodes.
+
+NOTE: Use caution when disabling the SR-IOV Network Operator Admission Controller webhook. You can disable the webhook under specific circumstances, such as troubleshooting, or if you want to use unsupported devices.
+
+
 The following is an example of the Operator Admission Controller webhook pods running in a cluster with three control plane nodes:
 
 [source,terminal]
@@ -302,4 +306,3 @@ spec:
   disableDrain: true
 ----
 ====
-

--- a/networking/hardware_networks/about-sriov.adoc
+++ b/networking/hardware_networks/about-sriov.adoc
@@ -68,6 +68,7 @@ A CNI plugin that attaches InfiniBand (IB) VF interfaces allocated from the SR-I
 [NOTE]
 ====
 The SR-IOV Network resources injector and SR-IOV Network Operator webhook are enabled by default and can be disabled by editing the `default` `SriovOperatorConfig` CR.
+Use caution when disabling the SR-IOV Network Operator Admission Controller webhook. You can disable the webhook under specific circumstances, such as troubleshooting, or if you want to use unsupported devices.
 ====
 
 include::modules/nw-sriov-supported-platforms.adoc[leveloffset=+2]


### PR DESCRIPTION
- Applies to 4.9 and above versions
- [Bugzilla](https://bugzilla.redhat.com/show_bug.cgi?id=2061349)
- [Preview 1](https://56369--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov.html)
- [Preview 2](https://56369--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html#about-sr-iov-operator-admission-control-webhook_configuring-sriov-operator)
@cgoncalves ptal and provide feedback
@zhaozhanqi can please QE verify