### PR TITLE
Fixed misspelled PostgreSQL

### DIFF
--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -137,7 +137,7 @@ Continuing our ongoing investment in scale and performance, {product-title-short
 * Typical widget load time in the {product-title-short} portal is less than 2 seconds even with a very large number of violations; for example, more than 100,000
 
 [id="postgresql-technology-preview-374"]
-== Features available if the PostgreSQSL database option is installed
+== Features available if the PostgreSQL database option is installed
 
 The features described in the following sections are available only if the PostgreSQL database option is installed.
 


### PR DESCRIPTION
> there is a typo referencing PostgreSQL

Fixes the spelling.

Cherrypick into `rhacs-docs-3.74`