### PR TITLE
OCP1883: Removed deprecated metric in defragmenting etcd data

### DIFF
--- a/modules/etcd-defrag.adoc
+++ b/modules/etcd-defrag.adoc
@@ -13,7 +13,7 @@ Monitor these key metrics:
 
 * `etcd_server_quota_backend_bytes`, which is the current quota limit
 * `etcd_mvcc_db_total_size_in_use_in_bytes`, which indicates the actual database usage after a history compaction
-* `etcd_debugging_mvcc_db_total_size_in_bytes`, which shows the database size, including free space waiting for defragmentation
+* `etcd_mvcc_db_total_size_in_bytes`, which shows the database size, including free space waiting for defragmentation
 
 Defragment etcd data to reclaim disk space after events that cause disk fragmentation, such as etcd history compaction.
 


### PR DESCRIPTION
Version: 4.9+

Scope: 
Removed deprecated command `etcd_debugging_mvcc_db_total_size_in_bytes` metric and replaced it with  `etcd_mvcc_db_total_size_in_bytes` metric in Defragmenting etcd data section. 
[OCPBUG1883](https://issues.redhat.com/browse/OCPBUGS-1883)

Additional Info:
[Upgrade](https://etcd.io/docs/v3.4/upgrades/upgrade_3_5/#deprecated-etcd_debugging_mvcc_db_total_size_in_bytes-prometheus-metrics)

Link to [Docs Preview]()

@geliu2016  ptal


