### PR TITLE
Updates to RHACS RNs for patch release 3.73.3

### DIFF
--- a/release_notes/373-release-notes.adoc
+++ b/release_notes/373-release-notes.adoc
@@ -15,6 +15,7 @@ toc::[]
 |`3.73.0` |6 December 2022
 |`3.73.1` |19 December 2022
 |`3.73.2` |6 February 2023
+|`3.73.3` |6 March 2023
 |====
 
 [id="about-this-release-373"]
@@ -339,6 +340,16 @@ The patch release 3.73.1 fixes this issue.
 
 * The patch release 3.73.2 fixes an issue where Central crashed during the migration from rocksDB to PostgreSQL. (link:https://issues.redhat.com/browse/ROX-14469[ROX-14469])
 * Because of an issue in {product-title-short} Operator versions 3.73.0 and 3.73.1, when you tried to update, the Operator incorrectly removed the `metadata.ownerReferences` field on the central PersistentVolumeClaim (PVC), and you could not update Central and Scanner. The patch release 3.73.2 fixes this issue. (link:https://issues.redhat.com/browse/ROX-14335[ROX-14335])
+
+[id="resolved-in-version-3733"]
+=== Resolved in version 3.73.3
+
+Release date: 6 March 2023
+
+* This release of {product-title-short} fixes link:https://access.redhat.com/security/cve/CVE-2022-47629[CVE-2022-47629] in the Docker base image.
+* Before this update, {product-title-short} did not show runtime data when the secured cluster was running {ocp} 4.12. For more information, refer to the Red Hat Knowledgebase article link:https://access.redhat.com/solutions/6999470[RHACS is not showing runtime data]. This issue is now fixed.
+* Previously, due to an issue with the alert reconciliation workflow, Central could crash when reconciling stored and new runtime policy violations. {product-title-short} now logs an error when an unexpected runtime process alert occurs. (ROX-15198)
+
 
 [id="image-versions-373"]
 == Image versions


### PR DESCRIPTION
Version(s):

`rhacs-docs-3.73`

[Issue](https://issues.redhat.com/browse/ROX-15417)

[Link to docs preview
](https://56772--docspreview.netlify.app/openshift-acs/latest/release_notes/373-release-notes.html#resolved-in-version-3733)

QE review:
- [x] QE has approved this change. **(ACS has no QE, reviewed & approved by SMEs)**

Additional information:

Replaces https://github.com/openshift/openshift-docs/pull/56724

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
