### PR TITLE
[RHACS] Updated sentence, suggested by team IBM

### DIFF
--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -43,7 +43,7 @@ toc::[]
 * {osp} 4.12 to IBM Power (ppc64le)
 * {osp} 4.10 and 4.12 to IBM zSystems (s390x) and IBM® LinuxONE (s390x)
 
-With {product-title-short} version 3.74, you can install secured cluster services on {osp} on {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} by using the {product-title-short} Operator.
+With {product-title-short} version 3.74, you can secure clusters running on {osp} on {ibm-power}, {ibm-zsystems}, and {ibm-linuxone} by using the {product-title-short} Operator.
 
 [NOTE]
 ====


### PR DESCRIPTION
Based on Slack feedback:
> this sentence is misleading
> With RHACS version 3.74, you can install secured cluster services on Red Hat OpenShift on IBM Power, IBM zSystems, and IBM® LinuxONE by using the RHACS Operator.
> Change it to the following
> With RHACS version 3.74, you can secure clusters running on Red Hat OpenShift on IBM Power, IBM zSystems, and IBM® LinuxONE by using the RHACS Operator. 

Cherrypick into `rhacs-docs-3.74`

Preview: https://56763--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes.html#ibm-power-z-374