### PR TITLE
TELCODOCS-423: release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -168,6 +168,12 @@ Netlink messages dropped by OVS kernel module due to netlink socket buffer overf
 ==== Update to HAProxy 2.6
 {product-title} updated to HAProxy 2.6.
 
+[id="ocp-4-13-nw-metallb-ipaddresspool-assignment"]
+==== Assign IP addresses in MetalLB IPAddressPool resources to specific namespaces and services
+With this update, you can assign IP addresses from a MetalLB `IPAddressPool` resource to services, namespaces, or both. This is useful in a muti-tenant, bare-metal environment that requires MetalLB to pin IP addresses from an IP address pool to specific services and namespaces. You can assign IP addresses from many IP address pools to services and namespaces. You can then define the prioritization for these IP address pools so that MetalLB assigns IP addresses starting from the higher priority IP address pool.
+
+For more information about assigning IP addresses from an IP address pool to services and namespaces, see xref:../networking/metallb/metallb-configure-address-pools.adoc#nw-metallb-configure-address-pool_configure-metallb-address-pools[Configuring MetalLB address pools].
+
 [id="ocp-4-13-storage"]
 === Storage
 


### PR DESCRIPTION
[TELCODOCS-423](https://issues.redhat.com//browse/TELCODOCS-423): RN for #55756 

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-423

Link to docs preview:
https://56457--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-nw-metallb-ipaddresspool-assignment

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->



