### PR TITLE
OSDOCS#5461: Adds notes for 4.12.6 MicroShift release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -117,3 +117,12 @@ Issued: 2023-02-28
 {product-title} release 4.12.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0893[RHBA-2023:0893] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0890[RHSA-2023:0890] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+
+[id="microshift-4-12-6-dp"]
+=== RHBA-2023:1037 - {product-title} 4.12.6 bug fix update
+
+Issued: 2023-03-07
+
+{product-title} release 4.12.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1037[RHBA-2023:1037] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1034[RHBA-2023:1034] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]


### PR DESCRIPTION
OSDOCS#5461: Adds notes for 4.12.6 MicroShift release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5461

Link to docs preview:
https://56843--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-6-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
note to reviewer the links will not work yet 
