### PR TITLE
OCPBUGS#9218: Editing note as mirroring is available for IPI too - CP to 4.11

### DIFF
--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -90,7 +90,8 @@ Mirroring does not support replacement of a failed disk. To restore the mirror t
 
 [NOTE]
 ====
-Mirroring is available only for user-provisioned infrastructure deployments on {op-system} systems. Mirroring support is available on x86_64 nodes booted with BIOS or UEFI and on ppc64le nodes.
+For user-provisioned infrastructure deployments, mirroring is available only on {op-system} systems.
+Support for mirroring is available on `x86_64` nodes booted with BIOS or UEFI and on `ppc64le` nodes.
 ====
 
 [id="installation-special-config-storage-procedure_{context}"]


### PR DESCRIPTION
CP to 4.11, relates to #57271 

OCPBUGS-9218: Updating note as mirroring is supported for IPI too. 

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OCPBUGS-9218

Link to docs preview:
https://57492--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/installing-customizing.html#installation-special-config-mirrored-disk_installing-customizing 


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

