### PR TITLE
OCPBUGS#9997: Updating FW support for IDRAC

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -27,7 +27,7 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 |====
 | Model | Management | Firmware versions
 
-| 15th Generation | iDRAC 9 | v5.10.00.00 - v5.10.50.00 only
+| 15th Generation | iDRAC 9 | v6.10.30.00
 | 14th Generation | iDRAC 9 | v5.10.00.00 - v5.10.50.00 only
 
 | 13th Generation .2+| iDRAC 8 | v2.75.75.75 or later


### PR DESCRIPTION
OCPBUGS-9997: Update table for supported IDRAC 9 drivers for IPI installations with Redfish virtual media. QE has tested version 6.10.30.00 with OCP 4.12+

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-9997

Link to docs preview:
https://57264--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
