### PR TITLE
enterprise-4.10 |RHDEVDOCS-3436 | Updated OCP>Support and OKD>Support pages for missing link to pipelines must-gather

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -63,6 +63,9 @@ endif::openshift-dedicated[]
 |`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v4.10.0`
 |Data collection for the Node Maintenance Operator.
 
+|`quay.io/openshift-pipeline/must-gather`
+|Data collection for Red Hat OpenShift Pipelines
+
 |===
 
 endif::openshift-origin[]
@@ -97,6 +100,8 @@ ifndef::openshift-dedicated[]
 |Data collection for Local Storage Operator.
 endif::openshift-dedicated[]
 
+|`quay.io/openshift-pipeline/must-gather`
+|Data collection for Red Hat OpenShift Pipelines
 |===
 
 endif::openshift-origin[]


### PR DESCRIPTION
Manual CP from https://github.com/openshift/openshift-docs/pull/56361 to 4.10

Aligned team: Dev Tools

Purpose: To resolve [RHDEVDOCS-3436](https://issues.redhat.com/browse/RHDEVDOCS-3436)

OCP version this PR applies to: enterprise 4.10