### PR TITLE
OSDOCS#5228: Installing a three-node Azure cluster

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -212,6 +212,8 @@ Topics:
     File: installing-azure-government-region
   - Name: Installing a cluster on Azure using ARM templates
     File: installing-azure-user-infra
+  - Name: Installing a three-node cluster on Azure
+    File: installing-azure-three-node
   - Name: Uninstalling a cluster on Azure
     File: uninstalling-cluster-azure
 - Name: Installing on Azure Stack Hub

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on Azure with customizations
 include::_attributes/common-attributes.adoc[]
 :context: installing-azure-customizations
+:platform: Azure
 
 toc::[]
 

--- a/installing/installing_azure/installing-azure-three-node.adoc
+++ b/installing/installing_azure/installing-azure-three-node.adoc
@@ -1,0 +1,22 @@
+:_content-type: ASSEMBLY
+[id="installing-azure-three-node"]
+= Installing a three-node cluster on Azure
+include::_attributes/common-attributes.adoc[]
+:context: installing-azure-three-node
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a three-node cluster on Microsoft Azure. A three-node cluster consists of three control plane machines, which also act as compute machines. This type of cluster provides a smaller, more resource efficient cluster, for cluster administrators and developers to use for testing, development, and production.
+
+You can install a three-node cluster using either installer-provisioned or user-provisioned infrastructure.
+
+[NOTE]
+====
+Deploying a three-node cluster using an Azure Marketplace image is not supported.
+====
+
+include::modules/installation-three-node-cluster-cloud-provider.adoc[leveloffset=+1]
+
+== Next steps
+* xref:../../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[Installing a cluster on Azure with customizations]
+* xref:../../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[Installing a cluster on Azure using ARM templates]

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on Azure using ARM templates
 include::_attributes/common-attributes.adoc[]
 :context: installing-azure-user-infra
+:platform: Azure
 
 toc::[]
 

--- a/modules/installation-creating-azure-worker.adoc
+++ b/modules/installation-creating-azure-worker.adoc
@@ -6,6 +6,7 @@
 ifeval::["{context}" == "installing-azure-user-infra"]
 :azure:
 :cp: Azure
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :ash:
@@ -20,6 +21,13 @@ You can create worker machines in Microsoft {cp} for your cluster
 to use by launching individual instances discretely or by automated processes
 outside the cluster, such as auto scaling groups. You can also take advantage of
 the built-in cluster scaling mechanisms and the machine API in {product-title}.
+
+ifdef::three-node-cluster[]
+[NOTE]
+====
+If you are installing a three-node cluster, skip this step. A three-node cluster consists of three control plane machines, which also act as compute machines.
+====
+endif::three-node-cluster[]
 
 In this example, you manually launch one instance by using the Azure Resource
 Manager (ARM) template. Additional instances can be launched by including
