### PR TITLE
OSDOCS-5264: shortening OSUS summary

### DIFF
--- a/installing/disconnected_install/installing-mirroring-disconnected.adoc
+++ b/installing/disconnected_install/installing-mirroring-disconnected.adoc
@@ -69,7 +69,7 @@ include::modules/oc-mirror-creating-image-set-config.adoc[leveloffset=+1]
 
 * xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#oc-mirror-imageset-config-params_installing-mirroring-disconnected[Image set configuration parameters]
 * xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#oc-mirror-image-set-examples_installing-mirroring-disconnected[Image set configuration examples]
-* xref:../../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-overview_updating-restricted-network-cluster-osus[About the OpenShift Update Service]
+* xref:../../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-overview_updating-restricted-network-cluster-osus[Using the OpenShift Update Service in a disconnected environment]
 
 [id="mirroring-image-set"]
 == Mirroring an image set to a mirror registry

--- a/modules/disconnected-osus-overview.adoc
+++ b/modules/disconnected-osus-overview.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * updating/understanding-openshift-updates.adoc
+
+:_content-type: CONCEPT
+[id="update-service-overview_{context}"]
+
+= Using the OpenShift Update Service in a disconnected environment
+
+The OpenShift Update Service (OSUS) provides update recommendations to {product-title} clusters. Red Hat publicly hosts the OpenShift Update Service, and clusters in a connected environment can connect to the service through public APIs to retrieve update recommendations.
+
+However, clusters in a disconnected environment cannot access these public APIs to retrieve update information. To have a similar update experience in a disconnected environment, you can install and configure the OpenShift Update Service locally so that it is available within the disconnected environment.
+
+The following sections describe how to install a local OSUS instance and configure it to provide update recommendations to a cluster.

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -1,16 +1,13 @@
 // Module included in the following assemblies:
 //
 // * architecture/architecture-installation.adoc
-// * updating/updating-cluster-within-minor.adoc
-// * updating/updating-cluster-cli.adoc
-// * updating/updating-cluster-rhel-compute.adoc
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/understanding-openshift-updates.adoc
 
 :_content-type: CONCEPT
-[id="update-service-overview_{context}"]
+[id="update-service-about_{context}"]
 = About the OpenShift Update Service
 
-The OpenShift Update Service (OSUS) provides updates to {product-title}, including {op-system-first}. It provides a graph, or diagram, that contains the _vertices_ of component Operators and the _edges_ that connect them. The edges in the graph show which versions you can safely update to. The vertices are update payloads that specify the intended state of the managed cluster components.
+The OpenShift Update Service (OSUS) provides update recommendations to {product-title}, including {op-system-first}. It provides a graph, or diagram, that contains the _vertices_ of component Operators and the _edges_ that connect them. The edges in the graph show which versions you can safely update to. The vertices are update payloads that specify the intended state of the managed cluster components.
 
 The Cluster Version Operator (CVO) in your cluster checks with the OpenShift Update Service to see the valid updates and update paths based on current component versions and information in the graph. When you request an update, the CVO uses the release image for that update to upgrade your cluster. The release artifacts are hosted in Quay as container images.
 ////

--- a/security/container_security/security-hosts-vms.adoc
+++ b/security/container_security/security-hosts-vms.adoc
@@ -31,7 +31,7 @@ ifndef::openshift-origin[]
 endif::[]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-encrypt-disk_installing-customizing[Disk encryption]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Chrony time service]
-* xref:../../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-overview_updating-restricted-network-cluster-osus[{product-title} cluster updates]
+* xref:../../updating/understanding-openshift-updates.adoc#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]
 
 // Virtualization versus containers
 include::modules/security-hosts-vms-vs-containers.adoc[leveloffset=+1]

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -10,7 +10,7 @@ You can update an {product-title} 4 cluster with a single operation by using the
 
 [id="updating-clusters-overview-understanding-container-platform-updates"]
 == Understanding OpenShift Container Platform updates
-xref:../updating/understanding-openshift-updates.adoc#understanding-openshift-updates[About the OpenShift Update Service]: For clusters with internet access, Red Hat provides over-the-air updates by using an {product-title} update service as a hosted service located behind public APIs.
+xref:../updating/understanding-openshift-updates.adoc#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]: For clusters with internet access, Red Hat provides over-the-air updates by using an {product-title} update service as a hosted service located behind public APIs.
 
 [id="updating-clusters-overview-upgrade-channels-and-releases"]
 == Understanding upgrade channels and releases

