### PR TITLE
OSDOCS-5537: Update Infrastructure sizing table and note

### DIFF
--- a/modules/infrastructure-node-sizing.adoc
+++ b/modules/infrastructure-node-sizing.adoc
@@ -11,15 +11,15 @@ _Infrastructure nodes_ are nodes that are labeled to run pieces of the {product-
 |===
 | Number of worker nodes |Cluster density, or number of namespaces |CPU cores |Memory (GB)
 
-| 25
+| 27
 | 500
 | 4
-| 48
+| 24
 
-| 100
+| 120
 | 1000
 | 8
-| 96
+| 48
 
 | 252
 | 4000
@@ -37,9 +37,9 @@ In general, three infrastructure nodes are recommended per cluster.
 
 [IMPORTANT]
 ====
-These sizing recommendations are based on scale tests, which create a large number of objects across the cluster. These tests include reaching some of the cluster maximums. In the case of 250 and 500 node counts on an {product-title} {product-version} cluster, these maximums are 10000 namespaces with 61000 pods, 10000 deployments, 181000 secrets, 400 config maps, and so on. Prometheus is a highly memory intensive application; the resource usage depends on various factors including the number of nodes, objects, the Prometheus metrics scraping interval, metrics or time series, and the age of the cluster. The disk size also depends on the retention period. You must take these factors into consideration and size them accordingly.
+These sizing recommendations should be used as a guideline. Prometheus is a highly memory intensive application; the resource usage depends on various factors including the number of nodes, objects, the Prometheus metrics scraping interval, metrics or time series, and the age of the cluster. In addition, the router resource usage can also be affected by the number of routes and the amount/type of inbound requests.
 
-These sizing recommendations are only applicable for the Prometheus, Router, and Registry infrastructure components, which are installed during cluster installation. Logging is a day-two operation and is not included in these recommendations.
+These recommendations apply only to infrastructure nodes hosting Monitoring, Ingress and Registry infrastructure components installed during cluster creation.
 ====
 
 [NOTE]


### PR DESCRIPTION
The infrastructure sizing table contains some incorrect information, updating it accordingly with the values we've obtained in our latest tests. Also updating the foot note comments.

Version(s):

4.10 and higher

4.10+ 

Issue:
[OSDOCS-5537](https://issues.redhat.com/browse/OSDOCS-5537)

Link to docs preview:
[Infrastructure node sizing](https://57546--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-host-practices.html#infrastructure-node-sizing_recommended-host-practices)