### PR TITLE
[OSDOCS-5328]: Adding procedure to restart hosted control plane components

### DIFF
--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -9,10 +9,8 @@ toc::[]
 If you encounter issues with {hcp}, see the following information to guide you through troubleshooting.
 
 include::modules/hosted-control-planes-troubleshooting.adoc[leveloffset=+1]
-
-//restarting hosted control plane components
+include::modules/hosted-restart-hcp-components.adoc[leveloffset=+1]
 include::modules/hosted-control-planes-pause-reconciliation.adoc[leveloffset=+1]
-
 include::modules/scale-down-data-plane.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/hosted-restart-hcp-components.adoc
+++ b/modules/hosted-restart-hcp-components.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assembly:
+//
+// * hosted_control_planes/index.adoc
+
+:_content-type: PROCEDURE
+[id="hosted-restart-hcp-components_{context}"]
+= Restarting hosted control plane components
+
+If you are an administrator for hosted control planes, you can use the `hypershift.openshift.io/restart-date` annotation to restart all control plane components for a particular `HostedCluster` resource. For example, you might need to restart control plane components for certificate rotation.
+
+.Procedure
+
+To restart a control plane, annotate the `HostedCluster` resource by entering the following command:
+
+[source,terminal]
+----
+$ oc annotate hostedcluster -n <hosted_cluster_namespace> <hosted_cluster_name> hypershift.openshift.io/restart-date=$(date --iso-8601=seconds)
+----
+
+.Verification
+
+The control plane is restarted whenever the value of the anonotation changes. The `date` command in the example serves as the source of a unique string. The annotation is treated as a string, not a timestamp.
+
+The following components are restarted:
+
+* catalog-operator
+* certified-operators-catalog
+* cluster-api
+* cluster-autoscaler
+* cluster-policy-controller
+* cluster-version-operator
+* community-operators-catalog
+* control-plane-operator
+* hosted-cluster-config-operator
+* ignition-server
+* ingress-operator
+* konnectivity-agent
+* konnectivity-server
+* kube-apiserver
+* kube-controller-manager
+* kube-scheduler
+* machine-approver
+* oauth-openshift
+* olm-operator
+* openshift-apiserver
+* openshift-controller-manager
+* openshift-oauth-apiserver
+* packageserver
+* redhat-marketplace-catalog
+* redhat-operators-catalog


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5328
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56947--ocpdocs-pr.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting#hosted-restart-hcp-components_hcp-troubleshooting
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
