### PR TITLE
OSDOCS-4928: Docs for cert-manager operator GA

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -949,7 +949,10 @@ Topics:
     File: cert-manager-operator-release-notes
   - Name: Installing the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-operator-install
-    # For GA release, add details here on requesting certificates, etc.
+  - Name: Managing certificates with an ACME issuer
+    File: cert-manager-operator-issuer-acme
+  - Name: Configuring the egress proxy for the cert-manager Operator for Red Hat OpenShift
+    File: cert-manager-operator-proxy
   - Name: Uninstalling the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-operator-uninstall
 - Name: Viewing audit logs

--- a/modules/cert-manager-acme-about.adoc
+++ b/modules/cert-manager-acme-about.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc
+
+:_content-type: CONCEPT
+[id="cert-manager-acme-about_{context}"]
+= About ACME issuers
+
+The ACME issuer type for the {cert-manager-operator} represents an Automated Certificate Management Environment (ACME) certificate authority (CA) server. ACME CA servers rely on a _challenge_ to verify that a client owns the domain names that the certificate is being requested for. If the challenge is successful, the {cert-manager-operator} can issue the certificate. If the challenge fails, the {cert-manager-operator} does not issue the certificate.

--- a/modules/cert-manager-acme-challenges-types.adoc
+++ b/modules/cert-manager-acme-challenges-types.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc
+
+:_content-type: CONCEPT
+[id="cert-manager-acme-challenges-types_{context}"]
+= Supported ACME challenges types
+
+The {cert-manager-operator} supports the following challenge types for ACME issuers:
+
+HTTP-01:: With the HTTP-01 challenge type, you provide a computed key at an HTTP URL endpoint in your domain. If the ACME CA server can get the key from the URL, it can validate you as the owner of the domain.
++
+For more information, see link:https://cert-manager.io/docs/configuration/acme/http01/[HTTP01] in the upstream cert-manager documentation.
+
+DNS-01:: With the DNS-01 challenge type, you provide a computed key at a DNS TXT record. If the ACME CA server can get the key by DNS lookup, it can validate you as the owner of the domain.
++
+For more information, see link:https://cert-manager.io/docs/configuration/acme/dns01/[DNS01] in the upstream cert-manager documentation.

--- a/modules/cert-manager-acme-dns-providers.adoc
+++ b/modules/cert-manager-acme-dns-providers.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc
+
+:_content-type: CONCEPT
+[id="cert-manager-acme-dns-providers_{context}"]
+= Supported DNS-01 providers
+
+The {cert-manager-operator} supports the following DNS-01 providers for ACME issuers:
+
+* Amazon Route 53
+* Azure DNS
++
+[NOTE]
+====
+The {cert-manager-operator} does not support using Azure Active Directory (Azure AD) pod identities to assign a managed identity to a pod.
+====
+* Google Cloud DNS
++
+[NOTE]
+====
+The {cert-manager-operator} does not support using Google workload identity federation.
+====

