### PR TITLE
OCPBUGS#9218: Editing note as mirroring is available for IPI too

### DIFF
--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -110,7 +110,7 @@ Reprovision the node to restore the mirror to a pristine, non-degraded state.
 
 [NOTE]
 ====
-Mirroring is available only for user-provisioned infrastructure deployments on {op-system} systems.
+For user-provisioned infrastructure deployments, mirroring is available only on {op-system} systems.
 Support for mirroring is available on `x86_64` nodes booted with BIOS or UEFI and on `ppc64le` nodes.
 ====
 


### PR DESCRIPTION
OCPBUGS-9218: Updating note as mirroring is supported for IPI too. 

Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/OCPBUGS-9218

Link to docs preview:
https://57271--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-mirrored-disk_installing-customizing

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
