### PR TITLE
Updates to 3.74 Release Notes for patch release

### DIFF
--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -12,7 +12,8 @@ toc::[]
 [options="header"]
 |====
 |{product-title-short} version |Released on
-|`3.74` |27 February 2023
+|`3.74.0` |27 February 2023
+|`3.74.1` | 20 March 2023
 |====
 
 [id="about-this-release-374"]
@@ -330,12 +331,16 @@ If you are using the in-product docs, you can instead download the link:https://
 * The `v1/alerts/summary/counts` endpoint, which is used by the *Policy violations by severity* and *Policy violations by category* widgets on the Dashboard, was fixed to prevent Central from crashing in highly-scaled environments. (ROX-13829)
 * {product-title-short} previously was not able to correctly identify the signature of images that contained the same content but were stored in different registries, causing problems with alerts and enforcement. This issue has been fixed and {product-title-short} now correctly identifies signatures of images from different registries. (ROX-12400)
 
+[id="resolved-in-version-3741"]
+=== Resolved in version 3.74.1
+
+* Previously, Sensor that was installed on secured clusters could not connect to Central when using a proxy, even if the proxy was specified in the proxy configuration file or in environment variables. This issue is fixed and Sensor on secured clusters now connects to Central when using a proxy. (ROX-15279)
+
 [id="known-issues-374"]
 === Known issues
 
 * Currently, {product-title-short} does not support alerts for security policy violations for containers running with default `seccomp profiles-Unconfined`. The alert violations for Unconfined `seccomp` profiles are generated only if the `seccomp` profile is explicitly set to "Unconfined" in the container specification. There is no workaround. (ROX-13490)
 * In the {product-title-short} portal, the *Platform Configuration* -> *Clusters* page does not display information in the *Cloud Provider* field for Azure Red Hat OpenShift and Red Hat OpenShift Service on AWS (ROSA) clusters. There is no workaround. (ROX-14399)
-
 
 [id="image-versions-373"]
 == Image versions


### PR DESCRIPTION
Version(s):
- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.74`

[Issue](https://issues.redhat.com/browse/ROX-15803)

[Link to docs preview
](https://57283--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

[Errata](https://errata.engineering.redhat.com/docs/show/110896)
