### PR TITLE
OCPBUG#9850- Corrected control plane node sizing values

### DIFF
--- a/modules/master-node-sizing.adoc
+++ b/modules/master-node-sizing.adoc
@@ -21,7 +21,7 @@ The control plane node resource requirements depend on the number and type of no
 |===
 | Number of worker nodes |Cluster-density (namespaces) | CPU cores |Memory (GB)
 
-| 27
+| 24
 | 500
 | 4
 | 16


### PR DESCRIPTION
Version(s): 4.10+

Issue: [OCPBUG9850](https://issues.redhat.com/browse/OCPBUGS-9850)

Docs Preview:
[Preview](https://57332--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#master-node-sizing_recommended-host-practices)

@sunilcio ptal
