### PR TITLE
Remove containerd changes during WMCO 6.0.0 update

### DIFF
--- a/modules/wmco-upgrades.adoc
+++ b/modules/wmco-upgrades.adoc
@@ -7,23 +7,6 @@
 
 When a new version of the Windows Machine Config Operator (WMCO) is released that is compatible with the current cluster version, the Operator is upgraded based on the upgrade channel and subscription approval strategy it was installed with when using the Operator Lifecycle Manager (OLM). The WMCO upgrade results in the Kubernetes components in the Windows machine being upgraded.
 
-//the following paragraph and lists taken from https://github.com/openshift/enhancements/pull/962/files#diff-be9b7fd31ea4585b2c617aa51f14f35cb1212da129acf3455806aba6cddf782dR137 
-Because WMCO 6.0.0 uses containerd as the default container runtime instead of Docker, note the following changes that are made during the upgrade:
-
-* For nodes created using a compute machine set:
-** All `machine` objects are deleted, which results in the draining and deletion of any Windows nodes.
-** New Windows nodes are created.
-** The upgraded WMCO configures the new Windows nodes with containerd as the default runtime.
-** After the new Windows nodes join the {product-title} cluster, you can deploy pods on those nodes.
-
-* For Bring-Your-Own-Host (BYOH) nodes:
-** The kubelet, kube-proxy, CNI, and the hybrid-overlay components, which were installed by the WMCO, are all uninstalled.
-** Any Windows OS-specific configurations that were created as part of configuring the instance, such as HNS networks, are deleted or reverted.
-** The WMCO installs containerd as the default runtime, and reinstalls the kubelet, kube-proxy, CNI, and hybrid-overlay components.
-** The kubelet service starts.
-** After the new Windows nodes join the {product-title} cluster, you can deploy pods on those nodes.
-** If any Docker service is present, it continues to run. Alternatively, you can manually uninstall Docker.
-
 [NOTE]
 ====
 If you are upgrading to a new version of the WMCO and want to use cluster monitoring, you must have the `openshift.io/cluster-monitoring=true` label present in the WMCO namespace. If you add the label to a pre-existing WMCO namespace, and there are already Windows nodes configured, restart the WMCO pod to allow monitoring graphs to display.


### PR DESCRIPTION
Remove section of the upgrade that is specific to WMCO 5.x to 6.x updates.

[Windows Machine Config Operator upgrades](http://file.rdu.redhat.com/mburke/winc-remove-containerd-chages/windows_containers/windows-node-upgrades.html#wmco-upgrades_windows-node-upgrades). Removed second paragraph and two bullet lists that followed.
[
Current version](https://docs.openshift.com/container-platform/4.12/windows_containers/windows-node-upgrades.html#wmco-upgrades_windows-node-upgrades)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

