### PR TITLE
OCPBUGS-9920 Issue in file networking/metallb/metallb-upgrading-operator.adoc

### DIFF
--- a/modules/nw-metalLB-basic-upgrade-operator.adoc
+++ b/modules/nw-metalLB-basic-upgrade-operator.adoc
@@ -45,7 +45,7 @@ metallb   33m
 +
 [NOTE]
 ====
-When installing the latest {product-version} version of the MetalLB Operator, you must install the Operator to the same namespace it was previously installed to. 
+When installing the latest {product-version} version of the MetalLB Operator, you must install the Operator to the same namespace it was previously installed to.
 ====
 
 . Verify the upgraded version of the Operator is now the {product-version} version.
@@ -56,9 +56,9 @@ $ oc get csv -n metallb-system
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME                                   DISPLAY            VERSION               REPLACES   PHASE
-metallb-operator.4.12.0-202207051316   MetalLB Operator   4.12.0-202207051316              Succeeded
+metallb-operator.4.{product-version}.0-202207051316   MetalLB Operator   4.{product-version}.0-202207051316              Succeeded
 ----
 

--- a/networking/metallb/metallb-upgrading-operator.adoc
+++ b/networking/metallb/metallb-upgrading-operator.adoc
@@ -1,23 +1,25 @@
 :_content-type: ASSEMBLY
 [id="metallb-upgrading-operator"]
-= Upgrading the MetalLB Operator
+= Upgrading the MetalLB
 include::_attributes/common-attributes.adoc[]
 :context: metallb-upgrading-operator
 
 toc::[]
 
-The automatic upgrade procedure does not work as expected from {product-title} 4.10 and earlier. A summary of the upgrade procedure is as follows:
+If you are currently running version 4.10 or an earlier version of the MetalLB Operator, please note that automatic updates to any version later than 4.10 do not work. Upgrading to a newer version from any version of the MetalLB Operator that is 4.11 or later is successful. For example, upgrading from version 4.12 to version 4.13 will occur smoothly.
 
-. Delete the previously installed Operator version for example 4.10. Ensure that the namespace and the `metallb` custom resource are not removed.
+A summary of the upgrade procedure for the MetalLB Operator from 4.10 and earlier is as follows:
 
-. Install the 4.11 version of the Operator using the CLI. Install the 4.11 version of the Operator in the same namespace that the previously installed Operator version was installed to.
+. Delete the installed MetalLB Operator version for example 4.10. Ensure that the namespace and the `metallb` custom resource are not removed.
+
+. Using the CLI, install the MetalLB Operator {product-version} in the same namespace where the previous version of the MetalLB Operator was installed.
 
 [NOTE]
 ====
 This procedure does not apply to automatic z-stream updates of the MetalLB Operator, which follow the standard straightforward method.
 ====
 
-For detailed steps to upgrade the Operator, see the guidance that follows. 
+For detailed steps to upgrade the MetalLB Operator from 4.10 and earlier, see the guidance that follows.
 
 //Delete metallb using web console
 include::modules/olm-deleting-metallb-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
@@ -25,7 +27,7 @@ include::modules/olm-deleting-metallb-operators-from-a-cluster-using-web-console
 //Delete metallb using cli
 include::modules/olm-deleting-metallb-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]
 
-//Upgrade the Operator
+//Upgrade the MetalLB
 include::modules/nw-metalLB-basic-upgrade-operator.adoc[leveloffset=+1]
 
 [id="additional-resources"]


### PR DESCRIPTION
[OCPBUGS-9920]: Upgrade does not address upgrade to latest version has hardcoded 4.11

Version(s):
main, 4.12 and 4.13
Issue:
https://issues.redhat.com/browse/OCPBUGS-9920

Link to docs preview:
https://57583--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-upgrading-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Will overide these changes for 4.12 https://github.com/openshift/openshift-docs/pull/56265 but with this change it should be more future proof and we will not have to keep updating with newer releases like 4.13, 4.14 etc..
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
