### PR TITLE
OSDOCS#4895: Installing a three-node vSphere cluster

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -466,6 +466,8 @@ Topics:
     File: installing-restricted-networks-installer-provisioned-vsphere
   - Name: Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure
     File: installing-restricted-networks-vsphere
+  - Name: Installing a three-node cluster on vSphere
+    File: installing-vsphere-three-node
   - Name: Uninstalling a cluster on vSphere that uses installer-provisioned infrastructure
     File: uninstalling-cluster-vsphere-installer-provisioned
   - Name: Using the vSphere Problem Detector Operator
@@ -490,6 +492,8 @@ Topics:
     File: installing-vmc-network-customizations-user-infra
   - Name: Installing a cluster on VMC in a restricted network with user-provisioned infrastructure
     File: installing-restricted-networks-vmc-user-infra
+  - Name: Installing a three-node cluster on VMC
+    File: installing-vmc-three-node
   - Name: Uninstalling a cluster on VMC
     File: uninstalling-cluster-vmc
 - Name: Installing on any platform

--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on AWS with customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-aws-customizations
+:platform: AWS
 
 toc::[]
 

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates
 include::_attributes/common-attributes.adoc[]
 :context: installing-aws-user-infra
+:platform: AWS
 
 toc::[]
 

--- a/installing/installing_vmc/installing-vmc-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-customizations.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on VMC with customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-vmc-customizations
+:platform: VMC
 
 toc::[]
 

--- a/installing/installing_vmc/installing-vmc-three-node.adoc
+++ b/installing/installing_vmc/installing-vmc-three-node.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+[id="installing-vmc-three-node"]
+= Installing a three-node cluster on VMC
+include::_attributes/common-attributes.adoc[]
+:context: installing-vmc-three-node
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a three-node cluster on your VMware vSphere instance by deploying it to link:https://cloud.vmware.com/vmc-aws[VMware Cloud (VMC) on AWS]. A three-node cluster consists of three control plane machines, which also act as compute machines. This type of cluster provides a smaller, more resource efficient cluster, for cluster administrators and developers to use for testing, development, and production.
+
+You can install a three-node cluster using either installer-provisioned or user-provisioned infrastructure.
+
+include::modules/installation-three-node-cluster-cloud-provider.adoc[leveloffset=+1]
+
+== Next steps
+* xref:../../installing/installing_vmc/installing-vmc-customizations.adoc#installing-vmc-customizations[Installing a cluster on VMC with customizations]
+* xref:../../installing/installing_vmc/installing-vmc-user-infra.adoc#installing-vmc-user-infra[Installing a cluster on VMC with user-provisioned infrastructure]

--- a/installing/installing_vmc/installing-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-user-infra.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on VMC with user-provisioned infrastructure
 include::_attributes/common-attributes.adoc[]
 :context: installing-vmc-user-infra
+:platform: VMC
 
 toc::[]
 

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on vSphere with customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere-installer-provisioned-customizations
+:platform: vSphere
 
 toc::[]
 

--- a/installing/installing_vsphere/installing-vsphere-three-node.adoc
+++ b/installing/installing_vsphere/installing-vsphere-three-node.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+[id="installing-vsphere-three-node"]
+= Installing a three-node cluster on vSphere
+include::_attributes/common-attributes.adoc[]
+:context: installing-vsphere-three-node
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a three-node cluster on VMware vSphere. A three-node cluster consists of three control plane machines, which also act as compute machines. This type of cluster provides a smaller, more resource efficient cluster, for cluster administrators and developers to use for testing, development, and production.
+
+You can install a three-node cluster using either installer-provisioned or user-provisioned infrastructure.
+
+include::modules/installation-three-node-cluster-cloud-provider.adoc[leveloffset=+1]
+
+== Next steps
+* xref:../../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installing-vsphere-installer-provisioned-customizations[Installing a cluster on vSphere with customizations]
+* xref:../../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[Installing a cluster on vSphere with user-provisioned infrastructure]

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on vSphere with user-provisioned infrastructure
 include::_attributes/common-attributes.adoc[]
 :context: installing-vsphere
