### PR TITLE
4.13 release note for adding namespace to must-gather

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -56,7 +56,7 @@ This release adds improvements related to the following components and concepts.
 === Installation and upgrade
 
 [id="ocp-4-13-installation-vsphere-8-support"]
-==== Support for VMware vSphere version 8.0 
+==== Support for VMware vSphere version 8.0
 {product-title} {product-version} supports VMware vSphere version 8.0. You can continue to install an {product-title} cluster on VMware vSphere version 7.0 Update 2.
 
 [id="ocp-4-13-installation-vsphere-region-zone"]
@@ -81,6 +81,13 @@ As an administrator, you can specify multiple failure domains for your {product-
 
 [id="ocp-4-13-oc"]
 === OpenShift CLI (oc)
+
+[id="ocp-4-13-oc-must-gather-namespace"]
+==== New flag added to run must-gather in a specified namespace
+
+With {product-title} 4.13, the `--run-namespace` flag is now available for the `oc adm must-gather` command. You can use this flag to specify an existing namespace to run the must-gather tool in.
+
+For more information, see xref:../support/gathering-cluster-data.adoc#about-must-gather_gathering-cluster-data[About the must-gather tool].
 
 [id="ocp-4-13-import-image"]
 ==== Importing manifests with the OpenShift CLI (oc)
@@ -216,9 +223,9 @@ For more information, see xref:../machine_management/control_plane_machine_manag
 [id="ocp-4-13-NUMA-scheduler-ga"]
 ==== NUMA-aware scheduling with the NUMA Resources Operator is generally available
 
-NUMA-aware scheduling with the NUMA Resources Operator was previously introduced as a Technology Preview in {product-title} 4.10 and is now generally available in {product-title} {product-version}. 
+NUMA-aware scheduling with the NUMA Resources Operator was previously introduced as a Technology Preview in {product-title} 4.10 and is now generally available in {product-title} {product-version}.
 
-The NUMA Resources Operator deploys a NUMA-aware secondary scheduler that makes scheduling decisions for workloads based on a complete picture of available NUMA zones in clusters. This enhanced NUMA-aware scheduling ensures that latency-sensitive workloads are processed in a single NUMA zone for maximum efficiency and performance. 
+The NUMA Resources Operator deploys a NUMA-aware secondary scheduler that makes scheduling decisions for workloads based on a complete picture of available NUMA zones in clusters. This enhanced NUMA-aware scheduling ensures that latency-sensitive workloads are processed in a single NUMA zone for maximum efficiency and performance.
 
 This update adds the following features:
 


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-5334](https://issues.redhat.com/browse/OSDOCS-5334)

Link to docs preview:
[Preview](https://57225--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#new-flag-added-to-run-must-gather-in-a-specified-namespace)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[PR with the about must-gather doc changes](https://github.com/openshift/openshift-docs/pull/56342)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
