### PR TITLE
OSDOCS-4755: mark out confusing paragraphs

### DIFF
--- a/microshift_rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.adoc
+++ b/microshift_rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.adoc
@@ -11,8 +11,7 @@ toc::[]
 Description::
 +
 --
-SecurityContextConstraints governs the ability to make requests that affect the SecurityContext that will be applied to a container. For historical reasons SCC was exposed under the core Kubernetes API group. That exposure is deprecated and will be removed in a future release - users should instead use the security.openshift.io group to manage SecurityContextConstraints. 
- Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
+SecurityContextConstraints (SCC) governs the ability to make requests that affect the SecurityContext that applies to a container. Use the security.openshift.io group to manage SecurityContextConstraints. Compatibility level 1: Stable within a major release for a minimum of 12 months or 3 minor releases (whichever is longer).
 --
 
 Type::
@@ -72,7 +71,7 @@ Required::
 
 | `allowedUnsafeSysctls`
 | ``
-| AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection. 
+| AllowedUnsafeSysctls is a list of explicitly allowed unsafe sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of allowed sysctls. Single * means all unsafe sysctls are allowed. Kubelet has to whitelist all allowed unsafe sysctls explicitly to avoid rejection.
  Examples: e.g. "foo/*" allows "foo/bar", "foo/baz", etc. e.g. "foo.*" allows "foo.bar", "foo.baz", etc.
 
 | `apiVersion`
@@ -89,7 +88,7 @@ Required::
 
 | `forbiddenSysctls`
 | ``
-| ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden. 
+| ForbiddenSysctls is a list of explicitly forbidden sysctls, defaults to none. Each entry is either a plain sysctl name or ends in "*" in which case it is considered as a prefix of forbidden sysctls. Single * means all sysctls are forbidden.
  Examples: e.g. "foo/*" forbids "foo/bar", "foo/baz", etc. e.g. "foo.*" forbids "foo.bar", "foo.baz", etc.
 
 | `fsGroup`
@@ -323,7 +322,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../security_apis/securitycontextconstraints-security-openshift-io-v1.adoc#securitycontextconstraints-security-openshift-io-v1[`SecurityContextConstraints`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -457,7 +456,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | `DeleteOptions` schema
-| 
+|
 |===
 
 .HTTP responses
@@ -529,7 +528,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | `Patch` schema
-| 
+|
 |===
 
 .HTTP responses
@@ -570,7 +569,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../security_apis/securitycontextconstraints-security-openshift-io-v1.adoc#securitycontextconstraints-security-openshift-io-v1[`SecurityContextConstraints`] schema
-| 
+|
 |===
 
 .HTTP responses

--- a/modules/api-compatibility-exceptions.adoc
+++ b/modules/api-compatibility-exceptions.adoc
@@ -1,12 +1,14 @@
 // Module included in the following assemblies:
 //
 // * rest_api/understanding-compatibility-guidelines.adoc
+// * microshift_rest_api/understanding-compatibility-guidelines.adoc
 
 [id="api-compatibility-exceptions_{context}"]
 = API compatibility exceptions
 
 The following are exceptions to compatibility in {product-title}:
 
+ifndef::microshift[]
 [discrete]
 [id="OS-file-system-modifications-not-made_{context}"]
 == RHEL CoreOS file system modifications not made with a supported Operator
@@ -18,6 +20,7 @@ No assurances are made at this time that a modification made to the host operati
 == Modifications to cluster infrastructure in cloud or virtualized environments
 
 No assurances are made at this time that a modification to the cloud hosting environment that supports the cluster is preserved except for where that modification is made through a public interface exposed in the product or is documented as a supported configuration. Cluster infrastructure providers are responsible for preserving their cloud or virtualized infrastructure except for where they delegate that authority to the product through an API.
+endif::microshift[]
 
 [discrete]
 [id="Functional-defaults-between-upgraded-cluster-new-installation_{context}"]


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-4755

Link to docs preview:
https://56777--docspreview.netlify.app/microshift/latest/microshift_rest_api/understanding-compatibility-guidelines.html#api-compatibility-exceptions_compatibility-guidelines

https://56777--docspreview.netlify.app/microshift/latest/microshift_rest_api/security_apis/securitycontextconstraints-security-openshift-io-v1.html (removed hard wrap and space)

OCP doc preview showing no change:
http://file.rdu.redhat.com/shdiaz/OSDOCS-4755/rest_api/understanding-compatibility-guidelines.html#api-compatibility-exceptions_compatibility-guidelines

QE review:
N/A, SME approval is sufficient

Additional information:
Ifdefing a couple paragraphs out of the MicroShift distro that aren't applicable and may confuse customers.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
