### PR TITLE
RHDEVDOCS-5017: Update the docs for Keycloak configuration

### DIFF
--- a/cicd/gitops/configuring-sso-for-argo-cd-using-keycloak.adoc
+++ b/cicd/gitops/configuring-sso-for-argo-cd-using-keycloak.adoc
@@ -10,6 +10,7 @@ After the {gitops-title} Operator is installed, Argo CD automatically creates a 
 
 .Prerequisites
 * Red Hat SSO is installed on the cluster.
+* {gitops-title} Operator is installed on the cluster.
 * Argo CD is installed on the cluster.
 
 include::modules/gitops-creating-a-new-client-using-keycloak.adoc[leveloffset=+1]

--- a/modules/gitops-creating-a-new-client-using-keycloak.adoc
+++ b/modules/gitops-creating-a-new-client-using-keycloak.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * configuring-sso-for-argo-cd-using-keycloak.adoc
+
 :_content-type: PROCEDURE
 [id="gitops-creating-a-new-client-in-keycloak_{context}"]
 = Configuring a new client in Keycloak
@@ -8,7 +12,7 @@ Dex is installed by default for all the Argo CD instances created by the Operato
 
 To configure Keycloak, follow these steps:
 
-. Delete the Dex configuration by removing the following section from the Argo CD Custom Resource (CR), and save the CR: 
+. Delete the Dex configuration by removing the `.spec.sso.dex` parameter from the Argo CD custom resource (CR), and save the CR: 
 +
 [source,yaml]
 ----
@@ -23,7 +27,11 @@ dex:
         memory: 
 ----
 
-. Configure Keycloak by editing the Argo CD CR, and updating the value for the `provider` parameter as `keycloak`. For example:
+. Set the value of the `provider` parameter to `keycloak` in the Argo CD CR.
+
+. Configure Keycloak by performing one of the following steps:
+
+* For a secure connection, set the value of the `rootCA` parameter as shown in the following example:
 +
 [source,yaml]
 ----
@@ -36,9 +44,33 @@ metadata:
 spec:
   sso:
     provider: keycloak
+    keycloak:
+      rootCA: "<PEM-encoded-root-certificate>" <1>
   server:
     route:
-     enabled: true
+      enabled: true
+----
+<1> A custom certificate used to verify the Keycloak's TLS certificate.
++ 
+The Operator reconciles changes in the `.spec.keycloak.rootCA` parameter and updates the `oidc.config` parameter with the PEM encoded root certificate in the `argocd-cm` configuration map.
+
+* For an insecure connection, leave the value of the `rootCA` parameter empty and use the `oidc.tls.insecure.skip.verify` parameter as shown below:
++
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: ArgoCD
+metadata:
+  name: example-argocd
+  labels:
+    example: basic
+spec:
+  extraConfig:
+    oidc.tls.insecure.skip.verify: "true"
+  sso:
+    provider: keycloak
+    keycloak:
+      rootCA: ""
 ----
 
 [NOTE]


### PR DESCRIPTION
[RHDEVDOCS-5017](https://issues.redhat.com/browse/RHDEVDOCS-5017): Update the docs for Keycloak configuration
    • **Aligned team**: Dev Tools
    • **OCP version for cherry-picking**: enterprise-4.10 and later
    • **JIRA issue**: [RHDEVDOCS-5017](https://issues.redhat.com/browse/RHDEVDOCS-5017)
    • **Preview page**: [Configuring a new client in Keycloak](https://56987--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring-sso-for-argo-cd-using-keycloak.html#gitops-creating-a-new-client-in-keycloak_configuring-sso-for-argo-cd-using-keycloak)
    • **SME Review**: Completed by @iam-veeramalla 
    • **QE review**: Completed by @varshab1210 
    • **Peer-review**: Completed by @shipsing @Srivaralakshmi 

