### PR TITLE
OCPBUGS#9284:Use different callouts

### DIFF
--- a/modules/setting-up-cpu-manager.adoc
+++ b/modules/setting-up-cpu-manager.adoc
@@ -96,9 +96,10 @@ sh-4.2# cat /host/etc/kubernetes/kubelet.conf | grep cpuManager
 [source,terminal]
 ----
 cpuManagerPolicy: static        <1>
-cpuManagerReconcilePeriod: 5s   <1>
+cpuManagerReconcilePeriod: 5s   <2>
 ----
-<1> These settings were defined when you created the `KubeletConfig` CR.
+<1> `cpuManagerPolicy` is defined when you create the `KubeletConfig` CR.
+<2> `cpuManagerReconcilePeriod` is defined when you create the `KubeletConfig` CR.
 
 . Create a pod that requests a core or multiple cores. Both limits and requests must have their CPU value set to a whole integer. That is the number of cores that will be dedicated to this pod:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-9284
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57377--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-cpu-manager.html#seting_up_cpu_manager_using-cpu-manager-and-topology_manager
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
