### PR TITLE
Changes to RHDEVDOCS-4828: Doc: Serverless function creation via import from Git with builder images and pipelines

### DIFF
--- a/modules/odc-importing-codebase-from-git-to-create-application.adoc
+++ b/modules/odc-importing-codebase-from-git-to-create-application.adoc
@@ -21,8 +21,11 @@ The following procedure walks you through the *From Git* option in the *Develope
 * *Context Dir* to specify the subdirectory for the application source code you want to use to build the application.
 * *Source Secret* to create a *Secret Name* with credentials for pulling your source code from a private repository.
 
-. Optional: You can import a `Devfile`, a `Dockerfile`, or a `Builder Image` through your Git repository to further customize your deployment.
-* If your Git repository contains a `Devfile`, a `Dockerfile`, or a `Builder Image`, it is automatically detected and populated on the respective path fields. If a `Devfile`, a `Dockerfile`, or a `Builder Image` are detected in the same repository, the `Devfile` is selected by default.
+. Optional: You can import a `Devfile`, a `Dockerfile`, `Builder Image`, or a `Serverless Function` through your Git repository to further customize your deployment.
+* If your Git repository contains a `Devfile`, a `Dockerfile`, a `Builder Image`, or a `func.yaml`, it is automatically detected and populated on the respective path fields. 
+* If a `Devfile`, a `Dockerfile`, or a `Builder Image` are detected in the same repository, the `Devfile` is selected by default.
+* If `func.yaml` is detected in the Git repository, the *Import Strategy* changes to `Serverless Function`.
+* Alternatively, you can create a serverless function by clicking *Create Serverless function* in the *+Add* view using the Git repository URL.
 * To edit the file import type and select a different strategy, click *Edit import strategy* option.
 * If multiple `Devfiles`, a `Dockerfiles`, or a `Builder Images` are detected, to import a specific instance, specify the respective paths relative to the context directory.
 
@@ -49,7 +52,7 @@ The resource name must be unique in a namespace. Modify the resource name if you
 +
 [NOTE]
 ====
-You can set the default resource preference for Import by browsing the User Preferences page and clicking *Applications* -> *Resource type* field. The *Serverless Deployment* option is displayed in the *Import from Git* form only if the {ServerlessOperatorName} is installed in your cluster. For further details, refer to the {ServerlessProductName} documentation.
+To set the default resource preference for importing an application, go to *User Preferences* -> *Applications* -> *Resource type* field. The *Serverless Deployment* option is displayed in the *Import from Git* form only if the {ServerlessOperatorName} is installed in your cluster. The *Resources* section is not available while creating a serverless function. For further details, refer to the {ServerlessProductName} documentation.
 ====
 
 . In the *Pipelines* section, select *Add Pipeline*, and then click *Show Pipeline Visualization* to see the pipeline for the application. A default pipeline is selected, but you can choose the pipeline you want from the list of available pipelines for the application. If *Configure PAC* is checked and the GitHub App is set up, you can see *Use GitHub App* and *Setup a webhook* options. If GitHub App is not set up, you can see *Setup a webhook* option.

--- a/modules/serverless-deploy-func-kn.adoc
+++ b/modules/serverless-deploy-func-kn.adoc
@@ -32,3 +32,8 @@ Function deployed at: http://func.example.com
 ** If no `namespace` is specified, the function is deployed in the current namespace.
 ** The function is deployed from the current directory, unless a `path` is specified.
 ** The Knative service name is derived from the project name, and cannot be changed using this command.
+
+[NOTE]
+====
+You can create a serverless function with a Git repository URL by using *Import from Git* or *Create Serverless Function* in the *+Add* view of the *Developer* perspective.
+====

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -27,6 +27,7 @@ ifdef::openshift-enterprise[]
 * xref:../../registry/securing-exposing-registry.adoc#securing-exposing-registry[Exposing a default registry manually]
 * link:https://plugins.jetbrains.com/plugin/16476-knative\--serverless-functions-by-red-hat[Marketplace page for the Intellij Knative plugin]
 * link:https://marketplace.visualstudio.com/items?itemName=redhat.vscode-knative&utm_source=VSCode.pro&utm_campaign=AhmadAwais[Marketplace page for the Visual Studio Code Knative plugin]
+* xref:../../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-the-developer-perspective[Creating applications using the Developer perspective]
 // This Additional resource applies only to OCP, but not to OSD nor ROSA.
 endif::[]
 


### PR DESCRIPTION
Change type: Doc update; Serverless function creation via import from Git with builder images and pipelines
Doc JIRA: https://issues.redhat.com/browse/RHDEVDOCS-4828
Dev JIRAs: https://issues.redhat.com/browse/ODC-7167 and https://issues.redhat.com/browse/ODC-6360
Fix Version: Openshift 4.13 Freeze

Doc Preview:
1. https://57543--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html#serverless-deploy-func-kn_serverless-functions-getting-started
2. https://57543--docspreview.netlify.app/openshift-enterprise/latest/applications/creating_applications/odc-creating-applications-using-developer-perspective.html#odc-importing-codebase-from-git-to-create-application_odc-creating-applications-using-developer-perspective

SME Review: @vikram-raj 
QE Review: @sanketpathak 
Peer Review: @max-cx 