### PR TITLE
OSDOCS#3724: Clarify STS install prereqs re. account association

### DIFF
--- a/modules/rosa-sts-aws-requirements-association-concept.adoc
+++ b/modules/rosa-sts-aws-requirements-association-concept.adoc
@@ -7,6 +7,6 @@
 [id="rosa-associating-concept_{context}"]
 = AWS account association
 
-{product-title} (ROSA) cluster-provisioning tasks require linking `ocm-role` and `user-role` {cluster-manager} IAM resources to your AWS account using your Amazon Resource Name (ARN).
+{product-title} (ROSA) cluster-provisioning tasks require linking `ocm-role` and `user-role` {cluster-manager} IAM roles to your AWS account using your Amazon Resource Name (ARN).
 
 The `ocm-role` ARN is stored as a label in your Red Hat organization while the `user-role` ARN is stored as a label inside your Red Hat user account. Red Hat uses these ARN labels to confirm that the user is a valid account holder and that the correct permissions are available to perform the necessary tasks in the AWS account.

--- a/modules/rosa-sts-aws-requirements-creating-association.adoc
+++ b/modules/rosa-sts-aws-requirements-creating-association.adoc
@@ -7,7 +7,7 @@
 [id="rosa-associating-account_{context}"]
 = Linking your AWS account
 
-You link your AWS account using the `rosa` CLI.
+You can link your AWS account to existing IAM roles by using the `rosa` CLI.
 
 .Prerequisites
 
@@ -15,7 +15,19 @@ You link your AWS account using the `rosa` CLI.
 * You are using {cluster-manager-url} to create clusters.
 * You have the permissions required to install AWS account-wide roles. See the "Additional resources" of this section for more information.
 * You have installed and configured the latest AWS (`aws`) and ROSA (`rosa`) CLIs on your installation host.
-* You have created your `ocm-role` and `user-role` IAM roles.
+* You have created your `ocm-role` and `user-role` IAM roles, but have not yet linked them to your AWS account. You can check whether your IAM roles are already linked by running the following commands:
++
+[source,terminal]
+----
+$ rosa list ocm-role
+----
++
+[source,terminal]
+----
+$ rosa list user-role
+----
++
+If `Yes` is displayed in the `Linked` column for both roles, you have already linked the roles to an AWS account.
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
main

Issue:
https://issues.redhat.com/browse/OSDOCS-3724

Link to docs preview:
https://57132--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#rosa-ocm-requirements_rosa-sts-aws-prereqs
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
