### PR TITLE
BZ#1976294: Added prereq to confirm disk is enabled for multipathing

### DIFF
--- a/modules/rhcos-enabling-multipath-day-2.adoc
+++ b/modules/rhcos-enabling-multipath-day-2.adoc
@@ -21,6 +21,7 @@ On IBM Z and LinuxONE, you can enable multipathing only if you configured your c
 .Prerequisites
 * You have a running {product-title} cluster that uses version 4.7 or later.
 * You are logged in to the cluster as a user with administrative privileges.
+* You have confirmed that the disk is enabled for multipathing. Multipathing is only supported on hosts that are connected to a SAN via an HBA adapter.
 
 .Procedure
 

--- a/modules/rhcos-enabling-multipath.adoc
+++ b/modules/rhcos-enabling-multipath.adoc
@@ -28,7 +28,7 @@ The following procedure enables multipath at installation time and appends kerne
 +
 [NOTE]
 ====
-{product-title} does not support enabling multipathing as a day-2 activity on nodes that have been upgraded from 4.6 or earlier. 
+{product-title} does not support enabling multipathing as a day-2 activity on nodes that have been upgraded from 4.6 or earlier.
 ====
 
 * You are logged in to the cluster as a user with administrative privileges.


### PR DESCRIPTION
Version(s):
4.9+

Issue:
This PR addresses [bz-1976294](https://bugzilla.redhat.com/show_bug.cgi?id=1976294).

Link to docs preview:

Post-installation machine configuration tasks > [Enabling multipathing with kernel arguments on RHCOS](https://56660--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#rhcos-enabling-multipath-day-2_post-install-machine-configuration-tasks)

QE review:
- [x] QE has approved this change.
