### PR TITLE
OSDOCS-3417: move out of ingress operator assembly

### DIFF
--- a/networking/ingress-operator.adoc
+++ b/networking/ingress-operator.adoc
@@ -67,14 +67,6 @@ include::modules/nw-configure-ingress-access-logging.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-setting-thread-count.adoc[leveloffset=+2]
 
-include::modules/nw-ingress-sharding.adoc[leveloffset=+2]
-
-include::modules/nw-ingress-sharding-default.adoc[leveloffset=+3]
-
-include::modules/nw-ingress-sharding-route-labels.adoc[leveloffset=+3]
-
-include::modules/nw-ingress-sharding-namespace-labels.adoc[leveloffset=+3]
-
 include::modules/nw-ingress-setting-internal-lb.adoc[leveloffset=+2]
 
 include::modules/nw-ingress-controller-configuration-gcp-global-access.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-3417
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/jdohmann/OSDOCS-3417/networking/ingress-operator.html (it's a removal)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
