### PR TITLE
OSDOCS-5488: fix typo

### DIFF
--- a/microshift_getting_started/microshift-architecture.adoc
+++ b/microshift_getting_started/microshift-architecture.adoc
@@ -13,7 +13,7 @@ Learn the specifics of {product-title} architecture including design intent, how
 == Architectural design
 {product-title} is a single-node container orchestration runtime designed to extend the benefits of using containers for running applications to low-resource edge environments. Because {product-title} is primarily a platform for deploying applications, only the APIs and features essential to operating in edge and small form factor computing environments are included.
 
-For example, {product-title} is contains only the following Kubernetes cluster capabilities:
+For example, {product-title} contains only the following Kubernetes cluster capabilities:
 
 * Networking
 * Ingress


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5488

Link to docs preview:
https://57062--docspreview.netlify.app/microshift/latest/microshift_getting_started/microshift-architecture.html#microshift-architectural-design_microshift-architecture (remove errant "is")

QE review:
- N/A typo/doc bug only

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
