### PR TITLE
OSDOCS-4972: Add support for OVN-Kubernetes as secondary network

### DIFF
--- a/modules/nw-multus-ovn-k8s-object.adoc
+++ b/modules/nw-multus-ovn-k8s-object.adoc
@@ -5,8 +5,7 @@
 [id="nw-multus-ovn-k8s-object_{context}"]
 = Configuration for an OVN-Kubernetes additional network
 
-The following object describes the configuration parameters for the macvlan CNI
-plugin:
+The following object describes the configuration parameters for the OVN-Kubernetes CNI plugin:
 
 .OVN-Kubernetes network plugin JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
@@ -23,33 +22,71 @@ plugin:
 
 |`type`
 |`string`
-|The name of the CNI plugin to configure: `macvlan`.
+|The name of the CNI plugin to configure: `ovn-k8s-cni-overlay`.
 
-|`mode`
+|`topology`
 |`string`
-|Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
+|
 
-|`master`
+|`subnets`
 |`string`
-|The Ethernet, bonded, or VLAN interface to associate with the virtual interface. If a value is not specified, then the host system's primary Ethernet interface is used.
+| For example, `10.128.0.0/16/24`.
 
 |`mtu`
 |`string`
 |The maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
-|`ipam`
-|`object`
-|The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition.
+|`netAttachDefName`
+|`string`
+| For example, `ns1/l3-network`.
 
 |====
 
 [id="nw-multus-macvlan-config-example_{context}"]
-== macvlan configuration example
+== OVN-Kubernetes plugin configuration examples
 
 The following example configures an additional network named `macvlan-net`:
 
+.OVN-Kubernetes CNI plugin layer 3 configuration example
 [source,json]
 ----
-{
-}
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: l3-network
+  namespace: ns1
+spec:
+  config: |2
+    {
+      "cniVersion": "0.3.1",
+      "name": "l3-network",
+      "type": "ovn-k8s-cni-overlay",
+      "topology":"layer3",
+      "subnets": "10.128.0.0/16/24",
+      "mtu": 1300,
+      "netAttachDefName": "ns1/l3-network"
+    }
+----
+
+The following example configures an additional network named `macvlan-net`:
+
+.OVN-Kubernetes CNI plugin layer 2 configuration example
+[source,json]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: l2-network
+  namespace: ns1
+spec:
+  config: |2
+    {
+      "cniVersion": "0.3.1",
+      "name": "l2-network",
+      "type": "ovn-k8s-cni-overlay",
+      "topology":"layer2",
+      "subnets": "10.100.200.0/24",
+      "mtu": 1300,
+      "netAttachDefName": "ns1/l2-network"
+    }
 ----

--- a/modules/nw-multus-ovn-k8s-object.adoc
+++ b/modules/nw-multus-ovn-k8s-object.adoc
@@ -5,7 +5,7 @@
 [id="nw-multus-ovn-k8s-object_{context}"]
 = Configuration for an OVN-Kubernetes additional network
 
-The following object describes the configuration parameters for the OVN-Kubernetes CNI plugin:
+The following object describes the configuration parameters for the OVN-Kubernetes CNI network plugin:
 
 .OVN-Kubernetes network plugin JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
@@ -26,11 +26,11 @@ The following object describes the configuration parameters for the OVN-Kubernet
 
 |`topology`
 |`string`
-|
+|The topological configuration for the network. The value must be either `layer2` or `layer3`.
 
 |`subnets`
 |`string`
-| For example, `10.128.0.0/16/24`.
+| The subnet to use for the network across the cluster. If you specify `layer3` for the `topology`, the value must include CIDR ranges for both the cluster and per node. For example, `10.128.0.0/16/24` specifies a `/16` cluster CIDR and a `/24` node CIDR range. If you specify `layer2` for the `topology`, only include the CIDR for the node. For example, `10.100.200.0/24`.
 
 |`mtu`
 |`string`
@@ -38,17 +38,17 @@ The following object describes the configuration parameters for the OVN-Kubernet
 
 |`netAttachDefName`
 |`string`
-| For example, `ns1/l3-network`.
+| The namespace and the network attachment name. The value must match the values specified for `namespace` and `name` when defining the network attachment definition object. For example, `ns1/l3-network` refers to the `ns1` namespace and the `l3-network` network attachment definition name.
 
 |====
 
-[id="nw-multus-macvlan-config-example_{context}"]
+[id="nw-multus-ovn-k8s-config-example_{context}"]
 == OVN-Kubernetes plugin configuration examples
 
-The following example configures an additional network named `macvlan-net`:
+The following examples describe additional networks that use the OVN-Kubernetes CNI network plugin.
 
 .OVN-Kubernetes CNI plugin layer 3 configuration example
-[source,json]
+[source,yaml]
 ----
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition
@@ -68,10 +68,8 @@ spec:
     }
 ----
 
-The following example configures an additional network named `macvlan-net`:
-
 .OVN-Kubernetes CNI plugin layer 2 configuration example
-[source,json]
+[source,yaml]
 ----
 apiVersion: k8s.cni.cncf.io/v1
 kind: NetworkAttachmentDefinition

