### PR TITLE
[enterprise-4.10] | CP | Pipelines as Code documentation for Pipeline 1.9

### DIFF
--- a/cicd/pipelines/using-pipelines-as-code.adoc
+++ b/cicd/pipelines/using-pipelines-as-code.adoc
@@ -6,8 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Pipelines as Code
-include::snippets/technology-preview.adoc[]
+// :FeatureName: Pipelines as Code
 
 [role="_abstract"]
 With {pac}, cluster administrators and users with the required privileges can define pipeline templates as part of source code Git repositories. When triggered by a source code push or a pull request for the configured Git repository, the feature runs the pipeline and reports the status.   
@@ -24,24 +23,113 @@ With {pac}, cluster administrators and users with the required privileges can de
 * Automatic task resolution in {pipelines-shortname}, including local tasks, Tekton Hub, and remote URLs.
 * Retrieval of configurations using GitHub blobs and objects API.
 * Access Control List (ACL) over a GitHub organization, or using a Prow style `OWNER` file.
-* The `tkn-pac` CLI plugin for managing bootstrapping and {pac} repositories.
+* The `tkn pac` CLI plugin for managing bootstrapping and {pac} repositories.
 * Support for GitHub App, GitHub Webhook, Bitbucket Server, and Bitbucket Cloud.
 
 include::modules/op-installing-pipelines-as-code-on-an-openshift-cluster.adoc[leveloffset=+1]
 
 include::modules/op-installing-pipelines-as-code-cli.adoc[leveloffset=+1]
 
-include::modules/op-configuring-pipelines-as-code-for-a-git-repository-hosting-service-provider.adoc[leveloffset=+1]
+[id="using-pipelines-as-code-with-a-git-repository-hosting-service-provider"]
+== Using {pac} with a Git repository hosting service provider 
 
-include::modules/op-configuring-pipelines-as-code-for-a-github-app.adoc[leveloffset=+2]
+[role="_abstract"]
+After installing {pac}, cluster administrators can configure a Git repository hosting service provider. Currently, the following services are supported:
 
-include::modules/op-pipelines-as-code-command-reference.adoc[leveloffset=+1]
+* GitHub App
+* GitHub Webhook
+* GitLab
+* Bitbucket Server
+* Bitbucket Cloud
+
+[NOTE]
+====
+GitHub App is the recommended service for using with {pac}.
+====
+
+include::modules/op-using-pipelines-as-code-with-a-github-app.adoc[leveloffset=+1]
+
+include::modules/op-creating-a-github-application-in-administrator-perspective.adoc[leveloffset=+2]
+
+include::modules/op-using-pipelines-as-code-with-github-webhook.adoc[leveloffset=+1]
+
+.Additional resources
+
+* link:https://docs.github.com/en/developers/webhooks-and-events/webhooks/creating-webhooks[GitHub Webhook documentation on GitHub]
+* link:https://docs.github.com/en/rest/guides/getting-started-with-the-checks-api[GitHub Check Runs documentation on GitHub]
+* link:https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token[Creating a personal access token on GitHub]
+* link:https://github.com/settings/tokens/new?description=pipelines-as-code-token&scopes=repo[Classic tokens with pre-filled permissions]
+
+include::modules/op-using-pipelines-as-code-with-gitlab.adoc[leveloffset=+1]
+
+.Additional resources
+
+* link:https://docs.gitlab.com/ee/user/profile/personal_access_tokens.html[GitLab Webhook documentation on GitLab]
+
+include::modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc[leveloffset=+1]
+
+.Additional resources
+
+* link:https://support.atlassian.com/bitbucket-cloud/docs/app-passwords/[Creating app password on Bitbucket Cloud]
+* link:https://developer.atlassian.com/cloud/bitbucket/bitbucket-api-changes-gdpr/#introducing-atlassian-account-id-and-nicknames[Introducing Altassian Account ID and Nicknames]
+
+include::modules/op-using-pipelines-as-code-with-bitbucket-server.adoc[leveloffset=+1]
+
+.Additional resources
+
+* link:https://confluence.atlassian.com/bitbucketserver/personal-access-tokens-939515499.html[Creating personal tokens on Bitbucket Server]
+* link:https://support.atlassian.com/bitbucket-cloud/docs/manage-webhooks/#Create-webhooks[Creating webhooks on Bitbucket server]
+
+include::modules/op-interfacing-pipelines-as-code-with-custom-certificates.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object[Enabling the cluster-wide proxy]
+
+include::modules/op-using-repository-crd-with-pipelines-as-code.adoc[leveloffset=+1]
+
+include::modules/op-setting-concurrency-limits-in-repository-crd.adoc[leveloffset=+2]
+
+include::modules/op-using-pipelines-as-code-resolver.adoc[leveloffset=+1]
+
+include::modules/op-using-remote-task-annotations-with-pipelines-as-code.adoc[leveloffset=+2]
+
+include::modules/op-using-remote-pipeline-annotations-with-pipelines-as-code.adoc[leveloffset=+2]
+
+include::modules/op-creating-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
+
+.Additional resources
+
+* link:https://github.com/google/cel-spec/blob/master/doc/langdef.md[CEL language specification]
+
+include::modules/op-running-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
+
+include::modules/op-monitoring-pipeline-run-status-using-pipelines-as-code.adoc[leveloffset=+1]
+
+.Additional resources
+
+* link:https://github.com/chmouel/tekton-slack-task-status[An example task to send Slack messages on success or failure]
+* link:https://github.com/openshift-pipelines/pipelines-as-code/blob/7b41cc3f769af40a84b7ead41c6f037637e95070/.tekton/push.yaml[An example of a pipeline run with `finally` tasks triggered on push events]
+
+include::modules/op-using-private-repositories-with-pipelines-as-code.adoc[leveloffset=+1]
+
+.Additional resources
+
+* link:https://github.com/openshift-pipelines/pipelines-as-code/blob/main/test/testdata/pipelinerun_git_clone_private.yaml[An example of the `git-clone` task used for cloning private repositories]
+
+include::modules/op-cleaning-up-pipeline-run-using-pipelines-as-code.adoc[leveloffset=+1]
+
+include::modules/op-using-incoming-webhook-with-pipelines-as-code.adoc[leveloffset=+1]
 
 include::modules/op-customizing-pipelines-as-code-configuration.adoc[leveloffset=+1]
+
+include::modules/op-pipelines-as-code-command-reference.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources-pac"]
 == Additional resources
+
+* link:https://github.com/openshift-pipelines/pipelines-as-code/tree/main/.tekton[An example of the `.tekton/` directory in the Pipelines as Code repository]
 
 * xref:../../cicd/pipelines/installing-pipelines.adoc#installing-pipelines[Installing OpenShift Pipelines]
 

--- a/modules/op-cleaning-up-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-cleaning-up-pipeline-run-using-pipelines-as-code.adoc
@@ -1,0 +1,26 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="cleaning-up-pipeline-run-using-pipelines-as-code_{context}"]
+= Cleaning up pipeline run using {pac} 
+
+[role="_abstract"]
+
+There can be many pipeline runs in a user namespace. By setting the `max-keep-runs` annotation, you can configure {pac} to retain a limited number of pipeline runs that matches an event. For example:
+
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/max-keep-runs: "<max_number>" <1>
+...
+----
+<1> {pac} starts cleaning up right after it finishes a successful execution, retaining only the maximum number of pipeline runs configured using the annotation.
++
+[NOTE]
+====
+* {pac} skips cleaning the running pipelines but cleans up the pipeline runs with an unknown status.
+* {pac} skips cleaning a failed pull request.
+====
+

--- a/modules/op-creating-a-github-application-in-administrator-perspective.adoc
+++ b/modules/op-creating-a-github-application-in-administrator-perspective.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * cicd/pipelines/creating-applications-with-cicd-pipelines.adoc
+
+:_content-type: PROCEDURE
+[id="creating-a-github-application-in-administrator-perspective_{context}"]
+
+= Creating a GitHub App in administrator perspective
+
+As a cluster administrator, you can configure your GitHub App with the {product-title} cluster to use {pac}. This configuration allows you to execute a set of tasks required for build deployment.
+
+.Prerequisites
+You have installed the {pipelines-title} `{pipelines-ver}` operator from the Operator Hub.
+
+.Procedure
+. In the administrator perspective, navigate to *Pipelines* using the navigation pane.
+. Click *Setup GitHub App* on the *Pipelines* page.
+. Enter your GitHub App name. For example, `pipelines-ci-clustername-testui`.
+. Click *Setup*.
+. Enter your Git password when prompted in the browser.
+. Click *Create GitHub App for <username>*, where `<username>` is your GitHub user name.
+
+.Verification
+After successful creation of the GitHub App, the {product-title} web console opens and displays the details about the application.
+
+image::Github-app-details.png[]
+
+The details of the GitHub App are saved as a secret in the `openShift-pipelines` namespace.
+
+To view details such as name, link, and secret associated with the GitHub applications, navigate to *Pipelines* and click *View GitHub App*. 

--- a/modules/op-creating-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-creating-pipeline-run-using-pipelines-as-code.adoc
@@ -1,0 +1,176 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="creating-pipeline-run-using-pipelines-as-code_{context}"]
+= Creating a pipeline run using {pac}
+
+[role="_abstract"]
+To run pipelines using {pac}, you can create pipelines definitions or templates as YAML files in the `.tekton/` directory of the repository. You can reference YAML files in other repositories using remote URLs, but pipeline runs are only triggered by events in the repository containing the `.tekton/` directory.
+
+The {pac} resolver bundles the pipeline runs with all tasks as a single pipeline run without external dependencies.
+
+[NOTE]
+====
+* For pipelines, use at least one pipeline run with a spec, or a separated `Pipeline` object.
+* For tasks, embed task spec inside a pipeline, or define it separately as a Task object.
+====
+
+[discrete]
+.Parameterizing commits and URLs
+
+You can specify the parameters of your commit and URL by using dynamic, expandable variables with the {{<var>}} format. Currently, you can use the following variables:
+
+* `{{repo_owner}}`: The repository owner.
+* `{{repo_name}}`: The repository name.
+* `{{repo_url}}`: The repository full URL.
+* `{{revision}}`: Full SHA revision of a commit.
+* `{{sender}}`: The username or account id of the sender of the commit.
+* `{{source_branch}}`: The branch name where the event originated.
+* `{{target_branch}}`: The branch name that the event targets. For push events, it's the same as the `source_branch`.
+* `{{pull_request_number}}`: The pull or merge request number, defined only for a `pull_request` event type.
+* `{{git_auth_secret}}`: The secret name that is generated automatically with Git provider's token for checking out private repos.
+
+[discrete]
+.Matching an event to a pipeline run
+
+You can match different Git provider events with each pipeline by using special annotations on the pipeline run. If there are multiple pipeline runs matching an event, {pac} runs them in parallel and posts the results to the Git provider as soon a pipeline run finishes.
+
+[discrete]
+.Matching a pull event to a pipeline run
+
+You can use the following example to match the `pipeline-pr-main` pipeline with a `pull_request` event that targets the `main` branch:
+
+[source,yaml]
+----
+...
+  metadata:
+    name: pipeline-pr-main
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[main]" <1>
+    pipelinesascode.tekton.dev/on-event: "[pull_request]"
+...
+----
+<1> You can specify multiple branches by adding comma-separated entries. For example, `"[main, release-nightly]"`. In addition, you can specify the following:
+* Full references to branches such as `"refs/heads/main"`
+* Globs with pattern matching such as `"refs/heads/\*"`
+* Tags such as `"refs/tags/1.\*"`
+
+[discrete]
+.Matching a push event to a pipeline run
+
+You can use the following example to match the `pipeline-push-on-main` pipeline with a `push` event targeting the `refs/heads/main` branch:
+
+[source,yaml]
+----
+...
+  metadata:
+    name: pipeline-push-on-main
+  annotations:
+    pipelinesascode.tekton.dev/on-target-branch: "[refs/heads/main]" <1>
+    pipelinesascode.tekton.dev/on-event: "[push]"
+...
+----
+<1> You can specifiy multiple branches by adding comma-separated entries. For example, `"[main, release-nightly]"`. In addition, you can specify the following:
+* Full references to branches such as `"refs/heads/main"`
+* Globs with pattern matching such as `"refs/heads/\*"`
+* Tags such as `"refs/tags/1.\*"`
+
+[discrete]
+.Advanced event matching
+
+{pac} supports using Common Expression Language (CEL) based filtering for advanced event matching. If you have the `pipelinesascode.tekton.dev/on-cel-expression` annotation in your pipeline run, {pac} uses the CEL expression and skips the `on-target-branch` annotation. Compared to the simple `on-target-branch` annotation matching, the CEL expressions allow complex filtering and negation.
+
+To use CEL-based filtering with {pac}, consider the following examples of annotations:
+
+* To match a `pull_request` event targeting the `main` branch and coming from the `wip` branch:
++
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/on-cel-expression: |
+    event == "pull_request" && target_branch == "main" && source_branch == "wip"
+...
+----
+
+* To run a pipeline only if a path has changed, you can use the `.pathChanged` suffix function with a glob pattern:
++
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/on-cel-expression: |
+    event == "pull_request" && "docs/\*.md".pathChanged() <1>
+...
+----
+<1> Matches all markdown files in the `docs` directory.
+
+* To match all pull requests starting with the title `[DOWNSTREAM]`:
++
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/on-cel-expression: |
+    event == "pull_request && event_title.startsWith("[DOWNSTREAM]")
+...
+----
+
+* To run a pipeline on a `pull_request` event, but skip the `experimental` branch:
++
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/on-cel-expression: |
+    event == "pull_request" && target_branch != experimental"
+...
+----
+
+For advanced CEL-based filtering while using {pac}, you can use the following fields and suffix functions:
+
+* `event`: A `push` or `pull_request` event.
+* `target_branch`: The target branch.
+* `source_branch`: The branch of origin of a `pull_request` event. For `push` events, it is same as the `target_branch`.
+* `event_title`: Matches the title of the event, such as the commit title for a `push` event, and the title of a pull or merge request for a `pull_request` event. Currently, only GitHub, Gitlab, and Bitbucket Cloud are the supported providers.
+* `.pathChanged`: A suffix function to a string. The string can be a glob of a path to check if the path has changed. Currently, only GitHub and Gitlab are supported as providers.
+
+[discrete]
+.Using the temporary GitHub App token for Github API operations
+
+You can use the temporary installation token generated by {pac} from GitHub App to access the GitHub API. The token value is stored in the temporary `{{git_auth_secret}}` dynamic variable generated for private repositories in the `git-provider-token` key.
+
+For example, to add a comment to a pull request, you can use the `github-add-comment` task from {tekton-hub} using a {pac} annotation:
+
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/task: "github-add-comment"
+...
+----
+
+You can then add a task to the `tasks` section or `finally` tasks in the pipeline run definition:
+
+[source,yaml]
+----
+[...]
+tasks:
+  - name:
+      taskRef:
+        name: github-add-comment
+      params:
+        - name: REQUEST_URL
+          value: "{{ repo_url }}/pull/{{ pull_request_number }}" <1>
+        - name: COMMENT_OR_FILE
+          value: "Pipelines as Code IS GREAT!"
+        - name: GITHUB_TOKEN_SECRET_NAME
+          value: "{{ git_auth_secret }}"
+        - name: GITHUB_TOKEN_SECRET_KEY
+          value: "git-provider-token"
+...
+----
+<1> By using the dynamic variables, you can reuse this snippet template for any pull request from any repository.
+
+[NOTE]
+====
+On GitHub Apps, the generated installation token is available for 8 hours and scoped to the repository from where the events originate unless configured differently on the cluster.
+====
+

--- a/modules/op-customizing-pipelines-as-code-configuration.adoc
+++ b/modules/op-customizing-pipelines-as-code-configuration.adoc
@@ -27,4 +27,22 @@ Note that this configmap setting does not affect the cleanups of a user's pipeli
 
 | `hub-url` | The base URL for the link:https://api.hub.tekton.dev/v1[Tekton Hub API]. | `https://hub.tekton.dev/`
 
+| `hub-catalog-name` | The Tekton Hub catalog name. | `tekton`
+
+| `tekton-dashboard-url` | The URL of the Tekton Hub dashboard. Pipelines as Code uses this URL to generate a `PipelineRun` URL on the Tekton Hub dashboard.  | NA
+
+| `bitbucket-cloud-check-source-ip` | Indicates whether to secure the service requests by querying IP ranges for a public Bitbucket. Changing the parameter's default value might result into a security issue. | `enabled`
+
+| `bitbucket-cloud-additional-source-ip` | Indicates whether to provide an additional set of IP ranges or networks, which are separated by commas. | NA
+
+| `max-keep-run-upper-limit` | A maximum limit for the `max-keep-run` value for a pipeline run. | NA
+
+| `default-max-keep-runs` | A default limit for the `max-keep-run` value for a pipeline run. If defined, the value is applied to all pipeline runs that do not have a `max-keep-run` annotation. | NA
+
+| `auto-configure-new-github-repo` | Configures new GitHub repositories automatically. Pipelines as Code sets up a namespace and creates a custom resource for your repository. This parameter is only supported with GitHub applications. | `disabled`
+
+| `auto-configure-repo-namespace-template` | Configures a template to automatically generate the namespace for your new repository, if `auto-configure-new-github-repo` is enabled. | `{repo_name}-pipelines`
+
+| `error-log-snippet` | Enables or disables the view of a log snippet for the failed tasks, with an error in a pipeline. You can disable this parameter in the case of data leakage from your pipeline. | `enabled` 
+
 |===

--- a/modules/op-installing-pipelines-as-code-cli.adoc
+++ b/modules/op-installing-pipelines-as-code-cli.adoc
@@ -7,9 +7,9 @@
 = Installing {pac} CLI 
 
 [role="_abstract"]
-Cluster administrators can use the `tkn-pac` CLI tool on local machines or as containers for testing. The `tkn-pac` CLI tool is installed automatically when you install the `tkn` CLI for {pipelines-title}.
+Cluster administrators can use the `tkn pac` and `opc` CLI tools on local machines or as containers for testing. The `tkn pac` and `opc` CLI tools are installed automatically when you install the `tkn` CLI for {pipelines-title}.
 
-You can also install the `tkn-pac` `tkn-pac` version `0.23.1` binaries for the supported platforms:
+You can install the `tkn pac` and `opc` version `1.9.1` binaries for the supported platforms:
 
 * link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.23.1/tkn-pac-linux-amd64-0.23.1.tar.gz[Linux (x86_64, amd64)]
 * link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/0.23.1/tkn-pac-linux-s390x-0.23.1.tar.gz[Linux on IBM Z and LinuxONE (s390x)]
@@ -22,11 +22,11 @@ You can also install the `tkn-pac` `tkn-pac` version `0.23.1` binaries for the s
 The binaries are compatible with `tkn` version `0.23.1`.
 ====
 
-// In addition, you can install `tkn-pac` using the following methods:
+// In addition, you can install `tkn pac` using the following methods:
 
 // [CAUTION]
 // ====
-// The `tkn-pac` CLI tool available using these methods is _not updated regularly_. 
+// The `tkn pac` CLI tool available using these methods is _not updated regularly_.
 // ====
 
 // * Install on Linux or Mac OS using the `brew` package manager:
@@ -48,7 +48,7 @@ The binaries are compatible with `tkn` version `0.23.1`.
 // [source,terminal]
 // ----
 // $ podman run -e KUBECONFIG=/tmp/kube/config -v ${HOME}/.kube:/tmp/kube \
-//      -it quay.io/openshift-pipeline/pipelines-as-code tkn-pac help
+//      -it quay.io/openshift-pipeline/pipelines-as-code tkn pac help
 // ----
 // +
 // You can also use `docker` as a substitute for `podman`.

--- a/modules/op-installing-pipelines-as-code-on-an-openshift-cluster.adoc
+++ b/modules/op-installing-pipelines-as-code-on-an-openshift-cluster.adoc
@@ -9,7 +9,35 @@
 [role="_abstract"]
 {pac} is installed by default when you install the {pipelines-title} Operator. If you are using {pipelines-shortname} 1.7 or later versions, skip the procedure for manual installation of {pac}.
 
-However, if you want to disable the default installation of {pac} with the {pipelines-title} Operator, set the value of the `enablePipelinesAsCode` field as `false` in the `TektonConfig` custom resource.
+To disable the default installation of {pac} with the Operator, set the value of the `enable` parameter to `false` in the `TektonConfig` custom resource. 
+
+[source,yaml]
+----
+...
+ spec:
+    platforms:
+      openshift:
+        pipelinesAsCode:
+          enable: false
+          settings:
+            application-name: Pipelines as Code CI
+            auto-configure-new-github-repo: "false"
+            bitbucket-cloud-check-source-ip: "true"
+            hub-catalog-name: tekton
+            hub-url: https://api.hub.tekton.dev/v1
+            remote-tasks: "true"
+            secret-auto-create: "true"
+...
+----
+
+Optionally, you can run the following command:
+
+[source,terminal]
+----
+$ oc patch tektonconfig config --type="merge" -p '{"spec": {"platforms": {"openshift":{"pipelinesAsCode": {"enable": false}}}}}'
+----
+
+To enable the default installation of {pac} with the {pipelines-title} Operator, set the value of the `enable` parameter to `true` in the `TektonConfig` custom resource:
 
 [source,yaml]
 ----
@@ -20,57 +48,9 @@ spec:
 ...
 ----
 
-To install {pac} using the Operator, set the value of the `enablePipelinesAsCode` field to `true`.
+Optionally, you can run the following command: 
 
-[discrete]
-.Procedure
-
-. To _manually_ install {pac} on a {product-title} cluster instead of the default installation with the {pipelines-title} Operator, run the following command:
-+
 [source,terminal]
 ----
-$ VERSION=0.5.4
-$ oc apply -f https://raw.githubusercontent.com/openshift-pipelines/pipelines-as-code/release-$VERSION/release-$VERSION.yaml
+$ oc patch tektonconfig config --type="merge" -p '{"spec": {"platforms": {"openshift":{"pipelinesAsCode": {"enable": true}}}}}'
 ----
-+
-[NOTE]
-====
-For the latest stable version, check the link:https://github.com/openshift-pipelines/pipelines-as-code/releases[release page]. In addition, check the {pipelines-title} release notes to ensure that the {pac} version is compatible with the {pipelines-title} version.
-====
-+
-This command installs {pac} in the `pipelines-as-code` namespace and creates user roles and the route URL for the {pac} event listener.
-
-. Note the route URL for the {pac} controller created on the cluster:
-+
-[source,terminal]
-----
-$ echo https://$(oc get route -n pipelines-as-code el-pipelines-as-code-interceptor -o jsonpath='{.spec.host}')
-----
-+
-This URL will be needed later when you configure the Git repository hosting service provider.
-
-. (Optional) To allow non-administrative users to create repository custom resource definitions (CRDs) in their respective namespaces, create a `RoleBinding` object with the name `openshift-pipeline-as-code-clusterrole` in the namespace. For example, to allow a user to create a repository CRD in the `user-ci` namespace, run the following command:
-+
-[source,terminal]
-----
-$ oc adm policy add-role-to-user openshift-pipeline-as-code-clusterrole user -n user-ci
-----
-+
-Alternatively, apply the following YAML file using the `oc apply -f <RoleBinding.yaml>` command: 
-+
-[source,yaml]
-----
-apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
-metadata:
-  name: openshift-pipeline-as-code-clusterrole
-  namespace: user-ci
-roleRef:
-  apiGroup: rbac.authorization.k8s.io
-  kind: ClusterRole
-  name: openshift-pipeline-as-code-clusterrole
-subjects:
-- apiGroup: rbac.authorization.k8s.io
-  kind: User
-  name: user
----- 

--- a/modules/op-interfacing-pipelines-as-code-with-custom-certificates.adoc
+++ b/modules/op-interfacing-pipelines-as-code-with-custom-certificates.adoc
@@ -1,0 +1,15 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="interfacing-pipelines-as-code-with-custom-certificates_{context}"]
+= Interfacing {pac} with custom certificates 
+
+[role="_abstract"]
+To configure {pac} with a Git repository that is accessible with a privately signed or custom certificate, you can expose the certificate to {pac}.
+
+.Procedure
+
+* If you have installed {pac} using the {pipelines-title} Operator, you can add your custom certificate to the cluster using the `Proxy` object. The Operator exposes the certificate in all {pipelines-title} components and workloads, including {pac}.
+

--- a/modules/op-monitoring-pipeline-run-status-using-pipelines-as-code.adoc
+++ b/modules/op-monitoring-pipeline-run-status-using-pipelines-as-code.adoc
@@ -1,0 +1,76 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="monitoring-pipeline-run-status-using-pipelines-as-code_{context}"]
+= Monitoring pipeline run status using {pac} 
+
+[role="_abstract"]
+Depending on the context and supported tools, you can monitor the status of a pipeline run in different ways.
+
+[discrete]
+.Status on GitHub Apps
+When a pipeline run finishes, the status is added in the *Check* tabs with limited information on how long each task of your pipeline took, and the output of the `tkn pipelinerun describe` command.
+
+[discrete]
+.Log error snippet
+When {pac} detects an error in one of the tasks of a pipeline, a small snippet consisting of the last 3 lines in the task breakdown of the first failed task is displayed.
+
+[NOTE]
+====
+{pac} avoids leaking secrets by looking into the pipeline run and replacing secret values with hidden characters. However, {pac} cannot hide secrets coming from workspaces and envFrom source.
+====
+
+[discrete]
+.Annotations for log error snippets
+
+In the {pac} config map, if you set the `error-detection-from-container-logs` parameter to `true`, {pac} detects the errors from the container logs and adds them as annotations on the pull request where the error occurred.
+
+[IMPORTANT]
+====
+This feature is in Technology Preview. 
+====
+
+Currently, {pac} supports only the simple cases where the error looks like `makefile` or `grep` output of the following format:
+[source,yaml]
+----
+<filename>:<line>:<column>: <error message>
+----
+
+You can customize the regular expression used to detect the errors with the `error-detection-simple-regexp` field. The regular expression uses named groups to give flexibility on how to specify the matching. The groups needed to match are filename, line, and error. You can view the {pac} config map for the default regular expression.
+
+[NOTE]
+====
+By default, {pac} scans only the last 50 lines of the container logs. You can increase this value in the `error-detection-max-number-of-lines` field or set `-1` for an unlimited number of lines. However, such configurations may increase the memory usage of the watcher.
+====
+
+[discrete]
+.Status for webhook
+For webhook, when the event is a pull request, the status is added as a comment on the pull or merge request.
+
+[discrete]
+.Failures
+If a namespace is matched to a `Repository` CRD, {pac} emits its failure log messages in the Kubernetes events inside the namespace.
+
+[discrete]
+.Status associated with Repository CRD
+The last 5 status messages for a pipeline run is stored inside the `Repository` custom resource.
+
+[source,terminal]
+----
+$ oc get repo -n <pipelines-as-code-ci>
+----
+
+[source,terminal]
+----
+NAME                  URL                                                        NAMESPACE             SUCCEEDED   REASON      STARTTIME   COMPLETIONTIME
+pipelines-as-code-ci   https://github.com/openshift-pipelines/pipelines-as-code   pipelines-as-code-ci   True        Succeeded   59m         56m
+----
+
+Using the `tkn pac describe` command, you can extract the status of the runs associated with your repository and its metadata.
+
+[discrete]
+.Notifications
+{pac} does not manage notifications. If you need to have notifications, use the `finally` feature of pipelines.
+

--- a/modules/op-pipelines-as-code-command-reference.adoc
+++ b/modules/op-pipelines-as-code-command-reference.adoc
@@ -7,7 +7,7 @@
 = {pac} command reference 
 
 [role="_abstract"]
-The `tkn-pac` CLI tool offers the following capabilities:
+The `tkn pac` CLI tool offers the following capabilities:
 
 * Bootstrap {pac} installation and configuration.
 * Create a new {pac} repository.

--- a/modules/op-release-notes-1-7.adoc
+++ b/modules/op-release-notes-1-7.adoc
@@ -244,7 +244,7 @@ Pipelines as Code supports the following features:
 
 * Access Control List (ACL) over a GitHub organization, or using a Prow-style `OWNER` file.
 
-* The `tkn-pac` plugin for the `tkn` CLI tool, which you can use to manage {pac} repositories and bootstrapping.
+* The `tkn pac` plugin for the `tkn` CLI tool, which you can use to manage {pac} repositories and bootstrapping.
 
 * Support for GitHub Application, GitHub Webhook, Bitbucket Server, and Bitbucket Cloud.
 

--- a/modules/op-running-pipeline-run-using-pipelines-as-code.adoc
+++ b/modules/op-running-pipeline-run-using-pipelines-as-code.adoc
@@ -1,0 +1,69 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="running-pipeline-run-using-pipelines-as-code_{context}"]
+= Running a pipeline run using {pac} 
+
+[role="_abstract"]
+With default configuration, {pac} runs any pipeline run in the `.tekton/` directory of the default branch of repository, when specified events such as pull request or push occurs on the repository. For example, if a pipeline run on the default branch has the annotation `pipelinesascode.tekton.dev/on-event: "[pull_request]"`, it will run whenever a pull request event occurs.
+
+In the event of a pull request or a merge request, {pac} also runs pipelines from branches other than the default branch, if the following conditions are met by the author of the pull request:
+
+* The author is the owner of the repository.
+* The author is a collaborator on the repository.
+* The author is a public member on the organization of the repository.
+* The pull request author is listed in an `OWNER` file located in the repository root of the `main` branch as defined in the GitHub configuration for the repository. Also, the  pull request author is added to either `approvers` or `reviewers` section. For example, if an author is listed in the `approvers` section, then a pull request raised by that author starts the pipeline run.
+
+[source,yaml]
+----
+...
+  approvers:
+    - approved
+...
+----
+
+If the pull request author does not meet the requirements, another user who meets the requirements can comment `/ok-to-test` on the pull request, and start the pipeline run.
+
+[discrete]
+.Pipeline run execution
+A pipeline run always runs in the namespace of the `Repository` CRD associated with the repository that generated the event.
+
+You can observe the execution of your pipeline runs using the `tkn pac` CLI tool.
+
+* To follow the execution of the last pipeline run, use the following example:
++
+[source,terminal]
+----
+$ tkn pac logs -n <my-pipeline-ci> -L <1>
+----
+<1> `my-pipeline-ci` is the namespace for the `Repository` CRD.
+
+* To follow the execution of any pipeline run interactively, use the following example:
++
+[source,terminal]
+----
+$ tkn pac logs -n <my-pipeline-ci> <1>
+----
+<1> `my-pipeline-ci` is the namespace for the `Repository` CRD.
+If you need to view a pipeline run other than the last one, you can use the `tkn pac logs` command to select a `PipelineRun` attached to the repository:
+
+If you have configured {pac} with a GitHub App, {pac} posts a URL in the *Checks* tab of the GitHub App. You can click the URL and follow the pipeline execution.
+
+[discrete]
+.Restarting a pipeline run
+
+You can restart a pipeline run with no events, such as sending a new commit to your branch or raising a pull request. On a GitHub App, go to the *Checks* tab and click *Re-run*.
+
+If you target a pull or merge request, use the following comments inside your pull request to restart all or specific pipeline runs:
+
+* The `/retest` comment restarts all pipeline runs.
+
+* The `/retest <pipelinerun-name>` comment restarts a specific pipeline run.
+
+* The `/cancel` comment cancels all pipeline runs.
+
+* The `/cancel <pipelinerun-name>` comment cancels a specific pipeline run.
+
+The results of the comments are visible under the *Checks* tab of a GitHub App.

--- a/modules/op-setting-concurrency-limits-in-repository-crd.adoc
+++ b/modules/op-setting-concurrency-limits-in-repository-crd.adoc
@@ -1,0 +1,23 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="setting-concurrency-limits-in-repository-crd_{context}"]
+= Setting concurrency limits in the `Repository` CRD 
+
+[role="_abstract"]
+You can use the `concurrency_limit` spec in the `Repository` CRD to define the maximum number of pipeline runs running simultaneously for a repository.
+
+[source,yaml]
+----
+...
+spec:
+  concurrency_limit: <number>
+  ...
+----
+
+If there are multiple pipeline runs matching an event, the pipeline runs that match the event start in an alphabetical order.
+
+For example, if you have three pipeline runs in the `.tekton` directory and you create a pull request with a `concurrency_limit` of `1` in the repository configuration, then all the pipeline runs are executed in an alphabetical order. At any given time, only one pipeline run is in the running state while the rest are queued.
+

--- a/modules/op-using-incoming-webhook-with-pipelines-as-code.adoc
+++ b/modules/op-using-incoming-webhook-with-pipelines-as-code.adoc
@@ -1,0 +1,68 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="using-incoming-webhook-with-pipelines-as-code_{context}"]
+= Using incoming webhook with {pac} 
+
+[role="_abstract"]
+Using an incoming webhook URL and a shared secret, you can start a pipeline run in a repository.
+
+To use incoming webhooks, specify the following within the `spec` section of the `Repository` CRD:
+
+* The incoming webhook URL that {pac} matches.
+* The Git provider and the user token. Currently, {pac} supports `github`, `gitlab`, and `bitbucket-cloud`.
++
+[NOTE]
+====
+When using incoming webhook URLs in the context of GitHub app, you must specify the token.
+====
+* The target branches and a secret for the incoming webhook URL.
+
+.Example: `Repository` CRD with incoming webhook
+[source,yaml]
+----
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: repo
+  namespace: ns
+spec:
+  url: "https://github.com/owner/repo"
+  git_provider:
+    type: github
+    secret:
+      name: "owner-token"
+  incoming:
+    - targets:
+      - main
+      secret:
+        name: repo-incoming-secret
+      type: webhook-url
+----
+
+.Example: The `repo-incoming-secret` secret for incoming webhook
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: repo-incoming-secret
+  namespace: ns
+type: Opaque
+stringData:
+  secret: <very-secure-shared-secret>
+----
+
+To trigger a pipeline run located in the `.tekton` directory of a Git repository, use the following command: 
+
+[source,terminal]
+----
+$ curl -X POST 'https://control.pac.url/incoming?secret=very-secure-shared-secret&repository=repo&branch=main&pipelinerun=target_pipelinerun'
+----
+
+{pac} matches the incoming URL and treats it as a `push` event. However, {pac} does not report status of the pipeline runs triggered by this command.
+
+To get a report or a notification, add it directly with a `finally` task to your pipeline. Alternatively, you can inspect the `Repository` CRD with the `tkn pac` CLI tool. 
+

--- a/modules/op-using-pipelines-as-code-resolver.adoc
+++ b/modules/op-using-pipelines-as-code-resolver.adoc
@@ -1,0 +1,29 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="using-pipelines-as-code-resolver_{context}"]
+= Using {pac} resolver 
+
+[role="_abstract"]
+The {pac} resolver ensures that a running pipeline run does not conflict with others.
+
+To split your pipeline and pipeline run, store the files in the `.tekton/` directory or its subdirectories. 
+
+If {pac} observes a pipeline run with a reference to a task or a pipeline in any YAML file located in the `.tekton/` directory, {pac} automatically resolves the referenced task to provide a single pipeline run with an embedded spec in a `PipelineRun` object. 
+
+If {pac} cannot resolve the referenced tasks in the `Pipeline` or `PipelineSpec` definition, the run fails before applying any changes to the cluster. You can see the issue on your Git provider platform and inside the events of the target namespace where the `Repository` CR is located.
+
+The resolver skips resolving if it observes the following type of tasks:
+
+* A reference to a cluster task.
+* A task or pipeline bundle.
+* A custom task with an API version that does not have a `tekton.dev/` prefix.
+
+The resolver uses such tasks literally, without any transformation.
+
+To test your pipeline run locally before sending it in a pull request, use the `tkn pac resolve` command.
+
+You can also reference remote pipelines and tasks.
+

--- a/modules/op-using-pipelines-as-code-with-a-github-app.adoc
+++ b/modules/op-using-pipelines-as-code-with-a-github-app.adoc
@@ -3,8 +3,8 @@
 // *cicd/pipelines/using-pipelines-as-code.adoc
 
 :_content-type: PROCEDURE
-[id="configuring-pipelines-as-code-for-a-github-app_{context}"]
-= Configuring {pac} for a GitHub App 
+[id="using-pipelines-as-code-with-a-github-app_{context}"]
+= Using {pac} with a GitHub App 
 
 [role="_abstract"]
 GitHub Apps act as a point of integration with {pipelines-title} and bring the advantage of Git-based workflows to OpenShift Pipelines. Cluster administrators can configure a single GitHub App for all cluster users. For GitHub Apps to work with Pipelines as Code, ensure that the webhook of the GitHub App points to the Pipelines as Code event listener route (or ingress endpoint) that listens for GitHub events.
@@ -28,19 +28,13 @@ To create and configure a GitHub App manually for {pac}, perform the following s
 
 . Sign in to your GitHub account.
 
-. Go to **Settings** --> **Developer settings** --> **GitHub Apps**, and click **New GitHub App**.
+. Go to **Settings** -> **Developer settings** -> **GitHub Apps**, and click **New GitHub App**.
 
 . Provide the following information in the GitHub App form: 
 
 * **GitHub Application Name**: `OpenShift Pipelines`
 * **Homepage URL**: OpenShift Console URL 
-* **Webhook URL**: The {pac} route or ingress URL. You can find it by executing the command `echo https://$(oc get route -n pipelines-as-code el-pipelines-as-code-interceptor -o jsonpath='{.spec.host}')`.
-+
-[NOTE]
-====
-For {pac} installated by default using the {pipelines-title} Operator, use the `openshift-pipelines` namespace instead of `pipelines-as-code`.
-====
-+
+* **Webhook URL**: The {pac} route or ingress URL. You can find it by running the command `echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controller -o jsonpath='{.spec.host}')`.
 * **Webhook secret**: An arbitrary secret. You can generate a secret by executing the command `openssl rand -hex 20`.
 
 . Select the following **Repository permissions**:
@@ -79,15 +73,14 @@ To configure {pac} to access the newly created GitHub App, execute the following
 +
 [source,terminal]
 ----
-$ oc -n <pipelines-as-code> create secret generic pipelines-as-code-secret \ <1>
-        --from-literal github-private-key="$(cat <PATH_PRIVATE_KEY>)" \ <2>
-        --from-literal github-application-id="<APP_ID>" \ <3>
-        --from-literal webhook.secret="<WEBHOOK_SECRET>" <4>
+$ oc -n openshift-pipelines create secret generic pipelines-as-code-secret \
+        --from-literal github-private-key="$(cat <PATH_PRIVATE_KEY>)" \ <1>
+        --from-literal github-application-id="<APP_ID>" \ <2>
+        --from-literal webhook.secret="<WEBHOOK_SECRET>" <3>
 ----
-<1> For {pac} installated by default using the {pipelines-title} Operator, use the `openshift-pipelines` namespace instead of `pipelines-as-code`.
-<2> The path to the private key you downloaded while configuring the GitHub App.
-<3> The **App ID** of the GitHub App.
-<4> The webhook secret provided when you created the GitHub App. 
+<1> The path to the private key you downloaded while configuring the GitHub App.
+<2> The **App ID** of the GitHub App.
+<3> The webhook secret provided when you created the GitHub App. 
 
 
 [NOTE]

