### PR TITLE
OCPBUGS#8027: Remove prefixes (http[s]) from `.docker/config.json` examples

### DIFF
--- a/modules/builds-docker-credentials-private-registries.adoc
+++ b/modules/builds-docker-credentials-private-registries.adoc
@@ -21,13 +21,13 @@ has the following format:
 [source,yaml]
 ----
 auths:
-  https://index.docker.io/v1/: <1>
+  index.docker.io/v1/: <1>
     auth: "YWRfbGzhcGU6R2labnRib21ifTE=" <2>
     email: "user@example.com" <3>
-  https://docker.io/my-namespace/my-user/my-image: <4>
+  docker.io/my-namespace/my-user/my-image: <4>
     auth: "GzhYWRGU6R2fbclabnRgbkSp=""
     email: "user@example.com"
-  https://docker.io/my-namespace: <5>
+  docker.io/my-namespace: <5>
     auth: "GzhYWRGU6R2deesfrRgbkSp=""
     email: "user@example.com"
 ----


### PR DESCRIPTION
Version(s): 4.9+

Issue: [OCPBUGS-8027](https://issues.redhat.com/browse/OCPBUGS-8027)

Link to docs preview: https://56541--docspreview.netlify.app/openshift-enterprise/latest/cicd/builds/creating-build-inputs.html#builds-docker-credentials-private-registries_creating-build-inputs

QE review:

Additional information:
https://docs.openshift.com/container-platform/4.9/cicd/builds/creating-build-inputs.html#builds-docker-credentials-private-registries_creating-build-inputs