@@ -86,6 +94,7 @@ endif::ash[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :!azure:
 :!cp: Azure
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :!ash:

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -72,6 +72,7 @@ ifeval::["{context}" == "installing-aws-outposts-remote-workers"]
 endif::[]
 ifeval::["{context}" == "installing-azure-customizations"]
 :azure:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-azure-network-customizations"]
 :azure:
@@ -81,7 +82,7 @@ ifeval::["{context}" == "installing-azure-vnet"]
 endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :azure:
-:azure-user-infra:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-gcp-customizations"]
 :gcp:
@@ -447,21 +448,6 @@ ifdef::openshift-origin[]
 This field is optional.
 endif::[]
 endif::rhv[]
-ifdef::azure-user-infra[]
-.. Optional: If you do not want the cluster to provision compute machines, empty
-the compute pool by editing the resulting `install-config.yaml` file to set
-`replicas` to `0` for the `compute` pool:
-+
-[source,yaml]
-----
-compute:
-- hyperthreading: Enabled
-  name: worker
-  platform: {}
-  replicas: 0 <1>
-----
-<1> Set to `0`.
-endif::[]
 
 ifdef::aws-outposts[]
 . Modify the `install-config.yaml` file. The AWS Outposts installation has the following limitations which require manual modification of the `install-config.yaml` file:
@@ -695,6 +681,7 @@ ifeval::["{context}" == "installing-aws-outposts-remote-workers"]
 endif::[]
 ifeval::["{context}" == "installing-azure-customizations"]
 :!azure:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-azure-network-customizations"]
 :!azure:
@@ -704,7 +691,7 @@ ifeval::["{context}" == "installing-azure-vnet"]
 endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :!azure:
-:!azure-user-infra:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-gcp-customizations"]
 :!gcp:

--- a/modules/installation-three-node-cluster-cloud-provider.adoc
+++ b/modules/installation-three-node-cluster-cloud-provider.adoc
@@ -1,8 +1,19 @@
 // Module included in the following assemblies:
 // * installing/installing_aws/installing-aws-three-node.adoc
-// * installing/installing_vsphere/installing-vsphere-three-node.adoc
+// * installing/installing_azure/installing-azure-three-node.adoc
 // * installing/installing_gcp/installing-gcp-three-node.adoc
+// * installing/installing_vsphere/installing-vsphere-three-node.adoc
+// * installing/installing_vmc/installing-vmc-three-node.adoc
 
+ifeval::["{context}" == "installing-aws-three-node"]
+:aws:
+endif::[]
+ifeval::["{context}" == "installing-azure-three-node"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-gcp-three-node"]
+:gcp:
+endif::[]
 ifeval::["{context}" == "installing-vsphere-three-node"]
 :vsphere:
 endif::[]
@@ -38,14 +49,29 @@ compute:
 ----
 ifndef::vsphere,vmc[]
 . If you are deploying a cluster with user-provisioned infrastructure:
-** After you create the Kubernetes manifest and Ignition config files, make sure that the `spec.mastersSchedulable` parameter is set to `true` in `cluster-scheduler-02-config.yml` file. You can locate this file in `<installation_directory>/manifests`.
+** After you create the Kubernetes manifest files, make sure that the `spec.mastersSchedulable` parameter is set to `true` in `cluster-scheduler-02-config.yml` file. You can locate this file in `<installation_directory>/manifests`.
+ifdef::aws[]
+For more information, see "Creating the Kubernetes manifest and Ignition config files" in "Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates".
+endif::aws[]
+ifdef::azure[]
+For more information, see "Creating the Kubernetes manifest and Ignition config files" in "Installing a cluster on Azure using ARM templates".
+endif::azure[]
+ifdef::gcp[]
+For more information, see "Creating the Kubernetes manifest and Ignition config files" in "Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates".
+endif::gcp[]
 ** Do not create additional worker nodes.
 endif::vsphere,vmc[]
 
 ifdef::vsphere,vmc[]
 . If you are deploying a cluster with user-provisioned infrastructure:
 ** Configure your application ingress load balancer to route HTTP and HTTPS traffic to the control plane nodes. In a three-node cluster, the Ingress Controller pods run on the control plane nodes. For more information, see the "Load balancing requirements for user-provisioned infrastructure".
-** After you create the Kubernetes manifest and Ignition config files, make sure that the `spec.mastersSchedulable` parameter is set to `true` in `cluster-scheduler-02-config.yml` file. You can locate this file in `<installation_directory>/manifests`.
+** After you create the Kubernetes manifest files, make sure that the `spec.mastersSchedulable` parameter is set to `true` in `cluster-scheduler-02-config.yml` file. You can locate this file in `<installation_directory>/manifests`.
+ifdef::vsphere[]
+For more information, see "Creating the Kubernetes manifest and Ignition config files" in "Installing a cluster on vSphere with user-provisioned infrastructure".
+endif::vsphere[]
+ifdef::vmc[]
+For more information, see "Creating the Kubernetes manifest and Ignition config files" in "Installing a cluster on VMC with user-provisioned infrastructure".
+endif::vmc[]
 ** Do not create additional worker nodes.
 endif::vsphere,vmc[]
 
@@ -64,6 +90,15 @@ spec:
 status: {}
 ----
 
+ifeval::["{context}" == "installing-aws-three-node"]
+:!aws:
+endif::[]
+ifeval::["{context}" == "installing-azure-three-node"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-gcp-three-node"]
+:!gcp:
+endif::[]
 ifeval::["{context}" == "installing-vsphere-three-node"]
 :!vsphere:
 endif::[]

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -33,6 +33,7 @@ endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :azure:
 :azure-user-infra:
+:three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :ash:
@@ -505,6 +506,7 @@ endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :!azure:
 :!azure-user-infra:
+:!three-node-cluster:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :!ash:


### PR DESCRIPTION
Version(s):
4.13+

Issue:
This PR addresses [osdocs-5228](https://issues.redhat.com/browse/OSDOCS-5228).

Link to docs preview:

- [Installing a three-node cluster on Azure](https://56859--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-three-node.html)
- Installing a cluster on Azure with customizations > [Creating the installation configuration file](https://56859--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#installation-initializing_installing-azure-customizations) (note under step 2)
- Installing a cluster on Azure using ARM templates > [Creating the installation configuration file](https://56859--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-initializing_installing-azure-user-infra) (note under step 2)
- Installing a cluster on Azure using ARM templates > [Creating the Kubernetes manifest and Ignition config files](https://56859--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-azure-user-infra) (warning before step 5)
- Installing a cluster on Azure using ARM templates > [Creating additional worker machines in Azure](https://56859--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-creating-azure-worker_installing-azure-user-infra) (first note)

QE review:
- [ ] QE has approved this change.