### PR TITLE
Update runbooks for 4.13

### DIFF
--- a/modules/virt-runbook-nodestatusmaximagesexceeded.adoc
+++ b/modules/virt-runbook-nodestatusmaximagesexceeded.adoc
@@ -15,7 +15,7 @@
 This alert fires when a node exceeds the configured maximum number of images
 reported in the node status (default: 50). Once this limit is reached, the
 scheduler might not be able to accurately schedule new pods because the reported
-image count is wrong.
+image count is wrong. link:https://bugzilla.redhat.com/1984442[BZ#1984442]
 
 [discrete]
 [id="impact-nodestatusmaximagesexceeded"]

--- a/virt/support/virt-runbooks.adoc
+++ b/virt/support/virt-runbooks.adoc
@@ -66,6 +66,8 @@ include::modules/virt-runbook-lowvirtoperatorcount.adoc[leveloffset=+1]
 
 include::modules/virt-runbook-networkaddonsconfignotready.adoc[leveloffset=+1]
 
+include::modules/virt-runbook-nodestatusmaximagesexceeded.adoc[leveloffset=+1]
+
 include::modules/virt-runbook-noleadingvirtoperator.adoc[leveloffset=+1]
 
 include::modules/virt-runbook-noreadyvirtcontroller.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS-<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: None
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56984--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-runbooks.html#virt-runbook-NodeStatusMaxImagesExceeded
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
