### PR TITLE
OSDOCS-5318: remove fixed iptable and node port workarounds

### DIFF
--- a/microshift_troubleshooting/microshift-troubleshooting.adoc
+++ b/microshift_troubleshooting/microshift-troubleshooting.adoc
@@ -8,8 +8,10 @@ toc::[]
 
 Read about troubleshooting and possible solutions for known issues.
 
-include::modules/microshift-ki-cni-iptables-deleted.adoc[leveloffset=+1]
-
 include::modules/microshift-troubleshooting-nodeport.adoc[leveloffset=+1]
 
-include::modules/microshift-nodeport-unreachable-workaround.adoc[leveloffset=+1]
+//include::modules/microshift-ki-cni-iptables-deleted.adoc[leveloffset=+1]
+//include::modules/microshift-nodeport-unreachable-workaround.adoc[leveloffset=+1]
+
+//TODO: move this module to release notes files in each branch
+//TODO: then delete this assembly from this title and topic map


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5318
also https://issues.redhat.com/browse/OCPBUGS-6908

Link to docs preview:
https://56610--docspreview.netlify.app/microshift/latest/microshift_troubleshooting/microshift-troubleshooting.html 

QE review:
- [x] QE has approved this change.

Additional information:
https://access.redhat.com/errata/RHSA-2023:0772 advisory verifying fix

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
