### PR TITLE
OSDOCS-5584:updates 4.13's  TP and Dep tables

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -231,14 +231,14 @@ For more information, see xref:../machine_management/control_plane_machine_manag
 [id="ocp-4-13-machine-config-operator-layering"]
 ==== Support for adding third party and custom content to {op-system}
 
-You can now use {op-system-first} image layering to add {op-system-base-full} and third-party packages to cluster nodes. 
+You can now use {op-system-first} image layering to add {op-system-base-full} and third-party packages to cluster nodes.
 
 For more information, see  xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering[{op-system-first} image layering].
 
 [id="ocp-4-13-machine-config-operator-core"]
 ==== Support for setting the `core` user password
 
-You can now create a password for the {op-system} `core` user. In the event that you cannot use SSH or the `oc debug node` command to access a node, this password allows you to use the `core` user to access the node through a cloud provider serial console or a bare metal baseboard controller manager (BMC). 
+You can now create a password for the {op-system} `core` user. In the event that you cannot use SSH or the `oc debug node` command to access a node, this password allows you to use the `core` user to access the node through a cloud provider serial console or a bare metal baseboard controller manager (BMC).
 
 For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#core-user-password_post-install-machine-configuration-tasks[Changing the core user password for node access].
 
@@ -906,7 +906,7 @@ In the following tables, features are marked with the following statuses:
 |Multi-architecture compute machines
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Mount shared entitlements in BuildConfigs in RHEL
 |Technology Preview
@@ -984,9 +984,9 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.11 |4.12 |4.13
 
 |Serverless functions
-|Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
+|General Availability
 
 |====
 
@@ -1115,7 +1115,7 @@ In the following tables, features are marked with the following statuses:
 
 |Platform Operators
 |Not Available
-|Not Available
+|Technology Preview
 |Technology Preview
 
 |RukPak
@@ -1125,8 +1125,8 @@ In the following tables, features are marked with the following statuses:
 
 |Cert-manager Operator
 |Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
 
 |====
 


### PR DESCRIPTION
[OSDOCS-5548](https://issues.redhat.com//browse/OSDOCS-5548): updates 4.13's TP and Dep tables
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5584
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://57591--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-technology-preview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
