### PR TITLE
RHDEVDOCS-4893 - 4.13 CMO config map reference - autogenerated

### DIFF
--- a/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -1,7 +1,7 @@
-// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
-// source code for the Cluster Monitoring Operator. Any changes made to this 
-// file will be overwritten when the content is re-generated. If you wish to 
-// make edits, read the docgen utility instructions in the source code for the 
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the
+// source code for the Cluster Monitoring Operator. Any changes made to this
+// file will be overwritten when the content is re-generated. If you wish to
+// make edits, read the docgen utility instructions in the source code for the
 // CMO.
 :_content-type: REFERENCE
 [id="config-map-reference-for-the-cluster-monitoring-operator"]
@@ -16,19 +16,19 @@ toc::[]
 
 [role="_abstract"]
 Parts of {product-title} cluster monitoring are configurable.
-The API is accessible by setting parameters defined in various config maps. 
+The API is accessible by setting parameters defined in various config maps.
 
-* To configure monitoring components, edit the `ConfigMap` object named `cluster-monitoring-config` in the `openshift-monitoring` namespace. 
+* To configure monitoring components, edit the `ConfigMap` object named `cluster-monitoring-config` in the `openshift-monitoring` namespace.
 These configurations are defined by link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration].
-* To configure monitoring components that monitor user-defined projects, edit the `ConfigMap` object named `user-workload-monitoring-config` in the `openshift-user-workload-monitoring` namespace. 
+* To configure monitoring components that monitor user-defined projects, edit the `ConfigMap` object named `user-workload-monitoring-config` in the `openshift-user-workload-monitoring` namespace.
 These configurations are defined by link:#userworkloadconfiguration[UserWorkloadConfiguration].
 
 The configuration file is always defined under the `config.yaml` key in the config map data.
 
 [NOTE]
 ====
-* Not all configuration parameters are exposed. 
-* Configuring cluster monitoring is optional. 
+* Not all configuration parameters are exposed.
+* Configuring cluster monitoring is optional.
 * If a configuration does not exist or is empty, default values are used.
 * If the configuration is invalid YAML data, the Cluster Monitoring Operator stops reconciling the resources and reports `Degraded=True` in the status conditions of the Operator.
 ====
@@ -48,7 +48,7 @@ link:#thanosrulerconfig[ThanosRulerConfig]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |apiVersion|string|Defines the API version of Alertmanager. Possible values are `v1` or `v2`. The default is `v2`.
 
 |bearerToken|*v1.SecretKeySelector|Defines the secret key reference containing the bearer token to use when authenticating to Alertmanager.
@@ -75,7 +75,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |enabled|*bool|A Boolean flag that enables or disables the main Alertmanager instance in the `openshift-monitoring` namespace. The default value is `true`.
 
 |enableUserAlertmanagerConfig|bool|A Boolean flag that enables or disables user-defined namespaces to be selected for `AlertmanagerConfig` lookups. This setting only applies if the user workload monitoring instance of Alertmanager is not enabled. The default value is `false`.
@@ -85,6 +85,8 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 |nodeSelector|map[string]string|Defines the nodes on which the Pods are scheduled.
 
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the Alertmanager container.
+
+|secrets|[]string|Defines a list of secrets to be mounted into Alertmanager. The secrets must reside within the same namespace as the Alertmanager object. They are added as volumes named `secret-<secret-name>` and mounted at `/etc/alertmanager/secrets/<secret-name>` in the `alertmanager` container of the Alertmanager pods.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
 
@@ -104,7 +106,7 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |enabled|bool|A Boolean flag that enables or disables a dedicated instance of Alertmanager for user-defined alerts in the `openshift-user-workload-monitoring` namespace. The default value is `false`.
 
 |enableAlertmanagerConfig|bool|A Boolean flag to enable or disable user-defined namespaces to be selected for `AlertmanagerConfig` lookup. The default value is `false`.
@@ -112,6 +114,8 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 |logLevel|string|Defines the log level setting for Alertmanager for user workload monitoring. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
 
 |resources|*v1.ResourceRequirements|Defines resource requests and limits for the Alertmanager container.
