### PR TITLE
OSDOCS#5230: Installing a three-node GCP cluster

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -260,6 +260,8 @@ Topics:
     File: installing-gcp-user-infra-vpc
   - Name: Installing a cluster on GCP in a restricted network with user-provisioned infrastructure
     File: installing-restricted-networks-gcp
+  - Name: Installing a three-node cluster on GCP
+    File: installing-gcp-three-node
   - Name: Uninstalling a cluster on GCP
     File: uninstalling-cluster-gcp
 - Name: Installing on IBM Cloud VPC

--- a/installing/installing_aws/installing-aws-three-node.adoc
+++ b/installing/installing_aws/installing-aws-three-node.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="installing-aws-three-node"]
-= Installing a three-node AWS cluster
+= Installing a three-node cluster on AWS
 include::_attributes/common-attributes.adoc[]
 :context: installing-aws-three-node
 

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on GCP with customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-gcp-customizations
+:platform: GCP
 
 toc::[]
 

--- a/installing/installing_gcp/installing-gcp-three-node.adoc
+++ b/installing/installing_gcp/installing-gcp-three-node.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+[id="installing-gcp-three-node"]
+= Installing a three-node cluster on GCP
+include::_attributes/common-attributes.adoc[]
+:context: installing-gcp-three-node
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a three-node cluster on Google Cloud Platform (GCP). A three-node cluster consists of three control plane machines, which also act as compute machines. This type of cluster provides a smaller, more resource efficient cluster, for cluster administrators and developers to use for testing, development, and production.
+
+You can install a three-node cluster using either installer-provisioned or user-provisioned infrastructure.
+
+include::modules/installation-three-node-cluster-cloud-provider.adoc[leveloffset=+1]
+
+== Next steps
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[Installing a cluster on GCP with customizations]
+* xref:../../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates]

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates
 include::_attributes/common-attributes.adoc[]
 :context: installing-gcp-user-infra
+:platform: GCP
 
 toc::[]
 

--- a/modules/installation-creating-gcp-worker.adoc
+++ b/modules/installation-creating-gcp-worker.adoc
@@ -3,6 +3,9 @@
 // * installing/installing_gcp/installing-gcp-user-infra.adoc
 // * installing/installing_gcp/installing-restricted-networks-gcp.adoc
 
+ifeval::["{context}" == "installing-gcp-user-infra"]
+:three-node-cluster:
+endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
 :shared-vpc:
 endif::[]
@@ -15,6 +18,13 @@ You can create worker machines in Google Cloud Platform (GCP) for your cluster
 to use by launching individual instances discretely or by automated processes
 outside the cluster, such as auto scaling groups. You can also take advantage of
 the built-in cluster scaling mechanisms and the machine API in {product-title}.
+
+ifdef::three-node-cluster[]
+[NOTE]
+====
+If you are installing a three-node cluster, skip this step. A three-node cluster consists of three control plane machines, which also act as compute machines.
+====
+endif::three-node-cluster[]
 
 In this example, you manually launch one instance by using the Deployment
 Manager template. Additional instances can be launched by including additional
@@ -135,6 +145,9 @@ $ gcloud deployment-manager deployments create ${INFRA_ID}-worker --config 06_wo
 ** {oke}: `\https://www.googleapis.com/compute/v1/projects/redhat-marketplace-public/global/images/redhat-coreos-oke-48-x86-64-202206140145`
 --
 
+ifeval::["{context}" == "installing-gcp-user-infra"]
+:!three-node-cluster:
+endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
 :!shared-vpc:
 endif::[]

--- a/modules/installation-generate-aws-user-infra-install-config.adoc
+++ b/modules/installation-generate-aws-user-infra-install-config.adoc
@@ -149,7 +149,7 @@ platform:
 endif::localzone[]
 
 ifdef::three-node-cluster[]
-. If you are installing a three-node cluster, modify the `install.config.yaml` file by setting the `compute.replicas` parameter to `0`. This ensures that the cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on AWS".
+. If you are installing a three-node cluster, modify the `install-config.yaml` file by setting the `compute.replicas` parameter to `0`. This ensures that the cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on AWS".
 endif::three-node-cluster[]
 
 . Optional: Back up the `install-config.yaml` file.

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -85,6 +85,7 @@ ifeval::["{context}" == "installing-azure-user-infra"]
 endif::[]
 ifeval::["{context}" == "installing-gcp-customizations"]
 :gcp:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-gcp-vpc"]
 :gcp:
