### PR TITLE
OSDOCS-4811: Documented supported instance types for AWS Local Zones

### DIFF
--- a/installing/installing_aws/installing-aws-localzone.adoc
+++ b/installing/installing_aws/installing-aws-localzone.adoc
@@ -66,6 +66,12 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/[AWS Local Zones features] in the AWS documentation for more information about AWS Local Zones and the supported instances types and services. 
+
 include::modules/installation-generate-aws-user-infra-install-config.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -1,4 +1,4 @@
-/ Module included in the following assemblies:
+// Module included in the following assemblies:
 //
 // * installing/installing_aws/installing-aws-customizations.adoc
 // * installing/installing_aws/installing-aws-government-region.adoc

--- a/modules/installation-aws-tested-machine-types.adoc
+++ b/modules/installation-aws-tested-machine-types.adoc
@@ -8,6 +8,7 @@
 // installing/installing_aws/installing-aws-user-infra.adoc
 // installing/installing_aws/installing-aws-vpc.adoc
 // installing/installing_aws/installing-restricted-networks-aws.adoc
+// installing-aws-localzone
 
 ifeval::["{context}" == "installing-aws-localzone"]
 :localzone:
@@ -23,7 +24,6 @@ endif::localzone[]
 ifdef::localzone[]
 {product-title} for use with AWS Local Zones.
 endif::localzone[]
-
 
 [NOTE]
 ====
@@ -41,11 +41,12 @@ ifdef::localzone[]
 .Machine types based on x86_64 architecture for AWS Local Zones
 [%collapsible]
 ====
-* `c5.2xlarge`
-* `c5d.2xlarge`
-* `m5.xlarge`
-* `m5.2xlarge`
-* `t3.xlarge`
+* `c5.*`
+* `c5d.*`
+* `m6i.*`
+* `m5.*`
+* `r5.*`
+* `t3.*`
 ====
 endif::localzone[]
 

--- a/modules/installation-supported-aws-machine-types.adoc
+++ b/modules/installation-supported-aws-machine-types.adoc
@@ -23,7 +23,6 @@ ifeval::["{context}" == "installing-aws-china-region"]
 :aws-china:
 endif::[]
 
-
 [id="installation-supported-aws-machine-types_{context}"]
 = Supported AWS machine types
 
@@ -408,7 +407,7 @@ The following Amazon Web Services (AWS) instance types are supported with {produ
 |===
 ====
 
-ifndef::aws-govcloud,aws-secret,aws-china,openshift-origin[]
+ifndef::aws-govcloud,aws-secret,aws-china,openshift-origin,localzone[]
 .Machine types based on arm64 architecture
 [%collapsible]
 ====


### PR DESCRIPTION
[OSDOCS-4811](https://issues.redhat.com/browse/OSDOCS-4811)

Version(s):
4.12 and 4.13

Link to docs preview:
[Preview link](https://57057--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone.html#installation-aws-tested-machine-types_installing-aws-localzone)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
