### PR TITLE
[WIP] Update node tasks docs with pxe booting

### DIFF
--- a/modules/machine-user-infra-machines-pxe.adoc
+++ b/modules/machine-user-infra-machines-pxe.adoc
@@ -20,7 +20,7 @@ You can create more {op-system-first} compute machines for your bare metal clust
 
 . Confirm that your PXE or iPXE installation for the {op-system} images is correct.
 
-** For PXE:
+** For PXE (x86_64):
 +
 ----
 DEFAULT pxeboot
@@ -33,25 +33,45 @@ LABEL pxeboot
 <1> Specify the location of the live `kernel` file that you uploaded to your HTTP server.
 <2> Specify locations of the {op-system} files that you uploaded to your HTTP server. The `initrd` parameter value is the location of the live `initramfs` file, the `coreos.inst.ignition_url` parameter value is the location of the worker Ignition config file, and the `coreos.live.rootfs_url` parameter value is the location of the live `rootfs` file. The `coreos.inst.ignition_url` and `coreos.live.rootfs_url` parameters only support HTTP and HTTPS.
 +
-+
 [NOTE]
 ====
 This configuration does not enable serial console access on machines with a graphical console.  To configure a different console, add one or more `console=` arguments to the `APPEND` line.  For example, add `console=tty0 console=ttyS0` to set the first PC serial port as the primary console and the graphical console as a secondary console.  For more information, see link:https://access.redhat.com/articles/7212[How does one set up a serial terminal and/or console in Red Hat Enterprise Linux?].
 ====
-
-** For iPXE:
+** For iPXE (x86_64 or AArch64):
 +
 ----
-kernel http://<HTTP_server>/rhcos-<version>-live-kernel-<architecture> initrd=main coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/worker.ign coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img <1>
-initrd --name main http://<HTTP_server>/rhcos-<version>-live-initramfs.<architecture>.img <2>
+kernel http://<HTTP_server>/rhcos-<version>-live-kernel-<architecture> initrd=main coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1> <2>
+initrd --name main http://<HTTP_server>/rhcos-<version>-live-initramfs.<architecture>.img <3>
+boot
 ----
 <1> Specify locations of the {op-system} files that you uploaded to your HTTP server. The `kernel` parameter value is the location of the `kernel` file, the `initrd=main` argument is needed for booting on UEFI systems, the `coreos.inst.ignition_url` parameter value is the location of the worker Ignition config file, and the `coreos.live.rootfs_url` parameter value is the location of the live `rootfs` file. The `coreos.inst.ignition_url` and `coreos.live.rootfs_url` parameters only support HTTP and HTTPS.
 <2> Specify the location of the `initramfs` file that you uploaded to your HTTP server.
+<3> Specify the location of the `initramfs` file that you uploaded to your HTTP server.
 +
-+
+
 [NOTE]
 ====
 This configuration does not enable serial console access on machines with a graphical console.  To configure a different console, add one or more `console=` arguments to the `kernel` line.  For example, add `console=tty0 console=ttyS0` to set the first PC serial port as the primary console and the graphical console as a secondary console.  For more information, see link:https://access.redhat.com/articles/7212[How does one set up a serial terminal and/or console in Red Hat Enterprise Linux?].
 ====
++
+[NOTE]
+====
+To network boot the CoreOS `kernel` on `arm64` architecture, you need to use a version of iPXE build with the `IMAGE_GZIP` option enabled. See link:https://ipxe.org/buildcfg/image_gzip[`IMAGE_GZIP` option in iPXE].
+====
+
+** For PXE (with UEFI and Grub as second stage) on AArch64:
++
+----
+menuentry 'Install CoreOS' {
+    linux rhcos-<version>-live-kernel-<architecture>  coreos.live.rootfs_url=http://<HTTP_server>/rhcos-<version>-live-rootfs.<architecture>.img coreos.inst.install_dev=/dev/sda coreos.inst.ignition_url=http://<HTTP_server>/bootstrap.ign <1> <2>
+    initrd rhcos-<version>-live-initramfs.<architecture>.img <3>
+}
+----
+<1> Specify the locations of the {op-system} files that you uploaded to your
+HTTP/TFTP server. The `kernel` parameter value is the location of the `kernel` file on your TFTP server.
+The `coreos.live.rootfs_url` parameter value is the location of the `rootfs` file, and the `coreos.inst.ignition_url` parameter value is the location of the bootstrap Ignition config file on your HTTP Server.
+<2> If you use multiple NICs, specify a single interface in the `ip` option.
+For example, to use DHCP on a NIC that is named `eno1`, set `ip=eno1:dhcp`.
+<3> Specify the location of the `initramfs` file that you uploaded to your TFTP server.
 
 . Use the PXE or iPXE infrastructure to create the required compute machines for your cluster.


### PR DESCRIPTION
**For versions:** 4.10+
**Issue:** Brought up in discussion with SMEs

**Description:**  Node task pxe boot module is missing pxe booting with aarch64 architecture. This PR adds the booting sample for aarch64 architectures. 

**Preview**

- [Node tasks -> Creating more RHCOS machines by PXE or iPXE booting](https://56716--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#machine-user-infra-machines-pxe_post-install-node-tasks)