### PR TITLE
[OCPBUGS-3829]: Add etcd module from KCS article

### DIFF
--- a/modules/move-etcd-different-disk.adoc
+++ b/modules/move-etcd-different-disk.adoc
@@ -1,0 +1,190 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-host-practices.adoc
+
+:_content-type: PROCEDURE
+[id="move-etcd-different-disk_{context}"]
+= Moving etcd to a different disk
+
+You can move etcd from a shared disk to a separate disk to prevent or resolve performance issues.
+
+.Prerequisites
+
+*  The `MachineConfigPool` must match `metadata.labels[machineconfiguration.openshift.io/role]`. This applies to a controller, worker, or a custom pool.
+*  The node's auxiliary storage device, such as `/dev/sdb`, must match the sdb. Change this reference in all places in the file.
+
+[NOTE]
+====
+This procedure does not move parts of the root file system, such as `/var/`, to another disk or partition on an installed node.
+====
+
+The Machine Config Operator (MCO) is responsible for mounting a secondary disk for an {product-title} {product-version} container storage.
+
+Use the following steps to move etcd to a different device:
+
+.Procedure
+.  Create a `machineconfig` YAML file named `etcd-mc.yml` and add the following information:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 98-var-lib-etcd
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Make File System on /dev/sdb
+          DefaultDependencies=no
+          BindsTo=dev-sdb.device
+          After=dev-sdb.device var.mount
+          Before=systemd-fsck@dev-sdb.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/usr/lib/systemd/systemd-makefs xfs /dev/sdb
+          TimeoutSec=0
+
+          [Install]
+          WantedBy=var-lib-containers.mount
+        enabled: true
+        name: systemd-mkfs@dev-sdb.service
+      - contents: |
+          [Unit]
+          Description=Mount /dev/sdb to /var/lib/etcd
+          Before=local-fs.target
+          Requires=systemd-mkfs@dev-sdb.service
+          After=systemd-mkfs@dev-sdb.service var.mount
+
+          [Mount]
+          What=/dev/sdb
+          Where=/var/lib/etcd
+          Type=xfs
+          Options=defaults,prjquota
+
+          [Install]
+          WantedBy=local-fs.target
+        enabled: true
+        name: var-lib-etcd.mount
+      - contents: |
+          [Unit]
+          Description=Sync etcd data if new mount is empty
+          DefaultDependencies=no
+          After=var-lib-etcd.mount var.mount
+          Before=crio.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecCondition=/usr/bin/test ! -d /var/lib/etcd/member
+          ExecStart=/usr/sbin/setenforce 0
+          ExecStart=/bin/rsync -ar /sysroot/ostree/deploy/rhcos/var/lib/etcd/ /var/lib/etcd/
+          ExecStart=/usr/sbin/setenforce 1
+          TimeoutSec=0
+
+          [Install]
+          WantedBy=multi-user.target graphical.target
+        enabled: true
+        name: sync-var-lib-etcd-to-etcd.service
+      - contents: |
+          [Unit]
+          Description=Restore recursive SELinux security contexts
+          DefaultDependencies=no
+          After=var-lib-etcd.mount
+          Before=crio.service
+
+          [Service]
+          Type=oneshot
+          RemainAfterExit=yes
+          ExecStart=/sbin/restorecon -R /var/lib/etcd/
+          TimeoutSec=0
+
+          [Install]
+          WantedBy=multi-user.target graphical.target
+        enabled: true
+        name: restorecon-var-lib-etcd.service
+
+----
+
+. Create the machine configuration by entering the following commands:
++
+[source,terminal]
+----
+$ oc login -u ${ADMIN} -p ${ADMINPASSWORD} ${API}
+... output omitted ...
+----
++
+[source,terminal]
+----
+$ oc create -f etcd-mc.yml
+machineconfig.machineconfiguration.openshift.io/98-var-lib-etcd created
+----
++
+[source,terminal]
+----
+$ oc login -u ${ADMIN} -p ${ADMINPASSWORD} ${API}
+ [... output omitted ...] 
+----
++
+[source, terminal]
+----
+$ oc create -f etcd-mc.yml machineconfig.machineconfiguration.openshift.io/98-var-lib-etcd created
+----
++
+The nodes are updated and rebooted. After the reboot completes, the following events occur:
++
+*  An XFS file system is created on the specified disk.
+*  The disk mounts to `/var/lib/etc`.
+*  The content from `/sysroot/ostree/deploy/rhcos/var/lib/etcd` syncs to `/var/lib/etcd`.
+*  A restore of `SELinux` labels is forced for `/var/lib/etcd`.
+*  The old content is not removed.
+.  After the nodes are on a separate disk, update the machine configuration file, `etcd-mc.yml` with the following information:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: master
+  name: 98-var-lib-etcd
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    systemd:
+      units:
+      - contents: |
+          [Unit]
+          Description=Mount /dev/sdb to /var/lib/etcd
+          Before=local-fs.target
+          Requires=systemd-mkfs@dev-sdb.service
+          After=systemd-mkfs@dev-sdb.service var.mount
+
+          [Mount]
+          What=/dev/sdb
+          Where=/var/lib/etcd
+          Type=xfs
+          Options=defaults,prjquota
+
+          [Install]
+          WantedBy=local-fs.target
+        enabled: true
+        name: var-lib-etcd.mount
+----
+. Apply the modified version that removes the logic for creating and syncing the device by entering the following command:
++
+[source,terminal]
+----
+$ oc replace -f etcd-mc.yml
+----
++
+The previous step prevents the nodes from rebooting.

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -45,6 +45,12 @@ include::modules/recommended-etcd-practices.adoc[leveloffset=+1]
 .Additional resources
 * link:https://access.redhat.com/solutions/4885641[How to use `fio` to check etcd disk performance in {product-title}]
 
+include::modules/move-etcd-different-disk.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.openshift.com/container-platform/4.11/architecture/architecture-rhcos.html[Red Hat Enterprise Linux CoreOS (RHCOS)]
+
 include::modules/etcd-defrag.adoc[leveloffset=+1]
 
 include::modules/infrastructure-node-sizing.adoc[leveloffset=+1]


### PR DESCRIPTION
[OCPBUGS-3829](https://issues.redhat.com/browse/OCPBUGS-3829)

Version(s): 4.9+

Link to docs preview (updated 3/28): http://file.rdu.redhat.com/tlove/etcd-ocpbugs-3829-tlove-new/scalability_and_performance/recommended-host-practices.html#move-etcd-different-disk_recommended-host-practices

QE review:
- [ x] QE has approved this change.

Additional information: [access.redhat.com/solutions/6973069](https://access.redhat.com/solutions/6973069)
This Jira is to add the content from this [KCS](https://github.com/openshift/openshift-docs/pull/url) article to the docs.
