### PR TITLE
Fix deprecated module for opm CLI reference

### DIFF
--- a/cli_reference/opm/cli-opm-ref.adoc
+++ b/cli_reference/opm/cli-opm-ref.adoc
@@ -31,6 +31,10 @@ include::modules/opm-cli-ref-init.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-render.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-validate.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-serve.adoc[leveloffset=+1]
+
+:FeatureName: The SQLite-based catalog format, including the related CLI commands,
+include::modules/deprecated-feature.adoc[]
+
 include::modules/opm-cli-ref-migrate.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-index.adoc[leveloffset=+1]
 

--- a/modules/opm-cli-ref-migrate.adoc
+++ b/modules/opm-cli-ref-migrate.adoc
@@ -7,9 +7,6 @@
 
 Migrate a SQLite database format index image or database file to a file-based catalog.
 
-:FeatureName: The SQLite-based catalog format, including the related CLI commands,
-include::modules/deprecated-feature.adoc[]
-
 .Command syntax
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->
I made a mistake put the derprecated feature module inside an module. This PR fixes that issue. 
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: n/a
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56893--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-ref.html#opm-cli-ref-server_cli-opm-ref

- Moved `[IMPORTANT]` admonition from inside the `opm migrate` module to the assembly below the `opm serve` module.
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: I think QE review is n/a because it is a typo level fix. Please let me know if you disagree :) 
~~- [ ] QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
