### PR TITLE
OSDOCS-4648: Adding GPU instance types to SD Policy

### DIFF
--- a/modules/rosa-sdpolicy-am-aws-compute-types.adoc
+++ b/modules/rosa-sdpolicy-am-aws-compute-types.adoc
@@ -102,7 +102,7 @@
 - t3a.2xlarge (8 vCPU, 32 GiB)
 ====
 
-.Memory-intensive
+.Memory intensive
 [%collapsible]
 ====
 - x1.16xlarge (64 vCPU, 976 GiB)
@@ -133,7 +133,7 @@
 - x2iezn.metal (48 vCPU, 1,536 GiB)
 ====
 
-.Memory-optimized
+.Memory optimized
 [%collapsible]
 ====
 - r4.xlarge (4 vCPU, 30.5 GiB)
@@ -224,8 +224,37 @@
 
 &#135; This instance type provides 48 logical processors on 24 physical cores.
 ====
+.Accelerated computing
+[%collapsible]
+====
+- p3.2xlarge (8 vCPU, 61 GiB)
+- p3.8xlarge (32 vCPU, 244 GiB)
+- p3.16xlarge (64 vCPU, 488 GiB)
+- p3dn.24xlarge (96 vCPU, 768 GiB)
+- p4d.24xlarge (96 vCPU, 1,152 GiB)
+- g4dn.xlarge (4 vCPU, 16 GiB)
+- g4dn.2xlarge (8 vCPU, 32 GiB)
+- g4dn.4xlarge (16 vCPU, 64 GiB)
+- g4dn.8xlarge (32 vCPU, 128 GiB)
+- g4dn.12xlarge (48 vCPU, 192 GiB)
+- g4dn.16xlarge (64 vCPU, 256 GiB)
+- g4dn.metal (96 vCPU, 384 GiB)
+- g5.xlarge (4 vCPU, 16 GiB)
+- g5.2xlarge (8 vCPU, 32 GiB)
+- g5.4xlarge (16 vCPU, 64 GiB)
+- g5.8xlarge (32 vCPU, 128 GiB)
+- g5.16xlarge (64 vCPU, 256 GiB)
+- g5.12xlarge (48 vCPU, 192 GiB)
+- g5.24xlarge (96 vCPU, 384 GiB)
+- g5.48xlarge (192 vCPU, 768 GiB)
+- dl1.24xlarge  (96 vCPU, 768 GiB)&#8224;
 
-.Compute-optimized
+
+&#8224; Intel specific; not covered by Nvidia
+
+Support for the GPU instance type software stack is provided by AWS. Ensure that your AWS service quotas can accommodate the desired GPU instance types.
+====
+.Compute optimized
 [%collapsible]
 ====
 - c5.metal (96 vCPU, 192 GiB)
@@ -292,7 +321,7 @@
 - c6id.32xlarge (128 vCPU, 256 GiB)
 ====
 
-.Storage-optimized
+.Storage optimized
 [%collapsible]
 ====
 - i3.metal (72&#8224; vCPU, 512 GiB)

--- a/modules/sdpolicy-am-aws-compute-types-ccs.adoc
+++ b/modules/sdpolicy-am-aws-compute-types-ccs.adoc
@@ -102,7 +102,7 @@
 - t3a.2xlarge (8 vCPU, 32 GiB)
 ====
 
-.Memory-intensive
+.Memory intensive
 [%collapsible]
 ====
 - x1.16xlarge (64 vCPU, 976 GiB)
@@ -133,7 +133,7 @@
 - x2iezn.metal (48 vCPU, 1,536 GiB)
 ====
 
-.Memory-optimized
+.Memory optimized
 [%collapsible]
 ====
 - r4.xlarge (4 vCPU, 30.5 GiB)
@@ -224,8 +224,37 @@
 
 &#135; This instance type provides 48 logical processors on 24 physical cores.
 ====
+.Accelerated computing
+[%collapsible]
+====
+- p3.2xlarge (8 vCPU, 61 GiB)
+- p3.8xlarge (32 vCPU, 244 GiB)
+- p3.16xlarge (64 vCPU, 488 GiB)
+- p3dn.24xlarge (96 vCPU, 768 GiB)
+- p4d.24xlarge (96 vCPU, 1,152 GiB)
+- g4dn.xlarge (4 vCPU, 16 GiB)
+- g4dn.2xlarge (8 vCPU, 32 GiB)
+- g4dn.4xlarge (16 vCPU, 64 GiB)
+- g4dn.8xlarge (32 vCPU, 128 GiB)
+- g4dn.12xlarge (48 vCPU, 192 GiB)
+- g4dn.16xlarge (64 vCPU, 256 GiB)
+- g4dn.metal (96 vCPU, 384 GiB)
+- g5.xlarge (4 vCPU, 16 GiB)
+- g5.2xlarge (8 vCPU, 32 GiB)
+- g5.4xlarge (16 vCPU, 64 GiB)
+- g5.8xlarge (32 vCPU, 128 GiB)
+- g5.16xlarge (64 vCPU, 256 GiB)
+- g5.12xlarge (48 vCPU, 192 GiB)
+- g5.24xlarge (96 vCPU, 384 GiB)
+- g5.48xlarge (192 vCPU, 768 GiB)
+- dl1.24xlarge  (96 vCPU, 768 GiB)&#8224;
 
-.Compute-optimized
+
+&#8224; Intel specific; not covered by Nvidia
+
+Support for the GPU instance type software stack is provided by AWS. Ensure that your AWS service quotas can accommodate the desired GPU instance types.
+====
+.Compute optimized
 [%collapsible]
 ====
 - c5.metal (96 vCPU, 192 GiB)
@@ -292,7 +321,7 @@
 - c6id.32xlarge (128 vCPU, 256 GiB)
 ====
 
-.Storage-optimized
+.Storage optimized
 [%collapsible]
 ====
 - i3.metal (72&#8224; vCPU, 512 GiB)


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
[4.12+](https://github.com/openshift/openshift-docs/pull/56583#issuecomment-1487589949)

Issue:
[OSDOCS-4648](https://issues.redhat.com/browse/OSDOCS-4648)

Link to docs preview:
[ROSA: Accelerated computing instance types](https://56583--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-aws-instance-types_rosa-service-definition)
[OSD: Accelerated computing instance types](https://56583--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#aws-instance-types-ccs_osd-service-definition)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
All reviews are complete.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
