### PR TITLE
Starting New features for Telco Core 413 RN

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -244,6 +244,17 @@ With this update, you can assign IP addresses from a MetalLB `IPAddressPool` res
 
 For more information about assigning IP addresses from an IP address pool to services and namespaces, see xref:../networking/metallb/metallb-configure-address-pools.adoc#nw-metallb-configure-address-pool_configure-metallb-address-pools[Configuring MetalLB address pools].
 
+[id="ocp-4-13-supporting-ocp-nodes-with-dual-port-nics"]
+==== Supporting {product-title} installation on nodes with dual-port NICs (Technology Preview)
+
+With this update, {product-title} cluster can be deployed on a bond interface with 2 virtual function (VFs) on 2 physical functions (PFs) using the following methods:
+
+* Agent-based installer
+* Installer-provisioned infrastructure installation
+* User-provisioned infrastructure installation
+
+For more information about installing {product-title} on nodes with dual-port NICs, see xref:../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adocl#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal[NIC partitioning for SR-IOV devices].
+
 [id="ocp-4-13-bf2-switching-dpu-nic"]
 ==== Support for switching the BlueField-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode is now GA
 
@@ -322,7 +333,7 @@ For more information, see  xref:../post_installation_configuration/coreos-layeri
 [id="ocp-4-13-machine-config-operator-core"]
 ==== Support for setting the `core` user password
 
-You can now create a password for the {op-system} `core` user. In the event that you cannot use SSH or the `oc debug node` command to access a node, this password allows you to use the `core` user to access the node through a cloud provider serial console or a bare metal baseboard controller manager (BMC).
+You can now create a password for the {op-system} `core` user. If you cannot use SSH or the `oc debug node` command to access a node, this password allows you to use the `core` user to access the node through a cloud provider serial console or a bare metal baseboard controller manager (BMC).
 
 For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#core-user-password_post-install-machine-configuration-tasks[Changing the core user password for node access].
 
@@ -369,6 +380,13 @@ This update adds the following features:
 * Configuration options at the node group level for the node topology exporter.
 
 For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-about-numa-aware-scheduling_numa-aware[Scheduling NUMA-aware workloads].
+
+[id="ocp-4-13-configuring-power-states-using-ztp"]
+==== Configuring power states using zero touch provisioning (ZTP)
+
+{product-title} 4.12 introduced the ability to set power states for critical and non-critical workloads. This release now enables the user to configure power states by using ZTP.
+
+For more information about the feature, see xref:../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-using-pgt-to-configure-power-saving-states_ztp-advanced-policy-config[Configuring power states using PolicyGenTemplates CRs].
 
 [id="ocp-4-13-insights-operator"]
 === Insights Operator


### PR DESCRIPTION
[TELCODOCS-1123]: Document new features

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13 

Issue:
https://issues.redhat.com/browse/TELCODOCS-1123

Link to docs preview:

- https://57258--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-supporting-ocp-nodes-with-dual-port-nics
- https://57258--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-configuring-power-states-using-ztp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
