### PR TITLE
OSDOCS-4810: Added module for deleting AWS LZ cluster

### DIFF
--- a/installing/installing_aws/installing-aws-localzone.adoc
+++ b/installing/installing_aws/installing-aws-localzone.adoc
@@ -110,15 +110,6 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 
 * See xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about the Telemetry service.
 
-[role="_additional-resources"]
-[id="installing-localzone-additional-resources"]
-== Additional resources
-
-* See link:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacks.html[Working with stacks] in the AWS documentation for more information about AWS CloudFormation stacks.
-* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#opt-in-local-zone[Opt into AWS Local Zones]
-* link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/locations[AWS Local Zones available locations]
-* link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/features[AWS Local Zones features]
-
 [id="installing-aws-localzone-next-steps"]
 == Next steps
 

--- a/installing/installing_aws/uninstalling-cluster-aws.adoc
+++ b/installing/installing_aws/uninstalling-cluster-aws.adoc
@@ -11,3 +11,14 @@ You can remove a cluster that you deployed to Amazon Web Services (AWS).
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]
 
 include::modules/cco-ccoctl-deleting-sts-resources.adoc[leveloffset=+1]
+
+include::modules/installation-aws-delete-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="installing-localzone-additional-resources"]
+.Additional resources
+
+* See link:https://docs.aws.amazon.com/AWSCloudFormation/latest/UserGuide/stacks.html[Working with stacks] in the AWS documentation for more information about AWS CloudFormation stacks.
+* link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#opt-in-local-zone[Opt into AWS Local Zones]
+* link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/locations[AWS Local Zones available locations]
+* link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/features[AWS Local Zones features]

--- a/modules/installation-aws-delete-cluster.adoc
+++ b/modules/installation-aws-delete-cluster.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/uninstalling-cluster-aws.adoc
+
+:_content-type: PROCEDURE
+[id="installation-aws-delete-cluster"]
+= Deleting a cluster with a configured AWS Local Zone infrastructure
+
+After you install a cluster on Amazon Web Services (AWS) into an existing Virtual Private Cloud (VPC), and you set subnets for each Local Zone location, you can delete the cluster and any AWS resources associated with it. 
+
+The example in the procedure assumes that you created a VPC and its subnets by using a CloudFormation template.
+
+.Prerequisites
+
+* You know the name of the CloudFormation stacks, `<local_zone_stack_name>` and `<vpc_stack_name>`, that were used during the creation of the network. You need the name of the stack to delete the cluster.
+* You have access rights to the directory that contains the installation files that were created by the installation program. 
+* Your account includes a policy that provides you with permissions to delete the CloudFormation stack.
+
+.Procedure
+
+. Change to the directory that contains the stored installation program, and delete the cluster by using the `destroy cluster` command:
++
+[source,terminal]
+----
+$ ./openshift-install destroy cluster --dir <installation_directory> \//<1> 
+   --log-level=debug <2>
+----
+<1> For `<installation_directory>`, specify the directory that stored any files created by the installation program.
+<2> To view different log details, specify `error`, `info`, or `warn` instead of `debug`.
+
+. Delete the CloudFormation stack for the Local Zone subnet:
++
+[source,terminal]
+----
+$ aws cloudformation delete-stack --stack-name <local_zone_stack_name>
+----
+
+. Delete the stack of resources that represent the VPC:
++
+[source,terminal]
+----
+$ aws cloudformation delete-stack --stack-name <vpc_stack_name>
+----
+
+.Verification
+
+* Check that you removed the stack resources by issuing the following commands in the AWS CLI. The AWS CLI outputs that no template component exists. 
++
+[source,terminal]
+----
+$ aws cloudformation describe-stacks --stack-name <local_zone_stack_name> 
+----
++
+[source,terminal]
+----
+$ aws cloudformation describe-stacks --stack-name <vpc_stack_name> 
+----


### PR DESCRIPTION
[OSDOCS-4810](https://issues.redhat.com/browse/OSDOCS-4810)

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
4.12 and 4.13

Link to docs preview: [Deleting a cluster with a configured AWS Local Zone infrastructure](https://56723--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/uninstalling-cluster-aws.html#installation-aws-delete-cluster)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
