### PR TITLE
Backporting 4.13 table title into 4.12

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
@@ -6,11 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The process for getting started with the Control Plane Machine Set Operator depends on the state of the `ControlPlaneMachineSet` custom resource (CR) in your cluster. 
+The process for getting started with the Control Plane Machine Set Operator depends on the state of the `ControlPlaneMachineSet` custom resource (CR) in your cluster.
 
-Clusters with an active generated CR:: Clusters that have a generated CR with an active state use the Operator by default. No administrator action is required. 
+Clusters with an active generated CR:: Clusters that have a generated CR with an active state use the Operator by default. No administrator action is required.
 //+
-//AWS clusters that are created with {product-title} version 4.12 or later use the Control Plane Machine Set Operator by default. 
+//AWS clusters that are created with {product-title} version 4.12 or later use the Control Plane Machine Set Operator by default.
 
 Clusters with an inactive generated CR:: For clusters that include an inactive generated CR, you must review the CR configuration and xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[activate the CR].
 //+
@@ -20,16 +20,16 @@ Clusters without a generated CR:: For clusters that do not include a generated C
 //+
 //For Azure and VMware vSphere clusters
 
-If you are uncertain about the state of the `ControlPlaneMachineSet` CR in your cluster, you can xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-checking-status_cpmso-getting-started[verify the CR status]. 
+If you are uncertain about the state of the `ControlPlaneMachineSet` CR in your cluster, you can xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-checking-status_cpmso-getting-started[verify the CR status].
 
 [id="cpmso-platform-matrix_{context}"]
 == Supported cloud providers
 
 In {product-title} {product-version}, the Control Plane Machine Set Operator is supported for Amazon Web Services (AWS), Microsoft Azure, and VMware vSphere clusters.
 
-The status of the Operator after installation depends on your cloud provider and the version of {product-title} that you installed on your cluster. 
+The status of the Operator after installation depends on your cloud provider and the version of {product-title} that you installed on your cluster.
 
-.Control Plane Machine Set Operator implementation matrix
+.Control plane machine set implementation for {product-title} {product-version}
 [cols="<.^5,^.^4,^.^4,^.^4"]
 |====
 |Cloud provider |Active by default |Generated CR |Manual CR required


### PR DESCRIPTION
Version(s):
4.12

Issue:
N/A

Link to docs preview:
[Supported cloud providers](https://57102--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-getting-started.html#cpmso-platform-matrix_cpmso-getting-started)

QE review:
- [ ] QE has approved this change.

Additional information:
* IMO, no dev or QE required. This updates the heading for clarity and to match 4.13 ([published here](https://docs.openshift.com/container-platform/4.13/machine_management/control_plane_machine_management/cpmso-getting-started.html#cpmso-platform-matrix_cpmso-getting-started))