### PR TITLE
OSDOCS#4962: GA support for Crun

### DIFF
--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -41,7 +41,7 @@ The `kubelet` service must not be newer than `kube-apiserver`, and can be up to 
 [id="defining-workers_{context}"]
 == Cluster workers
 
-In a Kubernetes cluster, the worker nodes are where the actual workloads requested by Kubernetes users run and are managed. The worker nodes advertise their capacity and the scheduler, which a control plane service, determines on which nodes to start pods and containers. Important services run on each worker node, including CRI-O, which is the container engine; Kubelet, which is the service that accepts and fulfills requests for running and stopping container workloads; a service proxy, which manages communication for pods across workers; and the runC or crun (Technology Preview) low-level container runtime, which creates and runs containers.
+In a Kubernetes cluster, the worker nodes are where the actual workloads requested by Kubernetes users run and are managed. The worker nodes advertise their capacity and the scheduler, which a control plane service, determines on which nodes to start pods and containers. Important services run on each worker node, including CRI-O, which is the container engine; Kubelet, which is the service that accepts and fulfills requests for running and stopping container workloads; a service proxy, which manages communication for pods across workers; and the runC or crun low-level container runtime, which creates and runs containers.
 
 [NOTE]
 ====

--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -27,9 +27,6 @@ The CRI-O flag is applied on the cgroup of the container, while the Kubelet flag
 * **Maximum log size**: Setting the maximum log size in the `ContainerRuntimeConfig` is expected to be deprecated. If a maximum log size is required, it is recommended to use the `containerLogMaxSize` field in the `KubeletConfig` CR instead.
 * **Container runtime**: The `defaultRuntime` parameter sets the container runtime to either `runc` or `crun`. The default is `runc`.
 
-:FeatureName: Support for the crun container runtime
-include::snippets/technology-preview.adoc[]
-
 You should have one `ContainerRuntimeConfig` CR for each machine config pool with all the config changes you want for that pool. If you are applying the same content to all the pools, you only need one `ContainerRuntimeConfig` CR for all the pools.
 
 You should edit an existing `ContainerRuntimeConfig` CR to modify existing settings or add new settings instead of creating a new CR for each change. It is recommended to create a new `ContainerRuntimeConfig` CR only to modify a different machine config pool, or for changes that are intended to be temporary so that you can revert the changes.

--- a/modules/rhcos-about.adoc
+++ b/modules/rhcos-about.adoc
@@ -27,9 +27,6 @@ The following list describes key features of the {op-system} operating system:
 +
 CRI-O can use either the runC or crun container runtime to start and manage containers. For information about how to enable crun, see the documentation for creating a `ContainerRuntimeConfig` CR. 
 
-:FeatureName: Support for the crun container runtime
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 * **Set of container tools**: For tasks such as building, copying, and otherwise managing containers, {op-system} replaces the Docker CLI tool with a compatible set of container tools. The podman CLI tool supports many container runtime features, such as running, starting, stopping, listing, and removing containers and container images. The skopeo CLI tool can copy, authenticate, and sign images. You can use the `crictl` CLI tool to work with containers and pods from the CRI-O container engine. While direct use of these tools in {op-system} is discouraged, you can use them for debugging purposes.
 
 * **rpm-ostree upgrades**: {op-system} features transactional upgrades using the `rpm-ostree` system. Updates are delivered by means of container images and are part of the {product-title} update process. When deployed, the container image is pulled, extracted, and written to disk, then the bootloader is modified to boot into the new version. The machine will reboot into the update in a rolling manner to ensure cluster capacity is minimally impacted.

--- a/nodes/containers/nodes-containers-using.adoc
+++ b/nodes/containers/nodes-containers-using.adoc
@@ -55,9 +55,6 @@ include::snippets/about-crio-snippet.adoc[]
 
 runC, developed by Docker and maintained by the Open Container Project, is a lightweight, portable container runtime written in Go. crun, developed by Red Hat, is a fast and low-memory container runtime fully written in C. As of {product-title} {product-version}, you can select between the two.
 
-:FeatureName: crun container runtime support
-include::snippets/technology-preview.adoc[]
-
 crun has several improvements over runC, including:
 
 * Smaller binary


### PR DESCRIPTION
[OSDOCS-4962](https://issues.redhat.com/browse/OSDOCS-4962)

4.13 feature

Previews:
Architecture -> Control plane arch -> [cluster workers](https://56428--docspreview.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#defining-workers_control-plane). Swapped _crun (Technology Preview) low-level container runtime_  to _crun low-level container runtime_ in first paragraph.

Post-install -> Machine config -> [Creating a ContainerRuntimeConfig CR](https://56428--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#create-a-containerruntimeconfig_post-install-machine-configuration-tasks). Removed TP snippet after the Container runtime bullet

 Architecture -> Red Hat Enterprise Linux CoreOS -> [Key RHCOS features](https://56428--docspreview.netlify.app/openshift-enterprise/latest/architecture/architecture-rhcos.html#rhcos-key-features_architecture-rhcos).  Removed TP snippet after the CRI-o container runtime bullet
 
 Nodes -> Working with containers -> Understanding containers -> [About the container engine and container runtime](https://56428--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-using.html#nodes-containers-runtimes). Removed TP snippet after the second paragraph