### PR TITLE
OSDOCS-5408: Documented release notes for the 4.11.29 z-stream release

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3303,3 +3303,23 @@ $ oc adm release info 4.11.28 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+
+[id="ocp-4-11-29"]
+=== RHSA-2023:0895 - {product-title} 4.11.29 bug fix and security update
+
+Issued: 2023-02-28
+
+{product-title} release 4.11.29, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0895[RHSA-2023:0895] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.29 --pullspecs
+----
+
+[id="ocp-4-11-29-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-5408](https://issues.redhat.com/browse/OSDOCS-5408)

Link to docs preview:
[Release notes for 4.11.29](https://56473--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-29)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
