### PR TITLE
OSDOCS-5176 removing post-install encryption module from Azure assemblies

### DIFF
--- a/installing/installing_azure/enabling-user-managed-encryption-azure.adoc
+++ b/installing/installing_azure/enabling-user-managed-encryption-azure.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster with a user-managed encryption key in Azure. To enable this feature, you can prepare an Azure DiskEncryptionSet before installation, modify the `install-config.yaml` file, and then perform post-installation steps.
+In {product-title} version {product-version}, you can install a cluster with a user-managed encryption key in Azure. To enable this feature, you can prepare an Azure DiskEncryptionSet before installation, modify the `install-config.yaml` file, and then complete the installation.
 
 include::modules/installation-azure-preparing-diskencryptionsets.adoc[leveloffset=+1]
 

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -53,8 +53,6 @@ include::modules/machineset-azure-enabling-accelerated-networking-new-install.ad
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
-include::modules/installation-azure-finalizing-encryption.adoc[leveloffset=+1]
-
 include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]

--- a/installing/installing_azure/installing-azure-government-region.adoc
+++ b/installing/installing_azure/installing-azure-government-region.adoc
@@ -58,8 +58,6 @@ include::modules/machineset-azure-enabling-accelerated-networking-new-install.ad
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
-include::modules/installation-azure-finalizing-encryption.adoc[leveloffset=+1]
-
 include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -68,8 +68,6 @@ include::modules/machineset-azure-enabling-accelerated-networking-new-install.ad
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
-include::modules/installation-azure-finalizing-encryption.adoc[leveloffset=+1]
-
 include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]

--- a/installing/installing_azure/installing-azure-private.adoc
+++ b/installing/installing_azure/installing-azure-private.adoc
@@ -55,8 +55,6 @@ include::modules/machineset-azure-enabling-accelerated-networking-new-install.ad
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
-include::modules/installation-azure-finalizing-encryption.adoc[leveloffset=+1]
-
 include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]

--- a/installing/installing_azure/installing-azure-vnet.adoc
+++ b/installing/installing_azure/installing-azure-vnet.adoc
@@ -49,8 +49,6 @@ include::modules/machineset-azure-enabling-accelerated-networking-new-install.ad
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
-include::modules/installation-azure-finalizing-encryption.adoc[leveloffset=+1]
-
 include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/cli-logging-in-kubeadmin.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5176

Link to docs preview:
https://57366--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/enabling-user-managed-encryption-azure.html
No previews for the install assemblies, since it's removing a module.

QE review:
- [X] QE has approved this change.