### PR TITLE
SRVKE-1363 fix xrefs issue for portal

### DIFF
--- a/serverless/eventing/brokers/kafka-broker.adoc
+++ b/serverless/eventing/brokers/kafka-broker.adoc
@@ -6,4 +6,4 @@ include::_attributes/common-attributes.adoc[]
 
 include::snippets/serverless-about-kafka-broker.adoc[]
 
-For information about using Kafka brokers, see xref:./serverless-using-brokers.adoc#serverless-using-brokers[Creating brokers].
+For information about using Kafka brokers, see xref:../../../serverless/eventing/brokers/serverless-using-brokers.adoc#serverless-using-brokers[Creating brokers].

--- a/serverless/eventing/brokers/serverless-using-brokers.adoc
+++ b/serverless/eventing/brokers/serverless-using-brokers.adoc
@@ -23,7 +23,7 @@ include::modules/serverless-creating-broker-admin-web-console.adoc[leveloffset=+
 
 [id="next-steps_serverless-using-brokers"]
 == Next steps
-* Configure event delivery parameters that are applied in cases where an event fails to be delivered to an event sink. See xref:./serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Examples of configuring event delivery parameters].
+* Configure event delivery parameters that are applied in cases where an event fails to be delivered to an event sink. See xref:../../../serverless/eventing/brokers/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Examples of configuring event delivery parameters].
 
 [id="additional-resources_serverless-using-brokers"]
 [role="_additional-resources"]
@@ -31,4 +31,4 @@ include::modules/serverless-creating-broker-admin-web-console.adoc[leveloffset=+
 * xref:../../../serverless/eventing/brokers/serverless-global-config-broker-class-default.adoc#serverless-global-config-broker-class-default[Configuring the default broker class]
 * xref:../../../serverless/eventing/triggers/serverless-triggers.adoc#serverless-triggers[Triggers]
 xref:../../../serverless/eventing/event-sources/knative-event-sources.adoc#knative-event-sources[Event sources]
-* xref:./serverless-event-delivery.adoc#serverless-event-delivery[Event delivery]
+* xref:../brokers/serverless-event-delivery.adoc#serverless-event-delivery[Event delivery]

--- a/serverless/eventing/channels/serverless-creating-channels.adoc
+++ b/serverless/eventing/channels/serverless-creating-channels.adoc
@@ -16,5 +16,5 @@ include::modules/serverless-create-kafka-channel-yaml.adoc[leveloffset=+1]
 [id="next-steps_serverless-creating-channels"]
 == Next steps
 
-* After you have created a channel, xref:../subscriptions/serverless-subs.adoc#serverless-subs[create a subscription] that allows event sinks to subscribe to channels and receive events.
-* Configure event delivery parameters that are applied in cases where an event fails to be delivered to an event sink. See xref:../brokers/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Examples of configuring event delivery parameters].
+* After you have created a channel, xref:../../../serverless/eventing/subscriptions/serverless-subs.adoc#serverless-subs[create a subscription] that allows event sinks to subscribe to channels and receive events.
+* Configure event delivery parameters that are applied in cases where an event fails to be delivered to an event sink. See xref:../../../serverless/eventing/brokers/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Examples of configuring event delivery parameters].

--- a/serverless/eventing/event-sinks/serverless-kafka-developer-sink.adoc
+++ b/serverless/eventing/event-sinks/serverless-kafka-developer-sink.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Kafka sinks are a type of xref:./serverless-event-sinks.adoc#serverless-event-sinks[event sink] that are available if a cluster administrator has enabled Kafka on your cluster. You can send events directly from an xref:../event-sources/knative-event-sources.adoc#knative-event-sources[event source] to a Kafka topic by using a Kafka sink.
+Kafka sinks are a type of xref:../event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[event sink] that are available if a cluster administrator has enabled Kafka on your cluster. You can send events directly from an xref:../event-sources/knative-event-sources.adoc#knative-event-sources[event source] to a Kafka topic by using a Kafka sink.
 
 // Kafka sink
 include::modules/serverless-kafka-sink.adoc[leveloffset=+1]

--- a/serverless/eventing/event-sources/knative-event-sources.adoc
+++ b/serverless/eventing/event-sources/knative-event-sources.adoc
@@ -12,10 +12,10 @@ You can create and manage Knative event sources by using the *Developer* perspec
 
 Currently, {ServerlessProductName} supports the following event source types:
 
-xref:./serverless-apiserversource.adoc#serverless-apiserversource[API server source]:: Brings Kubernetes API server events into Knative. The API server source sends a new event each time a Kubernetes resource is created, updated or deleted.
+xref:../../../serverless/eventing/event-sources/serverless-apiserversource.adoc#serverless-apiserversource[API server source]:: Brings Kubernetes API server events into Knative. The API server source sends a new event each time a Kubernetes resource is created, updated or deleted.
 
-xref:./serverless-pingsource.adoc#serverless-pingsource[Ping source]:: Produces events with a fixed payload on a specified cron schedule.
+xref:../../../serverless/eventing/event-sources/serverless-pingsource.adoc#serverless-pingsource[Ping source]:: Produces events with a fixed payload on a specified cron schedule.
 
-xref:./serverless-kafka-developer-source.adoc#serverless-kafka-developer-source[Kafka event source]:: Connects a Kafka cluster to a sink as an event source.
+xref:../../../serverless/eventing/event-sources/serverless-kafka-developer-source.adoc#serverless-kafka-developer-source[Kafka event source]:: Connects a Kafka cluster to a sink as an event source.
 
-You can also create a xref:./serverless-custom-event-sources.adoc#serverless-custom-event-sources[custom event source].
+You can also create a xref:../../../serverless/eventing/event-sources/serverless-custom-event-sources.adoc#serverless-custom-event-sources[custom event source].

--- a/serverless/eventing/subscriptions/serverless-subs.adoc
+++ b/serverless/eventing/subscriptions/serverless-subs.adoc
@@ -20,4 +20,4 @@ include::modules/serverless-update-subscriptions-kn.adoc[leveloffset=+1]
 
 [id="next-steps_serverless-subs"]
 == Next steps
-* Configure event delivery parameters that are applied in cases where an event fails to be delivered to an event sink. See xref:../brokers/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Examples of configuring event delivery parameters].
+* Configure event delivery parameters that are applied in cases where an event fails to be delivered to an event sink. See xref:../../../serverless/eventing/brokers/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Examples of configuring event delivery parameters].

--- a/serverless/eventing/triggers/serverless-triggers.adoc
+++ b/serverless/eventing/triggers/serverless-triggers.adoc
@@ -8,7 +8,7 @@ include::_attributes/common-attributes.adoc[]
 
 include::snippets/serverless-brokers-intro.adoc[]
 
-If you are using a Kafka broker, you can configure the delivery order of events from triggers to event sinks. See xref:./serverless-triggers.adoc#trigger-event-delivery-config_serverless-triggers[Configuring event delivery ordering for triggers].
+If you are using a Kafka broker, you can configure the delivery order of events from triggers to event sinks. See xref:../triggers/serverless-triggers.adoc#trigger-event-delivery-config_serverless-triggers[Configuring event delivery ordering for triggers].
 
 
 


### PR DESCRIPTION
Version(s):
4.8+

Issue:
[SRVKE-1363](https://issues.redhat.com//browse/SRVKE-1363) broken xref links on portal

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