+
+|secrets|[]string|Defines a list of secrets to be mounted into Alertmanager. The secrets must be located within the same namespace as the Alertmanager object. They are added as volumes named `secret-<secret-name>` and mounted at `/etc/alertmanager/secrets/<secret-name>` in the `alertmanager` container of the Alertmanager pods.
 
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
@@ -129,7 +133,7 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |alertmanagerMain|*link:#alertmanagermainconfig[AlertmanagerMainConfig]|`AlertmanagerMainConfig` defines settings for the Alertmanager component in the `openshift-monitoring` namespace.
 
 |enableUserWorkload|*bool|`UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects.
@@ -148,6 +152,8 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 
 |thanosQuerier|*link:#thanosquerierconfig[ThanosQuerierConfig]|`ThanosQuerierConfig` defines settings for the Thanos Querier component.
 
+|nodeExporter|link:#nodeexporterconfig[NodeExporterConfig]|`NodeExporterConfig` defines settings for the `node-exporter` agent.
+
 |===
 
 == DedicatedServiceMonitors
@@ -160,7 +166,7 @@ Appears in: link:#k8sprometheusadapter[K8sPrometheusAdapter]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |enabled|bool|When `enabled` is set to `true`, the Cluster Monitoring Operator (CMO) deploys a dedicated Service Monitor that exposes the kubelet `/metrics/resource` endpoint. This Service Monitor sets `honorTimestamps: true` and only keeps metrics that are relevant for the pod resource queries of Prometheus Adapter. Additionally, Prometheus Adapter is configured to use these dedicated metrics. Overall, this feature improves the consistency of Prometheus Adapter-based CPU usage measurements used by, for example, the `oc adm top pod` command or the Horizontal Pod Autoscaler.
 
 |===
@@ -175,7 +181,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |audit|*Audit|Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`.
 
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
@@ -196,10 +202,125 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
+
+|===
+
+== NodeExporterCollectorBuddyInfoConfig
+
+=== Description
+
+The `NodeExporterCollectorBuddyInfoConfig` resource works as an on/off switch for the `buddyinfo` collector of the `node-exporter` agent. By default, the `buddyinfo` collector is disabled.
+
+Appears in: link:#nodeexportercollectorconfig[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description
+|enabled|bool|A Boolean flag that enables or disables the `buddyinfo` collector.
+
+|===
+
+== NodeExporterCollectorConfig
+
+=== Description
+
+The `NodeExporterCollectorConfig` resource defines settings for individual collectors of the `node-exporter` agent.
+
+Appears in: link:#nodeexporterconfig[NodeExporterConfig]
+
+[options="header"]
+|===
+| Property | Type | Description
+|cpufreq|link:#nodeexportercollectorcpufreqconfig[NodeExporterCollectorCpufreqConfig]|Defines the configuration of the `cpufreq` collector, which collects CPU frequency statistics. Disabled by default.
+
+|tcpstat|link:#nodeexportercollectortcpstatconfig[NodeExporterCollectorTcpStatConfig]|Defines the configuration of the `tcpstat` collector, which collects TCP connection statistics. Disabled by default.
+
+|netdev|link:#nodeexportercollectornetdevconfig[NodeExporterCollectorNetDevConfig]|Defines the configuration of the `netdev` collector, which collects network devices statistics. Enabled by default.
+
+|netclass|link:#nodeexportercollectornetclassconfig[NodeExporterCollectorNetClassConfig]|Defines the configuration of the `netclass` collector, which collects information about network devices. Enabled by default.
+
+|buddyinfo|link:#nodeexportercollectorbuddyinfoconfig[NodeExporterCollectorBuddyInfoConfig]|Defines the configuration of the `buddyinfo` collector, which collects statistics about memory fragmentation from the `node_buddyinfo_blocks` metric. This metric collects data from `/proc/buddyinfo`. Disabled by default.
+
+|===
+
+== NodeExporterCollectorCpufreqConfig
+
+=== Description
+
+The `NodeExporterCollectorCpufreqConfig` resource works as an on/off switch for the `cpufreq` collector of the `node-exporter` agent. By default, the `cpufreq` collector is disabled. Under certain circumstances, enabling the cpufreq collector increases CPU usage on machines with many cores. If you enable this collector and have machines with many cores, monitor your systems closely for excessive CPU usage.
+
+Appears in: link:#nodeexportercollectorconfig[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description
+|enabled|bool|A Boolean flag that enables or disables the `cpufreq` collector.
+
+|===
+
+== NodeExporterCollectorNetClassConfig
+
+=== Description
+
+The `NodeExporterCollectorNetClassConfig` resource works as an on/off switch for the `netclass` collector of the `node-exporter` agent. By default, the `netclass` collector is enabled. If disabled, these metrics become unavailable: `node_network_info`, `node_network_address_assign_type`, `node_network_carrier`, `node_network_carrier_changes_total`, `node_network_carrier_up_changes_total`, `node_network_carrier_down_changes_total`, `node_network_device_id`, `node_network_dormant`, `node_network_flags`, `node_network_iface_id`, `node_network_iface_link`, `node_network_iface_link_mode`, `node_network_mtu_bytes`, `node_network_name_assign_type`, `node_network_net_dev_group`, `node_network_speed_bytes`, `node_network_transmit_queue_length`, `node_network_protocol_type`.
+
+Appears in: link:#nodeexportercollectorconfig[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description
+|enabled|bool|A Boolean flag that enables or disables the `netclass` collector.
+
+|useNetlink|bool|A Boolean flag that activates the `netlink` implementation of the `netclass` collector. By default, it is disabled. This implementation improves the performance of the `netclass` collector by omitting these metrics: `node_network_address_assign_type`, `node_network_name_assign_type`, `node_network_device_id`, `node_network_speed_bytes`. In addition, the `node_network_info` metric lacks the `duplex` label.
+
+|===
+
+== NodeExporterCollectorNetDevConfig
+
+=== Description
+
+The `NodeExporterCollectorNetDevConfig` resource works as an on/off switch for the `netdev` collector of the `node-exporter` agent. By default, the `netdev` collector is enabled. If disabled, these metrics become unavailable: `node_network_receive_bytes_total`, `node_network_receive_compressed_total`, `node_network_receive_drop_total`, `node_network_receive_errs_total`, `node_network_receive_fifo_total`, `node_network_receive_frame_total`, `node_network_receive_multicast_total`, `node_network_receive_nohandler_total`, `node_network_receive_packets_total`, `node_network_transmit_bytes_total`, `node_network_transmit_carrier_total`, `node_network_transmit_colls_total`, `node_network_transmit_compressed_total`, `node_network_transmit_drop_total`, `node_network_transmit_errs_total`, `node_network_transmit_fifo_total`, `node_network_transmit_packets_total`.
+
+Appears in: link:#nodeexportercollectorconfig[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description
+|enabled|bool|A Boolean flag that enables or disables the `netdev` collector.
+
+|===
+
+== NodeExporterCollectorTcpStatConfig
+
+=== Description
+
+The `NodeExporterCollectorTcpStatConfig` resource works as an on/off switch for the `tcpstat` collector of the `node-exporter` agent. By default, the `tcpstat` collector is disabled.
+
+Appears in: link:#nodeexportercollectorconfig[NodeExporterCollectorConfig]
+
+[options="header"]
+|===
+| Property | Type | Description
+|enabled|bool|A Boolean flag that enables or disables the `tcpstat` collector.
+
+|===
+
+== NodeExporterConfig
+
+=== Description
+
+The `NodeExporterConfig` resource defines settings for the `node-exporter` agent.
+
+Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
+
+[options="header"]
+|===
+| Property | Type | Description
+|collectors|link:#nodeexportercollectorconfig[NodeExporterCollectorConfig]|Defines which collectors are enabled and their additional configuration parameters.
 
 |===
 
