### PR TITLE
OSDOCS-5355: correct command for creating kustomization.yaml

### DIFF
--- a/modules/microshift-config-auto-apply-manifests.adoc
+++ b/modules/microshift-config-auto-apply-manifests.adoc
@@ -86,17 +86,10 @@ EOF
 [source,terminal]
 ----
 $ sudo cat << EOF > ${MANIFEST_DIR}/kustomization.yaml
-----
-.. Apply the YAML configuration:
-+
-[source,terminal]
-----
-$ {MANIFEST_DIR}/kustomization.yaml
-
+---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: busybox
----
 resources:
   - busybox.yaml
 images:


### PR DESCRIPTION
Version(s): 4.12, 4.13

Issue: [OSDOCS-5355](https://issues.redhat.com//browse/OSDOCS-5355)

Link to docs preview:
https://57349--docspreview.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-tools.html#microshift-manifests-example_microshift-configuring

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

The command uses bash "here document" syntax to create a file, but the
content of the file was in a separate text box and so could not be
selected all at one time. This patch combines the command for creating
the file with the contents of the file and removes a syntax error
from the middle of the content.

/assign @ShaunaDiaz