### PR TITLE
Add Operator rollback instructions for RHACS

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -57,11 +57,11 @@ Topics:
   Dir: installing_ocp
   Distros: openshift-acs
   Topics:
-  - Name: High-level overview of installing RHACS on Red Hat OpenShift 
+  - Name: High-level overview of installing RHACS on Red Hat OpenShift
     File: install-rhacs-ocp
   - Name: Prerequisites for RHACS on Red Hat OpenShift
     File: prerequisites-ocp
-  - Name: Installing Central services for RHACS on Red Hat OpenShift 
+  - Name: Installing Central services for RHACS on Red Hat OpenShift
     File: install-central-ocp
   - Name: Optional - Configuring Central configuration options for RHACS using the Operator
     File: install-central-config-options-ocp
@@ -91,7 +91,7 @@ Topics:
   Dir: installing_cloud_ocp
   Distros: openshift-acs
   Topics:
-  - Name: Setting up RHACS Cloud Service on Red Hat OpenShift 
+  - Name: Setting up RHACS Cloud Service on Red Hat OpenShift
     File: install-rhacs-cloud-ocp
   - Name: Prerequisites for RHACS Cloud Service on Red Hat OpenShift
     File: prerequisites-cloud-ocp
@@ -265,6 +265,8 @@ Name: Upgrading
 Dir: upgrading
 Distros: openshift-acs
 Topics:
+- Name: Upgrading using the Operator
+  File: upgrade-operator
 - Name: Upgrading using Helm charts
   File: upgrade-helm
 - Name: Upgrading using the roxctl CLI
@@ -282,9 +284,9 @@ Dir: troubleshooting
 Distros: openshift-acs
 Topics:
 - Name: Retrieving and analyzing the Collector logs and pod status
-  File: retrieving-and-analyzing-the-collector-logs-and-pod-status 
+  File: retrieving-and-analyzing-the-collector-logs-and-pod-status
 - Name: Commonly occurring error conditions
-  File: commonly-occurring-error-conditions 
+  File: commonly-occurring-error-conditions
 ---
 Name: Support
 Dir: support