--- a/updating/understanding-openshift-update-duration.adoc
+++ b/updating/understanding-openshift-update-duration.adoc
@@ -27,7 +27,7 @@ include::modules/update-duration-cvo.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../architecture/architecture-installation.adoc#update-service-overview_architecture-installation[Cluster Version Operator (CVO) overview]
+* xref:../updating/understanding-openshift-updates.adoc#update-service-about_understanding-openshift-updates[Cluster Version Operator (CVO) overview]
 
 include::modules/update-duration-mco.adoc[leveloffset=+2]
 

--- a/updating/understanding-openshift-updates.adoc
+++ b/updating/understanding-openshift-updates.adoc
@@ -17,13 +17,12 @@ After the CVO receives the update image from the registry, the CVO then applies 
 Operators previously installed through Operator Lifecycle Manager (OLM) follow a different process for updates. See xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Updating installed Operators] for more information.
 ====
 
+include::modules/update-service-overview.adoc[leveloffset=+1]
+
 include::modules/update-common-terms.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-overview-post-install-machine-configuration-tasks[Machine config overview]
-ifdef::openshift-enterprise[]
-* xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-overview_updating-restricted-network-cluster-osus[About the OpenShift Update Service]
-endif::openshift-enterprise[]
 * xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Update channels and releases]

--- a/updating/updating-restricted-network-cluster/index.adoc
+++ b/updating/updating-restricted-network-cluster/index.adoc
@@ -28,3 +28,9 @@ You can use one of the following procedures to update a disconnected {product-ti
 
 * xref:../../updating/updating-restricted-network-cluster/restricted-network-update.adoc#updating-restricted-network-cluster[Updating a cluster in a disconnected environment without the OpenShift Update Service]
 
+[id="about-disconnected-updates-uninstalling-osus"]
+== Uninstalling the OpenShift Update Service from a cluster
+
+You can use the following procedure to uninstall a local copy of the OpenShift Update Service (OSUS) from your cluster:
+
+* xref:../../updating/updating-restricted-network-cluster/uninstalling-osus.adoc#uninstalling-osus[Uninstalling the OpenShift Update Service from a cluster]

--- a/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
@@ -6,19 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-[id="update-restricted-network-cluster-update-service"]
+To get an update experience similar to connected clusters, you can use the following procedures to install and configure the OpenShift Update Service in a disconnected environment.
 
-include::modules/update-service-overview.adoc[leveloffset=+1]
+include::modules/disconnected-osus-overview.adoc[leveloffset=+1]
 
 .Additional resources
 
+* xref:../../updating/understanding-openshift-updates.adoc#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]
 * xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Understanding upgrade channels and releases]
-
-For clusters with internet accessibility, Red Hat provides update recommendations through an {product-title} update service as a hosted service located behind public APIs. However, clusters in a disconnected environment have no way to access public APIs for update information.
-
-To provide a similar update experience in a disconnected environment, you can install and configure the OpenShift Update Service locally so that it is available within a disconnected environment.
-
-The following sections describe how to provide updates for your disconnected cluster and its underlying operating system.
 
 [id="update-service-prereqs"]
 == Prerequisites

--- a/updating/updating-restricted-network-cluster/restricted-network-update.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+Use the following procedures to update a cluster in a disconnected environment without access to the OpenShift Update Service.
+
 == Prerequisites
 
 * You must have the `oc` command-line interface (CLI) tool installed.


### PR DESCRIPTION
Versions: 4.9+

Changes for [OSDOCS-5264](https://issues.redhat.com/browse/OSDOCS-5264):
- Took existing module for "About the OpenShift Update Service" and moved it from _Updating a cluster in a disconnected environment using the OpenShift Update Service_ to _Understanding OpenShift Container Platform updates_
- Replaced the gap in _Updating a cluster in a disconnected environment using the OpenShift Update Service_ with a new module that summarized information about the OpenShift Update Service
- Fixed links as needed

Additional changes for [OSDOCS-4683](https://issues.redhat.com/browse/OSDOCS-4683):
- Added section in _About cluster updates in a disconnected environment_ to introduce the new _Uninstalling OSUS from a cluster_ page
- Added abstracts to disconnected update pages that didn't have one

Live documentation: https://docs.openshift.com/container-platform/4.12/updating/updating-restricted-network-cluster/restricted-network-update-osus.html#update-service-overview_updating-restricted-network-cluster-osus

QE Review:
- [x] QE has approved this change

Preview: https://57033--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/restricted-network-update-osus.html#update-service-overview_updating-restricted-network-cluster-osus
and
https://57033--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/index.html#about-disconnected-updates-uninstalling-osus