### PR TITLE
Telcodocs-1010: Create Pre-flight and Pre-build content for KMMO

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -614,6 +614,8 @@ Topics:
     File: uninstalling-osus
 - Name: Updating hardware on nodes running on vSphere
   File: updating-hardware-on-nodes-running-on-vsphere
+- Name: Preflight validation for Kernel Module Management (KMM) Modules
+  File: kmm-preflight-validation
 # - Name: Troubleshooting an update
 #  File: updating-troubleshooting
 ---

--- a/modules/kmm-build-validation-stage.adoc
+++ b/modules/kmm-build-validation-stage.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * updating/kmm-preflight-validation.adoc
+
+:_content-type: CONCEPT
+[id="kmm-build-validation-stage_{context}"]
+= Build validation stage
+
+Build validation is executed only when image validation has failed and there is a `build` section in the `Module` that is relevant for the upgraded kernel. Build validation attempts to run the build job and validate that it finishes successfully.
+
+[NOTE]
+====
+You must specify the kernel version when running `depmod`, as shown here:
+[source,terminal]
+----
+$ RUN depmod -b /opt ${KERNEL_VERSION}
+----
+====
+
+If the `PushBuiltImage` flag is defined in the `PreflightValidationOCP` custom resource (CR), it will also try to push the resulting image into its repository. The resulting image name is taken from the definition of the `containerImage` field of the `Module` CR.
+
+[NOTE]
+====
+If the `sign` section is defined for the upgraded kernel, then the resulting image will not be the `containerImage` field of the `Module` CR, but a temporary image name, because the resulting image should be the product of Sign flow.
+====

--- a/modules/kmm-example-cr.adoc
+++ b/modules/kmm-example-cr.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * updating/kmm-preflight-validation.adoc
+
+:_content-type: CONCEPT
+[id="kmm-example-cr_{context}"]
+= Example PreflightValidationOCP resource
+
+This section shows an example of the `PreflightValidationOCP` resource in the YAML format.
+
+The example verifies all the currently present modules against the upcoming kernel version included in the {product-title} release 4.11.18, which the following release image points to:
+
+[source,terminal]
+----
+quay.io/openshift-release-dev/ocp-release@sha256:22e149142517dfccb47be828f012659b1ccf71d26620e6f62468c264a7ce7863
+----
+
+Because `.spec.pushBuiltImage` is set to `true`, KMM pushes the resulting images of Build/Sign into the defined repositories.
+
+[source,yaml]
+----
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: PreflightValidationOCP
+metadata:
+ name: preflight
+spec:
+ releaseImage: quay.io/openshift-release-dev/ocp-release@sha256:22e149142517dfccb47be828f012659b1ccf71d26620e6f62468c264a7ce7863
+ pushBuiltImage: true
+----

--- a/modules/kmm-image-validation-stage.adoc
+++ b/modules/kmm-image-validation-stage.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * updating/kmm-preflight-validation.adoc
+
+:_content-type: CONCEPT
+[id="kmm-image-validation-stage_{context}"]
+= Image validation stage
+
+Image validation is always the first stage of the preflight validation to be executed. If image validation is successful, no other validations are run on that specific module.
+
+Image validation consists of two stages:
+
+. Image existence and accessibility. The code tries to access the image defined for the upgraded kernel in the module and get its manifests.
+
+. Verify the presence of the kernel module defined in the `Module` in the correct path for future `modprobe` execution. The correct path is `<dirname>/lib/modules/<upgraded_kernel>/`.
+
+If this validation is successful, it probably means that the kernel module was compiled with the correct Linux headers.

--- a/modules/kmm-preflight-validation-stages-per-module.adoc
+++ b/modules/kmm-preflight-validation-stages-per-module.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * updating/kmm-preflight-validation.adoc
+
+:_content-type: CONCEPT
+[id="kmm-preflight-validation-stages-per-module_{context}"]
+= Preflight validation stages per Module
+
+Preflight runs the following validations on every KMM Module present in the cluster:
+
+. Image validation stage
+. Build validation stage
+. Sign validation stage

--- a/modules/kmm-sign-validation-stage.adoc
+++ b/modules/kmm-sign-validation-stage.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * updating/kmm-preflight-validation.adoc
+
+:_content-type: CONCEPT
+[id="kmm-sign-validation-stage_{context}"]
+= Sign validation stage
+
+Sign validation is executed only when image validation has failed, there is a `sign` section in the `Module` that is relevant for the upgrade kernel, and build validation finished successfully in the event there was a `build` section in the `Module` relevant for the upgraded kernel. Sign validation will try to run the sign job and validate that it finishes successfully.
+
+If the `PushBuiltImage` flag is defined in the `PreflightValidationOCP` CR, sign validation will also try to push the resulting image to its registry.
+
+The resulting image is always the image defined in the `containerImage` field of the `Module`. The input image is either the output of the Build stage, or an image defined in the `UnsignedImage` field.
+
+[NOTE]
+====
+If a `build` section exists, the `sign` section input image is the `build` section's output image. Therefore, in order for the input image to be available for the `sign` section, the `PushBuiltImage` flag must be defined in the `PreflightValidationOCP` CR.
+====

