### PR TITLE
OSDOCS-5284: Netobserv seamless upgrades version CRD change

### DIFF
--- a/modules/network-observability-flowcollector-api-specifications.adoc
+++ b/modules/network-observability-flowcollector-api-specifications.adoc
@@ -1003,6 +1003,14 @@ Type::
 |===
 | Property | Type | Description
 
+| `conversationEndTimeout`
+| `string`
+| conversation end timeout is the duration of time to wait from the last flow log to end a conversation
+
+| `conversationHeartbeatInterval`
+| `string`
+| conversation heartbeat interval is the duration of time to wait between heartbeat reports of a conversation
+
 | `debug`
 | `object`
 | Debug allows setting some aspects of the internal configuration of the flow processor. This section is aimed exclusively for debugging and fine-grained performance optimizations, such as GOGC and GOMAXPROCS env vars. Users setting its values do it at their own risk.
@@ -1042,6 +1050,10 @@ Type::
 | `logLevel`
 | `string`
 | logLevel of the collector runtime
+
+| `logTypes`
+| `string`
+| logTypes defines the desired record types to generate. Possible values are "FLOWS" (default) to export flowLogs, "CONVERSATIONS" to generate newConnection, heartbeat, endConnection events, "ENDED_CONVERSATIONS" to generate only endConnection events or "ALL" to generate both flow logs and conversations events
 
 | `metrics`
 | `object`
@@ -1106,6 +1118,10 @@ Type::
 [cols="1,1,1",options="header"]
 |===
 | Property | Type | Description
+
+| `disableAlerts`
+| `array (string)`
+| disableAlerts is a list of alerts that should be disabled. Possible values are: `NetObservNoFlows`, which is triggered when no flows are being observed for a certain period. `NetObservLokiError`, which is triggered when flows are being dropped due to Loki errors.
 
 | `ignoreTags`
 | `array (string)`

--- a/modules/network-observability-flowcollector-view.adoc
+++ b/modules/network-observability-flowcollector-view.adoc
@@ -17,7 +17,7 @@ The following example shows a sample `FlowCollector` resource for {product-title
 .Sample `FlowCollector` resource
 [source, yaml]
 ----
-apiVersion: flows.netobserv.io/v1alpha1
+apiVersion: flows.netobserv.io/v1beta1
 kind: FlowCollector
 metadata:
   name: cluster


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.10+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5284
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[API Reference](https://57128--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/flowcollector-api.html)

[View FlowCollector - version update to v1alpha1](https://57128--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/configuring-operator.html#network-observability-flowcollector-view_network_observability)
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
