### PR TITLE
[RHACS] IBMZ architecture and OCP version fixes

### DIFF
--- a/modules/installation-methods-for-different-architectures.adoc
+++ b/modules/installation-methods-for-different-architectures.adoc
@@ -20,11 +20,11 @@ a|Operator (preferred), Helm charts, or roxctl CLI (not recommended)
 
 | ppc64le ({ibm-power})
 |No
-|Yes ({ocp} versions 4.10, 4.11, and 4.12 only)
+|Yes ({ocp} versions 4.10 and 4.12 only)
 .2+a|Operator is the only supported install method.
 
-| ppc64le ({ibm-zsystems} and {ibm-linuxone})
+| s390x ({ibm-zsystems} and {ibm-linuxone})
 |No
-|Yes ({ocp} versions 4.10, 4.11, and 4.12 only)
+|Yes ({ocp} version 4.12 only)
 
 |===

--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -38,13 +38,15 @@ toc::[]
 [id="ibm-power-z-374"]
 === {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} support for secured clusters
 
-{product-title-short} version 3.74 extends support for {product-title-short} secured clusters for {osp} 4.10, 4.11, and 4.12 to {ibm-power} (ppc64le), {ibm-zsystems} (s390x), and {ibm-linuxone} (s390x) architectures. With {product-title-short} version 3.74, you can install secured cluster services on {osp} on {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} by using the {product-title-short} Operator. 
+{product-title-short} version 3.74 extends support for {product-title-short} secured clusters for {osp} 4.10 and 4.12 to {ibm-power} (ppc64le), {ibm-zsystems} (s390x), and {ibm-linuxone} (s390x) architectures. With {product-title-short} version 3.74, you can install secured cluster services on {osp} on {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} by using the {product-title-short} Operator.
 
 [NOTE]
 ====
 * You can now secure {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} clusters with {product-title-short}.  Central is not supported at this time.
-* The Collector is delivered as a kernel module and eBPF probe for {ibm-power}, but is only delivered as a kernel module for {ibm-zsystems} and {ibm-linuxone}.  Red Hat plans to add support for eBPF probes for {ibm-zsystems} and {ibm-linuxone} in a future release. 
-* Scanning is only supported for AMD64 images.
+* The Collector is delivered as a kernel module and eBPF probe for {ibm-power}, but is only delivered as a kernel module for {ibm-zsystems} and {ibm-linuxone}.  Red Hat plans to add support for eBPF probes for {ibm-zsystems} and {ibm-linuxone} in a future release.
+* {product-title-short} supports scanning IBM Power and IBM Z images with the following limitations for multi-architecture images:
+** When you scan a multi-architecture image with a tag reference,  {product-title-short} reports the image scan results of the AMD64 layer.
+** When you scan a multi-architecture image with an SHA reference to a specific architecture layer, {product-title-short} reports the image scan results of the specified architecture.
 ====
 
 [id="clair-v4-374"]
@@ -54,7 +56,7 @@ Clair is a set of microservices that perform vulnerability scanning of container
 
 [NOTE]
 ====
-* Red Hat has deprecated the previous CoreOS Clair integration in favor of Clair v4 integration. 
+* Red Hat has deprecated the previous CoreOS Clair integration in favor of Clair v4 integration.
 * The next major version, {product-title-short} 4.0, does not plan to support the link:https://quay.github.io/clair/concepts/authentication.html[JSON Web Token (JWT)-based authentication option] for Clair v4 integration.
 ====
 
@@ -67,13 +69,13 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 {product-title-short} includes a network graph upgrade that provides intuitive navigation, enhanced functionality, and crisp graphs by using the Patternfly library. The new graph provides high-level and detailed information about deployments, network flows, and network policies in your environment. You can view traffic in the graph by selecting one of the following views:
 
 * The *Active traffic* (default) view shows observed traffic, focused on the namespace or specific deployment that you click.
