### PR TITLE
[OSDOCS-5095]: Nutanix OoT provider is GA

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,7 +10,7 @@
 
 [NOTE]
 ====
-This Operator is only fully supported for Microsoft Azure Stack Hub, {rh-openstack-first}, and VMware vSphere.
+This Operator is General Availability for Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and VMware vSphere.
 
 It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud, IBM Cloud Power VS, and Microsoft Azure.
 ====


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OCPCLOUD-1405](https://issues.redhat.com//browse/OCPCLOUD-1405) | [OSDOCS-5095](https://issues.redhat.com//browse/OSDOCS-5095)

Link to docs preview:
[Cluster Cloud Controller Manager Operator](https://56422--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
- [ ] QE has approved this change.

Additional information: