### PR TITLE
OCPBUGS-10053-language

### DIFF
--- a/modules/psap-driver-toolkit-pulling.adoc
+++ b/modules/psap-driver-toolkit-pulling.adoc
@@ -24,7 +24,7 @@ The driver-toolkit image for the latest minor release are tagged with the minor 
 
 .Procedure
 
-. The image URL of the `driver-toolkit` corresponding to a certain release can be extracted from the release image using the `oc adm` command:
+. Use the `oc adm` command to extract the image URL of the `driver-toolkit` corresponding to a certain release:
 +
 [source,terminal,subs="attributes+"]
 ----
@@ -44,7 +44,7 @@ The output for the `ocp-release:4.12.0-x86_64` image is as follows:
 quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b53883ca2bac5925857148c4a1abc300ced96c222498e3bc134fe7ce3a1dd404
 ----
 
-. This image can be obtained using a valid pull secret, such as the pull secret required to install {product-title}.
+. Obtain this image using a valid pull secret, such as the pull secret required to install {product-title}:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Change sentence structure from passive to active in 'Red Hat OpenShift Container Platform' doc >  'Specialized hardware and driver enablement' chapter >  'Driver Toolkit' section > 'Finding the Driver Toolkit image URL in the payload' subsection > steps 1 and 2.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
main, 4.13, 4.12, 4.11

Issue:
https://issues.redhat.com/browse/OCPBUGS-10053

Link to docs preview:
http://file.emea.redhat.com/tshwartz/OCPBUGS-10053-language/hardware_enablement/psap-driver-toolkit.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
