### PR TITLE
OCPBUGS#1653: Rapidly changing clusters can lower the maximum practical size of a cluster

### DIFF
--- a/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
+++ b/scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc
@@ -12,6 +12,11 @@ These guidelines are based on the largest possible cluster. For smaller clusters
 
 In most cases, exceeding these numbers results in lower overall performance. It does not necessarily mean that the cluster will fail.
 
+[WARNING]
+====
+Clusters that experience rapid change, such as those with many starting and stopping pods, can have a lower practical maximum size than documented.
+====
+
 include::modules/openshift-cluster-maximums-major-releases.adoc[leveloffset=+1]
 
 include::modules/openshift-cluster-maximums-environment.adoc[leveloffset=+1]


### PR DESCRIPTION
Rapidly changing clusters can lower the maximum practical size of a cluster

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):  4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-1653
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56518--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
