### PR TITLE
Use PodOS field in e2e tests, and document it for users

### DIFF
--- a/modules/sample-windows-workload-deployment.adoc
+++ b/modules/sample-windows-workload-deployment.adoc
@@ -69,6 +69,8 @@ spec:
             runAsUserName: "ContainerAdministrator"
       nodeSelector:
         kubernetes.io/os: windows
+      os:
+        name: windows
 ----
 
 [NOTE]

--- a/modules/windows-pod-placement.adoc
+++ b/modules/windows-pod-placement.adoc
@@ -11,6 +11,8 @@ With multiple operating systems, and the ability to run multiple Windows OS vari
 
 For more information, see Microsoft's documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/update-containers#host-and-container-version-compatibility[Host and container version compatibility].
 
+Also, it is recommended that you set the `spec.os.name.windows` parameter in your workload pods. The Windows Machine Config Operator (WMCO) uses this field to authoritatively identify the pod operating system for validation and is used to enforce Windows-specific pod security context constraints (SCCs). Currently, this parameter has no effect on pod scheduling. For more information about this parameter, see the link:https://kubernetes.io/docs/concepts/workloads/pods/#pod-os[Kubernetes Pods documentation].
+
 [IMPORTANT]
 ====
 The container base image must be the same Windows OS version and build number that is running on the node where the conainer is to be scheduled. 

--- a/modules/wmco-upgrades.adoc
+++ b/modules/wmco-upgrades.adoc
@@ -31,6 +31,8 @@ If you are upgrading to a new version of the WMCO and want to use cluster monito
 
 For a non-disruptive upgrade, the WMCO terminates the Windows machines configured by the previous version of the WMCO and recreates them using the current version. This is done by deleting the `Machine` object, which results in the drain and deletion of the Windows node. To facilitate an upgrade, the WMCO adds a version annotation to all the configured nodes. During an upgrade, a mismatch in version annotation results in the deletion and recreation of a Windows machine. To have minimal service disruptions during an upgrade, the WMCO only updates one Windows machine at a time.
 
+After the update, it is recommended that you set the `spec.os.name.windows` parameter in your workload pods. The WMCO uses this field to authoritatively identify the pod operating system for validation and is used to enforce Windows-specific pod security context constraints (SCCs).
+
 [IMPORTANT]
 ====
 The WMCO is only responsible for updating Kubernetes components, not for Windows operating system updates. You provide the Windows image when creating the VMs; therefore, you are responsible for providing an updated image. You can provide an updated Windows image by changing the image configuration in the `MachineSet` spec.


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5531

[Sample Windows container workload deployment](https://57197--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/scheduling-windows-workloads.html#sample-windows-workload-deployment_scheduling-windows-workloads) -- New parameter in deployment example
[Windows pod placement](https://57197--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/scheduling-windows-workloads.html#windows-pod-placement_scheduling-windows-workloads) -- Fourth paragraph is new
[Windows Machine Config Operator upgrades](https://57197--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/windows-node-upgrades.html) -- Fourth paragraph is new

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
