### PR TITLE
TELCODOCS-1146: Installing a cluster on bare metal with AI

### DIFF
--- a/installing/index.adoc
+++ b/installing/index.adoc
@@ -25,6 +25,9 @@ include::modules/ipi-verifying-nodes-after-installation.adoc[leveloffset=+2]
 * xref:../installing/validating-an-installation.adoc#validating-an-installation[Validating an installation]
 
 * xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Agent-based Installer]
+
+* link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[Assisted Installer for OpenShift Container Platform]
+
 [discrete]
 === Installation scope
 

--- a/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
+++ b/installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc
@@ -24,7 +24,20 @@ include::modules/virt-planning-bare-metal-cluster-for-ocp-virt.adoc[leveloffset=
 [id="choosing-a-method-to-install-ocp-on-bare-metal"]
 == Choosing a method to install {product-title} on bare metal
 
-You can install {product-title} on installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provision. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
+The {product-title} installation program offers four methods for deploying a cluster:
+
+* *Interactive*: You can deploy a cluster with the web-based link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full}]. This is the recommended approach for clusters with networks connected to the internet. The {ai-full} is the easiest way to install {product-title}, it provides smart defaults, and it performs pre-flight validations before installing the cluster. It also provides a RESTful API for automation and advanced configuration scenarios.
+
+* *Local Agent-based*: You can deploy a cluster locally with the xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[agent-based installer] for air-gapped or restricted networks. It provides many of the benefits of the {ai-full}, but you must download and configure the link:https://console.redhat.com/openshift/install/metal/agent-based[agent-based installer] first. Configuration is done with a commandline interface. This approach is ideal for air-gapped or restricted networks.
+
+* *Automated*: You can xref:../../installing/installing_bare_metal_ipi/ipi-install-overview.adoc#ipi-install-overview[deploy a cluster on installer-provisioned infrastructure] and the cluster it maintains. The installer uses each cluster host's baseboard management controller (BMC) for provisioning. You can deploy clusters with both connected or air-gapped or restricted networks.
+
+* *Full control*: You can deploy a cluster on xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[infrastructure that you prepare and maintain], which provides maximum customizability. You can deploy clusters with both connected or air-gapped or restricted networks.
+
+The clusters have the following characteristics:
+
+* Highly available infrastructure with no single points of failure is available by default.
+* Administrators maintain control over what updates are applied and when.
 
 See xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process] for more information about installer-provisioned and user-provisioned installation processes.
 

--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -6,7 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on your Nutanix instance that uses installer-provisioned infrastructure.
+In {product-title} version {product-version}, you can install a cluster on your Nutanix instance with two methods:
+
+* Using the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full}] hosted at link:http://console.redhat.com[console.redhat.com]. This method requires no setup for the installer, and is ideal for connected environments like Nutanix. Installing with the {ai-full} also provides integration with Nutanix, enabling autoscaling. See xref:../../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#installing-on-prem-assisted[Installing an on-premise cluster using the {ai-full}] for additional details.
+
+* Using installer-provisioned infrastructure. Use the procedures in the following sections to use installer-provisioned infrastructure. Installer-provisioned infrastructure is ideal for installing in environments with air-gapped/restricted networks.
 
 == Prerequisites
 

--- a/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
+++ b/installing/installing_vsphere/preparing-to-install-on-vsphere.adoc
@@ -22,7 +22,9 @@ xref:../../installing/install_config/configuring-firewall.adoc#configuring-firew
 [id="choosing-a-method-to-install-ocp-on-vsphere"]
 == Choosing a method to install {product-title} on vSphere
 
