### PR TITLE
GH#55128: Added resource for Enabling Operator conditions

### DIFF
--- a/modules/olm-updating-use-operatorconditions.adoc
+++ b/modules/olm-updating-use-operatorconditions.adoc
@@ -7,7 +7,7 @@
 
 Operator Lifecycle Manager (OLM) automatically creates an `OperatorCondition` resource for each `ClusterServiceVersion` resource that it reconciles. All service accounts in the CSV are granted the RBAC to interact with the `OperatorCondition` owned by the Operator.
 
-An Operator author can develop their Operator to use the `operator-lib` library such that, after the Operator has been deployed by OLM, it can set its own conditions. For more on writing logic to set Operator conditions as an Operator author, see the Operator SDK documentation.
+An Operator author can develop their Operator to use the `operator-lib` library such that, after the Operator has been deployed by OLM, it can set its own conditions. For more resources about setting Operator conditions as an Operator author, see the link:https://docs.openshift.com/container-platform/4.12/operators/operator_sdk/osdk-generating-csvs.html#osdk-operatorconditions_osdk-generating-csvs[Enabling Operator conditions] page.
 
 [id="olm-updating-use-operatorconditions-defaults_{context}"]
 == Setting defaults


### PR DESCRIPTION
Paragraph includes: 
"For more on writing logic to set Operator conditions as an Operator author, see the Operator SDK documentation." without link.
Added a link to help users understand how to enable Operator conditions.

Version(s):
4.9+

Issue:
https://github.com/openshift/openshift-docs/issues/55128

Link to docs preview:
https://56948--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-operatorconditions.html#olm-updating-use-operatorconditions_olm-managing-operatorconditions

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
