### PR TITLE
TELCODOCS-1065: Create KMMO doc: Secure Boot

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -5,7 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: kernel-module-management-operator
 
 
-toc::[]             
+toc::[]
 
 Learn about the Kernel Module Management (KMM) Operator and how you can use it to deploy out-of-tree kernel modules and device plugins on {product-title} clusters.
 
@@ -16,3 +16,13 @@ include::modules/kmm-installation.adoc[leveloffset=+1]
 include::modules/kmm-installing-using-web-console.adoc[leveloffset=+2]
 include::modules/kmm-installing-using-cli.adoc[leveloffset=+2]
 include::modules/kmm-installing-older-versions.adoc[leveloffset=+2]
+// Added for TELCODOCS-1065
+include::modules/kmm-using-signing-with-kmm.adoc[leveloffset=+1]
+include::modules/kmm-adding-the-keys-for-secureboot.adoc[leveloffset=+1]
+include::modules/kmm-checking-the-keys.adoc[leveloffset=+2]
+include::modules/kmm-signing-a-prebuilt-driver-container.adoc[leveloffset=+1]
+include::modules/kmm-building-and-signing-a-moduleloader-container-image.adoc[leveloffset=+1]
+.Additional resources
+For information on creating a service account, see xref:https://docs.openshift.com/container-platform/4.12/authentication/understanding-and-creating-service-accounts.html#service-accounts-managing_understanding-service-accounts[Creating service accounts].
+
+include::modules/kmm-debugging-and-troubleshooting.adoc[leveloffset=+1]

--- a/modules/kmm-adding-the-keys-for-secureboot.adoc
+++ b/modules/kmm-adding-the-keys-for-secureboot.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-adding-the-keys-for-secureboot_{context}"]
+= Adding the keys for secureboot
+
+To use KMM Kernel Module Management (KMM) to sign kernel modules, a certificate and private key are required. For details on how to create these, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/signing-a-kernel-and-modules-for-secure-boot_managing-monitoring-and-updating-the-kernel#generating-a-public-and-private-key-pair_signing-a-kernel-and-modules-for-secure-boot[Generating a public and private key pair].
+
+For details on how to extract the public and private key pair, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/signing-a-kernel-and-modules-for-secure-boot_managing-monitoring-and-updating-the-kernel#signing-kernel-modules-with-the-private-key_signing-a-kernel-and-modules-for-secure-boot[Signing kernel modules with the private key]. Use steps 1 through 4 to extract the keys into files.
+
+.Procedure
+
+. Create the `sb_cert.cer` file that contains the certificate and the `sb_cert.priv` file that contains the private key:
++
+[source,terminal]
+----
+$ openssl req -x509 -new -nodes -utf8 -sha256 -days 36500 -batch -config configuration_file.config -outform DER -out my_signing_key_pub.der -keyout my_signing_key.priv
+----
+
+. Add the files by using one of the following methods:
++
+* Add the files as link:https://kubernetes.io/docs/concepts/configuration/secret/[secrets] directly:
++
+[source,terminal]
+----
+$ oc create secret generic my-signing-key --from-file=key=<my_signing_key.priv>
+----
++
+[source,terminal]
+----
+$ oc create secret generic my-signing-key-pub --from-file=key=<my_signing_key_pub.der>
+----
++
+* Add the files by base64 encoding them:
++
+[source,terminal]
+----
+$ cat sb_cert.priv | base64 -w 0 > my_signing_key2.base64
+----
++
+[source,terminal]
+----
+$ cat sb_cert.cer | base64 -w 0 > my_signing_key_pub.base64
+----
+
+. Add the encoded text to a YAML file:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-signing-key-pub
+  namespace: default <1>
+type: Opaque
+data:
+  cert: <base64_encoded_secureboot_public_key>
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-signing-key
+  namespace: default <1>
+type: Opaque
+data:
+  key: <base64_encoded_secureboot_private_key>
+----
+<1> `namespace` - Replace `default` with a valid namespace.
+
+. Apply the YAML file:
++
+[source,terminal]
+----
+$ oc apply -f <yaml_filename>
+----

