### PR TITLE
CNV-23499: 4.10+ HPP CSI only (4.13 RN repeat)

### DIFF
--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -103,9 +103,6 @@ The SVVP Certification applies to:
 
 Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
-* In a future release, support for the legacy HPP custom resource, and the associated storage class, will be deprecated. Beginning in {VirtProductName} {VirtVersion}, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. The Operator continues to support the existing (legacy) format of the HPP custom resource and the associated storage class. If you use the HPP Operator, plan to xref:../virt/virtual_machines/virtual_disks/virt-configuring-local-storage-for-vms.adoc#virt-configuring-local-storage-for-vms[create a storage class for the CSI driver] as part of your migration strategy.
-
-
 
 
 [id="virt-4-13-removed"]
@@ -116,6 +113,9 @@ Removed features are not supported in the current release.
 
 //CNV-19043 Release note: CHANGE Remove rhel6 support
 * Red Hat Enterprise Linux 6 is no longer supported on {VirtProductName}.
+
+//CNV-23499: Carry over/repeat removed feature from version 4.12 
+* Support for the legacy HPP custom resource, and the associated storage class, has been removed for all new deployments. In {VirtProductName} 4.13, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. Only in the case of an upgrade will a previously installed legacy HPP custom resource still be supported.
 
 
 


### PR DESCRIPTION
Version(s): 4.13


Issue: [CNV-23499](https://issues.redhat.com/browse/CNV-23499)

Link to docs preview: [Removed features](https://57514--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-13-release-notes.html#virt-4-13-removed) (second bullet) 

QE review:
- [x] QE has approved this change.


Additional information:



