### PR TITLE
OCPBUGS#10545: Configuring cluster wide proxy on the External DNS Operator

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1149,6 +1149,8 @@ Topics:
     File: nw-creating-dns-records-on-gcp
   - Name: Creating DNS records on a public DNS zone for Infoblox
     File: nw-creating-dns-records-on-infoblox
+  - Name: Configuring the cluster-wide proxy on the External DNS Operator
+    File: nw-configuring-cluster-wide-egress-proxy
 - Name: Network policy
   Dir: network_policy
   Topics:

--- a/modules/configuring-egress-proxy-edns-operator.adoc
+++ b/modules/configuring-egress-proxy-edns-operator.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * networking/external_dns_operator/nw-configuring-cluster-wide-egress-proxy.adoc
+
+:_content-type: PROCEDURE
+[id="nw-configuring-cluster-wide-proxy_{context}"]
+= Configuring the External DNS Operator to trust the certificate authority of the cluster-wide proxy
+
+You can configure the External DNS Operator to trust the certificate authority of the cluster-wide proxy.
+
+.Procedure
+
+. Create the config map to contain the CA bundle in the `external-dns-operator` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator create configmap trusted-ca
+----
+
+. To inject the trusted CA bundle into the config map, add the `config.openshift.io/inject-trusted-cabundle=true` label to the config map by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator label cm trusted-ca config.openshift.io/inject-trusted-cabundle=true
+----
+
+. Update the subscription of the External DNS Operator by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator patch subscription external-dns-operator --type='json' -p='[{"op": "add", "path": "/spec/config", "value":{"env":[{"name":"TRUSTED_CA_CONFIGMAP_NAME","value":"trusted-ca"}]}}]'
+----
+
+.Verification
+
+* After the deployment of the External DNS Operator is completed, verify that the trusted CA environment variable is added to the `external-dns-operator` deployment by running the following command:
++
+[source,terminal]
+----
+$ oc -n external-dns-operator exec deploy/external-dns-operator -c external-dns-operator -- printenv TRUSTED_CA_CONFIGMAP_NAME
+----
++
+.Example output
+[source,terminal]
+----
+trusted-ca
+----

--- a/networking/external_dns_operator/nw-configuring-cluster-wide-egress-proxy.adoc
+++ b/networking/external_dns_operator/nw-configuring-cluster-wide-egress-proxy.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+[id="external-dns-operator-cluster-wide-proxy"]
+= Configuring the cluster-wide proxy on the External DNS Operator
+include::_attributes/common-attributes.adoc[]
+:context: external-dns-operator-cluster-wide-proxy
+
+toc::[]
+
+You can configure the cluster-wide proxy in the External DNS Operator. After configuring the cluster-wide proxy in the External DNS Operator, Operator Lifecycle Manager (OLM) automatically updates all the deployments of the Operators with the environment variables such as `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY`.
+
+include::modules/configuring-egress-proxy-edns-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-10545
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57402--docspreview.netlify.app/openshift-enterprise/latest/networking/external_dns_operator/nw-configuring-cluster-wide-egress-proxy.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
