### PR TITLE
RHDEVDOCS-4233| Documented guidance on authentication strategies for pipelines

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1853,6 +1853,8 @@ Topics:
     File: securing-webhooks-with-event-listeners
   - Name: Authenticating pipelines using git secret
     File: authenticating-pipelines-using-git-secret
+  - Name: Authenticating pipelines and tasks using secrets
+    File: authenticating-pipelines-and-tasks-using-secrets
   - Name: Using Tekton Chains for OpenShift Pipelines supply chain security
     File: using-tekton-chains-for-openshift-pipelines-supply-chain-security
   - Name: Viewing pipeline logs using the OpenShift Logging Operator

--- a/cicd/pipelines/authenticating-pipelines-and-tasks-using-secrets.adoc
+++ b/cicd/pipelines/authenticating-pipelines-and-tasks-using-secrets.adoc
@@ -1,0 +1,18 @@
+:_content-type: ASSEMBLY
+[id="authenticating-pipelines-and-tasks-using-secrets"]
+= Authenticating pipelines and tasks using secrets
+include::_attributes/common-attributes.adoc[]
+:context: authenticating-pipelines-and-tasks-using-secrets
+
+toc::[]
+
+For authenticating to GitHub, GitLab, or Container Image Registry in your Pipeline and Task, you can use secrets. Secrets are sensitive pieces of data that you can securely store in your project and access when needed. To use secrets for authentication, use the following recommended approaches:
+
+* Using secrets and workspaces
+
+* Using ServiceAccount 
+
+
+include::modules/op-using-secrets-and-workspaces.adoc[leveloffset=+1]
+
+include::modules/op-using-serviceaccounts.adoc[leveloffset=+1]

