### PR TITLE
OSDOCS#5140:Adds a step that console supports Operator to specify where to run with CSV suggested namespace

### DIFF
--- a/modules/osdk-csv-manual-annotations.adoc
+++ b/modules/osdk-csv-manual-annotations.adoc
@@ -23,6 +23,9 @@ The following table lists Operator metadata annotations that can be manually def
 |`operatorframework.io/suggested-namespace`
 |Set a suggested namespace where the Operator should be deployed.
 
+|`operatorframework.io/suggested-namespace-template`
+|Set a manifest for a Namespace object with the namespace default node selector specified.
+
 |`operators.openshift.io/infrastructure-features`
 |Infrastructure features supported by the Operator. Users can view and filter by these features when discovering Operators through OperatorHub in the web console. Valid, case-sensitive values:
 

--- a/modules/osdk-suggested-namespace-node-selector.adoc
+++ b/modules/osdk-suggested-namespace-node-selector.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * operators/operator_sdk/osdk-generating-csvs.adoc
+
+:_content-type: PROCEDURE
+[id="osdk-suggested-namespace-default-node_{context}"]
+= Setting a suggested namespace with default node selector
+
+Some Operators expect to run only on control plane nodes, which can be done by setting a `nodeSelector` in the `Pod` spec by the Operator itself.
+
+To avoid getting duplicated and potentially conflicting cluster-wide default `nodeSelector`, you can set a default node selector on the namespace where the Operator runs. The default node selector will take precedence over the cluster default so the cluster default will not be applied to the pods in the Operators namespace.
+
+When adding the Operator to a cluster using OperatorHub, the web console auto-populates the suggested namespace for the cluster administrator during the installation process. The suggested namespace is created using the namespace manifest in YAML which is included in the cluster service version (CSV).
+
+.Procedure
+
+* In your CSV, set the `operatorframework.io/suggested-namespace-template` with a manifest for a `Namespace` object. The following sample is a manifest for an example `Namespace` with the namespace default node selector specified:
++
+[source,yaml]
+----
+metadata:
+  annotations:
+    operatorframework.io/suggested-namespace-template: <1>
+      {
+        "apiVersion": "v1",
+        "kind": "Namespace",
+        "metadata": {
+          "name": "vertical-pod-autoscaler-suggested-template",
+          "annotations": {
+            "openshift.io/node-selector": ""
+          }
+        }
+      }
+----
+<1> Set your suggested namespace.
++
+[NOTE]
+====
+If both `suggested-namespace` and `suggested-namespace-template` annotations are present in the CSV, `suggested-namespace-template` should take precedence.
+====

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -38,6 +38,7 @@ include::modules/osdk-csv-manual-annotations.adoc[leveloffset=+2]
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-init-resource_osdk-generating-csvs[Initializing required custom resources
 ]
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-suggested-namespace_osdk-generating-csvs[Setting a suggested namespace]
+* xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-suggested-namespace-default-node_osdk-generating-csvs[Setting a suggested namespace with default node selector]
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#olm-enabling-operator-for-restricted-network_osdk-generating-csvs[Enabling your Operator for restricted network environments] (disconnected mode)
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-hiding-internal-objects_osdk-generating-csvs[Hiding internal objects]
 * xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS crytography]
@@ -53,6 +54,7 @@ include::modules/olm-enabling-operator-for-multi-arch.adoc[leveloffset=+1]
 include::modules/olm-arch-os-support.adoc[leveloffset=+2]
 
 include::modules/osdk-suggested-namespace.adoc[leveloffset=+1]
+include::modules/osdk-suggested-namespace-node-selector.adoc[leveloffset=+1]
 include::modules/osdk-operatorconditions.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
OSDOCS#5140:Adds a step that console supports Operator to specify where to run with CSV suggested namespace

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5410
https://issues.redhat.com/browse/OSDOCS-5163

Link to docs preview:
https://56747--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html#osdk-suggested-namespace-default-node_osdk-generating-csvs

Table: https://56747--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-manual-annotations_osdk-generating-csvs

Additional references addition: https://56747--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html#osdk-csv-manual-annotations_osdk-generating-csvs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
