### PR TITLE
OCPBUGS#7608 - Removing iPXE for ZTP feature from 4.12 release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1182,12 +1182,6 @@ In {product-title} 4.11, a feature allowing you to manually add worker nodes to 
 
 For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-sno-additional-worker-node.adoc#ztp-additional-worker-sno_sno-additional-worker[Adding worker nodes to {sno} clusters with GitOps ZTP].
 
-[id="ocp-4-12-iPXE-ZTP"]
-==== Support for iPXE network booting with ZTP
-Zero touch provisioning (ZTP) uses the Metal3 service to boot RHCOS on the target host as part of the deployment of spoke clusters. With this update, ZTP leverages the capabilities of Metal3 by adding the option of Preboot Execution Environment (iPXE) network booting for these RHCOS installations.
-
-For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc#about-ztp_ztp-deploying-far-edge-clusters-at-scale[Using ZTP to provision clusters at the network far edge].
-
 [id="scalability-and-performance-factory-precaching-tool"]
 ==== {factory-prestaging-tool-caps} to reduce {product-title} and Operator deployment times (Technology Preview)
 


### PR DESCRIPTION
OCPBUGS#7608: Removing RN related to updated content in #56323 

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-7608

Link to docs preview:
https://56527--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html
(no hits for iPXE in release notes now)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