--- a/modules/op-using-secrets-and-workspaces.adoc
+++ b/modules/op-using-secrets-and-workspaces.adoc
@@ -1,0 +1,367 @@
+// This module is included in the following assembly:
+//
+// *openshift-docs/cicd/pipelines/authenticating-pipelines-and-tasks-using-secrets.adoc
+
+[id="op-using-secrets-and-workspaces_{context}"]
+= Using secrets and workspaces
+
+Using Secrets and Workspaces in the Tekton pipeline provides a flexible approach to managing credentials in Tekton pipelines. You can bind a Secret to a Workspace, and then use that Secret content in your Task. 
+
+The following examples illustrate how to use Secrets and Workspaces.
+
+== git-clone Task
+
+This approach involves creating a task called `git-clone`, which clones a git repository using SSH authentication. The following are the steps to use Secrets and Workspace in Tekton Pipelines:
+
+. Create a Task called `git-clone` that clones a git repository using SSH authentication. 
+
+. Define workspaces, describe the process to create a secret, and bind it to the workspace. For example:
+
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-github-ssh-credentials
+type: Opaque
+data:
+  id_ed25519: # […]
+  known_hosts: # […]
+  # config: # […] # optional
+----
+
++
+[NOTE]
+====
+To create the above secret, run `$ kubectl create secret generic my-github-ssh-credentials \
+  --from-file=id_ed25519=/path/to/.ssh/id_ed25519 \
+  --from-file=known_hosts=/path/to/.ssh/known_hosts
+secret/my-github-ssh-credentials created`
+====
+
+. Define task parameters for the repository URL, revision, and the git-init image that the Task uses.
+
+. Define results that the Task produces, for example, the commit SHA and the repository URL. 
+
+. Define the steps that the Task executes, for example, copying the content of the ssh secret to the user’s home directory and running the git-init binary to clone the repository. 
+
+. Start the Task with the required parameters and workspace bindings. To start the Task, run the following command:
+
++
+`$ tkn task start git-clone \
+      --param url=git@github.com:<username>/buildkit-tekton \
+      --workspace name=output,emptyDir="" \
+      --workspace name=ssh-directory,secret=my-github-ssh-credentials \
+      --use-param-defaults --showlog`
+
+
+.Example: Tekton Task for cloning a Git repository using an SSH key for authentication:
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+spec:
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this Workspace.
+    - name: ssh-directory <1>
+      description: | <2>
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types
+  params:
+    - name: url
+      description: Repository URL to clone from.
+      type: string
+    - name: revision
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      type: string
+      default: ""
+    - name: gitInitImage
+      description: The image providing the git-init binary that this Task runs.
+      type: string
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.37.0"
+  results:
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task.
+    - name: url
+      description: The precise URL that was fetched by this Task.
+  steps:
+    - name: clone
+      image: "$(params.gitInitImage)"
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        # This is necessary for recent version of git
+        git config --global --add safe.directory '*' <3>
+        cp -R "$(workspaces.ssh-directory.path)" "${HOME}"/.ssh
+        chmod 700 "${HOME}"/.ssh
+        chmod -R 400 "${HOME}"/.ssh/*
+        CHECKOUT_DIR="$(workspaces.output.path)/"
+        /ko-app/git-init \
+          -url="$(params.url)" \
+          -revision="$(params.revision)" \
+          -path="${CHECKOUT_DIR}"
+        cd "${CHECKOUT_DIR}"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        EXIT_CODE="$?"
+        if [ "${EXIT_CODE}" != 0 ] ; then
+          exit "${EXIT_CODE}"
+        fi
+        printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+        printf "%s" "$(params.url)" > "$(results.url.path)"
+----
+<1> The workspaces that the Task needs to run, for example, ssh-directory.
+<2> The description that outlines the process for creating the secret. 
+<3> The script copies the content of the secret (in the form of a folder) to ${HOME}/.ssh, which is the standard folder where `ssh` searches for credentials.
+
+== An existing docker configuration file
+
+This approach uses an existing docker configuration file inside a Task. The Task definition is the same as that of the “A git-clone task” approach, but Skopeo is used to replicate an image to a personal repository. This approach can be adapted to other tools such as Podman, Buildah, or Docker, as long as they are capable of interpreting a docker client configuration file.
+
+Following are the steps involved in using a Docker configuration file inside a Tekton pipeline task.
+
+. Define a Tekton Task in your Kubernetes cluster with a reference to Skopeo image that copies a docker image to a specified repository.
+
+. In the Task definition, create a workspace called `dockerconfig` that holds a `config.json` file.
+
+. Define a secret in Kubernetes containing the `config.json` file, which contains the Docker authentication information.
+
+. Use the `kubectl create secret` command to create the secret, specifying the path to the `config.json` file on your local machine.
+
+. Start the TeKton Task using the `tkn task start` command, specifying the name of the Task, the workspace name (`dockerconfig`),  and the secret name (`regcred`).
+
+. The Task executes the Skopeo container,  which reads the `DOCKER_CONFIG` environment variable to locate the `config.json` file containing the authentication information for accessing the Docker registry.
+
+. The Skopeo container then copies the specified Docker image to the specified repository.
+
+.Example: An existing docker configuration file inside a Task:
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: skopeo-copy
+spec:
+  workspaces:
+    - name: dockerconfig <1>
+      description: Includes a docker `config.json`
+  steps:
+    - name: clone
+      image: quay.io/skopeo/stable:v1.8.0
+      env:
+      - name: DOCKER_CONFIG
+        value: $(workspaces.dockerconfig.path) <2>
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        skopeo copy docker://docker.io/library/ubuntu:latest docker://docker.io/vdemeester/ubuntu-copy:latest
+----
+<1>  The name of the workspace that contains the config.json file. For a secret, this represents a key named config.json.
+<2> The DOCKER_CONFIG environment variable points to the `dockerconfig` workspace path `skopeo` to get the authentication information.
+
+
+== The git-clone Task with optional workspaces
+
+This approach uses the optional workspaces feature. With optional workspaces, a Workspace might be bound to a Pod or Container (also known as, mounties as a volume) or it might not be present. 
+
+To ensure that the task takes this optional property into account the `git-clone` task is adapted to include an optional workspace. The `apiversion`, `kind`, `metadata`, `params`, `results`, and `steps` of the `git-clone` task are defined as in the standard task, but two workspaces are defined, one of which is optional. The `name` and `description` of the optional workspace are defined and the script is updated to conditionally copy the content of the workspace to the user’s home directory only if the workspace is bound.
+
+The advantage of using optional workspaces is that it makes the task more flexible for example if a public Git repository is cloned, there s no need to bind a secret to a workspace. 
+
+The following steps illustrate how to use the optional workspace feature in the git-clone Task:
+
+. Create a Task called `git-clone-optional-ws` that clones a git repository using SSH authentication, with an optional workspace. 
+
+. Define workspaces for the `git-ssh` secret and the optional workspace `my-optional-workspace`. 
+
+. Define task parameters for the repository URL, revision, and the git-init image that the Task uses. 
+
+. Define results that the Task produces, for example, the commit SHA and the repository URL. 
+
+. Define the steps that the Task executes, including a condition to check if the optional workspace is bound before copying the content of the workspace to the user's home directory. 
+
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone-optional-ws
+spec:
+  workspaces:
+    - name: git-ssh
+      description: Workspace containing the git-ssh secret
+    - name: my-optional-workspace
+      description: Optional workspace that may be bound to a Pod or Container
+      optional: true
+  params:
+    - name: url
+      description: The URL of the Git repository to clone
+      type: string
+      default: ""
+    - name: revision
+      description: The Git revision to check out
+      type: string
+      default: "master"
+    - name: image
+      description: The image to use for the git-init container
+      type: string
+      default: "alpine/git:latest"
+  results:
+    - name: commit-sha
+      description: The commit SHA of the checked out revision
+    - name: repo-url
+      description: The URL of the cloned Git repository
+  steps:
+    - name: clone
+      image: $(params.image)
+      workingDir: /workspace/source
+      env:
+        - name: GIT_SSH_COMMAND
+          value: ssh -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no -i /workspace/git-ssh/ssh-privatekey
+      command:
+        - sh
+      args:
+        - -c
+        - |
+          git clone $(params.url) .
+          git checkout $(params.revision)
+          echo $(git rev-parse HEAD) > $(results.commit-sha.path)
+          echo $(params.url) > $(results.repo-url.path)
+    - name: optional-workspace
+      image: alpine:latest
+      workingDir: /workspace
+      command:
+        - sh
+      args:
+        - -c
+        - |
+          if [ -d "/workspace/my-optional-workspace" ]; then
+            cp -r /workspace/my-optional-workspace/* $HOME/
+          fi
+----
+
+. Create a secret with the ssh authentication content, for example, private key and known hosts. 
+
+. Start the Task with the required parameters and workspace bindings. You can optionally bind the `my-optional-workspace` workspace to the Pod or Container where the Task runs. 
+
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: my-git-clone-taskrun
+spec:
+  taskRef:
+    name: my-git-clone-task
+  params:
+    - name: url
+      value: https://github.com/my-org/my-repo.git
+    - name: revision
+      value: main
+  workspaces:
+    - name: my-workspace
+      persistentVolumeClaim:
+        claimName: my-pvc
+    - name: my-optional-workspace
+      volumeClaim:
+        claimName: my-optional-pvc
+  podTemplate:
+    spec:
+      containers:
+        - name: my-container
+          image: my-image
+          volumeMounts:
+            - name: my-workspace
+              mountPath: /workspace
+            - name: my-optional-workspace
+              mountPath: /optional-workspace
+----
+
+.Example: A modified git clone task  to incorporate the optional Workspace feature.
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+spec:
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this Workspace.
+    - name: ssh-directory <1>
+      description: | <2>
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types
+  params:
+    - name: url
+      description: Repository URL to clone from.
+      type: string
+    - name: revision
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      type: string
+      default: ""
+    - name: gitInitImage
+      description: The image providing the git-init binary that this Task runs.
+      type: string
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.37.0"
+  results:
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task.
+    - name: url
+      description: The precise URL that was fetched by this Task.
+  steps:
+    - name: clone
+      image: "$(params.gitInitImage)"
+      script: | 
+        #!/usr/bin/env sh
+        set -eu
+        # This is necessary for recent version of git
+        git config --global --add safe.directory '*' <3>
+        if [ "$(workspaces.ssh-directory.bound)" = "true" ] ; then
+          cp -R "$(workspaces.ssh-directory.path)" "${HOME}"/.ssh
+          chmod 700 "${HOME}"/.ssh
+          chmod -R 400 "${HOME}"/.ssh/*
+        fi
+        CHECKOUT_DIR="$(workspaces.output.path)/"
+        /ko-app/git-init \
+          -url="$(params.url)" \
+          -revision="$(params.revision)" \
+          -path="${CHECKOUT_DIR}"
+        cd "${CHECKOUT_DIR}"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        EXIT_CODE="$?"
+        if [ "${EXIT_CODE}" != 0 ] ; then
+          exit "${EXIT_CODE}"
+        fi
+        printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+        printf "%s" "$(params.url)" > "$(results.url.path)"
+----
+<1> The name of the workspace, for example, ssh-directory.
+<2> The description outlines the process for creating the secret.
+<3> The script that conditionally copies the content of the secret (in the form of a folder) to ${HOME}/.ssh, which is the standard folder where `ssh` searches for credentials. If the `Workspace` is bound, the script performs the copy operation.
+
+== git-credentials
+
+In this approach, the `git-clone` task includes an optional workspace for `git-credentials`. The script is updated to conditionally copy the contents of the git-credentials` workspace to the user’s home directory if the workspace is bound.
+
+.Example: A modified git clone task  to includes an optional workspace for `git-credentials`:
+
+[source,yaml,subs="attributes+"]
+----
+if [ "$(workspaces.basic_auth.bound)" = "true" ] ; then
+          cp "$(workspaces.basic_auth.path)/.git-credentials" "${HOME}/.git-credentials"
+          cp "$(workspaces.basic_auth.path)/.gitconfig" "${HOME}/.gitconfig"
+          chmod 400 "${HOME}/.git-credentials"
+          chmod 400 "${HOME}/.gitconfig"
+        fi
+----

--- a/modules/op-using-serviceaccounts.adoc
+++ b/modules/op-using-serviceaccounts.adoc
@@ -1,0 +1,91 @@
+// This module is included in the following assembly:
+//
+// *openshift-docs/cicd/pipelines/authenticating-pipelines-and-tasks-using-secrets.adoc
+
+[id="op-using-serviceaccounts_{context}"]
+= Using ServiceAccounts
+
+This approach involves the following steps:
+
+. Annotating specific secrets using either the Git or Docker annotation
+
+. Linking the annotated `Secrets` to `ServiceAccounts`
+
+. Specifying the `ServiceAccounts` on PipelineRun or TaskRuns
+
+== Annotations
+
+Tekton offers two types of authentication for secrets: 
+
+* `tekton.dev/git-{}` - Used to mark the annotated secret as a kid secret. 
+
+* `tekton.dev/docker-{}` - Used to mark the annotated secret as a docker secret.
+
+Additionally, Tekton supports different types of secrets for each authentication type. 
+
+For `git` it supports the following types of secrets:
+
+* kubernetes.io/basic-auth : basic authentication 
+
+* kubernetes.io/ssh-auth : ssh based authentication (keys, …)
+
+
+For `docker` it supports the following types of secrets:
+
+* kubernetes.io/basic-auth : basic authentications 
+
+* kubernetes.io/dockercfg : serialized ~/.dockercfg file kubernetes.io/dockerconfigjson : serialized ~/.docker/config.json file
+
+
+== Linking the annotated secrets to  ServiceAccounts
+
+To link a secret to a _ServiceAccount_, you can reference the Secret by the name in the *secrets* field of the _ServiceAccount_. For example:
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-bot
+secrets:
+  - name: regcred
+  - name: a-git-auth-secret
+----
+
+== Specifying the ServiceAccounts on PipelineRun or TaskRuns
+
+To specify a _ServiceAccount_ for a _PipelineRun_ or a _TaskRun_, use the `serviceAccountName` field,
+
+[source,yaml,subs="attributes+"]
+----
+# For a TaskRun
+
+apiVersion: tekton.dev/v1beta1
+kind: TaskRun
+metadata:
+  name: build-with-basic-auth
+spec:
+  serviceAccountName: build-bot
+  taskRef:
+    name: demo-task
+  # ...
+---
+# For a PipelineRun
+
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+  name: demo-pipeline
+  namespace: default
+spec:
+  serviceAccountName: build-bot
+  pipelineRef:
+    name: demo-pipeline
+  # […]
+----
+
+Alternatively, you can also use of the `tkn` command to specify a _ServiceAccount_ for a _PipelineRun_ or a _TaskRun_. 
+
+* To specify a _ServiceAccount_ for a _PipelineRun_ run, `$ tkn pipeline start demo-pipeline --serviceaccount build-bot --param # […]`.
+
+* To specify a _ServiceAccount_ for a _TaskRun_ run, `$ tkn task start demo-task --serviceaccount build-bot`.


### PR DESCRIPTION
- Aligned team: Dev Tools
- OCP version for cherry-picking: `enterprise-4.10`, `enterprise-4.11`, `enterprise-4.12`, and `enterprise-4.13`
- JIRA issue: [RHDEVDOCS-4233](https://issues.redhat.com/browse/RHDEVDOCS-4233)
- Preview pages: [Click to preview the docs in your browser](https://57140--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/authenticating-pipelines-and-tasks-using-secrets.html)
- SME review: @vdemeester  
- QE review: @ppitonak @VeereshAradhya 
- Peer review: