### PR TITLE
OSDOCS-4208: Promote BF2 DPU to NIC mode as GA

### DIFF
--- a/modules/proc-switching-bf2-nic.adoc
+++ b/modules/proc-switching-bf2-nic.adoc
@@ -6,17 +6,17 @@
 [id="proc-switching-bf2-nic_{context}"]
 = Switching Bluefield-2 from DPU mode to NIC mode
 
-Use the following procedure to switch Bluefield-2 from data processing units (DPU) mode to network interface controller (NIC) mode.  
+Use the following procedure to switch Bluefield-2 from data processing units (DPU) mode to network interface controller (NIC) mode.
 
 [IMPORTANT]
 ====
-Currently, only switching Bluefield-2 from DPU to NIC mode is supported. Switching from NIC mode to DPU mode is unsupported. 
+Currently, only switching Bluefield-2 from DPU to NIC mode is supported. Switching from NIC mode to DPU mode is unsupported.
 ====
 
 .Prerequisites
 
-* You have installed the SR-IOV Network Operator. For more information, see "Installing SR-IOV Network Operator". 
-* You have updated Bluefield-2 to the latest firmware. For more information, see link:https://network.nvidia.com/support/firmware/bluefield2/[Firmware for NVIDIA BlueField-2]. 
+* You have installed the SR-IOV Network Operator. For more information, see "Installing SR-IOV Network Operator".
+* You have updated Bluefield-2 to the latest firmware. For more information, see link:https://network.nvidia.com/support/firmware/bluefield2/[Firmware for NVIDIA BlueField-2].
 
 .Procedure
 
@@ -33,7 +33,7 @@ $ oc label node <example_node_name_two> node-role.kubernetes.io/sriov=
 
 ----
 
-. Create a machine config pool for the SR-IOV Operator, for example: 
+. Create a machine config pool for the SR-IOV Network Operator, for example:
 +
 [source,yaml]
 ----
@@ -45,10 +45,10 @@ metadata:
 spec:
   machineConfigSelector:
     matchExpressions:
-      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,sriov]}
+    - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker,sriov]}
   nodeSelector:
     matchLabels:
-            node-role.kubernetes.io/sriov: ""
+      node-role.kubernetes.io/sriov: ""
 ----
 
 . Apply the following `machineconfig.yaml` file to the worker nodes:
@@ -74,22 +74,22 @@ spec:
         path: /etc/default/switch_in_sriov_config_daemon.sh
     systemd:
       units:
-        - name: dpu-switch.service
-          enabled: true
-          contents: |
-            [Unit]
-            Description=Switch BlueField2 card to NIC/DPU mode
-            RequiresMountsFor=%t/containers
-            Wants=network.target
-            After=network-online.target kubelet.service
-            [Service]
-            SuccessExitStatus=0 120
-            RemainAfterExit=True
-            ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic || shutdown -r now' <1>
-            Type=oneshot
-            [Install]
-            WantedBy=multi-user.target
+      - name: dpu-switch.service
+        enabled: true
+        contents: |
+          [Unit]
+          Description=Switch BlueField2 card to NIC/DPU mode
+          RequiresMountsFor=%t/containers
+          Wants=network.target
+          After=network-online.target kubelet.service
+          [Service]
+          SuccessExitStatus=0 120
+          RemainAfterExit=True
+          ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic || shutdown -r now' <1>
+          Type=oneshot
+          [Install]
+          WantedBy=multi-user.target
 ----
-<1> Optional: The PCI address of a specific card can optionally be specified, for example `ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic 0000:5e:00.0 || echo done'`. By default, the first device is selected. If there is more than one device, you must specify which PCI address to be used. The PCI address must be the same on all nodes that are switching Bluefield-2 from DPU mode to NIC mode. 
+<1> Optional: The PCI address of a specific card can optionally be specified, for example `ExecStart=/bin/bash -c '/etc/default/switch_in_sriov_config_daemon.sh nic 0000:5e:00.0 || echo done'`. By default, the first device is selected. If there is more than one device, you must specify which PCI address to be used. The PCI address must be the same on all nodes that are switching Bluefield-2 from DPU mode to NIC mode.
 
-. Wait for the worker nodes to restart. After restarting, the Bluefield-2 network device on the worker nodes is switched into NIC mode. 
+. Wait for the worker nodes to restart. After restarting, the Bluefield-2 network device on the worker nodes is switched into NIC mode.

--- a/networking/hardware_networks/switching-bf2-nic-dpu.adoc
+++ b/networking/hardware_networks/switching-bf2-nic-dpu.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can switch the Bluefield-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode. 
 
-:FeatureName: Switching Bluefield-2 from data processing unit (DPU) mode to network interface controller (NIC) mode
-include::snippets/technology-preview.adoc[]
-
 include::modules/proc-switching-bf2-nic.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-4208

Preview
- [Switching Bluefield-2 from DPU mode to NIC mode](https://56693--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/switching-bf2-nic-dpu.html)

This removes TP from `networking/hardware_networks/switching-bf2-nic-dpu.adoc` and trims spacing for `machineconfig.yaml`.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
