### PR TITLE
OCPBUGS-7065 bare-metal network config with STP - CP to 4.9

### DIFF
--- a/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
+++ b/modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc
@@ -115,7 +115,7 @@ $ sudo nohup bash -c "
     # RHEL 8.1 appends the word \"System\" in front of the connection, delete in case it exists
     nmcli con down \"System $PUB_CONN\"
     nmcli con delete \"System $PUB_CONN\"
-    nmcli connection add ifname baremetal type bridge con-name baremetal
+    nmcli connection add ifname baremetal type bridge con-name baremetal bridge.stp no
     nmcli con add type bridge-slave ifname \"$PUB_CONN\" master baremetal
     pkill dhclient;dhclient baremetal
 "


### PR DESCRIPTION
CP to 4.9 due to merge conflict in #55686 

OCPBUGS-7065: If your interface is connected to a switch, need to check that there is no BPDU guard on the switch interface or disable stp on baremetal bridge.

Version(s):
4.9

Issue:
https://issues.redhat.com/browse/OCPBUGS-7065

Link to docs preview:

