### PR TITLE
[enterprise-4.10] Fix version in out-of-date OSDK note

### DIFF
--- a/cli_reference/osdk/cli-osdk-install.adoc
+++ b/cli_reference/osdk/cli-osdk-install.adoc
@@ -14,7 +14,7 @@ See xref:../../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Oper
 
 [NOTE]
 ====
-{product-title} 4.9 and later supports Operator SDK v1.16.0.
+{product-title} {product-version} supports Operator SDK v1.16.0.
 ====
 
 include::modules/osdk-installing-cli-linux-macos.adoc[leveloffset=+1]

--- a/operators/operator_sdk/osdk-about.adoc
+++ b/operators/operator_sdk/osdk-about.adoc
@@ -28,7 +28,7 @@ Operator authors with cluster administrator access to a Kubernetes-based cluster
 
 [NOTE]
 ====
-{product-title} {product-version} supports Operator SDK v1.16.0 or later.
+{product-title} {product-version} supports Operator SDK v1.16.0.
 ====
 
 [id="osdk-about-what-are-operators"]


### PR DESCRIPTION
4.10 version of https://github.com/openshift/openshift-docs/pull/56753.