### PR TITLE
OCPBUGS#8089: Extend the range to 4 bytes

### DIFF
--- a/modules/nw-metallb-bgppeer-cr.adoc
+++ b/modules/nw-metallb-bgppeer-cr.adoc
@@ -28,12 +28,12 @@ The fields for the BGP peer custom resource are described in the following table
 |`integer`
 |Specifies the Autonomous System number for the local end of the BGP session.
 Specify the same value in all BGP peer custom resources that you add.
-The range is `0` to `65535`.
+The range is `0` to `4294967295`.
 
 |`spec.peerASN`
 |`integer`
 |Specifies the Autonomous System number for the remote end of the BGP session.
-The range is `0` to `65535`.
+The range is `0` to `4294967295`.
 
 |`spec.peerAddress`
 |`string`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-8089
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57098--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-configure-bgp-peers.html#nw-metallb-bgppeer-cr_configure-metallb-bgp-peers
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

@asood-rh PTAL