### PR TITLE
OSDOCS-5061: Update ARM64 azure cloud provider docs

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -250,7 +250,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[&#10003;]
 |
 |xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
-|xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
+|
 |
 |
 |

--- a/installing/installing_azure/installing-azure-government-region.adoc
+++ b/installing/installing_azure/installing-azure-government-region.adoc
@@ -44,8 +44,6 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
-include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
-
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]


### PR DESCRIPTION
**For versions:** 4.12+ 
**Issue:** [OSDOCS-5061](https://issues.redhat.com//browse/OSDOCS-5061)

**Description:** Updating ARM64 Azure support for methods of installation 
 
**Preview:** 

- [Supported installation methods for different platforms](https://56609--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#supported-installation-methods-for-different-platforms)
- [Installing a cluster on Azure into a government region](https://56609--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-government-region.html#installation-azure-tested-machine-types_installing-azure-government-region) - ARM instance type section will be missing here, showing render of it not in the section

**QE review:**
- [x] QE approval