### PR TITLE
[RHACS] IBMZ architecture and OCP version fixes (round 2)

### DIFF
--- a/modules/installation-methods-for-different-architectures.adoc
+++ b/modules/installation-methods-for-different-architectures.adoc
@@ -20,11 +20,11 @@ a|Operator (preferred), Helm charts, or roxctl CLI (not recommended)
 
 | ppc64le ({ibm-power})
 |No
-|Yes ({ocp} versions 4.10 and 4.12 only)
+|Yes ({ocp} version 4.12 only)
 .2+a|Operator is the only supported install method.
 
 | s390x ({ibm-zsystems} and {ibm-linuxone})
 |No
-|Yes ({ocp} version 4.12 only)
+|Yes ({ocp} versions 4.10 and 4.12 only)
 
 |===

--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -38,13 +38,18 @@ toc::[]
 [id="ibm-power-z-374"]
 === {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} support for secured clusters
 
-{product-title-short} version 3.74 extends support for {product-title-short} secured clusters for {osp} 4.10 and 4.12 to {ibm-power} (ppc64le), {ibm-zsystems} (s390x), and {ibm-linuxone} (s390x) architectures. With {product-title-short} version 3.74, you can install secured cluster services on {osp} on {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} by using the {product-title-short} Operator.
+{product-title-short} version 3.74 extends support for {product-title-short} secured clusters for:
+
+* {osp} 4.12 to IBM Power (ppc64le)
+* {osp} 4.10 and 4.12 to IBM zSystems (s390x) and IBM® LinuxONE (s390x)
+
+With {product-title-short} version 3.74, you can install secured cluster services on {osp} on {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} by using the {product-title-short} Operator.
 
 [NOTE]
 ====
 * You can now secure {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} clusters with {product-title-short}.  Central is not supported at this time.
 * The Collector is delivered as a kernel module and eBPF probe for {ibm-power}, but is only delivered as a kernel module for {ibm-zsystems} and {ibm-linuxone}.  Red Hat plans to add support for eBPF probes for {ibm-zsystems} and {ibm-linuxone} in a future release.
-* {product-title-short} supports scanning IBM Power and IBM Z images with the following limitations for multi-architecture images:
+* {product-title-short} supports scanning {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} images with the following limitations for multi-architecture images:
 ** When you scan a multi-architecture image with a tag reference,  {product-title-short} reports the image scan results of the AMD64 layer.
 ** When you scan a multi-architecture image with an SHA reference to a specific architecture layer, {product-title-short} reports the image scan results of the specified architecture.
 ====


### PR DESCRIPTION
Based on the feedback:
>RHACS version 3.74 extends support for RHACS secured clusters for Red Hat OpenShift 4.10 and 4.12 to IBM Power (ppc64le), IBM zSystems (s390x), and IBM® LinuxONE (s390x) architectures.  is not clear. we need to explicitly mention that RHACS version 3.74 extends support for RHACS secured clusters for Red Hat OpenShift 4.12 on IBM Power (ppc64le), 4.10 and 4.12 on IBM zSystems (s390x), and IBM® LinuxONE (s390x) architectures.

Preview: https://56522--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes.html


Cherry-pick into `rhacs-docs-3.74`