### PR TITLE
OSDOCS#5414: Adds notes for MicroShift 4.12.5 and other RN edits

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -74,7 +74,7 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
 
 [id="microshift-4-12-1-dp"]
-=== RHBA-2023:0452 - {product-title} 4.12.1 bug fix
+=== RHBA-2023:0452 - {product-title} 4.12.1 bug fix update
 
 Issued: 2023-01-30
 
@@ -83,7 +83,7 @@ Issued: 2023-01-30
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
 
 [id="microshift-4-12-2-dp"]
-=== RHBA-2023:0572 - {product-title} 4.12.2 bug fix
+=== RHBA-2023:0572 - {product-title} 4.12.2 bug fix update
 
 Issued: 2023-02-07
 
@@ -92,7 +92,7 @@ Issued: 2023-02-07
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
 
 [id="microshift-4-12-3-dp"]
-=== RHBA-2023:0731 - {product-title} 4.12.3 bug fix
+=== RHBA-2023:0731 - {product-title} 4.12.3 bug fix update
 
 Issued: 2023-02-16
 
@@ -101,10 +101,19 @@ Issued: 2023-02-16
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
 
 [id="microshift-4-12-4-dp"]
-=== RHSA-2023:0769 - {product-title} 4.12.4 bug fix
+=== RHSA-2023:0769 - {product-title} 4.12.4 bug fix and security update
 
 Issued: 2023-02-20
 
-{product-title} release 4.12.4 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0769[RHSA-2023:0769] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0768[RHBA-2023:0768] advisory.
+{product-title} release 4.12.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0769[RHSA-2023:0769] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0768[RHBA-2023:0768] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+
+[id="microshift-4-12-5-dp"]
+=== RHBA-2023:0893 - {product-title} 4.12.5 bug fix update
+
+Issued: 2023-02-28
+
+{product-title} release 4.12.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0893[RHBA-2023:0893] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0890[RHSA-2023:0890] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]


### PR DESCRIPTION
OSDOCS#5414: Adds notes for MicroShift 4.12.5 and other RN edits

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5414

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
