### PR TITLE
OCPBUG3527: Added "allow-from-router" part as well as references.

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -123,3 +123,49 @@ spec:
 `NetworkPolicy` objects are additive, which means you can combine multiple `NetworkPolicy` objects together to satisfy complex network requirements.
 
 For example, for the `NetworkPolicy` objects defined in previous samples, you can define both `allow-same-namespace` and `allow-http-and-https` policies within the same project. Thus allowing the pods with the label `role=frontend`, to accept any connection allowed by each policy. That is, connections on any port from pods in the same namespace, and connections on ports `80` and `443` from pods in any namespace.
+
+[id="nw-networkpolicy-allow-from-router_{context}"]
+== Using the allow-from-router network policy
+
+Use the following `NetworkPolicy` to allow external traffic regardless of the router configuration:
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-router
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/ingress:""<1>
+  podSelector: {}
+  policyTypes:
+  - Ingress
+----
+<1> `policy-group.network.openshift.io/ingress:""` label supports both Openshift-SDN and OVN-Kubernetes.
+
+
+[id="nw-networkpolicy-allow-from-hostnetwork_{context}"]
+== Using the allow-from-hostnetwork network policy
+
+Add the following `allow-from-hostnetwork` `NetworkPolicy` object to direct traffic from the host network pods:
+
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-from-hostnetwork
+spec:
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          policy-group.network.openshift.io/host-network:""
+  podSelector: {}
+  policyTypes:
+  - Ingress
+----

--- a/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
+++ b/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.adoc
@@ -55,8 +55,12 @@ include::modules/nw-ingress-sharding-route-configuration.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* The Ingress Operator manages wildcard DNS. For more information, see
-xref:../../networking/ingress-operator.adoc#configuring-ingress[Ingress Operator in {product-title}],
-xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Installing a cluster on bare metal], and
-xref:../../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[Installing a cluster on vSphere].
-endif::[]
+The Ingress Operator manages wildcard DNS. For more information, see the following:
+
+* xref:../../networking/ingress-operator.adoc#configuring-ingress[Ingress Operator in {product-title}].
+
+* xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Installing a cluster on bare metal].
+
+* xref:../../installing/installing_vsphere/installing-vsphere.adoc#installing-vsphere[Installing a cluster on vSphere].
+
+* xref:../../networking/network_policy/about-network-policy.adoc#about-network-policy[About network policy].


### PR DESCRIPTION
Versions: 4.11+

Scope: Added allow-from-router part and given the same references in other respective sections.

[OCPBUG 3527](https://issues.redhat.com/browse/OCPBUGS-3527)

Links to Doc Preview:
[Preview 1](https://57464--docspreview.netlify.app/openshift-enterprise/latest/networking/network_policy/about-network-policy.html#nw-networkpolicy-allow-from-router_about-network-policy)
[Preview 2](https://57464--docspreview.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-ingress-controller.html#additional-resources)

Additional Information: 
[Enhancement doc](https://github.com/openshift/enhancements/blob/ce4d303db807622687159eb9d3248285a003fabb/enhancements/network/allow-from-router-networkpolicy.md)
[PR-8572](https://github.com/openshift/cucushift/pull/8572/files)

QE review:

- [ ] QE has approved

@asood-rh ptal