@@ -97,7 +98,7 @@ ifeval::["{context}" == "installing-gcp-network-customizations"]
 endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra"]
 :gcp:
-:gcp-user-infra:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
 :gcp:
@@ -446,7 +447,7 @@ ifdef::openshift-origin[]
 This field is optional.
 endif::[]
 endif::rhv[]
-ifdef::gcp-user-infra,azure-user-infra[]
+ifdef::azure-user-infra[]
 .. Optional: If you do not want the cluster to provision compute machines, empty
 the compute pool by editing the resulting `install-config.yaml` file to set
 `replicas` to `0` for the `compute` pool:
@@ -707,6 +708,7 @@ ifeval::["{context}" == "installing-azure-user-infra"]
 endif::[]
 ifeval::["{context}" == "installing-gcp-customizations"]
 :!gcp:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-gcp-network-customizations"]
 :!gcp:
@@ -719,7 +721,7 @@ ifeval::["{context}" == "installing-gcp-shared-vpc"]
 endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra"]
 :!gcp:
-:!gcp-user-infra:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
 :!gcp:

--- a/modules/installation-three-node-cluster-cloud-provider.adoc
+++ b/modules/installation-three-node-cluster-cloud-provider.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // * installing/installing_aws/installing-aws-three-node.adoc
 // * installing/installing_vsphere/installing-vsphere-three-node.adoc
-// *
+// * installing/installing_gcp/installing-gcp-three-node.adoc
 
 ifeval::["{context}" == "installing-vsphere-three-node"]
 :vsphere:
@@ -37,21 +37,17 @@ compute:
   replicas: 0
 ----
 ifndef::vsphere,vmc[]
-. If you are deploying a cluster with user-provisioned infrastructure, do not create additional worker nodes.
+. If you are deploying a cluster with user-provisioned infrastructure:
+** After you create the Kubernetes manifest and Ignition config files, make sure that the `spec.mastersSchedulable` parameter is set to `true` in `cluster-scheduler-02-config.yml` file. You can locate this file in `<installation_directory>/manifests`.
+** Do not create additional worker nodes.
 endif::vsphere,vmc[]
 
 ifdef::vsphere,vmc[]
 . If you are deploying a cluster with user-provisioned infrastructure:
 ** Configure your application ingress load balancer to route HTTP and HTTPS traffic to the control plane nodes. In a three-node cluster, the Ingress Controller pods run on the control plane nodes. For more information, see the "Load balancing requirements for user-provisioned infrastructure".
+** After you create the Kubernetes manifest and Ignition config files, make sure that the `spec.mastersSchedulable` parameter is set to `true` in `cluster-scheduler-02-config.yml` file. You can locate this file in `<installation_directory>/manifests`.
 ** Do not create additional worker nodes.
 endif::vsphere,vmc[]
-
-.Verification
-
-To verify that the control plane nodes are schedulable, open the `cluster-scheduler-02-config.yml` Kubernetes manifest file and confirm that the `spec.mastersSchedulable` parameter is set to `true`. You can locate this file in `<installation_directory>/manifests`.
-
-* If you install a cluster on infrastructure that the installation program provisions, you can complete this verification step after the cluster is deployed.
-* If you install a cluster on infrastructure that you provision, you can complete this verification step after creating the Kubernetes manifest and Ignition configuration files.
 
 .Example `cluster-scheduler-02-config.yml` file for a three-node cluster
 [source,yaml]

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -54,6 +54,7 @@ ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra"]
 :gcp:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
 :gcp:
@@ -511,6 +512,7 @@ ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra"]
 :!gcp:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-gcp-user-infra-vpc"]
 :!gcp:


### PR DESCRIPTION
Version(s):
4.13+

Issue:
This PR addresses [osdocs-5230](https://issues.redhat.com/browse/OSDOCS-5230).

Link to docs preview:

- [Installing a three-node cluster on GCP](https://56842--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-three-node.html)
- Installing a cluster on GCP with customizations > [Creating the installation configuration file](https://56842--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html#installation-initializing_installing-gcp-customizations) (note under step 2)
- Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates > [Creating the installation configuration file](https://56842--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-initializing_installing-gcp-user-infra) (note under step 2)
- Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates > [Creating the Kubernetes manifest and Ignition config files](https://56842--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-gcp-user-infra) (warning before step 5)
- Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates > [Creating additional worker machines in GCP](https://56842--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra.html#installation-creating-gcp-worker_installing-gcp-user-infra) (first note)

QE review:
- [ ] QE has approved this change.