### PR TITLE
CNV-18331: Cluster DPDK readiness checkup

### DIFF
--- a/modules/virt-checking-cluster-dpdk-readiness.adoc
+++ b/modules/virt-checking-cluster-dpdk-readiness.adoc
@@ -1,0 +1,212 @@
+// Module included in the following assemblies:
+//
+// * virt/support/monitoring/virt-running-cluster-checkups.adoc
+
+:_content-type: PROCEDURE
+[id="virt-checking-cluster-dpdk-readiness_{context}"]
+= Checking cluster readiness to run DPDK applications with zero packet loss
+
+Use a predefined checkup to verify if your {product-title} cluster node can run a virtual machine (VM) with a Data Plane Development Kit (DPDK) workload. The checkup runs traffic between a traffic generator pod and a VM running a test DPDK application, and checks for packet loss.
+
+.Prerequisites
+* You have access to the cluster as a user with `cluster-admin` permissions.
+* You have installed the OpenShift CLI (`oc`).
+* You have configured the compute nodes to run DPDK applications on VMs with zero packet loss.
+
+.Procedure
+. Create a manifest file that contains the `ServiceAccount`, `Role`, and `RoleBinding` objects with permissions that the checkup requires for cluster access:
++
+.Example roles manifest
+[%collapsible]
+====
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: dpdk-checkup-sa
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kiagnose-configmap-access
+rules:
+  - apiGroups: [ "" ]
+    resources: [ "configmaps" ]
+    verbs: [ "get", "update" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kiagnose-configmap-access
+subjects:
+  - kind: ServiceAccount
+    name: dpdk-checkup-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kiagnose-configmap-access
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: kubevirt-dpdk-checker
+rules:
+  - apiGroups: [ "kubevirt.io" ]
+    resources: [ "virtualmachineinstances" ]
+    verbs: [ "create", "get", "delete" ]
+  - apiGroups: [ "subresources.kubevirt.io" ]
+    resources: [ "virtualmachineinstances/console" ]
+    verbs: [ "get" ]
+  - apiGroups: [ "" ]
+    resources: [ "pods" ]
+    verbs: [ "create", "get", "delete" ]
+  - apiGroups: [ "" ]
+    resources: [ "pods/exec" ]
+    verbs: [ "create" ]
+  - apiGroups: [ "k8s.cni.cncf.io" ]
+    resources: [ "network-attachment-definitions" ]
+    verbs: [ "get" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: kubevirt-dpdk-checker
+subjects:
+  - kind: ServiceAccount
+    name: dpdk-checkup-sa
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: kubevirt-dpdk-checker
+----
+====
+
+. Apply the checkup roles manifest:
++
+[source,terminal]
+----
+$ oc apply -n <target_namespace> -f <dpdk_roles>.yaml
+----
+
+. Create a `ConfigMap` manifest that contains the input parameters for the checkup. The config map also stores the results of the checkup.
++
+.Example input config map
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dpdk-checkup-config
+data:
+  spec.timeout: 10m
+  spec.param.networkAttachmentDefinitionName: <network_name> <1>
+  spec.param.trafficGeneratorRuntimeClassName: <runtimeclass_name> <2>
+----
+<1> The name of the `NetworkAttachmentDefinition` object.
+<2> The `RuntimeClass` resource that the traffic generator pod uses.
+
+. Apply the config map manifest in the target namespace:
++
+[source,terminal]
+----
+$ oc apply -n <target_namespace> -f <dpdk_config_map>.yaml
+----
+
+. Create a `Job` object to run the checkup:
++
+.Example job manifest
+[source,yaml]
+----
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: dpdk-checkup
+spec:
+  backoffLimit: 0
+  template:
+    spec:
+      serviceAccountName: dpdk-checkup-sa
+      restartPolicy: Never
+      containers:
+        - name: dpdk-checkup
+          image: brew.registry.redhat.io/rh-osbs/container-native-virtualization-kubevirt-dpdk-checkup-rhel9:v4.13.0
+          imagePullPolicy: Always
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
+            runAsNonRoot: true
+            seccompProfile:
+              type: "RuntimeDefault"
+          env:
+            - name: CONFIGMAP_NAMESPACE
+              value: <target-namespace>
+            - name: CONFIGMAP_NAME
+              value: dpdk-checkup-config
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
+----
+
+. Apply the `Job` manifest:
++
+[source,terminal]
+----
+$ oc apply -n <target_namespace> -f <dpdk_job>.yaml
+----
+
+. Wait for the job to complete:
++
+[source,terminal]
+----
+$ oc wait job dpdk-checkup -n <target_namespace> --for condition=complete --timeout 10m
+----
+
+. Review the results of the checkup by running the following command:
++
+[source,terminal]
+----
+$ oc get configmap dpdk-checkup-config -n <target_namespace> -o yaml
+----
++
+.Example output config map (success)
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dpdk-checkup-config
+data:
+  spec.timeout: 1h2m
+  spec.param.NetworkAttachmentDefinitionName: "mlx-dpdk-network-1"
+  spec.param.trafficGeneratorRuntimeClassName: performance-performance-zeus10
+  status.succeeded: true
+  status.failureReason: " "
+  status.startTimestamp: 2022-12-21T09:33:06+00:00
+  status.completionTimestamp: 2022-12-21T11:33:06+00:00
+  status.result.actualTrafficGeneratorTargetNode: worker-dpdk1
+  status.result.actualDPDKVMTargetNode: worker-dpdk2
+  status.result.dropRate: 0
+----
+
+. Delete the job and config map resources that you previously created by running the following commands:
++
+[source,terminal]
+----
+$ oc delete job -n <target_namespace> dpdk-checkup
+----
++
+[source,terminal]
+----
+$ oc delete config-map -n <target_namespace> dpdk-checkup-config
+----
+
+. Optional: If you do not plan to run another checkup, delete the checkup roles manifest:
++
+[source,terminal]
+----
+$ oc delete -f <file_name>.yaml
+----

--- a/modules/virt-dpdk-config-map-parameters.adoc
+++ b/modules/virt-dpdk-config-map-parameters.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * virt/support/monitoring/virt-running-cluster-checkups.adoc
+
+:_content-type: REFERENCE
+[id="virt-dpdk-config-map-parameters_{context}"]
+= DPDK checkup config map parameters
+
+The following table shows the mandatory and optional parameters that you can set in the `data` stanza of the input `ConfigMap` manifest when you run a cluster DPDK readiness checkup:
+
+.DPDK checkup config map parameters
+[cols="1,1,1", options="header"]
+|====
+|Parameter
+|Description
+|Is Mandatory
+
+|`spec.timeout`
+|The time, in minutes, before the checkup fails.
+|True
+
+|`spec.param.networkAttachmentDefinitionName`
+|The name of the `NetworkAttachmentDefinition` object of the SR-IOV NICs connected.
+|True
+
+|`spec.param.trafficGeneratorRuntimeClassName`
+|The RuntimeClass resource that the traffic generator pod uses.
+|True
+
+|`spec.param.trafficGeneratorImage`
+|The container image for the traffic generator. The default value is `quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main`.
+|False
+
+|`spec.param.trafficGeneratorNodeSelector`
+|The node on which the traffic generator pod is to be scheduled. The node should be configured to allow DPDK traffic.
+|False
+
+|`spec.param.trafficGeneratorPacketsPerSecond`
+|The number of packets per second, in kilo (k) or million(m). The default value is 14m.
+|False
+
+|`spec.param.trafficGeneratorEastMacAddress`
+|The MAC address of the NIC connected to the traffic generator pod or VM. The default value is a random MAC address in the format `50:xx:xx:xx:xx:01`.
+|False
+
+|`spec.param.trafficGeneratorWestMacAddress`
+|The MAC address of the NIC connected to the traffic generator pod or VM. The default value is a random MAC address in the format `50:xx:xx:xx:xx:02`.
+|False
+
+|`spec.param.vmContainerDiskImage`
+|The container disk image for the VM. The default value is `quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main`.
+|False
+
+|`spec.param.DPDKLabelSelector`
+|The label of the node on which the VM runs. The node should be configured to allow DPDK traffic.
+|False
+
+|`spec.param.DPDKEastMacAddress`
+|The MAC address of the NIC that is connected to the VM. The default value is a random MAC address in the format `60:xx:xx:xx:xx:01`.
+|False
+
+|`spec.param.DPDKWestMacAddress`
+|The MAC address of the NIC that is connected to the VM. The default value is a random MAC address in the format `60:xx:xx:xx:xx:02`.
+|False
+
+|`spec.param.testDuration`
+|The duration, in minutes, for which the traffic generator runs. The default value is 5 minutes.
+|False
+
+|`spec.param.portBandwidthGB`
+|The maximum bandwidth of the SR-IOV NIC. The default value is 10GB.
+|False
+
+|`spec.param.verbose`
+|When set to `true`, it increases the verbosity of the checkup log. The default value is `false`.
+|False
+|====

--- a/virt/support/monitoring/virt-running-cluster-checkups.adoc
+++ b/virt/support/monitoring/virt-running-cluster-checkups.adoc
@@ -15,3 +15,13 @@ include::modules/virt-about-cluster-checkup-framework.adoc[leveloffset=+1]
 
 include::modules/virt-measuring-latency-vm-secondary-network.adoc[leveloffset=+1]
 
+include::modules/virt-checking-cluster-dpdk-readiness.adoc[leveloffset=+1]
+
+include::modules/virt-dpdk-config-map-parameters.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_running-cluster-checkups"]
+== Additional resources
+* xref:../../../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#virt-attaching-vm-multiple-networks[Attaching a virtual machine to multiple networks]
+* xref:../../../networking/hardware_networks/using-dpdk-and-rdma.adoc#example-vf-use-in-dpdk-mode-intel_using-dpdk-and-rdma[Using a virtual function in DPDK mode with an Intel NIC]
+* xref:../../../networking/hardware_networks/using-dpdk-and-rdma.adoc#nw-example-dpdk-line-rate_using-dpdk-and-rdma[Using SR-IOV and the Node Tuning Operator to achieve a DPDK line rate]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-18331](https://issues.redhat.com//browse/CNV-18331)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56593--docspreview.netlify.app/openshift-enterprise/latest/virt/support/monitoring/virt-running-cluster-checkups.html#virt-checking-cluster-dpdk-readiness_virt-running-cluster-checkups
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
