### PR TITLE
OSDOCS-5392 Updating vSphere 4.10 docs to require vSphere 7

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -68,6 +68,8 @@ You can host the VMware vSphere infrastructure on-premise or on a link:https://c
 Installing a cluster on VMware vSphere version 7.0 Update 1 is now deprecated. These versions are still fully supported, but version 4.10 of {product-title} requires vSphere virtual hardware version 15 or later. Hardware version 15 is now the default for vSphere virtual machines in {product-title}. To update the hardware version for your vSphere nodes, see the "Updating hardware on nodes running in vSphere" article.
 
 If your vSphere nodes are below hardware version 15 or your VMware vSphere version is earlier than 6.7U3, upgrading from {product-title} 4.10 to {product-title} 4.11 is not available.
+
+{product-title} {product-version} does not support ESXi version 8.
 ====
 
 .Minimum supported vSphere version for VMware components

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -24,7 +24,7 @@
 
 To install the vSphere CSI Driver Operator, the following requirements must be met:
 
-* VMware vSphere version 6.7U3 or later
+* VMware vSphere version 7.0.2 or later
 * Virtual machines of hardware version 15 or later
 * No third-party vSphere CSI driver already installed in the cluster
 

--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -156,14 +156,12 @@ Beginning with {product-title} {product-version}, if you configure a cluster wit
 To install a CSI driver on a cluster running on vSphere, you must have the following components installed:
 
 * Virtual hardware version 15 or later
-* vSphere version 6.7 Update 3 or later
-* VMware ESXi version 6.7 Update 3 or later
-
-Components with versions earlier than those above are still supported, but are deprecated. These versions are still fully supported, but version 4.11 of {product-title} will require vSphere virtual hardware version 15 or later.
+* vSphere version 7.0.1 or later
+* VMware ESXi version 7.0.1 or later
 
 [NOTE]
 ====
-If your cluster is deployed on vSphere, and the preceding components are lower than the version mentioned above, upgrading from {product-title} 4.9 to 4.10 on vSphere is supported, but no vSphere CSI driver will be installed. Bug fixes and other upgrades to 4.10 are still supported, however upgrading to 4.11 will be unavailable.
+If your cluster is deployed on vSphere, and the preceding components are lower than the version mentioned above, upgrading from {product-title} 4.9 to 4.10 on vSphere is unsupported and no vSphere CSI driver will be installed. Bug fixes and other upgrades to 4.10 are still supported, however upgrading to 4.11 will be unavailable.
 ====
 
 [id="ocp-4-10-installation-and-upgrade-alibaba-ipi"]
@@ -1445,15 +1443,30 @@ In the table, features are marked with the following statuses:
 |vSphere 6.7 Update 2 or earlier
 |GA
 |DEP
+|REM
+
+|vSphere 7.0 Update 1 
+|DEP
+|DEP
 |DEP
 
 |Virtual hardware version 13
 |GA
 |DEP
+|REM
+
+|Virtual hardware version 14
+|DEP
+|DEP
 |DEP
 
 |VMware ESXi 6.7 Update 3 or earlier
 |GA
+|DEP
+|REM
+
+|VMware ESXi 7.0 Update 1
+|DEP
 |DEP
 |DEP
 


### PR DESCRIPTION
Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OSDOCS-5392

Link to docs preview:
https://bscott-rh.github.io/openshift-docs/OSDOCS-5392/installing/installing_vsphere/preparing-to-install-on-vsphere.html#installation-vsphere-infrastructure_preparing-to-install-on-vsphere
https://bscott-rh.github.io/openshift-docs/OSDOCS-5392/release_notes/ocp-4-10-release-notes.html#ocp-4-10-installation-vsphere-csi
https://bscott-rh.github.io/openshift-docs/OSDOCS-5392/release_notes/ocp-4-10-release-notes.html#ocp-4-10-deprecated-removed-features

QE review:
- [x] QE has approved this change.