### PR TITLE
OCPBUGS#7765:Updates for ironic-api and ironic-conductor

### DIFF
--- a/modules/ipi-install-troubleshooting-bootstrap-vm-cannot-boot.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm-cannot-boot.adoc
@@ -12,8 +12,7 @@ During the deployment, it is possible for the bootstrap VM to fail to boot the c
 
 To verify the issue, there are three containers related to `ironic`:
 
-* `ironic-api`
-* `ironic-conductor`
+* `ironic`
 * `ironic-inspector`
 
 .Procedure
@@ -32,7 +31,7 @@ $ ssh core@172.22.0.2
 [core@localhost ~]$ sudo podman logs -f <container-name>
 ----
 +
-Replace `<container-name>` with one of `ironic-api`, `ironic-conductor`, or `ironic-inspector`. If you encounter an issue where the control plane nodes are not booting up via PXE, check the `ironic-conductor` pod. The `ironic-conductor` pod contains the most detail about the attempt to boot the cluster nodes, because it attempts to log in to the node over IPMI.
+Replace `<container-name>` with one of `ironic` or `ironic-inspector`. If you encounter an issue where the control plane nodes are not booting up from PXE, check the `ironic` pod. The `ironic` pod contains information about the attempt to boot the cluster nodes, because it attempts to log in to the node over IPMI.
 
 .Potential reason
 The cluster nodes might be in the `ON` state when deployment started.

--- a/modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc
@@ -54,9 +54,9 @@ If the bootstrap VM cannot access the URL to the images, use the `curl` command 
 [core@localhost ~]$ sudo podman ps
 ----
 
-. If there are issues with the pods, check the logs of the containers with issues. To check the log of the `ironic-api`, execute the following:
+. If there are issues with the pods, check the logs of the containers with issues. To check the logs of the `ironic` service, run the following command:
 +
 [source,terminal]
 ----
-[core@localhost ~]$ sudo podman logs <ironic-api>
+[core@localhost ~]$ sudo podman logs ironic
 ----


### PR DESCRIPTION
[OCPBUGS#7765]: Removes instances of `ironic-api` and `ironic-conductor` (These are replaced with `ironic` from 4.11 and later releases)

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-7765

Link to docs preview:
- [Bootstrap VM cannot boot up the cluster nodes](https://57027--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.html#ipi-install-troubleshooting-bootstrap-vm-cannot-boot_ipi-install-troubleshooting)
- [Inspecting logs](https://57027--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.html#ipi-install-troubleshooting-bootstrap-vm-inspecting-logs_ipi-install-troubleshooting)

QE review:
- [x] QE has approved this change.

Additional information:

- Related to https://github.com/openshift/openshift-docs/pull/57028
- Note to the peer reviewer: I have retained the formatting of the user replaced value as it was (with the dash) and not changed it to the recommended guideline of using underscore on purpose because it looks like this is a larger effort that needs to be taken for the entire chapter and not just the instance of ironic-api that I have changed. Created https://issues.redhat.com/browse/OCPBUGS-9944 for tracking

