### PR TITLE
[enterprise-4.13] OSDOCS-5051: add haproxy update

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -141,6 +141,10 @@ Netlink messages dropped by OVS vSwitch daemon due to netlink socket buffer over
 Netlink messages dropped by OVS kernel module due to netlink socket buffer overflow. This will result in packet loss.
 ----
 
+[id="ocp-4-13-networking-haproxy-update"]
+==== Update to HAProxy 2.6
+{product-title} updated to HAProxy 2.6.
+
 [id="ocp-4-13-storage"]
 === Storage
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5051
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/jdohmann/OSDOCS-5051/release_notes/ocp-4-13-release-notes.html#ocp-4-13-networking-haproxy-update
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: verbiage mirrors [4.11 RN entry](https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-ne-haproxy-update)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