-You can install {product-title} on vSphere by using installer-provisioned or user-provisioned infrastructure. The default installation type uses installer-provisioned infrastructure, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provide. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
+You can install {product-title} with the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full}]. This method requires no setup for the installer, and is ideal for connected environments like vSphere. Installing with the {ai-full} also provides integration with vSphere, enabling autoscaling. See xref:../../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#installing-on-prem-assisted[Installing an on-premise cluster using the {ai-full}] for additional details.
+
+You can also install {product-title} on vSphere by using installer-provisioned or user-provisioned infrastructure. Installer-provisioned infrastructure is ideal for installing in environments with air-gapped/restricted networks, where the installation program provisions the underlying infrastructure for the cluster. You can also install {product-title} on infrastructure that you provide. If you do not use infrastructure that the installation program provisions, you must manage and maintain the cluster resources yourself.
 
 See the xref:../../architecture/architecture-installation.html#installation-process_architecture-installation[Installation process] for more information about installer-provisioned and user-provisioned installation processes.
 

--- a/modules/assisted-installer-using-the-assisted-installer.adoc
+++ b/modules/assisted-installer-using-the-assisted-installer.adoc
@@ -6,7 +6,7 @@
 [id="using-the-assisted-installer_{context}"]
 = Using the Assisted Installer
 
-The {product-title} link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[{ai-full}] is a user-friendly installation solution offered on the link:http://console.redhat.com[Red Hat Hybrid Cloud Console]. The {ai-full} supports the various deployment platforms with a focus on bare metal and vSphere infrastructures.
+The {product-title} link:https://console.redhat.com/openshift/assisted-installer/clusters/~new[{ai-full}] is a user-friendly installation solution offered on the link:http://console.redhat.com[Red Hat Hybrid Cloud Console]. The {ai-full} supports the various deployment platforms with a focus on bare metal, Nutanix, and vSphere infrastructures.
 
 The {ai-full} provides installation functionality as a service. This software-as-a-service (SaaS) approach has the following advantages:
 
@@ -35,7 +35,7 @@ The {ai-full} provides installation functionality as a service. This software-as
 The {ai-full} supports installing {product-title} on premises in a connected environment, including with an optional HTTP/S proxy. It can install the following:
 
 * Highly available {product-title} or Single Node OpenShift (SNO)
-* {product-title} on bare metal or vSphere with full platform integration, or other virtualization platforms without integration
+* {product-title} on bare metal, Nutanix, or vSphere with full platform integration, or other virtualization platforms without integration
 * Optionally {VirtProductName} and {rh-storage} (formerly OpenShift Container Storage)
 
 The user interface provides an intuitive interactive workflow where automation does not exist or is not required. Users may also automate installations using the REST API.

--- a/modules/install-openshift-common-terms.adoc
+++ b/modules/install-openshift-common-terms.adoc
@@ -8,6 +8,12 @@
 
 This glossary defines common terms that are used in the installation content. These terms help you understand installation effectively.
 
+{ai-full}::
+An installer hosted at link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[console.redhat.com] that provides a web user interface or a RESTful API for creating a cluster configuration. The {ai-full} generates a discovery image. Cluster machines boot with the discovery image, which installs {op-system} and an agent. Together, the {ai-full} and agent provide pre-installation validation and installation for the cluster.
+
+Agent-based installer::
+An installer similar to the {ai-full}, but you must download the link:https://console.redhat.com/openshift/install/metal/agent-based[agent-based installer] first. The agent-based installer is ideal for air-gapped/restricted networks.
+
 Bootstrap node::
 A temporary machine that runs a minimal Kubernetes configuration to deploy the {product-title} control plane.
 

--- a/modules/installation-overview.adoc
+++ b/modules/installation-overview.adoc
@@ -7,32 +7,31 @@
 [id="installation-overview_{context}"]
 = About {product-title} installation
 
-The {product-title} installation program offers you flexibility. You can use the program to:
+The {product-title} installation program offers four methods for deploying a cluster: 
 
-* Deploy a cluster on provisioned infrastructure and the cluster it maintains.
-* Deploy a cluster on infrastructure that you prepare and maintain.
+* *Interactive*: You can deploy a cluster with the web-based link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full}]. This is the recommended approach for clusters with networks connected to the internet. The {ai-full} is the easiest way to install {product-title}, it provides smart defaults, and it performs pre-flight validations before installing the cluster. It also provides a RESTful API for automation and advanced configuration scenarios.
 
