### PR TITLE
TELCODOCS-1077 - Adding LVM via ZTP

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -170,3 +170,5 @@ endif::[]
 :osdk_ver: 1.25.4
 //Operator SDK version that shipped with the previous OCP 4.x release
 :osdk_ver_n1: 1.22.0
+:ztp-first: GitOps Zero Touch Provisioning (ZTP)
+:ztp: GitOps ZTP

--- a/modules/ztp-provisioning-lvm-storage.adoc
+++ b/modules/ztp-provisioning-lvm-storage.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
+
+:_content-type: PROCEDURE
+[id="ztp-provisioning-lvm-storage_{context}"]
+= Configuring {lvms} using PolicyGenTemplate CRs
+
+You can configure {lvms-first} for managed clusters that you deploy with {ztp-first}.
+
+[NOTE]
+====
+You use {lvms} to persist event subscriptions when you use PTP events or bare-metal hardware events with HTTP transport.
+====
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
+* Log in as a user with `cluster-admin` privileges.
+
+* Create a Git repository where you manage your custom site configuration data.
+
+.Procedure
+
+. To configure {lvms} for new managed clusters, add the following YAML to `spec.sourceFiles` in the `common-ranGen.yaml` file:
++
+[source,yaml,subs="attributes+"]
+----
+- fileName: StorageLVMOSubscriptionNS.yaml
+  policyName: subscription-policies
+- fileName: StorageLVMOSubscriptionOperGroup.yaml
+  policyName: subscription-policies
+- fileName: StorageLVMOSubscription.yaml
+  spec:
+    name: lvms-operator
+    channel: stable-{product-version}
+  policyName: subscription-policies
+----
+
+. Add the `LVMCluster` CR to `spec.sourceFiles` in your specific group or individual site configuration file. For example, in the `group-du-sno-ranGen.yaml` file, add the following:
++
+[source,yaml]
+----
+- fileName: StorageLVMCluster.yaml
+  policyName: "lvmo-config" <1>
+  spec:
+    storage:
+      deviceClasses:
+      - name: vg1
+        thinPoolConfig:
+          name: thin-pool-1
+          sizePercent: 90
+          overprovisionRatio: 10
+----
+<1> This example configuration creates a volume group (`vg1`) with all the available devices, except the disk where {product-title} is installed.
+A thin-pool logical volume is also created.
+
+. Merge any other required changes and files with your custom site repository.
+
+. Commit the `PolicyGenTemplate` changes in Git, and then push the changes to your site configuration repository to deploy {lvms} to new sites using {ztp}.

--- a/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
@@ -59,6 +59,8 @@ include::modules/ztp-using-pgt-to-configure-power-saving-mode.adoc[leveloffset=+
 
 include::modules/ztp-using-pgt-to-maximize-power-saving-mode.adoc[leveloffset=+2]
 
+include::modules/ztp-provisioning-lvm-storage.adoc[leveloffset=+1]
+
 include::modules/ztp-configuring-ptp-fast-events.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Adds ZTP procedure to adding LVM to managed clusters.
Version(s):
4.13+

https://issues.redhat.com/browse/TELCODOCS-1077

Link to docs preview:
https://57467--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html#ztp-provisioning-lvm-storage_ztp-advanced-policy-config

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
