### PR TITLE
[RHACS] Added missing s390x architecture

### DIFF
--- a/modules/acs-requirements.adoc
+++ b/modules/acs-requirements.adoc
@@ -36,7 +36,7 @@ For more information, see the link:https://access.redhat.com/node/5822721[{produ
 ====
 For deploying Central, use a machine type with four or more cores and apply scheduling policies to launch Central on such nodes.
 ====
-** *Architectures*: AMD64 or ppc64le.
+** *Architectures*: AMD64, ppc64le, or s390x.
 +
 [NOTE]
 ====


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-15819

Cherrypick into:
- rhacs-docs-3.74
- rhacs-docs-4.0