### PR TITLE
OCPBUG#7145: Deleted a step in 'Restoring to a previous cluster state'

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -101,7 +101,6 @@ $ sudo mv /var/lib/etcd/ /tmp
 
 . Access the recovery control plane host.
 
-
 . If the cluster-wide proxy is enabled, be sure that you have exported the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables.
 +
 [TIP]
@@ -223,7 +222,7 @@ csr-zhhhp   3m8s   kubernetes.io/kube-apiserver-client-kubelet   system:servicea
 ----
 <1> A pending kubelet service CSR (for user-provisioned installations).
 <2> A pending `node-bootstrapper` CSR.
-+
+
 .. Review the details of a CSR to verify that it is valid:
 +
 [source,terminal]
@@ -245,7 +244,6 @@ $ oc adm certificate approve <csr_name>
 ----
 $ oc adm certificate approve <csr_name>
 ----
-
 
 . Verify that the single member control plane has started successfully.
 
@@ -288,13 +286,12 @@ etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          
 +
 If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
 
-.. Repeat this step for each lost control plane host that is not the recovery host.
 +
 [NOTE]
 ====
 Perform the following step only if you are using `OVNKubernetes` network plugin.
 ====
-+
+
 . Delete the node objects that are associated with control plane hosts that are not the recovery control plane host.
 +
 [source,terminal]
@@ -309,7 +306,7 @@ Validating and mutating admission webhooks can reject pods. If you add any addit
 
 Alternatively, you can temporarily set the `failurePolicy` to `Ignore` while restoring the cluster state. After the cluster state is restored successfully, you can set the `failurePolicy` to `Fail`.
 ====
-+
+
 .. Remove the northbound database (nbdb) and southbound database (sbdb). Access the recovery host and the remaining control plane nodes by using Secure Shell (SSH) and run the following command:
 +
 [source,terminal]


### PR DESCRIPTION
Version: 4.9+

Scope: Modified the steps in 'Restoring to a previous cluster state'. 
Removed the step 11.c: Repeat this step for each lost control plane host that is not the recovery host.
[OCPBUG-7145](https://issues.redhat.com/browse/OCPBUGS-7145)

[Docs Preview](https://56658--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state)

@geliu2016  ptal