### PR TITLE
OCPBUG#5570: Modified steps related to Machine Config spec in managing nodes section.

### DIFF
--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -84,9 +84,6 @@ metadata:
     machineconfiguration.openshift.io/role: worker<1>
   name: 05-worker-kernelarg-selinuxpermissive<2>
 spec:
-  config:
-    ignition:
-      version: 3.2.0
   kernelArguments:
     - enforcing=0<3>
 ----

--- a/modules/nodes-nodes-working-setting-booleans.adoc
+++ b/modules/nodes-nodes-working-setting-booleans.adoc
@@ -29,7 +29,7 @@ metadata:
 spec:
   config:
     ignition:
-      version: 2.2.0
+      version: 3.2.0
     systemd:
       units:
       - contents: |


### PR DESCRIPTION
Versions: 4.10+

Scope: Modified machine config spec under managing nodes section.

Issue: [OCPBUG-5570](https://issues.redhat.com/browse/OCPBUGS-5570)

Link to Docs Preview:
[Preview_1](https://57205--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#nodes-nodes-working-setting-booleans)
[Preview_2](https://57205--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing.html#nodes-nodes-kernel-arguments_nodes-nodes-managing)

@yuqi-zhang  ptal