--- a/modules/cert-manager-acme-dns01-aws.adoc
+++ b/modules/cert-manager-acme-dns01-aws.adoc
@@ -1,0 +1,170 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc
+
+:_content-type: PROCEDURE
+[id="cert-manager-acme-dns01-aws_{context}"]
+= Configuring an ACME issuer to solve DNS-01 challenges
+
+You can use {cert-manager-operator} to set up an ACME issuer to solve DNS-01 challenges. This procedure uses _Let's Encrypt_ as the ACME CA server and shows how to solve DNS-01 challenges with Amazon Route 53.
+
+[NOTE]
+====
+Private DNS zones are not supported.
+====
+
+.Prerequisites
+
+* You have access to the {product-title} cluster as a user with the `cluster-admin` role.
+* You have set up an IAM role for Amazon Route 53. For more information, see link:https://cert-manager.io/docs/configuration/acme/dns01/route53/[Route53] in the upstream cert-manager documentation.
++
+[NOTE]
+====
+If your cluster is _not_ configured to use the AWS Security Token Service (STS), you must provide explicit `accessKeyID` and `secretAccessKey` credentials. If you cluster uses AWS STS, you can use implicit ambient credentials.
+====
+
+.Procedure
+
+. Optional: Override the nameserver settings for the DNS-01 self check:
++
+This step is required only when the target public-hosted zone overlaps with the cluster's default private-hosted zone.
+
+.. Edit the `CertManager` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit certmanager cluster
+----
+
+.. Add a `spec.controllerConfig` section with the following override arguments:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+  ...
+spec:
+  ...
+  controllerConfig:                                <1>
+    overrideArgs:
+      - '--dns01-recursive-nameservers=1.1.1.1:53' <2>
+      - '--dns01-recursive-nameservers-only'       <3>
+----
+<1> Add the `spec.controllerConfig` section.
+<2> Provide a comma-separated list of `<host>:<port>` nameservers to query for the DNS-01 self check.
+<3> Specify to only use recursive nameservers instead of checking the authoritative nameservers associated with that domain.
+
+.. Save the file to apply the changes.
+
+. Optional: Create a namespace for the issuer.
+
+.. Create a YAML file that defines a `Namespace` object:
++
+.Example `namespace.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-issuer-namespace <1>
+----
+<1> Specify the namespace for the issuer.
+
+.. Create the `Namespace` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f namespace.yaml
+----
+
+. Create a secret to store your AWS credentials in by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic aws-secret --from-literal=awsSecretAccessKey=<aws_secret_access_key> \ <1>
+    -n my-issuer-namespace
+----
+<1> Replace `<aws_secret_access_key>` with your AWS secret access key.
+
+. Create an issuer.
+
+.. Create a YAML file that defines the `Issuer` object:
++
+.Example `issuer.yaml` file
+[source,yaml]
+----
+apiVersion: cert-manager.io/v1
+kind: Issuer
+metadata:
+  name: letsencrypt-staging                                        <1>
+  namespace: my-issuer-namespace                                   <2>
+spec:
+  acme:
+    server: https://acme-staging-v02.api.letsencrypt.org/directory <3>
+    email: "<email_address>"                                       <4>
+    privateKeySecretRef:
+      name: <secret_private_key>                                   <5>
+    solvers:
+    - dns01:
+        route53:
+          accessKeyID: <aws_key_id>                                <6>
+          hostedZoneID: <hosted_zone_id>                           <7>
+          region: us-east-1
+          secretAccessKeySecretRef:
+            name: "aws-secret"                                     <8>
+            key: "awsSecretAccessKey"                              <9>
+----
+<1> Provide a name for the issuer.
+<2> Specify the namespace that you created for the issuer.
+<3> Specify the URL to access the ACME server's `directory` endpoint. This example uses the _Let's Encrypt_ staging environment.
+<4> Replace `<email_address>` with your email address.
+<5> Replace `<secret_private_key>` with the name of the secret to store the ACME account private key in.
+<6> Replace `<aws_key_id>` with your AWS key ID.
+<7> Replace `<hosted_zone_id>` with your hosted zone ID.
+<8> Specify the name of the secret you created.
+<9> Specify the key in the secret you created that stores your AWS secret access key.
+
+.. Create the `Issuer` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f issuer.yaml
+----
+
+. Create a certificate.
+
+.. Create a YAML file that defines the `Certificate` object:
++
+.Example `certificate.yaml` file
+[source,yaml]
+----
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: my-tls-cert              <1>
+  namespace: my-issuer-namespace <2>
+spec:
+  isCA: false
+  commonName: '<common_name>'    <3>
+  secretName: my-tls-cert        <4>
+  dnsNames:
+  - '<domain_name>'              <5>
+  issuerRef:
+    name: letsencrypt-staging    <6>
+    kind: Issuer
+----
+<1> Provide a name for the certificate.
+<2> Specify the namespace that you created for the issuer.
+<3> Replace `<common_name>` with your common name (CN).
+<4> Specify the name of the secret to create that will contain the certificate.
+<5> Replace `<domain_name>` with your domain name.
+<6> Specify the name of the issuer that you created.
+
+.. Create the `Certificate` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f certificate.yaml
+----

--- a/modules/cert-manager-acme-http01.adoc
+++ b/modules/cert-manager-acme-http01.adoc
@@ -1,0 +1,119 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc
+
+:_content-type: PROCEDURE
+[id="cert-manager-acme-http01_{context}"]
+= Configuring an ACME issuer to solve HTTP-01 challenges
+
+You can use {cert-manager-operator} to set up an ACME issuer to solve HTTP-01 challenges. This procedure uses Let's Encrypt as the ACME CA server.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have a service that you want to expose. In this procedure, the service is named `sample-workload`.
+
+.Procedure
+
+. Create an ACME cluster issuer.
+
+.. Create a YAML file that defines the `ClusterIssuer` object:
++
+.Example `acme-cluster-issuer.yaml` file
+[source,yaml]
+----
+apiVersion: cert-manager.io/v1
+kind: ClusterIssuer
+metadata:
+  name: letsencrypt-staging                                        <1>
+spec:
+  acme:
+    preferredChain: ""
+    privateKeySecretRef:
+      name: <secret_for_private_key>                               <2>
+    server: https://acme-staging-v02.api.letsencrypt.org/directory <3>
+    solvers:
+    - http01:
+        ingress:
+          class: openshift-default                                 <4>
+----
+<1> Provide a name for the cluster issuer.
+<2> Replace `<secret_private_key>` with the name of secret to store the ACME account private key in.
+<3> Specify the URL to access the ACME server's `directory` endpoint. This example uses the Let's Encrypt staging environment.
+<4> Specify the Ingress class.
+
+.. Create the `ClusterIssuer` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f acme-cluster-issuer.yaml
+----
+
+. Create an Ingress to expose the service of the user workload.
+
+.. Create a YAML file that defines a `Namespace` object:
++
+.Example `namespace.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: my-ingress-namespace <1>
+----
+<1> Specify the namespace for the Ingress.
+
+.. Create the `Namespace` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f namespace.yaml
+----
+
+.. Create a YAML file that defines the `Ingress` object:
++
+.Example `ingress.yaml` file
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: sample-ingress                                           <1>
+  namespace: my-ingress-namespace                                <2>
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging          <3>
+    acme.cert-manager.io/http01-ingress-class: openshift-default <4>
+spec:
+  ingressClassName: openshift-default                            <5>
+  tls:
+  - hosts:
+    - <hostname>                                                 <6>
+    secretName: sample-tls                                       <7>
+  rules:
+  - host: <hostname>                                             <8>
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: sample-workload                                <9>
+            port:
+              number: 80
+----
+<1> Specify the name of the Ingress.
+<2> Specify the namespace that you created for the Ingress.
+<3> Specify the cluster issuer that you created.
+<4> Specify the Ingress class.
+<5> Specify the Ingress class.
+<6> Replace `<hostname>` with the Subject Alternative Name to be associated with the certificate. This name is used to add DNS names to the certificate.
+<7> Specify the secret to store the created certificate in.
+<8> Replace `<hostname>` with the hostname. You can use the `<host_name>.<cluster_ingress_domain>` syntax to take advantage of the `*.<cluster_ingress_domain>` wildcard DNS record and serving certificate for the cluster. For example, you might use `apps.<cluster_base_domain>`. Otherwise, you must ensure that a DNS record exists for the chosen hostname.
+<9> Specify the name of the service to expose. This example uses a service named `sample-workload`.
+
+.. Create the `Ingress` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f ingress.yaml
+----