+:platform: vSphere
 
 toc::[]
 

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -66,6 +66,12 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :ibm-cloud-private:
 endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:three-node-cluster:
+endif::[]
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:three-node-cluster:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-initializing-manual_{context}"]
@@ -196,6 +202,10 @@ Make the following modifications:
 For more information about the parameters, see "Installation configuration parameters".
 endif::ash-default,ash-network[]
 
+ifdef::three-node-cluster[]
+. If you are installing a three-node cluster, modify the `install-config.yaml` file by setting the `compute.replicas` parameter to `0`. This ensures that the cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on {platform}".
+endif::three-node-cluster[]
+
 . Back up the `install-config.yaml` file so that you can use it to install
 multiple clusters.
 +
@@ -250,3 +260,10 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :!ibm-cloud-private:
 endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:!three-node-cluster:
+endif::[]
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:!three-node-cluster:
+endif::[]
+:!platform:

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -152,12 +152,14 @@ ifeval::["{context}" == "installing-rhv-default"]
 endif::[]
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
 :vsphere:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
 :vsphere:
 endif::[]
 ifeval::["{context}" == "installing-vmc-customizations"]
 :vsphere:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-vmc-network-customizations"]
 :vsphere:
@@ -477,7 +479,7 @@ ifdef::three-node-cluster[]
 +
 [NOTE]
 ====
-If you are installing a three-node cluster, be sure to set the `compute.replicas` parameter to `0`. This ensures that cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on AWS".
+If you are installing a three-node cluster, be sure to set the `compute.replicas` parameter to `0`. This ensures that cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on {platform}".
 ====
 endif::three-node-cluster[]
 
@@ -772,12 +774,14 @@ ifeval::["{context}" == "installing-rhv-default"]
 endif::[]
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
 :!vsphere:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
 :!vsphere:
 endif::[]
 ifeval::["{context}" == "installing-vmc-customizations"]
 :!vsphere:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-vmc-network-customizations"]
 :!vsphere:
