### PR TITLE
OSDOCS-3338: Added FIPS installation option to ROSA

### DIFF
--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -73,6 +73,13 @@ The following table describes the interactive cluster creation mode options:
 |`Host prefix`
 |Specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine. For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes and 512 pods per node, both of which are beyond our supported maximums. For information on the supported maximums, see the Additional resources section below.
 
+|`fips (optional)`
+|Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with RHCOS instead.
+[IMPORTANT]
+====
+The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+
 |`Encrypt etcd data (optional)`
 |In {product-title}, the control plane storage is encrypted at rest by default and this includes encryption of the etcd volumes. You can additionally enable the `Encrypt etcd data` option to encrypt the key values for some resources in etcd, but not the keys.
 


### PR DESCRIPTION
Version(s):
`enterprise-4.12+`

Issue:
[OSDOCS-3338](https://issues.redhat.com/browse/OSDOCS-3338)

Link to docs preview:
* [ROSA](https://56757--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.html#rosa-sts-interactive-cluster-creation-mode-options_rosa-sts-interactive-mode-reference)

Located as an entry in `Table 3. --interactive cluster creation mode options`

![image](https://user-images.githubusercontent.com/16167833/223435554-28ba07de-512c-42a5-8adb-462f9c0a7467.png)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Ported the FIPS installation option from OCP to ROSA