### PR TITLE
[rhacs-docs-3.72] Manual cherrypick - Fixed roxctl installation gaps for 3.72

### DIFF
--- a/modules/acs-quick-install-using-helm.adoc
+++ b/modules/acs-quick-install-using-helm.adoc
@@ -7,6 +7,9 @@
 
 Use the following instructions to install the `central-services` Helm chart to deploy the centralized components (Central and Scanner).
 
+.Prerequisites
+* You must have access to the Red Hat Container Registry. For information about downloading images from `registry.redhat.io`, see link:https://access.redhat.com/RegistryAuthentication[Red Hat Container Registry Authentication].
+
 .Procedure
 
 * Run the following command to install Central services and expose Central using a route:
@@ -15,7 +18,8 @@ Use the following instructions to install the `central-services` Helm chart to d
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.allowNone=true \
+  --set imagePullSecrets.username=<username> \
+  --set imagePullSecrets.password=<password> \
   --set central.exposure.route.enabled=true
 ----
 
@@ -25,7 +29,8 @@ $ helm install -n stackrox \
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.allowNone=true \
+  --set imagePullSecrets.username=<username> \
+  --set imagePullSecrets.password=<password> \
   --set central.exposure.loadBalancer.enabled=true
 ----
 
@@ -35,23 +40,28 @@ $ helm install -n stackrox \
 ----
 $ helm install -n stackrox \
   --create-namespace stackrox-central-services rhacs/central-services \
-  --set imagePullSecrets.allowNone=true
+  --set imagePullSecrets.username=<username> \
+  --set imagePullSecrets.password=<password>
 ----
 
 [IMPORTANT]
 ====
-If you are installing {product-title} in a cluster that requires a proxy to connect to external services, you must specify your proxy configuration by using the `proxyConfig` parameter. For example:
+* If you are installing {product-title} in a cluster that requires a proxy to connect to external services, you must specify your proxy configuration by using the `proxyConfig` parameter. For example:
 
 [source,yaml]
 ----
 env:
-  proxyConfig: |
+  proxyConfig: |code modules/install-secured-cluster-services-helm-chart.adoc
     url: http://proxy.name:port
     username: username
     password: password
     excludes:
     - some.domain
 ----
+* * If you already created one or more image pull secrets in the namespace in which you are installing, instead of using a username and password, you can use `--set imagePullSecrets.useExisting="<pull-secret-1;pull-secret-2>"`.
+* Do not use image pull secrets:
+** If you are pulling your images from `quay.io/stackrox-io` or a registry in a private network that does not require authentication. Use use `--set imagePullSecrets.allowNone=true` instead of specifying a username and password.
+** If you already configured image pull secrets in the default service account in the namespace you are installing. Use `--set imagePullSecrets.useFromDefaultServiceAccount=true` instead of specifying a username and password.
 ====
 
 The output of the installation command includes:

--- a/modules/install-secured-cluster-services-helm-chart.adoc
+++ b/modules/install-secured-cluster-services-helm-chart.adoc
@@ -12,6 +12,10 @@ After you configure the `values-public.yaml` and `values-private.yaml` files, in
 To install Collector on systems that have Unified Extensible Firmware Interface (UEFI) and that have Secure Boot enabled, you must use eBPF probes because kernel modules are unsigned, and the UEFI firmware cannot load unsigned packages. Collector identifies Secure Boot status at the start and switches to eBPF probes if required.
 ====
 
+.Prerequisites
+* You must have generated {product-title-short} init bundle for your cluster.
+* You must have the address and the port number that you are exposing the Central service on.
+
 .Procedure
 
 * Run the following command:

--- a/modules/install-sensor-roxctl.adoc
+++ b/modules/install-sensor-roxctl.adoc
@@ -9,6 +9,9 @@ To monitor a cluster, you must deploy Sensor.
 You must deploy Sensor into each cluster that you want to monitor.
 The following steps describe adding Sensor by using the RHACS portal.
 
+.Prerequisites
+* You must have already installed Central services.
+
 .Procedure
 . On the RHACS portal, navigate to *Platform Configuration* -> *Clusters*.
 . Select *+ New Cluster*.

--- a/modules/run-roxctl-from-container.adoc
+++ b/modules/run-roxctl-from-container.adoc
@@ -8,6 +8,9 @@
 The `roxctl` client is the default entry point in {product-title} `roxctl` image.
 To run the `roxctl` client in a container image:
 
+.Prerequisites
+* You must first generate an authentication token from the {product-title-short} portal.
+
 .Procedure
 
 . Log in to the `registry.redhat.io` registry.

--- a/modules/using-cli.adoc
+++ b/modules/using-cli.adoc
@@ -61,7 +61,7 @@ To secure a Kubernetes or an {ocp} cluster, you must deploy {product-title} serv
 You can generate deployment files in the RHACS portal by navigating to the *Platform Configuration* -> *Clusters* view, or you can use the `roxctl` CLI.
 
 [discrete]
-=== Generating Sensor deployment YAML file
+=== Generating Sensor deployment files
 
 .Kubernetes
 
@@ -74,8 +74,9 @@ $ roxctl -e "$ROX_CENTRAL_ADDRESS" sensor generate k8s --name <cluster_name> --c
 
 [source,terminal]
 ----
-$ roxctl -e "$ROX_CENTRAL_ADDRESS" sensor generate openshift --name <cluster_name> --central "$ROX_CENTRAL_ADDRESS"
+$ roxctl -e "$ROX_CENTRAL_ADDRESS" sensor generate openshift --openshift-version <ocp-version> --name <cluster_name> --central "$ROX_CENTRAL_ADDRESS" <1>
 ----
+<1> For the `--openshift-version` option specify the major {ocp} version number for your cluster. For example, specify `3` for {ocp} version `3.x` and specify `4` for {ocp} version `4.x`.
 
 Read the `--help` output to see other options that you might need to use depending on your system architecture.
 
@@ -94,6 +95,17 @@ To use `wss`, prefix the address with *`wss://`*, and
 $ roxctl sensor generate k8s --central wss://stackrox-central.example.com:443
 ----
 ====
+
+[discrete]
+=== Installing Sensor by using the generate YAML files
+When you generate the Sensor deployment files, `roxctl` creates a directory called `sensor-<cluster_name>` in your working directory. The script to install Sensor is present in this directory. Run the sensor installation script to install Sensor.
+
+[source,terminal]
+----
+$ ./sensor-<cluster_name>/sensor.sh
+----
+
+If you get a warning that you do not have the required permissions to install Sensor, follow the on-screen instructions, or contact your cluster administrator for help.
 
 [discrete]
 === Downloading Sensor bundle for existing clusters

--- a/modules/using-the-interactive-installer.adoc
+++ b/modules/using-the-interactive-installer.adoc
@@ -15,6 +15,11 @@ Use the interactive installer to generate the required secrets, deployment confi
 ----
 $ roxctl central generate interactive
 ----
++
+[IMPORTANT]
+====
+Installing {product-title} using `roxctl` CLI creates PodSecurityPolicy (PSP) objects by default for backward compatibility. If you install {product-title-short} on Kubernetes versions 1.25 and newer or {ocp} version 4.12 and newer, you must disable the PSP object creation. To do this, specify `--enable-pod-security-policies` option as `false` for the `roxctl central generate` and `roxctl sensor generate` commands.
+====
 . Press *Enter* to accept the default value for a prompt or enter custom values as required.
 +
 [source,terminal]


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/55791