### PR TITLE
OCPBUGS#7765: Updates for ipa-downloader

### DIFF
--- a/modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc
+++ b/modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc
@@ -14,10 +14,7 @@ bootstrapOSImage: http://<ip:port>/rhcos-43.81.202001142154.0-qemu.<architecture
 clusterOSImage: http://<ip:port>/rhcos-43.81.202001142154.0-openstack.<architecture>.qcow2.gz?sha256=a1bda656fa0892f7b936fdc6b6a6086bddaed5dafacedcd7a1e811abb78fe3b0
 ----
 
-The `ipa-downloader` and `coreos-downloader` containers download resources from a webserver or the external link:https://quay.io[quay.io] registry, whichever the `install-config.yaml` configuration file specifies. Verify the following two containers are up and running and inspect their logs as needed:
-
-* `ipa-downloader`
-* `coreos-downloader`
+The `coreos-downloader` container downloads resources from a webserver or from the external link:https://quay.io[quay.io] registry, whichever the `install-config.yaml` configuration file specifies. Verify that the `coreos-downloader` container is up and running and inspect its logs as needed.
 
 .Procedure
 
@@ -28,12 +25,8 @@ The `ipa-downloader` and `coreos-downloader` containers download resources from 
 $ ssh core@172.22.0.2
 ----
 
-. Check the status of the `ipa-downloader` and `coreos-downloader` containers within the bootstrap VM:
-+
-[source,terminal]
-----
-[core@localhost ~]$ sudo podman logs -f ipa-downloader
-----
+. Check the status of the `coreos-downloader` container within the bootstrap VM by running the following command:
+
 +
 [source,terminal]
 ----


### PR DESCRIPTION
[OCPBUGS#7765]: Removes instances of the `ipa-downloader` since only the `coreos-downloader` is supported from 4.10 and later releases.

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-7765

Link to docs preview:
[Inspecting logs](http://file.rdu.redhat.com/avbhatt/ocpbugs-7765-ipa/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.html#ipi-install-troubleshooting-bootstrap-vm-inspecting-logs_ipi-install-troubleshooting)

QE review:
 - [x] QE has approved this change.
 
Additional information:
Related to https://github.com/openshift/openshift-docs/pull/57027