### PR TITLE
RHDEVDOCS-4958: Updated the matrix table to fill in identified gaps

### DIFF
--- a/modules/op-release-notes-1-5.adoc
+++ b/modules/op-release-notes-1-5.adoc
@@ -5,7 +5,7 @@
 [id="op-release-notes-1-5_{context}"]
 = Release notes for {pipelines-title} General Availability 1.5
 
-{pipelines-title} General Availability (GA) 1.5 is now available on {product-title} 4.9.
+{pipelines-title} General Availability (GA) 1.5 is now available on {product-title} 4.8.
 
 [id="compatibility-support-matrix-1-5_{context}"]
 == Compatibility and support matrix

--- a/modules/op-release-notes-1-8.adoc
+++ b/modules/op-release-notes-1-8.adoc
@@ -5,7 +5,7 @@
 [id="op-release-notes-1-8_{context}"]
 = Release notes for {pipelines-title} General Availability 1.8
 
-With this update, {pipelines-title} General Availability (GA) 1.8 is available on {product-title} 4.10, 4.11 and 4.12.
+With this update, {pipelines-title} General Availability (GA) 1.8 is available on {product-title} 4.10, 4.11, and 4.12.
 
 [id="new-features-1-8_{context}"]
 == New features
@@ -545,7 +545,7 @@ securityContext:
 [id="release-notes-1-8-1_{context}"]
 == Release notes for {pipelines-title} General Availability 1.8.1
 
-With this update, {pipelines-title} General Availability (GA) 1.8.1 is available on {product-title} 4.10 and 4.11.
+With this update, {pipelines-title} General Availability (GA) 1.8.1 is available on {product-title} 4.10, 4.11, and 4.12.
 
 [id="known-issues-1-8-1_{context}"]
 === Known issues
@@ -614,7 +614,7 @@ config   1.8.1     True
 [id="release-notes-1-8-2_{context}"]
 == Release notes for {pipelines-title} General Availability 1.8.2
 
-With this update, {pipelines-title} General Availability (GA) 1.8.2 is available on {product-title} 4.10 and 4.11.
+With this update, {pipelines-title} General Availability (GA) 1.8.2 is available on {product-title} 4.10, 4.11, and 4.12.
 
 [id="fixed-issues-1-8-2_{context}"]
 === Fixed issues

--- a/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
+++ b/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
@@ -9,6 +9,8 @@ In the table, features are marked with the following statuses:
 TP:: Technology Preview
 GA:: General Availability
 
+// Writer, see http://dashboard.apps.cicd.ospqa.com/releases/componentmatrix/
+
 .Compatibility and support matrix
 [options="header"]
 |===
@@ -17,9 +19,9 @@ GA:: General Availability
 
 | Operator | Pipelines | Triggers | CLI | Catalog | Chains | Hub | {pac} | |
 
-|1.8 | 0.37.x | 0.20.x | 0.24.x | NA | 0.9.0 (TP) | 1.8.x (TP) | 0.10.x (TP) | 4.10, 4.11, 4.12 (planned) | GA
+|1.8 | 0.37.x | 0.20.x | 0.24.x | NA | 0.9.0 (TP) | 1.8.x (TP) | 0.10.x (TP) | 4.10, 4.11, 4.12 | GA
 
-|1.7 | 0.33.x | 0.19.x | 0.23.x | 0.33 | 0.8.0 (TP) | 1.7.0 (TP) | 0.5.4 (TP) | 4.9, 4.10 | GA
+|1.7 | 0.33.x | 0.19.x | 0.23.x | 0.33 | 0.8.0 (TP) | 1.7.0 (TP) | 0.5.x (TP) | 4.9, 4.10, 4.11 | GA
 
 |1.6 | 0.28.x | 0.16.x | 0.21.x | 0.28 | N/A | N/A | N/A | 4.9 | GA
 


### PR DESCRIPTION
Manual CP from https://github.com/openshift/openshift-docs/pull/56355 to 4.10

Aligned team: Dev Tools

Purpose: To resolve the following issue:
https://issues.redhat.com/browse/RHDEVDOCS-4985


OCP version this PR applies to: enterprise 4.10