--- a/modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc
+++ b/modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc
@@ -1,0 +1,199 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: PROCEDURE
+[id="using-pipelines-as-code-with-bitbucket-cloud_{context}"]
+= Using {pac} with Bitbucket Cloud
+
+[role="_abstract"]
+If your organization or project uses Bitbucket Cloud as the preferred platform, you can use {pac} for your repository with a webhook on Bitbucket Cloud.
+
+[discrete]
+.Prerequisites
+
+* Ensure that {pac} is installed on the cluster.
+
+* Create an app password on Bitbucket Cloud.
+
+** Check the following boxes to add appropriate permissions to the token:
+*** Account: `Email`, `Read`
+*** Workspace membership: `Read`, `Write`
+*** Projects: `Read`, `Write`
+*** Issues: `Read`, `Write`
+*** Pull requests: `Read`, `Write`
++
+[NOTE]
+====
+* If you want to configure the webhook using the `tkn pac` CLI, add the `Webhooks`: `Read` and `Write` permission to the token.
+
+* Once generated, save a copy of the password or token in an alternate location.
+====
+
+[discrete]
+.Procedure
+
+. Configure the webhook and create a `Repository` CR.
+
+** To configure a webhook and create a `Repository` CR _automatically_ using the `tkn pac` CLI tool, use the following command:
++
+[source,terminal]
+----
+$ tkn pac create repo
+----
++
+.Sample interactive output
+[source,terminal]
+----
+? Enter the Git repository url (default: https://bitbucket.org/workspace/repo):
+? Please enter the namespace where the pipeline should run (default: repo-pipelines):
+! Namespace repo-pipelines is not found
+? Would you like me to create the namespace repo-pipelines? Yes
+✓ Repository workspace-repo has been created in repo-pipelines namespace
+✓ Setting up Bitbucket Webhook for Repository https://bitbucket.org/workspace/repo
+? Please enter your bitbucket cloud username:  <username>
+ℹ ️You now need to create a Bitbucket Cloud app password, please checkout the docs at https://is.gd/fqMHiJ for the required permissions
+? Please enter the Bitbucket Cloud app password:  ************************************
+👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.example.com
+? Do you want me to use it? Yes
+✓ Webhook has been created on repository workspace/repo
+🔑 Webhook Secret workspace-repo has been created in the repo-pipelines namespace.
+🔑 Repository CR workspace-repo has been updated with webhook secret in the repo-pipelines namespace
+ℹ Directory .tekton has been created.
+✓ A basic template has been created in /home/Go/src/bitbucket/repo/.tekton/pipelinerun.yaml, feel free to customize it.
+----
+
+** To configure a webhook and create a `Repository` CR _manually_, perform the following steps:
+
+... On your OpenShift cluster, extract the public URL of the {pac} controller.
++
+[source,terminal]
+----
+$ echo https://$(oc get route -n pipelines-as-code pipelines-as-code-controller -o jsonpath='{.spec.host}')
+----
+
+... On Bitbucket Cloud, perform the following steps:
+
+.... Use the left navigation pane of your Bitbucket Cloud repository to go to *Repository settings* –> *Webhooks* and click *Add webhook*.
+
+.... Set a *Title*. For example, "Pipelines as Code".
+
+.... Set the *URL* to the {pac} controller public URL.
+
+.... Select these events: *Repository: Push*, *Pull Request: Created*, *Pull Request: Updated*, and *Pull Request: Comment created*.
+
+.... Click *Save*.
+
+... On your OpenShift cluster, create a `Secret` object with the app password in the target namespace.
++
+[source,terminal]
+----
+$ oc -n target-namespace create secret generic bitbucket-cloud-token \
+  --from-literal provider.token="<BITBUCKET_APP_PASSWORD>"
+----
+
+... Create a `Repository` CR.
++
+.Example: `Repository` CR
+[source,yaml]
+----
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: my-repo
+  namespace: target-namespace
+spec:
+  url: "https://bitbucket.com/workspace/repo"
+  branch: "main"
+  git_provider:
+    user: "<BITBUCKET_USERNAME>" <1>
+    secret:
+      name: "bitbucket-cloud-token" <2>
+      key: "provider.token" # Set this if you have a different key in your secret
+----
+<1> You can only reference a user by the `ACCOUNT_ID` in an owner file.
+<2> {pac} assumes that the secret referred in the `git_provider.secret` spec and the `Repository` CR is in the same namespace.
+
++
+[NOTE]
+====
+* The `tkn pac create` and `tkn pac bootstrap` commands are not supported on Bitbucket Cloud.
+
+* Bitbucket Cloud does not support webhook secrets. To secure the payload and prevent hijacking of the CI, {pac} fetches the list of Bitbucket Cloud IP addresses and ensures that the webhook receptions come only from those IP addresses.
+** To disable the default behavior, set the `bitbucket-cloud-check-source-ip key` to `false` in the {pac} config map for the `pipelines-as-code` namespace.
+** To allow additional safe IP addresses or networks, add them as comma separated values to the `bitbucket-cloud-additional-source-ip` key in the {pac} config map for the `pipelines-as-code` namespace.
+====
+
+. Optional: For an existing `Repository` CR, add multiple Bitbucket Cloud Webhook secrets or provide a substitute for a deleted secret.
+
+.. Add a webhook using the `tkn pac` CLI tool.
++
+.Example: Adding additional webhook using the `tkn pac` CLI
+[source,terminal]
+----
+$ tkn pac webhook add -n repo-pipelines
+----
++
+.Sample interactive output
+[source,terminal]
+----
+✓ Setting up Bitbucket Webhook for Repository https://bitbucket.org/workspace/repo
+? Please enter your bitbucket cloud username:  <username>
+👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.example.com
+? Do you want me to use it? Yes
+✓ Webhook has been created on repository workspace/repo
+🔑 Secret workspace-repo has been updated with webhook secret in the repo-pipelines namespace.
+----
++
+[NOTE]
+====
+Use the `[-n <namespace>]` option with the `tkn pac webhook add` command only when the `Repository` CR exists in a namespace other than the default namespace.
+====
+
+.. Update the `webhook.secret` key in the existing OpenShift `Secret` object.
+
+. Optional: For an existing `Repository` CR, update the personal access token.
+
+** Update the personal access token using the `tkn pac` CLI tool.
++
+.Example: Updating personal access token using the `tkn pac` CLI
+[source,terminal]
+----
+$ tkn pac webhook update-token -n repo-pipelines
+----
++
+.Sample interactive output
+[source,terminal]
+----
+? Please enter your personal access token:  ****************************************
+🔑 Secret owner-repo has been updated with new personal access token in the repo-pipelines namespace.
+----
++
+[NOTE]
+====
+Use the `[-n <namespace>]` option with the `tkn pac webhook update-token` command only when the `Repository` CR exists in a namespace other than the default namespace.
+====
+
+** Alternatively, update the personal access token by modifying the `Repository` CR.
+
+... Find the name of the secret in the `Repository` CR.
++
+[source,yaml]
+----
+...
+spec:
+  git_provider:
+    user: "<BITBUCKET_USERNAME>"
+    secret:
+      name: "bitbucket-cloud-token"
+      key: "provider.token"
+...
+----
+
+... Use the `oc patch` command to update the values of the `$password` in the `$target_namespace` namespace.
++
+[source,terminal]
+----
+$ oc -n $target_namespace patch secret bitbucket-cloud-token -p "{\"data\": {\"provider.token\": \"$(echo -n $NEW_TOKEN|base64 -w0)\"}}"
+----
+

--- a/modules/op-using-pipelines-as-code-with-bitbucket-server.adoc
+++ b/modules/op-using-pipelines-as-code-with-bitbucket-server.adoc
@@ -1,0 +1,98 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: PROCEDURE
+[id="using-pipelines-as-code-with-bitbucket-server_{context}"]
+= Using {pac} with Bitbucket Server 
+
+[role="_abstract"]
+If your organization or project uses Bitbucket Server as the preferred platform, you can use {pac} for your repository with a webhook on Bitbucket Server. 
+
+[discrete]
+.Prerequisites
+
+* Ensure that {pac} is installed on the cluster.
+
+* Generate a personal access token as the manager of the project on Bitbucket Server, and save a copy of it in an alternate location. 
++
+[NOTE]
+====
+* The token must have the `PROJECT_ADMIN` and `REPOSITORY_ADMIN` permissions.
+* The token must have access to forked repositories in pull requests.
+====
+
+[discrete]
+.Procedure
+
+. On your OpenShift cluster, extract the public URL of the {pac} controller.
++
+[source,terminal]
+----
+$ echo https://$(oc get route -n pipelines-as-code pipelines-as-code-controller -o jsonpath='{.spec.host}')
+----
+
+. On Bitbucket Server, perform the following steps:
+
+.. Use the left navigation pane of your Bitbucket Data Center repository to go to *Repository settings* –> *Webhooks* and click *Add webhook*.
+
+.. Set a *Title*. For example, "Pipelines as Code".
+
+.. Set the *URL* to the {pac} controller public URL.
+
+.. Add a webhook secret and save a copy of it in an alternate location. If you have `openssl` installed on your local machine, generate a random secret using the following command:
++
+[source,terminal]
+----
+$ openssl rand -hex 20
+---- 
+
+.. Select the following events: 
+*** *Repository: Push*
+*** *Repository: Modified*
+*** *Pull Request: Opened*
+*** *Pull Request: Source branch updated*
+*** *Pull Request: Comment added* 
+
+.. Click *Save*.
+
+. On your OpenShift cluster, create a `Secret` object with the app password in the target namespace.
++
+[source,terminal]
+----
+$ oc -n target-namespace create secret generic bitbucket-server-webhook-config \
+  --from-literal provider.token="<PERSONAL_TOKEN>" \
+  --from-literal webhook.secret="<WEBHOOK_SECRET>"
+----
+
+. Create a `Repository` CR.
++
+.Example: `Repository` CR
+[source,yaml]
+----
+---
+  apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+  kind: Repository
+  metadata:
+    name: my-repo
+    namespace: target-namespace
+  spec:
+    url: "https://bitbucket.com/workspace/repo"
+    git_provider:
+      url: "https://bitbucket.server.api.url/rest" <1>
+      user: "<BITBUCKET_USERNAME>" <2>
+      secret: <3>
+        name: "bitbucket-server-webhook-config"
+        key: "provider.token" # Set this if you have a different key in your secret
+      webhook_secret:
+        name: "bitbucket-server-webhook-config"
+        key: "webhook.secret" # Set this if you have a different key for your secret
+----
+<1> Ensure that you have the right Bitbucket Server API URL without the `/api/v1.0` suffix. Usually, the default install has a `/rest` suffix.
+<2> You can only reference a user by the `ACCOUNT_ID` in an owner file.
+<3> {pac} assumes that the secret referred in the `git_provider.secret` spec and the `Repository` CR is in the same namespace.
++
+[NOTE]
+====
+The `tkn pac create` and `tkn pac bootstrap` commands are not supported on Bitbucket Server.  
+====

--- a/modules/op-using-pipelines-as-code-with-github-webhook.adoc
+++ b/modules/op-using-pipelines-as-code-with-github-webhook.adoc
@@ -1,0 +1,214 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: PROCEDURE
+[id="using-pipelines-as-code-with-github-webhook_{context}"]
+= Using {pac} with GitHub Webhook 
+
+[role="_abstract"]
+Use {pac} with GitHub Webhook on your repository if you cannot create a GitHub App. However, using {pac} with GitHub Webhook does not give you access to the GitHub Check Runs API. The status of the tasks is added as comments on the pull request and is unavailable under the *Checks* tab.
+
+[NOTE]
+====
+{pac} with GitHub Webhook does not support GitOps comments such as `/retest` and `/ok-to-test`. To restart the continuous integration (CI), create a new commit to the repository. For example, to create a new commit without any changes, you can use the following command:
+
+[source,terminal]
+----
+$ git --amend -a --no-edit && git push --force-with-lease <origin> <branchname>
+---- 
+====
+
+[discrete]
+.Prerequisites
+
+* Ensure that {pac} is installed on the cluster.
+
+* For authorization, create a personal access token on GitHub.
+
+** To generate a secure and fine-grained token, restrict its scope to a specific repository and grant the following permissions:
++
+.Permissions for fine-grained tokens
+[options="header"]
+|===
+
+| Name | Access 
+
+| Administration | Read-only 
+
+| Metadata | Read-only 
+
+| Content | Read-only 
+
+| Commit statuses | Read and Write 
+
+| Pull request | Read and Write 
+
+| Webhooks | Read and Write
+
+|===
+
+** To use classic tokens, set the scope as `public_repo` for public repositories and `repo` for private repositories. In addition, provide a short token expiration period and note the token in an alternate location.
++
+[NOTE]
+====
+If you want to configure the webhook using the `tkn pac` CLI, add the `admin:repo_hook` scope.
+====
+
+[discrete]
+.Procedure
+
+. Configure the webhook and create a `Repository` custom resource (CR).
+
+** To configure a webhook and create a `Repository` CR _automatically_ using the `tkn pac` CLI tool, use the following command:
++
+[source,terminal]
+----
+$ tkn pac create repo
+----
++
+.Sample interactive output
+[source,terminal]
+----
+? Enter the Git repository url (default: https://github.com/owner/repo):
+? Please enter the namespace where the pipeline should run (default: repo-pipelines):
+! Namespace repo-pipelines is not found
+? Would you like me to create the namespace repo-pipelines? Yes
+✓ Repository owner-repo has been created in repo-pipelines namespace
+✓ Setting up GitHub Webhook for Repository https://github.com/owner/repo
+👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.example.com
+? Do you want me to use it? Yes
+? Please enter the secret to configure the webhook for payload validation (default: sJNwdmTifHTs):  sJNwdmTifHTs
+ℹ ️You now need to create a GitHub personal access token, please checkout the docs at https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token for the required scopes
+? Please enter the GitHub access token:  ****************************************
+✓ Webhook has been created on repository owner/repo
+🔑 Webhook Secret owner-repo has been created in the repo-pipelines namespace.
+🔑 Repository CR owner-repo has been updated with webhook secret in the repo-pipelines namespace
+ℹ Directory .tekton has been created.
+✓ We have detected your repository using the programming language Go.
+✓ A basic template has been created in /home/Go/src/github.com/owner/repo/.tekton/pipelinerun.yaml, feel free to customize it.
+----
+
+** To configure a webhook and create a `Repository` CR _manually_, perform the following steps:
+
+... On your OpenShift cluster, extract the public URL of the {pac} controller.
++
+[source,terminal]
+----
+$ echo https://$(oc get route -n pipelines-as-code pipelines-as-code-controller -o jsonpath='{.spec.host}')
+----
+
+... On your GitHub repository or organization, perform the following steps:
+
+.... Go to *Settings* –> *Webhooks* and click *Add webhook*.
+
+.... Set the *Payload URL* to the {pac} controller public URL.
+
+.... Select the content type as *application/json*.
+
+.... Add a webhook secret and note it in an alternate location. With `openssl` installed on your local machine, generate a random secret.
++
+[source,terminal]
+----
+$ openssl rand -hex 20
+---- 
+
+.... Click *Let me select individual events* and select these events: *Commit comments*, *Issue comments*, *Pull request*, and *Pushes*.
+
+.... Click *Add webhook*.
+
+... On your OpenShift cluster, create a `Secret` object with the personal access token and webhook secret.
++
+[source,terminal]
+----
+$ oc -n target-namespace create secret generic github-webhook-config \
+  --from-literal provider.token="<GITHUB_PERSONAL_ACCESS_TOKEN>" \
+  --from-literal webhook.secret="<WEBHOOK_SECRET>"
+----
+
+... Create a `Repository` CR.
++
+.Example: `Repository` CR
+[source,yaml]
+----
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: my-repo
+  namespace: target-namespace
+spec:
+  url: "https://github.com/owner/repo"
+  git_provider:
+    secret:
+      name: "github-webhook-config"
+      key: "provider.token" # Set this if you have a different key in your secret
+    webhook_secret:
+      name: "github-webhook-config"
+      key: "webhook.secret" # Set this if you have a different key for your secret
+----
++
+[NOTE]
+====
+{pac} assumes that the OpenShift `Secret` object and the `Repository` CR are in the same namespace.
+====
+
+. Optional: For an existing `Repository` CR, add multiple GitHub Webhook secrets or provide a substitute for a deleted secret.
+
+.. Add a webhook using the `tkn pac` CLI tool.
++
+.Example: Additional webhook using the `tkn pac` CLI
+[source,terminal]
+----
+$ tkn pac webhook add -n repo-pipelines
+----
++
+.Sample interactive output
+[source,terminal]
+----
+✓ Setting up GitHub Webhook for Repository https://github.com/owner/repo
+👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.example.com
+? Do you want me to use it? Yes
+? Please enter the secret to configure the webhook for payload validation (default: AeHdHTJVfAeH):  AeHdHTJVfAeH
+✓ Webhook has been created on repository owner/repo
+🔑 Secret owner-repo has been updated with webhook secert in the repo-pipelines namespace.
+----
+
+.. Update the `webhook.secret` key in the existing OpenShift `Secret` object.
+
+. Optional: For an existing `Repository` CR, update the personal access token.
+
+** Update the personal access token using the `tkn pac` CLI tool.
++
+.Example: Updating personal access token using the `tkn pac` CLI
+[source,terminal]
+----
+$ tkn pac webhook update-token -n repo-pipelines
+----
++
+.Sample interactive output
+[source,terminal]
+----
+? Please enter your personal access token:  ****************************************
+🔑 Secret owner-repo has been updated with new personal access token in the repo-pipelines namespace.
+----
+
+** Alternatively, update the personal access token by modifying the `Repository` CR.
+
+... Find the name of the secret in the `Repository` CR.
++
+[source,yaml]
+----
+...
+spec:
+  git_provider:
+    secret:
+      name: "github-webhook-config"
+...
+----
+
+... Use the `oc patch` command to update the values of the `$NEW_TOKEN` in the `$target_namespace` namespace.
++
+[source,terminal]
+----
+$ oc -n $target_namespace patch secret github-webhook-config -p "{\"data\": {\"provider.token\": \"$(echo -n $NEW_TOKEN|base64 -w0)\"}}"
+----

--- a/modules/op-using-pipelines-as-code-with-gitlab.adoc
+++ b/modules/op-using-pipelines-as-code-with-gitlab.adoc
@@ -1,0 +1,186 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: PROCEDURE
+[id="using-pipelines-as-code-with-gitlab_{context}"]
+= Using {pac} with GitLab 
+
+[role="_abstract"]
+If your organization or project uses GitLab as the preferred platform, you can use {pac} for your repository with a webhook on GitLab. 
+
+[discrete]
+.Prerequisites
+
+* Ensure that {pac} is installed on the cluster.
+
+* For authorization, generate a personal access token as the manager of the project or organization on GitLab.
++
+[NOTE]
+====
+* If you want to configure the webhook using the `tkn pac` CLI, add the `admin:repo_hook` scope to the token.
+
+* Using a token scoped for a specific project cannot provide API access to a merge request (MR) sent from a forked repository. In such cases, {pac} displays the result of a pipeline as a comment on the MR.
+====
+
+[discrete]
+.Procedure
+
+. Configure the webhook and create a `Repository` custom resource (CR).
+
+** To configure a webhook and create a `Repository` CR _automatically_ using the `tkn pac` CLI tool, use the following command:
++
+[source,terminal]
+----
+$ tkn pac create repo
+----
++
+.Sample interactive output
+[source,terminal]
+----
+? Enter the Git repository url (default: https://gitlab.com/owner/repo):
+? Please enter the namespace where the pipeline should run (default: repo-pipelines):
+! Namespace repo-pipelines is not found
+? Would you like me to create the namespace repo-pipelines? Yes
+✓ Repository repositories-project has been created in repo-pipelines namespace
+✓ Setting up GitLab Webhook for Repository https://gitlab.com/owner/repo
+? Please enter the project ID for the repository you want to be configured,
+  project ID refers to an unique ID (e.g. 34405323) shown at the top of your GitLab project : 17103
+👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.example.com
+? Do you want me to use it? Yes
+? Please enter the secret to configure the webhook for payload validation (default: lFjHIEcaGFlF):  lFjHIEcaGFlF
+ℹ ️You now need to create a GitLab personal access token with `api` scope
+ℹ ️Go to this URL to generate one https://gitlab.com/-/profile/personal_access_tokens, see https://is.gd/rOEo9B for documentation
+? Please enter the GitLab access token:  **************************
+? Please enter your GitLab API URL::  https://gitlab.com
+✓ Webhook has been created on your repository
+🔑 Webhook Secret repositories-project has been created in the repo-pipelines namespace.
+🔑 Repository CR repositories-project has been updated with webhook secret in the repo-pipelines namespace
+ℹ Directory .tekton has been created.
+✓ A basic template has been created in /home/Go/src/gitlab.com/repositories/project/.tekton/pipelinerun.yaml, feel free to customize it.
+----
+
+** To configure a webhook and create a `Repository` CR _manually_, perform the following steps:
+
+... On your OpenShift cluster, extract the public URL of the {pac} controller.
++
+[source,terminal]
+----
+$ echo https://$(oc get route -n pipelines-as-code pipelines-as-code-controller -o jsonpath='{.spec.host}')
+----
+
+... On your GitLab project, perform the following steps:
+
+.... Use the left sidebar to go to *Settings* –> *Webhooks*.
+
+.... Set the *URL* to the {pac} controller public URL.
+
+.... Add a webhook secret and note it in an alternate location. With `openssl` installed on your local machine, generate a random secret.
++
+[source,terminal]
+----
+$ openssl rand -hex 20
+---- 
+
+.... Click *Let me select individual events* and select these events: *Commit comments*, *Issue comments*, *Pull request*, and *Pushes*. 
+
+.... Click *Save changes*.
+
+... On your OpenShift cluster, create a `Secret` object with the personal access token and webhook secret.
++
+[source,terminal]
+----
+$ oc -n target-namespace create secret generic gitlab-webhook-config \
+  --from-literal provider.token="<GITLAB_PERSONAL_ACCESS_TOKEN>" \
+  --from-literal webhook.secret="<WEBHOOK_SECRET>"
+----
+
+... Create a `Repository` CR.
++
+.Example: `Repository` CR
+[source,yaml]
+----
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: my-repo
+  namespace: target-namespace
+spec:
+  url: "https://gitlab.com/owner/repo" <1>
+  git_provider:
+    secret:
+      name: "gitlab-webhook-config"
+      key: "provider.token" # Set this if you have a different key in your secret
+    webhook_secret:
+      name: "gitlab-webhook-config"
+      key: "webhook.secret" # Set this if you have a different key for your secret
+----
+<1> Currently, {pac} does not automatically detects private instances for GitLab. In such cases, specify the API URL under the `git_provider.url` spec. In general, you can use the `git_provider.url` spec to manually override the API URL.
+
++
+[NOTE]
+====
+* {pac} assumes that the OpenShift `Secret` object and the `Repository` CR are in the same namespace.
+====
+
+. Optional: For an existing `Repository` CR, add multiple GitLab Webhook secrets or provide a substitute for a deleted secret.
+
+.. Add a webhook using the `tkn pac` CLI tool.
++
+.Example: Adding additional webhook using the `tkn pac` CLI
+[source,terminal]
+----
+$ tkn pac webhook add -n repo-pipelines
+----
++
+.Sample interactive output
+[source,terminal]
+----
+✓ Setting up GitLab Webhook for Repository https://gitlab.com/owner/repo
+👀 I have detected a controller url: https://pipelines-as-code-controller-openshift-pipelines.apps.example.com
+? Do you want me to use it? Yes
+? Please enter the secret to configure the webhook for payload validation (default: AeHdHTJVfAeH):  AeHdHTJVfAeH
+✓ Webhook has been created on repository owner/repo
+🔑 Secret owner-repo has been updated with webhook secert in the repo-pipelines namespace.
+----
+
+.. Update the `webhook.secret` key in the existing OpenShift `Secret` object.
+
+. Optional: For an existing `Repository` CR, update the personal access token.
+
+** Update the personal access token using the `tkn pac` CLI tool.
++
+.Example: Updating personal access token using the `tkn pac` CLI
+[source,terminal]
+----
+$ tkn pac webhook update-token -n repo-pipelines
+----
++
+.Sample interactive output
+[source,terminal]
+----
+? Please enter your personal access token:  ****************************************
+🔑 Secret owner-repo has been updated with new personal access token in the repo-pipelines namespace.
+----
+
+** Alternatively, update the personal access token by modifying the `Repository` CR.
+
+... Find the name of the secret in the `Repository` CR.
++
+[source,yaml]
+----
+...
+spec:
+  git_provider:
+    secret:
+      name: "gitlab-webhook-config"
+...
+----
+
+... Use the `oc patch` command to update the values of the `$NEW_TOKEN` in the `$target_namespace` namespace.
++
+[source,terminal]
+----
+$ oc -n $target_namespace patch secret gitlab-webhook-config -p "{\"data\": {\"provider.token\": \"$(echo -n $NEW_TOKEN|base64 -w0)\"}}"
+----
+

--- a/modules/op-using-private-repositories-with-pipelines-as-code.adoc
+++ b/modules/op-using-private-repositories-with-pipelines-as-code.adoc
@@ -1,0 +1,56 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="using-private-repositories-with-pipelines-as-code_{context}"]
+= Using private repositories with {pac} 
+
+[role="_abstract"]
+{pac} supports private repositories by creating or updating a secret in the target namespace with the user token. The `git-clone` task from {tekton-hub} uses the user token to clone private repositories.
+
+Whenever {pac} creates a new pipeline run in the target namespace, it creates or updates a secret with the  `pac-gitauth-<REPOSITORY_OWNER>-<REPOSITORY_NAME>-<RANDOM_STRING>` format.
+
+You must reference the secret with the `basic-auth` workspace in your pipeline run and pipeline definitions, which is then passed on to the `git-clone` task.
+
+[source,yaml]
+----
+...
+  workspace:
+  - name: basic-auth
+    secret:
+      secretName: "{{ git_auth_secret }}"
+...
+----
+
+In the pipeline, you can reference the `basic-auth` workspace for the `git-clone` task to reuse:
+
+[source,yaml]
+----
+...
+workspaces:
+  - name basic-auth
+params:
+    - name: repo_url
+    - name: revision
+...
+tasks:
+  workspaces:
+    - name: basic-auth
+      workspace: basic-auth
+  ...
+  tasks:
+  - name: git-clone-from-catalog
+      taskRef:
+        name: git-clone <1>
+      params:
+        - name: url
+          value: $(params.repo_url)
+        - name: revision
+          value: $(params.revision)
+...
+----
+<1> The `git-clone` task picks up the `basic-auth` workspace and uses it to clone the private repository.
+
+You can modify this configuration by setting the `secret-auto-create` flag to either a `false` or `true` value, as required in the {pac} config map.
+

--- a/modules/op-using-remote-pipeline-annotations-with-pipelines-as-code.adoc
+++ b/modules/op-using-remote-pipeline-annotations-with-pipelines-as-code.adoc
@@ -1,0 +1,24 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="using-remote-pipeline-annotations-with-pipelines-as-code_{context}"]
+= Using remote pipeline annotations with {pac} 
+
+[role="_abstract"]
+You can share a pipeline definition across multiple repositories by using the remote pipeline annotation.
+
+[source,yaml]
+----
+...
+    pipelinesascode.tekton.dev/pipeline: "<https://git.provider/raw/pipeline.yaml>" <1>
+...
+----
+<1> URL to the remote pipeline definition. You can also provide locations for files inside the same repository.
+
+[NOTE]
+====
+You can reference only one pipeline definition using the annotation.
+====
+

--- a/modules/op-using-remote-task-annotations-with-pipelines-as-code.adoc
+++ b/modules/op-using-remote-task-annotations-with-pipelines-as-code.adoc
@@ -1,0 +1,98 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="using-remote-task-annotations-with-pipelines-as-code_{context}"]
+= Using remote task annotations with {pac} 
+
+[role="_abstract"]
+{pac} supports fetching remote tasks or pipelines by using annotations in a pipeline run. If you reference a remote task in a pipeline run, or a pipeline in a `PipelineRun` or a `PipelineSpec` object, the {pac} resolver automatically includes it. If there is any error while fetching the remote tasks or parsing them, {pac} stops processing the tasks.
+
+To include remote tasks, refer to the following examples of annotation:
+
+[discrete]
+.Reference remote tasks in {tekton-hub}
+
+* Reference a single remote task in {tekton-hub}.
+
++
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/task: "git-clone" <1> 
+...
+----
+<1> {pac} includes the latest version of the task from the {tekton-hub}.
+
+
+* Reference multiple remote tasks from {tekton-hub}
+
++
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/task: "[git-clone, golang-test, tkn]"
+...
+----
+
+* Reference multiple remote tasks from {tekton-hub} using the `-<NUMBER>` suffix.
+
++
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/task: "git-clone"
+  pipelinesascode.tekton.dev/task-1: "golang-test"
+  pipelinesascode.tekton.dev/task-2: "tkn" <1>
+...
+----
+<1> By default, {pac} interprets the string as the latest task to fetch from {tekton-hub}.
+
+
+* Reference a specific version of a remote task from {tekton-hub}.
+
++
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/task: "[git-clone:0.1]" <1>
+...
+----
+<1> Refers to the `0.1` version of the `git-clone` remote task from {tekton-hub}.
+
+
+[discrete]
+.Remote tasks using URLs
+
+[source,yaml]
+----
+...
+  pipelinesascode.tekton.dev/task: "<https://remote.url/task.yaml>" <1>
+...
+----
+<1> The public URL to the remote task.
++
+[NOTE]
+====
+* If you use GitHub and the remote task URL uses the same host as the `Repository` CRD, {pac} uses the GitHub token and fetches the URL using the GitHub API.
++
+For example, if you have a repository URL similar to `https://github.com/<organization>/<repository>` and the remote HTTP URL references a GitHub blob similar to `https://github.com/<organization>/<repository>/blob/<mainbranch>/<path>/<file>`, {pac} fetches the task definition files from that private repository with the GitHub App token. 
++
+When you work on a public GitHub repository, {pac} acts similarly for a GitHub raw URL such as `https://raw.githubusercontent.com/<organization>/<repository>/<mainbranch>/<path>/<file>`.
+
+
+* GitHub App tokens are scoped to the owner or organization where the repository is located. When you use the GitHub webhook method, you can fetch any private or public repository on any organization where the personal token is allowed.
+====
+
+[discrete]
+.Reference a task from a YAML file inside your repository
+
+[source,yaml]
+----
+...
+pipelinesascode.tekton.dev/task: "<share/tasks/git-clone.yaml>" <1>
+...
+----
+<1> Relative path to the local file containing the task definition. 
+

