### PR TITLE
SRVKE-1363 fix xrefs that didn't have full path

### DIFF
--- a/serverless/eventing/brokers/serverless-using-brokers.adoc
+++ b/serverless/eventing/brokers/serverless-using-brokers.adoc
@@ -31,4 +31,4 @@ include::modules/serverless-creating-broker-admin-web-console.adoc[leveloffset=+
 * xref:../../../serverless/eventing/brokers/serverless-global-config-broker-class-default.adoc#serverless-global-config-broker-class-default[Configuring the default broker class]
 * xref:../../../serverless/eventing/triggers/serverless-triggers.adoc#serverless-triggers[Triggers]
 xref:../../../serverless/eventing/event-sources/knative-event-sources.adoc#knative-event-sources[Event sources]
-* xref:../brokers/serverless-event-delivery.adoc#serverless-event-delivery[Event delivery]
+* xref:../../../serverless/eventing/brokers/serverless-event-delivery.adoc#serverless-event-delivery[Event delivery]

--- a/serverless/eventing/event-sinks/serverless-kafka-developer-sink.adoc
+++ b/serverless/eventing/event-sinks/serverless-kafka-developer-sink.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Kafka sinks are a type of xref:../event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[event sink] that are available if a cluster administrator has enabled Kafka on your cluster. You can send events directly from an xref:../event-sources/knative-event-sources.adoc#knative-event-sources[event source] to a Kafka topic by using a Kafka sink.
+Kafka sinks are a type of xref:../../../serverless/eventing/event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[event sink] that are available if a cluster administrator has enabled Kafka on your cluster. You can send events directly from an xref:../../../serverless/eventing/event-sources/knative-event-sources.adoc#knative-event-sources[event source] to a Kafka topic by using a Kafka sink.
 
 // Kafka sink
 include::modules/serverless-kafka-sink.adoc[leveloffset=+1]

--- a/serverless/eventing/event-sources/knative-event-sources.adoc
+++ b/serverless/eventing/event-sources/knative-event-sources.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-A Knative _event source_ can be any Kubernetes object that generates or imports cloud events, and relays those events to another endpoint, known as a xref:../event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[_sink_]. Sourcing events is critical to developing a distributed system that reacts to events.
+A Knative _event source_ can be any Kubernetes object that generates or imports cloud events, and relays those events to another endpoint, known as a xref:../../../serverless/eventing/event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[_sink_]. Sourcing events is critical to developing a distributed system that reacts to events.
 
 You can create and manage Knative event sources by using the *Developer* perspective in the {product-title} web console, the Knative (`kn`) CLI, or by applying YAML files.
 

--- a/serverless/eventing/triggers/serverless-triggers.adoc
+++ b/serverless/eventing/triggers/serverless-triggers.adoc
@@ -8,7 +8,7 @@ include::_attributes/common-attributes.adoc[]
 
 include::snippets/serverless-brokers-intro.adoc[]
 
-If you are using a Kafka broker, you can configure the delivery order of events from triggers to event sinks. See xref:../triggers/serverless-triggers.adoc#trigger-event-delivery-config_serverless-triggers[Configuring event delivery ordering for triggers].
+If you are using a Kafka broker, you can configure the delivery order of events from triggers to event sinks. See xref:../../../serverless/eventing/triggers/serverless-triggers.adoc#trigger-event-delivery-config_serverless-triggers[Configuring event delivery ordering for triggers].
 
 
 
@@ -17,4 +17,4 @@ include::modules/trigger-event-delivery-config.adoc[leveloffset=+1]
 
 [id="next-steps_serverless-triggers"]
 == Next steps
-* Configure event delivery parameters that are applied in cases where an event fails to be delivered to an event sink. See xref:../brokers/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Examples of configuring event delivery parameters].
+* Configure event delivery parameters that are applied in cases where an event fails to be delivered to an event sink. See xref:../../../serverless/eventing/brokers/serverless-event-delivery.adoc#serverless-configuring-event-delivery-examples_serverless-event-delivery[Examples of configuring event delivery parameters].


### PR DESCRIPTION
Version(s):
4.8+

Issue:
[SRVKE-1363](https://issues.redhat.com//browse/SRVKE-1363)

Link to docs preview:
https://56459--docspreview.netlify.app/openshift-enterprise/latest/serverless/about/about-serverless.html

