### PR TITLE
OSDOCS-5536: Adds notes for MS 4.12.8 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -135,3 +135,12 @@ Issued: 2023-03-13
 {product-title} release 4.12.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1166[RHBA-2023:1166] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1163[RHBA-2023:1163] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-8-dp"]
+=== RHBA-2023:1272 - {product-title} 4.12.8 bug fix update
+
+Issued: 2023-03-21
+
+{product-title} release 4.12.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1272[RHBA-2023:1272] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1269[RHBA-2023:1269] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
[OSDOCS-5536](https://issues.redhat.com//browse/OSDOCS-5536): Adds notes for MS 4.12.8 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5536

Link to docs preview:
https://57441--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-8-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Links will not work yet
