### PR TITLE
OCPBUGS-10550 removing erroneous line as per PR 54754

### DIFF
--- a/modules/nw-sriov-rdma-example-mellanox.adoc
+++ b/modules/nw-sriov-rdma-example-mellanox.adoc
@@ -41,7 +41,7 @@ spec:
   deviceType: netdevice <2>
   isRdma: true <3>
 ----
-<1> Specify the device hex code of SR-IOV network device. The only allowed values for Mellanox cards are `1015`, `1017`.
+<1> Specify the device hex code of the SR-IOV network device.
 <2> Specify the driver type for the virtual functions to `netdevice`.
 <3> Enable RDMA mode.
 +


### PR DESCRIPTION
[OCPBUGS-10550]: Removing line "The only allowed values for Mellanox cards are 1015, 1017."

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
main, 4.13, 4.12, 4.11

Issue:
https://issues.redhat.com/browse/OCPBUGS-10550

Link to docs preview:
https://57399--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/using-dpdk-and-rdma.html#example-vf-use-in-rdma-mode-mellanox_using-dpdk-and-rdma

When I got this https://github.com/openshift/openshift-docs/pull/54754 merged, I should have followed through on the other instance in the docs. This PR addresses that oversight. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
