### PR TITLE
Metallb

### DIFF
--- a/modules/metallb-installing-using-web-console.adoc
+++ b/modules/metallb-installing-using-web-console.adoc
@@ -18,7 +18,7 @@ As a cluster administrator, you can install the MetalLB Operator by using the {p
 
 . Scroll or type a keyword into the *Filter by keyword* box to find the Operator you want. For example, type `metallb` to find the MetalLB Operator.
 
-  You can also filter options by *Infrastructure Features*. For example, select *Disconnected* if you want to see Operators that work in disconnected environments, also known as restricted network environments.
+  You can also filter options by *Infrastructure features*. For example, select *Disconnected* if you want to see Operators that work in disconnected environments, also known as restricted network environments.
 
 . On the *Install Operator* page, accept the defaults and click *Install*.
 

--- a/modules/metallb-installing-using-web-console.adoc
+++ b/modules/metallb-installing-using-web-console.adoc
@@ -16,7 +16,9 @@ As a cluster administrator, you can install the MetalLB Operator by using the {p
 
 . In the {product-title} web console, navigate to *Operators* -> *OperatorHub*.
 
-. Search for the MetalLB Operator, then click *Install*.
+. Scroll or type a keyword into the *Filter by keyword* box to find the Operator you want. For example, type `metallb` to find the MetalLB Operator.
+
+  You can also filter options by *Infrastructure Features*. For example, select *Disconnected* if you want to see Operators that work in disconnected environments, also known as restricted network environments.
 
 . On the *Install Operator* page, accept the defaults and click *Install*.
 


### PR DESCRIPTION
As per the document https://docs.openshift.com/container-platform/4.9/networking/metallb/metallb-operator-install.html#olm-installing-from-operatorhub-using-web-console_metallb-operator-install  the MetalLB Operator is supported and can be installed in disconnected environment in Openshift 4.9 as well as in Openshift 4.11 but the same has not been mentioned in the document[1]

[1] https://docs.openshift.com/container-platform/4.11/networking/metallb/metallb-operator-install.html#installing-the-metallb-operator-using-web-console_metallb-operator-install

Version(s): 

Issue:

Link to docs preview:

QE review:

Additional information:
