### PR TITLE
document V2 limitation for CPU pinning

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -231,6 +231,11 @@ status:
   runtimeClass: performance-manual
 ----
 
+[NOTE]
+====
+Currently, disabling CPU load balancing is not supported with cgroup v2.
+====
+
 The Node Tuning Operator is responsible for the creation of the high-performance runtime handler config snippet under relevant nodes and for creation of the high-performance runtime class under the cluster. It will have the same content as default runtime handler except it enables the CPU load balancing configuration functionality.
 
 To disable the CPU load balancing for the pod, the `Pod` specification must include the following fields:

--- a/modules/cnf-understanding-low-latency.adoc
+++ b/modules/cnf-understanding-low-latency.adoc
@@ -21,6 +21,11 @@ Administrators must be able to manage their many Edge sites and local services i
 
 {product-title} uses the Node Tuning Operator to implement automatic tuning to achieve low latency performance for {product-title} applications. The cluster administrator uses this performance profile configuration that makes it easier to make these changes in a more reliable way. The administrator can specify whether to update the kernel to kernel-rt, reserve CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolate CPUs for application containers to run the workloads.
 
+[NOTE]
+====
+Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performace profiles.
+====
+
 {product-title} also supports workload hints for the Node Tuning Operator that can tune the `PerformanceProfile` to meet the demands of different industry environments. Workload hints are available for `highPowerConsumption` (very low latency at the cost of increased power consumption) and `realTime` (priority given to optimum latency). A combination of `true/false` settings for these hints can be used to deal with application-specific workload profiles and requirements.
 
 Workload hints simplify the fine-tuning of performance to industry sector settings. Instead of a “one size fits all” approach, workload hints can cater to usage patterns such as placing priority on:

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -35,6 +35,11 @@ The Node Tuning Operator uses the Performance Profile controller to implement au
 * Choosing CPUs for housekeeping.
 * Choosing CPUs for running workloads.
 
+[NOTE]
+====
+Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performace profiles.
+====
+
 The Node Tuning Operator is part of a standard {product-title} installation in version 4.1 and later.
 
 [NOTE]

--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -26,6 +26,11 @@ ifdef::nodes[]
 You can enable link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1.html[Linux control group version 1] (cgroup v1) or link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2)  by editing the `node.config` object. The default is cgroup v1.
 endif::nodes[]
 
+[NOTE]
+====
+Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performace profiles. 
+====
+
 .Prerequisites
 * You have a running {product-title} cluster that uses version 4.12 or later.
 * You are logged in to the cluster as a user with administrative privileges.

--- a/scalability_and_performance/cnf-create-performance-profiles.adoc
+++ b/scalability_and_performance/cnf-create-performance-profiles.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Learn about the Performance Profile Creator (PPC) and how you can use it to create a performance profile.
 
+[NOTE]
+====
+Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performace profiles. 
+====
+
 include::modules/cnf-about-the-profile-creator-tool.adoc[leveloffset=+1]
 
 include::modules/cnf-gathering-data-about-cluster-using-must-gather.adoc[leveloffset=+2]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5556

Added notes re: cgroup v2 and lack of ability to disable CPU load balancing.

Link to docs previews:
[Creating a performance profile](https://57369--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-create-performance-profiles.html)
[Understanding low latency](https://57369--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html)
[Optional: Disabling CPU load balancing for DPDK](https://57369--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#node-tuning-operator-disabling-cpu-load-balancing-for-dpdk_cnf-master)
[About the Node Tuning Operator](https://57369--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator.html)
[Configuring Linux cgroup](https://57369--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html#nodes-clusters-cgroups-2_nodes-cluster-cgroups-2)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

