### PR TITLE
OCPBUGS#7592: Adds clarification for IPv6 support

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -214,6 +214,11 @@ You can create the agent ISO image with the following IP address configurations:
 * IPv6
 * IPv4 and IPv6 in parallel (dual-stack)
 
+[NOTE]
+====
+IPv6 is supported only on bare metal platforms.
+====
+
 For more information, see xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent_installing-with-agent-based-installer[Dual and single IP stack clusters].
 
 [id="ocp-4-12-agent-based-install-mce"]
@@ -235,6 +240,11 @@ For more information, see xref:../installing/installing_with_agent_based_install
 ==== Configure static networking in a Agent-based installation
 With the Agent-based {product-title} Installer, you can configure static IP addresses for IPv4, IPv6, or dual-stack (both IPv4 and IPv6) for all the hosts prior to creating the agent ISO image. You can add the static addresses to the `hosts` section of the `agent-config.yaml` file or in the `NMStateConfig.yaml` file if you are using the ZTP manifests.
 Note that the configuration of the addresses must follow the syntax rules for NMState as described in link:https://nmstate.io/examples.html[NMState state examples].
+
+[NOTE]
+====
+IPv6 is supported only on bare metal platforms.
+====
 
 For more information, see xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#agent-install-networking_preparing-to-install-with-agent-based-installer[About networking].
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-7592
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57041--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-agent-based-install-dual-stack
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
