### PR TITLE
OCPBUGS#7914: Add link to oc install guide for accessing cluster

### DIFF
--- a/microshift_cli_ref/microshift-oc-cli-install.adoc
+++ b/microshift_cli_ref/microshift-oc-cli-install.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id="cli-getting-started"]
+[id="microshift-oc-cli-install"]
 = Getting started with the OpenShift CLI
 include::_attributes/attributes-microshift.adoc[]
 :context: cli-oc-installing
@@ -8,7 +8,7 @@ toc::[]
 
 To use the OpenShift CLI (`oc`) tool, you must download and install it separately from your {product-title} installation.
 
-[id="installing-the-openshift-cli_{context}"]
+[id="installing-the-openshift-cli"]
 == Installing the OpenShift CLI
 
 You can install the OpenShift CLI (`oc`) either by downloading the binary or by using Homebrew.

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -31,16 +31,18 @@ include::modules/microshift-install-rpm-preparing.adoc[leveloffset=+1]
 include::modules/microshift-installing-from-rpm.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="_additional-resources_microshift-install-rpm-section-two"]
 .Additional resources
-
 * xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-system-requirements_microshift-install-rpm[System requirements for installing MicroShift].
-
 * xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm-preparing_microshift-install-rpm[Preparing to install MicroShift from an RPM package].
 
 include::modules/microshift-service-starting.adoc[leveloffset=+1]
 include::modules/microshift-service-stopping.adoc[leveloffset=+1]
 include::modules/microshift-accessing.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../microshift_cli_ref/microshift-oc-cli-install.adoc#microshift-oc-cli-install[Installing the OpenShift CLI tool].
+
 include::modules/microshift-accessing-cluster-locally.adoc[leveloffset=+2]
 include::modules/microshift-accessing-cluster-remotely-admin.adoc[leveloffset=+2]
 include::modules/microshift-accessing-cluster-remotely-non-admin.adoc[leveloffset=+2]

--- a/modules/microshift-accessing.adoc
+++ b/modules/microshift-accessing.adoc
@@ -4,6 +4,6 @@
 
 :_content-type: CONCEPT
 [id="accessing-microshift-cluster_{context}"]
-= Accessing the {product-title} cluster
+= How to access the {product-title} cluster
 
-Use the procedures in this section to access the {product-title} cluster locally, either from the same machine running the {product-title} service or remotely from a workstation. You can use this access to observe and administrate workloads.
+Use the procedures in this section to access the {product-title} cluster locally, either from the same machine running the {product-title} service or remotely from a workstation. You can use this access to observe and administrate workloads. The {OCP} CLI tool (`oc`) is employed for cluster access.


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-7914

Link to docs preview:
https://56429--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#accessing-microshift-cluster_microshift-install-rpm

QE review:
N/A, xref only

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
