### PR TITLE
[Enterprise-4.9]: RHDEVDOCS-4958: Updating the matrix table to fill in identified gaps

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,9 +23,9 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
-include::modules/gitops-release-notes-1-7-1.adoc[leveloffset=+1]
+// include::modules/gitops-release-notes-1-7-1.adoc[leveloffset=+1]
 
-include::modules/gitops-release-notes-1-7-0.adoc[leveloffset=+1]
+// include::modules/gitops-release-notes-1-7-0.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-6-4.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-2-1.adoc
+++ b/modules/gitops-release-notes-1-2-1.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-2-1_{context}"]
 = Release notes for {gitops-title} 1.2.1
 
-{gitops-title} 1.2.1 is now available on {product-title} 4.7 and 4.8.
+{gitops-title} 1.2.1 is now available on {product-title} 4.8.
 
 [id="support-matrix-1-2-1_{context}"]
 == Support matrix

--- a/modules/gitops-release-notes-1-2.adoc
+++ b/modules/gitops-release-notes-1-2.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-2_{context}"]
 = Release notes for {gitops-title} 1.2
 
-{gitops-title} 1.2 is now available on {product-title} 4.7, 4.8, and 4.9.
+{gitops-title} 1.2 is now available on {product-title} 4.8.
 
 [id="support-matrix-1-2_{context}"]
 == Support matrix

--- a/modules/gitops-release-notes-1-3-0.adoc
+++ b/modules/gitops-release-notes-1-3-0.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-3_{context}"]
 = Release notes for {gitops-title} 1.3
 
-{gitops-title} 1.3 is now available on {product-title} 4.7, 4.8, and 4.9.
+{gitops-title} 1.3 is now available on {product-title} 4.7, 4.8, 4.9, and 4.6 with limited GA support.
 
 [id="new-features-1-3_{context}"]
 == New features
@@ -14,7 +14,7 @@ In addition to the fixes and stability improvements, the following sections high
 * For a fresh install of v1.3.0, Dex is automatically configured. You can log into the default Argo CD instance in the `openshift-gitops` namespace using the OpenShift or `kubeadmin` credentials.  As an admin you can disable the Dex installation after the Operator is installed which will remove the Dex deployment from the `openshift-gitops` namespace.
 * The default Argo CD instance installed by the  Operator as well as accompanying controllers can now run on the infrastructure nodes of the cluster by setting a simple configuration toggle.
 * Internal communications in Argo CD can now be secured using the TLS and the OpenShift cluster certificates. The Argo CD routes can now leverage the OpenShift cluster certificates in addition to using external certificate managers such as the cert-manager.
-* Use the improved *environment details* view in the *Developer* perspective of the console 4.9 to gain insights into the GitOps environments.
+* Use the improved *Environments* page in the *Developer* perspective of the console 4.9 to gain insights into the GitOps environments.
 * You can now access custom health checks in Argo CD for `DeploymentConfig` resources, `Route` resources, and Operators installed using OLM.
 * The GitOps Operator now conforms to the naming conventions recommended by the latest Operator-SDK:
 ** The prefix `gitops-operator-` is added to all resources

--- a/modules/gitops-release-notes-1-3-1.adoc
+++ b/modules/gitops-release-notes-1-3-1.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-3-1_{context}"]
 = Release notes for {gitops-title} 1.3.1
 