-These two basic types of {product-title} clusters are frequently called:
+* *Local Agent-based*: You can deploy a cluster locally with the agent-based installer for air-gapped or restricted networks. It provides many of the benefits of the {ai-full}, but you must download and configure the link:https://console.redhat.com/openshift/install/metal/agent-based[agent-based installer] first. Configuration is done with a commandline interface. This approach is ideal for air-gapped or restricted networks.
 
-* Installer-provisioned infrastructure clusters.
-* User-provisioned infrastructure clusters.
+* *Automated*: You can deploy a cluster on installer-provisioned infrastructure and the cluster it maintains. The installer uses each cluster host's baseboard management controller (BMC) for provisioning. You can deploy clusters with both connected or air-gapped or restricted networks.
 
-Both cluster types have the following characteristics:
+* *Full control*: You can deploy a cluster on infrastructure that you prepare and maintain, which provides maximum customizability. You can deploy clusters with both connected or air-gapped or restricted networks.
+
+The clusters have the following characteristics:
 
 * Highly available infrastructure with no single points of failure is available by default.
 * Administrators maintain control over what updates are applied and when.
 
-The Agent-based Installer is part of the {product-title} Installer. The installer provides you with the flexibility of user-provisioned infrastructure (UPI) installation and the ease of use of the Assisted Installer (AI).
-
 [id="about-the-installation-program"]
 == About the installation program
 
-You can use the installation program to deploy both types of clusters. The installation program generates main assets such as Ignition config files for the bootstrap, master, and worker machines. You can start an {product-title} cluster with these three configurations and correctly configured infrastructure.
+You can use the installation program to deploy each type of cluster. The installation program generates main assets such as Ignition config files for the bootstrap, control plane (master), and worker machines. You can start an {product-title} cluster with these three configurations and correctly configured infrastructure.
 
 The {product-title} installation program uses a set of targets and dependencies to manage cluster installations. The installation program has a set of targets that it must achieve, and each target has a set of dependencies. Because each target is only concerned with its own dependencies, the installation program can act to achieve multiple targets in parallel with the ultimate target being a running cluster. The installation program recognizes and uses existing components instead of running commands to create them again because the program meets dependencies.
 
 .{product-title} installation targets and dependencies
 image::targets-and-dependencies.png[{product-title} installation targets and dependencies]
+
 
 [id="about-rhcos"]
 == About {op-system-first}

--- a/modules/installation-process.adoc
+++ b/modules/installation-process.adoc
@@ -6,7 +6,7 @@
 [id="installation-process_{context}"]
 = Installation process
 
-When you install an {product-title} cluster, you download the installation program from
+Except for the {ai-full}, when you install an {product-title} cluster, you download the installation program from
 ifndef::openshift-origin[]
 the appropriate link:https://console.redhat.com/openshift/install[Infrastructure Provider] page on the {cluster-manager} site. This site manages:
 
@@ -20,11 +20,15 @@ endif::[]
 
 In {product-title} {product-version}, the installation program is a Go binary file that performs a series of file transformations on a set of assets. The way you interact with the installation program differs depending on your installation type.
 
