### PR TITLE
OSDOCS-5112: ConnectX-6 Dx supports HWOL

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1248,7 +1248,7 @@ Topics:
     File: ovn-kubernetes-troubleshooting-sources
   - Name: OVN-Kubernetes traffic tracing
     File: ovn-kubernetes-tracing-using-ovntrace
-  - Name: Migrating from the OpenShift SDN network plug-in
+  - Name: Migrating from the OpenShift SDN network plugin
     File: migrate-from-openshift-sdn
   - Name: Rolling back to the OpenShift SDN network plugin
     File: rollback-to-openshift-sdn

--- a/modules/nw-sriov-hwol-supported-devices.adoc
+++ b/modules/nw-sriov-hwol-supported-devices.adoc
@@ -24,15 +24,15 @@ Hardware offloading is supported on the following network interface controllers:
 |1019
 |===
 
+|Mellanox 
+|MT2892 Family [ConnectX&#8209;6 Dx]
+|15b3
+|101d
+
 .Technology Preview network interface controllers
 [cols="1,2,1,1"]
 |===
 |Manufacturer |Model |Vendor ID | Device ID
-
-|Mellanox 
-|MT2892 Family [ConnectX-6 Dx]
-|15b3
-|101d
 
 |Mellanox 
 |MT2894 Family [ConnectX-6 Lx]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-5112

This PR moves this device ID from the TP section to the GA list of device IDs.

Preview:
- [Supported devices](https://57126--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-hardware-offloading.html#supported_devices_configuring-hardware-offloading)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
