### PR TITLE
Introduces secondary network configuration for OVNK in OCP docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3754,7 +3754,7 @@ Topics:
   - Name: Installing the Serverless Operator
     File: install-serverless-operator
   - Name: Installing the Knative CLI
-    File: installing-kn    
+    File: installing-kn
   - Name: Installing Knative Serving
     File: installing-knative-serving
   - Name: Installing Knative Eventing
@@ -3971,7 +3971,7 @@ Topics:
     Dir: tuning
     Topics:
     - Name: Overriding deployment configurations
-      File: override-config    
+      File: override-config
     - Name: High availability
       File: serverless-ha
   - Name: kn-event plugin
@@ -4089,12 +4089,12 @@ Topics:
   Dir: integrations
   Topics:
   - Name: Integrating Service Mesh with OpenShift Serverless
-    File: serverless-ossm-setup  
+    File: serverless-ossm-setup
   - Name: Integrating Serverless with the cost management service
     File: serverless-cost-management-integration
   - Name: Using NVIDIA GPU resources with serverless applications
     File: gpu-resources
-# Removing  
+# Removing
 - Name: Removing Serverless
   Dir: removing
   Topics:

--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -1,0 +1,46 @@
+:_content-type: REFERENCE
+[id="configuration-ovnk-network-plugin-json-object_{context}"]
+= OVN-Kubernetes network plugin JSON configuration table
+
+The following table describes the configuration parameters for the OVN-Kubernetes CNI network plugin:
+
+.OVN-Kubernetes network plugin JSON configuration table
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`cniVersion`
+|`string`
+|The CNI specification version. The required value is `0.3.1`.
+
+|`name`
+|`string`
+|The name of the network. This value must be unique across all `NetworkAttachmentDefinitions`. Failure to make this attribute unique might result in the merging of two networks with the same name. Merging two networks by sharing similar names is unsupported.
+
+|`type`
+|`string`
+|The name of the CNI plugin to configure. The required value is `ovn-k8s-cni-overlay`.
+
+|`topology`
+|`string`
+|The topological configuration for the network. The required value is `layer2`.
+
+|`subnets`
+|`string`
+| The subnet to use for the network across the cluster. When specifying `layer2` for the `topology`, only include the CIDR for the node. For example, `10.100.200.0/24`.
+
+For `"topology":"layer2"` deployments, IPv6 (`2001:DBB::/64`) and dual-stack (`192.168.100.0/24,2001:DBB::/64`) subnets are supported.
+
+|`mtu`
+|`string`
+|The maximum transmission unit (MTU) to the specified value. The default value, `1300`, is automatically set by the kernel.
+
+|`netAttachDefName`
+|`string`
+| The namespace and the network attachment name. The value must match the values specified for `namespace` and `name` when defining the network attachment definition object. For example, `ns1/l2-network` refers to the `ns1` namespace and the `l2-network` network attachment definition name.
+
+|`excludeSubnets`
+|`string`
+|A comma-separated list of CIDRs and IPs. IPs are removed from the assignable IP pool, and are never passed to the pods. When omitted, the logical switch implementing the network only provides layer 2 communication, and users must configure IPs for the pods. Port security only prevents MAC spoofing.
+
+|====

--- a/modules/configuring-layer-three-routed-topology.adoc
+++ b/modules/configuring-layer-three-routed-topology.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_content-type: CONCEPT
+[id="configuration-layer-three-routed-topology_{context}"]
+= Configuration for a routed topology
+
+The routed (layer 3) topology networks are a simplified topology for the cluster default network without egress or ingress. In this topology, there is one logical switch per node, each with a different subnet, and a router interconnecting all logical switches.
+
+This configuration can be used for IPv6 and dual-stack deployments.
+
+[NOTE]
+====
+* Layer 3 routed topology networks only allow for the transfer of data packets between pods within a cluster.
+* Creating a secondary network with an IPv6 subnet or dual-stack subnets fails on a single-stack {product-title} cluster. This is a known limitation and will be fixed a future version of {product-title}.
+====
+
+The following `NetworkAttachmentDefinition` custom resource definition (CRD) YAML describes the fields needed to configure a routed secondary network.
+
+[source,yaml]
+----
+    {
+            "cniVersion": "0.3.1",
+            "name": "ns1-l3-network",
+            "type": "ovn-k8s-cni-overlay",
+            "topology":"layer3",
+            "subnets": "10.128.0.0/16/24",
+            "mtu": 1300,
+            "netAttachDefName": "ns1/l3-network"
+    }
+----

--- a/modules/configuring-layer-two-switched-topology.adoc
+++ b/modules/configuring-layer-two-switched-topology.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_content-type: CONCEPT
+[id="configuration-layer-two-switched-topology_{context}"]
+= Configuration for a switched topology
+
+The switched (layer 2) topology networks interconnect the workloads through a cluster-wide logical switch. This configuration can be used for IPv6 and dual-stack deployments.
+
+[NOTE]
+====
+Layer 2 switched topology networks only allow for the transfer of data packets between pods within a cluster.
+====
+
+The following `NetworkAttachmentDefinition` custom resource definition (CRD) YAML describes the fields needed to configure a switched secondary network.
+
+[source,yaml]
+----
+    {
+            "cniVersion": "0.3.1",
+            "name": "ns1-l2-network",
+            "type": "ovn-k8s-cni-overlay",
+            "topology":"layer2",
+            "subnets": "10.100.200.0/24",
+            "mtu": 1300,
+            "netAttachDefName": "ns1/l2-network",
+            "excludeSubnets": "10.100.200.0/29"
+    }
+----

