### PR TITLE
TELCODOCS-1126 adding NIC partitioing for SR-IOV to TP for installation (Day 1)

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1067,6 +1067,11 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |General Availability
 
+|Enabling NIC partitioning for SR-IOV devices
+|Not Available
+|Not Available
+|Technology Preview
+
 |====
 
 [discrete]


### PR DESCRIPTION
[TELCODOCS-1126](https://issues.redhat.com//browse/TELCODOCS-1126): Updating the TP table and other misc updates 

Version(s):
4.13 RN

Issue:
https://issues.redhat.com/browse/TELCODOCS-1126

Link to docs preview:
https://57287--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-technology-preview

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
