### PR TITLE
OSDOCS-5508: Bare metal reference in release notes for dual-stack

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -880,9 +880,9 @@ Resulting from the switch to an external OpenStack cloud provider, UDP is now su
 If you configured and deployed your hosting service cluster, you can now deploy the SR-IOV Operator for a hosted cluster. For more information, see xref:../networking/hardware_networks/configuring-sriov-operator.adoc#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes].
 
 [id="ocp-4-12-nw-api-ingress-ipv6-support"]
-==== Support for IPv6 virtual IP (VIP) addresses for the Ingress VIP and API VIP services
+==== Support for IPv6 virtual IP (VIP) addresses for the Ingress VIP and API VIP services on bare metal
 
-With this update, in installer-provisioned infrastructure clusters, the `ingressVIP` and `apiVIP` configuration settings in the `install-config.yaml` file are deprecated. Instead, use the `ingressVIPs` and `apiVIPs` configuration settings. These settings support dual-stack networking for applications that require IPv4 and IPv6 access to the cluster by using the Ingress VIP and API VIP services. The `ingressVIPs` and `apiVIPs` configuration settings use a list format to specify an IPv4 address, an IPv6 address, or both IP address formats. The order of the list indicates the primary and secondary VIP address for each service. The primary IP address must be from the IPv4 network when using dual stack networking.
+With this update, in installer-provisioned infrastructure clusters, the `ingressVIP` and `apiVIP` configuration settings in the `install-config.yaml` file are deprecated. Instead, use the `ingressVIPs` and `apiVIPs` configuration settings. These settings support dual-stack networking for applications on bare metal that require IPv4 and IPv6 access to the cluster by using the Ingress VIP and API VIP services. The `ingressVIPs` and `apiVIPs` configuration settings use a list format to specify an IPv4 address, an IPv6 address, or both IP address formats. The order of the list indicates the primary and secondary VIP address for each service. The primary IP address must be from the IPv4 network when using dual stack networking.
 
 [id="ocp-4-12-bf2-switching-dpu-nic"]
 ==== Support for switching the Bluefield-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode (Technology Preview)


### PR DESCRIPTION
Version(s): 4.12

Issue: https://issues.redhat.com/browse/OSDOCS-5508

Link to docs preview: https://57139--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-nw-api-ingress-ipv6-support

QE review:
- [x] QE has approved this change. - @rbbratta 