### PR TITLE
PSAP-1003: NTO: reapply_sysctl and verify Profiles improvements

### DIFF
--- a/modules/cluster-node-tuning-operator-verify-profiles.adoc
+++ b/modules/cluster-node-tuning-operator-verify-profiles.adoc
@@ -28,3 +28,21 @@ worker-b         openshift-node            True      False      6h28m
 * `APPLIED`: `True` if the TuneD daemon applied the desired profile. (`True/False/Unknown`).
 * `DEGRADED`: `True` if any errors were reported during application of the TuneD profile (`True/False/Unknown`).
 * `AGE`: Time elapsed since the creation of Profile object.
+
+The `ClusterOperator/node-tuning` object also contains useful information about the Operator and its node agents' health. For example, Operator misconfiguration is reported by `ClusterOperator/node-tuning` status messages.
+
+To get status information about the `ClusterOperator/node-tuning` object, run the following command:
+
+[source,terminal]
+----
+$ oc get co/node-tuning -n openshift-cluster-node-tuning-operator
+----
+
+.Example output
+[source,terminal]
+----
+NAME          VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
+node-tuning   4.13.1    True        False         True       60m     1/5 Profiles with bootcmdline conflict
+----
+
+If either the `ClusterOperator/node-tuning` or a profile object's status is `DEGRADED`, additional information is provided in the Operator or operand logs.

--- a/modules/custom-tuning-example.adoc
+++ b/modules/custom-tuning-example.adoc
@@ -84,3 +84,36 @@ the `openshift-node` TuneD daemon profile shipped within the default
 Tuned CR to use OpenShift-specific tuning for compute nodes.
 
 // Note the issues with including profiles sharing the same ancestor: see link:https://bugzilla.redhat.com/show_bug.cgi?id=1825882[BZ#1825882]
+
+*Overriding host-level sysctls*
+
+Various kernel parameters can be changed at runtime by using `/run/sysctl.d/`, `/etc/sysctl.d/`, and `/etc/sysctl.conf` host configuration files. {product-title} adds several host configuration files which set kernel parameters at runtime; for example, `net.ipv[4-6].`, `fs.inotify.`, and `vm.max_map_count`. These runtime parameters provide basic functional tuning for the system prior to the kubelet and the Operator start.
+
+The Operator does not override these settings unless the `reapply_sysctl` option is set to `false`. Setting this option to `false` results in `TuneD` not applying the settings from the host configuration files after it applies its custom profile.
+
+.Example: overriding host-level sysctls
+[source,yaml]
+----
+apiVersion: tuned.openshift.io/v1
+kind: Tuned
+metadata:
+  name: openshift-no-reapply-sysctl
+  namespace: openshift-cluster-node-tuning-operator
+spec:
+  profile:
+  - data: |
+      [main]
+      summary=Custom OpenShift profile
+      include=openshift-node
+      [sysctl]
+      vm.max_map_count=>524288
+    name: openshift-no-reapply-sysctl
+  recommend:
+  - match:
+    - label: tuned.openshift.io/openshift-no-reapply-sysctl
+    priority: 15
+    profile: openshift-no-reapply-sysctl
+    operand:
+      tunedConfig:
+        reapply_sysctl: false
+----


### PR DESCRIPTION
This PR adds an example of using reapply_sysctl to override host-level sysctls and adds information on checking about the NTO and its node agents' health.

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/PSAP-1003

Link to docs preview:
https://56773--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator.html

QE review:
- [ ] QE has approved this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
