### PR TITLE
OCPBUGS-7037: Updating syncrepo command

### DIFF
--- a/modules/microshift-adding-repos-to-image-builder.adoc
+++ b/modules/microshift-adding-repos-to-image-builder.adoc
@@ -36,7 +36,7 @@ $ sudo yum install -y yum-utils
 [source,terminal,subs="attributes+"]
 ----
 $ sudo reposync --arch=$(uname -i) --arch=noarch --gpgcheck \
-    --download-path REPO_PATH=/var/repos/microshift-local \
+    --download-path /var/repos/microshift-local \
     --repo=rhocp-{product-version}-for-rhel-{op-system-version-major}-$(uname -i)-rpms \
     --repo=fast-datapath-for-rhel-{op-system-version-major}-$(uname -i)-rpms
 ----


### PR DESCRIPTION
**For Versions:** 4.12+
**Issue:** [OCPBUGS-7037](https://issues.redhat.com/browse/OCPBUGS-7037)

**Description:** Updating current command for MicroShift reps to Image builders 

**Preview:** 
[Embedding MicroShift in a RHEL for Edge Image -> Adding MicroShift repositories to Image Builder ](https://57239--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#adding-MicroShift-repos-image-builder_microshift-embed-in-rpm-ostree)

**QE review:** 
N/A