### PR TITLE
OCPBUGS-7298: Added RN for namespace exclusion working for LowNodeUti…

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -598,6 +598,8 @@ With this release, replacement control plane nodes are assigned to the correct i
 [id="ocp-4-13-node-bug-fixes"]
 ==== Node
 
+* Previously, the `LowNodeUtilization` strategy, which is enabled by the `LifecycleAndUtilization` descheduler profile, did not support namespace exclusion. With this release, namespaces are excluded properly when the `LifecycleAndUtilization` descheduler profile is set. (link:https://issues.redhat.com/browse/OCPBUGS-513[*OCPBUGS-513*])
+
 [discrete]
 [id="ocp-4-13-openshift-cli-bug-fixes"]
 ==== OpenShift CLI (oc)


### PR DESCRIPTION
…lization

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-7298

Link to docs preview:
https://57517--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-node-bug-fixes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
