### PR TITLE
BZ#2094494: Added a section titled 'Backup CR status remains in PartiallyFailed'

### DIFF
--- a/modules/oadp-backup-restore-cr-issues.adoc
+++ b/modules/oadp-backup-restore-cr-issues.adoc
@@ -51,3 +51,37 @@ $ oc delete backup <backup> -n openshift-adp
 You do not need to clean up the backup location because a `Backup` CR in progress has not uploaded  files to object storage.
 
 . Create a new `Backup` CR.
+
+[id="backup-cr-remains-partiallyfailed_{context}"]
+== Backup CR status remains in PartiallyFailed
+
+The status of a `Backup` CR without Restic in use remains in the `PartiallyFailed` phase and does not complete. A snapshot of the affiliated PVC is not created. 
+
+.Cause
+
+If the backup is created based on the CSI snapshot class, but the label is missing, CSI snapshot plugin fails to create a snapshot. As a result, the `Velero` pod logs an error similar to the following:
++
+[source,text]
+----
+time="2023-02-17T16:33:13Z" level=error msg="Error backing up item" backup=openshift-adp/user1-backup-check5 error="error executing custom action (groupResource=persistentvolumeclaims, namespace=busy1, name=pvc1-user1): rpc error: code = Unknown desc = failed to get volumesnapshotclass for storageclass ocs-storagecluster-ceph-rbd: failed to get volumesnapshotclass for provisioner openshift-storage.rbd.csi.ceph.com, ensure that the desired volumesnapshot class has the velero.io/csi-volumesnapshot-class label" logSource="/remote-source/velero/app/pkg/backup/backup.go:417" name=busybox-79799557b5-vprq
+----
+
+.Solution
+
+. Delete the `Backup` CR:
++
+[source,terminal]
+----
+$ oc delete backup <backup> -n openshift-adp
+----
+
+. If required, clean up the stored data on the `BackupStorageLocation` to free up space.
+
+. Apply label `velero.io/csi-volumesnapshot-class=true` to the `VolumeSnapshotClass` object:
++
+[source,terminal]
+----
+$ oc label volumesnapshotclass/<snapclass_name> velero.io/csi-volumesnapshot-class=true
+----
+
+. Create a new `Backup` CR.


### PR DESCRIPTION
Version: 4.9+

Scope: Added a section 'Backup CR status remains in PartiallyFailed' in backup and restore issues chapter.

[BZ-2094494](https://bugzilla.redhat.com/show_bug.cgi?id=2094494)

Links to docs Preview:
[Preview](https://56408--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#backup-cr-remains-partiallyfailed_oadp-troubleshooting)

Additional Information:
[Draft for the Backup CR section](https://docs.google.com/document/d/1oI1H2CBE1sUiLLpUejN3dN5tld6TarW7222rrvUN2t8/edit)

QE approved.