### PR TITLE
OSDOCS-3586: Wording Update for Support Period

### DIFF
--- a/modules/life-cycle-minor-versions.adoc
+++ b/modules/life-cycle-minor-versions.adoc
@@ -1,16 +1,16 @@
 // Module included in the following assemblies:
-//
+// * osd_architecture/osd_policy/osd-life-cycle.adoc
 // * rosa_policy/rosa-life-cycle.adoc
 
 [id="rosa-minor-versions_{context}"]
 = Minor versions (x.Y.z)
 
 Starting with the 4.8 OpenShift Container Platform minor version, Red Hat supports all minor
-versions within a 14 month period following general availability of the given minor version. Patch
-versions are not affected by the 14 month supportability period.
+versions for at least a 14 month period following general availability of the given minor version. Patch
+versions are not affected by the support period.
 
-Customers are notified 60, 30, and 15 days prior to the end of the 14 month period. Clusters must be upgraded to
-a supported minor version prior to the end of the 14 month period, or the cluster will enter
+Customers are notified 60, 30, and 15 days prior to the end of the support period. Clusters must be upgraded to
+a supported minor version prior to the end of the support period, or the cluster will enter
 a "Limited Support" status.
 
 .Example


### PR DESCRIPTION
OSDOCS- 3586

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-3586

Link to docs preview:
OSD: https://56955--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-life-cycle.html
ROSA: https://56955--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