@@ -213,7 +334,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
@@ -230,7 +351,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |additionalAlertmanagerConfigs|[]link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]|Configures additional Alertmanager instances that receive alerts from the Prometheus component. By default, no additional Alertmanager instances are configured.
 
 |enforcedBodySizeLimit|string|Enforces a body size limit for Prometheus scraped metrics. If a scraped target's body response is larger than the limit, the scrape will fail. The following values are valid: an empty value to specify no limit, a numeric value in Prometheus size format (such as `64MB`), or the string `automatic`, which indicates that the limit will be automatically calculated based on cluster capacity. The default value is empty, which indicates no limit.
@@ -255,6 +376,8 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 |topologySpreadConstraints|[]v1.TopologySpreadConstraint|Defines the pod's topology spread constraints.
 
+|collectionProfile|CollectionProfile|Defines the metrics collection profile that Prometheus uses to collect metrics from the platform components. Supported values are `full` or `minimal`. In the `full` profile (default), Prometheus collects all metrics that are exposed by the platform components. In the `minimal` profile, Prometheus only collects metrics necessary for the default platform alerts, recording rules, telemetry, and console dashboards.
+
 |volumeClaimTemplate|*monv1.EmbeddedPersistentVolumeClaim|Defines persistent storage for Prometheus. Use this setting to configure the persistent volume claim, including storage class, volume size and name.
 
 |===
