### PR TITLE
CMP-1877: File Integrity Operator 1.2.0 release notes

### DIFF
--- a/modules/file-integrity-important-attributes.adoc
+++ b/modules/file-integrity-important-attributes.adoc
@@ -43,4 +43,7 @@ longer interval. Defaults to `900`, or 15 minutes.
 
 |`spec.config.key`
 |Key that contains actual AIDE configuration in a config map specified by `name` and `namespace`. The default value is `aide.conf`.
+
+|`spec.config.initialDelay`
+|The number of seconds to wait before starting the first AIDE integrity check. Default is set to 0. This attribute is optional.
 |===

--- a/modules/file-integrity-operator-installing-cli.adoc
+++ b/modules/file-integrity-operator-installing-cli.adoc
@@ -68,7 +68,7 @@ metadata:
   name: file-integrity-operator
   namespace: openshift-file-integrity
 spec:
-  channel: "v1"
+  channel: "stable"
   installPlanApproval: Automatic
   name: file-integrity-operator
   source: redhat-operators

--- a/modules/file-integrity-understanding-file-integrity-cr.adoc
+++ b/modules/file-integrity-understanding-file-integrity-cr.adoc
@@ -23,10 +23,35 @@ metadata:
   name: worker-fileintegrity
   namespace: openshift-file-integrity
 spec:
-  nodeSelector:
+  nodeSelector: <1>
       node-role.kubernetes.io/worker: ""
-  config: {}
+  tolerations: <2>
+  - key: "myNode"
+    operator: "Exists"
+    effect: "NoSchedule"
+  config: <3>
+    name: "myconfig"
+    namespace: "openshift-file-integrity"
+    key: "config"
+    gracePeriod: 20 <4>
+    maxBackups: 5 <5>
+    initialDelay: 60 <6>
+  debug: false
+status:
+  phase: Active <7>
 ----
+<1> Defines the selector for scheduling node scans.
+<2> Specify `tolerations` to schedule on nodes with custom taints. When not specified, a default toleration allowing running on main and infra nodes is applied.
+<3> Define a `ConfigMap` containing an AIDE configuration to use.
+<4> The number of seconds to pause in between AIDE integrity checks. Frequent AIDE checks on a node might be resource intensive, so it can be useful to specify a longer interval. Default is 900 seconds (15 minutes).
+<5> The maximum number of AIDE database and log backups (leftover from the re-init process) to keep on a node. Older backups beyond this number are automatically pruned by the daemon. Default is set to 5.
+<6> The number of seconds to wait before starting the first AIDE integrity check. Default is set to 0.
+<7> The running status of the `FileIntegrity` instance. Statuses are `Initializing`, `Pending`, or `Active`.
++
+[horizontal]
+`Initializing`:: The `FileIntegrity` object is currently initializing or re-initializing the AIDE database.
+`Pending`:: The `FileIntegrity` deployment is still being created.
+`Active`:: The scans are active and ongoing.
 
 . Apply the YAML file to the `openshift-file-integrity` namespace:
 +

--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -15,14 +15,26 @@ For an overview of the File Integrity Operator, see xref:../../security/file_int
 
 To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-updating.adoc#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator].
 
+[id="file-integrity-operator-release-notes-1-2-0"]
+== OpenShift File Integrity Operator 1.2.0
+
+The following advisory is available for the OpenShift File Integrity Operator 1.2.0:
+
+* link:https://access.redhat.com/errata/RHBA-2023:1273[RHBA-2023:1273 OpenShift File Integrity Operator Enhancement Update]
+
+[id="file-integrity-operator-1-2-0-new-features-and-enhancements"]
+=== New features and enhancements
+
+* The File Integrity Operator Custom Resource (CR) now contains an `initialDelay` feature that specifies the number of seconds to wait before starting the first AIDE integrity check. For more information, see xref:../../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-custom-resource_file-integrity-operator[Creating the FileIntegrity custom resource].
+
+* The File Integrity Operator is now stable and the release channel is upgraded to `stable`. Future releases will follow link:https://semver.org/[Semantic Versioning]. To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-updating.html#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator].
+
 [id="file-integrity-operator-release-notes-1-0-0"]
 == OpenShift File Integrity Operator 1.0.0
 
 The following advisory is available for the OpenShift File Integrity Operator 1.0.0:
 
 * link:https://access.redhat.com/errata/RHBA-2023:0037[RHBA-2023:0037 OpenShift File Integrity Operator Bug Fix Update]
-
-The File Integrity Operator is now stable and the release channel is upgraded to `v1`. Future releases will follow link:https://semver.org/[Semantic Versioning]. To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-updating.html#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator].
 
 [id="file-integrity-operator-release-notes-0-1-32"]
 == OpenShift File Integrity Operator 0.1.32


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/CMP-1877

Link to docs preview:
[OpenShift File Integrity Operator 1.2.0](http://file.rdu.redhat.com/antaylor/CMP-1877/security/file_integrity_operator/file-integrity-operator-release-notes.html#file-integrity-operator-release-notes-1-2-0)
[Creating the FileIntegrity custom resource](http://file.rdu.redhat.com/antaylor/CMP-1877/security/file_integrity_operator/file-integrity-operator-understanding.html#understanding-file-integrity-custom-resource_file-integrity-operator)
[Important attributes](http://file.rdu.redhat.com/antaylor/CMP-1877/security/file_integrity_operator/file-integrity-operator-configuring.html#important-file-integrity-object-attributes_file-integrity-operator)
[Installing the File Integrity Operator using the CLI](http://file.rdu.redhat.com/antaylor/CMP-1877/security/file_integrity_operator/file-integrity-operator-installation.html#installing-file-integrity-operator-using-cli_file-integrity-operator-installation)

QE review:
- [x] QE has approved this change.