### PR TITLE
OSDOCS-4943: Include OVN-Kubernetes reserved address range

### DIFF
--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -17,6 +17,11 @@ ifdef::openshift-rosa,openshift-dedicated[]
 When specifying subnet CIDR ranges, ensure that the subnet CIDR range is within the defined Machine CIDR. You must verify that the subnet CIDR ranges allow for enough IP addresses for all intended workloads, including at least eight IP addresses for possible AWS Load Balancers.
 endif::[]
 
+[IMPORTANT]
+====
+OVN-Kubernetes, the default network provider in {product-title} 4.11 and later, uses the `100.64.0.0/16` IP address range internally. If your cluster uses OVN-Kubernetes, do not include the `100.64.0.0/16` IP address range in any other CIDR definitions in your cluster.
+====
+
 [id="machine-cidr-description"]
 == Machine CIDR
 In the Machine CIDR field, you must specify the IP address range for machines or cluster nodes. This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. The default is `10.0.0.0/16`. This range must not conflict with any connected networks.


### PR DESCRIPTION
Version(s):
4.11 and up

Issue:
https://issues.redhat.com/browse/OSDOCS-4943

Link to docs preview:
https://57257--docspreview.netlify.app/openshift-rosa/latest/networking/cidr-range-definitions.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: None.