### PR TITLE
OSDOCS-5448: Documented 4.9.57 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-9-release-notes.adoc
+++ b/release_notes/ocp-4-9-release-notes.adoc
@@ -3405,3 +3405,29 @@ $ oc adm release info 4.9.56 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-9-57"]
+=== RHBA-2023:1026 - {product-title} 4.9.57 bug fix and security update
+
+Issued: 2023-03-08
+
+{product-title} release 4.9.57, which includes security updates, is now available. The bug fixes that are included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:1026[RHBA-2023:1026] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1025[RHBA-2023:1025] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.9.57 --pullspecs
+----
+
+[id="ocp-4-9-57-bug-fixes"]
+==== Bug fixes
+
+* Previously, a missing definition for `spec.provider` caused the *Operator details* page to fail when attempting to show `ClusterServiceVersion`. With this update, the user interface works without `spec.provider` and the *Operator details* page does not fail. (link:https://issues.redhat.com/browse/OCPBUGS-6694[*OCPBUGS-6694*])
+
+* Previously, the `cluster-image-registry-operator` would revert to using a persistent volume claim (PVC) when the operator could not connect to Swift. This would impact how your {product-title} cluster runs on OpenStack. With this update, `cluster-image-registry-operator` includes a mechanism for automatically choosing the storage backend during the initial boot operation. If Swift is available, the operator chooses Swift as the storage backend. Otherwise, the operator issues a PVC and uses block storage. The fallback to PVC only occurs if the OpenStack catalog is found. (link:https://issues.redhat.com/browse/OCPBUGS-7371[*OCPBUGS-7371*])
+
+[id="ocp-4-9-57-updating"]
+==== Updating
+
+To update an existing {product-title} 4.9 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.9

Issue:
[OSDOCS-5448](https://issues.redhat.com/browse/OSDOCS-5448)

Link to docs preview:
[Release notes 4.9.57](http://file.emea.redhat.com/dfitzmau/OSDOCS-5448/release_notes/ocp-4-9-release-notes.html#ocp-4-9-57)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
