### PR TITLE
OSDOCS-5432: update links for 4.13

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,15 +4,14 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.12
-:rhel-major: rhel-8
+:ocp-version: 4.13
+:rhel-major: rhel-9
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system: RHEL
 :op-system-ostree-first: Red Hat Enterprise Linux (RHEL) for Edge
 :op-system-ostree: RHEL for Edge
-:op-system-version: 8.7
-:op-system-version-major: 8
-:op-system-ram: 2GB RAM
+:op-system-version: 9.2
+:op-system-version-major: 9
 :op-system-bundle: Red Hat Device Edge
 :op-system-bundle-short: RHDE
 :VirtProductName: OpenShift Virtualization

--- a/microshift_cli_ref/microshift-cli-overview.adoc
+++ b/microshift_cli_ref/microshift-cli-overview.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id="cli-tools-overview"]
+[id="microshift-cli-overview"]
 = {product-title} CLI tools
 include::_attributes/attributes-microshift.adoc[]
 :context: cli-tools-overview
@@ -18,9 +18,8 @@ In addition to built-in `microshift` command types and Linux CLI tools, the opti
 [id="additional-resources_cli-tools-overview"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/microshift/4.12/html/microshift_cli_ref/microshift-cli-using-oc.adoc#microshift-cli-oc-about[Installing the `oc` tool for MicroShift].
+* xref:..//microshift_cli_ref/microshift-oc-cli-install.adoc#microshift-oc-cli-install[Installing the OpenShift CLI tool for MicroShift].
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/cli_tools/openshift-cli-oc[OpenShift CLI (oc)]: A full description of `oc` as provided by the {OCP} documentation. Commands focused on multi-node deployments, projects, and developer tooling are not supported by {product-title}.
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/cli_tools/openshift-cli-oc[OpenShift CLI (oc)]: A full description of `oc` as provided by the {OCP} documentation. Commands focused on multi-node deployments, projects, and developer tooling are not supported by {product-title}.
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9[Red Hat Enterprise Linux (RHEL)]: The RHEL documentation for your specific use case.
-//NEED INFO: drill down to more specific links within RHEL docs

--- a/microshift_cli_ref/microshift-cli-using-oc.adoc
+++ b/microshift_cli_ref/microshift-cli-using-oc.adoc
@@ -1,5 +1,5 @@
 :_content-type: ASSEMBLY
-[id="microshift-using-oc"]
+[id="microshift-cli-using-oc"]
 = Using the `oc` tool
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-using-oc

--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -13,16 +13,16 @@ include::snippets/microshift-tech-preview-snip.adoc[leveloffset=+1]
 [id="preparing-for-image-building_{context}"]
 == Preparing for image building
 
-Familiarize yourself with the documentation about https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images[Composing, installing, and managing RHEL for Edge images].
+Familiarize yourself with the documentation about https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images[Composing, installing, and managing RHEL for Edge images].
 
 [IMPORTANT]
 ====
 {product-title} deployments have only been tested with {op-system-ostree-first} {op-system-version}. Other versions of {op-system} are not recommended.
 ====
 
-To build an {op-system-ostree-first} {op-system-version} image for a given CPU architecture, you need a {op-system} {op-system-version} build host of the same CPU architecture that meets the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-image-builder-system-requirements_setting-up-image-builder[Image Builder system requirements].
+To build an {op-system-ostree-first} {op-system-version} image for a given CPU architecture, you need a {op-system} {op-system-version} build host of the same CPU architecture that meets the https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-image-builder-system-requirements_setting-up-image-builder[Image Builder system requirements].
 
-Follow the instructions in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-installing-image-builder_setting-up-image-builder[Installing Image Builder] to install Image Builder and the `composer-cli` tool.
+Follow the instructions in https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-installing-image-builder_setting-up-image-builder[Installing Image Builder] to install Image Builder and the `composer-cli` tool.
 
 //include::modules/microshift-preparing-for-image-building.adoc[leveloffset=+1]
 
@@ -31,15 +31,15 @@ include::modules/microshift-adding-repos-to-image-builder.adoc[leveloffset=+1]
 [role="_additional-resources_microshift-embed-in-rpm-ostree"]
 .Additional resources
 
-* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-image-builder-system-requirements_setting-up-image-builder[Image Builder system requirements].
-* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-installing-image-builder_setting-up-image-builder[Installing Image Builder].
+* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-image-builder-system-requirements_setting-up-image-builder[Image Builder system requirements].
+* https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-installing-image-builder_setting-up-image-builder[Installing Image Builder].
 
 include::modules/microshift-adding-service-to-blueprint.adoc[leveloffset=+2]
 
 [role="_additional-resources_microshift-embed-in-rpm-ostree"]
 .Additional resources
 
-* For further customizations such as adding users, firewall rules, or kernel arguments to a blueprint, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images#image-customizations_composing-a-rhel-for-edge-image-using-image-builder-command-line[supported image customizations].
+* For further customizations such as adding users, firewall rules, or kernel arguments to a blueprint, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images#image-customizations_composing-a-rhel-for-edge-image-using-image-builder-command-line[supported image customizations].
 
 //include::modules/microshift-adding-containers-to-blueprint.adoc[leveloffset=+2]
 include::modules/microshift-provisioning-ostree.adoc[leveloffset=+1]
@@ -47,14 +47,16 @@ include::modules/microshift-provisioning-ostree.adoc[leveloffset=+1]
 [role="_additional-resources_microshift-embed-in-rpm-ostree"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/composing_installing_and_managing_rhel_for_edge_images/index[{op-system-ostree} documentation].
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index[{op-system-ostree} documentation].
 * xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-system-requirements_microshift-install-rpm[System requirements for installing MicroShift].
 * Red Hat Hybrid Cloud Console link:https://console.redhat.com/openshift/install/pull-secret[pull secret].
 * xref:../microshift_networking/microshift-firewall.adoc#microshift-firewall-req-settings_microshift-firewall[Required firewall settings].
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/performing_an_advanced_rhel_8_installation/creating-kickstart-files_installing-rhel-as-an-experienced-user[Creating a Kickstart file].
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/performing_an_advanced_rhel_9_installation/creating-kickstart-files_installing-rhel-as-an-experienced-user[Creating a Kickstart file].
 * link:https://access.redhat.com/solutions/60959[How to embed a Kickstart file into an ISO image].
 
 include::modules/microshift-accessing.adoc[leveloffset=+1]
 include::modules/microshift-accessing-cluster-locally.adoc[leveloffset=+2]
 include::modules/microshift-accessing-cluster-remotely-admin.adoc[leveloffset=+2]
 include::modules/microshift-accessing-cluster-remotely-non-admin.adoc[leveloffset=+2]
+
+//note: System requirements for installing MicroShift xref works on Netlify and local previews

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -21,9 +21,9 @@ include::modules/microshift-install-rpm-preparing.adoc[leveloffset=+1]
 
 * xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-using-config-tools[Configuring MicroShift].
 
-* For more options on partition configuration, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/performing_a_standard_rhel_8_installation/index#manual-partitioning_graphical-installation[Configuring Manual Partitioning].
+* For more options on partition configuration, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/performing_a_standard_rhel_9_installation/index#manual-partitioning_graphical-installation[Configuring Manual Partitioning].
 
-* For more information about resizing your existing LVs to free up capacity in your VGs, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_logical_volumes/index#managing-lvm-volume-groups_configuring-and-managing-logical-volumes[Managing LVM Volume Groups].
+* For more information about resizing your existing LVs to free up capacity in your VGs, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/configuring_and_managing_logical_volumes/index#managing-lvm-volume-groups_configuring-and-managing-logical-volumes[Managing LVM Volume Groups].
 
 include::modules/microshift-installing-from-rpm.adoc[leveloffset=+1]
 
@@ -43,3 +43,5 @@ include::modules/microshift-accessing.adoc[leveloffset=+1]
 include::modules/microshift-accessing-cluster-locally.adoc[leveloffset=+2]
 include::modules/microshift-accessing-cluster-remotely-admin.adoc[leveloffset=+2]
 include::modules/microshift-accessing-cluster-remotely-non-admin.adoc[leveloffset=+2]
+
+//all xrefs working on previews

--- a/microshift_networking/microshift-firewall.adoc
+++ b/microshift_networking/microshift-firewall.adoc
@@ -16,8 +16,3 @@ include::modules/microshift-firewall-allow-traffic.adoc[leveloffset=+1]
 include::modules/microshift-firewall-apply-settings.adoc[leveloffset=+1]
 include::modules/microshift-firewall-verify-settings.adoc[leveloffset=+1]
 include::modules/microshift-firewall-known-issue.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-[id="additional-resources_microshift-using-a-firewall"]
-.Additional resources
-* xref:../microshift_troubleshooting/microshift-troubleshooting.adoc#microshift-ki-cni-iptables-deleted[Troubleshooting iptables deleted].

--- a/microshift_networking/microshift-networking.adoc
+++ b/microshift_networking/microshift-networking.adoc
@@ -24,11 +24,3 @@ include::modules/microshift-http-proxy.adoc[leveloffset=+1]
 include::modules/microshift-cri-o-container-runtime.adoc[leveloffset=+1]
 include::modules/microshift-ovs-snapshot.adoc[leveloffset=+1]
 include::modules/microshift-mDNS.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-[id="additional-resources_microshift-applying-networking-settings"]
-.Additional resources
-
-* xref:../microshift_troubleshooting/microshift-troubleshooting.adoc#microshift-version[Troubleshooting]
-* xref:../microshift_troubleshooting/microshift-troubleshooting.adoc#microshift-troubleshooting-nodeport[Troubleshooting the NodePort service]
-* xref:../microshift_troubleshooting/microshift-troubleshooting.adoc#microshift-nodeport-unreachable-workaround[NodePort unreachable workround]


### PR DESCRIPTION
Version(s):
4.13 only

Issue:
https://issues.redhat.com/browse/OSDOCS-5432

Link to docs preview:
https://57198--docspreview.netlify.app/microshift/latest/microshift_cli_ref/microshift-cli-overview.html
https://57198--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html
https://57198--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html
removed links from:
https://57198--docspreview.netlify.app/microshift/latest/microshift_networking/microshift-networking.html
https://57198--docspreview.netlify.app/microshift/latest/microshift_networking/microshift-firewall.html

QE review:
- N/A internal docs structure

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
