### PR TITLE
[OSDOCS-5095]: Nutanix OoT provider is GA (rel notes)

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -135,11 +135,8 @@ With {product-title} {product-version}, running `oc describe` on an image now re
 ==== Cloud controller managers for additional cloud providers
 
 The Kubernetes community plans to deprecate the use of the Kubernetes controller manager to interact with underlying cloud platforms in favor of using cloud controller managers. As a result, there is no plan to add Kubernetes controller manager support for any new cloud platforms.
-//Can reuse this for Nutanix in 4.13:
-//The Alibaba Cloud and IBM Cloud implementations that are added in this release of {product-title} use cloud controller managers.
 
-//In addition, this
-This release introduces the General Availability of using cloud controller managers for VMware vSphere.
+The Nutanix implementation that is added in this release of {product-title} uses cloud controller managers. In addition, this release introduces the General Availability of using cloud controller managers for VMware vSphere.
 
 To learn more about the cloud controller manager, see the link:https://kubernetes.io/docs/concepts/architecture/cloud-controller/[Kubernetes Cloud Controller Manager documentation].
 


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OCPCLOUD-1405](https://issues.redhat.com//browse/OCPCLOUD-1405) | [OSDOCS-5095](https://issues.redhat.com//browse/OSDOCS-5095)

Link to docs preview:
[Cloud controller managers for additional cloud providers](https://56423--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-cluster-cloud-controller-manager-operator) in _Notable technical changes_

QE review:
- [ ] QE has approved this change.

Additional information: