### PR TITLE
OSDOCS-5159 installing on vSphere using encrypted VMs (UPI)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -541,6 +541,8 @@ Topics:
   File: bare-metal-configuration
 - Name: Configuring multi-architecture compute machines on an OpenShift cluster
   File: multi-architecture-configuration
+- Name: Enabling encryption on a vSphere cluster
+  File: vsphere-post-installation-encryption
 - Name: Machine configuration tasks
   File: machine-configuration-tasks
 - Name: Cluster tasks

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -61,6 +61,11 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-vsphere-encrypted-vms.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[Creating an encrypted storage class]
+
 include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
@@ -148,3 +153,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * Optional: xref:../../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#vsphere-problem-detector-viewing-events_vsphere-problem-detector[View the events from the vSphere Problem Detector Operator] to determine if the cluster has permission or storage configuration issues.
+* Optional: if you created encrypted virtual machines, xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[create an encrypted storage class].

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -53,6 +53,11 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-vsphere-encrypted-vms.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[Creating an encrypted storage class]
+
 include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
@@ -135,3 +140,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Set up your registry and configure registry storage].
 * Optional: xref:../../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#vsphere-problem-detector-viewing-events_vsphere-problem-detector[View the events from the vSphere Problem Detector Operator] to determine if the cluster has permission or storage configuration issues.
+* Optional: if you created encrypted virtual machines, xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[create an encrypted storage class].

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -53,6 +53,11 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+include::modules/installation-vsphere-encrypted-vms.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[Creating an encrypted storage class]
+
 include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
@@ -138,3 +143,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Set up your registry and configure registry storage].
 * Optional: xref:../../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#vsphere-problem-detector-viewing-events_vsphere-problem-detector[View the events from the vSphere Problem Detector Operator] to determine if the cluster has permission or storage configuration issues.
+* Optional: if you created encrypted virtual machines, xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[create an encrypted storage class].

--- a/modules/installation-vsphere-encrypted-vms.adoc
+++ b/modules/installation-vsphere-encrypted-vms.adoc
@@ -1,0 +1,20 @@
+// module is included in the following assemblies:
+// ../installing/installing_vsphere/installing-vsphere.adoc
+
+:_content-type: PROCEDURE
+[id="installation-vsphere-encrypted-vms_{context}"]
+= Requirements for encrypting virtual machines
+
+You can encrypt your virtual machines prior to installing {product-title} {product-version} by meeting the following requirements. 
+
+* You have configured a Standard key provider in vSphere. For more information, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vsan.doc/GUID-AC06B3C3-901F-402E-B25F-1EE7809D1264.html[Adding a KMS to vCenter Server].
++
+[IMPORTANT]
+====
+The Native key provider in vCenter is not supported. For more information, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-54B9FBA2-FDB1-400B-A6AE-81BF3AC9DF97.html[vSphere Native Key Provider Overview].
+====
+
+* You have enabled host encryption mode on all of the ESXi hosts that are hosting the cluster. For more information, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-A9E1F016-51B3-472F-B8DE-803F6BDB70BC.html[Enabling host encryption mode].
+* You have a vSphere account which has all cryptographic privileges enabled. For more information, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-660CCB35-847F-46B3-81CA-10DDDB9D7AA9.html[Cryptographic Operations Privileges].
+
+When you deploy the OVF template in the section titled "Installing RHCOS and starting the OpenShift Container Platform bootstrap process", select the option to "Encrypt this virtual machine" when you are selecting storage for the OVF template. After completing cluster installation, create a storage class that uses the encryption storage policy you used to encrypt the virtual machines. 

--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -114,6 +114,7 @@ In the following steps, you create a template and then clone the template for al
 .. On the *Select storage* tab, configure the storage options for your VM.
 *** Select *Thin Provision* or *Thick Provision*, based on your storage preferences.
 *** Select the datastore that you specified in your `install-config.yaml` file.
+*** If you want to encrypt your virtual machines, select *Encrypt this virtual machine*. See the section titled "Requirements for encrypting virtual machines" for more information.
 .. On the *Select network* tab, specify the network that you configured for the cluster, if available.
 .. When creating the OVF template, do not specify values on the *Customize template* tab or configure the template any further.
 +

--- a/modules/vsphere-encrypting-vms.adoc
+++ b/modules/vsphere-encrypting-vms.adoc
@@ -1,0 +1,27 @@
+:_content-type: PROCEDURE
+[id="encrypting-virtual-machines_{context}"]
+= Encrypting virtual machines
+
+You can encrypt your virtual machines with the following process. You can drain your virtual machines, power them down and encrypt them using the vCenter interface. Finally, you can create a storage class to use the encrypted storage.
+
+.Prerequisites
+
+* You have configured a Standard key provider in vSphere. For more information, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vsan.doc/GUID-AC06B3C3-901F-402E-B25F-1EE7809D1264.html[Adding a KMS to vCenter Server].
++
+[IMPORTANT]
+====
+The Native key provider in vCenter is not supported. For more information, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-54B9FBA2-FDB1-400B-A6AE-81BF3AC9DF97.html[vSphere Native Key Provider Overview].
+====
+
+* You have enabled host encryption mode on all of the ESXi hosts that are hosting the cluster. For more information, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-A9E1F016-51B3-472F-B8DE-803F6BDB70BC.html[Enabling host encryption mode].
+* You have a vSphere account which has all cryptographic privileges enabled. For more information, see link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.security.doc/GUID-660CCB35-847F-46B3-81CA-10DDDB9D7AA9.html[Cryptographic Operations Privileges].
+
+.Procedure
+
+. Drain and cordon one of your nodes. For detailed instructions on node management, see "Working with Nodes".
+. Shutdown the virtual machine associated with that node in the vCenter interface.
+. Right-click on the virtual machine in the vCenter interface and select *VM Policies* -> *Edit VM Storage Policies*.
+. Select an encrypted storage policy and select *OK*.
+. Start the encrypted virtual machine in the vCenter interface.
+. Repeat steps 1-5 for all nodes that you want to encrypt.
+. Configure a storage class that uses the encrypted storage policy. For more information about configuring an encrypted storage class, see "VMware vSphere CSI Driver Operator".

--- a/post_installation_configuration/vsphere-post-installation-encryption.adoc
+++ b/post_installation_configuration/vsphere-post-installation-encryption.adoc
@@ -1,0 +1,18 @@
+:_content-type: ASSEMBLY
+[id="vsphere-post-installation-encryption"]
+= Enabling encryption on a vSphere cluster
+include::_attributes/common-attributes.adoc[]
+:context: vsphere-post-installation-encryption
+
+toc::[]
+
+You can encrypt your virtual machines after installing {product-title} {product-version} on vSphere by draining and shutting down your nodes one at a time. While each virtual machine is shutdown, you can enable encryption in the vCenter web interface.
+
+include::modules/vsphere-encrypting-vms.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_enabling-encryption-installation"]
+== Additional resources
+* xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-evacuating_nodes-nodes-working[Working with nodes]
+* xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[vSphere encryption]
+* xref:../installing/installing_vsphere/installing-vsphere.adoc#installation-vsphere-encrypted-vms_installing-vsphere[Installing a cluster on vSphere with user-provisioned infrastructure]


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5159

Link to docs preview:
[Requirements for encrypting VMs](https://56739--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-encrypted-vms_installing-vsphere)
[Encrypting VM (step 7)](https://56739--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere)
[Enabling encryption post-installation](https://56739--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/vsphere-post-installation-encryption.html)

QE review:
- [X] QE has approved this change.

Note: the xref to the storage class content is based on https://github.com/openshift/openshift-docs/pull/56655