### PR TITLE
ML-RHDEVDOCS-3382: Updated the Pipeline builder instances

### DIFF
--- a/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
+++ b/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.adoc
@@ -11,10 +11,10 @@ You can use the *Developer* perspective of the {product-title} web console to cr
 
 In the *Developer* perspective:
 
-* Use the *Add* -> *Pipeline* -> *Pipeline Builder* option to create customized pipelines for your application.
+* Use the *Add* -> *Pipeline* -> *Pipeline builder* option to create customized pipelines for your application.
 * Use the *Add* -> *From Git* option to create pipelines using operator-installed pipeline templates and resources while creating an application on {product-title}.
 
-After you create the pipelines for your application, you can view and visually interact with the deployed pipelines in the *Pipelines* view. You can also use the *Topology* view to interact with the pipelines created using the *From Git* option. You need to apply custom labels to a pipeline created using the *Pipeline Builder* to see it in the *Topology* view.
+After you create the pipelines for your application, you can view and visually interact with the deployed pipelines in the *Pipelines* view. You can also use the *Topology* view to interact with the pipelines created using the *From Git* option. You must apply custom labels to pipelines created using the *Pipeline builder* to see them in the *Topology* view.
 
 [discrete]
 == Prerequisites

--- a/modules/cnf-installing-numa-resources-operator-cli.adoc
+++ b/modules/cnf-installing-numa-resources-operator-cli.adoc
@@ -35,7 +35,7 @@ metadata:
 $ oc create -f nro-namespace.yaml
 ----
 
-. Create the operator group for the NUMA Resources Operator:
+. Create the Operator group for the NUMA Resources Operator:
 
 .. Save the following YAML in the `nro-operatorgroup.yaml` file:
 +

--- a/modules/nw-ptp-installing-operator-web-console.adoc
+++ b/modules/nw-ptp-installing-operator-web-console.adoc
@@ -10,7 +10,7 @@ As a cluster administrator, you can install the PTP Operator using the web conso
 
 [NOTE]
 ====
-You have to create the namespace and operator group as mentioned
+You have to create the namespace and Operator group as mentioned
 in the previous section.
 ====
 
@@ -37,7 +37,7 @@ If the installation later succeeds with an *InstallSucceeded* message, you can i
 ====
 
 +
-If the operator does not appear as installed, to troubleshoot further:
+If the Operator does not appear as installed, to troubleshoot further:
 
 +
 * Go to the *Operators* -> *Installed Operators* page and inspect

--- a/modules/nw-rfhe-installing-operator-web-console.adoc
+++ b/modules/nw-rfhe-installing-operator-web-console.adoc
@@ -36,7 +36,7 @@ Optional: You can verify that the Operator installed successfully by performing 
 During installation an Operator might display a *Failed* status. If the installation later succeeds with an *InstallSucceeded* message, you can ignore the *Failed* message.
 ====
 
-If the operator does not appear as installed, to troubleshoot further:
+If the Operator does not appear as installed, to troubleshoot further:
 
 * Go to the *Operators* -> *Installed Operators* page and inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors under *Status*.
 * Go to the *Workloads* -> *Pods* page and check the logs for pods in the project namespace.

--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -14,12 +14,12 @@ Complete the steps to modify the relevant configuration only if the default beha
 ====
 
 The SR-IOV Network Operator adds the `SriovOperatorConfig.sriovnetwork.openshift.io` CustomResourceDefinition resource.
-The operator automatically creates a SriovOperatorConfig custom resource (CR) named `default` in the `openshift-sriov-network-operator` namespace.
+The Operator automatically creates a SriovOperatorConfig custom resource (CR) named `default` in the `openshift-sriov-network-operator` namespace.
 
 [NOTE]
 =====
 The `default` CR contains the SR-IOV Network Operator configuration for your cluster.
-To change the operator configuration, you must modify this CR.
+To change the Operator configuration, you must modify this CR.
 =====
 
 [id="nw-sriov-operator-cr_{context}"]

--- a/modules/nw-sriov-installing-operator.adoc
+++ b/modules/nw-sriov-installing-operator.adoc
@@ -132,7 +132,7 @@ If the installation later succeeds with an *InstallSucceeded* message, you can i
 ====
 
 +
-If the operator does not appear as installed, to troubleshoot further:
+If the Operator does not appear as installed, to troubleshoot further:
 
 +
 * Inspect the *Operator Subscriptions* and *Install Plans* tabs for any failure or errors under *Status*.

--- a/modules/op-constructing-pipelines-using-pipeline-builder.adoc
+++ b/modules/op-constructing-pipelines-using-pipeline-builder.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="op-constructing-pipelines-using-pipeline-builder_{context}"]
-= Constructing Pipelines using the Pipeline Builder
+= Constructing Pipelines using the Pipeline builder
 
 [role="_abstract"]
 In the *Developer* perspective of the console, you can use the *+Add* -> *Pipeline* -> *Pipeline builder* option to:
@@ -36,7 +36,7 @@ The *Pipeline builder* view supports a limited number of fields whereas the *YAM
 .YAML view
 image::op-pipeline-yaml.png[]
 +
-Configure your pipeline using the *Pipeline Builder*:
+. Configure your pipeline by using *Pipeline builder*:
 
 .. In the *Name* field, enter a unique name for the pipeline.
 .. In the *Tasks* section:
@@ -54,7 +54,7 @@ The search list contains all the Tekton Hub tasks and tasks available in the clu
 **** Search for a task using the quick search field and select the required task from the displayed list.
 **** Click *Add* or *Install and add*.
 +
-.Pipeline Builder
+.Pipeline builder
 image::op-pipeline-builder.png[]
 
 *** To add a final task:

--- a/modules/op-editing-pipelines.adoc
+++ b/modules/op-editing-pipelines.adoc
@@ -12,8 +12,8 @@ You can edit the Pipelines in your cluster using the *Developer* perspective of 
 
 . In the *Pipelines* view of the *Developer* perspective, select the Pipeline you want to edit to see the details of the Pipeline.
 In the *Pipeline Details* page, click *Actions* and select *Edit Pipeline*.
-. In the *Pipeline Builder* page:
-* You can add additional Tasks, parameters, or resources to the Pipeline.
-* You can click the Task you want to modify to see the Task details in the side panel and modify the required Task details, such as the display name, parameters and resources.
+. On the *Pipeline builder* page, you can perform the following tasks:
+* Add additional Tasks, parameters, or resources to the Pipeline.
+* Click the Task you want to modify to see the Task details in the side panel and modify the required Task details, such as the display name, parameters, and resources.
 * Alternatively, to delete the Task, click the Task, and in the side panel, click *Actions* and select *Remove Task*.
 . Click *Save* to save the modified Pipeline.

--- a/modules/op-opting-out-of-tekton-hub-in-the-developer-perspective.adoc
+++ b/modules/op-opting-out-of-tekton-hub-in-the-developer-perspective.adoc
@@ -7,7 +7,7 @@
 = Opting out of Tekton Hub in the Developer perspective
 
 [role="_abstract"]
-Cluster administrators can opt out of displaying {tekton-hub} resources, such as tasks and pipelines, in the **Pipeline Builder** view of the **Developer** perspective of an {product-title} cluster. 
+Cluster administrators can opt out of displaying {tekton-hub} resources, such as tasks and pipelines, in the **Pipeline builder** page of the **Developer** perspective of an {product-title} cluster. 
 
 [discrete]
 .Prerequisite

--- a/modules/op-starting-pipelines-from-topology-view.adoc
+++ b/modules/op-starting-pipelines-from-topology-view.adoc
@@ -10,7 +10,7 @@ For pipelines created using the *From Git* option, you can use the *Topology* vi
 
 [NOTE]
 ====
-To see the pipelines created using the *Pipeline Builder* in the *Topology* view, customize the pipeline labels to link the pipeline with the application workload.
+To see the pipelines created using *Pipeline builder* in the *Topology* view, customize the pipeline labels to link the pipeline with the application workload.
 ====
 .Procedure
 

--- a/modules/op-using-custom-pipeline-template-for-git-import.adoc
+++ b/modules/op-using-custom-pipeline-template-for-git-import.adoc
@@ -58,12 +58,12 @@ addon:
 +
 [NOTE]
 ====
-If you manually delete the default pipeline templates, the operator will restore the defaults during an upgrade.
+If you manually delete the default pipeline templates, the Operator restores the defaults during an upgrade.
 ====
 +
 [WARNING]
 ====
-As a cluster admin, you can disable installation of the default pipeline templates in the operator configuration. However, such a configuration will disable (delete) all default pipeline templates, and not only the one you want to customize.
+As a cluster admin, you can disable the installation of the default pipeline templates in the Operator configuration. However, such a configuration deletes all default pipeline templates, not just the one you want to customize.
 ====
 +
 

--- a/modules/ztp-configuring-cluster-policies.adoc
+++ b/modules/ztp-configuring-cluster-policies.adoc
@@ -8,7 +8,7 @@
 
 Zero touch provisioning (ZTP) uses {rh-rhacm-first} to configure clusters by using a policy-based governance approach to applying the configuration.
 
-The policy generator or `PolicyGen` is a plugin for the GitOps operator that enables creation of {rh-rhacm} policies from a concise template. The tool can combine multiple CRs into a single policy, and you can generate multiple policies that apply to various subsets of clusters in your fleet.
+The policy generator or `PolicyGen` is a plugin for the GitOps Operator that enables the creation of {rh-rhacm} policies from a concise template. The tool can combine multiple CRs into a single policy, and you can generate multiple policies that apply to various subsets of clusters in your fleet.
 
 [NOTE]
 ====


### PR DESCRIPTION
Purpose: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-3382

Aligned team: DevTools

OCP versions this PR applies to: enterprise 4.9 and later

Content for preview: https://57392--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.html

SME review: @vdemeester 

QE review: Veeresh Aradhya

Peer review: @mramendi 
