### PR TITLE
GH#56764: Changed rustic to restic and base46 to base64

### DIFF
--- a/modules/oadp-backing-up-applications-restic.adoc
+++ b/modules/oadp-backing-up-applications-restic.adoc
@@ -12,7 +12,7 @@ You do not need to specify a snapshot location in the `DataProtectionApplication
 
 [IMPORTANT]
 ====
-Restic does not support backing up `hostPath` volumes. For more information, see link:https://{velero-domain}/docs/v{velero-version}/restic/#limitations[additional Rustic limitations].
+Restic does not support backing up `hostPath` volumes. For more information, see link:https://{velero-domain}/docs/v{velero-version}/restic/#limitations[additional Restic limitations].
 ====
 
 .Prerequisites

--- a/modules/oadp-self-signed-certificate.adoc
+++ b/modules/oadp-self-signed-certificate.adoc
@@ -37,5 +37,5 @@ spec:
           insecureSkipTLSVerify: "false" <2>
 ...
 ----
-<1> Specify the Base46-encoded CA certificate string.
+<1> Specify the Base64-encoded CA certificate string.
 <2> The `insecureSkipTLSVerify` configuration can be set to either `"true"` or `"false"`. If set to `"true"`, SSL/TLS security is disabled. If set to `"false"`, SSL/TLS security is enabled.


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://github.com/openshift/openshift-docs/issues/56764

Link to docs preview:
https://56778--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-backing-up-applications-restic_backing-up-applications

AND

https://56778--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.html#oadp-self-signed-certificate_installing-oadp-ocs

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
