### PR TITLE
OSDOCS-5336: Adding PDBUnhealthyPodEvictionPolicy as tech preview fea…

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -32,6 +32,7 @@ The following Technology Preview features are enabled by this feature set:
 ** External cloud providers. Enables support for external cloud providers for clusters on vSphere, AWS, Azure, and GCP. Support for OpenStack is GA. (`ExternalCloudProvider`)
 ** Pod topology spread constraints. Enables the `matchLabelKeys` parameter for pod topology constraints. The parameter is list of pod label keys to select the pods over which spreading will be calculated. (`MatchLabelKeysInPodTopologySpread`)
 ** Pod security admission enforcement. Enables restricted enforcement for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)
+** Pod disruption budget (PDB) unhealthy pod eviction policy. Enables support for specifying how unhealthy pods are considered for eviction when using PDBs. (`PDBUnhealthyPodEvictionPolicy`)
 --
 
 ////

--- a/modules/nodes-pods-pod-disruption-configuring.adoc
+++ b/modules/nodes-pods-pod-disruption-configuring.adoc
@@ -33,7 +33,7 @@ spec:
 <2> The minimum number of pods that must be available simultaneously. This can
 be either an integer or a string specifying a percentage, for example, `20%`.
 <3> A label query over a set of resources. The result of `matchLabels` and
- `matchExpressions` are logically conjoined. Leave this paramter blank, for example `selector {}`, to select all pods in the project.
+ `matchExpressions` are logically conjoined. Leave this parameter blank, for example `selector {}`, to select all pods in the project.
 +
 Or:
 +
@@ -53,7 +53,7 @@ spec:
 <2> The maximum number of pods that can be unavailable simultaneously. This can
 be either an integer or a string specifying a percentage, for example, `20%`.
 <3> A label query over a set of resources. The result of `matchLabels` and
- `matchExpressions` are logically conjoined. Leave this paramter blank, for example `selector {}`, to select all pods in the project.
+ `matchExpressions` are logically conjoined. Leave this parameter blank, for example `selector {}`, to select all pods in the project.
 
 . Run the following command to add the object to project:
 +

--- a/modules/pod-disruption-eviction-policy.adoc
+++ b/modules/pod-disruption-eviction-policy.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-pods-configuring.adoc
+// * nodes/nodes-cluster-pods-configuring
+// * post_installation_configuration/cluster-tasks.adoc
+
+:_content-type: PROCEDURE
+[id="pod-disruption-eviction-policy_{context}"]
+= Specifying the eviction policy for unhealthy pods
+
+When you use pod disruption budgets (PDBs) to specify how many pods must be available simultaneously, you can also define the criteria for how unhealthy pods are considered for eviction.
+
+You can choose one of the following policies:
+
+IfHealthyBudget:: Running pods that are not yet healthy can be evicted only if the guarded application is not disrupted.
+
+AlwaysAllow:: Running pods that are not yet healthy can be evicted regardless of whether the criteria in the pod disruption budget is met. This policy can help evict malfunctioning applications, such as ones with pods stuck in the `CrashLoopBackOff` state or failing to report the `Ready` status.
+
+:FeatureName: Specifying the unhealthy pod eviction policy for pod disruption budgets
+include::snippets/technology-preview.adoc[]
+
+To use this Technology Preview feature, you must have enabled the `TechPreviewNoUpgrade` feature set.
+
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. You should not enable this feature set on production clusters.
+====
+
+.Procedure
+
+. Create a YAML file that defines a `PodDisruptionBudget` object and specify the unhealthy pod eviction policy:
++
+.Example `pod-disruption-budget.yaml` file
+[source,yaml]
+----
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: my-pdb
+spec:
+  minAvailable: 2
+  selector:
+    matchLabels:
+      foo: bar
+  unhealthyPodEvictionPolicy: AlwaysAllow <1>
+----
+<1> Choose either `IfHealthyBudget` or `AlwaysAllow` as the unhealthy pod eviction policy. The default is `IfHealthyBudget` when the `unhealthyPodEvictionPolicy` field is empty.
+
+. Create the `PodDisruptionBudget` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f pod-disruption-budget.yaml
+----
+
+With a PDB that has the `AlwaysAllow` unhealthy pod eviction policy set, you can now drain nodes and evict the pods for a malfunctioning application guarded by this PDB.

--- a/nodes/clusters/nodes-cluster-pods-configuring.adoc
+++ b/nodes/clusters/nodes-cluster-pods-configuring.adoc
@@ -10,7 +10,7 @@ As an administrator, you can create and maintain an efficient cluster for pods.
 
 By keeping your cluster efficient, you can provide a better environment for your developers using
 such tools as what a pod does when it exits, ensuring that the required number of pods is always running,
-when to restart pods designed to run only once, limit the bandwidth available to pods, and how to keep 
+when to restart pods designed to run only once, limit the bandwidth available to pods, and how to keep
 pods running during disruptions.
 
 // The following include statements pull in the module files that comprise
@@ -26,7 +26,14 @@ include::modules/nodes-pods-pod-disruption-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-pod-disruption-configuring.adoc[leveloffset=+2]
 
+include::modules/pod-disruption-eviction-policy.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy] in the Kubernetes documentation
+
 include::modules/nodes-pods-configuring-pod-critical.adoc[leveloffset=+1]
 
 // modules/nodes-pods-configuring-run-once.adoc[leveloffset=+1]
-

--- a/nodes/pods/nodes-pods-configuring.adoc
+++ b/nodes/pods/nodes-pods-configuring.adoc
@@ -10,7 +10,7 @@ As an administrator, you can create and maintain an efficient cluster for pods.
 
 By keeping your cluster efficient, you can provide a better environment for your developers using
 such tools as what a pod does when it exits, ensuring that the required number of pods is always running,
-when to restart pods designed to run only once, limit the bandwidth available to pods, and how to keep 
+when to restart pods designed to run only once, limit the bandwidth available to pods, and how to keep
 pods running during disruptions.
 
 // The following include statements pull in the module files that comprise
@@ -26,8 +26,14 @@ include::modules/nodes-pods-pod-disruption-about.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-pod-disruption-configuring.adoc[leveloffset=+2]
 
+include::modules/pod-disruption-eviction-policy.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy] in the Kubernetes documentation
+
 include::modules/nodes-pods-configuring-pod-critical.adoc[leveloffset=+1]
 
 // modules/nodes-pods-configuring-run-once.adoc[leveloffset=+1]
-
-

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -668,6 +668,13 @@ Understand and configure pod disruption budgets.
 
 include::modules/nodes-pods-pod-disruption-about.adoc[leveloffset=+2]
 include::modules/nodes-pods-pod-disruption-configuring.adoc[leveloffset=+2]
+include::modules/pod-disruption-eviction-policy.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling[Enabling features using feature gates]
+* link:https://kubernetes.io/docs/tasks/run-application/configure-pdb/#unhealthy-pod-eviction-policy[Unhealthy Pod Eviction Policy] in the Kubernetes documentation
 
 [id="post-install-rotate-remove-cloud-creds"]
 == Rotating or removing cloud provider credentials


### PR DESCRIPTION
…ture

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5336

Link to docs preview:
[https://57505--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#pod-disruption-evic[…]des-pods-configuring](https://57505--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#pod-disruption-eviction-policy_nodes-pods-configuring)
[https://57505--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster[…]ster-enabling](https://57505--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
