### PR TITLE
OCPBUGS#10503: Add a label to MCP before using must-gather

### DIFF
--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -21,6 +21,28 @@ In earlier versions of {product-title}, the Performance Addon Operator provided 
 
 .Procedure
 
+. Optional: Verify that a matching machine config pool exists with a label:
++
+[source,terminal]
+----
+$ oc describe mcp/worker-rt
+----
++
+.Example output
+[source,terminal]
+----
+Name:         worker-rt
+Namespace:
+Labels:       machineconfiguration.openshift.io/role=worker-rt
+----
+
+. If a matching label does not exist add a label for a machine config pool (MCP) that matches with the MCP name:
++
+[source,terminal]
+----
+$ oc label mcp <mcp_name> <mcp_name>=""
+----
+
 . Navigate to the directory where you want to store the `must-gather` data.
 
 . Run `must-gather` on your cluster:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-10503
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57527--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-create-performance-profiles.html#gathering-data-about-your-cluster-using-must-gather_cnf-create-performance-profiles
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
