### PR TITLE
OCPBUGS8098: troubleshooting broken API links

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -68,12 +68,12 @@ Topics:
   Dir: network_apis
   Topics:
     # FIXME: need to incorporate the supported k8s APIs
-  - Name: 'Route [route.openshift.io/v1]'
+  - Name: Route [route.openshift.io/v1]
     File: route-route-openshift-io-v1
 - Name: Security APIs
   Dir: security_apis
   Topics:
-  - Name: 'SecurityContextConstraints [security.openshift.io/v1]'
+  - Name: SecurityContextConstraints [security.openshift.io/v1]
     File: securitycontextconstraints-security-openshift-io-v1
 ---
 Name: CLI tools

--- a/microshift_getting_started/microshift-architecture.adoc
+++ b/microshift_getting_started/microshift-architecture.adoc
@@ -63,7 +63,7 @@ In {oke} and other {OCP} deployments, all of the components from the operating s
 [id="microshift-openshift-apis_{context}"]
 == {product-title} OpenShift APIs
 
-In addition to the standard Kubernetes APIs, {product-title} includes a subset of the APIs supported by {OCP}.
+In addition to standard Kubernetes APIs, {product-title} includes a small subset of the APIs supported by {OCP}.
 
 [cols="1,1",options="header"]
 |===


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-8098

Link to docs preview:
(https://57085--docspreview.netlify.app/microshift/latest/microshift_getting_started/microshift-architecture.html#microshift-openshift-apis_microshift-architecture)

QE review:
- N/A internal docs bug

Additional information:
Xrefs appear to be in the correct syntax; troubleshooting; these work in the preview, but not on the Portal. Trying taking the backticks out of the filenames in the yaml since we aren't auto-generating to MicroShift.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
