### PR TITLE
OCPBUGS-5054-chronyd-4_10: Disable chronyd in PolicyGenTemplate CR se…

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -1176,9 +1176,9 @@ For more information, see xref:../scalability_and_performance/cnf-numa-aware-sch
 You can now use filters to customize `SiteConfig` CRs to include or exclude other CRs for use in the installation phase of the zero touch provisioning (ZTP) GitOps pipeline. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc#ztp-filtering-ai-crs-using-siteconfig_ztp-advanced-install-ztp[Filtering custom resources using SiteConfig filters].
 
 [id="ocp-4-10-RAN-disabling-chronyd"]
-====  Disable chronyd in the PolicyGenTemplate CR
+====  Disable chronyd in the PolicyGenTemplate CR for vDU use cases
 
-You must disable `chronyd` if you update to {product-title} 4.10 from earlier versions. To disable `chronyd`, add the following line in the `[service]` section under `.spec.profile.data` of the `TunedPerformancePatch.yaml` file. The `TunedPerformancePatch.yaml` file is referenced in the group `PolicyGenTemplate` CR:
+On nodes running RAN vDU applications, you must disable `chronyd` if you update to {product-title} 4.10 from earlier versions. To disable `chronyd`, add the following line in the `[service]` section under `.spec.profile.data` of the `TunedPerformancePatch.yaml` file. The `TunedPerformancePatch.yaml` file is referenced in the group `PolicyGenTemplate` CR:
 
 [source,yaml]
 ----


### PR DESCRIPTION
Description of change:
Adding "for vDU use cases" to the title and updating first sentence, in the "Disable chronyd in the PolicyGenTemplate CR" section.

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OCPBUGS-5054?filter=-1

Link to docs preview:
https://56807--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-10-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

