### PR TITLE
[OCPBUGS-8100]: Update the OPP user guide for the latest product versions

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -37,7 +37,11 @@
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:ocp-supported-version: 4.11
+:ocp-supported-version: 4.12
+:rhacs-version: 3.74
+:quay-version: 3.8
+:rhacm-version: 2.7
+:odf-version: 4.12
 // Following variables are required for publishing using PV2
 :product-title: OpenShift Platform Plus
 :product-version: .1

--- a/modules/opp-architecture-architecture.adoc
+++ b/modules/opp-architecture-architecture.adoc
@@ -13,7 +13,7 @@
 * Integrated data management
 * A global container registry
 
-{product-title} protects and manages applications across open hybrid cloud environments and application lifecycles.
+{product-title} protects and manages applications for open hybrid cloud environments and application lifecycles.
 
 image::242_OpenShift_Plus_0422.png[]
 

--- a/modules/opp-architecture-compatibility-matrix.adoc
+++ b/modules/opp-architecture-compatibility-matrix.adoc
@@ -15,8 +15,8 @@
 |{quay}
 |{rh-storage-essentials-first}
 
-|2.6
-|3.73
-|3.8
-|4.11
+|{rhacm-version}
+|{rhacs-version}
+|{quay-version}
+|{odf-version}
 |===

--- a/modules/opp-architecture-installation.adoc
+++ b/modules/opp-architecture-installation.adoc
@@ -8,8 +8,8 @@
 
 To install {product-title}, you must install two products in a specific order. Install {ocp} first. Then, install {rh-rhacm}. It does not matter what order you install the remaining products: {quay}, {rh-storage-essentials-first}, and {acs}. See the following detailed installation information for each product:
 
-* {ocp} - link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
-* {rh-rhacm} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.0/html/install/installing[Installing {rh-rhacm}]
-* {acs} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.73/html/installing/installing-rhacs-on-red-hat-openshift[Installing {acs-short} on Red Hat OpenShift]
-* {rh-storage-essentials-first} - link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.11[Deploying {rh-storage-data-foundation}]
+* {ocp} - link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
+* {rh-rhacm} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/install/installing[Installing {rh-rhacm}]
+* {acs} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.74/html/installing/installing-rhacs-on-red-hat-openshift#install-rhacs-ocp[Installing {acs-short} on Red Hat OpenShift]
+* {rh-storage-essentials-first} - link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12[Deploying {rh-storage-data-foundation}]
 * {quay} - link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.8/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/index[Deploy {quay} on OpenShift with the Quay Operator]

--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -8,8 +8,8 @@
 
 The release note information for each product is accessible from the following list:
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/release_notes/index[{ocp}]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/release_notes/red-hat-advanced-cluster-management-for-kubernetes-release-notes[{rh-rhacm} for Kubernetes]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/release_notes/index[{ocp}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/release_notes/red-hat-advanced-cluster-management-for-kubernetes-release-notes[{rh-rhacm} for Kubernetes]
 * link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.8/html/red_hat_quay_release_notes/index[{quay} Release Notes]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.73/html/release_notes/release-notes-373[{acs} for Kubernetes 3.7.3]
-* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.11/html/4.11_release_notes/index[{rh-storage-data-foundation}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.74/html/release_notes/index[{acs} for Kubernetes 3.7.4]
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/4.12_release_notes/index[{rh-storage-data-foundation}]

--- a/modules/opp-architecture-support.adoc
+++ b/modules/opp-architecture-support.adoc
@@ -8,4 +8,4 @@
 
 Red Hat offers cluster administrator tools for gathering data, monitoring, and troubleshooting your cluster.
 
-If you need assistance with your {product-title} solution, log a case in the appropriate product using its entitlement name. See the link:https://access.redhat.com/support/cases/#/case/list?query=%20orderBy%20lastModifiedDate%20desc&p=1&size=10&searchType=basic[Red Hat customer support portal] to open a support case.
+If you need help with your {product-title} solution, log a case in the appropriate product by using its subscription name. See the link:https://access.redhat.com/support/cases/#/case/list?query=%20orderBy%20lastModifiedDate%20desc&p=1&size=10&searchType=basic[Red Hat customer support portal] to open a support case.


### PR DESCRIPTION
[OCPBUGS-8100](https://issues.redhat.com/browse/OCPBUGS-8100)

Version: This PR is based on the ‘opp-docs’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Link to docs preview (3/27): http://file.rdu.redhat.com/tlove/opp-ocpbugs-8100-tlove/architecture/opp-architecture.html#opp-architecture-support_opp-architecture

QE review:
- [x ] QE has approved this change.
