### PR TITLE
OSDOCS-5451: move KI to release notes

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,7 +4,7 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.12
+:ocp-version: 4.13
 :rhel-major: rhel-8
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system: RHEL
@@ -12,7 +12,6 @@
 :op-system-ostree: RHEL for Edge
 :op-system-version: 8.7
 :op-system-version-major: 8
-:op-system-ram: 2GB RAM
 :op-system-bundle: Red Hat Device Edge
 :op-system-bundle-short: RHDE
 :VirtProductName: OpenShift Virtualization

--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -180,5 +180,3 @@ Topics:
   File: microshift-version
 - Name: Additional information
   File: microshift-things-to-know
-- Name: Troubleshooting
-  File: microshift-troubleshooting

--- a/microshift_networking/microshift-firewall.adoc
+++ b/microshift_networking/microshift-firewall.adoc
@@ -16,8 +16,3 @@ include::modules/microshift-firewall-allow-traffic.adoc[leveloffset=+1]
 include::modules/microshift-firewall-apply-settings.adoc[leveloffset=+1]
 include::modules/microshift-firewall-verify-settings.adoc[leveloffset=+1]
 include::modules/microshift-firewall-known-issue.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-[id="additional-resources_microshift-using-a-firewall"]
-.Additional resources
-* xref:../microshift_troubleshooting/microshift-troubleshooting.adoc#microshift-ki-cni-iptables-deleted[Troubleshooting iptables deleted].

--- a/microshift_networking/microshift-networking.adoc
+++ b/microshift_networking/microshift-networking.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id="microshift-applying-networking-settings"]
+[id="microshift-understanding-networking-settings"]
 = Understanding networking settings
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-networking
@@ -16,6 +16,11 @@ Cluster Administrators have several options for exposing applications that run i
 
 By default, Kubernetes allocates each pod an internal IP address for applications running within the pod. Pods and their containers can have traffic between them, but clients outside the cluster do not have direct network access to pods except when exposed with a service such as NodePort.
 
+[NOTE]
+====
+To troubleshoot NodePort connection problems, read about the known issue in the Release Notes.
+====
+
 include::modules/microshift-cni.adoc[leveloffset=+1]
 include::modules/microshift-configuring-ovn.adoc[leveloffset=+1]
 include::modules/microshift-restart-ovnkube-master.adoc[leveloffset=+1]
@@ -26,9 +31,7 @@ include::modules/microshift-ovs-snapshot.adoc[leveloffset=+1]
 include::modules/microshift-mDNS.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-[id="additional-resources_microshift-applying-networking-settings"]
+[id="additional-resources_microshift-understanding-networking-settings"]
 .Additional resources
 
-* xref:../microshift_troubleshooting/microshift-troubleshooting.adoc#microshift-version[Troubleshooting]
-* xref:../microshift_troubleshooting/microshift-troubleshooting.adoc#microshift-troubleshooting-nodeport[Troubleshooting the NodePort service]
-* xref:../microshift_troubleshooting/microshift-troubleshooting.adoc#microshift-nodeport-unreachable-workaround[NodePort unreachable workround]
+* xref:../microshift_release_notes/microshift-4-13-release-notes.adoc#microshift-4-13-known-issues[{product-title} {product-version} release notes --> Known issues]

--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -6,22 +6,23 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-{product-title} provides developers and IT organizations with small-form-factor and edge computing, delivered as an application that customers can deploy on top of their managed {op-system-first} devices at the edge. Built on {op-system-first} and Kubernetes, {product-title} provides an efficient way to operate single-node clusters in low-resource edge environments.
+{product-title} provides developers and IT organizations with small-form-factor and edge computing, delivered as an application that customers can deploy on top of their managed {op-system-base-full} devices at the edge. Built on {OCP} and Kubernetes, {product-title} provides an efficient way to operate single-node clusters in low-resource edge environments.
 
 {product-title} is designed to make control plane restarts economical and be lifecycle-managed as a single unit by the operating system. Updates, roll-backs, and configuration changes consist of simply staging another version in parallel and then - without relying on a network - flipping to and from that version and restarting.
 
 [id="microshift-4-13-about-this-release"]
 == About this release
 
-The Red Hat build of {product-title} is now available as Technology Preview software. Features and known issues that pertain to {product-title} {product-version} are included in this topic. For more information about the support scope of Red Hat Technology Preview software, see link:https://access.redhat.com/support/offerings/
+The Red Hat build of {product-title} is Technology Preview only. Features and known issues that pertain to {product-title} {ocp-version} are included in this topic. This Technology Preview software is not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using {product-title} in production. Technology Preview provides early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, read link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 
 //need messaging and link here
 
 [IMPORTANT]
 ====
-Red Hat does not provide or support an update or upgrade path from the Technology Preview version to later versions of {product-title}. A new installation is necessary.
+Red Hat does not support an update path from the Technology Preview version to later versions of {product-title}. A new installation is necessary.
 ====
