### PR TITLE
OSDOCS-5115: IPv6 support for single interface

### DIFF
--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -69,6 +69,8 @@ include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[lev
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+include::modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc[leveloffset=+2]
+
 include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 // begin network customization

--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -1,6 +1,10 @@
 // This is included in the following assemblies:
 //
 // ipi-install-configuration-files.adoc
+// installing-vsphere-installer-provisioned-network-customizations.adoc
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vSphere:
+endif::[]
 
 :_content-type: PROCEDURE
 [id='modifying-install-config-for-dual-stack-network_{context}']
@@ -36,3 +40,20 @@ platform:
       - <wildcard_ipv4>
       - <wildcard_ipv6>
 ----
+
+ifdef::vSphere[]
+[IMPORTANT]
+====
+You can configure dual-stack networking on a single interface only.
+====
+
+[NOTE]
+====
+* In a vSphere cluster configured for dual-stack networking, the node custom resource object has only the IP address from the primary network listed in `Status.addresses` field.
+* In the pod that uses the host networking with dual-stack connectivity, the `Status.podIP` and `Status.podIPs` fields contain only the IP address from the primary network.
+====
+endif::vSphere[]
+
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:!vSphere:
+endif::[]


### PR DESCRIPTION
Version(s): 4.13

Issue:https://issues.redhat.com/browse/OSDOCS-5115?filter=-1

Link to docs preview: https://56830--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#modifying-install-config-for-dual-stack-network_installing-vsphere-installer-provisioned-network-customizations

Preview without new notes: https://56830--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow

QE review:
- [x] QE has approved this change. @rbbratta 

SME review:
- [x] SME has approved this change.
