### PR TITLE
CNV-18414: VM secondary network DNS access

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3650,6 +3650,8 @@ Topics:
       File: virt-configuring-ip-for-vms
     - Name: Viewing the IP address of NICs on a virtual machine
       File: virt-viewing-ip-of-vm-nic
+    - Name: Accessing a virtual machine on a secondary network by using the cluster domain name
+      File: virt-accessing-vm-secondary-network-fqdn
     - Name: Using a MAC address pool for virtual machines
       File: virt-using-mac-address-pool-for-vms
 #A BETTER NAME THAN 'STORAGE 4 U'

--- a/modules/virt-configuring-secondary-dns-server.adoc
+++ b/modules/virt-configuring-secondary-dns-server.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
+
+:_content-type: PROCEDURE
+[id="virt-configuring-secondary-dns-server_{context}"]
+= Configuring DNS server for secondary networks
+
+The Cluster Network Addons Operator (CNAO) deploys the Domain Name Server (DNS) server and monitoring components when you enable the `KubeSecondaryDNS` feature gate in the `HyperConverged` custom resource (CR).
+
+.Prerequisites
+* You installed the OpenShift CLI (`oc`).
+* You have access to an {product-title} cluster with `cluster-admin` permissions.
+
+.Procedure
+. Create a `LoadBalancer` service using MetalLB or any other load balancer to expose the DNS server outside the cluster. The service listens on port 53 and targets port 5353. For example:
++
+[source,terminal]
+----
+$ oc expose -n openshift-cnv deployment/secondary-dns --name=dns-lb --type=LoadBalancer --port=53 --target-port=5353 --protocol='UDP'
+----
+
+. Retrieve the public IP address of the service by querying the `Service` object:
++
+[source,terminal]
+----
+$ oc get service -n openshift-cnv
+----
++
+.Example output
+[source,terminal]
+----
+NAME        TYPE            CLUSTER-IP     EXTERNAL-IP      PORT(S)          AGE
+dns-lb   LoadBalancer       172.30.27.5    10.46.41.94      53:31829/TCP     5s
+----
+
+. Deploy the DNS server and monitoring components by editing the `HyperConverged` CR:
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+  name: kubevirt-hyperconverged
+  namespace: openshift-cnv
+spec:
+    featureGates:
+      deployKubeSecondaryDNS: true <1>
+    kubeSecondaryDNSNameServerIP: "10.46.41.94" <2>
+#...
+----
+<1> Set the `KubeSecondaryDNS` feature gate to `true`.
+<2> Set the IP address of the service to the value retrieved in step 2.
+
+. Retrieve the FQDN of the {product-title} cluster by using the following command:
++
+[source,terminal]
+----
+$ oc get dnses.config.openshift.io cluster -o json | jq .spec.baseDomain
+----
++
+.Example output
+[source,terminal]
+----
+openshift.example.com
+----
+
+. Point to the DNS server by using one of the following methods:
+** Add the `kubeSecondaryDNSNameServerIP` value to the `resolv.conf` file on your local machine.
++
+[NOTE]
+====
+Editing the `resolv.conf` file overwrites any existing DNS settings.
+====
+
+** Add the `kubeSecondaryDNSNameServerIP` value and the cluster FQDN to the enterprise DNS server records. For example:
++
+[source,terminal]
+----
+vm.<FQDN>. IN NS ns.vm.<FQDN>.
+----
++
+[source,terminal]
+----
+ns.vm.<FQDN>. IN A 10.46.41.94
+----

