### PR TITLE
Adds known limitation when working with manifest lists

### DIFF
--- a/modules/images-imagestream-import-import-mode.adoc
+++ b/modules/images-imagestream-import-import-mode.adoc
@@ -5,7 +5,9 @@
 [id="images-imagestream-import-import-mode_{context}"]
 = Working with manifest lists
 
-You can import a single sub-manifest, or all manifests, of a manifest list when using `oc import-image` or `oc tag` CLI commands by adding the `--import-mode` flag. Refer to the commands below to create an image stream that includes a single sub-manifest or multi-architecture images.
+You can import a single sub-manifest, or all manifests, of a manifest list when using `oc import-image` or `oc tag` CLI commands by adding the `--import-mode` flag.
+
+Refer to the commands below to create an image stream that includes a single sub-manifest or multi-architecture images.
 
 .Procedure
 
@@ -41,3 +43,13 @@ $ oc import-image <multiarch-image-stream-tag>  --from=<registry>/<project_name>
 ====
 The `--import-mode=` default value is `Legacy`. Excluding this value, or failing to specify either `Legacy` or `PreserveOriginal`, imports a single sub-manifest. An invalid import mode returns the following error: `error: valid ImportMode values are Legacy or PreserveOriginal`.
 ====
+
+[discrete]
+[id="images-imagestream-import-import-mode-limitations"]
+== Limitations
+
+Working with manifest lists has the following limitations:
+
+* In some cases, users might want to use sub-manifests directly. When `oc adm prune images` is run, or the `CronJob` pruner runs, they cannot detect when a sub-manifest list is used. As a result, an administrator using `oc adm prune images`, or the `CronJob` pruner, might delete entire manifest lists, including sub-manifests.
++
+To avoid this limitation, you can use the manifest list by tag or by digest instead.


### PR DESCRIPTION
Adds known limitation when working with manifest lists

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13 

Issue:
https://issues.redhat.com/browse/OSDOCS-5444

Link to docs preview:
https://56604--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/image-streams-manage.html#images-imagestream-import-import-mode_image-streams-managing

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
