### PR TITLE
TELCODOCS-1199: Removed  module from assembly.

### DIFF
--- a/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc
@@ -12,8 +12,6 @@ include::modules/ztp-challenges-of-far-edge-deployments.adoc[leveloffset=+1]
 
 include::modules/about-ztp.adoc[leveloffset=+1]
 
-include::modules/specifying-the-platform-type-for-managed-clusters.adoc[leveloffset=+1]
-
 include::modules/ztp-creating-ztp-crs-for-multiple-managed-clusters.adoc[leveloffset=+1]
 
 include::modules/ztp-configuring-cluster-policies.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes: [TELCODOCS-1199](https://issues.redhat.com/browse/TELCODOCS-1199)

For: Version 4.12+

Doc Preview [here](https://57430--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.html)

Signed-off-by: Katie Tothill ktothill@redhat.com