--- a/modules/nw-multus-ovn-k8s-object.adoc
+++ b/modules/nw-multus-ovn-k8s-object.adoc
@@ -50,41 +50,27 @@ The following examples describe additional networks that use the OVN-Kubernetes 
 .OVN-Kubernetes CNI plugin layer 3 configuration example
 [source,yaml]
 ----
-apiVersion: k8s.cni.cncf.io/v1
-kind: NetworkAttachmentDefinition
-metadata:
-  name: l3-network
-  namespace: ns1
-spec:
-  config: |2
-    {
-      "cniVersion": "0.3.1",
-      "name": "l3-network",
-      "type": "ovn-k8s-cni-overlay",
-      "topology":"layer3",
-      "subnets": "10.128.0.0/16/24",
-      "mtu": 1300,
-      "netAttachDefName": "ns1/l3-network"
-    }
+{
+  "cniVersion": "0.3.1",
+  "name": "l3-network",
+  "type": "ovn-k8s-cni-overlay",
+  "topology":"layer3",
+  "subnets": "10.128.0.0/16/24",
+  "mtu": 1300,
+  "netAttachDefName": "ns1/l3-network"
+}
 ----
 
 .OVN-Kubernetes CNI plugin layer 2 configuration example
 [source,yaml]
 ----
-apiVersion: k8s.cni.cncf.io/v1
-kind: NetworkAttachmentDefinition
-metadata:
-  name: l2-network
-  namespace: ns1
-spec:
-  config: |2
-    {
-      "cniVersion": "0.3.1",
-      "name": "l2-network",
-      "type": "ovn-k8s-cni-overlay",
-      "topology":"layer2",
-      "subnets": "10.100.200.0/24",
-      "mtu": 1300,
-      "netAttachDefName": "ns1/l2-network"
-    }
+{
+  "cniVersion": "0.3.1",
+  "name": "l2-network",
+  "type": "ovn-k8s-cni-overlay",
+  "topology":"layer2",
+  "subnets": "10.100.200.0/24",
+  "mtu": 1300,
+  "netAttachDefName": "ns1/l2-network"
+}
 ----

--- a/modules/nw-multus-ovn-k8s-object.adoc
+++ b/modules/nw-multus-ovn-k8s-object.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+[id="nw-multus-ovn-k8s-object_{context}"]
+= Configuration for an OVN-Kubernetes additional network
+
+The following object describes the configuration parameters for the macvlan CNI
+plugin:
+
+.OVN-Kubernetes network plugin JSON configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`cniVersion`
+|`string`
+|The CNI specification version. The `0.3.1` value is required.
+
+|`name`
+|`string`
+|The value for the `name` parameter you provided previously for the CNO configuration.
+
+|`type`
+|`string`
+|The name of the CNI plugin to configure: `macvlan`.
+
+|`mode`
+|`string`
+|Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
+
+|`master`
+|`string`
+|The Ethernet, bonded, or VLAN interface to associate with the virtual interface. If a value is not specified, then the host system's primary Ethernet interface is used.
+
+|`mtu`
+|`string`
+|The maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
+
+|`ipam`
+|`object`
+|The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition.
+
+|====
+
+[id="nw-multus-macvlan-config-example_{context}"]
+== macvlan configuration example
+
+The following example configures an additional network named `macvlan-net`:
+
+[source,json]
+----
+{
+}
+----

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -12,6 +12,7 @@ As a cluster administrator, you can configure an additional network for your clu
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-host-device-object_configuring-additional-network[Host device]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[IPVLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[MACVLAN]
+ * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ovn-k8s-object_configuring-additional-network[OVN-Kubernetes]
 
 [id="{context}_approaches-managing-additional-network"]
 == Approaches to managing an additional network
@@ -119,6 +120,7 @@ include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
+include::modules/nw-multus-ovn-k8s-object.adoc[leveloffset=+2]
 
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
 

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -55,7 +55,6 @@ networks in your cluster:
 
  * *macvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[Configure a macvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts by using a physical network interface. Each pod that is attached to a macvlan-based additional network is provided a unique MAC address.
 
-// TODO - link
- * *OVN-Kubernetes*: Configure an OVN-Kubernetes as an additional network in either of switched or routed modes.
+ * *OVN-Kubernetes*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ovn-k8s-object_configuring-additional-network[Configure the OVN-Kubernetes network plugin] as an additional network in either switched or routed modes.
 
  * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configure an SR-IOV based additional network] to allow pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -54,5 +54,8 @@ networks in your cluster:
  * *ipvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[Configure an ipvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts, similar to a macvlan-based additional network. Unlike a macvlan-based additional network, each pod shares the same MAC address as the parent physical network interface.
 
  * *macvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[Configure a macvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts by using a physical network interface. Each pod that is attached to a macvlan-based additional network is provided a unique MAC address.
- 
+
+// TODO - link
+ * *OVN-Kubernetes*: Configure an OVN-Kubernetes as an additional network in either of switched or routed modes.
+
  * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configure an SR-IOV based additional network] to allow pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [Additional networks in OpenShift Container Platform](https://56590--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html#additional-networks-provided)
- [Configuration for an OVN-Kubernetes additional network](https://56590--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-ovn-k8s-object_configuring-additional-network)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
