### PR TITLE
OSDOCS#5449: Release note for IBM Cloud VPC

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -76,6 +76,12 @@ Beginning with {product-title} {product-version}, deploying a three-node cluster
 
 For more information, see xref:../installing/installing_aws/installing-aws-three-node.adoc#installing-aws-three-node[Installing a three-node cluster on AWS], xref:../installing/installing_azure/installing-azure-three-node.adoc#installing-azure-three-node[Installing a three-node cluster on Azure], xref:../installing/installing_gcp/installing-gcp-three-node.adoc#installing-gcp-three-node[Installing a three-node cluster on GCP], and xref:../installing/installing_vsphere/installing-vsphere-three-node.adoc#installing-vsphere-three-node[Installing a three-node cluster on vSphere].
 
+[id="ocp-4-13-installation-and-upgrade-ibm-cloud-vpc"]
+==== IBM Cloud VPC and existing VPC resources
+If you are deploying an {product-title} cluster to an existing virtual private cloud (VPC), you can now use the `networkResourceGroupName` parameter to specify the name of the resource group that contains these existing resources. This enhancement lets you keep the existing VPC resources and subnets separate from the cluster resources that the installation program provisions. You can then use the `resourceGroupName` parameter to specify the name of an existing resource group that the installation program can use to deploy all of the installer-provisioned cluster resources. If `resourceGroupName` is undefined, a new resource group is created for the cluster.
+
+For more information, see xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installation-configuration-parameters-additional-ibm-cloud_installing-ibm-cloud-customizations[Additional IBM Cloud VPC configuration parameters].
+
 [id="ocp-4-13-post-installation"]
 === Post-installation configuration
 
@@ -1207,77 +1213,6 @@ This script removes unauthenticated subjects from the following cluster role bin
 --
 +
 (link:https://bugzilla.redhat.com/show_bug.cgi?id=1821771[*BZ#1821771*])
-
-// TODO: This known issue should be removed when RHCOS images begin using RHEL 9. RHEL 9 prevents this issue from occurring.
-* Intermittently, an IBM Cloud VPC cluster might fail to install because some worker machines do not start. Rather, these worker machines remain in the `Provisioned` phase.
-+
-There is a workaround for this issue. From the host where you performed the initial installation, delete the failed machines and run the installation program again.
-+
-. Verify that the status of the internal application load balancer (ALB) for the master API server is `active`.
-.. Identify the cluster's infrastructure ID by running the following command:
-+
-[source,terminal]
-----
-$ oc get infrastructure/cluster -ojson | jq -r '.status.infrastructureName'
-----
-.. Log into the IBM Cloud account for your cluster and target the correct region for your cluster.
-.. Verify that the internal ALB status is `active` by running the following command:
-+
-[source,terminal]
-----
-$ ibmcloud is lb <cluster_ID>-kubernetes-api-private  --output json | jq -r '.provisioning_status'
-----
-. Identify the machines that are in the `Provisioned` phase by running the following command:
-+
-[source,terminal]
-----
-$ oc get machine -n openshift-machine-api
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                                    PHASE         TYPE       REGION    ZONE        AGE
-example-public-1-x4gpn-master-0         Running       bx2-4x16   us-east   us-east-1   23h
-example-public-1-x4gpn-master-1         Running       bx2-4x16   us-east   us-east-2   23h
-example-public-1-x4gpn-master-2         Running       bx2-4x16   us-east   us-east-3   23h
-example-public-1-x4gpn-worker-1-xqzzm   Running       bx2-4x16   us-east   us-east-1   22h
-example-public-1-x4gpn-worker-2-vg9w6   Provisioned   bx2-4x16   us-east   us-east-2   22h
-example-public-1-x4gpn-worker-3-2f7zd   Provisioned   bx2-4x16   us-east   us-east-3   22h
-----
-. Delete each failed machine by running the following command:
-+
-[source,terminal]
-----
-$ oc delete machine <name_of_machine> -n openshift-machine-api
-----
-. Wait for the deleted worker machines to be replaced, which can take up to 10 minutes.
-. Verify that the new worker machines are in the `Running` phase by running the following command:
-+
-[source,terminal]
-----
-$ oc get machine -n openshift-machine-api
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                                    PHASE     TYPE       REGION    ZONE        AGE
-example-public-1-x4gpn-master-0         Running   bx2-4x16   us-east   us-east-1   23h
-example-public-1-x4gpn-master-1         Running   bx2-4x16   us-east   us-east-2   23h
-example-public-1-x4gpn-master-2         Running   bx2-4x16   us-east   us-east-3   23h
-example-public-1-x4gpn-worker-1-xqzzm   Running   bx2-4x16   us-east   us-east-1   23h
-example-public-1-x4gpn-worker-2-mnlsz   Running   bx2-4x16   us-east   us-east-2   8m2s
-example-public-1-x4gpn-worker-3-7nz4q   Running   bx2-4x16   us-east   us-east-3   7m24s
-----
-. Complete the installation by running the following command. Running the installation program again ensures that the cluster's `kubeconfig` is initialized properly:
-+
-[source,terminal]
-----
-$ ./openshift-install wait-for install-complete
-----
-+
-(link:https://issues.redhat.com/browse/OCPBUGS-1327[*OCPBUGS#1327*])
 
 // TODO: This known issue should carry forward to 4.9 and beyond!
 * The `oc annotate` command does not work for LDAP group names that contain an equal sign (`=`), because the command uses the equal sign as a delimiter between the annotation name and value. As a workaround, use `oc patch` or `oc edit` to add the annotation. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1917280[*BZ#1917280*])


### PR DESCRIPTION
Version(s):
4.13

Issue:
This PR address [osdocs-5449.](https://issues.redhat.com/browse/OSDOCS-5449)

Link to docs preview:
[IBM Cloud VPC and existing VPC resources](https://57270--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-installation-and-upgrade-ibm-cloud-vpc)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The original PR for the IBM Cloud VPC RN ended up in an indeterminate state during a rebase. https://github.com/openshift/openshift-docs/pull/56621 was closed and replaced by this PR.
