### PR TITLE
[enterprise-4.10] Update 4.10 docs per style guide

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -18,9 +18,9 @@ Before you install an {product-title} cluster, you need to select the best insta
 If you want to install and manage {product-title} yourself, you can install it on the following platforms:
 
 * Alibaba Cloud
-* Amazon Web Services (AWS) on x86_64 instances
+* Amazon Web Services (AWS) on 64-bit x86 instances
 ifndef::openshift-origin[]
-* Amazon Web Services (AWS) on arm64 instances
+* Amazon Web Services (AWS) on 64-bit ARM instances
 endif::openshift-origin[]
 * Microsoft Azure
 * Microsoft Azure Stack Hub
@@ -127,7 +127,7 @@ Not all installation options are supported for all platforms, as shown in the fo
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS (x86_64) |AWS (arm64) |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
+||Alibaba |AWS (64-bit x86) |AWS (64-bit ARM) |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Power
 
 |Default
 |xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[&#10003;]
@@ -440,7 +440,7 @@ endif::openshift-origin[]
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
+||Alibaba |AWS |Azure |Azure Stack Hub |GCP |{rh-openstack} |{rh-openstack} on SR-IOV |RHV |Bare metal (64-bit x86) |Bare metal (64-bit ARM) |vSphere |VMC |IBM Cloud VPC |IBM Z |IBM Z with {op-system-base} KVM |IBM Power |Platform agnostic
 
 |Custom
 |

--- a/installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc
+++ b/installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can install {product-title} on on-premise hardware or on-premise VMs using the {ai-full}. Installing {product-title} using the {ai-full} supports both x86-64 and arm64 CPU architectures.
+You can install {product-title} on on-premise hardware or on-premise VMs using the {ai-full}. Installing {product-title} using the {ai-full} supports both x86_64 and AArch64 CPU architectures.
 
 include::modules/assisted-installer-using-the-assisted-installer.adoc[leveloffset=+1]
 

--- a/modules/architecture-rhcos-updating-bootloader.adoc
+++ b/modules/architecture-rhcos-updating-bootloader.adoc
@@ -41,7 +41,7 @@ Component EFI
 ----
 ifndef::openshift-origin[]
 +
-.Example output for `arm64`
+.Example output for `aarch64`
 [source, terminal]
 ----
 Component EFI

--- a/modules/assisted-installer-setting-the-cluster-details.adoc
+++ b/modules/assisted-installer-setting-the-cluster-details.adoc
@@ -35,7 +35,7 @@ The base domain must be a valid DNS name. You must not have a wild card domain s
 
 . Optional: The {ai-full} already has the pull secret associated to your account. If you want to use a different pull secret, select *Edit pull secret*.
 
-. Optional: {ai-full} defaults to using `x86_64` CPU architecture. If you are installing {product-title} on `arm64` CPUs, select *Use arm64 CPU architecture*. Keep in mind, some features are not available with `arm64` CPU architecture.
+. Optional: {ai-full} defaults to using x86_64 CPU architecture. If you are installing {product-title} on 64-bit ARM CPUs, select *Use arm64 CPU architecture*. Keep in mind, some features are not available with AArch64 CPU architectures.
 
 . Optional: If you are using a static IP configuration for the cluster nodes instead of DHCP reservations, select *Static network configuration*.
 

--- a/modules/installation-aws-ami-stream-metadata.adoc
+++ b/modules/installation-aws-ami-stream-metadata.adoc
@@ -28,7 +28,7 @@ To parse the stream metadata, use one of the following methods:
 
 ** Print the current `x86_64`
 ifndef::openshift-origin[]
-or `arm64`
+or `aarch64`
 endif::openshift-origin[]
 AMI for an AWS region, such as `us-west-1`:
 +

--- a/modules/installation-aws-arm-tested-machine-types.adoc
+++ b/modules/installation-aws-arm-tested-machine-types.adoc
@@ -10,16 +10,16 @@
 // installing/installing_aws/installing-restricted-networks-aws.adoc
 
 [id="installation-aws-arm-tested-machine-types_{context}"]
-= Tested instance types for AWS ARM
+= Tested instance types for AWS on 64-bit ARM infrastructures 
 
-The following Amazon Web Services (AWS) ARM instance types have been tested with {product-title}.
+The following Amazon Web Services (AWS) ARM64 instance types have been tested with {product-title}.
 
 [NOTE]
 ====
 Use the machine types included in the following charts for your AWS ARM instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements that are listed in "Minimum resource requirements for cluster installation". 
 ====
 
-.Machine types based on arm64 architecture
+.Machine types based on 64-bit ARM architecture
 [%collapsible]
 ====
 include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/aws/tested_instance_types_aarch64.md[]

--- a/modules/installation-aws-tested-machine-types.adoc
+++ b/modules/installation-aws-tested-machine-types.adoc
@@ -19,7 +19,7 @@ The following Amazon Web Services (AWS) instance types have been tested with {pr
 Use the machine types included in the following charts for your AWS instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements that are listed in "Minimum resource requirements for cluster installation". 
 ====
 
-.Machine types based on x86_64 architecture
+.Machine types based on 64-bit x86 architecture
 [%collapsible]
 ====
 include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/aws/tested_instance_types_x86_64.md[]

--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -93,7 +93,7 @@ ifndef::openshift-origin[]
 
 |===
 
-.arm64 {op-system} AMIs
+.aarch64 {op-system} AMIs
 
 [cols="2a,2a",options="header"]
 |===

--- a/modules/installation-user-infra-machines-pxe.adoc
+++ b/modules/installation-user-infra-machines-pxe.adoc
@@ -205,7 +205,7 @@ This configuration does not enable serial console access on machines with a grap
 ifndef::only-pxe[]
 ** For iPXE (`x86_64`
 ifndef::openshift-origin[]
-+ `arm64`
++ `aarch64`
 endif::openshift-origin[]
 ):
 +
@@ -232,12 +232,12 @@ This configuration does not enable serial console access on machines with a grap
 ifndef::openshift-origin[]
 [NOTE]
 ====
-To network boot the CoreOS `kernel` on `arm64` architecture, you need to use a version of iPXE build with the `IMAGE_GZIP` option enabled. See link:https://ipxe.org/buildcfg/image_gzip[`IMAGE_GZIP` option in iPXE].
+To network boot the CoreOS `kernel` on `aarch64` architecture, you need to use a version of iPXE build with the `IMAGE_GZIP` option enabled. See link:https://ipxe.org/buildcfg/image_gzip[`IMAGE_GZIP` option in iPXE].
 ====
 endif::openshift-origin[]
 endif::only-pxe[]
 ifndef::only-pxe,openshift-origin[]
-** For PXE (with UEFI and Grub as second stage) on `arm64`:
+** For PXE (with UEFI and Grub as second stage) on `aarch64`:
 +
 ----
 menuentry 'Install CoreOS' {

--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -363,7 +363,7 @@ a|`--insecure-ignition`
 a|Allow Ignition URL without HTTPS or hash.
 
 a|`--architecture <name>`
-a|Target CPU architecture. Valid values are `x86_64` and `arm64`.
+a|Target CPU architecture. Valid values are `x86_64` and `aarch64`.
 
 a|`--preserve-on-error`
 a|Do not clear partition table on error.


### PR DESCRIPTION
**For version:** 4.10 

**Description:** Updates 4.10 docs with the correct guidelines per updated style guide. Link to style guide: https://redhat-documentation.github.io/supplementary-style-guide/#aarch64 

**Previews:** 

- [Selecting an installation method and preparing a cluster -> Support installation methods for different platforms ](https://kelbrown20.github.io/Docs-previews/previews/Updating-docs-per-architecture-guidelines/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)
- Installing a user-provisioned cluster on bare metal ->
    1.[ Installing RHCOS by using PXE or IPXE booting](https://kelbrown20.github.io/Docs-previews/previews/Updating-docs-per-architecture-guidelines/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-pxe_installing-bare-metal) 
    2. [Advanced RHCOS installation reference](https://kelbrown20.github.io/Docs-previews/previews/Updating-docs-per-architecture-guidelines/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-advanced_installing-bare-metal) 
- Installing on-premise with Assisted installer
  1. [Installing an on-premise cluster using the Assisted installer](https://kelbrown20.github.io/Docs-previews/previews/Updating-docs-per-architecture-guidelines/installing/installing_on_prem_assisted/installing-on-prem-assisted.html) 
  2. [Installing with the assisted installer -> Setting the cluster details](https://kelbrown20.github.io/Docs-previews/previews/Updating-docs-per-architecture-guidelines/installing/installing_on_prem_assisted/assisted-installer-installing.html#setting-the-cluster-details_assisted-installer-installing) 
- Installing a cluster on AWS in a restricted network with user-provisioned infrastructure 
  1. [Accessing the RHCOS AMI with stream metadata ](https://kelbrown20.github.io/Docs-previews/previews/Updating-docs-per-architecture-guidelines/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-ami-stream-metadata_installing-restricted-networks-aws)
  2. [RHCOS AMIs for the AWS infrastructure](https://kelbrown20.github.io/Docs-previews/previews/Updating-docs-per-architecture-guidelines/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-user-infra-rhcos-ami_installing-restricted-networks-aws) 
- Installing a cluster on AWS with customizations 
  1. [Tested instance types for AWS on 64-bit ARM infrastructures](https://kelbrown20.github.io/Docs-previews/previews/Updating-docs-per-architecture-guidelines/installing/installing_aws/installing-aws-customizations.html#installation-aws-arm-tested-machine-types_installing-aws-customizations) 
  2. [Tested instance types for AWS](https://kelbrown20.github.io/Docs-previews/previews/Updating-docs-per-architecture-guidelines/installing/installing_aws/installing-aws-customizations.html#installation-aws-tested-machine-types_installing-aws-customizations)
