### PR TITLE
CNV-23499: 4.10+ HPP CSI only - content

### DIFF
--- a/modules/virt-about-hostpath-provisioner.adoc
+++ b/modules/virt-about-hostpath-provisioner.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc
+
 
 :_content-type: CONCEPT
 [id="virt-about-hostpath-provisioner_{context}"]
@@ -8,21 +8,4 @@
 
 When you install the {VirtProductName} Operator, the Hostpath Provisioner (HPP) Operator is automatically installed. The HPP is a local storage provisioner designed for {VirtProductName} that is created by the Hostpath Provisioner Operator. To use the HPP, you must create an HPP custom resource (CR).
 
-[IMPORTANT]
-====
-In {VirtProductName} 4.10, the HPP Operator configures the Kubernetes CSI driver. The Operator also recognizes the existing (legacy) format of the HPP CR.
 
-The legacy HPP and the Container Storage Interface (CSI) driver are supported in parallel for a number of releases. However, at some point, the legacy HPP will no longer be supported. If you use the HPP, plan to create a storage class for the CSI driver as part of your migration strategy.
-====
-
-If you upgrade to {VirtProductName} version 4.10 on an existing cluster, the HPP Operator is upgraded and the system performs the following actions:
-
-* The CSI driver is installed.
-* The CSI driver is configured with the contents of your legacy HPP CR.
-
-If you install {VirtProductName} version 4.10 on a new cluster, you must perform the following actions:
-
-* Create an HPP CR with a basic storage pool.
-* Create a storage class for the CSI driver.
-
-Optional: You can create a storage pool with a PVC template for multiple HPP volumes.

--- a/modules/virt-creating-storage-class-csi-driver.adoc
+++ b/modules/virt-creating-storage-class-csi-driver.adoc
@@ -8,10 +8,6 @@
 
 You create a storage class custom resource (CR) for the hostpath provisioner (HPP) CSI driver.
 
-.Prerequisites
-
-* You must have {VirtProductName} 4.10 or later.
-
 .Procedure
 
 . Create a `storageclass_csi.yaml` file to define the storage class:
