### PR TITLE
[enterprise-4.13] remove NE entry and add RHCOS entry

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -188,10 +188,6 @@ Netlink messages dropped by OVS vSwitch daemon due to netlink socket buffer over
 Netlink messages dropped by OVS kernel module due to netlink socket buffer overflow. This will result in packet loss.
 ----
 
-[id="ocp-4-13-networking-haproxy-update"]
-==== Update to HAProxy 2.6
-{product-title} updated to HAProxy 2.6.
-
 [id="ocp-4-13-nw-metallb-ipaddresspool-assignment"]
 ==== Assign IP addresses in MetalLB IPAddressPool resources to specific namespaces and services
 With this update, you can assign IP addresses from a MetalLB `IPAddressPool` resource to services, namespaces, or both. This is useful in a muti-tenant, bare-metal environment that requires MetalLB to pin IP addresses from an IP address pool to specific services and namespaces. You can assign IP addresses from many IP address pools to services and namespaces. You can then define the prioritization for these IP address pools so that MetalLB assigns IP addresses starting from the higher priority IP address pool.
@@ -568,6 +564,10 @@ The `ImageContentSourcePolicy` (ICSP) object is now deprecated. You can now use 
 For more information on these new objects, see xref:../post_installation_configuration/preparing-for-users.adoc#images-configuration-registry-mirror_post-install-preparing-for-users[Configuring image registry repository mirroring].
 
 For more information on converting existing ICSP YAML files to IDMS YAML files, see xref:../post_installation_configuration/preparing-for-users.adoc#images-configuration-registry-mirror-convert_post-install-preparing-for-users[Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring].
+
+[id="ocp-4-13-toolbox-deprecation"]
+==== Toolbox is deprecated in {op-system}
+The toolbox library is deprecated and support will be removed from a future {product-title} release.
 
 [id="ocp-4-13-removed-features"]
 === Removed features


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: n/a
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/jdohmann/minor-RN-edits/release_notes/ocp-4-13-release-notes.html#ocp-4-13-toolbox-deprecation
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: HAProxy update has been removed from the 4.13 program, toolbox deprecation as been added
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