@@ -270,7 +393,7 @@ link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |logLevel|string|Defines the log level settings for Prometheus Operator. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
 
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
@@ -289,7 +412,7 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |additionalAlertmanagerConfigs|[]link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]|Configures additional Alertmanager instances that receive alerts from the Prometheus component. By default, no additional Alertmanager instances are configured.
 
 |enforcedLabelLimit|*uint64|Specifies a per-scrape limit on the number of labels accepted for a sample. If the number of labels exceeds this limit after metric relabeling, the entire scrape is treated as failed. The default value is `0`, which means that no limit is set.
@@ -338,7 +461,7 @@ link:#prometheusrestrictedconfig[PrometheusRestrictedConfig]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |authorization|*monv1.SafeAuthorization|Defines the authorization settings for remote write storage.
 
 |basicAuth|*monv1.BasicAuth|Defines basic authentication settings for the remote write endpoint URL.
@@ -369,11 +492,37 @@ link:#prometheusrestrictedconfig[PrometheusRestrictedConfig]
 
 |===
 
+== TLSConfig
+
+=== Description
+
+The `TLSConfig` resource configures the settings for TLS connections.
+
+=== Required
+* `insecureSkipVerify`
+
+Appears in: link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]
+
+[options="header"]
+|===
+| Property | Type | Description
+|ca|*v1.SecretKeySelector|Defines the secret key reference containing the Certificate Authority (CA) to use for the remote host.
+
+|cert|*v1.SecretKeySelector|Defines the secret key reference containing the public certificate to use for the remote host.
+
+|key|*v1.SecretKeySelector|Defines the secret key reference containing the private key to use for the remote host.
+
+|serverName|string|Used to verify the hostname on the returned certificate.
+
+|insecureSkipVerify|bool|When set to `true`, disables the verification of the remote host's certificate and name.
+
+|===
+
 == TelemeterClientConfig
 
 === Description
 
-The `TelemeterClientConfig` resource defines settings for the `telemeter-client` component.
+`TelemeterClientConfig` defines settings for the Telemeter Client component.
 
 === Required
 * `nodeSelector`
@@ -383,7 +532,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
@@ -400,7 +549,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |enableRequestLogging|bool|A Boolean flag that enables or disables request logging. The default value is `false`.
 
 |logLevel|string|Defines the log level setting for Thanos Querier. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
@@ -423,7 +572,7 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |additionalAlertmanagerConfigs|[]link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]|Configures how the Thanos Ruler component communicates with additional Alertmanager instances. The default value is `nil`.
 
 |logLevel|string|Defines the log level setting for Thanos Ruler. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
@@ -442,32 +591,6 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 |===
 
-== TLSConfig
-
-=== Description
-
-The `TLSConfig` resource configures the settings for TLS connections.
-
-=== Required
-* `insecureSkipVerify`
-
-Appears in: link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]
-
-[options="header"]
-|===
-| Property | Type | Description 
-|ca|*v1.SecretKeySelector|Defines the secret key reference containing the Certificate Authority (CA) to use for the remote host.
-
-|cert|*v1.SecretKeySelector|Defines the secret key reference containing the public certificate to use for the remote host.
-
-|key|*v1.SecretKeySelector|Defines the secret key reference containing the private key to use for the remote host.
-
-|serverName|string|Used to verify the hostname on the returned certificate.
-
-|insecureSkipVerify|bool|When set to `true`, disables the verification of the remote host's certificate and name.
-
-|===
-
 == UserWorkloadConfiguration
 
 === Description
@@ -476,7 +599,7 @@ The `UserWorkloadConfiguration` resource defines the settings responsible for us
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |alertmanager|*link:#alertmanageruserworkloadconfig[AlertmanagerUserWorkloadConfig]|Defines the settings for the Alertmanager component in user workload monitoring.
 
 |prometheus|*link:#prometheusrestrictedconfig[PrometheusRestrictedConfig]|Defines the settings for the Prometheus component in user workload monitoring.


### PR DESCRIPTION
Summary: This PR updates the Cluster Monitoring Operator config map API reference with autogenerated content from the CMO for 4.13.

- Aligned team: DevTools
- For branches: 4.13+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-4893
- Direct link to doc preview: https://57142--docspreview.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator.html
- SME review: n/a
- QE review: @juzhao @Tai-RedHat 
- Peer review: @gabriel-rh 