### PR TITLE
CNV-25641: Adding the deprecation of marking virtual machine templates as favorites to the release notes

### DIFF
--- a/virt/virt-4-11-release-notes.adoc
+++ b/virt/virt-4-11-release-notes.adoc
@@ -137,6 +137,8 @@ You must perform one of the following tasks before updating to {VirtProductName}
 ** Move all nodes out of maintenance mode.
 ** Install the standalone NMO and replace the `nodemaintenances.nodemaintenance.kubevirt.io` custom resource (CR) with a `nodemaintenances.nodemaintenance.medik8s.io` CR.
 
+* You can no longer mark virtual machine templates as favorites.
+
 //[id="virt-4-11-changes"]
 //== Notable technical changes
 


### PR DESCRIPTION
Version(s):
4.11 only

Issue:
https://issues.redhat.com/browse/CNV-25641

Link to docs preview:
https://56921--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-11-release-notes.html#virt-4-11-removed

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The PR for the actual doc change here https://github.com/openshift/openshift-docs/pull/55614
