### PR TITLE
OADP 1.1.2 Release notes

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-1-2.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-1-1.adoc[leveloffset=+1]
 
 :!oadp-release-notes:

--- a/modules/oadp-release-notes-1-1-2.adoc
+++ b/modules/oadp-release-notes-1-1-2.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="migration-oadp-release-notes-1-1-2_{context}"]
+= OADP 1.1.2 release notes
+
+The OADP 1.1.2 release notes include product recommendations, a list of fixed bugs and descriptions of known issues.
+
+[id="product-recommendations_{context}"]
+== Product recommendations
+
+.VolSync
+
+To prepare for the upgrade from VolSync 0.5.1 to the latest version available from the VolSync *stable* channel,  you must add this annotation in the `openshift-adp` namespace by running the following command:
+
+[source,terminal]
+----
+$ oc annotate --overwrite namespace/openshift-adp volsync.backube/privileged-movers='true'
+----
+
+.Velero
+
+In this release, Velero has been upgraded from version 1.9.2 to version link:https://github.com/vmware-tanzu/velero/releases/tag/v1.9.5[1.9.5].
+
+.Restic
+
+In this release, Restic has been upgraded from version 0.13.1 to version link:https://github.com/restic/restic/releases/tag/v0.14.0[0.14.0].
+
+[id="fixed-bugs_{context}"]
+== Fixed bugs
+
+The following bugs have been fixed in this release:
+
+* link:https://issues.redhat.com/browse/OADP-1150[OADP-1150]
+* link:https://issues.redhat.com/browse/OADP-290[OADP-290]
+* link:https://issues.redhat.com/browse/OADP-1056[OADP-1056]
+
+[id="known-issues_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+* OADP currently does not support backup and restore of AWS EFS volumes using restic in Velero (link:https://issues.redhat.com/browse/OADP-778[*OADP-778*]).
+
+* CSI backups might fail due to a Ceph limitation of `VolumeSnapshotContent` snapshots per PVC.
++
+You can create many snapshots of the same persistent volume claim (PVC) but cannot schedule periodic creation of snapshots:
++
+--
+** For CephFS, you can create up to 100 snapshots per PVC. (link:https://issues.redhat.com/browse/OADP-804[*OADP-804*])
+** For RADOS Block Device (RBD), you can create up to 512 snapshots for each PVC. (link:https://issues.redhat.com/browse/OADP-975[*OADP-975*])
+--
++
+For more information, see https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.11/html/managing_and_allocating_storage_resources/volume-snapshots_rhodf[Volume Snapshots].


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OADP-1215
OADP 1.1.2
OCP 4.9+
Preview: https://56940--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-release-notes.html