### PR TITLE
TELCODOCS-649 release note for GA

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -165,6 +165,20 @@ Netlink messages dropped by OVS kernel module due to netlink socket buffer overf
 [id="ocp-4-13-scalability-and-performance"]
 === Scalability and performance
 
+[id="ocp-4-13-NUMA-scheduler-ga"]
+==== NUMA-aware scheduling with the NUMA Resources Operator is generally available
+
+NUMA-aware scheduling with the NUMA Resources Operator was previously introduced as a Technology Preview in {product-title} 4.10 and is now generally available in {product-title} {product-version}. 
+
+The NUMA Resources Operator deploys a NUMA-aware secondary scheduler that makes scheduling decisions for workloads based on a complete picture of available NUMA zones in clusters. This enhanced NUMA-aware scheduling ensures that latency-sensitive workloads are processed in a single NUMA zone for maximum efficiency and performance. 
+
+This update adds the following features:
+
+* Fine-tuning of API polling for NUMA resource reports.
+* Configuration options at the node group level for the node topology exporter.
+
+For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-about-numa-aware-scheduling_numa-aware[Scheduling NUMA-aware workloads].
+
 [id="ocp-4-13-insights-operator"]
 === Insights Operator
 
@@ -917,6 +931,11 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Not Available
 |Technology Preview
+
+|NUMA-aware scheduling with NUMA Resources Operator
+|Technology Preview
+|Technology Preview
+|General Availability
 
 |====
 


### PR DESCRIPTION
[TELCODOCS-649](https://issues.redhat.com//browse/TELCODOCS-649): RN to move NUMA scheduling with the NUMA Resources Operator to GA. Also some new features added since TP. 
Related content updates in #55855 

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-649

Link to docs preview:
https://56849--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-NUMA-scheduler-ga

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
When this RN is approved and peer reviewed, this PR will be closed and the RN text moved to JIRA for publishing separately. 