### PR TITLE
OCPBUGS#7984: Installing OCP on a single node is supported on certified third-party hypervisors

### DIFF
--- a/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
+++ b/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
@@ -9,7 +9,7 @@ Installing {product-title} on a single node alleviates some of the requirements 
 
 * *Administration host:* You must have a computer to prepare the ISO, to create the USB boot drive, and to monitor the installation.
 
-* *Supported platforms:* Installing {product-title} on a single node is supported on bare metal, vSphere, Red Hat OpenStack, and Red Hat Virtualization platforms. In all cases, you must specify the `platform.none: {}` parameter in the `install-config.yaml` configuration file.
+* *Supported platforms:* Installing {product-title} on a single node is supported on bare metal and link:https://access.redhat.com/articles/973163[Certified third-party hypervisors]. In all cases, you must specify the `platform.none: {}` parameter in the `install-config.yaml` configuration file.
 
 * *Production-grade server:* Installing {product-title} on a single node requires a server with sufficient resources to run {product-title} services and a production workload.
 +


### PR DESCRIPTION
Installing OCP on a single node is supported on certified third-party hypervisors

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-7984
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56472--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-preparing-to-install-sno.html#install-sno-requirements-for-installing-on-a-single-node_install-sno-preparing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