-* The *Extraneous flows* view shows potential flows allowed by your network policies, helping you identify missing network policies needed to achieve tighter isolation. 
+* The *Extraneous flows* view shows potential flows allowed by your network policies, helping you identify missing network policies needed to achieve tighter isolation.
 
 The new views use URLs that are displayed in your browser’s address bar, allowing you to easily navigate, save views as bookmarks, and share links.
 
 Filters and controls help you customize the information that is displayed. You can use the expanded top-level filter to focus on namespaces and deployments of interest. You can also collapse display items in the details tab to reduce clutter. The *Legend* button displays descriptions of the icons used in the graph.
 
-The following image provides an example of the network graph. In this example, based on the options that the user has chosen, the graph depicts deployments and traffic flows between them. It also uses a red badge to indicate deployments that are missing policies and therefore allowing all network traffic. 
+The following image provides an example of the network graph. In this example, based on the options that the user has chosen, the graph depicts deployments and traffic flows between them. It also uses a red badge to indicate deployments that are missing policies and therefore allowing all network traffic.
 
 image::network-graph-20-overview.png[Overview of the Network graph showing deployments and connections]
 
@@ -85,7 +87,7 @@ When you click an item in the graph, the rearranged side panel with collapsible 
 
 image::network-graph-20-deployment-mode.png[Side panel for a deployment]
 
-In Namespace mode, the side panel includes a search bar and a list of deployments. You can click on a deployment to view its information. In Namespace mode, the side panel also includes a new *Network policies* tab. From this tab, you can view, copy to the clipboard, or export any network policy defined in that namespace, as shown in the following example. 
+In Namespace mode, the side panel includes a search bar and a list of deployments. You can click on a deployment to view its information. In Namespace mode, the side panel also includes a new *Network policies* tab. From this tab, you can view, copy to the clipboard, or export any network policy defined in that namespace, as shown in the following example.
 
 image::network-graph-20-namespace-mode.png[Side panel for a namespace showing network policy information]
 
@@ -108,7 +110,7 @@ For more information, see xref:../integration/integrate-using-syslog-protocol.ad
 [id="troubleshooting-collector-374"]
 === Troubleshooting guide enhanced when the Collector kernel module is missing
 
-The Collector troubleshooting guide has been updated with practical tips to help you navigate the most common startup errors and understand how to fix them. In addition, the {product-title-short} portal health status dashboard  has also been enhanced to redirect you to troubleshooting documents when the Collector status is unhealthy. 
+The Collector troubleshooting guide has been updated with practical tips to help you navigate the most common startup errors and understand how to fix them. In addition, the {product-title-short} portal health status dashboard  has also been enhanced to redirect you to troubleshooting documents when the Collector status is unhealthy.
 
 [id="scale-performance-improvements-374"]
 === Scale and performance improvements
@@ -131,14 +133,14 @@ include::snippets/technology-preview.adoc[]
 
 {product-title-short} introduces a new concept called “collections” that provides the ability to define a collection of deployments by using matching patterns, and name this collection for repeatable use. A collection in {product-title-short} is a user-defined, named reference. It defines a logical grouping by using selection rules, offering you a power of expression as follows:
 
-* Rules can match by using the name or the label of a deployment, namespace, or cluster. 
-* You can specify rules by using exact matches or regular expressions. 
-* Collections are resolved at run time. The rules can refer to objects that do not exist at the time of definition. 
+* Rules can match by using the name or the label of a deployment, namespace, or cluster.
+* You can specify rules by using exact matches or regular expressions.
+* Collections are resolved at run time. The rules can refer to objects that do not exist at the time of definition.
 * Collections can be constructed by using other collections to describe complex hierarchies.
 
 Collections provide you with a language to describe how your dynamic infrastructure is organized, eliminating the need for cloning and repetitive editing of {product-title-short} properties such as inclusion and exclusion scopes.
 
-You can use collections to identify any group of deployments in your system, such as: 
+You can use collections to identify any group of deployments in your system, such as:
 
 * An infrastructure area that is owned by a specific development team
 * An application which requires different policy exceptions when running in a development or in a production cluster