@@ -801,3 +805,4 @@ ifeval::["{context}" == "installing-restricted-networks-nutanix-installer-provis
 :!nutanix:
 :!restricted:
 endif::[]
+:!platform:

--- a/modules/installation-three-node-cluster-cloud-provider.adoc
+++ b/modules/installation-three-node-cluster-cloud-provider.adoc
@@ -1,7 +1,14 @@
 // Module included in the following assemblies:
 // * installing/installing_aws/installing-aws-three-node.adoc
+// * installing/installing_vsphere/installing-vsphere-three-node.adoc
 // *
-// *
+
+ifeval::["{context}" == "installing-vsphere-three-node"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vmc-three-node"]
+:vmc:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-three-node-cluster_{context}"]
@@ -29,7 +36,15 @@ compute:
   platform: {}
   replicas: 0
 ----
+ifndef::vsphere,vmc[]
 . If you are deploying a cluster with user-provisioned infrastructure, do not create additional worker nodes.
+endif::vsphere,vmc[]
+
+ifdef::vsphere,vmc[]
+. If you are deploying a cluster with user-provisioned infrastructure:
+** Configure your application ingress load balancer to route HTTP and HTTPS traffic to the control plane nodes. In a three-node cluster, the Ingress Controller pods run on the control plane nodes. For more information, see the "Load balancing requirements for user-provisioned infrastructure".
+** Do not create additional worker nodes.
+endif::vsphere,vmc[]
 
 .Verification
 
@@ -52,3 +67,10 @@ spec:
     name: ""
 status: {}
 ----
+
+ifeval::["{context}" == "installing-vsphere-three-node"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vmc-three-node"]
+:!vmc:
+endif::[]

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -77,9 +77,11 @@ ifeval::["{context}" == "installing-openstack-user-sr-iov-kuryr"]
 endif::[]
 ifeval::["{context}" == "installing-vsphere"]
 :vsphere:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-vmc-user-infra"]
 :vmc:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-platform-agnostic"]
 :baremetal:
@@ -542,9 +544,11 @@ ifeval::["{context}" == "installing-openstack-user-sr-iov-kuryr"]
 endif::[]
 ifeval::["{context}" == "installing-vsphere"]
 :!vsphere:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-vmc-user-infra"]
 :!vmc:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :!vsphere:

--- a/modules/machine-vsphere-machines.adoc
+++ b/modules/machine-vsphere-machines.adoc
@@ -8,11 +8,25 @@
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
 // * machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
 
+ifeval::["{context}" == "installing-vsphere"]
+:three-node-cluster:
+endif::[]
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:three-node-cluster:
+endif::[]
+
 :_content-type: PROCEDURE
 [id="machine-vsphere-machines_{context}"]
 = Adding more compute machines to a cluster in vSphere
 
 You can add more compute machines to a user-provisioned {product-title} cluster on VMware vSphere.
+
+ifdef::three-node-cluster[]
+[NOTE]
+====
+If you are installing a three-node cluster, skip this step. A three-node cluster consists of three control plane machines, which also act as compute machines.
+====
+endif::three-node-cluster[]
 
 .Prerequisites
 
@@ -43,3 +57,10 @@ Ensure that all virtual machine names across a vSphere installation are unique.
 .. Complete the configuration and power on the VM.
 
 . Continue to create more compute machines for your cluster.
+
+ifeval::["{context}" == "installing-vsphere"]
+:!three-node-cluster:
+endif::[]
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:!three-node-cluster:
+endif::[]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
This PR addresses [osdocs-4895](https://issues.redhat.com/browse/OSDOCS-4895)

Link to docs preview:

**vSphere**
- [Installing a three-node cluster on vSphere](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-three-node.html)
- Installing a cluster on vSphere with customizations > [Creating the installation configuration file](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-initializing_installing-vsphere-installer-provisioned-customizations) (note under step 2)
- Installing a cluster on vSphere with user-provisioned infrastructure > [Manually creating the installation configuration file](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-initializing-manual_installing-vsphere) (step 3)
- Installing a cluster on vSphere with user-provisioned infrastructure > [Creating the Kubernetes manifest and Ignition config files](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-user-infra-generate-k8s-manifest-ignition_installing-vsphere) (warning before step 3)
- Installing a cluster on vSphere with user-provisioned infrastructure > [Adding more compute machines to a cluster in vSphere](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#machine-vsphere-machines_installing-vsphere) (first note)

**VMC**

- [Installing a three-node cluster on VMC](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-three-node.html)
- Installing a cluster on VMC with customizations > [Creating the installation configuration file](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-customizations.html#installation-initializing_installing-vmc-customizations) (note under step 2)
- Installing a cluster on VMC with user-provisioned infrastructure > [Manually creating the installation configuration file](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-user-infra.html#installation-initializing-manual_installing-vmc-user-infra) (step 3)
- Installing a cluster on VMC with user-provisioned infrastructure > [Creating the Kubernetes manifest and Ignition config files](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-vmc-user-infra) (warning before step 3)
- Installing a cluster on VMC with user-provisioned infrastructure > [Adding more compute machines to a cluster in vSphere](https://56729--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-user-infra.html#machine-vsphere-machines_installing-vmc-user-infra) (first note)

QE review:
- [x] QE has approved this change.


Additional information:
Per the engineering installer [plan](https://docs.google.com/spreadsheets/d/1yl7p0IGQh0itLnoN1eJQWWtBq9zFdjGrM6mSyZVU-Ck/edit#gid=2101423022) this work is QE and docs only. SME approval is not required.