### PR TITLE
OSDOCS-5395: create an uninstalling OSUS page

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -599,6 +599,8 @@ Topics:
     File: restricted-network-update-osus
   - Name: Updating a cluster in a disconnected environment without OSUS
     File: restricted-network-update
+  - Name: Uninstalling OSUS from a cluster
+    File: uninstalling-osus
 - Name: Updating hardware on nodes running on vSphere
   File: updating-hardware-on-nodes-running-on-vsphere
 # - Name: Troubleshooting an update
@@ -3754,7 +3756,7 @@ Topics:
   - Name: Installing the Serverless Operator
     File: install-serverless-operator
   - Name: Installing the Knative CLI
-    File: installing-kn    
+    File: installing-kn
   - Name: Installing Knative Serving
     File: installing-knative-serving
   - Name: Installing Knative Eventing
@@ -3971,7 +3973,7 @@ Topics:
     Dir: tuning
     Topics:
     - Name: Overriding deployment configurations
-      File: override-config    
+      File: override-config
     - Name: High availability
       File: serverless-ha
   - Name: kn-event plugin
@@ -4089,12 +4091,12 @@ Topics:
   Dir: integrations
   Topics:
   - Name: Integrating Service Mesh with OpenShift Serverless
-    File: serverless-ossm-setup  
+    File: serverless-ossm-setup
   - Name: Integrating Serverless with the cost management service
     File: serverless-cost-management-integration
   - Name: Using NVIDIA GPU resources with serverless applications
     File: gpu-resources
-# Removing  
+# Removing
 - Name: Removing Serverless
   Dir: removing
   Topics:

--- a/modules/update-service-delete-service-cli.adoc
+++ b/modules/update-service-delete-service-cli.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating-restricted-network-cluster/uninstalling-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-delete-service-cli_{context}"]

--- a/modules/update-service-delete-service-web-console.adoc
+++ b/modules/update-service-delete-service-web-console.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating-restricted-network-cluster/uninstalling-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-delete-service-web-console_{context}"]

--- a/modules/update-service-uninstall-cli.adoc
+++ b/modules/update-service-uninstall-cli.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating-restricted-network-cluster/uninstalling-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-uninstall-cli_{context}"]

--- a/modules/update-service-uninstall-web-console.adoc
+++ b/modules/update-service-uninstall-web-console.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating-restricted-network-cluster/uninstalling-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-uninstall-web-console_{context}"]

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -79,8 +79,8 @@ xref:../updating/updating-restricted-network-cluster/index.adoc#about-restricted
 * xref:../updating/updating-restricted-network-cluster/restricted-network-update.adoc#generating-icsp-object-scoped-to-a-registry_updating-restricted-network-cluster[Widening the scope of the mirror image catalog to reduce the frequency of cluster node reboots]
 * xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-install[Installing the OpenShift Update Service Operator]
 * xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-create-service[Creating an OpenShift Update Service application]
-* xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-delete-service[Deleting an OpenShift Update Service application]
-* xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-uninstall[Uninstalling the OpenShift Update Service Operator]
+* xref:../updating/updating-restricted-network-cluster/uninstalling-osus.adoc#update-service-delete-service[Deleting an OpenShift Update Service application]
+* xref:../updating/updating-restricted-network-cluster/uninstalling-osus.adoc#update-service-uninstall[Uninstalling the OpenShift Update Service Operator]
 
 [id="updating-clusters-overview-vsphere-updating-hardware"]
 == Updating hardware on nodes running in vSphere

--- a/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
@@ -98,20 +98,20 @@ include::modules/update-service-configure-cvo.adoc[leveloffset=+3]
 See xref:../../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object[Enabling the cluster-wide proxy] to configure the CA to trust the update server.
 ====
 
-[id="update-service-delete-service"]
-== Deleting an OpenShift Update Service application
+[id="next-steps_updating-restricted-network-cluster-osus"]
+== Next steps
 
-You can delete an OpenShift Update Service application by using the {product-title} web console or CLI.
+Before updating your cluster, confirm that the following conditions are met:
 
-include::modules/update-service-delete-service-web-console.adoc[leveloffset=+2]
+* The Cluster Version Operator (CVO) is configured to use your locally-installed OpenShift Update Service application.
+* The release image signature config map for the new release is applied to your cluster.
+* The current release and update target release images are mirrored to a locally accessible registry.
+* A recent graph data container image has been mirrored to your local registry.
 
-include::modules/update-service-delete-service-cli.adoc[leveloffset=+2]
+After you configure your cluster to use the locally-installed OpenShift Update Service and local mirror registry, you can use any of the following update methods:
 
-[id="update-service-uninstall"]
-== Uninstalling the OpenShift Update Service Operator
-
-To uninstall the OpenShift Update Service, you must first delete all OpenShift Update Service applications by using the {product-title} web console or CLI.
-
-include::modules/update-service-uninstall-web-console.adoc[leveloffset=+2]
-
-include::modules/update-service-uninstall-cli.adoc[leveloffset=+2]
+** xref:../../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster using the web console]
+** xref:../../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]
+** xref:../../updating/preparing-eus-eus-upgrade.adoc#preparing-eus-eus-upgrade[Preparing to perform an EUS-to-EUS update]
+** xref:../../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools[Performing a canary rollout update]
+** xref:../../updating/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-compute[Updating a cluster that includes RHEL compute machines]

--- a/updating/updating-restricted-network-cluster/uninstalling-osus.adoc
+++ b/updating/updating-restricted-network-cluster/uninstalling-osus.adoc
@@ -1,0 +1,27 @@
+:_content-type: ASSEMBLY
+[id="uninstalling-osus"]
+= Uninstalling the OpenShift Update Service from a cluster
+include::_attributes/common-attributes.adoc[]
+:context: uninstalling-osus
+
+toc::[]
+
+To remove a local copy of the OpenShift Update Service (OSUS) from your cluster, you must first delete the OSUS application and then uninstall the OSUS Operator.
+
+[id="update-service-delete-service"]
+== Deleting an OpenShift Update Service application
+
+You can delete an OpenShift Update Service application by using the {product-title} web console or CLI.
+
+include::modules/update-service-delete-service-web-console.adoc[leveloffset=+2]
+
+include::modules/update-service-delete-service-cli.adoc[leveloffset=+2]
+
+[id="update-service-uninstall"]
+== Uninstalling the OpenShift Update Service Operator
+
+You can uninstall the OpenShift Update Service Operator by using the {product-title} web console or CLI.
+
+include::modules/update-service-uninstall-web-console.adoc[leveloffset=+2]
+
+include::modules/update-service-uninstall-cli.adoc[leveloffset=+2]


### PR DESCRIPTION
[OSDOCS-5395](https://issues.redhat.com/browse/OSDOCS-5395) and [OSDOCS-5148](https://issues.redhat.com/browse/OSDOCS-5148)

Versions: 4.9+

This PR makes two changes to content on the **Updating a cluster in a disconnected environment using the OpenShift Update Service** page:

1. The last two sections, **Deleting this OSUS application** and **Uninstalling the OSUS operator**, have been moved to a new page, titled **Uninstalling the OpenShift Update Service from a cluster**
2. A Next Steps section has been added, instructing users on which update procedures they can use after making additional configurations for a disconnected cluster

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Live Documentation: https://docs.openshift.com/container-platform/4.12/updating/updating-restricted-network-cluster/restricted-network-update-osus.html#update-service-delete-service

Preview:
https://56587--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/uninstalling-osus.html
and
https://56587--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/restricted-network-update-osus.html#nexts-steps_updating-restricted-network-cluster-osus