-//still true?
 
 [id="microshift-4-13-new-features-and-enhancements"]
 == New features and enhancements
@@ -72,7 +73,36 @@ This release adds improvements related to the following components and concepts.
 [id="microshift-4-13-known-issues"]
 == Known issues
 
-//bullets, update as needed
+* OVN-Kubernetes sets up an iptable chain in the network address translation (NAT) table to handle incoming traffic to the NodePort service. When the NodePort service is not reachable or the connection is refused, check the iptable rules on the host to make sure the relevant rules are properly inserted.
++
+. View the iptable rules for the NodePort service by running the following command:
++
+[source, terminal]
+----
+$ iptables-save | grep NODEPORT
+----
++
+.Example output
+[source, terminal]
+----
+-A OUTPUT -j OVN-KUBE-NODEPORT
+-A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 30326 -j DNAT --to-destination 10.43.95.170:80
+----
+OVN-Kubernetes configures the `OVN-KUBE-NODEPORT` iptable chain in the NAT table to match the destination port and Destination Network Address Translates (DNATs) the packet to the `clusterIP` service. The packet is then routed to the OVN network through the gateway bridge `br-ex` using routing rules on the host.
++
+. Route the packet through the network with routing rules by running the following command:
++
+[source, terminal]
+----
+$ ip route
+----
++
+.Example output
+[source, terminal]
+----
+10.43.0.0/16 via 192.168.122.1 dev br-ex mtu 1400
+----
+This routing rule matches the Kubernetes service IP address range and forwards the packet to the gateway bridge `br-ex`. You must enable `ip_forward` on the host. After the packet is forwarded to the OVS bridge `br-ex`, it is handled by OpenFlow rules in OVS. OpenFlow then steers the packet to the OVN network and eventually to the pod.
 
 [id="microshift-4-13-asynchronous-errata-updates"]
 == Asynchronous errata updates
@@ -86,4 +116,4 @@ Red Hat Customer Portal users can enable errata notifications in the account set
 Red Hat Customer Portal user accounts must have systems registered and consuming {product-title} entitlements for {product-title} errata notification emails to generate.
 ====
 
-This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {product-version}. Versioned asynchronous releases, for example with the form {product-title} {product-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
+This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {ocp-version}. Versioned asynchronous releases, for example with the form {product-title} {ocp-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.

--- a/microshift_troubleshooting/microshift-troubleshooting.adoc
+++ b/microshift_troubleshooting/microshift-troubleshooting.adoc
@@ -2,16 +2,14 @@
 [id="microshift-troubleshooting"]
 = Troubleshooting
 include::_attributes/attributes-microshift.adoc[]
-:context: microshift-known-issues
+:context: microshift-troubleshooting
 
 toc::[]
 
-Read about troubleshooting and possible solutions for known issues.
+//DEPRECATED: This assembly is being deprecated for 4.13 and removed from the topic map. Remove it and associated modules from repo for GA if not needed.
 
-include::modules/microshift-troubleshooting-nodeport.adoc[leveloffset=+1]
+//Read about troubleshooting and possible solutions for known issues.
 
+//include::modules/microshift-troubleshooting-nodeport.adoc[leveloffset=+1]
 //include::modules/microshift-ki-cni-iptables-deleted.adoc[leveloffset=+1]
 //include::modules/microshift-nodeport-unreachable-workaround.adoc[leveloffset=+1]
-
-//TODO: move this module to release notes files in each branch
-//TODO: then delete this assembly from this title and topic map

--- a/modules/microshift-cni.adoc
+++ b/modules/microshift-cni.adoc
@@ -47,7 +47,7 @@ Networking features not available with {product-title} {product-version}:
 
 //Q: are there immutable network settings we should tell users about?
 [id="microshift-network-comps-svcs_{context}"]
-== {product-title} networking components and services overview
+== {product-title} networking components and services
 This brief overview describes networking components and their operation in {product-title}. The `microshift-networking` RPM is a package that automatically pulls in any networking-related dependencies and systemd services to initialize networking, for example, the `microshift-ovs-init` systemd service.
 
 NetworkManager::


### PR DESCRIPTION
Version(s):
4.13 only

Issue:
https://issues.redhat.com/browse/OSDOCS-5451

Link to docs preview:
https://57048--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes.html#microshift-4-13-known-issues (main move to release notes)

https://57048--docspreview.netlify.app/microshift/latest/microshift_troubleshooting/microshift-version.html (change to Troubleshooting book)

https://57048--docspreview.netlify.app/microshift/latest/microshift_networking/microshift-networking.html#microshift-mDNS_microshift-networking (changed xref)

https://57048--docspreview.netlify.app/microshift/latest/microshift_networking/microshift-networking.html#microshift-network-comps-svcs_microshift-networking (line edit of heading)


QE review:
- N/A, docs structure only

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
