### PR TITLE
OSDOCS#4002: Improve AWS quota links and guidance

### DIFF
--- a/modules/rosa-required-aws-service-quotas.adoc
+++ b/modules/rosa-required-aws-service-quotas.adoc
@@ -11,10 +11,10 @@ The table below describes the AWS service quotas and levels required to create a
 
 [NOTE]
 ====
-The AWS SDK allows ROSA to check quotas, but the AWS SDK calculation does not include your existing usage. Therefore, it is possible that the quota check can pass in the AWS SDK yet the cluster creation can fail. To fix this issue, increase your quota.
+The AWS SDK allows ROSA to check quotas, but the AWS SDK calculation does not account for your existing usage. Therefore, it is possible that the quota check can pass in the AWS SDK yet the cluster creation can fail. To fix this issue, increase your quota.
 ====
 
-If you need to modify or increase a specific quota, see Amazon's documentation on link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[requesting a quota increase].
+If you need to modify or increase a specific quota, see Amazon's documentation on link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[requesting a quota increase]. Large quota requests are submitted to Amazon Support for review, and take some time to be approved. If your quota request is urgent, contact AWS Support.
 
 [IMPORTANT]
 ====
@@ -129,4 +129,6 @@ The default value of 5 vCPUs is not sufficient to create ROSA clusters. ROSA has
 
 [role="_additional-resources"]
 == Additional resources
-* See link:https://docs.aws.amazon.com/ROSA/latest/userguide/service-quotas-rosa.html[ROSA service quotas]
+* link:https://aws.amazon.com/premiumsupport/knowledge-center/request-service-quota-increase-cli/[How can I request, view, and manage service quota increase requests using AWS CLI commands?]
+* link:https://docs.aws.amazon.com/ROSA/latest/userguide/service-quotas-rosa.html[ROSA service quotas]
+* link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[Request a quota increase]


### PR DESCRIPTION
Version(s):
current and future releases (main)

Issue:
https://issues.redhat.com/browse/OSDOCS-4002

Link to docs preview:
https://57255--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-required-aws-service-quotas.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Added detail to the introductory text of the module to note AWS approval time
- Added more useful links to Additional resources section
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
