### PR TITLE
OCPBUGS2214: Deploying an extension rpm with a MachineConfig and a custom osImage at the same time breaks the machine config pool

### DIFF
--- a/post_installation_configuration/coreos-layering.adoc
+++ b/post_installation_configuration/coreos-layering.adoc
@@ -17,7 +17,7 @@ With {op-system} image layering, you can install RPMs into your base image, and 
 
 [IMPORTANT]
 ====
-RPMs installed through a custom layered image can conflict with RPMs installed by using a machine config. It is recommended to use either machine config or a custom layered image to add extensions, but not both, unless you are certain there will be no conflicts. If there is a conflict, the MCO enters a `degraded` state when it tries to install the machine config RPM. You need to remove the conflicting extension from your machine config before proceeding.
+Installing realtime kernel and extensions RPMs as custom layered content is not recommended. This is because these RPMs can conflict with RPMs installed by using a machine config. If there is a conflict, the MCO enters a `degraded` state when it tries to install the machine config RPM. You need to remove the conflicting extension from your machine config before proceeding.
 ====
 
 As soon as you apply the custom layered image to your cluster, you effectively _take ownership_ of your custom layered images and those nodes. While Red Hat remains responsible for maintaining and updating the base {op-system} image on standard nodes, you are responsible for maintaining and updating images on nodes that use a custom layered image. You assume the responsibility for the package you applied with the custom layered image and any issues that might arise with the package.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-2214

Preview: https://57245--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html

Update the wording in the IMPORTANT note with the [Known Issue in the Custom Content on RHCOS TE slides](https://docs.google.com/presentation/d/1g2Y4lTZG9w5--X5G-emAzu7p-a5oFkKQXsDAYV-VPX8/edit#slide=id.g1165ecc17b8_0_0) 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

