### PR TITLE
CNV-18462: Release Note Change - Retire Storage Alpha APIs

### DIFF
--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -78,7 +78,7 @@ The SVVP Certification applies to:
 === Storage
 
 //CNV-18462 Release note: CHANGE Retire alpha APIs for Storage
-
+* {VirtProductName} storage resources now migrate automatically to the beta API versions. Alpha API versions are no longer supported.
 
 [id="virt-4-13-web-new"]
 === Web console
@@ -116,6 +116,7 @@ Removed features are not supported in the current release.
 
 //CNV-19043 Release note: CHANGE Remove rhel6 support
 * Red Hat Enterprise Linux 6 is no longer supported on {VirtProductName}.
+
 
 
 //NOTE: Removed features for 4.13 are above this line.


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/CNV-18462

Link to docs preview:
https://57129--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-13-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
NA
