### PR TITLE
OCPBUGS-10053-412: Updates for 4.12 only

### DIFF
--- a/modules/psap-driver-toolkit-pulling.adoc
+++ b/modules/psap-driver-toolkit-pulling.adoc
@@ -24,16 +24,22 @@ The driver-toolkit image for the latest minor release are tagged with the minor 
 
 .Procedure
 
-. The image URL of the `driver-toolkit` corresponding to a certain release can be extracted from the release image using the `oc adm` command:
+. Use the `oc adm` command to extract the image URL of the `driver-toolkit` corresponding to a certain release:
++
+--
+* For an x86 image, enter the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
-# For x86 image:
 $ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version}.z-x86_64 --image-for=driver-toolkit
-
-# For ARM image:
+----
+* For an ARM image, enter the following command:
++
+[source,terminal,subs="attributes+"]
+----
 $ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version}.z-aarch64 --image-for=driver-toolkit
 ----
+--
 +
 .Example output
 [source,terminal]
@@ -41,8 +47,8 @@ $ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version
 quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:0fd84aee79606178b6561ac71f8540f404d518ae5deff45f6d6ac8f02636c7f4
 ----
 
-. This image can be obtained using a valid pull secret, such as the pull secret required to install {product-title}.
-
+. Obtain this image by using a valid pull secret, such as the pull secret required to install {product-title}:
++
 [source,terminal]
 ----
 $ podman pull --authfile=path/to/pullsecret.json quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:<SHA>


### PR DESCRIPTION
Updated 'Red Hat OpenShift Container Platform' doc > 'Specialized hardware and driver enablement' chapter > 'Driver toolkit' section > 'Finding the Driver Toolkit image URL in the payload' subsection.

Updates for 4.12 version only. Cherry-picking of original PR by squad failed for versions 4.12 and 4.11.

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-10053

Link to docs preview:
https://57545--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/psap-driver-toolkit.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
