### PR TITLE
OSDOCS-5407:adds 4.12.5 zstream to RNs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3253,3 +3253,33 @@ $ oc adm release info 4.12.4 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-12-5"]
+=== RHSA-2023:0890 - {product-title} 4.12.5 bug fix and security update
+
+Issued: 2023-02-28
+
+{product-title} release 4.12.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0890[RHSA-2023:0890] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0889[RHBA-2023:0889] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.5 --pullspecs
+----
+
+[id="ocp-4-12-5-bug-fixes"]
+==== Bug fixes
+
+* Previously, in the repositories list, you could see the *PipelineRuns* only when the status was `Succeeded` or `Failed` but not when the status was `Running`. With this fix, when the *PipelineRuns* is triggered, you can see it in the repositories list with the status `Running`. (link:https://issues.redhat.com/browse/OCPBUGS-6816[*OCPBUGS-6816*])
+
+* Previously, when creating a `Secret`, the *Start Pipeline* model created an invalid JSON value, As a result, the Secret was unusable and the `PipelineRun` could fail. With this fix, the *Start Pipeline* model creates a valid JSON value for the `Secret`. Now, you can create valid Secrets while starting a Pipeline. (link:https://issues.redhat.com/browse/OCPBUGS-6671[*OCPBUGS-6671*])
+
+* Previously, when a `BindableKinds` resource did not have a status, the web console crashed, fetching and showing the same data in a loop. With this fix, you can set the `BindableKinds` resource status array to `[]`, expecting it to exist without a status field. As a result, the web browser or the application does not crash. (link:https://issues.redhat.com/browse/OCPBUGS-4072[*OCPBUGS-4072*])
+
+* Previously, the associated webhook `<kn-service-name>-github-webhook-secret` did not delete when deleting a Knative (`kn`) service from {product-title}. With this fix, all the associated webhook secrets are deleted. Now, you can create a Knative (`kn`) service with the same name as the deleted one. (link:https://issues.redhat.com/browse/OCPBUGS-7437[*OCPBUGS-7437*])
+
+[id="ocp-4-12-5-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5407](https://issues.redhat.com//browse/OSDOCS-5407): adds 4.12.5 zstream 
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5407
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://56530--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-5
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
