### PR TITLE
OSDOCS-4648: Adding GPU instance types to SD Policy

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -207,6 +207,8 @@ Topics:
   Topics:
   - Name: About machine pools
     File: rosa-nodes-machinepools-about
+  - Name: Configuring machine pools
+    File: rosa-nodes-machinepools-configuring
   - Name: Managing compute nodes
     File: rosa-managing-worker-nodes
     Distros: openshift-rosa

--- a/modules/rosa-nodes-machine-pools-local-zones.adoc
+++ b/modules/rosa-nodes-machine-pools-local-zones.adoc
@@ -1,0 +1,76 @@
+
+// Module included in the following assemblies:
+//
+// * assemblies/rosa-nodes-machinepools-configuring.adoc
+:_content-type: CONCEPT
+[id="rosa-nodes-machine-pools-local-zones_{context}"]
+= Local Zones
+
+Use the following steps to configure Local Zones for machine pools.
+
+[IMPORTANT]
+====
+AWS Local Zones are supported on Red Hat OpenShift Service on AWS 4.12, and must be enabled by opening a support case with xref:rosa_architecture/rosa-getting-support.html#rosa-getting-support_rosa-getting-support [Red Hat Support].
+====
+.Prerequisites
+
+* ROSA is live/GA in the parent region of choice. See the link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/locations/?pg=ln&cp=bn#GA[AWS generally available locations list] to determine the Local Zone available to specific AWS regions.
+* The ROSA cluster was initially built in an existing AWS VPC (BYO-VPC).
+* The maximum transmission unit (MTU) for the ROSA cluster is set at 1200.
++
+[IMPORTANT]
+====
+Generally, the Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. See link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation. 
+The cluster network MTU must be always less than the EC2 MTU to account for the overhead. The specific overhead is determined by your network plugin, for example:
+
+- OVN-Kubernetes: `100 bytes`
+- OpenShift SDN: `50 bytes`
+
+The network plugin could provide additional features, like IPsec, that also must be decreased the MTU. Check the documentation for additional information.
+
+====
+* The AWS account has link:https://docs.aws.amazon.com/local-zones/latest/ug/getting-started.html#getting-started-find-local-zone[Local Zones enabled].
+* The AWS account has a link:https://docs.aws.amazon.com/local-zones/latest/ug/getting-started.html#getting-started-create-local-zone-subnet[Local Zone subnet] for the same VPC as the cluster.
+
+.Procedure
+
+. Create a machine pool on the cluster in ROSA CLI.
++
+[source,terminal]
+----
+$ rosa create machinepool -c <cluster-name> -i 
+----
++
+. Add the subnet and instance type for the machine pool in ROSA CLI. After several minutes, the cluster will provision the nodes.
++
+[source, terminal]
+----
+I: Enabling interactive mode <1>
+? Machine pool name: xx-lz-xx <2>
+? Create multi-AZ machine pool: No <3>
+? Select subnet for a single AZ machine pool (optional): Yes <4>
+? Subnet ID: subnet-<a> (region-info) <5>
+? Enable autoscaling (optional): No <6>
+? Replicas: 2 <7>
+I: Fetching instance types <8>
+----
++
+
+<1> Enables interactive mode.
+<2> Names the machine pool. This is limited to alphanumeric and a maximum length of 30 characters.
+<3> Set this option to no.
+<4> Set this option to yes.
+<5> Selects a subnet ID from the list. Associate the subnet with a routing table that has a route to a NAT gateway.
+<6> Set this option to no.
+<7> Selects the number of machines for the machine pool. This number can be anywhere from 1 - 180.
+<8> Selects an instance type from the list. Only instance types that are supported in the selected Local Zone will appear.
++
+. Add the `kubernetes.io/cluster/<infra_id>: shared` tag to the subnet.
+. Provide the subnet ID to provision the machine pool in the Local Zone.
+
+See the link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/locations/[AWS Local Zones locations] list on AWS for generally available and announced AWS Local Zone locations.
+
+[NOTE]
+====
+Local machine pools can be added to single Availability Zone clusters.
+====