@@ -147,16 +149,16 @@ You can use collections to identify any group of deployments in your system, suc
 
 [NOTE]
 ====
-In this Technology Preview release, collections are included only in the Vulnerability Reporting workflow, and existing report scopes are automatically migrated to collections. You must verify that the migration resulted in the correct configuration for your existing reports. See the “Migration of report scopes to collections” section for more information about the migration process. 
+In this Technology Preview release, collections are included only in the Vulnerability Reporting workflow, and existing report scopes are automatically migrated to collections. You must verify that the migration resulted in the correct configuration for your existing reports. See the “Migration of report scopes to collections” section for more information about the migration process.
 
 In upcoming releases, it is anticipated that collections will be made available in other workflows in the product, starting with simplified policy management. Over time, it is planned that collections will be available in the dashboards, the network graph, and everywhere a {product-title-short} search or filter is used, allowing you to easily focus on an area of interest.
 ====
 
 [id="policy-categories-374"]
 === Policy categories
-Policy categories help you manage violations that are related to a similar cause by grouping and filtering violations according to policy category. Before {product-title-short} version 3.74, you could create policy categories inline within a policy. In version 3.74, policy categories receive higher visibility and greater importance in {product-title-short} systems using the PostgreSQL database option. 
+Policy categories help you manage violations that are related to a similar cause by grouping and filtering violations according to policy category. Before {product-title-short} version 3.74, you could create policy categories inline within a policy. In version 3.74, policy categories receive higher visibility and greater importance in {product-title-short} systems using the PostgreSQL database option.
 
-The {product-title-short} portal introduces a new *Policy Categories* tab in *Policy Management*. This tab provides the ability to view, create, rename, or delete categories. Before deleting a category, {product-title-short} determines if a category is used by any policy. System-defined policy categories are protected and you cannot modify or delete them. 
+The {product-title-short} portal introduces a new *Policy Categories* tab in *Policy Management*. This tab provides the ability to view, create, rename, or delete categories. Before deleting a category, {product-title-short} determines if a category is used by any policy. System-defined policy categories are protected and you cannot modify or delete them.
 
 The same actions for policy categories that are available in the {product-title-short} portal are also available through the API by using the `PolicyCategoryService` service. For more information, see the API documentation by navigating to *Help* -> *API reference* in the {product-title-short} portal.
 
@@ -279,7 +281,7 @@ The permission `Access` is planned to replace `Role` in permission sets in the {
 [id="action-permissions-access"]
 ===== Actions you must take
 
-Preemptively replace the `Role` resource within your permission sets with `Access`. 
+Preemptively replace the `Role` resource within your permission sets with `Access`.
 
 [id="change-scopemgr"]
 ===== Change to ScopeManager role


### PR DESCRIPTION
Based on the following feedback:
> 1. IBM Power should list OpenShift 4.10 and 4.12 (apparently, they didn’t test 4.11)
> 2. IBM Z systems support OpenShift 4.12 only
> 3. [Table 2](https://docs.openshift.com/acs/3.74/installing/acs-installation-platforms.html) should mention LinuxONE. It can say “IBM zSystems and IBM LinuxONE (s390x)” in the same cell as they are the same architecture

> Replace the RN statement “scanning is only supported for AMD64 images” with the following info:
RHACS supports scanning IBM Power and IBM Z images with the following limitations for multi-architecture images.
> * If scanning a multi-architecture image with a tag reference,  RHACS reports the image scan results of the AMD64 layer.
> * If scanning a multi-arch image with a SHA reference to a specific architecture layer, RHACS reports the image scan results of the architecture specified.

Preview: 
- Table updates at https://56515--docspreview.netlify.app/openshift-acs/latest/installing/acs-installation-platforms.html#installation-methods-for-different-architectures_acs-installation-platforms
- Release notes at https://56515--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes.html#ibm-power-z-374

Cherrypick into `rhacs-docs-3.74`