### PR TITLE
OSDOCS-4208: Add release note for BF2 switch to NIC mode GA

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -198,6 +198,13 @@ With this update, you can assign IP addresses from a MetalLB `IPAddressPool` res
 
 For more information about assigning IP addresses from an IP address pool to services and namespaces, see xref:../networking/metallb/metallb-configure-address-pools.adoc#nw-metallb-configure-address-pool_configure-metallb-address-pools[Configuring MetalLB address pools].
 
+[id="ocp-4-13-bf2-switching-dpu-nic"]
+==== Support for switching the BlueField-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode is now GA
+
+In this release, switching the BlueField-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode is now generally available.
+
+For more information, see xref:../networking/hardware_networks/switching-bf2-nic-dpu.adoc#switching-bf2-nic-dpu[Switching BlueField-2 from DPU to NIC].
+
 [id="ocp-4-13-storage"]
 === Storage
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-4208

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

Preview: https://56694--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-bf2-switching-dpu-nic

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
