### PR TITLE
OSDOCS-4757:adds session affinity to OVN-K

### DIFF
--- a/modules/nw-ovn-kubernetes-session-affinity.adoc
+++ b/modules/nw-ovn-kubernetes-session-affinity.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+
+:_content-type: CONCEPT
+[id="nw-ovn-kubernetes-session-affinity_{context}"]
+= Session affinity
+Session affinity is a feature that applies to Kubernetes `Service` objects. You can use _session affinity_ if you want to ensure that each time you connect to a <service_VIP>:<Port>, the traffic is always load balanced to the same back end. For more information, including how to set session affinity based on a client's IP address, see link:https://kubernetes.io/docs/reference/networking/virtual-ips/#session-affinity[Session affinity].
+
+[discrete]
+[id="nw-ovn-kubernetes-session-affinity-stickyness-timeout_{context}"]
+== Stickiness timeout for session affinity
+The OVN-Kubernetes network plugin for {product-title} calculates the stickiness timeout for a session from a client based on the last packet. For example, if you run a `curl` command 10 times, the sticky session timer starts from the tenth packet not the first. As a result, if the client is continuously contacting the service, then the session never times out. The timeout starts when the service has not received a packet for the amount of time set by the link:https://kubernetes.io/docs/reference/networking/virtual-ips/#session-stickiness-timeout[`timeoutSeconds`] parameter.

--- a/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
+++ b/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc
@@ -41,6 +41,8 @@ include::modules/nw-ovn-kubernetes-matrix.adoc[leveloffset=+1]
 
 include::modules/nw-ovn-kuberentes-limitations.adoc[leveloffset=+1]
 
+include::modules/nw-ovn-kubernetes-session-affinity.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
[OSDOCS-4757](https://issues.redhat.com//browse/OSDOCS-4757): adds session affinity to OVN-K docs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-4757
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://56678--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.html#nw-ovn-kubernetes-session-affinity_about-ovn-kubernetes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @tssurya 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