--- a/modules/kmm-validation-kickoff.adoc
+++ b/modules/kmm-validation-kickoff.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * updating/kmm-preflight-validation.adoc
+
+:_content-type: CONCEPT
+[id="kmm-validation-kickoff_{context}"]
+= Validation kickoff
+
+Preflight validation is triggered by creating a `PreflightValidationOCP` resource in the cluster. This spec contains two fields:
+
+[source,terminal]
+----
+type PreflightValidationOCPSpec struct {
+	// releaseImage describes the OCP release image that all Modules need to be checked against.
+	// +kubebuilder:validation:Required
+	ReleaseImage string `json:"releaseImage"` <1>
+	// Boolean flag that determines whether images build during preflight must also
+	// be pushed to a defined repository
+	// +optional
+	PushBuiltImage bool `json:"pushBuiltImage"` <2>
+}
+----
+
+<1> `ReleaseImage` - Mandatory field that provides the name of the release image for the {product-title} version the cluster is upgraded to.
+
+<2> `PushBuiltImage` - If `true`, then the images created during the Build and Sign validation are pushed to their repositories (`false` by default).

--- a/modules/kmm-validation-lifecycle.adoc
+++ b/modules/kmm-validation-lifecycle.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * updating/kmm-preflight-validation.adoc
+
+:_content-type: CONCEPT
+[id="kmm-validation-lifecycle_{context}"]
+= Validation lifecycle
+
+Preflight validation attempts to validate every module loaded in the cluster. Preflight will stop running validation on a `Module` resource after the validation is successful. In case module validation has failed, you can change the module definitions and Preflight will try to validate the module again in the next loop.
+
+If you want to run Preflight validation for an additional kernel, then you should create another `PreflightValidationOCP` resource for that kernel. After all the modules have been validated, it is recommended to delete the `PreflightValidationOCP` resource.

--- a/modules/kmm-validation-status.adoc
+++ b/modules/kmm-validation-status.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * updating/kmm-preflight-validation.adoc
+
+:_content-type: CONCEPT
+[id="kmm-validation-status_{context}"]
+= Validation status
+
+Preflight reports the status and progress of each module in the cluster that it attempts to
+validate.
+
+[source,terminal]
+----
+type CRStatus struct {
+	// Status of Module CR verification: true (verified), false (verification failed),
+	// error (error during verification process), unknown (verification has not started yet)
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=True;False
+	VerificationStatus string `json:"verificationStatus"` <1>
+	// StatusReason contains a string describing the status source.
+	// +optional
+	StatusReason string `json:"statusReason,omitempty"` <2>
+	// Current stage of the verification process:
+	// image (image existence verification), build(build process verification)
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Enum=Image;Build;Sign;Requeued;Done
+	VerificationStage string `json:"verificationStage"` <3>
+	// LastTransitionTime is the last time the CR status transitioned from one status to another.
+	// This should be when the underlying status changed.  If that is not known, then using the time when the API field changed is acceptable.
+	// +required
+	// +kubebuilder:validation:Required
+	// +kubebuilder:validation:Type=string
+	// +kubebuilder:validation:Format=date-time
+	LastTransitionTime metav1.Time `json:"lastTransitionTime" protobuf:"bytes,4,opt,name=lastTransitionTime"` <4>
+}
+----
+
+The following fields apply to each module:
+
+<1> `VerificationStatus` - `true` or `false`, validated or not.
+
+<2> `StatusReason` - Verbal explanation regarding the status.
+
+<3> `VerificationStage` - Describes the validation stage being executed (Image, Build, Sign).
+
+<4> `LastTransitionTime` - The time of the last update to the status.

--- a/updating/kmm-preflight-validation.adoc
+++ b/updating/kmm-preflight-validation.adoc
@@ -1,0 +1,20 @@
+:_content-type: ASSEMBLY
+[id="kmm-preflight-validation"]
+= Preflight validation for Kernel Module Management (KMM) Modules
+include::_attributes/common-attributes.adoc[]
+:context: kmm-preflight-validation
+
+toc::[]
+
+Before performing an upgrade on the cluster with applied KMM modules, the administrator must verify that kernel modules installed using KMM are able to be installed on the nodes after the cluster upgrade and possible kernel upgrade. Preflight attempts to validate every `Module` loaded in the cluster, in parallel. Preflight does not wait for validation of one `Module` to complete before starting validation of another `Module`.
+
+:FeatureName: Kernel Module Management Operator Preflight validation
+
+include::modules/kmm-validation-kickoff.adoc[leveloffset=+1]
+include::modules/kmm-validation-lifecycle.adoc[leveloffset=+1]
+include::modules/kmm-validation-status.adoc[leveloffset=+1]
+include::modules/kmm-preflight-validation-stages-per-module.adoc[leveloffset=+1]
+include::modules/kmm-image-validation-stage.adoc[leveloffset=+2]
+include::modules/kmm-build-validation-stage.adoc[leveloffset=+2]
+include::modules/kmm-sign-validation-stage.adoc[leveloffset=+2]
+include::modules/kmm-example-cr.adoc[leveloffset=+1]


### PR DESCRIPTION
Create Pre-flight and Pre-build content for KMMO

OCP version: openshift-4.12.z

Version: [KMMO 1.0](https://issues.redhat.com/issues/?jql=project+%3D+TELCODOCS+AND+fixVersion+%3D+%22KMMO+1.0%22)

Issue: https://issues.redhat.com/browse/TELCODOCS-1010

Link to docs preview: https://56634--docspreview.netlify.app/openshift-enterprise/latest/updating/kmm-preflight-validation.html

SME review: [@quba](https://redhat-internal.slack.com/team/U02GW51L0GZ)
T&PS: @slovern 
Dev @yevgeny-shnaidman
QE review: [@Costi](https://redhat-internal.slack.com/team/ULP4MT9GB)



