### PR TITLE
OCPBUGS-9218: Editing note as mirroring is available for IPI too - CP to 4.10

### DIFF
--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -89,7 +89,8 @@ Mirroring does not support replacement of a failed disk. To restore the mirror t
 
 [NOTE]
 ====
-Mirroring is available only for user-provisioned infrastructure deployments on {op-system} systems. Mirroring support is available on x86_64 nodes booted with BIOS or UEFI and on ppc64le nodes.
+For user-provisioned infrastructure deployments, mirroring is available only on {op-system} systems.
+Support for mirroring is available on `x86_64` nodes booted with BIOS or UEFI and on `ppc64le` nodes.
 ====
 
 [id="installation-special-config-storage-procedure_{context}"]


### PR DESCRIPTION
CP to 4.10, relates to #57271 

OCPBUGS-9218: Updating note as mirroring is supported for IPI too. 

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OCPBUGS-9218

Link to docs preview:


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

