### PR TITLE
Added separate variables for unsupported versions for ACS and origin

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -41,7 +41,12 @@
 <body onload="selectVersion('<%= version %>');">
   <%= render("_templates/_topnav.html.erb", :distro_key => distro_key) %>
   <%
-    unsupported_versions = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "3.65", "3.66", "3.67", "3.68", "3.69", "3.70", "3.71"];
+    unsupported_versions = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7"];
+
+    unsupported_versions_acs = ["3.65", "3.66", "3.67", "3.68", "3.69", "3.70", "3.71"];
+
+    unsupported_versions_origin = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "3.11", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"];
+
   %>
   <div class="container">
     <button id="hc-open-btn" class="open-btn-sm" onclick="openNav()" aria-label="Open"><span class="fa fa-bars" /></button>
@@ -72,7 +77,7 @@
 
       <% end %>
 
-      <% if ((unsupported_versions.include? version) && (distro_key == "openshift-acs")) %>
+      <% if ((unsupported_versions_acs.include? version) && (distro_key == "openshift-acs")) %>
 
         <span>
           <div class="alert alert-danger" role="alert" id="support-alert">
@@ -82,7 +87,7 @@
 
       <% end %>
 
-      <% if ((unsupported_versions.include? version) && (distro_key == "openshift-origin")) %>
+      <% if ((unsupported_versions_origin.include? version) && (distro_key == "openshift-origin")) %>
 
         <span>
           <div class="alert alert-danger" role="alert" id="support-alert">
@@ -221,7 +226,7 @@
               <span class="material-icons-outlined" title="Page history">history
               </span>
             </a>
-            <% unless (unsupported_versions.include? version) %>
+            <% unless (unsupported_versions_acs.include? version) %>
               <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12331224&issuetype=1&components=12366876&priority=4&summary=<%= "[rhacs-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
                 <span class="material-icons-outlined" title="Open an issue">bug_report
                 </span>


### PR DESCRIPTION
We currently use a single `unsupported_versions` variable to mark unsupported versions of docs for OCP, Origin, and ACS. However, only the `latest` version is supported for Origin, and ACS is changing the version numbers to 4.x. 

This PR fixes this issue by separating unsupported version numbers for Origin and ACS.

How to test (for Origin):
1. Download this branch locally.
1. Replace the contents of `_distro_map.yml` file with the following:
```
openshift-origin:
  name: OKD
  author: OKD Documentation Project <dev@lists.openshift.redhat.com>
  site: community
  site_name: Documentation
  site_url: https://docs.okd.io/
  branches:
    okd-banner:
      name: '4.11'
      dir: '4.11'
```
3. Commit the changes.
4. Run `asciibinder build --distro openshift-origin`.
5. Verify that the unsupported banner appears.
