### PR TITLE
OADP-1378: Check OADP 1.1.2 documentation for references to earlier versions

### DIFF
--- a/modules/oadp-ibm-power-test-support.adoc
+++ b/modules/oadp-ibm-power-test-support.adoc
@@ -6,4 +6,4 @@
 [id="oadp-ibm-power-test-matrix_{context}"]
 = OADP support for target backup locations using IBM Power
 
-IBM Power running with {product-title} 4.11 and OpenShift API for Data Protection (OADP) 1.1.0 was tested successfully against an AWS S3 backup location target. Although the test involved only an AWS S3 target, Red Hat supports running IBM Power with {product-title} 4.11 and OADP 1.1.0 against all non-AWS S3 backup location targets as well.
+IBM Power running with {product-title} 4.11 and 4.12, and OpenShift API for Data Protection (OADP) 1.1.2 was tested successfully against an AWS S3 backup location target. Although the test involved only an AWS S3 target, Red Hat supports running IBM Power with {product-title} 4.11 and 4.12, and OADP 1.1.2 against all non-AWS S3 backup location targets as well.

--- a/modules/oadp-ibm-z-test-support.adoc
+++ b/modules/oadp-ibm-z-test-support.adoc
@@ -6,4 +6,4 @@
 [id="oadp-ibm-z-test-support_{context}"]
 = OADP testing and support for target backup locations using {ibmzProductName}
 
-{ibmzProductName} running with {product-title} 4.11 and OpenShift API for Data Protection (OADP) 1.1.0 was tested successfully against an AWS S3 backup location target. Although the test involved only an AWS S3 target, Red Hat supports running {ibmzProductName} with {product-title} 4.11 and OADP 1.1.0 against all non-AWS S3 backup location targets as well.
+{ibmzProductName} running with {product-title} 4.11 and 4.12, and OpenShift API for Data Protection (OADP) 1.1.2 was tested successfully against an AWS S3 backup location target. Although the test involved only an AWS S3 target, Red Hat supports running {ibmzProductName} with {product-title} 4.11 and 4.12, and OADP 1.1.2 against all non-AWS S3 backup location targets as well.

--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -9,7 +9,7 @@
 :FeatureName: Data Mover for CSI snapshots
 include::snippets/technology-preview.adoc[]
 
-The OADP 1.1.0 Data Mover enables customers to back up container storage interface (CSI) volume snapshots to a remote object store.  When Data Mover is enabled, you can restore stateful applications from the store if a failure, accidental deletion, or corruption of the cluster occurs. The OADP 1.1.0 Data Mover solution uses the Restic option of VolSync.
+The OADP 1.1.2 Data Mover enables customers to back up container storage interface (CSI) volume snapshots to a remote object store. When Data Mover is enabled, you can restore stateful applications from the store if a failure, accidental deletion, or corruption of the cluster occurs. The OADP 1.1.2 Data Mover solution uses the Restic option of VolSync.
 
 [NOTE]
 =====


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OADP-1378
OADP 1.1.2
OCP 4.9+
Preview:
https://56956--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-features-plugins.html#oadp-support-for-ibm-power-and-ibm-z
https://56956--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-features-plugins.html#oadp-ibm-power-test-matrix_oadp-features-plugins
https://56956--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-using-data-mover-for-csi-snapshots_backing-up-applications