### PR TITLE
OSDOCS-5336: Release notes for PDB unhealthy eviction policy

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -436,6 +436,20 @@ The crun low-level container runtime is now generally available in {product-titl
 
 Linux Control Group version 2 (cgroup v2) is now generally available in {product-title} 4.13. There is no new functionality in the GA version.
 
+[id="ocp-4-13-pdb-eviction-policy"]
+==== Pod disruption budget (PDB) unhealthy pod eviction policy (Technology Preview)
+
+With this release, specifying an unhealthy pod eviction policy for pod disruption budgets (PDBs) is available as a Technology Preview feature. This can help evict malfunctioning applications during a node drain.
+
+To use this Technology Preview feature, you must enable the `TechPreviewNoUpgrade` feature set.
+
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. You should not enable this feature set on production clusters.
+====
+
+For more information, see xref:../nodes/pods/nodes-pods-configuring.adoc#pod-disruption-eviction-policy_nodes-pods-configuring[Specifying the eviction policy for unhealthy pods].
+
 [id="ocp-4-13-monitoring"]
 === Monitoring
 The monitoring stack for this release includes the following new and modified features.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5336

Link to docs preview:
https://57512--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-pdb-eviction-policy

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The link at the end of the section won't jump to the right module yet, because it depends on #57505 being merged first.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
