### PR TITLE
OCPBUGS#5951: Fix OSDK project migration code callouts

### DIFF
--- a/modules/osdk-updating-v1220-to-v1250.adoc
+++ b/modules/osdk-updating-v1220-to-v1250.adoc
@@ -202,14 +202,16 @@ $(KUSTOMIZE): $(LOCALBIN)
 .PHONY: controller-gen
 controller-gen: $(CONTROLLER_GEN) ## Download controller-gen locally if necessary.
 $(CONTROLLER_GEN): $(LOCALBIN)
-	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION) <1>
+	test -s $(LOCALBIN)/controller-gen || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-tools/cmd/controller-gen@$(CONTROLLER_TOOLS_VERSION) <2>
 
 .PHONY: envtest
 envtest: $(ENVTEST) ## Download envtest-setup locally if necessary.
 $(ENVTEST): $(LOCALBIN)
-	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest <1>
+	test -s $(LOCALBIN)/setup-envtest || GOBIN=$(LOCALBIN) go install sigs.k8s.io/controller-runtime/tools/setup-envtest@latest <3>
 ----
 <1> Add `test -s $(LOCALBIN)/<binary-name> ||` before the instruction to download a binary.
+<2> Add `test -s $(LOCALBIN)/<binary-name> ||` before the instruction to download a binary.
+<3> Add `test -s $(LOCALBIN)/<binary-name> ||` before the instruction to download a binary.
 
 .. Update `controller-tools` to version `v0.9.2` as shown in the following example:
 +
@@ -290,16 +292,18 @@ require (
   github.com/onsi/ginkgo/v2 v2.1.4 <2>
   github.com/onsi/gomega v1.19.0 <3>
   k8s.io/api v0.25.0 <4>
-  k8s.io/apimachinery v0.25.0 <4>
-  k8s.io/client-go v0.25.0 <4>
-  sigs.k8s.io/controller-runtime v0.13.0 <5>
+  k8s.io/apimachinery v0.25.0 <5>
+  k8s.io/client-go v0.25.0 <6>
+  sigs.k8s.io/controller-runtime v0.13.0 <7>
 )
 ----
 <1> Update version `1.18` to `1.19`.
 <2> Update version `v1.16.5` to `v2.1.4`.
 <3> Update version `v1.18.1` to `v1.19.0`.
 <4> Update version `v0.24.0` to `v0.25.0`.
-<5> Update version `v0.12.1` to `v0.13.0`.
+<5> Update version `v0.24.0` to `v0.25.0`.
+<6> Update version `v0.24.0` to `v0.25.0`.
+<7> Update version `v0.12.1` to `v0.13.0`.
 
 . To download the updated versions, clean up the dependencies, and apply the changes in your `go.mod` file, run the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-5951](https://issues.redhat.com/browse/OCPBUGS-5951)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Updating go-based projects](https://56435--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-updating-projects.html#osdk-upgrading-projects_osdk-golang-updating-projects)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: I believe that this is an information archtecture/typo level fix. There are no changes to the wording or information, just fixing callouts that don't render correctly on the customer portal.
~~- [ ] QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
