### PR TITLE
RHDEVDOCS-4365-new: Added a procedure to customize the Argo CD link

### DIFF
--- a/cicd/gitops/setting-up-argocd-instance.adoc
+++ b/cicd/gitops/setting-up-argocd-instance.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="setting-up-argocd-instance"]
-= Setting up a new Argo CD instance
+= Setting up an Argo CD instance
 include::_attributes/common-attributes.adoc[]
 :context: setting-up-argocd-instance
 
@@ -13,3 +13,5 @@ include::modules/gitops-argo-cd-installation.adoc[leveloffset=+1]
 include::modules/gitops-enable-replicas-for-argo-cd-server.adoc[leveloffset=+1]
 
 include::modules/gitops-deploy-resources-different-namespaces.adoc[leveloffset=+1]
+
+include::modules/gitops-customize-argo-cd-consolelink.adoc[leveloffset=+1]

--- a/modules/gitops-argo-cd-installation.adoc
+++ b/modules/gitops-argo-cd-installation.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * gitops-argo-cd-installation.adoc
+// * cicd/gitops/setting-up-argocd-instance.adoc
 
 :_content-type: PROCEDURE
 [id="gitops-argo-cd-installation_{context}"]
@@ -23,4 +23,4 @@ To manage cluster configurations or deploy applications, you can install and dep
 
 .. Create an external OS Route to access Argo CD server. Click *Server* -> *Route* and check *Enabled*.  
 
-. To open the Argo CD web UI, click the route by navigating to **Networking -> Routes -> <instance name> -> server** in the project where the Argo CD instance is installed.
+. To open the Argo CD web UI, click the route by navigating to **Networking -> Routes -> <instance name>-server** in the project where the Argo CD instance is installed.

--- a/modules/gitops-customize-argo-cd-consolelink.adoc
+++ b/modules/gitops-customize-argo-cd-consolelink.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assembly:
+//
+// * cicd/gitops/setting-up-argocd-instance.adoc
+
+:_content-type: PROCEDURE
+[id="gitops-customize-argo-cd-consolelink_{context}"]
+= Customizing the Argo CD console link
+
+In a multi-tenant cluster, users might have to deal with multiple instances of Argo CD. For example, after installing an Argo CD instance in your namespace, you might find a different Argo CD instance attached to the Argo CD console link, instead of your own Argo CD instance, in the Console Application Launcher. 
+
+You can customize the Argo CD console link by setting the `DISABLE_DEFAULT_ARGOCD_CONSOLELINK` environment variable:  
+
+* When you set `DISABLE_DEFAULT_ARGOCD_CONSOLELINK` to `true`, the Argo CD console link is permanently deleted.
+* When you set `DISABLE_DEFAULT_ARGOCD_CONSOLELINK` to `false` or use the default value, the Argo CD console link is temporarily deleted and visible again when the Argo CD route is reconciled.
+
+.Prerequisites
+* You have logged in to the {product-title} cluster as an administrator.
+* You have installed the {gitops-title} Operator.
+
+.Procedure
+
+. In the *Administrator* perspective, navigate to *Administration* -> *CustomResourceDefinitions*.
+. Find the *Subscription* CRD and click to open it.
+. Select the *Instances* tab and click the *openshift-gitops-operator* subscription.
+. Select the *YAML* tab and make your customization:
+** To enable or disable the Argo CD console link, edit the value of `DISABLE_DEFAULT_ARGOCD_CONSOLELINK` as needed:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: openshift-gitops-operator
+spec:
+  config:
+    env:
+    - name: DISABLE_DEFAULT_ARGOCD_CONSOLELINK
+      value: 'true'    
+----

--- a/modules/gitops-deploy-resources-different-namespaces.adoc
+++ b/modules/gitops-deploy-resources-different-namespaces.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * gitops-argo-cd-installation.adoc
+// * cicd/gitops/setting-up-argocd-instance.adoc
 
 :_content-type: PROCEDURE
 [id="gitops-deploy-resources-different-namespaces_{context}"]

--- a/modules/gitops-enable-replicas-for-argo-cd-server.adoc
+++ b/modules/gitops-enable-replicas-for-argo-cd-server.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * gitops-argo-cd-installation.adoc
+// * cicd/gitops/setting-up-argocd-instance.adoc
 
 :_content-type: PROCEDURE
 [id="gitops-enable-replicas-for-argo-cd-server_{context}"]

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -35,7 +35,7 @@ In the table, features are marked with the following statuses:
 [id="GitOps-technology-preview_{context}"]
 == Technology Preview features
 
-Some features in this release are currently in Technology Preview (TP). These experimental features are not intended for production use. 
+The features mentioned in the following table are currently in Technology Preview (TP). These experimental features are not intended for production use. 
 
 .Technology Preview tracker
 [cols="4,1,1",options="header"]


### PR DESCRIPTION
**Purpose**: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-4365

**Aligned team**: DevTools

**OCP versions this PR applies to**:  enterprise 4.10 and later

**Content for preview**:  https://56632--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/setting-up-argocd-instance.html#gitops-customize-argo-cd-consolelink_setting-up-argocd-instance

**SME review**: @reginapizza 

**QE review**: @varshab1210 

**Peer review**: @gabriel-rh 