### PR TITLE
Fix version in out-of-date OSDK note

### DIFF
--- a/cli_reference/osdk/cli-osdk-install.adoc
+++ b/cli_reference/osdk/cli-osdk-install.adoc
@@ -14,7 +14,7 @@ See xref:../../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Oper
 
 [NOTE]
 ====
-{product-title} 4.9 and later supports Operator SDK v1.16.0.
+{product-title} {product-version} supports Operator SDK {osdk_ver}.
 ====
 
 include::modules/osdk-installing-cli-linux-macos.adoc[leveloffset=+1]

--- a/operators/operator_sdk/osdk-about.adoc
+++ b/operators/operator_sdk/osdk-about.adoc
@@ -28,7 +28,7 @@ Operator authors with cluster administrator access to a Kubernetes-based cluster
 
 [NOTE]
 ====
-{product-title} {product-version} supports Operator SDK v1.25.4 or later.
+{product-title} {product-version} supports Operator SDK {osdk_ver}.
 ====
 
 [id="osdk-about-what-are-operators"]


### PR DESCRIPTION
No JIRA.

Noticed 4.10 and later were still showing 4.9-related info in https://docs.openshift.com/container-platform/4.10/cli_reference/osdk/cli-osdk-install.html.

4.12+ 

Manual fixes for branches that did not get the recent `osdk_ver` common attribute changes:

4.11: https://github.com/openshift/openshift-docs/pull/56756
4.10: https://github.com/openshift/openshift-docs/pull/56755

Preview: https://56753--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/osdk/cli-osdk-install.html