### PR TITLE
OCP6264: Added RHEL 8.6 version in OCP 4.12 release note

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -19,7 +19,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy OpenShift clusters to either on-premises or cloud environments.
 
 // Double check OP system versions
-{product-title} {product-version} is supported on {op-system-base-full} 8.4 and 8.5, as well as on {op-system-first} 4.12.
+{product-title} {product-version} is supported on {op-system-base-full} 8.6 as well as on {op-system-first} 4.12.
 
 You must use {op-system} machines for the control plane, and you can use either {op-system} or {op-system-base} for compute machines.
 //Removed the note per https://issues.redhat.com/browse/GRPA-3517


### PR DESCRIPTION
Version(s): 4.12 only

Scope: Corrected the supported RHEL version.

Changed "OpenShift Container Platform 4.12 is supported on Red Hat Enterprise Linux (RHEL) 8.4 and 8.5, as well as on Red Hat Enterprise Linux CoreOS (RHCOS) 4.12." to "OpenShift Container Platform 4.12 is supported on Red Hat Enterprise Linux (RHEL) 8.6 as well as on Red Hat Enterprise Linux CoreOS (RHCOS) 4.12."

Issue:
[OCPBUG6264](https://issues.redhat.com/browse/OCPBUGS-6264)

Link to the Docs Preview:
[Preview](https://56697--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-about-this-release)

QE review: @gpei ptal