### PR TITLE
TELCODOCS-1052: Added requirements for installing an SNO cluster on AWS.

### DIFF
--- a/installing/installing_aws/preparing-to-install-on-aws.adoc
+++ b/installing/installing_aws/preparing-to-install-on-aws.adoc
@@ -26,6 +26,11 @@ You can install {product-title} on installer-provisioned or user-provisioned inf
 
 See xref:../../architecture/architecture-installation.adoc#installation-process_architecture-installation[Installation process] for more information about installer-provisioned and user-provisioned installation processes.
 
+[id="choosing-an-method-to-install-ocp-on-aws-single-node"]
+=== Installing a cluster on a single node
+
+Installing {product-title} on a single node alleviates some of the requirements for high availability and large scale clusters. However, you must address the xref:../installing_sno/install-sno-preparing-to-install-sno.adoc#install-sno-requirements-for-installing-on-a-single-node_install-sno-preparing[requirements for installing on a single node], and the xref:../installing_sno/install-sno-installing-sno.adoc#additional-requirements-for-installing-on-a-single-node-on-aws_install-sno-installing-sno-with-the-assisted-installer[additional requirements for installing on a single node on AWS]. After addressing the requirements for single node installation, use the xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Installing a customized cluster on AWS] procedure to install the cluster. The xref:../installing_sno/install-sno-installing-sno.adoc#install-sno-installing-sno-manually[installing single-node OpenShift manually] section contains an exemplary `install-config.yaml` file when installing an {product-title} cluster on a single node.
+
 [id="choosing-an-method-to-install-ocp-on-aws-installer-provisioned"]
 === Installing a cluster on installer-provisioned infrastructure
 

--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -29,6 +29,7 @@ include::modules/install-sno-installing-with-the-assisted-installer.adoc[levelof
 
 endif::openshift-origin[]
 
+[id="install-sno-installing-sno-manually"]
 == Installing {sno} manually
 
 To install {product-title} on a single node, first generate the installation ISO, and then boot the server from the ISO. You can monitor the installation using the `openshift-install` installation program.
@@ -51,6 +52,17 @@ include::modules/install-sno-monitoring-the-installation-manually.adoc[leveloffs
 * xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API]
 
 * xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc#nodes-sno-worker-nodes[Adding worker nodes to {sno} clusters]
+
+== Installing {sno} on AWS
+
+include::modules/install-sno_additional-requirements-for-installing-on-a-single-node-on-aws.adoc[leveloffset=+2]
+
+include::modules/installation-aws_con_installing-sno-on-aws.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Installing a cluster on AWS with customizations]
 
 include::modules/install-sno-installing-with-usb-media.adoc[leveloffset=+1]
 

--- a/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
+++ b/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
@@ -1,6 +1,7 @@
 // This is included in the following assemblies:
 //
 // installing_sno/install-sno-preparing-to-install-sno.adoc
+:_content-type: CONCEPT
 
 [id="install-sno-requirements-for-installing-on-a-single-node_{context}"]
 = Requirements for installing OpenShift on a single node
@@ -11,7 +12,7 @@ Installing {product-title} on a single node alleviates some of the requirements 
 
 * *CPU Architecture:* Installing {product-title} on a single node supports `x86_64` and `arm64` CPU architectures.
 
-* *Supported platforms:* Installing {product-title} on a single node is supported on bare metal, vSphere, Red Hat OpenStack, and Red Hat Virtualization platforms. In all cases, you must specify the `platform.none: {}` parameter in the `install-config.yaml` configuration file.
+* *Supported platforms:* Installing {product-title} on a single node is supported on bare metal, vSphere, AWS, Red Hat OpenStack, and Red Hat Virtualization platforms. In all cases, you must specify the `platform.none: {}` parameter in the `install-config.yaml` configuration file.
 
 * *Production-grade server:* Installing {product-title} on a single node requires a server with sufficient resources to run {product-title} services and a production workload.
 +

--- a/modules/install-sno_additional-requirements-for-installing-on-a-single-node-on-aws.adoc
+++ b/modules/install-sno_additional-requirements-for-installing-on-a-single-node-on-aws.adoc
@@ -1,0 +1,18 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_sno/install-sno-preparing-to-install-sno.adoc
+
+:_content-type: CONCEPT
+[id="additional-requirements-for-installing-on-a-single-node-on-aws_{context}"]
+= Additional requirements for installing on a single node on AWS
+
+The AWS documentation for installer-provisioned installation is written with a high availability cluster consisting of three control plane nodes. When referring to the AWS documentation, consider the differences between the requirements for a {sno} cluster and a high availability cluster.
+
+* The required machines for cluster installation in AWS documentation indicates a temporary bootstrap machine, three control plane machines, and at least two compute machines. You require only a temporary bootstrap machine and one AWS instance for the control plane node and no worker nodes.
+
+* The minimum resource requirements for cluster installation in the AWS documentation indicates a control plane node with 4 vCPUs and 100GB of storage. For a single node cluster, you must have a minimum of 8 vCPU cores and 120GB of storage.
+
+* The `controlPlane.replicas` setting in the `install-config.yaml` file should be set to `1`.
+
+* The `compute.replicas` setting in the `install-config.yaml` file should be set to `0`.
+This makes the control plane node schedulable.

--- a/modules/installation-aws_con_installing-sno-on-aws.adoc
+++ b/modules/installation-aws_con_installing-sno-on-aws.adoc
@@ -1,0 +1,9 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_sno/install-sno-installing-sno.adoc
+
+:_content-type: CONCEPT
+[id="installing-sno-on-aws_{context}"]
+= Installing {sno} on AWS
+
+Installing a single node cluster on AWS requires installer-provisioned installation using the "Installing a cluster on AWS with customizations" procedure.


### PR DESCRIPTION

Version(s): 4.13

Issue: https://issues.redhat.com/browse/TELCODOCS-1052

Link to docs preview: http://jowilkin.com:8080/TELCODOCS-1052/installing/installing_aws/preparing-to-install-on-aws.html#choosing-an-method-to-install-ocp-on-aws-single-node and http://jowilkin.com:8080/TELCODOCS-1052/installing/installing_sno/install-sno-preparing-to-install-sno.html#additional-requirements-for-installing-on-a-single-node-on-aws_install-sno-preparing

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->