### PR TITLE
OCPBUGS#5135: Correct scaling worker latency profiles related  information

### DIFF
--- a/modules/nodes-cluster-worker-latency-profiles-about.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-about.adoc
@@ -26,9 +26,9 @@ Manually modifying the `node-monitor-grace-period` parameter is not supported.
 
 The following Operators monitor the changes to the worker latency profiles and respond accordingly:
 
-* The Machine Config Operator (MCO) updates the `node-status-frequency` parameter on the worker nodes.
-* The Kubernetes API Server Operator updates the `node-monitor-grace-period` parameter on the control plane nodes.
-* The Kubernetes Controller Manager Operator updates the `default-not-ready-toleration-seconds` and `default-unreachable-toleration-seconds` parameters on the control plance nodes. 
+* The Machine Config Operator (MCO) updates the `node-status-update-frequency` parameter on the worker nodes.
+* The Kubernetes Controller Manager Operator updates the `node-monitor-grace-period` parameter on the control plane nodes.
+* The Kubernetes API Server Operator updates the `default-not-ready-toleration-seconds` and `default-unreachable-toleration-seconds` parameters on the control plance nodes.
 
 While the default configuration works in most cases, {product-title} offers two other worker latency profiles for situations where the network is experiencing higher latency than usual. The three worker latency profiles are described in the following sections:
 


### PR DESCRIPTION
Correct scaling worker latency profiles related  information

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-5135
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56447--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/scaling-worker-latency-profiles.html#nodes-cluster-worker-latency-profiles-about_scaling-worker-latency-profiles
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
