### PR TITLE
OCPBUGS#7489: Webhook OpenShift timeout cannot be increased above 13s

### DIFF
--- a/modules/admission-webhooks-about.adoc
+++ b/modules/admission-webhooks-about.adoc
@@ -48,5 +48,5 @@ Some common webhook admission plugin use cases include:
 
 [NOTE]
 ====
-The default webhook timeout value in {product-title} is 13 seconds and cannot be changed.
+The maximum default webhook timeout value in {product-title} is 13 seconds, and it cannot be changed.
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> ---> As per reporter's feedback this PR adds some minor changes in the wordings

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-7489
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  https://56441--docspreview.netlify.app/openshift-enterprise/latest/architecture/admission-plug-ins.html#admission-webhooks-about_admission-plug-ins
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @gangwgr 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
