### PR TITLE
TELCODOCS-654: updating procedure to make it work for IPI baremetal installs

### DIFF
--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -316,12 +316,27 @@ NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
 baremetal   4.12.0    True        False         False      3d15h
 ----
 
-. Delete the machine of the unhealthy member using this command:
+. Remove the old `BareMetalHost` object by running the following command:
++
+[source,terminal]
+----
+$ oc delete bmh openshift-control-plane-2 -n openshift-machine-api
+----
++
+.Example output
+[source,terminal]
+----
+baremetalhost.metal3.io "openshift-control-plane-2" deleted
+----
+
+. Delete the machine of the unhealthy member by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete machine -n openshift-machine-api examplecluster-control-plane-2
 ----
++
+After you remove the `BareMetalHost` and `Machine` objects, then the `Machine` controller automatically deletes the `Node` object.
 +
 If deletion of the machine is delayed for any reason or the command is obstructed and delayed, you can force deletion by removing the machine object finalizer field.
 +
@@ -330,27 +345,28 @@ If deletion of the machine is delayed for any reason or the command is obstructe
 Do not interrupt machine deletion by pressing `Ctrl+c`. You must allow the command to proceed to completion. Open a new terminal window to edit and delete the finalizer fields.
 ====
 +
+.. Edit the machine configuration by running the following command:
++
 [source,terminal]
 ----
 $ oc edit machine -n openshift-machine-api examplecluster-control-plane-2
 ----
 +
-.. Find and delete the fields:
+.. Delete the following fields in the `Machine` custom resource, and then save the updated file:
 +
-[source,terminal]
+[source,yaml]
 ----
 finalizers:
 - machine.machine.openshift.io
 ----
 +
-Save your changes:
-+
+.Example output
 [source,terminal]
 ----
 machine.machine.openshift.io/examplecluster-control-plane-2 edited
 ----
-+
-.. Verify the machine was deleted by running the following command:
+
+. Verify that the machine was deleted by running the following command:
 +
 [source,terminal]
 ----
@@ -366,32 +382,8 @@ examplecluster-control-plane-1    Running                          3h11m   opens
 examplecluster-compute-0          Running                          165m    openshift-compute-0         baremetalhost:///openshift-machine-api/openshift-compute-0/3d685b81-7410-4bb3-80ec-13a31858241f         provisioned
 examplecluster-compute-1          Running                          165m    openshift-compute-1         baremetalhost:///openshift-machine-api/openshift-compute-1/0fdae6eb-2066-4241-91dc-e7ea72ab13b9         provisioned
 ----
-
-. Remove the old `BareMetalHost` object with this command:
 +
-[source,terminal]
-----
-$ oc delete bmh openshift-control-plane-2 -n openshift-machine-api
-----
-+
-.Example output
-[source,terminal]
-----
-baremetalhost.metal3.io "openshift-control-plane-2" deleted
-----
-+
-After you remove the `BareMetalHost` and `Machine` objects, then the `Machine` controller automatically deletes the `Node` object.
-+
-If, after deletion of the `BareMetalHost` object, the machine node requires excessive time for deletion, the machine node can be deleted using:
-+
-[source,terminal]
-----
-$ oc delete node openshift-control-plane-2
-
-node "openshift-control-plane-2" deleted
-----
-+
-Verify the node has been deleted:
+. Verify that the node has been deleted by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -260,13 +260,19 @@ metadata:
   providerID: aws:///us-east-1a/i-0fdb85790d76d0c3f
 ----
 
-.. Delete the machine of the unhealthy member:
+.. Delete the `BareMetalHost` object by running the following command, replacing `<host_name>` with the name of the bare-metal host for the unhealthy node:
 +
 [source,terminal]
 ----
-$ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0 <1>
+$ oc delete bmh -n openshift-machine-api <host_name>
 ----
-<1> Specify the name of the control plane machine for the unhealthy node.
+
+..  Delete the machine of the unhealthy member by running the following command, replacing `<machine_name>` with the name of the control plane machine for the unhealthy node, for example `clustername-8qw5l-master-0`:
++
+[source,terminal]
+----
+$ oc delete machine -n openshift-machine-api <machine_name>
+----
 
 .. Verify that the machine was deleted:
 +
@@ -292,7 +298,6 @@ clustername-8qw5l-worker-us-east-1c-pkg26   Running   m4.large    us-east-1   us
 ----
 $ oc apply -f new-master-machine.yaml
 ----
-
 
 .. Verify that the new machine has been created:
 +


### PR DESCRIPTION
[TELCODOCS-654](https://issues.redhat.com//browse/TELCODOCS-654): This work spawned from an older [bug](https://bugzilla.redhat.com/show_bug.cgi?id=2089766). It is suspected that deleting a machine before deleting the BMH is not the correct workflow and may result in orphaned machine. This PR changes the procedure to first delete the BMH and then the machine. 

Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/TELCODOCS-654

Link to docs preview:
- https://56878--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member
- https://56878--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

