### PR TITLE
OSDOCS-5447:adds to  RNs for 4.11.30

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3310,7 +3310,7 @@ To update an existing {product-title} 4.11 cluster to this latest release, see x
 
 Issued: 2023-02-28
 
-{product-title} release 4.11.29, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0895[RHSA-2023:0895] advisory.
+{product-title} release 4.11.29, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0895[RHSA-2023:0895] advisory. There are no RPM packages for this update.
 
 You can view the container images in this release by running the following command:
 
@@ -3320,6 +3320,30 @@ $ oc adm release info 4.11.29 --pullspecs
 ----
 
 [id="ocp-4-11-29-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-30"]
+=== RHSA-2023:1030 - {product-title} 4.11.30 bug fix and security update
+
+Issued: 2023-03-07
+
+{product-title} release 4.11.30, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1030[RHSA-2023:1030] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1029[RHBA-2023:1029] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.30 --pullspecs
+----
+
+[id="ocp-4-11-30-bug-fixes"]
+==== Bug fixes
+* Previously, when creating a `Secret`, the *Start Pipeline* model created an invalid JSON value. As a result, the `Secret` was unusable and the `PipelineRun` could fail. With this fix, the *Start Pipeline* model creates a valid JSON value for the Secret. Now, you can create valid secrets while starting a pipeline. (link:https://issues.redhat.com/browse/OCPBUGS-7494[*OCPBUGS-7494*])
+
+
+[id="ocp-4-11-30-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5447](https://issues.redhat.com//browse/OSDOCS-5447):adds zstream 4.11.30 to RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5447
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://56862--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-30<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
