### PR TITLE
Updates OMR to 1.3.1

### DIFF
--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -11,6 +11,17 @@ These release notes track the development of the _mirror registry for Red Hat Op
 
 For an overview of the _mirror registry for Red Hat OpenShift_, see xref:../../installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-flags_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift].
 
+[id="mirror-registry-for-openshift-1-3-1"]
+== Mirror registry for Red Hat OpenShift 1.3.1
+
+Issued: 2023-03-7
+
+_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.3.
+
+The following advisory is available for the _mirror registry for Red Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2023:1086[RHBA-2023:1086 - mirror registry for Red Hat OpenShift 1.3.1]
+
 [id="mirror-registry-for-openshift-1-3-0"]
 == Mirror registry for Red Hat OpenShift 1.3.0
 


### PR DESCRIPTION
Add OMR 1.3.1 release notes to OCP. 

Version bump skipped 3.8.2

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-5484

Link to docs preview:
https://56886--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-for-openshift-1-3-1

QE review:
Not needed. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