-* For clusters with installer-provisioned infrastructure, you delegate the infrastructure bootstrapping and provisioning to the installation program instead of doing it yourself. The installation program creates all of the networking, machines, and operating systems that are required to support the cluster.
+* To deploy a cluster with the {ai-full}, you configure the cluster settings using the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full}]. There is no installer to download and configure. After you complete the configuration, you download a discovery ISO and boot cluster machines with that image. You can install clusters with the {ai-full} on Nutanix, vSphere, and bare metal with full integration, and other platforms without integration. If you install on bare metal, you must provide all of the cluster infrastructure and resources, including the networking, load balancing, storage, and individual cluster machines.
+
+* To deploy clusters with the agent-based installer, you download the link:https://console.redhat.com/openshift/install/metal/agent-based[agent-based installer] first. Then, you configure the cluster and generate a discovery image. You boot cluster machines with the discovery image, which installs an agent that communicates with the installation program and handles the provisioning for you instead of you interacting with the installation program or setting up a provisioner machine yourself. You must provide all of the cluster infrastructure and resources, including the networking, load balancing, storage, and individual cluster machines. This approach is ideal for air-gapped or restricted network environments.
+
+* For clusters with installer-provisioned infrastructure, you delegate the infrastructure bootstrapping and provisioning to the installation program instead of doing it yourself. The installation program creates all of the networking, machines, and operating systems that are required to support the cluster, except if you install on bare metal. If you install on bare metal, you must provide all of the cluster infrastructure and resources, including the bootstrap machine, networking, load balancing, storage, and individual cluster machines.
 
 * If you provision and manage the infrastructure for your cluster, you must provide all of the cluster infrastructure and resources, including the bootstrap machine, networking, load balancing, storage, and individual cluster machines.
 
-You use three sets of files during installation: an installation configuration file that is named `install-config.yaml`, Kubernetes manifests, and Ignition config files for your machine types.
+The installer uses three sets of files during installation: an installation configuration file that is named `install-config.yaml`, Kubernetes manifests, and Ignition config files for your machine types.
 
 [IMPORTANT]
 ====
@@ -39,6 +43,22 @@ The installation configuration files are all pruned when you run the installatio
 ====
 You cannot modify the parameters that you set during installation, but you can modify many cluster attributes after installation.
 ====
+
+[discrete]
+== The installation process with the {ai-full}
+
+Installation with the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full}] involves creating a cluster configuration interactively using the web-based user interface or using the RESTful API. The {ai-full} user interface prompts you for required values and provides reasonable default values for the remaining parameters, unless you change them in the user interface or with the API.  The {ai-full} generates a discovery image, which you download and use to boot the cluster machines. The image installs {op-system} and an agent, and the agent handles the provisioning for you. You can install {product-title} with the {ai-full} and full integration on Nutanix, vSphere, and bare metal, and on other platforms without integration.
+
+{product-title} manages all aspects of the cluster, including the operating system itself. Each machine boots with a configuration that references resources hosted in the cluster that it joins. This configuration allows the cluster to manage itself as updates are applied.
+
+If possible, use this feature to avoid having to download and configure the agent-based installer.
+
+[discrete]
+== The installation process with agent-based infrastructure
+
+Agent-based installation is similar to using the {ai-full}, except that you download and install the link:https://console.redhat.com/openshift/install/metal/agent-based[agent-based installer] first. Agent-based installation is recommended when you want all the convenience of the {ai-full}, but you need to install with an air-gapped or disconnected network.
+
+If possible, use this feature to avoid having to create a provisioner machine with a bootstrap VM and provision and maintain the cluster infrastructure.
 
 [discrete]
 == The installation process with installer-provisioned infrastructure
@@ -102,6 +122,3 @@ Bootstrapping a cluster involves the following steps:
 . The control plane installs additional services in the form of a set of Operators.
 
 The result of this bootstrapping process is a running {product-title} cluster. The cluster then downloads and configures remaining components needed for the day-to-day operation, including the creation of compute machines in supported environments.
-
-
-


### PR DESCRIPTION
Revised installation introduction to include Assisted Installer. Revised additional docs to include AI for Nutanix and vSphere.

Fixes: [TELCODOCS-1146](https://issues.redhat.com//browse/TELCODOCS-1146)

See https://issues.redhat.com/browse/TELCODOCS-1146 for additional details.

Preview URL: http://jowilkin.com:8080/TELCODOCS-1146/installing/index.html http://jowilkin.com:8080/TELCODOCS-1146/installing/installing_vsphere/preparing-to-install-on-vsphere.html#choosing-a-method-to-install-ocp-on-vsphere http://jowilkin.com:8080/TELCODOCS-1146/installing/installing_nutanix/installing-nutanix-installer-provisioned.html

For release(s): 4.12+
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
