### PR TITLE
Add kernel module collection as deprecated in RHACS 3.74

### DIFF
--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -195,7 +195,7 @@ In the table, features are marked with the following statuses:
 - NA: Not applicable
 
 
-.Deprecated and removed features tracker
+.Deprecated and removed features tracker (updated 20 March 2023)
 [cols="3,1,1,1",options="header"]
 |====
 | Feature | {product-title-short} 3.72 |{product-title-short} 3.73 | {product-title-short} 3.74
@@ -220,6 +220,11 @@ In the table, features are marked with the following statuses:
 a|
 * DEP in {product-title-short} 3.73
 * REM in Advanced Cluster Security Cloud Service (ACSCS) (Field Trial)
+| DEP
+
+| Kernel module collection method
+| GA
+| GA
 | DEP
 
 | `Policy` permission
@@ -309,6 +314,22 @@ The default `ScopeManager` role is planned for removal in the {product-title-sho
 ===== Actions you must take
 
 If authentication provider rules reference the `ScopeManager` role for other purposes than Vulnerability Report management, you should manually create a similar role and replace references to `ScopeManager` with the new role in the authentication provider rules.
+
+[id="kernel-collection-module"]
+== Remove kernel module as collection method
+
+*Added 20 March 2023*
+
+Currently, secured clusters can specify three options of collection methods for runtime events: eBPF (selected by default), kernel module, or no collection. Kernel module as a collection method is deprecated in the {product-title-short} version 3.74 release and is planned for removal in the {product-title-short} version 4.1 release.
+
+=== Actions you must take
+Verify the collection method of your secured clusters. This value is set in the `collector.collectionMethod` parameter and is one of the following methods:
+
+- `EBPF`
+- `KERNEL_MODULE`
+- `NO_COLLECTION`
+
+If any of your secured clusters uses `KERNEL_MODULE` as a collection method, change it to `EBPF`.
 
 [id="in-product-docs-removal"]
 === In-product docs removal


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.74`

[Issue](https://issues.redhat.com/browse/ROX-15950)

[Link to docs preview
](https://57406--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes.html#kernel-collection-module)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
