### PR TITLE
Revert "RHDEVDOCS-3436 | Updated OCP>Support and OKD>Support pages for missing link to pipelines must-gather"

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -65,10 +65,6 @@ endif::openshift-dedicated[]
 
 |`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v<installed-version-NMO>`
 |Data collection for the Node Maintenance Operator (NMO).
-
-
-|`quay.io/openshift-pipeline/must-gather`
-|Data collection for Red Hat OpenShift Pipelines
 |===
 
 endif::openshift-origin[]
@@ -103,8 +99,6 @@ ifndef::openshift-dedicated[]
 |Data collection for Local Storage Operator.
 endif::openshift-dedicated[]
 
-|`quay.io/openshift-pipeline/must-gather`
-|Data collection for Red Hat OpenShift Pipelines
 |===
 
 endif::openshift-origin[]


### PR DESCRIPTION
Reverts openshift/openshift-docs#56361

Should not go on main, as it is not applicable to 4.13+