### PR TITLE
OSDOCS#5498: Adds notes for MicroShift 4.12.7 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -80,7 +80,7 @@ Issued: 2023-01-30
 
 {product-title} release 4.12.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0452[RHBA-2023:0452] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0449[RHSA-2023:0449] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-2-dp"]
 === RHBA-2023:0572 - {product-title} 4.12.2 bug fix update
@@ -89,7 +89,7 @@ Issued: 2023-02-07
 
 {product-title} release 4.12.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0572[RHBA-2023:0572] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0569[RHSA-2023:0569] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-3-dp"]
 === RHBA-2023:0731 - {product-title} 4.12.3 bug fix update
@@ -98,7 +98,7 @@ Issued: 2023-02-16
 
 {product-title} release 4.12.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0731[RHBA-2023:0731] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0728[RHSA-2023:0728] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-4-dp"]
 === RHSA-2023:0769 - {product-title} 4.12.4 bug fix and security update
@@ -107,7 +107,7 @@ Issued: 2023-02-20
 
 {product-title} release 4.12.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0769[RHSA-2023:0769] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0768[RHBA-2023:0768] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-5-dp"]
 === RHBA-2023:0893 - {product-title} 4.12.5 bug fix update
@@ -116,7 +116,7 @@ Issued: 2023-02-28
 
 {product-title} release 4.12.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0893[RHBA-2023:0893] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0890[RHSA-2023:0890] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-6-dp"]
 === RHBA-2023:1037 - {product-title} 4.12.6 bug fix update
@@ -125,4 +125,13 @@ Issued: 2023-03-07
 
 {product-title} release 4.12.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1037[RHBA-2023:1037] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1034[RHBA-2023:1034] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8]
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-7-dp"]
+=== RHBA-2023:1166 - {product-title} 4.12.7 bug fix update
+
+Issued: 2023-03-13
+
+{product-title} release 4.12.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1166[RHBA-2023:1166] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1163[RHBA-2023:1163] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#5498: Adds notes for MicroShift 4.12.7 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5498

Link to docs preview:
https://57031--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-7-dp

QE review:
QE not needed for this change


Additional information:
Links will not work until live
