### PR TITLE
[OCPBUGS-8373, OCPBUGS-8367] - Fix podman command typos

### DIFF
--- a/modules/ztp-generating-install-and-config-crs-manually.adoc
+++ b/modules/ztp-generating-install-and-config-crs-manually.adoc
@@ -27,10 +27,10 @@ $ mkdir -p ./out
 +
 [source,terminal,subs="attributes+"]
 ----
-$ podman run --log-driver=none --rm registry.redhat.io/openshift4/ztp-site-generate-rhel8:v{product-version}.1 extract /home/ztp --tar | tar x -C ./out
+$ podman run --log-driver=none --rm registry.redhat.io/openshift4/ztp-site-generate-rhel8:v{product-version} extract /home/ztp --tar | tar x -C ./out
 ----
 +
-The `./out` directory contains the reference `PolicyGenTemplate` and `SiteConfig` CRs in the `out/argocd/example/` folder.
+The `./out` directory has the reference `PolicyGenTemplate` and `SiteConfig` CRs in the `out/argocd/example/` folder.
 +
 .Example output
 [source,terminal]

--- a/modules/ztp-preparing-the-ztp-git-repository.adoc
+++ b/modules/ztp-preparing-the-ztp-git-repository.adoc
@@ -32,7 +32,7 @@ $ mkdir -p ./out
 +
 [source,terminal,subs="attributes+"]
 ----
-$ podman run --log-driver=none --rm registry.redhat.io/openshift4/ztp-site-generate-rhel8:v{product-version}.1 extract /home/ztp --tar | tar x -C ./out
+$ podman run --log-driver=none --rm registry.redhat.io/openshift4/ztp-site-generate-rhel8:v{product-version} extract /home/ztp --tar | tar x -C ./out
 ----
 
 . Check that the `out` directory contains the following subdirectories:


### PR DESCRIPTION
The following command fails when run: 

```cmd
podman run --log-driver=none --rm registry.redhat.io/openshift4/ztp-site-generate-rhel8:v{product-version}.1 extract /home/ztp --tar | tar x -C ./out
```

Version(s):
4.10+

Issue:
* https://issues.redhat.com/browse/OCPBUGS-8367
* https://issues.redhat.com/browse/OCPBUGS-8373

Link to docs preview:

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->