-{gitops-title} 1.3.1 is now available on {product-title} 4.6, 4.7, 4.8, and 4.9.
+{gitops-title} 1.3.1 is now available on {product-title} 4.7, 4.8, 4.9, and 4.6 with limited GA support.
 
 [id="fixed-issues-1-3-1_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-3-2.adoc
+++ b/modules/gitops-release-notes-1-3-2.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-3-2_{context}"]
 = Release notes for {gitops-title} 1.3.2
 
-{gitops-title} 1.3.2 is now available on {product-title} 4.6, 4.7, 4.8, and 4.9.
+{gitops-title} 1.3.2 is now available on {product-title} 4.7, 4.8, 4.9, and 4.6 with limited GA support.
 
 [id="new-features-1-3-2_{context}"]
 == New features

--- a/modules/gitops-release-notes-1-3-3.adoc
+++ b/modules/gitops-release-notes-1-3-3.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-3-3_{context}"]
 = Release notes for {gitops-title} 1.3.3
 
-{gitops-title} 1.3.3 is now available on {product-title} 4.7, 4.8, and 4.9.
+{gitops-title} 1.3.3 is now available on {product-title} 4.7, 4.8, 4.9, and 4.6 with limited GA support.
 
 [id="fixed-issues-1-3-3_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-3-6.adoc
+++ b/modules/gitops-release-notes-1-3-6.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-3-6_{context}"]
 = Release notes for {gitops-title} 1.3.6
 
-{gitops-title} 1.3.6 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
+{gitops-title} 1.3.6 is now available on {product-title} 4.7, 4.8, 4.9, and 4.6 with limited GA support.
 
 [id="fixed-issues-1-3-6_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-3-7.adoc
+++ b/modules/gitops-release-notes-1-3-7.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-3-7_{context}"]
 = Release notes for {gitops-title} 1.3.7
 
-{gitops-title} 1.3.7 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
+{gitops-title} 1.3.7 is now available on {product-title} 4.7, 4.8, 4.9, and 4.6 with limited GA support.
 
 [id="fixed-issues-1-3-7_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-4-0.adoc
+++ b/modules/gitops-release-notes-1-4-0.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-4-0_{context}"]
 = Release notes for {gitops-title} 1.4.0
 
-{gitops-title} 1.4.0 is now available on {product-title} 4.7, 4.8, and 4.9.
+{gitops-title} 1.4.0 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
 
 [id="new-features-1-4-0_{context}"]
 == New features
@@ -26,7 +26,7 @@ The current release adds the following improvements.
 +
 With this update, administrators can configure a common cluster role for all the managed namespaces. In role bindings for the Argo CD application controller, the Operator refers to the `CONTROLLER_CLUSTER_ROLE` environment variable. In role bindings for the Argo CD server, the Operator refers to the `SERVER_CLUSTER_ROLE` environment variable. If these environment variables contain custom roles, the Operator doesn't create the default admin role. Instead, it uses the existing custom role for all managed namespaces. link:https://issues.redhat.com/browse/GITOPS-1290[GITOPS-1290]
 
-* With this update, the Environment page in the {product-title} Developer Console displays a broken heart icon to indicate degraded resources, excluding ones whose status is Progressing, Missing, and Unknown. The console displays a yellow yield sign icon to indicate out-of-sync resources. link:https://issues.redhat.com/browse/GITOPS-1307[GITOPS-1307]
+* With this update, the *Environments* page in the {product-title} *Developer* perspective displays a broken heart icon to indicate degraded resources, excluding ones whose status is `Progressing`, `Missing`, and `Unknown`. The console displays a yellow yield sign icon to indicate out-of-sync resources. link:https://issues.redhat.com/browse/GITOPS-1307[GITOPS-1307]
 
 [id="fixed-issues-1-4-0_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-4-1.adoc
+++ b/modules/gitops-release-notes-1-4-1.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-4-1_{context}"]
 = Release notes for {gitops-title} 1.4.1
 
-{gitops-title} 1.4.1 is now available on {product-title} 4.7, 4.8, and 4.9.
+{gitops-title} 1.4.1 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
 
 [id="fixed-issues-1-4-1_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-4-11.adoc
+++ b/modules/gitops-release-notes-1-4-11.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-4-11_{context}"]
 = Release notes for {gitops-title} 1.4.11
 
-{gitops-title} 1.4.11 is now available on {product-title} 4.8, 4.9, and 4.10.
+{gitops-title} 1.4.11 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
 
 [id="new-features-1-4-11_{context}"]
 == New features

--- a/modules/gitops-release-notes-1-4-12.adoc
+++ b/modules/gitops-release-notes-1-4-12.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-4-12_{context}"]
 = Release notes for {gitops-title} 1.4.12
 
-{gitops-title} 1.4.12 is now available on {product-title} 4.7 and above.
+{gitops-title} 1.4.12 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
 
 [id="fixed-issues-1-4-12_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-4-13.adoc
+++ b/modules/gitops-release-notes-1-4-13.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-4-13_{context}"]
 = Release notes for {gitops-title} 1.4.13
 
-{gitops-title} 1.4.13 is now available on {product-title} 4.7, 4.8, 4.9, 4.10 and 4.11.
+{gitops-title} 1.4.13 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
 
 [id="fixed-issues-1-4-13_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-4-2.adoc
+++ b/modules/gitops-release-notes-1-4-2.adoc
@@ -6,7 +6,7 @@
 = Release notes for {gitops-title} 1.4.2
 
 [role="_abstract"]
-{gitops-title} 1.4.2 is now available on {product-title} 4.7, 4.8, and 4.9.
+{gitops-title} 1.4.2 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
 
 [id="fixed-issues-1-4-2_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-4-3.adoc
+++ b/modules/gitops-release-notes-1-4-3.adoc
@@ -6,7 +6,7 @@
 = Release notes for {gitops-title} 1.4.3
 
 [role="_abstract"]
-{gitops-title} 1.4.3 is now available on {product-title} 4.7, 4.8, and 4.9.
+{gitops-title} 1.4.3 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
 
 [id="fixed-issues-1-4-3_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-4-5.adoc
+++ b/modules/gitops-release-notes-1-4-5.adoc
@@ -6,7 +6,7 @@
 = Release notes for {gitops-title} 1.4.5
 
 [role="_abstract"]
-{gitops-title} 1.4.5 is now available on {product-title} 4.7, 4.8, 4.9 and 4.10.
+{gitops-title} 1.4.5 is now available on {product-title} 4.7, 4.8, 4.9, and 4.10.
 
 [id="fixed-issues-1-4-5_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-0.adoc
+++ b/modules/gitops-release-notes-1-5-0.adoc
@@ -6,7 +6,7 @@
 = Release notes for {gitops-title} 1.5.0
 
 [role="_abstract"]
-{gitops-title} 1.5.0 is now available on {product-title} 4.8 and above.
+{gitops-title} 1.5.0 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="new-features-1-5-0_{context}"]
 == New features

--- a/modules/gitops-release-notes-1-5-1.adoc
+++ b/modules/gitops-release-notes-1-5-1.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-1_{context}"]
 = Release notes for {gitops-title} 1.5.1
 
-{gitops-title} 1.5.1 is now available on {product-title} 4.8 and above.
+{gitops-title} 1.5.1 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="fixed-issues-1-5-1_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-2.adoc
+++ b/modules/gitops-release-notes-1-5-2.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-2_{context}"]
 = Release notes for {gitops-title} 1.5.2
 
-{gitops-title} 1.5.2 is now available on {product-title} 4.8 and above.
+{gitops-title} 1.5.2 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="fixed-issues-1-5-2_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-3.adoc
+++ b/modules/gitops-release-notes-1-5-3.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-3_{context}"]
 = Release notes for {gitops-title} 1.5.3
 
-{gitops-title} 1.5.3 is now available on {product-title} 4.8 and above.
+{gitops-title} 1.5.3 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="fixed-issues-1-5-3_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-4.adoc
+++ b/modules/gitops-release-notes-1-5-4.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-4_{context}"]
 = Release notes for {gitops-title} 1.5.4
 
-{gitops-title} 1.5.4 is now available on {product-title} 4.8 and above.
+{gitops-title} 1.5.4 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="fixed-issues-1-5-4_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-5.adoc
+++ b/modules/gitops-release-notes-1-5-5.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-5_{context}"]
 = Release notes for {gitops-title} 1.5.5
 
-{gitops-title} 1.5.5 is now available on {product-title} 4.8 and above.
+{gitops-title} 1.5.5 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="new-features-1-5-5_{context}"]
 == New features

--- a/modules/gitops-release-notes-1-5-6.adoc
+++ b/modules/gitops-release-notes-1-5-6.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-6_{context}"]
 = Release notes for {gitops-title} 1.5.6
 
-{gitops-title} 1.5.6 is now available on {product-title} 4.8 and above.
+{gitops-title} 1.5.6 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="fixed-issues-1-5-6_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-7.adoc
+++ b/modules/gitops-release-notes-1-5-7.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-7_{context}"]
 = Release notes for {gitops-title} 1.5.7
 
-{gitops-title} 1.5.7 is now available on {product-title} 4.8, 4.9, 4.10 and 4.11.
+{gitops-title} 1.5.7 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="fixed-issues-1-5-7_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-5-9.adoc
+++ b/modules/gitops-release-notes-1-5-9.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-5-9_{context}"]
 = Release notes for {gitops-title} 1.5.9
 
-{gitops-title} 1.5.9 is now available on {product-title} 4.8, 4.9, 4.10, 4.11, and 4.12.
+{gitops-title} 1.5.9 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="fixed-issues-1-5-9_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-6-0.adoc
+++ b/modules/gitops-release-notes-1-6-0.adoc
@@ -6,7 +6,7 @@
 [id="gitops-release-notes-1-6-0_{context}"]
 = Release notes for {gitops-title} 1.6.0
 
-{gitops-title} 1.6.0 is now available on {product-title} 4.8 and above.
+{gitops-title} 1.6.0 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="new-features-1-6-0_{context}"]
 == New features
@@ -31,7 +31,7 @@ include::snippets/technology-preview.adoc[]
 
 * With this update, you can add entries to the `argocd-cm` configMap using the `extraConfig` field of {gitops-title} Argo CD custom resource. The specified entries are reconciled to the live `config-cm` configMap without validations. link:https://issues.redhat.com/browse/GITOPS-1964[GITOPS-1964]
 
-* With this update, on {product-title} 4.11 and later, the {gitops-title} **Environments Details** page in the {gitops-title} developer perspective shows the history of successful deployments of application environments, along with links to the revisions for each deployment. link:https://issues.redhat.com/browse/GITOPS-1269[GITOPS-1269]
+* With this update, on {product-title} 4.11, the {gitops-title} *Environments* page in the *Developer* perspective shows history of the successful deployments of the application environments, along with links to the revision for each deployment. link:https://issues.redhat.com/browse/GITOPS-1269[GITOPS-1269]
 
 * With this update, you can manage resources with Argo CD that are also being used as template resources or "source" by an Operator. link:https://issues.redhat.com/browse/GITOPS-982[GITOPS-982]
 

--- a/modules/gitops-release-notes-1-6-1.adoc
+++ b/modules/gitops-release-notes-1-6-1.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-6-1_{context}"]
 = Release notes for {gitops-title} 1.6.1
 
-{gitops-title} 1.6.1 is now available on {product-title} 4.8 and above.
+{gitops-title} 1.6.1 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="fixed-issues-1-6-1_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-6-4.adoc
+++ b/modules/gitops-release-notes-1-6-4.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-6-4_{context}"]
 = Release notes for {gitops-title} 1.6.4
 
-{gitops-title} 1.6.4 is now available on {product-title} 4.8, 4.9, 4.10, 4.11, and 4.12.
+{gitops-title} 1.6.4 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
 
 [id="fixed-issues-1-6-4_{context}"]
 == Fixed issues

--- a/modules/gitops-release-notes-1-7-0.adoc
+++ b/modules/gitops-release-notes-1-7-0.adoc
@@ -6,7 +6,7 @@
 [id="gitops-release-notes-1-7-0_{context}"]
 = Release notes for {gitops-title} 1.7.0
 
-{gitops-title} 1.7.0 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
+{gitops-title} 1.7.0 is now available on {product-title} 4.10, 4.11, and 4.12.
 
 [id="new-features-1-7-0_{context}"]
 == New features
@@ -38,7 +38,7 @@ link:https://issues.redhat.com/browse/GITOPS-1561[GITOPS-1561]
 In future releases, there is a possibility to deprecate the old method of customizing resource behavior by using only resourceCustomization and not subkeys.
 ====
 
-* With this update, to use the *Environments* feature on the *Developer* tab you must upgrade if you are using a {gitops-title} version prior to 1.7 and {product-title} 4.15 or above. link:https://issues.redhat.com/browse/GITOPS-2415[GITOPS-2415] 
+* With this update, to use the *Environments* page in the *Developer* perspective, you must upgrade if you are using a {gitops-title} version prior to 1.7 and {product-title} 4.15 or above. link:https://issues.redhat.com/browse/GITOPS-2415[GITOPS-2415] 
 
 * With this update, you can create applications, which are managed by the same control plane Argo CD instance, in any namespace in the same cluster. As an administrator, perform the following actions to enable this update: 
 ** Add the namespace to the `.spec.sourceNamespaces` attribute for a cluster-scoped Argo CD instance that manages the application.

--- a/modules/gitops-release-notes-1-7-1.adoc
+++ b/modules/gitops-release-notes-1-7-1.adoc
@@ -6,7 +6,7 @@
 [id="gitops-release-notes-1-7-1_{context}"]
 = Release notes for {gitops-title} 1.7.1
 
-{gitops-title} 1.7.1 is now available on {product-title} 4.8, 4.9, 4.10, 4.11, and 4.12.
+{gitops-title} 1.7.1 is now available on {product-title} 4.10, 4.11, and 4.12.
 
 [id="errata-updates-1-7-1_{context}"]
 == Errata updates

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -2,6 +2,8 @@
 //
 // * gitops/gitops-release-notes.adoc
 
+:_content-type: REFERENCE
+[id="GitOps-compatibility-support-matrix_{context}"]
 = Compatibility and support matrix
 
 Some features in this release are currently in link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]. These experimental features are not intended for production use.
@@ -10,21 +12,46 @@ In the table, features are marked with the following statuses:
 
 * *TP*: _Technology Preview_
 * *GA*: _General Availability_
+* *NA*: _Not Applicable_
 
 |===
-|*OpenShift GitOps* 8+|*Component Versions*|*OpenShift Versions*
+|*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
 
-|*Version* |*kam*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |*Notifications Controller*|
-|1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |2.4.5 GA       |2.35.1 GA |7.5.1 GA |2.4.5 TP|4.8-4.11
-|1.6.0    |0.0.46 TP |3.8.1 GA|4.4.1 GA   |2.4.5 GA |2.4.5 GA       |2.30.3 GA |7.5.1 GA |2.4.5 TP|4.8-4.10
-|1.5.0    |0.0.42 TP|3.8.0 GA|4.4.1 GA   |2.3.3 GA |0.4.1 TP        |2.30.3 GA |7.5.1 GA ||4.8-4.10
-|1.4.0    |0.0.41 TP|3.7.1 GA|4.2.0 GA   |2.2.2 GA |0.2.0 TP        |2.30.0 GA |7.4.0 GA ||4.7-4.9
-|1.3.0    |0.0.40 TP|3.6.0 GA|4.2.0 GA   |2.1.2 GA |0.2.0 TP        |2.28.0 GA |7.4.0 GA ||4.7-4.9
-
+|*Version* |*kam*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |
+|1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
+|1.6.0    |0.0.46 TP |3.8.1 GA|4.4.1 GA   |2.4.5 GA |GA and included in ArgoCD component    |2.30.3 GA |7.5.1 GA |4.8-4.11
+|1.5.0    |0.0.42 TP|3.8.0 GA|4.4.1 GA   |2.3.3 GA |0.4.1 TP       |2.30.3 GA |7.5.1 GA |4.8-4.11
+|1.4.0    |0.0.41 TP|3.7.1 GA|4.2.0 GA   |2.2.2 GA |0.2.0 TP       |2.30.0 GA |7.4.0 GA |4.7-4.10
+|1.3.0    |0.0.40 TP|3.6.0 GA|4.2.0 GA   |2.1.2 GA |0.2.0 TP       |2.28.0 GA |7.4.0 GA |4.7-4.9, 4.6 with limited GA support
+|1.2.0    |0.0.38 TP |3.5.0 GA |3.9.4 GA  |2.0.5 GA |0.1.0 TP      |NA |7.4.0 GA|4.8
+|1.1.0    |0.0.32 TP |3.5.0 GA |3.9.4 GA  |2.0.0 GA |NA            |NA |NA |4.7
 |===
 
 * "kam" is an abbreviation for {gitops-title} Application Manager (kam).
 * "RH SSO" is an abbreviation for Red Hat SSO.
-* The *Environments* page in the *Developer* perspective of the {product-title} web console is also in Technology Preview.
 
 // Writer, to update this support matrix, refer to https://spaces.redhat.com/display/GITOPS/GitOps+Component+Matrix
+
+[id="GitOps-technology-preview_{context}"]
+== Technology Preview features
+
+The features mentioned in the following table are currently in Technology Preview (TP). These experimental features are not intended for production use. 
+
+.Technology Preview tracker
+[cols="4,1,1",options="header"]
+|====
+|Feature |TP in OCP versions|GA in OCP versions
+
+|Argo CD applications in non-control plane namespaces
+|4.8, 4.9, 4.10, 4.11, 4.12
+|NA
+
+|The {gitops-title} *Environments* page in the *Developer* perspective of the {product-title} web console 
+|4.7, 4.8, 4.9, 4.10, 4.11, 4.12
+|NA
+
+
+|Argo CD Notifications controller
+|4.8, 4.9, 4.10, 4.11, 4.12
+|NA
+|====


### PR DESCRIPTION
Manual CP from https://github.com/openshift/openshift-docs/pull/56052 to 4.9

Aligned team: Dev Tools

Purpose: To resolve the following issue:
https://issues.redhat.com/browse/RHDEVDOCS-4958
https://issues.redhat.com/browse/GITOPS-1776

OCP version this PR applies to: enterprise 4.9