### PR TITLE
OSDOCS-5157:Updates to dynamic plugin extensions and api docs

### DIFF
--- a/modules/dynamic-plug-in-api.adoc
+++ b/modules/dynamic-plug-in-api.adoc
@@ -2,15 +2,21 @@
 //
 // * web_console/dynamic-plug-ins-reference.adoc
 
+:power-bi-url:
+https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html
+//needed to add an attribute for the url because escaping the underscore in the link would not work and the build was failing.
+
 :_content-type: REFERENCE
 [id="dynamic-plug-in-api_{context}"]
 = {product-title} console API
+:source-highlighter: rouge
 
 [discrete]
 == `useActivePerspective`
 
 Hook that provides the currently active perspective and a callback for setting the active perspective. It returns a tuple containing the current active perspective and setter callback.
 
+.Example
 [source,tsx]
 ----
 const Component: React.FC = (props) => {
@@ -31,6 +37,7 @@ const Component: React.FC = (props) => {
 
 Component for displaying a green check mark circle icon.
 
+.Example
 [source,tsx]
 ----
 <GreenCheckCircleIcon title="Healthy" />
@@ -49,6 +56,7 @@ Component for displaying a green check mark circle icon.
 
 Component for displaying a red exclamation mark circle icon.
 
+.Example
 [source,tsx]
 ----
 <RedExclamationCircleIcon title="Failed" />
@@ -67,6 +75,7 @@ Component for displaying a red exclamation mark circle icon.
 
 Component for displaying a yellow triangle exclamation icon.
 
+.Example
 [source,tsx]
 ----
 <YellowExclamationTriangleIcon title="Warning" />
@@ -85,6 +94,7 @@ Component for displaying a yellow triangle exclamation icon.
 
 Component for displaying a blue info circle icon.
 
+.Example
 [source,tsx]
 ----
 <BlueInfoCircleIcon title="Info" />
@@ -103,6 +113,7 @@ Component for displaying a blue info circle icon.
 
 Component for displaying an error status popover.
 
+.Example
 [source,tsx]
 ----
 <ErrorStatus title={errorMsg} />
@@ -123,6 +134,7 @@ Component for displaying an error status popover.
 
 Component for displaying an information status popover.
 
+.Example
 [source,tsx]
 ----
 <InfoStatus title={infoMsg} />
@@ -143,6 +155,7 @@ Component for displaying an information status popover.
 
 Component for displaying a progressing status popover.
 
+.Example
 [source,tsx]
 ----
 <ProgressStatus title={progressMsg} />
@@ -163,6 +176,7 @@ Component for displaying a progressing status popover.
 
 Component for displaying a success status popover.
 
+.Example
 [source,tsx]
 ----
 <SuccessStatus title={successMsg} />
@@ -207,7 +221,8 @@ Hook that provides information about user access to a given resource. It returns
 
 React hook for consuming Console extensions with resolved `CodeRef` properties. This hook accepts the same argument(s) as `useExtensions` hook and returns an adapted list of extension instances, resolving all code references within each extension's properties. Initially, the hook returns an empty array. Once the resolution is complete, the React component is re-rendered with the hook returning an adapted list of extensions. When the list of matching extensions changes, the resolution is restarted. The hook will continue to return the previous result until the resolution completes. The hook's result elements are guaranteed to be referentially stable across re-renders. It returns a tuple containing a list of adapted extension instances with resolved code references, a boolean flag indicating whether the resolution is complete, and a list of errors detected during the resolution.
 
-[source,tsx]
+.Example
+[source,ts]
 ----
 const [navItemExtensions, navItemsResolved] = useResolvedExtensions<NavItem>(isNavItem);
 // process adapted extensions and render your component
@@ -226,7 +241,9 @@ not the extension meets desired type constraints
 
 A component that creates a Navigation bar for a page.- Routing is handled as part of the component.- `console.tab/horizontalNav` can be used to add additional content to any horizontal nav.
 
-[source,tsx]
+.Example
+
+[source,jsx]
 ----
 const HomePage: React.FC = (props) => {
     const page = {
@@ -254,7 +271,8 @@ K8sResourceCommon type
 
 A component for making virtualized tables.
 
-[source,tsx]
+.Example
+[source,text]
 ----
 const MachineList: React.FC<MachineListProps> = (props) => {
   return (
@@ -292,7 +310,8 @@ const MachineList: React.FC<MachineListProps> = (props) => {
 
 Component for displaying table data within a table row.
 
-[source,tsx]
+.Example
+[source,jsx]
 
 ----
 const PodRow: React.FC<RowProps<K8sResourceCommon>> = ({ obj, activeColumnIDs }) => {
@@ -322,15 +341,16 @@ const PodRow: React.FC<RowProps<K8sResourceCommon>> = ({ obj, activeColumnIDs })
 
 A hook that provides a list of user-selected active TableColumns.
 
-[source,tsx]
+.Example
+[source,text]
 ----
-  // See implementation for more details on TableColumn type
+// See implementation for more details on TableColumn type
   const [activeColumns, userSettingsLoaded] = useActiveColumns({
     columns,
     showNamespaceOverride: false,
     columnManagementID,
   });
-  return userSettingsAreLoaded ? <VirtualizedTable columns= {activeColumns} {...otherProps} /> : null
+  return userSettingsAreLoaded ? <VirtualizedTable columns={activeColumns} {...otherProps} /> : null
 ----
 
 [cols=",",options="header",]
@@ -338,14 +358,14 @@ A hook that provides a list of user-selected active TableColumns.
 |Parameter Name |Description
 |`options` |Which are passed as a key-value map
 
-|`` |\{TableColumn[]} options.columns - An array of all available
+|`\{TableColumn[]} options.columns` | An array of all available
 TableColumns
 
-|`` |\{boolean} [options.showNamespaceOverride] - (optional) If true, a
+|`\{boolean} [options.showNamespaceOverride]` |(optional) If true, a
 namespace column will be included, regardless of column management
 selections
 
-|`` |\{string} [options.columnManagementID] - (optional) A unique id
+|`\{string} [options.columnManagementID]` |(optional) A unique id
 used to persist and retrieve column management selections to and from
 user settings. Usually a 'group~verion~kind' string for a resource.
 |===
@@ -357,7 +377,8 @@ A tuple containing the current user selected active columns (a subset of options
 
 Component for generating a page header.
 
-[source,tsx]
+.Example
+[source,jsx]
 ----
 const exampleList: React.FC = () => {
   return (
@@ -381,7 +402,8 @@ const exampleList: React.FC = () => {
 
 Component for adding a create button for a specific resource kind that automatically generates a link to the create YAML for this resource.
 
-[source,tsx]
+.Example
+[source,jsx]
 ----
 const exampleList: React.FC<MyProps> = () => {
   return (
@@ -405,7 +427,8 @@ const exampleList: React.FC<MyProps> = () => {
 
 Component for creating a stylized link.
 
-[source,tsx]
+.Example
+[source,jsx]
 ----
 const exampleList: React.FC<MyProps> = () => {
  return (
@@ -434,7 +457,8 @@ determine access
 
 Component for creating button.
 
-[source,tsx]
+.Example
+[source,jsx]
 ----
 const exampleList: React.FC<MyProps> = () => {
   return (
@@ -461,7 +485,8 @@ determine access
 
 Component for creating a dropdown wrapped with permissions check.
 
-[source,tsx]
+.Example
+[source,jsx]
 ----
 const exampleList: React.FC<MyProps> = () => {
   const items = {
@@ -496,6 +521,7 @@ determine access
 
 Component that generates filter for list page.
 
+.Example
 [source,tsx]
 ----
   // See implementation for more details on RowFilter and FilterValue types
@@ -547,6 +573,7 @@ both name and label filter
 
 A hook that manages filter state for the ListPageFilter component. It returns a tuple containing the data filtered by all static filters, the data filtered by all static and row filters, and a callback that updates rowFilters.
 
+.Example
 [source,tsx]
 ----
   // See implementation for more details on RowFilter and FilterValue types
@@ -584,6 +611,7 @@ statically applied to the data
 
 Component that creates a link to a specific resource type with an icon badge.
 
+.Example
 [source,tsx]
 ----
   <ResourceLink
@@ -598,7 +626,7 @@ Component that creates a link to a specific resource type with an icon badge.
 |Parameter Name |Description
 |`kind` |(optional) the kind of resource i.e. Pod, Deployment, Namespace
 
-|`groupVersionKind` |(optional) object with groupd, version, and kind
+|`groupVersionKind` |(optional) object with group, version, and kind
 
 |`className` |(optional) class style for component
 
@@ -631,6 +659,7 @@ link to
 
 Component that creates an icon badge for a specific resource type.
 
+.Example
 [source,tsx]
 ----
 <ResourceIcon kind="Pod"/>
@@ -649,7 +678,8 @@ Component that creates an icon badge for a specific resource type.
 
 Hook that retrieves the k8s model for provided K8sGroupVersionKind from redux. It returns an array with the first item as k8s model and second item as `inFlight` status.
 
-[source,tsx]
+.Example
+[source,ts]
 ----
 const Component: React.FC = () => {
   const [model, inFlight] = useK8sModel({ group: 'app'; version: 'v1'; kind: 'Deployment' });
@@ -660,10 +690,9 @@ const Component: React.FC = () => {
 [cols=",",options="header",]
 |===
 |Parameter Name |Description
-|`groupVersionKind` |group, version, kind of k8s resource \{@link
-K8sGroupVersionKind} is preferred alternatively can pass reference for
-group, version, kind which is deprecated i.e `group~version~kind`
-\{@link K8sResourceKindReference}.
+|`groupVersionKind` |group, version, kind of k8s resource
+K8sGroupVersionKind is preferred alternatively can pass reference for
+group, version, kind which is deprecated i.e `group~version~kind` K8sResourceKindReference.
 |===
 
 [discrete]
@@ -671,7 +700,8 @@ group, version, kind which is deprecated i.e `group~version~kind`
 
 Hook that retrieves all current k8s models from redux. It returns an array with the first item as the list of k8s model and second item as `inFlight` status.
 
-[source,tsx]
+.Example
+[source,ts]
 ----
 const Component: React.FC = () => {
   const [models, inFlight] = UseK8sModels();
@@ -684,7 +714,8 @@ const Component: React.FC = () => {
 
 Hook that retrieves the k8s resource along with status for loaded and error. It returns an array with first item as resource(s), second item as loaded status and third item as error state if any.
 
-[source,tsx]
+.Example
+[source,ts]
 ----
 const Component: React.FC = () => {
   const watchRes = {
@@ -706,6 +737,7 @@ const Component: React.FC = () => {
 
 Hook that retrieves the k8s resources along with their respective status for loaded and error. It returns a map where keys are as provided in initResouces and value has three properties data, loaded and error.
 
+.Example
 [source,tsx]
 ----
 const Component: React.FC = () => {
@@ -801,23 +833,21 @@ model. In case of failure, the promise gets rejected with HTTP error response.
 |Parameter Name |Description
 |`options` |Which are passed as key-value pairs in the map
 
-|`` |options.model - k8s model
+|`options.model` |k8s model
 
-|`` |options.name - The name of the resource, if not provided then it'll
+|`options.name` |The name of the resource, if not provided then it'll
 look for all the resources matching the model.
 
-|`` |options.ns - The namespace to look into, should not be specified
+|`options.ns` | The namespace to look into, should not be specified
 for cluster-scoped resources.
 
-|`` |options.path - Appends as subpath if provided
+|`options.path` |Appends as subpath if provided
 
-|`` |options.queryParams - The query parameters to be included in the
+|`options.queryParams` |The query parameters to be included in the
 URL.
 
-|`` |options.requestInit - The fetch init object to use. This can have
-request headers, method, redirect, etc. See more (link:
-https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html)
-
+|`options.requestInit` |The fetch init object to use. This can have
+request headers, method, redirect, etc. See more link:{power-bi-url}[Interface RequestInit]
 |===
 
 [discrete]
@@ -830,13 +860,13 @@ It creates a resource in the cluster, based on the provided options. It returns 
 |Parameter Name |Description
 |`options` |Which are passed as key-value pairs in the map
 
-|`` |options.model - k8s model
+|`options.model` |k8s model
 
-|`` |options.data - payload for the resource to be created
+|`options.data` |payload for the resource to be created
 
-|`` |options.path - Appends as subpath if provided
+|`options.path` |Appends as subpath if provided
 
-|`` |options.queryParams - The query parameters to be included in the
+|`options.queryParams` |The query parameters to be included in the
 URL.
 |===
 
@@ -850,18 +880,18 @@ It updates the entire resource in the cluster, based on providedoptions. When a 
 |Parameter Name |Description
 |`options` |which are passed as key-value pair in the map
 
-|`` |options.model - k8s model
+|`options.model` | k8s model
 
-|`` |options.data - payload for the k8s resource to be updated
+|`options.data` |payload for the k8s resource to be updated
 
-|`` |options.ns - namespace to look into, it should not be specified for
+|`options.ns` |namespace to look into, it should not be specified for
 cluster-scoped resources.
 
-|`` |options.name - resource name to be updated.
+|`options.name` |resource name to be updated.
 
-|`` |options.path - Appends as subpath if provided
+|`options.path` | Appends as subpath if provided
 
-|`` |options.queryParams - The query parameters to be included in the
+|`options.queryParams` | The query parameters to be included in the
 URL.
 |===
 
@@ -876,16 +906,16 @@ k8sPatch. Alternatively can use k8sUpdate to replace an existing resource entire
 |Parameter Name |Description
 |`options` |Which are passed as key-value pairs in the map.
 
-|`` |options.model - k8s model
+|`options.model` | k8s model
 
-|`` |options.resource - The resource to be patched.
+|`options.resource` |The resource to be patched.
 
-|`` |options.data - Only the data to be patched on existing resource
+|`options.data` |Only the data to be patched on existing resource
 with the operation, path, and value.
 
-|`` |options.path - Appends as subpath if provided.
+|`options.path` |Appends as subpath if provided.
 
-|`` |options.queryParams - The query parameters to be included in the
+|`options.queryParams` | The query parameters to be included in the
 URL.
 |===
 
@@ -894,30 +924,29 @@ URL.
 
 It deletes resources from the cluster, based on the provided model, resource. The garbage collection works based on 'Foreground'|'Background', can be configured with propagationPolicy property in provided model or passed in json. It returns a promise that resolves to the response of kind Status. In case of failure promise gets rejected with HTTP error response.
 
-....
-{ kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy }
-....
+.Example
+`kind: 'DeleteOptions', apiVersion: 'v1', propagationPolicy`
+
 
 [cols=",",options="header",]
 |===
 |Parameter Name |Description
 |`options` |which are passed as key-value pair in the map.
 
-|`` |options.model - k8s model
+|`options.model` | k8s model
 
-|`` |options.resource - The resource to be deleted.
+|`options.resource` | The resource to be deleted.
 
-|`` |options.path - Appends as subpath if provided
+|`options.path` |Appends as subpath if provided
 
-|`` |options.queryParams - The query parameters to be included in the
+|`options.queryParams` |The query parameters to be included in the
 URL.
 
-|`` |options.requestInit - The fetch init object to use. This can have
-request headers, method, redirect, etc. See more \{@link
-https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html
-}
+|`options.requestInit` |The fetch init object to use. This can have
+request headers, method, redirect, etc. See more link:{power-bi-url}[Interface Request Init]
 
-|`` |options.json - Can control garbage collection of resources
+
+|`options.json` |Can control garbage collection of resources
 explicitly if provided else will default to model's "propagationPolicy".
 |===
 
@@ -931,21 +960,19 @@ Lists the resources as an array in the cluster, based on provided options. It re
 |Parameter Name |Description
 |`options` |Which are passed as key-value pairs in the map
 
-|`` |options.model - k8s model
+|`options.model` |k8s model
 
-|`` |options.queryParams - The query parameters to be included in the
+|`options.queryParams` |The query parameters to be included in the
 URL and can pass label selector's as well with key "labelSelector".
 
-|`` |options.requestInit - The fetch init object to use. This can have
-request headers, method, redirect, etc. See more \{@link
-https://microsoft.github.io/PowerBI-JavaScript/interfaces/_node_modules_typedoc_node_modules_typescript_lib_lib_dom_d_.requestinit.html
-}
+|`options.requestInit` |The fetch init object to use. This can have
+request headers, method, redirect, etc. See more link:{power-bi-url}[Interface RequestInit]
 |===
 
 [discrete]
 == `k8sListResourceItems`
 
-Same interface as \{@link k8sListResource} but returns the sub items. It returns the apiVersion for the model i.e `group/version`.
+Same interface as k8sListResource but returns the sub items. It returns the apiVersion for the model i.e `group/version`.
 
 [discrete]
 == `getAPIVersionForModel`
@@ -985,6 +1012,7 @@ Provides a group, version, and kind for a k8s model. This returns the group, ver
 
 Component that shows the status in a popup window. Helpful component for building `console.dashboards/overview/health/resource` extensions.
 
+.Example
 [source,tsx]
 ----
   <StatusPopupSection
@@ -1013,7 +1041,8 @@ Component that shows the status in a popup window. Helpful component for buildin
 
 Status element used in status popup; used in `StatusPopupSection`.
 
-[source,tsx]
+.Example
+[source,text]
 ----
 <StatusPopupSection
    firstColumn='Example'
@@ -1041,7 +1070,8 @@ Status element used in status popup; used in `StatusPopupSection`.
 
 Creates a wrapper component for a dashboard.
 
-[source,tsx]
+.Example
+[source,text]
 ----
     <Overview>
       <OverviewGrid mainCards={mainCards} leftCards={leftCards} rightCards={rightCards} />
@@ -1060,7 +1090,8 @@ Creates a wrapper component for a dashboard.
 
 Creates a grid of card elements for a dashboard; used within `Overview`.
 
-[source,tsx]
+.Example
+[source,text]
 ----
     <Overview>
       <OverviewGrid mainCards={mainCards} leftCards={leftCards} rightCards={rightCards} />
@@ -1080,6 +1111,7 @@ Creates a grid of card elements for a dashboard; used within `Overview`.
 
 Creates an inventory card item.
 
+.Example
 [source,tsx]
 ----
   return (
@@ -1103,6 +1135,7 @@ Creates an inventory card item.
 
 Creates a title for an inventory card item; used within `InventoryItem`.
 
+.Example
 [source,tsx]
 ----
  return (
@@ -1126,6 +1159,7 @@ Creates a title for an inventory card item; used within `InventoryItem`.
 
 Creates the body of an inventory card; used within `InventoryCard` and can be used with `InventoryTitle`.
 
+.Example
 [source,tsx]
 ----
  return (
@@ -1150,6 +1184,7 @@ Creates the body of an inventory card; used within `InventoryCard` and can be us
 
 Creates a count and icon for an inventory card with optional link address; used within `InventoryItemBody`
 
+.Example
 [source,tsx]
 ----
  return (
@@ -1175,6 +1210,7 @@ Creates a count and icon for an inventory card with optional link address; used 
 
 Creates a skeleton container for when an inventory card is loading; used with `InventoryItem` and related components
 
+.Example
 [source,tsx]
 ----
 if (loadError) {
@@ -1205,7 +1241,8 @@ Hook that returns the given feature flag from FLAGS redux state. It returns the 
 
 A basic lazy loaded YAML editor with hover help and completion.
 
-[source,tsx]
+.Example
+[source,text]
 ----
 <React.Suspense fallback={<LoadingBox />}>
   <YAMLEditor
@@ -1219,8 +1256,7 @@ A basic lazy loaded YAML editor with hover help and completion.
 |Parameter Name |Description
 |`value` |String representing the yaml code to render.
 
-|`options` |Monaco editor options. For more details, please, visit
-https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneEditorConstructionOptions.html.
+|`options` |Monaco editor options.
 
 |`minHeight` |Minimum editor height in valid CSS height values.
 
@@ -1235,17 +1271,16 @@ section on top of the editor.
 
 |`ref` |React reference to `{ editor?: IStandaloneCodeEditor }`. Using
 the 'editor' property, you are able to access to all methods to control
-the editor. For more information, visit
-https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneCodeEditor.html.
+the editor.
 |===
 
 [discrete]
 == `ResourceYAMLEditor`
 
-A lazy loaded YAML editor for Kubernetes resources with hover help and completion. The component use the YAMLEditor and add on top of it more functionality likeresource update handling, alerts, save, cancel and reload buttons, accessibility and more. Unless `onSave` callback is provided, the resource update is automatically handled.It should be
-wrapped in a React.Suspense component.
+A lazy loaded YAML editor for Kubernetes resources with hover help and completion. The component use the YAMLEditor and add on top of it more functionality likeresource update handling, alerts, save, cancel and reload buttons, accessibility and more. Unless `onSave` callback is provided, the resource update is automatically handled.It should be wrapped in a React.Suspense component.
 
-[source,tsx]
+.Example
+[source,text]
 ----
 <React.Suspense fallback={<LoadingBox />}>
   <ResourceYAMLEditor
@@ -1273,6 +1308,7 @@ default update performed on the resource by the editor
 
 A component to show events related to a particular resource.
 
+.Example
 [source,tsx]
 ----
 const [resource, loaded, loadError] = useK8sWatchResource(clusterResource);
@@ -1293,24 +1329,24 @@ Sets up a poll to Prometheus for a single query. It returns a tuple containing t
 [cols=",",options="header",]
 |===
 |Parameter Name |Description
-|`` |\{PrometheusEndpoint} props.endpoint - one of the
+|`\{PrometheusEndpoint} props.endpoint` |one of the
 PrometheusEndpoint (label, query, range, rules, targets)
 
-|`` |\{string} [props.query] - (optional) Prometheus query string. If
+|`\{string} [props.query]` |(optional) Prometheus query string. If
 empty or undefined, polling is not started.
 
-|`` |\{number} [props.delay] - (optional) polling delay interval (ms)
+|`\{number} [props.delay]` |(optional) polling delay interval (ms)
 
-|`` |\{number} [props.endTime] - (optional) for QUERY_RANGE enpoint, end
+|`\{number} [props.endTime]` |(optional) for QUERY_RANGE enpoint, end
 of the query range
 
-|`` |\{number} [props.samples] - (optional) for QUERY_RANGE enpoint
+|`\{number} [props.samples]` |(optional) for QUERY_RANGE enpoint
 
-|`` |\{number} [options.timespan] - (optional) for QUERY_RANGE enpoint
+|`\{number} [options.timespan]` | (optional) for QUERY_RANGE enpoint
 
-|`` |\{string} [options.namespace] - (optional) a search param to append
+|`\{string} [options.namespace]` | (optional) a search param to append
 
-|`` |\{string} [options.timeout] - (optional) a search param to append
+|`\{string} [options.timeout]` | (optional) a search param to append
 |===
 
 [discrete]
@@ -1337,6 +1373,7 @@ tooltip.
 
 A hook to launch Modals.
 
+.Example
 [source,tsx]
 ----
 const context: AppPage: React.FC = () => {<br/> const [launchModal] = useModal();<br/> const onClick = () => launchModal(ModalComponent);<br/> return (<br/>   <Button onClick={onClick}>Launch a Modal</Button><br/> )<br/>}<br/>`
@@ -1347,7 +1384,8 @@ const context: AppPage: React.FC = () => {<br/> const [launchModal] = useModal()
 
 Component that allows to receive contributions from other plugins for the `console.action/provider` extension type.
 
-[source,tsx]
+.Example
+[source,text]
 ----
    const context: ActionContext = { 'a-context-id': { dataFromDynamicPlugin } };
 
@@ -1373,7 +1411,8 @@ Component that allows to receive contributions from other plugins for the `conso
 
 A component that renders a horizontal toolbar with a namespace dropdown menu in the leftmost position. Additional components can be passed in as children and will be rendered to the right of the namespace dropdown. This component is designed to be used at the top of the page. It should be used on pages where the user needs to be able to change the active namespace, such as on pages with k8s resources.
 
-[source,tsx]
+.Example
+[source,text]
 ----
    const logNamespaceChange = (namespace) => console.log(`New namespace: ${namespace}`);
 
@@ -1411,6 +1450,7 @@ toolbar to the right of the namespace dropdown.
 
 Creates full page ErrorBoundaryFallbackPage component to display the "Oh no! Something went wrong." message along with the stack trace and other helpful debugging information. This is to be used inconjunction with an component.
 
+.Example
 [source,tsx]
 ----
 //in ErrorBoundary component

--- a/modules/dynamic-plug-in-sdk-extensions.adoc
+++ b/modules/dynamic-plug-in-sdk-extensions.adoc
@@ -82,18 +82,22 @@ which returns actions for the given resource model
 [discrete]
 == `console.alert-action`
 
+This extension can be used to trigger a specific action when a specific Prometheus alert is observed by the Console based on its `rule.name` value.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
-|`alert` |`string` |no |
+|`alert` |`string` |no | Alert name as defined by `alert.rule.name` property
 
 |`text` |`string` |no |
 
-|`action` |`CodeRef<(alert: any) => void>` |no |
+|`action` |`CodeRef<(alert: any) => void>` |no | Function to perform side effect |
 |===
 
 [discrete]
 == `console.catalog/item-filter`
+
+This extension can be used for plugins to contribute a handler that can filter specific catalog items. For example, the plugin can contribute a filter that filters helm charts from specific provider.
 
 [cols=",,,",options="header",]
 |===
@@ -111,6 +115,8 @@ returns a subset based on the filter criteria.
 [discrete]
 == `console.catalog/item-metadata`
 
+This extension can be used to contribute a provider that adds extra metadata to specific catalog items.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -126,6 +132,8 @@ catalog this provider contributes to.
 
 [discrete]
 == `console.catalog/item-provider`
+
+This extension allows plugins to contribute a provider for a catalog item type. For example, a Helm Plugin can add a provider that fetches all the Helm Charts. This extension can also be used by other plugins to add more items to a specific catalog item type.
 
 [cols=",,,",options="header",]
 |===
@@ -150,6 +158,8 @@ providers.
 [discrete]
 == `console.catalog/item-type`
 
+This extension allows plugins to contribute a new type of catalog item. For example, a Helm plugin can define a new catalog item type as HelmCharts that it wants to contribute to the Developer Catalog.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -172,6 +182,8 @@ to the catalog item.
 
 [discrete]
 == `console.catalog/item-type-metadata`
+
+This extension allows plugins to contribute extra metadata like custom filters or groupings for any catalog item type. For example, a plugin can attach a custom filter for HelmCharts that can filter based on chart provider.
 
 [cols=",,,",options="header",]
 |===
@@ -277,6 +289,25 @@ Ignored for small screens; defaults to `12`.
 |===
 
 [discrete]
+== `console.dashboards/custom/overview/detail/item`
+
+Adds an item to the Details card of Overview Dashboard
+
+[cols=",,,",options="header",]
+|===
+|Name |Value Type |Optional |Description
+|`title` |`string` |no | Details card title.
+
+|`component` |`CodeRef<React.ComponentType<{}>>` |no | The value, rendered by the OverviewDetailItem component
+
+|`valueClassName` |`string` |yes | Value for a className
+
+|`isLoading` |`CodeRef<() => boolean>` |yes | Function returning the loading state of the component
+
+| `error` | `CodeRef<() => string>` | yes | Function returning errors to be displayed by the component
+|===
+
+[discrete]
 == `console.dashboards/overview/activity/resource`
 
 Adds an activity to the Activity Card of Overview Dashboard where the triggering of activity is based on watching a Kubernetes resource.
@@ -296,18 +327,6 @@ every resource represents activity.
 
 |`getTimestamp` |`CodeRef<(resource: T) => Date>` |yes |Time stamp for
 the given action, which will be used for ordering.
-|===
-
-[discrete]
-== `console.dashboards/overview/detail/item`
-
-Adds an item to the *Details* card of *Overview* dashboard.
-
-[cols=",,,",options="header",]
-|===
-|Name |Value Type |Optional |Description
-|`component` |`CodeRef<React.ComponentType<{}>>` |no |The value, based
-on the `DetailItem` component
 |===
 
 [discrete]
@@ -399,16 +418,12 @@ Adds a health subsystem to the status card of Overview dashboard where the sourc
 |`url` |`string` |no |The URL to fetch data from. It will be prefixed
 with base Kubernetes URL.
 
-|`healthHandler`
-|`CodeRef<URLHealthHandler<T, K8sResourceCommon | K8sResourceCommon[]>>`
-|no |Resolve the subsystem's health.
+|`healthHandler`|`CodeRef<URLHealthHandler<T, K8sResourceCommon \| K8sResourceCommon[]>>`|no |Resolve the subsystem's health.
 
 |`additionalResource` |`CodeRef<FirehoseResource>` |yes |Additional
 resource which will be fetched and passed to `healthHandler`.
 
-|`popupComponent`
-|`CodeRef<React.ComponentType<{ healthResult?: T; healthResultError?: any; k8sResult?: FirehoseResult<R>; }>>`
-|yes |Loader for popup content. If defined, a health item will be
+|`popupComponent`|`CodeRef<React.ComponentType<{ healthResult?: T; healthResultError?: any; k8sResult?: FirehoseResult<R>; }>>`|yes |Loader for popup content. If defined, a health item will be
 represented as a link which opens popup with given content.
 
 |`popupTitle` |`string` |yes |The title of the popover.
@@ -519,6 +534,8 @@ and when adding cards to this tab.
 [discrete]
 == `console.file-upload`
 
+This extension can be used to provide a handler for the file drop action on specific file extensions.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -567,6 +584,8 @@ Adds a new web console feature flag driven by the presence of a CRD on the clust
 [discrete]
 == `console.global-config`
 
+This extension identifies a resource used to manage the configuration of the cluster.<br/>A link to the resource will be added to the Administration - Cluster Settings - Configuration page.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -611,6 +630,8 @@ uppercase characters in `kind`, up to 4 characters long. Requires that `kind` is
 [discrete]
 == `console.navigation/href`
 
+This extension can be used to contribute a navigation item that points to a specific link in the UI.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -647,6 +668,8 @@ item referenced here. For arrays, the first one found in order is used.
 [discrete]
 == `console.navigation/resource-cluster`
 
+This extension can be used to contribute a navigation item that points to a cluster resource details page. The K8s model of that resource can be used to define the navigation item.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -680,6 +703,8 @@ name of the link will equal the plural value of the model.
 
 [discrete]
 == `console.navigation/resource-ns`
+
+This extension can be used to contribute a navigation item that points to a namespaced resource details page. The K8s model of that resource can be used to define the navigation item.
 
 [cols=",,,",options="header",]
 |===
@@ -715,6 +740,8 @@ name of the link will equal the plural value of the model.
 [discrete]
 == `console.navigation/section`
 
+This extension can be used to define a new section of navigation items in the navigation tab.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -739,6 +766,8 @@ separator will be shown above the section.
 
 [discrete]
 == `console.navigation/separator`
+
+This extension can be used to add a separator between navigation items in the navigation.
 
 [cols=",,,",options="header",]
 |===
@@ -836,6 +865,8 @@ the `location.pathname` exactly.
 [discrete]
 == `console.perspective`
 
+This extension contributes a new perspective to the console which enables customization of the navigation menu.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -905,6 +936,8 @@ query.
 [discrete]
 == `console.pvc/alert`
 
+This extension can be used to contribute custom alerts on the PVC details page.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -915,6 +948,8 @@ query.
 [discrete]
 == `console.pvc/create-prop`
 
+This extension can be used to specify additional properties that will be used when creating PVC resources on the PVC list page.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -924,6 +959,8 @@ query.
 
 [discrete]
 == `console.pvc/delete`
+
+This extension allows hooking into deleting PVC resources. It can provide an alert with additional information and custom PVC delete logic.
 
 [cols=",,,",options="header",]
 |===
@@ -971,6 +1008,8 @@ function, operating on the reducer-managed substate.
 [discrete]
 == `console.resource/create`
 
+This extension allows plugins to provide a custom component (ie wizard or form) for specific resources, which will be rendered, when users try to create a new resource instance.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -983,20 +1022,60 @@ component to be rendered when the model matches
 |===
 
 [discrete]
-== `console.storage-provider`
+== `console.storage-class/provisioner`
+
+Adds a new storage class provisioner as an option during storage class creation.
 
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
-|`name` |`string` |no |
+|`CSI` |`ProvisionerDetails` |yes | Container Storage Interface provisioner type
+
+|`OTHERS`
+|`ProvisionerDetails`
+|yes
+|Other provisioner type
+|===
+
+[discrete]
+== `console.storage-provider`
+
+This extension can be used to contribute a new storage provider to select, when attaching storage and a provider specific component.
+
+[cols=",,,",options="header",]
+|===
+|Name |Value Type |Optional |Description
+|`name` |`string` |no | Displayed name of the provider.
 
 |`Component`
 |`CodeRef<React.ComponentType<Partial<RouteComponentProps<{}, StaticContext, any>>>>`
-|no |
+|no | Provider specific component to render. |
+|===
+
+[discrete]
+== `console.tab`
+
+Adds a tab to a horizontal nav matching the `contextId`.
+
+[cols=",,,",options="header",]
+|===
+|Name |Value Type |Optional |Description
+|`contextId` |`string` |no | Context ID assigned to the horizontal nav in which the tab will be injected. Possible values:`dev-console-observe`
+
+
+|`name` |`string` |no | The display label of the tab
+
+|`href` |`string` |no | The href appended to the existing URL
+
+|`component`
+|`CodeRef<React.ComponentType<PageComponentProps<K8sResourceCommon>>>`
+|no |Tab content component.
 |===
 
 [discrete]
 == `console.tab/horizontalNav`
+
+This extension can be used to add a tab on the resource details page.
 
 [cols=",,,",options="header",]
 |===
@@ -1015,6 +1094,8 @@ horizontal tab. It takes tab name as name and href of the tab
 [discrete]
 == `console.telemetry/listener`
 
+This component can be used to register a listener function receiving telemetry events. These events include user identification, page navigation, and other application specific events. The listener may use this data for reporting and analytics purposes.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -1025,14 +1106,14 @@ events
 [discrete]
 == `console.topology/adapter/build`
 
-`BuildAdapter` contributes an adapter to adapt element to data that can be used by the `Build` component.
+`BuildAdapter` contributes an adapter to adapt element to data that can be used by the Build component.
 
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
 |`adapt`
-|`CodeRef<(element: GraphElement) => AdapterDataType<BuildConfigData> | undefined>`
-|no |
+|`CodeRef<(element: GraphElement) => AdapterDataType<BuildConfigData> \| undefined>`
+|no |adapter to adapt element to data that can be used by Build component.
 |===
 
 [discrete]
@@ -1045,7 +1126,7 @@ events
 |Name |Value Type |Optional |Description
 |`adapt`
 |`CodeRef<(element: GraphElement) => NetworkAdapterType | undefined>`
-|no |
+|no |adapter to adapt element to data that can be used by Networking component.
 |===
 
 [discrete]
@@ -1057,8 +1138,8 @@ events
 |===
 |Name |Value Type |Optional |Description
 |`adapt`
-|`CodeRef<(element: GraphElement) => AdapterDataType<PodsAdapterDataType> | undefined>`
-|no |
+|`CodeRef<(element: GraphElement) => AdapterDataType<PodsAdapterDataType> \| undefined>`
+|no | adapter to adapt element to data that can be used by Pod component. |
 |===
 
 [discrete]
@@ -1120,10 +1201,10 @@ Topology Decorator Provider Extension
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
-|`id` |`string` |no |
-|`priority` |`number` |no |
-|`quadrant` |`TopologyQuadrant` |no |
-|`decorator` |`CodeRef<TopologyDecoratorGetter>` |no |
+|`id` |`string` |no |id for topology decorator specific to the extension
+|`priority` |`number` |no |priority for topology decorator specific to the extension
+|`quadrant` |`TopologyQuadrant` |no | quadrant for topology decorator specific to the extension
+|`decorator` |`CodeRef<TopologyDecoratorGetter>` |no |decorator specific to the extension |
 |===
 
 [discrete]
@@ -1150,8 +1231,7 @@ alert should not be shown after dismissed.
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
-|`link`
-|`CodeRef<(element: GraphElement) => React.Component | undefined>` |no
+|`link`|`CodeRef<(element: GraphElement) => React.Component \| undefined>` |no
 |Return the resource link if provided, otherwise undefined. Use the `ResourceIcon` and `ResourceLink` properties for styles.
 
 |`priority` |`number` |yes |A higher priority factory will get the first
@@ -1195,8 +1275,7 @@ contribute to.
 returns a component, or if null or undefined renders in the
 topology sidebar.SDK component: <Section title=\{}>... padded area
 
-|`section`
-|`CodeRef<(element: GraphElement, renderNull?: () => null) => React.Component | undefined>`
+|`section`|`CodeRef<(element: GraphElement, renderNull?: () => null) => React.Component \| undefined>`
 |no |@deprecated Fallback if no provider is defined. renderNull is a
 no-op already.
 
@@ -1216,8 +1295,8 @@ Topology Display Filters Extension
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
-|`getTopologyFilters` |`CodeRef<() => TopologyDisplayOption[]>` |no |
-|`applyDisplayOptions` |`CodeRef<TopologyApplyDisplayOptions>` |no |
+|`getTopologyFilters` |`CodeRef<() => TopologyDisplayOption[]>` |no | Getter for topology filters specific to the extension
+|`applyDisplayOptions` |`CodeRef<TopologyApplyDisplayOptions>` |no | Function to apply filters to the model
 |===
 
 [discrete]
@@ -1228,14 +1307,16 @@ Topology relationship provider connector extension
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
-|`provides` |`CodeRef<RelationshipProviderProvides>` |no |
-|`tooltip` |`string` |no |
-|`create` |`CodeRef<RelationshipProviderCreate>` |no |
-|`priority` |`number` |no |
+|`provides` |`CodeRef<RelationshipProviderProvides>` |no |use to determine if a connection can be created between the source and target node
+|`tooltip` |`string` |no | tooltip to show when connector operation is hovering over the drop target ex: "Create a Visual Connector"
+|`create` |`CodeRef<RelationshipProviderCreate>` |no | callback to execute when connector is drop over target node to create a connection
+|`priority` |`number` |no |priority for relationship, higher will be preferred in case of multiple
 |===
 
 [discrete]
 == `console.user-preference/group`
+
+This extension can be used to add a group on the console user-preferences page. It will appear as a vertical tab option on the console user-preferences page.
 
 [cols=",,,",options="header",]
 |===
@@ -1253,6 +1334,8 @@ this group should be placed
 
 [discrete]
 == `console.user-preference/item`
+
+This extension can be used to add an item to the user preferences group on the console user preferences page.
 
 [cols=",,,",options="header",]
 |===
@@ -1296,6 +1379,8 @@ to mark this as the default template.
 [discrete]
 == `dev-console.add/action`
 
+This extension allows plugins to contribute an add action item to the add page of developer perspective. For example, a Serverless plugin can add a new action item for adding serverless functions to the add page of developer console.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -1319,6 +1404,8 @@ access review to control the visibility or enablement of the action.
 [discrete]
 == `dev-console.add/action-group`
 
+This extension allows plugins to contibute a group in the add page of developer console.<br/>Groups can be referenced by actions, which will be grouped together in the add action page based on their extension definition.<br/>For example, a Serverless plugin can contribute a Serverless group and together with multiple add actions.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -1336,6 +1423,8 @@ should be placed
 [discrete]
 == `dev-console.import/environment`
 
+This extension can be used to specify extra build environment variable fields under the builder image selector in the dev console git import form. When set, the fields will override environment variables of the same name in the build section.
+
 [cols=",,,",options="header",]
 |===
 |Name |Value Type |Optional |Description
@@ -1345,6 +1434,18 @@ custom environment variables for
 |`imageStreamTags` |`string[]` |no |List of supported image stream tags
 
 |`environments` |`ImageEnvironment[]` |no |List of environment variables
+|===
+
+[discrete]
+== `console.dashboards/overview/detail/item`
+
+Deprecated. use `CustomOverviewDetailItem` type instead
+
+[cols=",,,",options="header",]
+|===
+|Name |Value Type |Optional |Description
+|`component` |`CodeRef<React.ComponentType<{}>>` |no |The value, based
+on the `DetailItem` component
 |===
 
 [discrete]


### PR DESCRIPTION
[OSDOCS-5157](https://issues.redhat.com//browse/OSDOCS-5157):Updates to dynamic plugin extensions and api docs

Version(s):
 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5157

Link to docs preview:
extensions: https://57513--docspreview.netlify.app/openshift-enterprise/latest/web_console/dynamic-plug-in/dynamic-plug-ins-reference.html#dynamic-plug-in-sdk-extensions_dynamic-plug-ins-reference
API:https://57513--docspreview.netlify.app/openshift-enterprise/latest/web_console/dynamic-plug-in/dynamic-plug-ins-reference.html#dynamic-plug-in-api_dynamic-plug-ins-reference

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
**Note for Reviewer:** 
I am not really sure how to get the red highlight off on some of the code blocks in the API docs other than that this is ready for review. It should be reviewed like the API docs as these should stay true to what the console team has in these files https://github.com/openshift/console/tree/master/frontend/packages/console-dynamic-plugin-sdk/docs