### PR TITLE
OCPBUGS#6273: Add note for TechPreview fail message in PO

### DIFF
--- a/modules/olm-installing-po-after.adoc
+++ b/modules/olm-installing-po-after.adoc
@@ -32,6 +32,17 @@ spec:
 ----
 $ oc apply -f cert-manager.yaml
 ----
++
+[NOTE]
+====
+If your cluster does not have the `TechPreviewNoUpgrades` feature set enabled, the object creation fails with the following message:
+
+[source,terminal]
+----
+error: resource mapping not found for name: "cert-manager" namespace: "" from "cert-manager.yaml": no matches for kind "PlatformOperator" in version "platform.openshift.io/v1alpha1"
+ensure CRDs are installed first
+----
+====
 
 .Verification
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-6273

The Prerequisites section at the assembly level links to how to enable the feature set, but this provides context for the error message received if you try to create the PO after cluster creation but haven't enabled the feature set.

Preview: https://56679--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-po.html#olm-installing-po-after_olm-managing-po