--- a/modules/rollback-operator-upgrades-cli.adoc
+++ b/modules/rollback-operator-upgrades-cli.adoc
@@ -1,0 +1,151 @@
+// Module included in the following assemblies:
+//
+// * upgrade/upgrade-operator.adoc
+:_content-type: PROCEDURE
+[id="rollback-operator-upgrades_{context}"]
+= Rolling back an Operator upgrade by using the CLI
+
+You can roll back the Operator version by using CLI commands.
+
+.Procedure
+
+. Delete the {olm} subscription by running the following command:
+* For {ocp}, run the following command:
++
+[source,terminal]
+----
+$ oc -n rhacs-operator delete subscription rhacs-operator
+----
+* For Kubernetes, run the following command:
++
+[source,terminal]
+----
+$ kubectl -n rhacs-operator delete subscription rhacs-operator
+----
+. Delete the cluster service version (CSV) by running the following command:
+* For {ocp}, run the following command:
++
+[source,terminal]
+----
+$ oc -n rhacs-operator delete csv -l operators.coreos.com/rhacs-operator.rhacs-operator
+----
+* For Kubernetes, run the following command:
++
+[source,terminal]
+----
+$ kubectl -n rhacs-operator delete csv -l operators.coreos.com/rhacs-operator.rhacs-operator
+----
+. Determine the previous version you want to roll back to by choosing one of the following options:
+* If the current Central instance is running, query the {product-title-short} API to get the rollback version by running the following command:
++
+[source,terminal]
+----
+$ curl -k -s -u <user>:<password> https://<central hostname>/v1/centralhealth/upgradestatus | jq -r .upgradeStatus.forceRollbackTo
+----
+* If the current Central instance is not running, perform the following steps:
++
+[NOTE]
+====
+This procedure can only be used for {product-title-short} release 3.74 and earlier when the `rocksdb` database is installed.
+====
+.. Ensure the Central deployment is scaled down by running the following command:
+** For {ocp}, run the following command:
++
+[source,terminal]
+----
+$ oc scale -n <central namespace> –replicas=0 deploy/central
+----
+** For Kubernetes, run the following command:
++
+[source,terminal]
+----
+$ kubectl scale -n <central namespace> –replicas=0 deploy/central
+----
+.. Save the following pod spec as a YAML file:
++
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: get-previous-db-version
+spec:
+  containers:
+  - name: get-previous-db-version
+    image: registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:<rollback version>
+    command:
+    - sh
+    args:
+    - '-c'
+    - "cat /var/lib/stackrox/.previous/migration_version.yaml | grep '^image:' | cut -f 2 -d : | tr -d ' '"
+    volumeMounts:
+    - name: stackrox-db
+      mountPath: /var/lib/stackrox
+  volumes:
+  - name: stackrox-db
+    persistentVolumeClaim:
+      claimName: stackrox-db
+----
+.. Create a pod in your Central namespace by running the following command using the YAML file that you saved:
+** For {ocp}, run the following command:
++
+[source,terminal]
+----
+$ oc create -n <central namespace> -f pod.yaml
+----
+** For Kubernetes, run the following command:
++
+[source,terminal]
+----
+$ kubectl create -n <central namespace> -f pod.yaml
+----
+.. After pod creation is complete, get the version by running the following command:
+** For {ocp}, run the following command:
++
+[source,terminal]
+----
+$ oc logs -n <central namespace> get-previous-db-version
+----
+** For Kubernetes, run the following command:
++
+[source,terminal]
+----
+$ kubectl logs -n <central namespace> get-previous-db-version
+----
+
+. Edit the `central-config.yaml` `ConfigMap` to set the `maintenance.forceRollBackVersion:<version>` parameter by running the following command:
+* For {ocp}, run the following command:
++
+[source,terminal]
+----
+$ oc get configmap -n <central namespace> central-config -o yaml | sed -e "s/forceRollbackVersion: none/forceRollbackVersion: <version>/" | oc -n <central namespace> apply -f -
+----
+* For Kubernetes, run the following command:
++
+[source,terminal]
+----
+$ kubectl get configmap -n <central namespace> central-config -o yaml | sed -e "s/forceRollbackVersion: none/forceRollbackVersion: <version>/" | kubectl -n <central namespace> apply -f -
+----
+. Set the image for the Central deployment using the version string shown in Step 3 as the image tag. For example, run the following command:
+* For {ocp}, run the following command:
++
+[source,terminal]
+----
+$ oc set image -n <central namespace> deploy/central central=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:<version>
+----
+* For Kubernetes, run the following command:
++
+[source,terminal]
+----
+$ kubectl set image -n <central namespace> deploy/central central=registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:<version>
+----
+
+.Verification
+
+. Ensure that the Central pod starts and has a `ready` status. If the pod crashes, check the logs to see if the backup was restored. A successful log message appears similar to the following example:
++
+----
+Clone to Migrate ".previous", ""
+----
+. Reinstall the Operator on the rolled back channel. For example, `3.71.3` is installed on the `rhacs-3.71` channel.