--- a/modules/rosa-sdpolicy-am-aws-compute-types.adoc
+++ b/modules/rosa-sdpolicy-am-aws-compute-types.adoc
@@ -102,7 +102,7 @@
 - t3a.2xlarge (8 vCPU, 32 GiB)
 ====
 
-.Memory-intensive
+.Memory intensive
 [%collapsible]
 ====
 - x1.16xlarge (64 vCPU, 976 GiB)
@@ -133,7 +133,7 @@
 - x2iezn.metal (48 vCPU, 1,536 GiB)
 ====
 
-.Memory-optimized
+.Memory optimized
 [%collapsible]
 ====
 - r4.xlarge (4 vCPU, 30.5 GiB)
@@ -224,8 +224,35 @@
 
 &#135; This instance type provides 48 logical processors on 24 physical cores.
 ====
+.Accelerated computing
+[%collapsible]
+====
+- p3.2xlarge (8 vCPU, 61 GiB)
+- p3.8xlarge (32 vCPU, 244 GiB)
+- p3.16xlarge (64 vCPU, 488 GiB)
+- p3dn.24xlarge (96 vCPU, 768 GiB)
+- p4d.24xlarge (96 vCPU, 1,152 GiB)
+- g4dn.xlarge (4 vCPU, 16 GiB)
+- g4dn.2xlarge (8 vCPU, 32 GiB)
+- g4dn.4xlarge (16 vCPU, 64 GiB)
+- g4dn.8xlarge (32 vCPU, 128 GiB)
+- g4dn.12xlarge (48 vCPU, 192 GiB)
+- g4dn.16xlarge (64 vCPU, 256 GiB)
+- g4dn.metal (96 vCPU, 384 GiB)
+- g5.xlarge (4 vCPU, 16 GiB)
+- g5.2xlarge (8 vCPU, 32 GiB)
+- g5.4xlarge (16 vCPU, 64 GiB)
+- g5.8xlarge (32 vCPU, 128 GiB)
+- g5.16xlarge (64 vCPU, 256 GiB)
+- g5.12xlarge (48 vCPU, 192 GiB)
+- g5.24xlarge (96 vCPU, 384 GiB)
+- g5.48xlarge (192 vCPU, 768 GiB)
+- dl1.24xlarge  (96 vCPU, 768 GiB)&#8224;
 
-.Compute-optimized
+
+&#8224; Intel specific, and not covered by Nvidia)
+====
+.Compute optimized
 [%collapsible]
 ====
 - c5.metal (96 vCPU, 192 GiB)
@@ -292,7 +319,7 @@
 - c6id.32xlarge (128 vCPU, 256 GiB)
 ====
 
-.Storage-optimized
+.Storage optimized
 [%collapsible]
 ====
 - i3.metal (72&#8224; vCPU, 512 GiB)

--- a/modules/rosa-sdpolicy-am-local-zones.adoc
+++ b/modules/rosa-sdpolicy-am-local-zones.adoc
@@ -1,0 +1,11 @@
+
+// Module included in the following assemblies:
+//
+// * assemblies/rosa-service-definition.adoc
+:_content-type: CONCEPT
+[id="rosa-sdpolicy-local-zones_{context}"]
+= Local Zones
+
+{product-title} supports the use of AWS Local Zones, which are metropolis-centralized availability zones where customers can place latency-sensitive application workloads. Local Zones are extensions of AWS Regions that have their own internet connection. For more information about AWS Local Zones, see the AWS documentation link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work].
+
+For steps to enable AWS Local Zones and add a Local Zone to a machine pool, see xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.adoc#rosa-nodes-machine-pools-local-zones[Local Zones].