@@ -21,17 +17,17 @@ You create a storage class custom resource (CR) for the hostpath provisioner (HP
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: hostpath-csi <1>
+  name: hostpath-csi 
 provisioner: kubevirt.io.hostpath-provisioner
-reclaimPolicy: Delete <2>
-volumeBindingMode: WaitForFirstConsumer <3>
+reclaimPolicy: Delete <1>
+volumeBindingMode: WaitForFirstConsumer <2>
 parameters:
-  storagePool: my-storage-pool <4>
+  storagePool: my-storage-pool <3>
 ----
-<1> Assign any meaningful name to the storage class. In this example, `csi` is used to specify that the class is using the CSI provisioner instead of the legacy provisioner. Choosing descriptive names for storage classes, based on legacy or CSI driver provisioning, eases implementation of your migration strategy.
-<2> The two possible `reclaimPolicy` values are `Delete` and `Retain`. If you do not specify a value, the default value is `Delete`.
-<3> The `volumeBindingMode` parameter determines when dynamic provisioning and volume binding occur. Specify `WaitForFirstConsumer` to delay the binding and provisioning of a persistent volume (PV) until after a pod that uses the persistent volume claim (PVC) is created. This ensures that the PV meets the pod's scheduling requirements.
-<4> Specify the name of the storage pool defined in the HPP CR.
+
+<1> The two possible `reclaimPolicy` values are `Delete` and `Retain`. If you do not specify a value, the default value is `Delete`.
+<2> The `volumeBindingMode` parameter determines when dynamic provisioning and volume binding occur. Specify `WaitForFirstConsumer` to delay the binding and provisioning of a persistent volume (PV) until after a pod that uses the persistent volume claim (PVC) is created. This ensures that the PV meets the pod's scheduling requirements.
+<3> Specify the name of the storage pool defined in the HPP CR.
 
 . Save the file and exit.
 

--- a/virt/install/installing-virt-cli.adoc
+++ b/virt/install/installing-virt-cli.adoc
@@ -34,4 +34,4 @@ include::modules/virt-deploying-operator-cli.adoc[leveloffset=+1]
 
 You might want to additionally configure the following components:
 
-* The xref:../../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-about-hostpath-provisioner_virt-configuring-local-storage-for-vms[hostpath provisioner] is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.
+* The xref:../../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-creating-hpp-basic-storage-pool_virt-configuring-local-storage-for-vms[hostpath provisioner] is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.

--- a/virt/install/installing-virt-web.adoc
+++ b/virt/install/installing-virt-web.adoc
@@ -18,4 +18,4 @@ include::modules/virt-installing-virt-operator.adoc[leveloffset=+1]
 
 You might want to additionally configure the following components:
 
-* The xref:../../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-about-hostpath-provisioner_virt-configuring-local-storage-for-vms[hostpath provisioner] is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.
+* The xref:../../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-creating-hpp-basic-storage-pool_virt-configuring-local-storage-for-vms[hostpath provisioner] is a local storage provisioner designed for {VirtProductName}. If you want to configure local storage for virtual machines, you must enable the hostpath provisioner first.

--- a/virt/virt-architecture.adoc
+++ b/virt/virt-architecture.adoc
@@ -18,8 +18,6 @@ image::cnv_components_main.png[CNV Deployments]
 
 * xref:../virt/virt-using-the-cli-tools.adoc#virt-virtctl-commands_virt-using-the-cli-tools[Virtctl client commands]
 
-* xref:../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-about-hostpath-provisioner_virt-configuring-local-storage-for-vms[About the hostpath provisioner]
-
 include::modules/virt-about-hco-operator.adoc[leveloffset=+1]
 
 include::modules/virt-about-cdi-operator.adoc[leveloffset=+1]

--- a/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc
@@ -6,17 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can configure local storage for virtual machines by using the hostpath provisioner (HPP).
+You can configure local storage for virtual machines by using the hostpath provisioner (HPP). 
 
-include::modules/virt-about-hostpath-provisioner.adoc[leveloffset=+1]
+When you install the {VirtProductName} Operator, the Hostpath Provisioner (HPP) Operator is automatically installed. The HPP is a local storage provisioner designed for {VirtProductName} that is created by the Hostpath Provisioner Operator. To use the HPP, you must create an HPP custom resource (CR).
 
 include::modules/virt-creating-hpp-basic-storage-pool.adoc[leveloffset=+1]
 
-include::modules/virt-about-creating-storage-classes.adoc[leveloffset=+1]
+include::modules/virt-about-creating-storage-classes.adoc[leveloffset=+2]
 
 include::modules/virt-creating-storage-class-csi-driver.adoc[leveloffset=+2]
-
-include::modules/virt-creating-storage-class-legacy-hpp.adoc[leveloffset=+2]
 
 include::modules/virt-about-storage-pools-pvc-templates.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s): 4.11, 4.12, 4.13

Issue: [CNV-23499: 4.10+ HPP CSI only - content](https://issues.redhat.com/browse/CNV-23499)

Links to docs previews:

-[Creating a storage class for the CSI driver with the storagePools stanza](https://57422--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.html#virt-creating-storage-class-csi-driver_virt-configuring-local-storage-for-vms)--removed prerequisite requiring version 4.10 and references to legacy provisioner

-[Configuring local storage for virtual machines](https://57422--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.html)--moved content from **About the hostpath provisioner** module into this assembly, removed the **About the hostpath provisioner** module, and removed paragraphs related to 4.10

-[Installing OpenShift Virtualization using the CLI](https://57422--docspreview.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-cli.html)-- corrected broken xref in **Next steps**

-[Installing OpenShift Virtualization using the web console](https://57422--docspreview.netlify.app/openshift-enterprise/latest/virt/install/installing-virt-web.html)----corrected broken xref in **Next steps**


QE review:
- [x] QE has approved this change. (LGTM from Kevin in corresponding Jira.)

Additional information:

There are two additional PRs related to this one: 

[#57514](https://github.com/openshift/openshift-docs/pull/57514)--to repeat in the 4.13 release notes the removal of support for the legacy HPP in version 4.12

[https://github.com/openshift/openshift-docs/pull/57355](https://github.com/openshift/openshift-docs/pull/57355)--to move discontinuation of legacy HPP support from Deprecated to Removed feature in 4.12 release notes


