### PR TITLE
RHDEVDOCS-4958: Updated the matrix table to fill in identified gaps

### DIFF
--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -18,7 +18,6 @@ In the table, features are marked with the following statuses:
 |*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
 
 |*Version* |*kam*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |
-|1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
 |1.6.0    |0.0.46 TP |3.8.1 GA|4.4.1 GA   |2.4.5 GA |GA and included in ArgoCD component    |2.30.3 GA |7.5.1 GA |4.8-4.11
 |1.5.0    |0.0.42 TP|3.8.0 GA|4.4.1 GA   |2.3.3 GA |0.4.1 TP       |2.30.3 GA |7.5.1 GA |4.8-4.11
 |1.4.0    |0.0.41 TP|3.7.1 GA|4.2.0 GA   |2.2.2 GA |0.2.0 TP       |2.30.0 GA |7.4.0 GA |4.7-4.10

--- a/modules/op-release-notes-1-5.adoc
+++ b/modules/op-release-notes-1-5.adoc
@@ -5,7 +5,7 @@
 [id="op-release-notes-1-5_{context}"]
 = Release notes for {pipelines-title} General Availability 1.5
 
-{pipelines-title} General Availability (GA) 1.5 is now available on {product-title} 4.9.
+{pipelines-title} General Availability (GA) 1.5 is now available on {product-title} 4.8.
 
 [id="compatibility-support-matrix-1-5_{context}"]
 == Compatibility and support matrix

--- a/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
+++ b/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
@@ -9,17 +9,23 @@ In the table, features are marked with the following statuses:
 TP:: Technology Preview
 GA:: General Availability
 
+// Writer, see http://dashboard.apps.cicd.ospqa.com/releases/componentmatrix/
+
 .Compatibility and support matrix
 [options="header"]
 |===
 
-| {pipelines-title} Version 4+| Component Version | OpenShift Version | Support Status
+| {pipelines-title} Version 7+| Component Version | OpenShift Version | Support Status
 
-|Operator | Pipelines | Triggers | CLI | Catalog | |
+| Operator | Pipelines | Triggers | CLI | Catalog | Chains | Hub | {pac} | |
 
-|1.6 | 0.28.x | 0.16.x      | 0.21.x | 0.28 | 4.9 | GA
-|1.5 | 0.24.x | 0.14.x      | 0.19.x | 0.24 | 4.8 | GA
-|1.4 | 0.22.x | 0.12.x      | 0.17.x | 0.22 | 4.7 | GA
+|1.7 | 0.33.x | 0.19.x | 0.23.x | 0.33 | 0.8.0 (TP) | 1.7.0 (TP) | 0.5.x (TP) | 4.9, 4.10, 4.11 | GA
+
+|1.6 | 0.28.x | 0.16.x | 0.21.x | 0.28 | N/A | N/A | N/A | 4.9 | GA
+
+|1.5 | 0.24.x | 0.14.x (TP) | 0.19.x | 0.24 | N/A | N/A | N/A | 4.8 | GA
+
+|1.4 | 0.22.x | 0.12.x (TP) | 0.17.x | 0.22 | N/A | N/A | N/A | 4.7 | GA
 
 |===
 


### PR DESCRIPTION
Manual CP from https://github.com/openshift/openshift-docs/pull/56355 to 4.9

Aligned team: Dev Tools

Purpose: To resolve the following issue:
https://issues.redhat.com/browse/RHDEVDOCS-4985

OCP version this PR applies to: enterprise 4.9