### PR TITLE
OSDOCS-5380: Documented configuring external LB for multiple subnets

### DIFF
--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -3,7 +3,40 @@
 // * networking/TBD
 // * networking/load-balancing-openstack.adoc
 // * installing/installing_bare_metal_ipi/ipi-install-post-installation-configuration.adoc jowilkin
-// For thinking and reviewing, adding to networking/load-balancing-openstack.adoc
+// * installing/installing-vsphere-installer-provisioned.adoc
+// * installing/installing-vsphere-installer-provisioned-customizations.adoc
+// * installing/installing-vsphere-installer-provisioned-network-customizations.adoc
+// * installing/installing-restricted-networks-installer-provisioned-vsphere.adoc
+// * installing_vmc/installing-vmc.adoc
+// * installing_vmc/installing-vmc-customizations.adoc
+// * installing_vmc/installing-vmc-network-customizations.adoc
+// * installing_vmc/installing-restricted-networks-vmc.adoc
+
+
+ifeval::["{context}" == "installing-vsphere-installer-provisioned"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == installing-restricted-networks-installer-provisioned-vsphere]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vmc"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc"]
+:vmc:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="nw-osp-configuring-external-load-balancer_{context}"]
@@ -15,23 +48,32 @@ on {rh-openstack-first}
 endif::[]
 to use an external load balancer in place of the default load balancer.
 
-// Maybe an About mod in support
+You can also configure an {product-title} cluster to use an external load balancer that supports multiple subnets. If you use multiple subnets, you can explicitly list all the IP addresses in any networks that are used by your load balancer targets. This configuration can reduce maintenance overhead because you can create and destroy nodes within those networks without reconfiguring the load balancer targets.
 
+If you deploy your ingress pods by using a machine set on a smaller network, such as a `/27` or `/28`, you can simplify your load balancer targets.
 
+[NOTE]
+====
+You do not need to specify API and Ingress static addresses for your installation program. If you choose this configuration, you must take additional actions to define network targets that accept an IP address from each referenced vSphere subnet.
+====
 
 .Prerequisites
 
-* On your load balancer, TCP over ports 6443, 443, and 80 must be available to any users of your system.
+* On your load balancer, TCP over ports 6443, 443, and 80 must be reachable by all users of your system that are located outside the cluster.
+
+* Load balance the application ports, 443 and 80, between all the compute nodes.
 
 * Load balance the API port, 6443, between each of the control plane nodes.
 
-* Load balance the application ports, 443 and 80, between all of the compute nodes.
-
 * On your load balancer, port 22623, which is used to serve ignition startup configurations to nodes, is not exposed outside of the cluster.
 
-* Your load balancer must be able to access every machine in your cluster. Methods to allow this access include:
-** Attaching the load balancer to the cluster's machine subnet.
-** Attaching floating IP addresses to machines that use the load balancer.
+* Your load balancer can access the required ports on each node in your cluster. You can ensure this level of access by completing the following actions: 
+** The API load balancer can access ports 22623 and 6443 on the control plane nodes.
+** The ingress load balancer can access ports 443 and 80 on the nodes where the ingress pods are located.
+
+ifdef::vsphere,vmc[]
+* Optional: If you are using multiple networks, you can create targets for every IP address in the network that can host nodes. This configuration can reduce the maintenance overhead of your cluster.
+endif::vsphere,vmc[]
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
[OSDOCS-5380](https://issues.redhat.com/browse/OSDOCS-5380)

Version(s):
4.13

Link to docs preview:
[Configuring an external load balancer](https://57297--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html#nw-osp-configuring-external-load-balancer_installing-vsphere-installer-provisioned)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
