### PR TITLE
OSDOCS-5340 Adding categories and projects to Nutanix install doc

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1831,6 +1831,62 @@ Additional Nutanix configuration parameters are described in the following table
 |====
 |Parameter|Description|Values
 
+|`compute.platform.nutanix.categories.key`
+|The name of a prism category key to apply to compute VMs. This parameter must be accompanied by the `value` parameter, and both `key` and `value` parameters must exist in Prism Central. For more information on categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
+|String
+
+|`compute.platform.nutanix.categories.value`
+|The value of a prism category key-value pair to apply to compute VMs. This parameter must be accompanied by the `key` parameter, and both `key` and `value` parameters must exist in Prism Central.
+|String
+
+|`compute.platform.nutanix.project.type`
+|The type of identifier you use to select a project for compute VMs.  Projects define logical groups of user roles for managing permissions, networks, and other parameters. For more information on projects, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_9:ssp-app-mgmt-project-env-c.html[Projects Overview].
+|`name` or `uuid`
+
+|`compute.platform.nutanix.project.name` or `compute.platform.nutanix.project.uuid`
+|The name or UUID of a project with which compute VMs are associated. This parameter must be accompanied by the `type` parameter.
+|String
+
+|`compute.platform.nutanix.bootType`
+|The boot type that the compute machines use. You must use the `Legacy` boot type in {product-title} {product-version}. For more information on boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment].
+|`Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
+
+|`controlPlane.platform.nutanix.categories.key`
+|The name of a prism category key to apply to control plane VMs. This parameter must be accompanied by the `value` parameter, and both `key` and `value` parameters must exist in Prism Central. For more information on categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
+|String
+
+|`controlPlane.platform.nutanix.categories.value`
+|The value of a prism category key-value pair to apply to control plane VMs. This parameter must be accompanied by the `key` parameter, and both `key` and `value` parameters must exist in Prism Central.
+|String
+
+|`controlPlane.platform.nutanix.project.type`
+|The type of identifier you use to select a project for control plane VMs.  Projects define logical groups of user roles for managing permissions, networks, and other parameters. For more information on projects, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_9:ssp-app-mgmt-project-env-c.html[Projects Overview].
+|`name` or `uuid`
+
+|`controlPlane.platform.nutanix.project.name` or `controlPlane.platform.nutanix.project.uuid`
+|The name or UUID of a project with which control plane VMs are associated. This parameter must be accompanied by the `type` parameter.
+|String
+
+|`platform.nutanix.defaultMachinePlatform.categories.key`
+|The name of a prism category key to apply to all VMs. This parameter must be accompanied by the `value` parameter, and both `key` and `value` parameters must exist in Prism Central. For more information on categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
+|String
+
+|`platform.nutanix.defaultMachinePlatform.categories.value`
+|The value of a prism category key-value pair to apply to all VMs. This parameter must be accompanied by the `key` parameter, and both `key` and `value` parameters must exist in Prism Central.
+|String
+
+|`platform.nutanix.defaultMachinePlatform.project.type`
+|The type of identifier you use to select a project for all VMs. Projects define logical groups of user roles for managing permissions, networks, and other parameters. For more information on projects, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_9:ssp-app-mgmt-project-env-c.html[Projects Overview].
+|`name` or `uuid`.
+
+|`platform.nutanix.defaultMachinePlatform.project.name` or `platform.nutanix.defaultMachinePlatform.project.uuid`
+|The name or UUID of a project with which all VMs are associated. This parameter must be accompanied by the `type` parameter.
+|String
+
+|`platform.nutanix.defaultMachinePlatform.bootType`
+|The boot type for all machines. You must use the `Legacy` boot type in {product-title} {product-version}. For more information on boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment].
+|`Legacy`, `SecureBoot` or `UEFI`. The default is `Legacy`.
+
 |`platform.nutanix.apiVIP`
 |The virtual IP (VIP) address that you configured for control plane API access.
 |IP address

--- a/modules/installation-nutanix-config-yaml.adoc
+++ b/modules/installation-nutanix-config-yaml.adoc
@@ -37,6 +37,9 @@ compute: <2>
       memoryMiB: 8196
       osDisk:
         diskSizeGiB: 120
+      categories: <5>
+      - key: <category_key_name>
+        value: <category_value>
 controlPlane: <2>
   hyperthreading: Enabled <3>
   name: master
@@ -48,6 +51,9 @@ controlPlane: <2>
       memoryMiB: 16384
       osDisk:
         diskSizeGiB: 120
+      categories: <5>
+      - key: <category_key_name>
+        value: <category_value>
 metadata:
   creationTimestamp: null
   name: test-cluster <1>
@@ -57,12 +63,20 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <5>
+  networkType: OVNKubernetes <6>
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   nutanix:
     apiVIP: 10.40.142.7 <1>
+    defaultMachinePlatform:
+      bootType: Legacy
+      categories: <5>
+      - key: <category_key_name>
+        value: <category_value>
+      project: <7>
+        type: name
+        name: <project_name>
     ingressVIP: 10.40.142.8 <1>
     prismCentral:
       endpoint:
@@ -77,16 +91,16 @@ platform:
       uuid: 0005b0f1-8f43-a0f2-02b7-3cecef193712
     subnetUUIDs:
     - c7938dc6-7659-453e-a688-e26020c68e43
-    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2 <6>
+    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2 <8>
 credentialsMode: Manual
 publish: External
 pullSecret: '{"auths": ...}' <1>
 ifndef::openshift-origin[]
-fips: false <7>
-sshKey: ssh-ed25519 AAAA... <8>
+fips: false <9>
+sshKey: ssh-ed25519 AAAA... <10>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <7>
+sshKey: ssh-ed25519 AAAA... <9>
 endif::openshift-origin[]
 ----
 <1> Required. The installation program prompts you for this value.
@@ -98,20 +112,22 @@ endif::openshift-origin[]
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance.
 ====
 <4> Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines.
-<5> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
+<5> Optional: Provide one or more pairs of a prism category key and a prism category value. These category key-value pairs must exist in Prism Central. You can provide separate categories to compute machines, control plane machines, or all machines.
+<6> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
 ifndef::openshift-origin[]
-<6> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
-<7> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<7> Optional: Specify a project with which VMs are associated. Specify either `name` or `uuid` for the project type, and then provide the corresponding UUID or project name. You can associate projects to compute machines, control plane machines, or all machines.
+<8> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
+<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<8> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
+<10> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<6> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
-<7> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
+<7> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
+<8> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 +
 [NOTE]
@@ -136,6 +152,9 @@ compute: <2>
       memoryMiB: 8196
       osDisk:
         diskSizeGiB: 120
+      categories: <5>
+      - key: <category_key_name>
+        value: <category_value>
 controlPlane: <2>
   hyperthreading: Enabled <3>
   name: master
@@ -147,6 +166,9 @@ controlPlane: <2>
       memoryMiB: 16384
       osDisk:
         diskSizeGiB: 120
+      categories: <5>
+      - key: <category_key_name>
+        value: <category_value>
 metadata:
   creationTimestamp: null
   name: test-cluster <1>
@@ -156,13 +178,21 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <5>
+  networkType: OVNKubernetes <6>
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   nutanix:
     apiVIP: 10.40.142.7 <1>
     ingressVIP: 10.40.142.8 <1>
+    defaultMachinePlatform:
+      bootType: Legacy
+      categories: <5>
+      - key: <category_key_name>
+        value: <category_value>
+      project: <7>
+        type: name
+        name: <project_name>
     prismCentral:
       endpoint:
         address: your.prismcentral.domainname <1>
@@ -176,23 +206,23 @@ platform:
       uuid: 0005b0f1-8f43-a0f2-02b7-3cecef193712
     subnetUUIDs:
     - c7938dc6-7659-453e-a688-e26020c68e43
-    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2 <6>
+    clusterOSImage: http://example.com/images/rhcos-47.83.202103221318-0-nutanix.x86_64.qcow2 <8>
 credentialsMode: Manual
 publish: External
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <7>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <9>
 ifndef::openshift-origin[]
-fips: false <8>
-sshKey: ssh-ed25519 AAAA... <9>
+fips: false <10>
+sshKey: ssh-ed25519 AAAA... <11>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <8>
+sshKey: ssh-ed25519 AAAA... <10>
 endif::openshift-origin[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <10>
+additionalTrustBundle: | <12>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <11>
+imageContentSources: <13>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -201,11 +231,11 @@ imageContentSources: <11>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <9>
+additionalTrustBundle: | <11>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <10>
+imageContentSources: <12>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -223,18 +253,20 @@ endif::openshift-origin[]
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance.
 ====
 <4> Optional: Provide additional configuration for the machine pool parameters for the compute and control plane machines.
-<5> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
-<6> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server or Nutanix Objects and pointing the installation program to the image.
-<7> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+<5> Optional: Provide one or more pairs of a prism category key and a prism category value. These category key-value pairs must exist in Prism Central. You can provide separate categories to compute machines, control plane machines, or all machines.
+<6> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
+<7> Optional: Specify a project with which VMs are associated. Specify either `name` or `uuid` for the project type, and then provide the corresponding UUID or project name. You can associate projects to compute machines, control plane machines, or all machines.
+<8> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server or Nutanix Objects and pointing the installation program to the image.
+<9> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
 ifndef::openshift-origin[]
-<8> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<9> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
+<11> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
 +
 [NOTE]
 ====
@@ -242,7 +274,7 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<8> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
+<10> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
 +
 [NOTE]
 ====
@@ -250,12 +282,12 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 endif::openshift-origin[]
 ifndef::openshift-origin[]
-<10> Provide the contents of the certificate file that you used for your mirror registry.
-<11> Provide these values from the `metadata.name: release-0` section of the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
+<12> Provide the contents of the certificate file that you used for your mirror registry.
+<13> Provide these values from the `metadata.name: release-0` section of the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<9> Provide the contents of the certificate file that you used for your mirror registry.
-<10> Provide these values from the `metadata.name: release-0` section of the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
+<11> Provide the contents of the certificate file that you used for your mirror registry.
+<12> Provide these values from the `metadata.name: release-0` section of the `imageContentSourcePolicy.yaml` file that was created when you mirrored the registry.
 endif::openshift-origin[]
 endif::restricted[]
 


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5340

Link to docs preview:
[Installing a cluster on Nutanix (table 4)](https://57130--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#installation-configuration-parameters_installing-nutanix-installer-provisioned)
[Installing a cluster on Nutanix (sample yaml file)](https://57130--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#installation-nutanix-config-yaml_installing-nutanix-installer-provisioned)
[Restricted cluster (table 4)](https://57130--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.html#installation-configuration-parameters_installing-restricted-networks-nutanix-installer-provisioned)
[Restricted cluster (sample yaml file)](https://57130--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.html#installation-nutanix-config-yaml_installing-restricted-networks-nutanix-installer-provisioned)

QE review:
- [X] QE has approved this change.
