### PR TITLE
OSDOCS-5410: Release notes for suggested namespace

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -270,6 +270,13 @@ In {product-title} {product-version}, {lvms} is supported in dual-stack for IPv4
 [id="ocp-4-13-osdk"]
 === Operator development
 
+[id="ocp-4-13-suggested-namespace-template"]
+==== Setting a suggested namespace template with default node selector
+
+With this release, Operator authors can set a default node selector on the suggested namespace where the Operator runs. The suggested namespace is created using the namespace manifest in the YAML which is included in the `ClusterServiceVersion` (CSV).  When adding the Operator to a cluster using OperatorHub, the web console automatically populates the suggested namespace for the cluster administrator during the installation process.
+
+For more information, see xref:../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-suggested-namespace-default-node_osdk-generating-csvs[Setting a suggested namespace with default node selector].
+
 [id="ocp-4-13-machine-api"]
 === Machine API
 


### PR DESCRIPTION
[OSDOCS-5410](https://issues.redhat.com//browse/OSDOCS-5410): Release notes for suggested namespace

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5523
https://issues.redhat.com/browse/OSDOCS-5410

Link to docs preview:
https://57447--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-suggested-namespace-template

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
FYI @michaelryanpeter @adellape 
