### PR TITLE
OCPBUG6804: Added correct reference links in Additional Resources under Networking

### DIFF
--- a/networking/network_observability/installing-operators.adoc
+++ b/networking/network_observability/installing-operators.adoc
@@ -23,7 +23,7 @@ include::modules/network-observability-operator-install.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-To see more information about Flow Collector specifications, see the xref:../network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference] and the xref:../network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource].
+To see more information about Flow Collector specifications, see the xref:../networking/network_observability/flowcollector-api.html#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference] and the xref:../networking/network_observability/configuring-operator.html#network-observability-flowcollector-view_network_observability[Flow Collector sample resource].
 
 include::modules/network-observability-operator-uninstall.adoc[leveloffset=+1]
 

--- a/networking/network_observability/observing-network-traffic.adoc
+++ b/networking/network_observability/observing-network-traffic.adoc
@@ -30,4 +30,4 @@ Alternatively, you can access the traffic flow data in the *Network Traffic* tab
 
 [role="_additional-resources"]
 .Additional resources
-For more information about configuring quick filters in the `FlowCollector`, see xref:../network_observability/configuring-operator.adoc#network-observability-config-quick-filters_network_observability[Configuring Quick Filters] and the xref:../network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource].
+For more information about configuring quick filters in the `FlowCollector`, see xref:../networking/network_observability/configuring-operator.html#network-observability-config-quick-filters_network_observability[Configuring Quick Filters] and the xref:../networking/network_observability/configuring-operator.html#network-observability-flowcollector-view_network_observability[Flow Collector sample resource].


### PR DESCRIPTION
Version(s): 4.10+

Scope: Added correct reference links under Additional Resources.
[OCPBUG6804](https://issues.redhat.com/browse/OCPBUGS-6804)

Links to Docs Preview:
[Preview File_1](https://56768--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/installing-operators.html#network-observability-operator-installation_network_observability)

[Preview File_2](https://56768--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/observing-network-traffic.html#network-observability-quickfilternw-observe-network-traffic)


ptal