### PR TITLE
[OSDOCS-5527]: Adding 'Configuring hosted control planes' assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2125,6 +2125,8 @@ Distros: openshift-enterprise, openshift-origin
 Topics:
 - Name: Hosted control planes overview
   File: index
+- Name: Configuring hosted control planes
+  File: hcp-configuring
 - Name: Managing hosted control planes
   File: hcp-managing
 ---

--- a/hosted_control_planes/hcp-configuring.adoc
+++ b/hosted_control_planes/hcp-configuring.adoc
@@ -1,0 +1,40 @@
+:_content-type: ASSEMBLY
+[id="hcp-configuring"]
+= Configuring hosted control planes
+include::_attributes/common-attributes.adoc[]
+:context: hcp-configuring
+
+toc::[]
+
+To get started with hosted control planes for {product-title}, you first configure your hosted cluster on the provider that you want to use. Then, you complete a few management tasks. 
+
+:FeatureName: Hosted control planes
+include::snippets/technology-preview.adoc[]
+
+You can view the procedures by selecting from one of the following providers:
+
+[id="hcp-configuring-aws"]
+== Amazon Web Services (AWS)
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring the hosted cluster on AWS]: The tasks to configure a hosted cluster on AWS include creating the AWS S3 OIDC secret, creating a routable public zone, enabling external DNS, enabling AWS PrivateLink, enabling the hosted control planes feature, and installing the hosted control planes CLI.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosted-control-planes-manage-aws[Managing hosted control plane clusters on AWS]: Management tasks include creating, importing, accessing, or deleting a hosted cluster on AWS.
+* xref:../backup_and_restore/control_plane_backup_and_restore/etcd-backup-restore-hosted-cluster.adoc#etcd-backup-restore-hosted-cluster[Backing up and restoring etcd on a hosted cluster]: The procedure to back up and restore etcd on a hosted cluster differs from the typical procedure for {product-title}.
+* xref:../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/dr-hosted-cluster-within-aws-region.adoc#dr-hosted-cluster-within-aws-region[Disaster recovery for a hosted cluster within an AWS region]: In a disaster situation, such as when a hosted cluster becomes read-only because of a failure, learn how to restore the hosted cluster.
+
+[id="hcp-configuring-bm"]
+== Bare metal
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-configure-bm[Configuring the hosted cluster on bare metal]: Configure DNS before you create a hosted cluster. 
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal]: Create a hosted cluster, create an `InfraEnv` resource, add agents, access the hosted cluster, scale the `NodePool` object, handle Ingress, enable node auto-scaling, or delete a hosted cluster.
+
+// To be added after ACM 2.8 goes live:
+
+//{VirtProductName}
+
+// To be added after ACM 2.9 goes live:
+
+//{ibmpowerProductName}
+
+
+
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5527
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57171--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-configuring.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds an assembly to the "Hosted control planes" book that points to the getting started/configuring tasks for hosted control planes, which are published in the ACM docs.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