--- a/modules/cert-manager-install-console.adoc
+++ b/modules/cert-manager-install-console.adoc
@@ -24,12 +24,11 @@ You can use the web console to install the {cert-manager-operator}.
 . Select the *{cert-manager-operator}* and click *Install*.
 
 . On the *Install Operator* page:
-.. The *Update channel* is set to *tech-preview*, which installs the latest Technology Preview release of the {cert-manager-operator}.
-.. The *Installation Mode* is set to *All namespaces on the cluster (default)*. This mode installs the Operator in the Operator-recommended `openshift-cert-manager-operator` namespace to watch and be made available to all namespaces in the cluster.
-.. Choose the *Installed Namespace* for the Operator. The default Operator recommended namespace is `openshift-cert-manager-operator`.
+.. Update the *Update channel*, if necessary. The channel defaults to *stable-v1*, which installs the latest stable release of the {cert-manager-operator}.
+.. Choose the *Installed Namespace* for the Operator. The default Operator namespace is `cert-manager-operator`.
 +
-If the `openshift-cert-manager-operator` namespace does not exist, it is created for you.
-.. Click the *Enable Operator recommended cluster monitoring on the Namespace* checkbox to enable cluster monitoring for the Operator.
+If the `cert-manager-operator` namespace does not exist, it is created for you.
+
 .. Select an *Update approval* strategy.
 +
 * The *Automatic* strategy allows Operator Lifecycle Manager (OLM) to automatically update the Operator when a new version is available.
@@ -41,4 +40,4 @@ If the `openshift-cert-manager-operator` namespace does not exist, it is created
 .Verification
 
 . Navigate to *Operators* -> *Installed Operators*.
-. Verify that *{cert-manager-operator}* is listed with a *Status* of *Succeeded*.
+. Verify that *{cert-manager-operator}* is listed with a *Status* of *Succeeded* in the `cert-manager-operator` namespace.

--- a/modules/cert-manager-issuer-types.adoc
+++ b/modules/cert-manager-issuer-types.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/index.adoc
+
+:_content-type: CONCEPT
+[id="cert-manager-issuer-types_{context}"]
+= Supported issuer types
+
+The {cert-manager-operator} supports the following issuer types:
+
+* Automated Certificate Management Environment (ACME)
+* Certificate authority (CA)
+* Self-signed

--- a/modules/cert-manager-proxy-support.adoc
+++ b/modules/cert-manager-proxy-support.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-operator-proxy.adoc
+
+:_content-type: PROCEDURE
+[id="cert-manager-proxy-support_{context}"]
+= Injecting a custom CA certificate for the {cert-manager-operator}
+
+If your {product-title} cluster has the cluster-wide proxy enabled, you can inject any CA certificates that are required for proxying HTTPS connections into the {cert-manager-operator}.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have enabled the cluster-wide proxy for {product-title}.
+
+.Procedure
+
+. Create a config map in the `cert-manager` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create configmap trusted-ca -n cert-manager
+----
+
+. Inject the CA bundle that is trusted by {product-title} into the config map by running the following command:
++
+[source,terminal]
+----
+$ oc label cm trusted-ca config.openshift.io/inject-trusted-cabundle=true -n cert-manager
+----
+
+. Update the deployment for the {cert-manager-operator} to use the config map by running the following command:
++
+[source,terminal]
+----
+$ oc -n cert-manager-operator patch subscription cert-manager-operator --type='merge' -p '{"spec":{"config":{"env":[{"name":"TRUSTED_CA_CONFIGMAP_NAME","value":"trusted-ca"}]}}}'
+----
+
+.Verification
+
+. Verify that the deployments have finished rolling out by running the following command:
++
+[source,terminal]
+----
+$ oc rollout status deployment/cert-manager-operator-controller-manager -n cert-manager-operator && \
+oc rollout status deployment/cert-manager -n cert-manager && \
+oc rollout status deployment/cert-manager-webhook -n cert-manager && \
+oc rollout status deployment/cert-manager-cainjector -n cert-manager
+----
++
+.Example output
+[source,terminal]
+----
+deployment "cert-manager-operator-controller-manager" successfully rolled out
+deployment "cert-manager" successfully rolled out
+deployment "cert-manager-webhook" successfully rolled out
+deployment "cert-manager-cainjector" successfully rolled out
+----
+
+. Verify that the CA bundle was mounted as a volume by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment cert-manager -n cert-manager -o=jsonpath={.spec.template.spec.'containers[0].volumeMounts'}
+----
++
+.Example output
+[source,terminal]
+----
+[{"mountPath":"/etc/pki/tls/certs/cert-manager-tls-ca-bundle.crt","name":"trusted-ca","subPath":"ca-bundle.crt"}]
+----
+
+. Verify that the source of the CA bundle is the `trusted-ca` config map by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment cert-manager -n cert-manager -o=jsonpath={.spec.template.spec.volumes}
+----
++
+.Example output
+[source,terminal]
+----
+[{"configMap":{"defaultMode":420,"name":"trusted-ca"},"name":"trusted-ca"}]
+----

--- a/modules/cert-manager-remove-resources-console.adoc
+++ b/modules/cert-manager-remove-resources-console.adoc
@@ -27,14 +27,13 @@ Optionally, after uninstalling the {cert-manager-operator}, you can remove its r
 
 *** `Certificate`
 *** `CertificateRequest`
-*** `CertManager` (`config.openshift.io`)
 *** `CertManager` (`operator.openshift.io`)
 *** `Challenge`
 *** `ClusterIssuer`
 *** `Issuer`
 *** `Order`
 
-. Remove the `openshift-cert-manager-operator` namespace.
+. Remove the `cert-manager-operator` namespace.
 .. Navigate to *Administration* -> *Namespaces*.
