### PR TITLE
[enterprise-4.11] updated versioning for eus updates

### DIFF
--- a/modules/updating-eus-to-eus-upgrade-cli.adoc
+++ b/modules/updating-eus-to-eus-upgrade-cli.adoc
@@ -37,18 +37,18 @@ master   rendered-master-ecbb9582781c1091e1c9f19d50cf836c       True  	  False
 worker   rendered-worker-00a3f0c68ae94e747193156b491553d5       True  	  False
 ----
 
-. Change to the `eus-4.12` channel by running the following command:
+. Change to the `eus-4.10` channel by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm upgrade channel eus-4.12
+$ oc adm upgrade channel eus-4.10
 ----
 +
 [NOTE]
 ====
 
-If you receive an error message indicating that `eus-4.12` is not one of the
-available channels, this indicates that Red Hat is still rolling out 4.10 to 4.12 EUS updates.
+If you receive an error message indicating that `eus-4.10` is not one of the
+available channels, this indicates that Red Hat is still rolling out 4.8 to 4.10 EUS updates.
 This rollout process generally takes 45-90 days starting at the GA date.
 ====
 +
@@ -76,7 +76,7 @@ $ oc adm upgrade --to-latest
 +
 [source,terminal]
 ----
-Updating to latest version 4.11.18
+Updating to latest version 4.9.18
 ----
 
 . Review the cluster version to ensure that the updates are complete by running the following command:
@@ -91,17 +91,17 @@ $ oc adm upgrade
 [source,terminal]
 ----
 NAME  	  VERSION  AVAILABLE  PROGRESSING   SINCE   STATUS
-version   4.11.18   True       False         6m29s   Cluster version is 4.11.18
+version   4.9.18   True       False         6m29s   Cluster version is 4.9.18
 ----
 
-. Update to version 4.12 by running the following command:
+. Update to version 4.10 by running the following command:
 +
 [source,terminal]
 ----
 $ oc adm upgrade --to-latest
 ----
 
-. Retrieve the cluster version to ensure that the 4.12 updates are complete by running the following command:
+. Retrieve the cluster version to ensure that the 4.10 updates are complete by running the following command:
 +
 [source,terminal]
 ----
@@ -113,10 +113,10 @@ $ oc adm upgrade
 [source,terminal]
 ----
 NAME  	  VERSION  AVAILABLE  PROGRESSING   SINCE   STATUS
-version   4.12.1   True       False         6m29s   Cluster version is 4.12.1
+version   4.10.1   True       False         6m29s   Cluster version is 4.10.1
 ----
 
-. To update your worker nodes to 4.12, unpause all previously paused machine config pools by running the following command:
+. To update your worker nodes to 4.10, unpause all previously paused machine config pools by running the following command:
 +
 [source,terminal]
 ----
@@ -128,7 +128,7 @@ $ oc patch mcp/worker --type merge --patch '{"spec":{"paused":false}}'
 If pools are not unpaused, the cluster is not permitted to update to any future minor versions, and maintenance tasks such as certificate rotation are inhibited. This puts the cluster at risk for future degradation.
 ====
 
-. Verify that your previously paused pools are updated and that the update to version 4.12 is complete by running the following command:
+. Verify that your previously paused pools are updated and that the update to version 4.10 is complete by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/updating-eus-to-eus-upgrade-console.adoc
+++ b/modules/updating-eus-to-eus-upgrade-console.adoc
@@ -24,21 +24,21 @@ To view the status of all machine config pools, click *Compute* -> *MachineConfi
 If your machine config pools have an `Updating` status, please wait for this status to change to `Up to date`. This process could take several minutes.
 ====
 
-. Set your channel to `eus-4.12`. 
+. Set your channel to `eus-4.10`. 
 +
 To set your channel, click *Administration* -> *Cluster Settings* -> *Channel*. You can edit your channel by clicking on the current hyperlinked channel.
 
 . Pause all worker machine pools except for the master pool. You can perform this action on the *MachineConfigPools* tab under the *Compute* page. Select the vertical ellipses next to the machine config pool you'd like to pause and click *Pause updates*.
 
-. Update to version 4.11 and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources". 
+. Update to version 4.9 and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources". 
 
-. Ensure that the 4.11 updates are complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab. 
+. Ensure that the 4.9 updates are complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab. 
 
 . If necessary, update your OLM Operators by using the Administrator perspective on the web console. You can find more information on how to perform these actions in "Updating installed Operators"; see "Additional resources".
 
-. Update to version 4.12 and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources". 
+. Update to version 0 and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources". 
 
-. Ensure that the 4.12 update is complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab. 
+. Ensure that the 4.10 update is complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab. 
 
 . Unpause all previously paused machine config pools. You can perform this action on the *MachineConfigPools* tab under the *Compute* page. Select the vertical ellipses next to the machine config pool you'd like to unpause and click *Unpause updates*. 
 +
@@ -47,7 +47,7 @@ To set your channel, click *Administration* -> *Cluster Settings* -> *Channel*. 
 If pools are not unpaused, the cluster is not permitted to upgrade to any future minor versions, and maintenance tasks such as certificate rotation are inhibited. This puts the cluster at risk for future degradation.
 ====
 
-. Verify that your previously paused pools are updated and that your cluster has completed the update to version 4.12. 
+. Verify that your previously paused pools are updated and that your cluster has completed the update to version 4.10. 
 +
 You can verify that your pools have updated on the *MachineConfigPools* tab under the *Compute* page by confirming that the *Update status* has a value of *Up to date*.
 +

--- a/modules/updating-eus-to-eus-upgrade.adoc
+++ b/modules/updating-eus-to-eus-upgrade.adoc
@@ -6,12 +6,12 @@
 [id="updating-eus-to-eus-upgrade_{context}"]
 = EUS-to-EUS update
 
-The following procedure pauses all non-master machine config pools and performs updates from {product-title} 4.10 to 4.11 to 4.12, then unpauses the previously paused machine config pools.
+The following procedure pauses all non-master machine config pools and performs updates from {product-title} 4.8 to 4.9 to 4.10, then unpauses the previously paused machine config pools.
 Following this procedure reduces the total update duration and the number of times worker nodes are restarted.
 
 .Prerequisites
 
-* Review the release notes for {product-title} 4.11 and 4.12
+* Review the release notes for {product-title} 4.9 and 4.10.
 * Review the release notes and product lifecycles for any layered products and Operator Lifecycle Manager (OLM) Operators. Some may require updates either before or during an EUS-to-EUS update.
-* Ensure that you are familiar with version-specific prerequisites, such as link:https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-prepare.html#update-preparing-migrate_updating-cluster-prepare[administrator acknowledgement] that is required prior to updating from {product-title} 4.11 to 4.12.
+
 


### PR DESCRIPTION
Removed and replaced 4.12 versioning verbiage

Version(s):
4.11

Link to docs preview:
https://docs.openshift.com/container-platform/4.11/updating/preparing-eus-eus-upgrade.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
