### PR TITLE
OCPBUGS#5193: Added descriptive commands in opm CLI reference section.

### DIFF
--- a/cli_reference/opm/cli-opm-ref.adoc
+++ b/cli_reference/opm/cli-opm-ref.adoc
@@ -19,8 +19,11 @@ $ opm <command> [<subcommand>] [<argument>] [<flags>]
 |===
 |Flag |Description
 
-|`--skip-tls`
+|`-skip-tls-verify`
 |Skip TLS certificate verification for container image registries while pulling bundles or indexes.
+
+|`--use-http`
+|When you pull bundles, use plain HTTP for container image registries.
 
 |===
 
@@ -37,6 +40,7 @@ include::modules/deprecated-feature.adoc[]
 
 include::modules/opm-cli-ref-migrate.adoc[leveloffset=+1]
 include::modules/opm-cli-ref-index.adoc[leveloffset=+1]
+include::modules/opm-cli-ref-generate.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/opm-cli-ref-generate.adoc
+++ b/modules/opm-cli-ref-generate.adoc
@@ -1,0 +1,74 @@
+//Module included in the following assemblies:
+//
+//*cli_reference/opm/cli-opm-ref.adoc
+
+[id="opm-cli-ref-generate_{Context}"]
+= generate
+
+Generate various artifacts for declarative config indexes.
+
+.Command syntax
+[source,terminal]
+----
+$ opm generate [command]
+----
+
+.`generate` flags
+[options="header",cols="1,3"]
+|===
+|Flags |Description
+
+|`-h`, `--help`
+|Help for generate.
+
+|===
+
+.Command syntax
+[source,terminal]
+----
+$ opm generate <subcommand> [<flags>]
+----
+
+.`generate` subcommands
+[options="header",cols="1,3"]
+|===
+|Subcommand |Description
+
+|`dockerfile`
+|Generate a Dockerfile for a declarative config index.
+
+|===
+
+[id="opm-cli-ref-generate-dockerfile_{context}"]
+== dockerfile
+
+Generate a Dockerfile for a declarative config index.
+
+[IMPORTANT]
+====
+This command creates a Dockerfile in the same directory as the <dcRootDir> (named <dcDirName>.Dockerfile) that is used to build the index. If a Dockerfile with the same name already exists, this command fails.
+
+When specifying extra labels, if duplicate keys exist, only the last value of each duplicate key gets added to the generated Dockerfile.
+====
+
+.Command syntax
+[source,terminal]
+----
+$ opm generate dockerfile <dcRootDir> [flags]
+----
+
+.`generate dockerfile` flags
+[options="header",cols="1,3"]
+|===
+|Flag |Description
+
+|`-i,` `--binary-image` (string)
+|Image in which to build catalog. The default value is `quay.io/operator-framework/opm:latest`.
+
+|`-l`, `--extra-labels` (string)
+|Extra labels to include in the generated Dockerfile. Labels have the form `key=value`.
+
+|`-h`, `--help`
+|Help for Dockerfile.
+
+|===

--- a/modules/opm-cli-ref-serve.adoc
+++ b/modules/opm-cli-ref-serve.adoc
@@ -23,13 +23,28 @@ $ opm serve <source_path> [<flags>]
 |===
 |Flag |Description
 
+|`--cache-dir` (string)
+|If this flag is set, it syncs and persists the server cache directory.
+
+|`--cache-enforce-integrity`
+|Exits with an error if the cache is not present or is invalidated. The default value is `true` when the `--cache-dir` flag is set and the `--cache-only` flag is `false`. Otherwise, the default is `false`.
+
+|`--cache-only`
+|Syncs the serve cache and exits without serving.
+
 |`--debug`
-|Enable debug logging.
+|Enables debug logging.
+
+|`h`, `--help`
+|Help for serve.
 
 |`-p`, `--port` (string)
-|Port number to serve on. Default: `50051`.
+|The port number for the service. The default value is `50051`.
+
+|`--pprof-addr` (string)
+|The address of the startup profiling endpoint. The format is `Addr:Port`.
 
 |`-t`, `--termination-log` (string)
-|Path to a container termination log file. Default: `/dev/termination-log`.
+|The path to a container termination log file. The default value is `/dev/termination-log`.
 
 |===


### PR DESCRIPTION
Scope: Added descriptive commands related to opm CLI reference. Newly added `opm generate` section.

Version: 4.12+

Issue: [OCPBUGS#5193](https://issues.redhat.com/browse/OCPBUGS-5193)


Link to docs preview:
[Preview 1](https://57337--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-ref.html)
[Preview 2](https://57337--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-ref.html#opm-cli-ref-server_cli-opm-ref)
[Preview 3](https://57337--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-ref.html#opm-cli-ref-generate_cli-opm-ref)


QE review: @Xia-Zhao-rh, @grokspawn ptal