### PR TITLE
RHDEVDOCS-4989 | Corrected the description for the ssh-privatekey and known_hosts in the secret definition

### DIFF
--- a/modules/op-configuring-ssh-authentication-for-git.adoc
+++ b/modules/op-configuring-ssh-authentication-for-git.adoc
@@ -19,7 +19,8 @@ Consider using SSH-based authentication rather than basic authentication.
 .Procedure
 
 . Generate an link:https://docs.github.com/en/authentication/connecting-to-github-with-ssh/generating-a-new-ssh-key-and-adding-it-to-the-ssh-agent[SSH private key], or copy an existing private key, which is usually available in the `~/.ssh/id_rsa` file.
-. In the `secret.yaml` file, set the value of `ssh-privatekey` to the name of the SSH private key file, and set the value of `known_hosts` to the name of the known hosts file.
+. In the `secret.yaml` file, set the value of `ssh-privatekey` to the content of the SSH private key file, and set the value of `known_hosts` to the content of the known hosts file.
+
 +
 [source,yaml,subs="attributes+"]
 ----
@@ -35,8 +36,8 @@ stringData:
   known_hosts: <3>
 ----
 <1> Name of the secret containing the SSH private key. In this example, `ssh-key`.
-<2> Name of the file containing the SSH private key string. 
-<3> Name of the file containing a list of known hosts.
+<2> The content of the SSH private key file.
+<3> The content of the known hosts file.
 +
 [CAUTION]
 ====

--- a/modules/op-understanding-credential-selection.adoc
+++ b/modules/op-understanding-credential-selection.adoc
@@ -42,4 +42,4 @@ type: kubernetes.io/ssh-auth
 stringData:
   ssh-privatekey: <1>
 ----
-<1> Name of the file containing the SSH private key string.
+<1> The content of the SSH private key file.


### PR DESCRIPTION
- Aligned team: Dev Tools
- OCP version for cherry-picking: `enterprise-4.10`, `enterprise-4.11`, `enterprise-4.12`, and `enterprise-4.13`
- JIRA issue: [RHDEVDOCS-4989](https://issues.redhat.com/browse/RHDEVDOCS-4989)
- Preview pages: [Click to preview the docs in your browser](https://56455--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/authenticating-pipelines-using-git-secret.html#op-configuring-ssh-authentication-for-git_authenticating-pipelines-using-git-secret)
- SME review: @vdemeester  
- QE review: @VeereshAradhya @ppitonak 
- Peer review: @deerskindoll 