### PR TITLE
Change link in ACS docs from html to adoc for xref

### DIFF
--- a/modules/retrieving-the-collector-logs.adoc
+++ b/modules/retrieving-the-collector-logs.adoc
@@ -9,6 +9,6 @@
 First, you should examine the logs from failing Collectors. Depending on your environment and access rights, you can obtain these logs in two ways:
 
 
-* xref:../troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.html#retrieving-the-logs-with-the-oc-or-kubectl-command_logs-and-pod-status[Retrieving the logs with the `oc` or `kubectl` command]
+* xref:../troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.adoc#retrieving-the-logs-with-the-oc-or-kubectl-command_logs-and-pod-status[Retrieving the logs with the `oc` or `kubectl` command]
 
 * xref:../troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.adoc#retrieving-logs-from-a-rhacs-diagnostic-bundle_logs-and-pod-status[Retrieving logs from a RHACS diagnostic bundle]


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.74`
- Cherry pick to `rhacs-docs-3.73`
- Cherry pick to `rhacs-docs-3.73.3` (Note: We don't normally pick to x.xx.x releases, but the link is broken when Engineering is trying to compile a patch release, and the release won't build, so it needs to be fixed in the patch branch)

Issue: none

[Link to docs preview
](https://56491--docspreview.netlify.app/openshift-acs/latest/troubleshooting/retrieving-and-analyzing-the-collector-logs-and-pod-status.html#retrieving-the-collector-logs_logs-and-pod-status)

QE review:
- [ ] QE has approved this change. **N/A**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
