### PR TITLE
OSDOCS-4718 vSphere DRS Anti-Affinity Rule configuration During UPI Install 2nd PR

### DIFF
--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -130,6 +130,8 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 You can add extra compute machines after the cluster installation is completed by following xref:../../machine_management/user_infra/adding-vsphere-compute-user-infra.adoc#adding-vsphere-compute-user-infra[Adding compute machines to vSphere].
 
+include::modules/vsphere-anti-affinity.adoc[leveloffset=+1]
+
 include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -117,6 +117,8 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 You can add extra compute machines after the cluster installation is completed by following xref:../../machine_management/user_infra/adding-vsphere-compute-user-infra.adoc#adding-vsphere-compute-user-infra[Adding compute machines to vSphere].
 
+include::modules/vsphere-anti-affinity.adoc[leveloffset=+1]
+
 include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -119,6 +119,8 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 
 You can add extra compute machines after the cluster installation is completed by following xref:../../machine_management/user_infra/adding-vsphere-compute-user-infra.adoc#adding-vsphere-compute-user-infra[Adding compute machines to vSphere].
 
+include::modules/vsphere-anti-affinity.adoc[leveloffset=+1]
+
 include::modules/persistent-storage-vsphere-backup.adoc[leveloffset=+1]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]

--- a/modules/vsphere-anti-affinity.adoc
+++ b/modules/vsphere-anti-affinity.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere.adoc
+
+:_content-type: PROCEDURE
+[id="anti-affinity-vsphere_{context}"]
+= Configuring vSphere DRS anti-affinity rules for control plane nodes
+
+vSphere Distributed Resource Scheduler (DRS) anti-affinity rules can be configured to support higher availability of {product-title} control plane nodes. Anti-affinity rules ensure that the vSphere Virtual Machines for the {product-title} control plane nodes are not scheduled to the same vSphere Host. 
+
+[IMPORTANT]
+====
+* The following information applies to compute DRS only and does not apply to storage DRS.
+
+* The `govc`` command is an open-source command available from VMware; it is not available from Red Hat. The `govc` command is not supported by the Red Hat support. 
+
+* Instructions for downloading and installing `govc` are found on the VMware documentation website.
+==== 
+
+// https://docs.vmware.com/en/VMware-Telco-Cloud-Operations/1.4.0/deployment-guide-140/GUID-5249E662-D792-4A1A-93E6-CF331552364C.html#:~:text=Govc%20is%20an%20open%20source,operations%20on%20the%20target%20vCenter.
+
+Create an anti-affinity rule by running the following command:
+
+.Example command
+
+[source,terminal]
+----
+$ govc cluster.rule.create \
+  -name openshift4-control-plane-group \
+  -dc MyDatacenter -cluster MyCluster \
+  -enable \
+  -anti-affinity master-0 master-1 master-2
+----
+
+After creating the rule, your control plane nodes are automatically migrated by vSphere so they are not running on the same hosts. This might take some time while vSphere reconciles the new rule. Successful command completion is shown in the following procedure.
+
+[NOTE]
+====
+The migration occurs automatically and might cause brief OpenShift API outage or latency until the migration finishes.
+====
+
+The vSphere DRS anti-affinity rules need to be updated manually in the event of a control plane VM name change or migration to a new vSphere Cluster.
+
+.Procedure
+
+. Remove any existing DRS anti-affinity rule by running the following command:
++
+[source,terminal]
+----
+$ govc cluster.rule.remove \
+  -name openshift4-control-plane-group \
+  -dc MyDatacenter -cluster MyCluster
+----
++
+.Example Output
+[source,terminal]
+----
+[13-10-22 09:33:24] Reconfigure /MyDatacenter/host/MyCluster...OK
+----
+
+. Create the rule again with updated names by running the following command:
++
+[source,terminal]
+----
+$ govc cluster.rule.create \
+  -name openshift4-control-plane-group \
+  -dc MyDatacenter -cluster MyOtherCluster \
+  -enable \
+  -anti-affinity master-0 master-1 master-2
+----


### PR DESCRIPTION
How to configure DRS anti-affinity rules during IPI installation

Status: *merge review requested.* 
This is a new PR of the docs in https://github.com/openshift/openshift-docs/pull/51584 which has already been merged. QE and SME approval are needed for 4.11 and 4.10.  *SME and QE LGTM have been given.*

Version(s):
4.11 (this PR)
Please cherrypick to 4.10 also.

Issue:
THIS PR: https://issues.redhat.com/browse/OSDOCS-4718
original: https://issues.redhat.com/browse/SPLAT-597

Links to docs previews:

( This is a "small size/M" because it's the same original module referenced in three places. )

https://57030--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#anti-affinity-vsphere_installing-vsphere

https://57030--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations.html#anti-affinity-vsphere_installing-vsphere-network-customizations

https://57030--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere.html#anti-affinity-vsphere_installing-restricted-networks-vsphere

SME Review: Joseph Callen @jcpowermac
QE Review: Shang Gao @sgaoshang