### PR TITLE
OSDOCS-5567: replacing OSUS mirroring admonition

### DIFF
--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -6,6 +6,11 @@
 [id="update-mirror-repository-adm-release-mirror_{context}"]
 = Mirroring images using the oc adm release mirror command
 
+[IMPORTANT]
+====
+To avoid excessive memory usage by the OpenShift Update Service application, you must mirror release images to a separate repository as described in the following procedure.
+====
+
 .Prerequisites
 
 * You configured a mirror registry to use in your disconnected environment and can access the certificate and credentials that you configured.
@@ -51,6 +56,16 @@ $ LOCAL_REPOSITORY='<local_repository_name>'
 +
 For `<local_repository_name>`, specify the name of the repository to create in your
 registry, such as `ocp4/openshift4`.
+
+.. If you are using the OpenShift Update Service, export an additional local repository name to contain the release images:
++
+[source,terminal]
+----
+$ LOCAL_RELEASE_IMAGES_REPOSITORY='<local_release_images_repository_name>'
+----
++
+For `<local_release_images_repository_name>`, specify the name of the repository to
+create in your registry, such as `ocp4/openshift4-release-images`.
 
 .. Export the name of the repository to mirror:
 +
@@ -135,7 +150,16 @@ $ oc apply -f ${REMOVABLE_MEDIA_PATH}/mirror/config/<image_signature_file> <1>
 +
 <1> For `<image_signature_file>`, specify the path and name of the file, for example, `signature-sha256-81154f5c03294534.yaml`.
 
-** If the local container registry and the cluster are connected to the mirror host, directly push the release images to the local registry and apply the config map  to the cluster by using following command:
+... If you are using the OpenShift Update Service, mirror the release image to a separate repository:
++
+[source,terminal]
+----
+$ oc image mirror -a ${LOCAL_SECRET_JSON} ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE} ${LOCAL_REGISTRY}/${LOCAL_RELEASE_IMAGES_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}
+----
+
+** If the local container registry and the cluster are connected to the mirror host, take the following actions:
+
+... Directly push the release images to the local registry and apply the config map  to the cluster by using following command:
 +
 [source,terminal]
 ----
@@ -147,3 +171,10 @@ $ oc adm release mirror -a ${LOCAL_SECRET_JSON} --from=quay.io/${PRODUCT_REPO}/$
 ====
 If you include the `--apply-release-image-signature` option, do not create the config map for image signature verification.
 ====
+
+... If you are using the OpenShift Update Service, mirror the release image to a separate repository:
++
+[source,terminal]
+----
+$ oc image mirror -a ${LOCAL_SECRET_JSON} ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE} ${LOCAL_REGISTRY}/${LOCAL_RELEASE_IMAGES_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}
+----


### PR DESCRIPTION
[OSDOCS-5567](https://issues.redhat.com//browse/OSDOCS-5567)

Versions: 4.9+

This PR replaces an admonition that was accidentally removed in #55448

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Preview: https://57578--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/mirroring-image-repository.html#update-mirror-repository-adm-release-mirror_mirroring-ocp-image-repository