### PR TITLE
[OSDOCS-5101]: Replacement control plane nodes in correct group

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -467,6 +467,11 @@ In {product-title} 4.12, support for Kuryr on clusters that run on {rh-openstack
 [id="ocp-4-13-cloud-compute-bug-fixes"]
 ==== Cloud Compute
 
+* For some configurations of Google Cloud Platform clusters, the internal load balancer uses instance groups that are created by the installation program. Previously, when a control plane machine was replaced manually, the new control plane node was not assigned to a control plane instance group. This prevented the node from being reachable via the internal load balancer. To resolve the issue, administrators had to manually move the control plane machine to the correct instance group by using the Google Cloud console.
++
+With this release, replacement control plane nodes are assigned to the correct instance group.
+(link:https://bugzilla.redhat.com/show_bug.cgi?id=1970464[*BZ#1970464*], link:https://issues.redhat.com/browse/OCPCLOUD-1562[*OCPCLOUD-1562*])
+
 [discrete]
 [id="ocp-4-13-dev-console-bug-fixes"]
 ==== Developer Console


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OCPCLOUD-1562](https://issues.redhat.com//browse/OCPCLOUD-1562) | [BZ#1970464](https://bugzilla.redhat.com/show_bug.cgi?id=1970464) | [OSDOCS-5101](https://issues.redhat.com//browse/OSDOCS-5101)

Link to docs preview:
[Bugfix writeup](https://56525--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-bug-fixes)

QE review:
- [ ] QE has approved this change.

Additional information: