### PR TITLE
Adds a link to the procedure for manifest lists

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -71,7 +71,7 @@ With {product-title} {product-version}, a new `oc` command line interface (CLI) 
 
 With this enhancement, users can set the `--import-mode` flag to `Legacy` or `PreserveOriginal`, which provides users the option to import a single sub-manifest, or all manifests, of a manifest list when running the `oc import-image` or `oc tag` commands.
 
-//Insert reference for feature procedure
+For more information, see xref:../openshift_images/image-streams-manage.adoc#images-imagestream-import-import-mode_image-streams-managing[Working with manifest lists].
 
 [id="ocp-4-13-oc-describe-enhancement"]
 ==== Returning os/arch and digests of an image


### PR DESCRIPTION
Adds xref to procedure for manifest lists feature. 

Version(s):
4.13 

Issue:
Follow up to https://github.com/openshift/openshift-docs/pull/56041

Link to docs preview:
https://56599--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/image-streams-manage.html#images-imagestream-import-import-mode_image-streams-managing

QE review:
N/A

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
