### PR TITLE
[OSDOCS-5436]: Adding versioning info about HyperShift Operator

### DIFF
--- a/modules/hosted-control-planes-version-support.adoc
+++ b/modules/hosted-control-planes-version-support.adoc
@@ -12,7 +12,20 @@ With each major, minor, or patch version release of {product-title}, two compone
 * HyperShift Operator
 * Command-line interface (CLI)
 
-The HyperShift Operator manages the lifecycle of hosted clusters that are represented by `HostedCluster` API resources. The HyperShift Operator is released with each {product-title} release.
+The HyperShift Operator manages the lifecycle of hosted clusters that are represented by `HostedCluster` API resources. The HyperShift Operator is released with each {product-title} release. After the HyperShift Operator is installed, it creates a config map called `supported-versions` in the HyperShift namespace, as shown in the following example. The config map describes the HostedCluster versions that can be deployed.
+
+[source,yaml]
+----
+    apiVersion: v1
+    data:
+      supported-versions: '{"versions":["4.13","4.12","4.11"]}'
+    kind: ConfigMap
+    metadata:
+      labels:
+        hypershift.openshift.io/supported-versions: "true"
+      name: supported-versions
+      namespace: hypershift
+----
 
 The CLI is a helper utility for development purposes. The CLI is released as part of any HyperShift Operator release. No compatibility policies are guaranteed.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5436
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56603--docspreview.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#hosted-control-planes-version-support_control-plane
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds versioning information about the HyperShift Operator.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
