### PR TITLE
Update RHEC URL for disconnected Operator search

### DIFF
--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -22,14 +22,17 @@ After enabling OLM in a restricted network, you can continue to use your unrestr
 
 [IMPORTANT]
 ====
-While OLM can manage Operators from local sources, the ability for a given Operator to run successfully in a restricted network still depends on the Operator itself. The Operator must:
+While OLM can manage Operators from local sources, the ability for a given Operator to run successfully in a restricted network still depends on the Operator itself meeting the following criteria:
 
 * List any related images, or other container images that the Operator might require to perform their functions, in the `relatedImages` parameter of its `ClusterServiceVersion` (CSV) object.
 * Reference all specified images by a digest (SHA) and not by a tag.
 
-You can search on the Red Hat Ecosystem Catalog for a list of Red Hat Operators that support running in disconnected mode by selecting the *Disconnected* filter under *Infrastucture Features*:
+You can search software on the link:https://catalog.redhat.com/software/search?p=1&deployed_as=Operator&type=Containerized%20application&badges_and_features=Disconnected[Red Hat Ecosystem Catalog] for a list of Red Hat Operators that support running in disconnected mode by filtering with the following selections:
 
-link:https://catalog.redhat.com/software/operators/search[]
+[horizontal]
+Type:: Containerized application
+Deployment method:: Operator
+Infrastructure features:: Disconnected
 ====
 
 [role="_additional-resources"]


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-docs/issues/55905

4.9+ 

Preview: https://56508--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html

Changes:

* A change to the Red Hat Ecosystem Catalog (RHEC) caused the `Infrastructure Features` category filter on the left nav to disappear if `Deployment method: Operator` was set but `Type: Containerized application` was not set. This PR updates the `IMPORTANT` admonition referencing the RHEC to use the correct pre-selected URL as well as explain _all_ filters that must be set.
* Also update some nearby wording to better adhere to IBM SG.

Note: The RHEC team is aware of the UI bug and will be addressing in a future update, but for now this docs workaround will get readers to the correct search view.