-.. Click the Options menu {kebab} next to the *openshift-cert-manager-operator* and select *Delete Namespace*.
-.. In the confirmation dialog, enter `openshift-cert-manager-operator` in the field and click *Delete*.
+.. Click the Options menu {kebab} next to the *cert-manager-operator* and select *Delete Namespace*.
+.. In the confirmation dialog, enter `cert-manager-operator` in the field and click *Delete*.

--- a/security/cert_manager_operator/cert-manager-operator-install.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-install.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 The {cert-manager-operator} is not installed in {product-title} by default. You can install the {cert-manager-operator} by using the web console.
 
-:FeatureName: The {cert-manager-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 // Installing the {cert-manager-operator} using the web console
 include::modules/cert-manager-install-console.adoc[leveloffset=+1]
 

--- a/security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-issuer-acme.adoc
@@ -1,0 +1,24 @@
+:_content-type: ASSEMBLY
+[id="cert-manager-operator-issuer-acme"]
+= Managing certificates with an ACME issuer
+include::_attributes/common-attributes.adoc[]
+:context: cert-manager-operator-issuer-acme
+
+toc::[]
+
+The {cert-manager-operator} supports using ACME CA servers, such as Let's Encrypt, to issue certificates.
+
+// About ACME issuers
+include::modules/cert-manager-acme-about.adoc[leveloffset=+1]
+
+// Supported ACME challenges types
+include::modules/cert-manager-acme-challenges-types.adoc[leveloffset=+2]
+
+// Supported DNS-01 providers
+include::modules/cert-manager-acme-dns-providers.adoc[leveloffset=+2]
+
+// Configuring an ACME issuer to solve HTTP01 challenges
+include::modules/cert-manager-acme-http01.adoc[leveloffset=+1]
+
+// Configuring an ACME issuer to solve DNS01 challenges
+include::modules/cert-manager-acme-dns01-aws.adoc[leveloffset=+1]

--- a/security/cert_manager_operator/cert-manager-operator-proxy.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-proxy.adoc
@@ -1,0 +1,20 @@
+:_content-type: ASSEMBLY
+[id="cert-manager-operator-proxy"]
+= Configuring the egress proxy for the {cert-manager-operator}
+include::_attributes/common-attributes.adoc[]
+:context: cert-manager-operator-proxy
+
+toc::[]
+
+If a cluster-wide egress proxy is configured in {product-title}, Operator Lifecycle Manager (OLM) automatically configures Operators that it manages with the cluster-wide proxy. OLM automatically updates all of the Operator's deployments with the `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY` environment variables.
+
+You can inject any CA certificates that are required for proxying HTTPS connections into the {cert-manager-operator}.
+
+// Injecting a custom CA certificate for the {cert-manager-operator}
+include::modules/cert-manager-proxy-support.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="cert-manager-operator-proxy_additional-resources"]
+== Additional resources
+
+* xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configuring proxy support in Operator Lifecycle Manager]

--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -10,10 +10,69 @@ The {cert-manager-operator} is a cluster-wide service that provides application 
 
 These release notes track the development of {cert-manager-operator}.
 