--- a/modules/rosa-sdpolicy-am-regions-az.adoc
+++ b/modules/rosa-sdpolicy-am-regions-az.adoc
@@ -7,6 +7,9 @@
 = Regions and availability zones
 The following AWS regions are supported by Red Hat OpenShift 4 and are supported for {product-title}. Note: China and GovCloud (US) regions are not supported, regardless of their support on OpenShift 4.
 
+.AWS Regions
+[%collapsible]
+====
 * af-south-1 (Cape Town, AWS opt-in required)
 * ap-east-1 (Hong Kong, AWS opt-in required)
 * ap-northeast-1 (Tokyo)
@@ -29,6 +32,7 @@ The following AWS regions are supported by Red Hat OpenShift 4 and are supported
 * us-east-2 (Ohio)
 * us-west-1 (N. California)
 * us-west-2 (Oregon)
+====
 
 Multiple availability zone clusters can only be deployed in regions with at least 3 availability zones. For more information, see the link:https://aws.amazon.com/about-aws/global-infrastructure/regions_az/[Regions and Availability Zones] section in the AWS documentation.
 
@@ -38,3 +42,4 @@ Each new {product-title} cluster is installed within an installer-created or pre
 ====
 The region and the choice of single or multiple availability zone cannot be changed after a cluster has been deployed.
 ====
+

--- a/modules/rosa-sdpolicy-am-sla.adoc
+++ b/modules/rosa-sdpolicy-am-sla.adoc
@@ -5,4 +5,5 @@
 :_content-type: CONCEPT
 [id="rosa-sdpolicy-sla_{context}"]
 = Service Level Agreement (SLA)
+
 Any SLAs for the service itself are defined in Appendix 4 of the link:https://www.redhat.com/licenses/Appendix_4_Red_Hat_Online_Services_20220720.pdf[Red Hat Enterprise Agreement Appendix 4 (Online Subscription Services)].

--- a/modules/rosa-sdpolicy-am-support.adoc
+++ b/modules/rosa-sdpolicy-am-support.adoc
@@ -5,6 +5,7 @@
 :_content-type: CONCEPT
 [id="rosa-sdpolicy-support_{context}"]
 = Support
+
 {product-title} includes Red Hat Premium Support, which can be accessed by using the link:https://access.redhat.com/support?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[Red Hat Customer Portal].
 
 See {product-title} link:https://access.redhat.com/support/offerings/openshift/sla?extIdCarryOver=true&sc_cid=701f2000001Css5AAC[SLAs] for support response times.

--- a/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc
@@ -31,6 +31,7 @@ include::modules/rosa-sdpolicy-am-aws-compute-types.adoc[leveloffset=+2]
 * link:https://aws.amazon.com/ec2/instance-types[AWS Instance Types]
 
 include::modules/rosa-sdpolicy-am-regions-az.adoc[leveloffset=+2]
+include::modules/rosa-sdpolicy-am-local-zones.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-sla.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-limited-support.adoc[leveloffset=+2]
 include::modules/rosa-sdpolicy-am-support.adoc[leveloffset=+2]

--- a/rosa_cli/rosa-manage-objects-cli.adoc
+++ b/rosa_cli/rosa-manage-objects-cli.adoc
@@ -2,6 +2,7 @@
 include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="rosa-managing-objects-cli"]
 = Managing objects with the rosa CLI
+
 :context: rosa-managing-objects-cli
 
 toc::[]

--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.adoc
@@ -1,0 +1,10 @@
+:_content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="rosa-nodes-machinepools-configuring"]
+= Configuring machine pools
+:context: rosa-nodes-machinepools-configuring
+
+toc::[]
+Configuration of machine pools.
+
+include::modules/rosa-nodes-machine-pools-local-zones.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
[OSDOCS-4648](https://issues.redhat.com/browse/OSDOCS-4648)

Link to docs preview:
[Accelerated computing instance types](https://56468--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-aws-instance-types_rosa-service-definition)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