--- a/modules/virt-connecting-vm-secondarynw-using-fqdn.adoc
+++ b/modules/virt-connecting-vm-secondarynw-using-fqdn.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
+
+:_content-type: PROCEDURE
+[id="virt-connecting-vm-secondarynw-fqdn_{context}"]
+= Connecting to a virtual machine on a secondary network by using the cluster FQDN
+
+You can access a virtual machine (VM) that is attached to a secondary network interface from outside the cluster by using the fully qualified domain name (FQDN) of the cluster.
+
+.Prerequisites
+* The QEMU guest agent must be running on the virtual machine.
+* The IP address of the VM that you want to connect to, by using a DNS client, must be public.
+* You have configured the DNS server for secondary networks.
+* You have retrieved the fully qualified domain name (FQDN) of the cluster.
+
+.Procedure
+. Retrieve the VM configuration by using the following command:
++
+[source,terminal]
+----
+$ oc get vm -n secondary-test vm-test-sec-dns -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  labels:
+    kubevirt.io/vm: vm-test-sec-dns
+  name: vm-test-sec-dns <1>
+  namespace: secondary-test <2>
+spec:
+  running: true
+  template:
+    metadata:
+      labels:
+        kubevirt.io/vm: vm-test-sec-dns
+    spec:
+      domain:
+        devices:
+#...
+          interfaces:
+            - bridge: {}
+              name: nic1
+#...
+      networks:
+      - multus:
+          networkName: bridge-conf
+        name: nic1 <3>
+#...
+----
+<1> The name of the `VirtualMachine` object.
+<2> The namespace in which the `VirtualMachine` object is defined.
+<3> The name of the secondary network interface.
+
+. Connect to the VM by using the following command:
++
+--
+[source,terminal]
+----
+<interface_name>.<vm_name>.<namespace>.vm.<FQDN>
+----
+
+where:
+
+* `<interface_name>` specifies the name of the secondary network interface.
+* `<vm_name>` specifies the name of the `VirtualMachine` object.
+* `<namespace>` specifies the namespace in which the `VirtualMachine` object is defined.
+* `<FQDN>` specifies the fully qualified domain name of the cluster.
+--
++
+.Example
+[source,terminal]
+----
+nic1.vm-test-sec-dns.secondary-test.vm.openshift.example.com
+----

--- a/virt/virtual_machines/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
+++ b/virt/virtual_machines/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc
@@ -1,0 +1,24 @@
+:_content-type: ASSEMBLY
+[id="virt-accessing-vm-secondary-network-fqdn"]
+= Accessing a virtual machine on a secondary network by using the cluster domain name
+include::_attributes/common-attributes.adoc[]
+:context: virt-accessing-vm-secondary-network-fqdn
+
+toc::[]
+
+You can access a virtual machine (VM) that is attached to a secondary network interface from outside the cluster by using the fully qualified domain name (FQDN) of the cluster.
+
+:FeatureName: Accessing VMs by using the cluster FQDN
+include::snippets/technology-preview.adoc[]
+
+include::modules/virt-configuring-secondary-dns-server.adoc[leveloffset=+1]
+
+include::modules/virt-connecting-vm-secondarynw-using-fqdn.adoc[leveloffset=+1]
+
+
+[role="_additional-resources"]
+[id="additional-resources_accessing-vm-secondary-network-fqdn"]
+== Additional resources
+* xref:../../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc#configuring-ingress-cluster-traffic-load-balancer[Configuring ingress cluster traffic using a load balancer]
+* xref:../../../networking/metallb/about-metallb.adoc#about-metallb[Load balancing with MetalLB]
+* xref:../../../virt/virtual_machines/vm_networking/virt-configuring-ip-for-vms.adoc#virt-configuring-ip-for-vms[Configuring IP addresses for virtual machines]

--- a/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
+++ b/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc
@@ -45,3 +45,8 @@ include::modules/virt-vm-creating-nic-web.adoc[leveloffset=+2]
 include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
 
 include::modules/virt-attaching-vm-secondary-network-cli.adoc[leveloffset=+2]
+
+[id="next-steps_virt-attaching-vm-multiple-networks"]
+== Next steps
+
+* xref:../../../virt/virtual_machines/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc#virt-accessing-vm-secondary-network-fqdn[Accessing a virtual machine on a secondary network by using the cluster domain name]

--- a/virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.adoc
+++ b/virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.adoc
@@ -23,3 +23,8 @@ include::modules/nw-sriov-configuring-device.adoc[leveloffset=+1]
 include::modules/nw-sriov-network-attachment.adoc[leveloffset=+1]
 
 include::modules/virt-attaching-vm-to-sriov-network.adoc[leveloffset=+1]
+
+[id="next-steps_virt-attaching-vm-to-sriov-network"]
+== Next steps
+
+* xref:../../../virt/virtual_machines/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc#virt-accessing-vm-secondary-network-fqdn[Accessing a virtual machine on a secondary network by using the cluster domain name]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-18414](https://issues.redhat.com//browse/CNV-18414)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56582--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-accessing-vm-secondary-network-fqdn.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!---Additional information:  --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