--- a/modules/kmm-building-and-signing-a-moduleloader-container-image.adoc
+++ b/modules/kmm-building-and-signing-a-moduleloader-container-image.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-building-and-signing-a-moduleloader-container-image_{context}"]
+= Building and signing a ModuleLoader container image
+
+Use this procedure if you have source code and must build your image first.
+
+The following YAML file builds a new container image using the source code from the repository. The image produced is saved back in the registry with a temporary name, and this temporary image is then signed using the parameters in the `sign` section.
+
+The temporary image name is based on the final image name and is set to be `<containerImage>:<tag>-<namespace>_<module name>_kmm_unsigned`.
+
+For example, using the following YAML file, Kernel Module Management (KMM) builds an image named `example.org/repository/minimal-driver:final-default_example-module_kmm_unsigned` containing the build with unsigned kmods and push it to the registry. Then it creates a second image named `example.org/repository/minimal-driver:final` that contains the signed kmods. It is this second image that is loaded by the `DaemonSet` object and deploys the kmods to the cluster nodes.
+
+After it is signed, the temporary image can be safely deleted from the registry. It will be rebuilt, if needed.
+
+.Prerequisites
+
+* The `keySecret` and `certSecret` secrets have been created.
+
+.Procedure
+
+. Apply the YAML file:
++
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: example-module-dockerfile
+  namespace: default <1>
+data:
+  Dockerfile: |
+    ARG DTK_AUTO
+    ARG KERNEL_VERSION
+    FROM ${DTK_AUTO} as builder
+    WORKDIR /build/
+    RUN git clone -b main --single-branch https://github.com/rh-ecosystem-edge/kernel-module-management.git
+    WORKDIR kernel-module-management/ci/kmm-kmod/
+    RUN make
+    FROM registry.access.redhat.com/ubi8/ubi:latest
+    ARG KERNEL_VERSION
+    RUN yum -y install kmod && yum clean all
+    RUN mkdir -p /opt/lib/modules/${KERNEL_VERSION}
+    COPY --from=builder /build/kernel-module-management/ci/kmm-kmod/*.ko /opt/lib/modules/${KERNEL_VERSION}/
+    RUN /usr/sbin/depmod -b /opt
+---
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: example-module
+  namespace: default <1>
+spec:
+  moduleLoader:
+    serviceAccountName: default <2>
+    container:
+      modprobe:
+        moduleName: simple_kmod
+      kernelMappings:
+        - regexp: '^.*\.x86_64$'
+          containerImage: < the name of the final driver container to produce>
+          build:
+            dockerfileConfigMap:
+              name: example-module-dockerfile
+          sign:
+            keySecret:
+              name: <private key secret name>
+            certSecret:
+              name: <certificate secret name>
+            filesToSign:
+              - /opt/lib/modules/4.18.0-348.2.1.el8_5.x86_64/kmm_ci_a.ko
+  imageRepoSecret: <3>
+    name: repo-pull-secret
+  selector: # top-level selector
+    kubernetes.io/arch: amd64
+----
+
+<1> `namespace` - Replace `default` with a valid namespace.
+
+<2> `serviceAccountName` - The default `serviceAccountName` does not have the required permissions to run a module that is privileged. For information on creating a service account, see "Creating service accounts" in the "Additional resources" of this section.
+
+<3> `imageRepoSecret` - Used as `imagePullSecrets` in the `DaemonSet` object and to pull and push for the build and sign features.

--- a/modules/kmm-checking-the-keys.adoc
+++ b/modules/kmm-checking-the-keys.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-checking-the-keys_{context}"]
+= Checking the keys
+
+After you have added the keys, you must check them to ensure they are set correctly.
+
+.Procedure
+
+. Check to ensure the public key secret is set correctly:
++
+[source,terminal]
+----
+$ oc get secret -o yaml <certificate secret name> | awk '/cert/{print $2; exit}' | base64 -d  | openssl x509 -inform der -text
+----
++
+This should display a certificate with a Serial Number, Issuer, Subject, and more.
+
+. Check to ensure the private key secret is set correctly:
++
+[source,terminal]
+----
+$ oc get secret -o yaml <private key secret name> | awk '/key/{print $2; exit}' | base64 -d
+----
++
+This should display the key enclosed in the `-----BEGIN PRIVATE KEY-----` and `-----END PRIVATE KEY-----` lines.

--- a/modules/kmm-debugging-and-troubleshooting.adoc
+++ b/modules/kmm-debugging-and-troubleshooting.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-debugging-and-troubleshooting_{context}"]
+= Debugging and troubleshooting
+
+If the kmods in your driver container are not signed or are signed with the wrong key, then the container can enter a `PostStartHookError` or `CrashLoopBackOff` status. You can verify by running the `oc describe` command on your container, which displays the following message in this scenario:
+
+[source,terminal]
+----
+modprobe: ERROR: could not insert '<your_kmod_name>': Required key not available
+----

--- a/modules/kmm-signing-a-prebuilt-driver-container.adoc
+++ b/modules/kmm-signing-a-prebuilt-driver-container.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-signing-a-prebuilt-driver-container_{context}"]
+= Signing a pre-built driver container
+
+Use this procedure if you have a pre-built image, such as an image either distributed by a hardware vendor or built elsewhere.
+
+The following YAML file adds the public/private key-pair as secrets with the required key names - `key` for the private key, `cert` for the public key. The cluster then pulls down the `unsignedImage` image, opens it, signs the kernel modules listed in `filesToSign`, adds them back, and pushes the resulting image as `containerImage`.
+
+
+Kernel Module Management (KMM) should then deploy the DaemonSet that loads the signed kmods onto all the nodes that match the selector. The driver containers should run successfully on any nodes that have the public key in their MOK database, and any nodes that are not secure-boot enabled, which ignore the signature. They should fail to load on any that have secure-boot enabled but do not have that key in their MOK database.
+
+.Prerequisites
+
+* The `keySecret` and `certSecret` secrets have been created.
+
+.Procedure
+
+. Apply the YAML file:
++
+[source,yaml]
+----
+---
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: example-module
+spec:
+  moduleLoader:
+    serviceAccountName: default
+    container:
+      modprobe: <1>
+        moduleName: '<your module name>'
+      kernelMappings:
+        # the kmods will be deployed on all nodes in the cluster with a kernel that matches the regexp
+        - regexp: '^.*\.x86_64$'
+          # the container to produce containing the signed kmods
+          containerImage: <image name e.g. quay.io/myuser/my-driver:<kernelversion>-signed>
+          sign:
+            # the image containing the unsigned kmods (we need this because we are not building the kmods within the cluster)
+            unsignedImage: <image name e.g. quay.io/myuser/my-driver:<kernelversion> >
+            keySecret: # a secret holding the private secureboot key with the key 'key'
+              name: <private key secret name>
+            certSecret: # a secret holding the public secureboot key with the key 'cert'
+              name: <certificate secret name>
+            filesToSign: # full path within the unsignedImage container to the kmod(s) to sign
+              - /opt/lib/modules/4.18.0-348.2.1.el8_5.x86_64/kmm_ci_a.ko
+  imageRepoSecret:
+    # the name of a secret containing credentials to pull unsignedImage and push containerImage to the registry
+    name: repo-pull-secret
+  selector:
+    kubernetes.io/arch: amd64
+----
+
+<1> `modprobe` - The name of the kmod to load.

--- a/modules/kmm-using-signing-with-kmm.adoc
+++ b/modules/kmm-using-signing-with-kmm.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-using-signing-with-kmm_{context}"]
+= Using signing with Kernel Module Management (KMM)
+
+On a Secure Boot enabled system, all kernel modules (kmods) must be signed with a public/private key-pair enrolled into the Machine Owner's Key (MOK) database. Drivers distributed as part of a distribution should already be signed by the distribution's private key, but for kernel modules build out-of-tree, KMM supports signing kernel modules using the `sign` section of the kernel mapping.
+
+For more details on using Secure Boot, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_monitoring_and_updating_the_kernel/signing-a-kernel-and-modules-for-secure-boot_managing-monitoring-and-updating-the-kernel#generating-a-public-and-private-key-pair_signing-a-kernel-and-modules-for-secure-boot[Generating a public and private key pair]
+
+.Prerequisites
+
+* A public private key pair in the correct (DER) format.
+* At least one secure-boot enabled node with the public key enrolled in its MOK database.
+* Either a pre-built driver container image, or the source code and `Dockerfile` needed to build one in-cluster.


### PR DESCRIPTION
Create KMMO doc: Secure Boot

Jira:[ https://issues.redhat.com/browse/TELCODOCS-1065](https://issues.redhat.com/browse/TELCODOCS-1065)

Version: openshift-4.12.z

Preview: https://56972--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-using-signing-with-kmm_kernel-module-management-operator

Dev:[ @qbarrand](https://github.com/qbarrand) @chr15p 
T&PS:[ @slovern](https://github.com/slovern)
QE: [@cdvultur 