### PR TITLE
TELCODOCS-1120 removing section on incompatibility with IP failover

### DIFF
--- a/modules/nw-metallb-when-metallb.adoc
+++ b/modules/nw-metallb-when-metallb.adoc
@@ -12,3 +12,8 @@ You must configure your networking infrastructure to ensure that network traffic
 
 After deploying MetalLB with the MetalLB Operator, when you add a service of type `LoadBalancer`, MetalLB provides a platform-native load balancer.
 
+MetalLB operating in layer2 mode provides support for failover by utilizing a mechanism similar to IP failover. However, instead of relying on the virtual router redundancy protocol (VRRP) and keepalived, MetalLB leverages a gossip-based protocol to identify instances of node failure. When a failover is detected, another node assumes the role of the leader node, and a gratuitous ARP message is dispatched to broadcast this change.
+
+MetalLB operating in layer3 or border gateway protocol (BGP) mode delegates failure detection to the network. The BGP router or routers that the {product-title} nodes have established a connection with will identify any node failure and terminate the routes to that node.
+
+Using MetalLB instead of IP failover is preferable for ensuring high availability of pods and services.

--- a/networking/metallb/about-metallb.adoc
+++ b/networking/metallb/about-metallb.adoc
@@ -39,12 +39,6 @@ include::modules/nw-metallb-layer2-limitations.adoc[leveloffset=+2]
 // BGP limitations
 include::modules/nw-metallb-bgp-limitations.adoc[leveloffset=+2]
 
-// Incompat with IP failover
-[id="incompatibility-with-ip-failover_{context}"]
-=== Incompatibility with IP failover
-
-MetalLB is incompatible with the IP failover feature. Before you install the MetalLB Operator, remove IP failover.
-
 [role="_additional-resources"]
 [id="additional-resources_about-metallb-and-metallb-operator"]
 == Additional resources


### PR DESCRIPTION
[TELCODOCS-1120]: Misleading text in MetalLB incompatibility section
[OCPBUGS-9222]: This section has generated quite a lot of discussions on e-mails and on slack
Version(s):
main, 4.13, 4.12, 4.11, 4.10, 4.9

Issue:
https://issues.redhat.com/browse/TELCODOCS-1120

Link to docs preview:https://57579--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/about-metallb.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
