### PR TITLE
typo: cgroup_no_vi should be cgroup_no_v1

### DIFF
--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -173,7 +173,7 @@ metadata:
 spec:
   kernelArguments:
   - systemd_unified_cgroup_hierarchy=1 <1>
-  - cgroup_no_vi="all" <2>
+  - cgroup_no_v1="all" <2>
   - psi=1 <3>
 ----
 <1> Enables cgroup v2 in systemd.


### PR DESCRIPTION
Version(s):
main, enterprise-4.13, enterprise-4.12

Issue:
JIRA is down right now, but I can create one once it's back if you'd like

Link to docs preview:
[Configuring Linux cgroup,](https://57087--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2) Verification step 3, Example output for cgroup v2 

QE review:
- [x] QE has approved this change.