--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-secondary-networks.adoc
+
+:_content-type: REFERENCE
+[id="configuration-localnet-switched-topology_{context}"]
+= Configuration for a localnet switched topology
+
+The switched (localnet) topology interconnects the workloads through a cluster-wide logical switch to a physical network.
+
+The following `NetworkAttachmentDefinition` custom resource definition (CRD) YAML describes the fields needed to configure a localnet secondary network.
+
+[source,yaml]
+----
+    {
+            "cniVersion": "0.3.1",
+            "name": "ns1-localnet-network",
+            "type": "ovn-k8s-cni-overlay",
+            "topology":"localnet",
+            "subnets": "202.10.130.112/28",
+            "vlanID": 33,
+            "mtu": 1500,
+            "netAttachDefName": "ns1/localnet-network"
+            "excludeSubnets": "10.100.200.0/29"
+
+    }
+----

--- a/modules/configuring-ovnk-additional-networks.adoc
+++ b/modules/configuring-ovnk-additional-networks.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_content-type: CONCEPT
+[id="configuration-ovnk-additional-networks_{context}"]
+= Configuration for an OVN-Kubernetes additional network
+
+The {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. To configure secondary network interfaces, you must define the configurations in the `NetworkAttachmentDefinition` custom resource definition (CRD).
+
+:FeatureName: Configuration for an OVN-Kubernetes additional network
+include::snippets/technology-preview.adoc[]
+
+The following sections provide example configurations for each of the topologies that OVN-Kubernetes currently allows for secondary networks.
+
+[NOTE]
+====
+Networks names must be unique. For example, creating multiple `NetworkAttachmentDefinition` CRDs with different configurations that reference the same network is unsupported.
+====

--- a/modules/configuring-pods-secondary-network.adoc
+++ b/modules/configuring-pods-secondary-network.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_content-type: REFERENCE
+[id="configuring-pods-secondary-network_{context}"]
+= Configuring pods for additional networks
+
+You must specify the secondary network attachments through the `k8s.v1.cni.cncf.io/networks` annotation.
+
+The following example provisions a pod with two secondary attachments, one for each of the attachment configurations presented in this guide.
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/networks: l2-network
+  name: tinypod
+  namespace: ns1
+spec:
+  containers:
+  - args:
+    - pause
+    image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+    imagePullPolicy: IfNotPresent
+    name: agnhost-container
+----

--- a/modules/configuring-pods-static-ip.adoc
+++ b/modules/configuring-pods-static-ip.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_content-type: CONCEPT
+[id="configuring-pods-static-ip_{context}"]
+= Configuring pods with a static IP address
+
+The following example provisions a pod with a static IP address.
+
+[NOTE]
+====
+* You can only specify the IP address for a pod's secondary network attachment for layer 2 attachments.
+* Specifying a static IP address for the pod is only possible when the attachment configuration does not feature subnets.
+====
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  annotations:
+    k8s.v1.cni.cncf.io/networks: '[
+      {
+        "name": "l2-network", <1>
+        "mac": "02:03:04:05:06:07", <2>
+        "interface": "myiface1", <3>
+        "ips": [
+          "192.0.2.20/24"
+          ] <4>
+      }
+    ]'
+  name: tinypod
+  namespace: ns1
+spec:
+  containers:
+  - args:
+    - pause
+    image: k8s.gcr.io/e2e-test-images/agnhost:2.36
+    imagePullPolicy: IfNotPresent
+    name: agnhost-container
+----
+<1> The name of the network. This value must be unique across all `NetworkAttachmentDefinitions`.
+<2> The MAC address to be assigned for the interface.
+<3> The name of the network interface to be created for the pod.
+<4> The IP addresses to be assigned to the network interface.

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -12,6 +12,7 @@ As a cluster administrator, you can configure an additional network for your clu
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-host-device-object_configuring-additional-network[Host device]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[IPVLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[MACVLAN]
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuration-ovnk-additional-networks_configuring-additional-network[OVN-Kubernetes]
 
 [id="{context}_approaches-managing-additional-network"]
 == Approaches to managing an additional network
@@ -119,6 +120,13 @@ include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
+include::modules/configuring-ovnk-additional-networks.adoc[leveloffset=+2]
+include::modules/configuration-ovnk-network-plugin-json-object.adoc[leveloffset=+3]
+//include::modules/configuring-layer-three-routed-topology.adoc[leveloffset=+3]
+include::modules/configuring-layer-two-switched-topology.adoc[leveloffset=+3]
+//include::modules/configuring-localnet-switched-topology.adoc[leveloffset=+3]
+include::modules/configuring-pods-secondary-network.adoc[leveloffset=+3]
+include::modules/configuring-pods-static-ip.adoc[leveloffset=+3]
 
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5450

Link to docs preview:
https://56657--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#configuration-ovnk-additional-networks

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Based on https://github.com/ovn-org/ovn-kubernetes/blob/master/docs/multi-homing.md#switched---localnet---topology
