### PR TITLE
OSDOCS-4630: L2 advertisement using interfaces

### DIFF
--- a/modules/nw-metallb-configure-l2-advertisement-interface.adoc
+++ b/modules/nw-metallb-configure-l2-advertisement-interface.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * networking/metallb/about-advertising-ipaddresspool.adoc
+
+:_content-type: PROCEDURE
+[id="nw-metallb-configure-with-L2-advertisement-interface_{context}"]
+= Configuring MetalLB with an L2 advertisement for selected interfaces
+
+By default, the IP addresses from IP address pool that has been assigned to the service, is advertised from all the network interfaces. The `interfaces` field in the `L2Advertisement` custom resource definition is used to restrict those network interfaces that advertise the IP address pool.
+
+This example shows how to configure MetalLB so that the IP address pool is advertised only from the network interfaces listed in the `interfaces` field of all nodes.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You are logged in as a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create an IP address pool.
+
+.. Create a file, such as `ipaddresspool.yaml`, and enter the configuration details like the following example:
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: IPAddressPool
+metadata:
+  namespace: metallb-system
+  name: doc-example-l2
+spec:
+  addresses:
+    - 4.4.4.0/24
+  autoAssign: false
+----
+
+.. Apply the configuration for the IP address pool like the following example:
++
+[source,terminal]
+----
+$ oc apply -f ipaddresspool.yaml
+----
+
+. Create a L2 advertisement advertising the IP with `interfaces` selector.
+
+.. Create a YAML file, such as `l2advertisement.yaml`, and enter the configuration details like the following example:
++
+[source,yaml]
+----
+apiVersion: metallb.io/v1beta1
+kind: L2Advertisement
+metadata:
+  name: l2advertisement
+  namespace: metallb-system
+spec:
+  ipAddressPools:
+   - doc-example-l2
+   interfaces:
+   - interfaceA
+   - interfaceB
+----
+
+.. Apply the configuration for the advertisement like the following example:
++
+[source,terminal]
+----
+$ oc apply -f l2advertisement.yaml
+----
+
+[IMPORTANT]
+====
+The interface selector does not affect how MetalLB chooses the node to announce a given IP by using L2. The chosen node does not announce the service if the node does not have the selected interface.
+====

--- a/modules/nw-metallb-l2padvertisement-cr.adoc
+++ b/modules/nw-metallb-l2padvertisement-cr.adoc
@@ -40,4 +40,8 @@ Specify the same namespace that the MetalLB Operator uses.
 :FeatureName: Limiting the nodes to announce as next hops
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
+|`spec.interfaces`
+|`string`
+|Optional: The list of `interfaces` that are used to announce the load balancer IP.
+
 |===

--- a/networking/metallb/about-advertising-ipaddresspool.adoc
+++ b/networking/metallb/about-advertising-ipaddresspool.adoc
@@ -28,7 +28,7 @@ include::modules/nw-metallb-configure-bgp-advertisement-advanced.adoc[leveloffse
 // Advertise MetalLB with a BGP advertisement
 include::modules/nw-metallb-advertise-address-pool-with-bgp-advanced.adoc[leveloffset=+2]
 
-// Advertise IP address pools from a subset of nodes 
+// Advertise IP address pools from a subset of nodes
 include::modules/nw-metallb-advertise-ip-pools-from-node-subset.adoc[leveloffset=+1]
 
 // L2 advertisement custom resource
@@ -39,6 +39,9 @@ include::modules/nw-metallb-configure-l2-advertisement.adoc[leveloffset=+1]
 
 // Configure MetalLB with a L2 advertisement using label
 include::modules/nw-metallb-configure-l2-advertisement-label.adoc[leveloffset=+1]
+
+// Configure MetalLB with a L2 advertisement using interface
+include::modules/nw-metallb-configure-l2-advertisement-interface.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_about-advertiseipaddress"]


### PR DESCRIPTION
Version(s):4.13

Issue: https://issues.redhat.com/browse/OSDOCS-4630

Link to docs preview: 

- https://57137--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/about-advertising-ipaddresspool.html#nw-metallb-configure-with-L2-advertisement-interface_about-advertising-ip-address-pool
- https://57137--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/about-advertising-ipaddresspool.html#nw-metallb-l2padvertisement-cr_about-advertising-ip-address-pool

QE review:
- [x] QE has approved this change. - @asood-rh 

SME review:
- [x] SME has approved this change. - @fedepaol 