-:FeatureName: The {cert-manager-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
+
+[id="cert-manager-operator-release-notes-1.10.2"]
+== Release notes for {cert-manager-operator} 1.10.2
+
+Issued: 2023-03-23
+
+The following advisory is available for the {cert-manager-operator} 1.10.2:
+
+* link:https://access.redhat.com/errata/RHEA-2023:1238[RHEA-2023:1238]
+
+For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.10[cert-manager project release notes for v1.10].
+
+[IMPORTANT]
+====
+If you used the Technology Preview version of the {cert-manager-operator}, you must uninstall it and remove all related resources for the Technology Preview version before installing this version of the {cert-manager-operator}.
+
+For more information, see xref:../../security/cert_manager_operator/cert-manager-operator-uninstall.adoc#cert-manager-operator-uninstall[Uninstalling the {cert-manager-operator}].
+====
+
+[id="cert-manager-operator-1.10.2-new-features-and-enhancements"]
+=== New features and enhancements
+
+This is the general availability (GA) release of the {cert-manager-operator}.
+
+* The following issuer types are supported:
+** Automated Certificate Management Environment (ACME)
+** Certificate authority (CA)
+** Self-signed
+
+* The following ACME challenge types are supported:
+** DNS-01
+** HTTP-01
+
+* The following DNS-01 providers for ACME issuers are supported:
+** Amazon Route 53
+** Azure DNS
+** Google Cloud DNS
+
+* The {cert-manager-operator} now supports injecting custom CA certificates and propagating cluster-wide egress proxy environment variables.
+
+[id="cert-manager-operator-1.10.2-bug-fixes"]
+=== Bug fixes
+
+* Previously, the `unsupportedConfigOverrides` field replaced user-provided arguments instead of appending them. Now, the `unsupportedConfigOverrides` field properly appends user-provided arguments. (link:https://issues.redhat.com/browse/CM-23[*CM-23*])
++
+[WARNING]
+====
+Using the `unsupportedConfigOverrides` section to modify the configuration of an Operator is unsupported and might block cluster upgrades.
+====
+
+* Previously, the {cert-manager-operator} was installed as a cluster Operator. With this release, the {cert-manager-operator} is now properly installed as an OLM Operator. (link:https://issues.redhat.com/browse/CM-35[*CM-35*])
+
+[id="cert-manager-operator-1.10.2-known-issues"]
+=== Known issues
+
+* Using `Route` objects is not fully supported. Currently, to use {cert-manager-operator} with `Routes`, users must create `Ingress` objects, which are translated to `Route` objects by the Ingress-to-Route Controller. (link:https://issues.redhat.com/browse/CM-16[*CM-16*])
+
+* The {cert-manager-operator} does not support using Azure Active Directory (Azure AD) pod identities to assign a managed identity to a pod. As a workaround, you can use a service principal to assign a managed identity. (link:https://issues.redhat.com/browse/OCPBUGS-8665[*OCPBUGS-8665*])
+
+* The {cert-manager-operator} does not support using Google workload identity federation. (link:https://issues.redhat.com/browse/OCPBUGS-9998[*OCPBUGS-9998*])
+
+* When uninstalling the {cert-manager-operator}, if you select the *Delete all operand instances for this operator* checkbox in the {product-title} web console, the Operator is not uninstalled properly. As a workaround, do not select this checkbox when uninstalling the {cert-manager-operator}. (link:https://issues.redhat.com/browse/OCPBUGS-9960[*OCPBUGS-9960*])
 
 [id="cert-manager-operator-release-notes-1.7.1-1"]
 == Release notes for {cert-manager-operator} 1.7.1-1 (Technology Preview)
@@ -42,4 +101,4 @@ For more information, see the link:https://cert-manager.io/docs/release-notes/re
 [id="cert-manager-operator-1.7.1-1-known-issues"]
 === Known issues
 
-* Using `Route` objects is not fully supported. Currently, {cert-manager-operator} integrates with `Route` objects by creating `Ingress` objects through the Ingress Controller. (link:https://issues.redhat.com/projects/CM/issues/CM-16[*CM-16*])
+* Using `Route` objects is not fully supported. Currently, {cert-manager-operator} integrates with `Route` objects by creating `Ingress` objects through the Ingress Controller. (link:https://issues.redhat.com/browse/CM-16[*CM-16*])

--- a/security/cert_manager_operator/cert-manager-operator-uninstall.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-uninstall.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 You can remove the {cert-manager-operator} from {product-title} by uninstalling the Operator and removing its related resources.
 
-:FeatureName: The {cert-manager-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 // Uninstalling the {cert-manager-operator}
 include::modules/cert-manager-uninstall-console.adoc[leveloffset=+1]
 

--- a/security/cert_manager_operator/index.adoc
+++ b/security/cert_manager_operator/index.adoc
@@ -8,11 +8,11 @@ toc::[]
 
 The {cert-manager-operator} is a cluster-wide service that provides application certificate lifecycle management. The {cert-manager-operator} allows you to integrate with external certificate authorities and provides certificate provisioning, renewal, and retirement.
 
-:FeatureName: The {cert-manager-operator}
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 // About the {cert-manager-operator}
 include::modules/cert-manager-about.adoc[leveloffset=+1]
+
+// Supported issuer types
+include::modules/cert-manager-issuer-types.adoc[leveloffset=+1]
 
 // Certificate request methods
 include::modules/cert-manager-request-methods.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-4928

Link to docs preview:
https://56754--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/index.html
(and subsequent pages)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
