### PR TITLE
OCPBUGS-10053-code

### DIFF
--- a/modules/psap-driver-toolkit-pulling.adoc
+++ b/modules/psap-driver-toolkit-pulling.adoc
@@ -26,14 +26,21 @@ The driver-toolkit image for the latest minor release are tagged with the minor 
 
 . The image URL of the `driver-toolkit` corresponding to a certain release can be extracted from the release image using the `oc adm` command:
 +
+--
+* For an x86 image, the command is as follows:
++
 [source,terminal,subs="attributes+"]
 ----
-# For x86 image:
 $ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version}.z-x86_64 --image-for=driver-toolkit
+----
 
-# For ARM image: 
+* For an ARM image, the command is as follows:
++
+[source,terminal,subs="attributes+"]
+----
 $ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version}.z-aarch64 --image-for=driver-toolkit
 ----
+--
 +
 .Example output
 


### PR DESCRIPTION
Change code format in 'Red Hat OpenShift Container Platform' doc > 'Driver Toolkit' chapter > 'Specialized hardware and driver enablement' section > 'Finding the Driver Toolkit image URL in the payload' subsection > step 1, to match that of the 4.11 version (requested by peer review squad).

Version(s):
main, 4.13, 4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-10053

Link to docs preview:
http://file.emea.redhat.com/tshwartz/OCPBUGS-10053-code/hardware_enablement/psap-driver-toolkit.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
