### PR TITLE
OCPBUGS 1931: Adding the bindDN and bindPassword to example

### DIFF
--- a/modules/ldap-syncing-config-rfc2307.adoc
+++ b/modules/ldap-syncing-config-rfc2307.adoc
@@ -28,6 +28,9 @@ kind: LDAPSyncConfig
 apiVersion: v1
 url: ldap://LDAP_SERVICE_IP:389 <1>
 insecure: false <2>
+bindDN: cn=admin,dc=example,dc=com
+bindPassword:
+  file: "/etc/secrets/bindPassword"
 rfc2307:
     groupsQuery:
         baseDN: "ou=groups,dc=example,dc=com"


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-1931

Link to docs preview:
https://57519--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/ldap-syncing.html#ldap-syncing-config-rfc2307_ldap-syncing-groups

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
