### PR TITLE
Updates to Release Notes for network graph 2.0

### DIFF
--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -47,10 +47,10 @@ With {product-title-short} version 3.74, you can install secured cluster service
 
 [NOTE]
 ====
-* You can now secure {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} clusters with {product-title-short}.  Central is not supported at this time.
-* The Collector is delivered as a kernel module and eBPF probe for {ibm-power}, but is only delivered as a kernel module for {ibm-zsystems} and {ibm-linuxone}.  Red Hat plans to add support for eBPF probes for {ibm-zsystems} and {ibm-linuxone} in a future release.
+* You can now secure {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} clusters with {product-title-short}. Central is not supported at this time.
+* The Collector is delivered as a kernel module and eBPF probe for {ibm-power}, but is only delivered as a kernel module for {ibm-zsystems} and {ibm-linuxone}. Red Hat plans to add support for eBPF probes for {ibm-zsystems} and {ibm-linuxone} in a future release.
 * {product-title-short} supports scanning {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} images with the following limitations for multi-architecture images:
-** When you scan a multi-architecture image with a tag reference,  {product-title-short} reports the image scan results of the AMD64 layer.
+** When you scan a multi-architecture image with a tag reference, {product-title-short} reports the image scan results of the AMD64 layer.
 ** When you scan a multi-architecture image with an SHA reference to a specific architecture layer, {product-title-short} reports the image scan results of the specified architecture.
 ====
 
@@ -96,6 +96,17 @@ In Namespace mode, the side panel includes a search bar and a list of deployment
 
 image::network-graph-20-namespace-mode.png[Side panel for a namespace showing network policy information]
 
+[id="known-limitations-network-graph"]
+==== Known limitations with network graph 2.0
+
+The *Network graph 2.0 preview* menu item is available in the {product-title-short} portal with the existing *Network graph (1.0)* menu item to make it easier for you to try it and provide us with feedback. The network graph 2.0 has the following known limitations:
+
+- When you filter the graph, the result contains your filtered deployments and other derived deployments and namespaces they interact with. A way to visualize and control the additional (derived) deployments is needed.
+- The simulate network policy feature is limited. Specifically, the graphic view does not reflect the simulation, whether it was generated from the *Simulate network policy* panel or as a result of uploading a YAML file.
+- An option to toggle the view of orchestration components is missing.
+- You cannot clear the new *Namespaces* or *Deployments* selection filter. You must deselect each entry to clear it.
+- The *Active traffic/Extraneous flows* drop-down list stays up and responds to clicks. Clicking *Active traffic* at that point results in switching to *Extraneous flows* mode.
+
 [id="global-search-updates-374"]
 === Updated global search in the {product-title-short} portal
 
@@ -115,7 +126,7 @@ For more information, see xref:../integration/integrate-using-syslog-protocol.ad
 [id="troubleshooting-collector-374"]
 === Troubleshooting guide enhanced when the Collector kernel module is missing
 
-The Collector troubleshooting guide has been updated with practical tips to help you navigate the most common startup errors and understand how to fix them. In addition, the {product-title-short} portal health status dashboard  has also been enhanced to redirect you to troubleshooting documents when the Collector status is unhealthy.
+The Collector troubleshooting guide has been updated with practical tips to help you navigate the most common startup errors and understand how to fix them. In addition, the {product-title-short} portal health status dashboard has also been enhanced to redirect you to troubleshooting documents when the Collector status is unhealthy.
 
 [id="scale-performance-improvements-374"]
 === Scale and performance improvements


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.74`

Issue: none - via Slack

[Link to docs preview
](https://56499--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes.html#known-limitations-network-graph)

QE review:
- [x] QE has approved this change. **ACS has no QE - approved by SMEs via Slack**
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Note: Removed some extra spaces in file that Vale caught.

