### PR TITLE
CNV-22622: Version bump for HCOVersion 4.12.2

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -104,7 +104,7 @@ endif::[]
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.12
 :KubeVirtVersion: v0.58.0
-:HCOVersion: 4.12.1
+:HCOVersion: 4.12.2
 :delete: image:delete.png[title="Delete"]
 ifdef::openshift-origin[]
 :VirtProductName: OKD Virtualization


### PR DESCRIPTION
**Version(s):**
4.12 only

**Issue:**
https://issues.redhat.com/browse/CNV-22622

**Link to docs preview:**
N/A

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
N/A