### PR TITLE
[OCPBUGS-8246]: OVN-K control plane re-deployment after node deletion

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -299,6 +299,17 @@ Perform the following step only if you are using `OVNKubernetes` network plugin.
 $ oc delete node <non-recovery-controlplane-host-1> <non-recovery-controlplane-host-2>
 ----
 
+. Verify that the Cluster Network Operator (CNO) redeploys the OVN-Kubernetes control plane and that it no longer references the wrong controller IP addresses. To verify this result, regularly check the output of the following command. Wait until it returns an empty result before you proceed with the next step.
++
+[source,terminal]
+----
+$ oc -n openshift-ovn-kubernetes get ds/ovnkube-master -o yaml | grep -E '<wrong_master_ip_1>|<wrong_master_ip_2>'
+----
++
+[NOTE]
+====
+It can take at least 5-10 minutes for the OVN-Kubernetes control plane to be redeployed and the previous command to return empty output.
+====
 . Turn off the quorum guard by entering the following command:
 +
 [source,terminal]


### PR DESCRIPTION
[OCPBUGS-8246](https://issues.redhat.com/browse/OCPBUGS-8246)

Version(s): 4.11+

**Merge review team: This PR was in merge review and a change was made to the command as a result.  Adding back to the queue.

Link to docs preview: (March 24)
http://file.rdu.redhat.com/tlove/etcd-ocpbugs-8246-tlove/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html

QE review:
- [x ] QE has approved this change.
