### PR TITLE
Compliance timeout updates

### DIFF
--- a/modules/compliance-timeout.adoc
+++ b/modules/compliance-timeout.adoc
@@ -33,5 +33,5 @@ schedule: '0 1 * * *'
 timeout: '10m0s' <1>
 maxRetryOnTimeout: 3 <2>
 ----
-<1> The `timeout` variable is defined as a duration string, such as `1h30m`. The default value is `30m`.
+<1> The `timeout` variable is defined as a duration string, such as `1h30m`. The default value is `30m`. To disable the timeout, set the value to `0s`.
 <2> The `maxRetryOnTimeout` variable defines how many times a retry is attempted. The default value is `3`.


### PR DESCRIPTION
Version(s):
4.9+

Link to docs preview (VPN required):
[Configuring ScanSetting timeout](http://file.rdu.redhat.com/antaylor/compliance-timeout/security/compliance_operator/compliance-operator-troubleshooting.html#compliance-timeout_compliance-troubleshooting)

Additional information:
While reviewing https://github.com/openshift/openshift-docs/pull/55380, an error was indicated with the timeout `0s` option. It was later [determined by QE](https://redhat-internal.slack.com/archives/CHCRR73PF/p1677126755245889?thread_ts=1677126709.987399&cid=CHCRR73PF) to be a flaw in the test environment and the code works as expected. This pull request adds in the `0s` timeout details.
