### PR TITLE
OCPBUGS#7939 Fix copied CSVs admonition

### DIFF
--- a/modules/olm-disabling-copied-csvs.adoc
+++ b/modules/olm-disabling-copied-csvs.adoc
@@ -19,6 +19,7 @@ If you disable copied CSVs, a user's ability to discover Operators in the Operat
 If an Operator is configured to reconcile events in the user's namespace but is installed in a different namespace, the user cannot view the Operator in the OperatorHub or CLI. Operators affected by this limitation are still available and continue to reconcile events in the user's namespace.
 
 This behavior occurs for the following reasons:
+
 * Copied CSVs identify the Operators available for a given namespace.
 * Role-based access control (RBAC) scopes the user's ability to view and discover Operators in the OperatorHub and CLI.
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
TYPO: Fixes the unordered list at the end of the warning admonition block by adding a carraige return
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:  [OCPBUGS-7939](https://issues.redhat.com/browse/OCPBUGS-7939)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Disabling copied CSVs](https://56414--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-config.html#olm-disabling-copied-csvs_olm-config)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: I believe this is exempt because it is a typo level fix.
~~- [ ] QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
