### PR TITLE
OCPBUGS-7877: Update accessing microshift cluster permissions in kube…

### DIFF
--- a/modules/microshift-accessing-cluster-locally.adoc
+++ b/modules/microshift-accessing-cluster-locally.adoc
@@ -28,6 +28,13 @@ $ mkdir -p ~/.kube/
 $ sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig > ~/.kube/config
 ----
 
+. Update the permissions on your `~/.kube/config` file by running the following command: 
++
+[source,terminal]
+----
+$ chmod go-r ~/.kube/config
+----
+
 . Verify that {product-title} is running by entering the following command:
 +
 [source,terminal]

--- a/modules/microshift-accessing-cluster-remotely-non-admin.adoc
+++ b/modules/microshift-accessing-cluster-remotely-non-admin.adoc
@@ -39,6 +39,13 @@ Use the following procedure to access the {product-title} cluster from a remote 
 [user@workstation]$ ssh <user>@$MICROSHIFT_MACHINE "sudo cat /var/lib/microshift/resources/kubeadmin/kubeconfig" > ~/.kube/config
 ----
 
+. Update the permissions on your `~/.kube/config` file by running the following command: 
++
+[source,terminal]
+----
+$ chmod go-r ~/.kube/config
+----
+
 . As `user@workstation`, replace the `server` field in your `kubeconfig` file with the name or IP address of your {op-system} machine running {product-title} by running the following command:
 +
 [source,terminal]


### PR DESCRIPTION
**For versions:** 4.12+ 
**Issue:** [OCPBUGS-7877](https://issues.redhat.com/browse/OCPBUGS-7877)

**Description:** Incorrect permissions are set in ~/.kube/config file, adding command to update correct permissions 

**Preview:**
- [Accessing the MicroShift cluster locally  ](https://56962--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#accessing-microshift-cluster-locally_microshift-install-rpm)
- [Accessing the MicroShift cluster remotely from a workstation](https://56962--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#accessing-microshift-cluster-remotely-non-admin_microshift-install-rpm) 

**QE review:** 
N/A
