### PR TITLE
OSDOCS-5521: Created post-install procedure for extending edge nodes …

### DIFF
--- a/modules/extend-edge-nodes-existing-cluster.adoc
+++ b/modules/extend-edge-nodes-existing-cluster.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * /post_installation_configuration/cluster-tasks.adoc
+
+:_content-type: PROCEDURE
+[id="extend-edge-nodes-existing-cluster_{context}"]
+= Extending edge worker nodes into an existing cluster
+
+You can use Local Zones subnets to extend regular worker nodes to edge networks. You can improve network performance by extending worker nodes in this way, because nodes operate close to their target location.
+
+You must ensure that the VPC that deploys the cluster contains sufficient Classless Inter-Domain Routing (CIDR) blocks for creating subnets in each target Local Zone location.
+
+
+.Prerequisites
+
+* You assigned sufficient CIDR blocks to your VPC.
+* You created the Kubernetes manifest files for your cluster.
+* You opted in to the Local Zone group. See _Opting into AWS Local Zones_.
+* You installed the AWS Load Balancer (ALB) Operator, and created an ALB Controller instance in your cluster.  
+
+.Procedure
+
+. Extract public and private subnet IDs for your VPC from the `CloudFormation` template.
++
+[source,terminal]
+----
+$ export VPC_ID=$(aws cloudformation describe-stacks \
+  --stack-name ${STACK_VPC} \
+  | jq -r '.Stacks[0].Outputs[] | select(.OutputKey=="VpcId").OutputValue' )
+----
+
+. Use the AWS ALB Operator to create a custom Ingress Controller for each AWS Local Zone location.
++
+[source,terminal]
+----
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress-lz-nyc-1
+  namespace: lz-apps
+  annotations:
+    alb.ingress.kubernetes.io/scheme: internet-facing
+    alb.ingress.kubernetes.io/target-type: instance
+    alb.ingress.kubernetes.io/subnets: ${SUBNET_ID}
+  labels:
+    zone_group: ${ZONE_GROUP_NAME}
+spec:
+  ingressClassName: cloud
+  rules:
+    - http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: lz-app-nyc-1
+                port:
+                  number: 80
+----
++
+You can now deploy worker nodes to AWS Local Zone locations.
+
+
+.Verification
+
+. Verify the status of the custom Ingress resource to show the host of the provisioned AWS Load Balancer (ALB) by running the following command:
++
+[source,terminal]
+----
+$ HOST=$(oc get ingress -n lz-apps ingress-lz-nyc-1 --template='{{(index .status.loadBalancer.ingress 0).hostname}}')
+----
+
+. Verify the status of the provisioned AWS Load Balancer (ALB) host by running the following command:
++
+[source,terminal]
+----
+$ curl $HOST
+----

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -544,6 +544,19 @@ include::modules/machineset-delete-policy.adoc[leveloffset=+2]
 
 include::modules/nodes-scheduler-node-selectors-cluster.adoc[leveloffset=+2]
 
+[id="post-install-extend-edge-worker-nodes"]
+== Edge worker nodes
+You can use Local Zones subnets to extend regular worker nodes to edge networks, where worker nodes are more dedicated to running user workloads. 
+
+include::modules/extend-edge-nodes-existing-cluster.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* See xref:../installing/installing_aws/installing-aws-localzone.adoc#installation-aws-add-local-zone-locations_installing-aws-localzone[Opting into AWS Local Zones]
+
+* See xref:../installing/installing_aws/installing-aws-localzone.adoc#installation-localzone-generate-k8s-manifest_installing-aws-localzone[Creating the Kubernetes manifest files]
+
 [id="post-worker-latency-profiles"]
 == Improving cluster stability in high latency environments using worker latency profiles
 


### PR DESCRIPTION
[OSDOCS-5521](https://issues.redhat.com/browse/OSDOCS-5521)

Version(s):
4.13

Link to docs preview:
[Edge worker nodes docs preview](https://57112--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#post-install-extend-edge-worker-nodes)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