--- a/modules/op-using-repository-crd-with-pipelines-as-code.adoc
+++ b/modules/op-using-repository-crd-with-pipelines-as-code.adoc
@@ -1,0 +1,41 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="using-repository-crd-with-pipelines-as-code_{context}"]
+= Using the `Repository` CRD with {pac} 
+
+[role="_abstract"]
+The `Repository` custom resource (CR) has the following primary functions:
+
+* Inform {pac} about processing an event from a URL.
+* Inform {pac} about the namespace for the pipeline runs.
+* Reference an API secret, username, or an API URL necessary for Git provider platforms when using webhook methods. 
+* Provide the last pipeline run status for a repository.
+
+You can use the `tkn pac` CLI or other alternative methods to create a `Repository` CR inside the target namespace. For example:
+
+[source,terminal]
+----
+cat <<EOF|kubectl create -n my-pipeline-ci -f- <1>
+
+apiVersion: "pipelinesascode.tekton.dev/v1alpha1"
+kind: Repository
+metadata:
+  name: project-repository
+spec:
+  url: "https://github.com/<repository>/<project>"
+EOF
+----
+<1> `my-pipeline-ci` is the target namespace.
+
+Whenever there is an event coming from the URL such as `https://github.com/<repository>/<project>`, {pac} matches it and starts checking out the content of the `<repository>/<project>` repository for pipeline run to match the content in the `.tekton/` directory.
+
+[NOTE]
+====
+* You must create the `Repository` CRD in the same namespace where pipelines associated with the source code repository will be executed; it cannot target a different namespace.
+
+* If multiple `Repository` CRDs match the same event, {pac} will process only the oldest one. If you need to match a specific namespace, add the `pipelinesascode.tekton.dev/target-namespace: "<mynamespace>"` annotation. Such explicit targeting prevents a malicious actor from executing a pipeline run in a namespace to which they do not have access.
+====
+


### PR DESCRIPTION
Manual CP from https://github.com/openshift/openshift-docs/pull/57455 to 4.10

Aligned team: Dev Tools

Purpose: To resolve https://github.com/openshift/openshift-docs/pull/53813

OCP version this PR applies to: enterprise 4.10