### PR TITLE
Creating content for Troubleshooting section in the GitOps 1.8 Release

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1866,6 +1866,8 @@ Topics:
     File: run-gitops-control-plane-workload-on-infra-nodes
   - Name: Sizing requirements for GitOps Operator
     File: about-sizing-requirements-gitops
+  - Name: Troubleshooting issues in GitOps
+    File: troubleshooting-issues-in-GitOps
 - Name: Jenkins
   Dir: jenkins
   Distros: openshift-enterprise

--- a/cicd/gitops/troubleshooting-issues-in-GitOps.adoc
+++ b/cicd/gitops/troubleshooting-issues-in-GitOps.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+[id="troubleshooting-issues-in-GitOps"]
+
+= Troubleshooting issues in Red Hat OpenShift GitOps
+include::_attributes/common-attributes.adoc[]
+:context: troubleshooting-issues-in-GitOps
+
+When working with {gitops-title}, you might face issues related to performance, monitoring, configuration, and other aspects. This section helps you to understand those issues and provide solutions to resolve them.
+
+include::modules/con_auto-reboot-during-argo-cd-sync-with-machine-configurations.adoc[leveloffset=+1]
+include::modules/performance-challenges-in-machine-configurations-and-argo-cd.adoc[leveloffset=+2]
+

--- a/modules/con_auto-reboot-during-argo-cd-sync-with-machine-configurations.adoc
+++ b/modules/con_auto-reboot-during-argo-cd-sync-with-machine-configurations.adoc
@@ -1,0 +1,10 @@
+:_content-type: CONCEPT
+
+[id="auto-reboot-during-argo-cd-sync-with-machine-configurations"]
+= Issue: Auto-reboot during Argo CD sync with machine configurations
+
+In the Red Hat OpenShift Container Platform, nodes are updated automatically through the Red Hat OpenShift Machine Config Operator (MCO). A Machine Config Operator (MCO) is a custom resource that is used by the cluster to manage the complete life cycle of its nodes.
+
+When an MCO resource is created or updated in a cluster, the MCO picks up the update, performs the necessary changes to the selected nodes, and restarts the nodes gracefully by cordoning, draining, and rebooting those nodes. It handles everything from the kernel to the kubelet.
+
+However, interactions between the MCO and the GitOps workflow can introduce major performance issues and other undesired behaviors. This section shows how to make the MCO and the Argo CD GitOps orchestration tool work well together.

--- a/modules/performance-challenges-in-machine-configurations-and-argo-cd.adoc
+++ b/modules/performance-challenges-in-machine-configurations-and-argo-cd.adoc
@@ -1,0 +1,14 @@
+:_content-type: CONCEPT
+
+[id="performance-challenges-in-machine-configurations-and-argo-cd"]
+= Solution: Enhance performance in machine configurations and Argo CD
+
+When you are using a Machine Config Operator as part of a GitOps workflow, the following sequence can produce suboptimal performance:
+
+* Argo CD starts an automated sync job after a commit to the Git repository that contains application resources.
+
+* If Argo CD notices a new or an updated machine configuration while the sync operation is in process, MCO picks up the change to the machine configuration and starts rebooting the nodes to apply the change.
+
+* If a rebooting node in the cluster contains the Argo CD application controller, the application controller terminates, and the application sync is aborted.
+
+As the MCO reboots the nodes in sequential order, and the Argo CD workloads can be rescheduled on each reboot, it can take some time for the sync to be completed. This results in an undefined behavior until the MCO has rebooted all nodes affected by the machine configurations within the sync.


### PR DESCRIPTION
Purpose: To resolve the following issue:

https://issues.redhat.com/browse/RHDEVDOCS-3825

Aligned team: DevTools

OCP version this PR applies to (cherrypicking): enterprise 4.11 and later

Content for preview: https://56809--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/preventing-auto-reboot-during-argo-cd-sync-with-machine-configurations.html

SME review : @iam-veeramalla   

QE review: @varshab1210 

Peer review: @themr0c 