### PR TITLE
OCPBUGS-7713 correcting spelling engress to egress

### DIFF
--- a/modules/nw-ovn-kubernetes-running-ovnkube-trace.adoc
+++ b/modules/nw-ovn-kubernetes-running-ovnkube-trace.adoc
@@ -101,7 +101,7 @@ $ ./ovnkube-trace \
   -loglevel 2
 ----
 
-The output from this increased log level is too much to list here. In a failure situation the output of this command shows which flow is dropping that traffic. For example an engress or ingress network policy may be configured on the cluster that does not allow that traffic.
+The output from this increased log level is too much to list here. In a failure situation the output of this command shows which flow is dropping that traffic. For example an egress or ingress network policy may be configured on the cluster that does not allow that traffic.
 
 .Example: Verifying by using debug output a configured default deny
 


### PR DESCRIPTION
[OCPBUGS-7713]: Issue in file networking/ovn_kubernetes_network_provider/ovn-kubernetes-tracing-using-ovntrace.adoc

Version(s):
main, 4.13, 4.12
Issue:
https://issues.redhat.com/browse/OCPBUGS-7713

Link to docs preview:
https://57582--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-tracing-using-ovntrace.html#nw-ovn-kubernetes-running-ovnkube-trace_ovn-kubernetes-tracing-with-ovnkube

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
