### PR TITLE
OSDOCS-5526: Update internal image streams in multi-arch docs

### DIFF
--- a/modules/multi-architecture-import-imagestreams.adoc
+++ b/modules/multi-architecture-import-imagestreams.adoc
@@ -1,6 +1,6 @@
 //Module included in the following assemblies
 //
-//post_installation_configuration/cluster-tasks.adoc
+//post_installation_configuration/multi-architecture-configuration.adoc
 
 :_content-type: PROCEDURE
 [id="multi-architecture-import-imagestreams_{context}"]
@@ -8,16 +8,6 @@
 = Importing manifest lists in image streams on your multi-architecture compute machines 
 
 On an {product-title} {product-version} cluster with multi-architecture compute machines, the image streams in the cluster do not import manifest lists automatically. You must manually change the default `importMode` option to the `PreserveOriginal` option in order to import the manifest list.
-
-[IMPORTANT]
-====
-The `referencePolicy.type` field of your `ImageStream` object must be set to the `Source` type for this procedure to run successfully.
-[source,yaml]
-----
-referencePolicy:
-    type: Source 
-----
-====
 
 .Prerequisites 
 
@@ -29,7 +19,7 @@ referencePolicy:
 +
 [source,terminal]
 ----
-oc patch is/cli-artifacts -n openshift -p '{"spec":{"tags":[{"name":"latest","importPolicy":{"importMode":"PreserveOriginal"}}]}}'
+$ oc patch is/cli-artifacts -n openshift -p '{"spec":{"tags":[{"name":"latest","importPolicy":{"importMode":"PreserveOriginal"}}]}}'
 ----
 
 .Verification 
@@ -38,7 +28,7 @@ oc patch is/cli-artifacts -n openshift -p '{"spec":{"tags":[{"name":"latest","im
 +
 [source,terminal]
 ----
-oc get istag cli-artifacts:latest -n openshift -oyaml
+$ oc get istag cli-artifacts:latest -n openshift -oyaml
 ----
 
 + 

--- a/post_installation_configuration/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/multi-architecture-configuration.adoc
@@ -6,7 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. Clusters with multi-architecture compute machines are available only on AWS or Azure installer-provisioned infrastructures and bare metal user-provisioned infrastructures with `x86_64` control plane machines. 
+An {product-title} cluster with multi-architecture compute machines is a cluster that supports compute machines with different architectures. Clusters with multi-architecture compute machines are available only on AWS or Azure installer-provisioned infrastructures and bare metal user-provisioned infrastructures with `x86_64` control plane machines.
+
+[NOTE]
+====
+When there are nodes with multiple architectures in your cluster, the architecture of your image must be consistent with the architecture of the node. You need to ensure that the pod is assigned to the node with the appropriate architecture and that it matches the image architecture. For more information on assigning pods to nodes, see link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/[Assigning pods to nodes].
+====
+
+[IMPORTANT]
+====
+The Cluster Samples Operator is not supported on clusters with multi-architecture compute machines. Your cluster can be created without this capability. For more information, see xref:../post_installation_configuration/enabling-cluster-capabilities.adoc#enabling-cluster-capabilities[Enabling cluster capabilities]
+====
 
 == Creating a cluster with multi-architecture compute machine on Azure 
 


### PR DESCRIPTION
**For version:** 4.13+ 
**Issue:** [OSDOCS-5526](https://issues.redhat.com//browse/OSDOCS-5526)

**Description:** Removing 'Important' block from Image streams docs as it is no longer necessary for 4.13+ 

**Preview:** 
- [Configuring multi-architecture compute machines on an OpenShift Container Platform cluster](https://57160--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html)

**QE review:** 

- [x] QE approved 
