### PR TITLE
SO-100: Adding the announcement for Downsizing of Samples operator

### DIFF
--- a/openshift_images/configuring-samples-operator.adoc
+++ b/openshift_images/configuring-samples-operator.adoc
@@ -8,6 +8,32 @@ toc::[]
 
 The Cluster Samples Operator, which operates in the `openshift` namespace, installs and updates the {op-system-base-full}-based {product-title} image streams and {product-title} templates.
 
+[IMPORTANT]
+.Cluster Samples Operator is being downsized  
+====
+* Starting from {product-title} 4.13, Cluster Samples Operator is downsized. Cluster Samples Operator will stop providing the following updates for non-Source-to-Image (Non-S2I) image streams and templates:
+- new image streams and templates
+- updates to the existing image streams and templates unless it is a CVE update
+
+* Cluster Samples Operator will provide support for Non-S2I image streams and templates as per the link:https://access.redhat.com/support/policy/updates/openshift#dates[{product-title} lifecycle policy dates and support guidelines].
+
+* Cluster Samples Operator will continue to support the S2I builder image streams and templates and accept the updates. S2I image streams and templates include:
+- Ruby
+- Python
+- Node.js
+- Perl
+- PHP
+- HTTPD
+- Nginx
+- EAP
+- Java
+- Webserver
+- .NET
+- Go
+
+* Starting from {product-title} 4.16, Cluster Samples Operator will stop managing non-S2I image streams and templates. You can contact the image stream or template owner for any requirements and future plans. In addition, refer to the link:https://github.com/openshift/library/blob/master/official.yaml[list of the repositories hosting the image stream or templates].
+====
+
 include::modules/samples-operator-overview.adoc[leveloffset=+1]
 
 [discrete]


### PR DESCRIPTION
Version(s): 4.13+
Aligned team: Dev Tools
OCP version for cherry-picking: enterprise-4.13 and later
JIRA issues: [SO-100](https://issues.redhat.com/browse/SO-100)
Preview pages: [Configuring the Cluster Samples Operator](https://56521--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/configuring-samples-operator.html)
SME Review: @dperaza4dustbit 
QE review: QE review not required as this is just the announcement of downsizing
Peer-review: @Srivaralakshmi 