--- a/modules/rollback-operator-upgrades-console.adoc
+++ b/modules/rollback-operator-upgrades-console.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * upgrade/upgrade-operator.adoc
+:_content-type: PROCEDURE
+[id="rollback-operator-upgrades-console_{context}"]
+= Rolling back an Operator upgrade by using the web console
+
+You can roll back the Operator version by using the {ocp} web console.
+
+.Prerequisites
+
+- You have access to an {ocp} cluster web console using an account with `cluster-admin` permissions.
+
+.Procedure
+
+. Navigate to the *Operators* -> *Installed Operators* page.
+. Locate the {product-title-short} Operator and click on it.
+. On the *Operator Details* page, select *Uninstall Operator* from the *Actions* list. Following this action, the Operator stops running and no longer receives updates.
+. Determine the previous version you want to roll back to by choosing one of the following options:
+* If the current Central instance is running, you can query the {product-title-short} API to get the rollback version by running the following command from a terminal window:
++
+[source,terminal]
+----
+$ curl -k -s -u <user>:<password> https://<central hostname>/v1/centralhealth/upgradestatus | jq -r .upgradeStatus.forceRollbackTo
+----
+* You can create a pod to extract the previous version by performing the following steps:
++
+[NOTE]
+====
+This procedure can only be used for {product-title-short} release 3.74 and earlier when the `rocksdb` database is installed.
+====
+.. Navigate to *Workloads* -> *Deployments* -> *central*.
+.. Under *Deployment details*, click the down arrow next to the pod count to scale down the pod.
+.. Navigate to *Workloads* -> *Pods* -> *Create Pod* and paste the contents of the pod spec as shown in the following example into the editor:
++
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: get-previous-db-version
+spec:
+  containers:
+  - name: get-previous-db-version
+    image: registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:<rollback version>
+    command:
+    - sh
+    args:
+    - '-c'
+    - "cat /var/lib/stackrox/.previous/migration_version.yaml | grep '^image:' | cut -f 2 -d : | tr -d ' '"
+    volumeMounts:
+    - name: stackrox-db
+      mountPath: /var/lib/stackrox
+  volumes:
+  - name: stackrox-db
+    persistentVolumeClaim:
+      claimName: stackrox-db
+----
+. Click *Create*.
+. After the pod is created, click the *Logs* tab to get the version string.
+. Update the rollback configuration by performing the following steps:
+.. Navigate to *Workloads* -> *ConfigMaps* -> *central-config* and select *Edit ConfigMap* from the *Actions* list.
+.. Find the `forceRollbackVersion` line in the value of the `central-config.yaml` key.
+.. Replace `none` with `3.73.3`, and then save the file.
+. Update Central to the earlier version by performing the following steps:
+.. Navigate to *Workloads* -> *Deployments* -> *central* and select *Edit Deployment* from the Actions list.
+.. Update the image name, and then save the changes.
+
+.Verification
+
+. Ensure that the Central pod starts and has a `ready` status. If the pod crashes, check the logs to see if the backup was restored. A successful log message appears similar to the following example:
++
+----
+Clone to Migrate ".previous", ""
+----
+. Reinstall the Operator on the rolled back channel. For example, `3.71.3` is installed on the `rhacs-3.71` channel.

--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -1,0 +1,24 @@
+:_content-type: ASSEMBLY
+[id="upgrade-operator"]
+= Upgrading by using the Operator
+include::modules/common-attributes.adoc[]
+:context: upgrade-operator
+
+toc::[]
+
+[role="_abstract"]
+Upgrades through the {rh-rhacs-first} Operator are performed automatically or manually, depending on the *Update approval* option you chose at installation.
+
+If you installed {product-title-short} using the Operator and selected *Automatic* in the *Update approval* field, {product-title-short} is automatically updated when a new software version is released. If you selected *Manual*, you must approve subsequent Operator updates by using Operator Lifecycle Manager (OLM). For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/administrator-tasks#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update].
+
+To roll back an Operator upgrade, you must perform the steps described in one of the following sections. You can roll back an Operator upgrade by using the CLI or the {ocp} web console.
+
+include::modules/rollback-operator-upgrades-cli.adoc[leveloffset=+1]
+include::modules/rollback-operator-upgrades-console.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../installing/installing_ocp/install-central-ocp.adoc#install-central-operator_install-central-ocp[Installing Central using the Operator method]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/understanding-operators#olm-workflow[Operator Lifecycle Manager workflow]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/administrator-tasks#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update]


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.74`
- Cherry pick to `rhacs-docs-3.73`

Issues:
- [ROX-15253](https://issues.redhat.com/browse/ROX-15253)
- also addresses [ROX-12080](https://issues.redhat.com/browse/ROX-12080) in part

[Link to docs preview
](https://57249--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-operator.html)

QE review:
- [x] QE has approved this change. (Approved by SME because ACS has no QE.)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
