### PR TITLE
[OSDOCS-5535]: Adding instructions to delete hosted control planes

### DIFF
--- a/hosted_control_planes/hcp-managing.adoc
+++ b/hosted_control_planes/hcp-managing.adoc
@@ -16,4 +16,5 @@ After you configure your environment for hosted control planes and create a host
 //configuring metrics sets
 include::modules/node-tuning-hosted-cluster.adoc[leveloffset=+1]
 //automated machine management
+include::modules/delete-hosted-cluster.adoc[leveloffset=+1]
 

--- a/modules/delete-hosted-cluster.adoc
+++ b/modules/delete-hosted-cluster.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assembly:
+//
+// * hosted_control_planes/hcp-managing.adoc
+
+:_content-type: PROCEDURE
+[id="delete-hosted-cluster_{context}"]
+= Deleting a hosted cluster
+
+The steps to delete a hosted cluster differ depending on which provider you use.
+
+.Procedure
+
+* If the cluster is on AWS, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-aws[Destroying a hosted cluster on AWS].
+
+* If the cluster is on bare metal, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-bm[Destroying a hosted cluster on bare metal].
+
+.Next steps
+
+If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5535
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57238--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-managing.html#delete-hosted-cluster_hcp-managing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds a page to the "Hosted control planes" book that points to instructions in the ACM docs to delete the hosted control planes feature.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
