### PR TITLE
OSDOCS-5592: Removed references to Azure and GCP

### DIFF
--- a/logging/cluster-logging-external.adoc
+++ b/logging/cluster-logging-external.adoc
@@ -178,7 +178,9 @@ include::modules/cluster-logging-troubleshooting-loki-entry-out-of-order-errors.
 
 * link:https://grafana.com/docs/loki/latest/configuration/[Configuring Loki server]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/cluster-logging-collector-log-forward-gcp.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/logging-forward-splunk.adoc[leveloffset=+1]
 

--- a/modules/osd-applications-config-custom-domains.adoc
+++ b/modules/osd-applications-config-custom-domains.adoc
@@ -84,7 +84,7 @@ NAME               ENDPOINT                                                    D
 <company_name>     xxrywp.<company_name>.cluster-01.opln.s1.openshiftapps.com  *.apps.<company_name>.io     Ready
 ----
 
-. Using the endpoint value, add a new wildcard CNAME recordset to your managed DNS provider, such as Route53, Azure DNS, or Google DNS.
+. Using the endpoint value, add a new wildcard CNAME recordset to your managed DNS provider, such as Route53.
 +
 .Example
 +

--- a/modules/ossm-federation-across-cluster.adoc
+++ b/modules/ossm-federation-across-cluster.adoc
@@ -27,6 +27,7 @@ service.beta.kubernetes.io/aws-load-balancer-type: nlb
 
 The Fully Qualified Domain Name found in the `.status.loadBalancer.ingress.hostname` field of the ingress gateway `Service` object should be specified as one of the entries in the `.spec.remote.addresses` field of the `ServiceMeshPeer` object.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 == Exposing the federation ingress on Azure
 On Microsoft Azure, merely setting the service type to `LoadBalancer` suffices for mesh federation to operate correctly.
 
@@ -36,3 +37,4 @@ The IP address found in the `.status.loadBalancer.ingress.ip` field of the ingre
 On Google Cloud Platform, merely setting the service type to `LoadBalancer` suffices for mesh federation to operate correctly.
 
 The IP address found in the `.status.loadBalancer.ingress.ip` field of the ingress gateway `Service` object should be specified as one of the entries in the `.spec.remote.addresses` field of the `ServiceMeshPeer` object.
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -606,7 +606,12 @@ New Custom Resource Definitions (CRDs) have been added to support federating ser
 
 * `ImportedServiceSet` - Defines which services for a given `ServiceMeshPeer` are imported from the peer mesh. These services must also be made available by the peer’s `ExportedServiceMeshSet` resource.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 Service Mesh Federation is not supported between clusters on Red Hat OpenShift Service on AWS (ROSA), Azure Red Hat OpenShift (ARO), or OpenShift Dedicated (OSD).
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+Service Mesh Federation is not supported between clusters on Red Hat OpenShift Service on AWS (ROSA) or OpenShift Dedicated (OSD).
+endif::openshift-dedicated,openshift-rosa[]
 
 === OVN-Kubernetes Container Network Interface (CNI) generally available
 
@@ -824,9 +829,17 @@ spec:
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 == {SMProductName} on {product-dedicated} and Microsoft Azure Red Hat OpenShift
 
 {SMProductName} is now supported through {product-dedicated} and Microsoft Azure Red Hat OpenShift.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+== {SMProductName} on {product-dedicated}
+
+{SMProductName} is now supported through {product-dedicated}.
+endif::openshift-dedicated,openshift-rosa[]
+
 
 == New features {SMProductName} 2.0.6
 

--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -17,7 +17,9 @@ The {SMProductName} Operator supports multiple versions of the `ServiceMeshContr
 
 * Red Hat {product-title} version 4.9 or later.
 * {product-dedicated} version 4.
+ifndef::openshift-dedicated,openshift-rosa[]
 * Azure Red Hat OpenShift (ARO) version 4.
+endif::openshift-dedicated,openshift-rosa[]
 * Red Hat OpenShift Service on AWS (ROSA).
 
 [id="ossm-unsupported-configurations_{context}"]

--- a/networking/routes/secured-routes.adoc
+++ b/networking/routes/secured-routes.adoc
@@ -9,6 +9,7 @@ toc::[]
 
 Secure routes provide the ability to use several types of TLS termination to serve certificates to the client. The following sections describe how to create re-encrypt, edge, and passthrough routes with custom certificates.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [IMPORTANT]
 ====
 If you create routes in Microsoft Azure through public endpoints, the resource
@@ -17,6 +18,7 @@ terms. For a list of terms that Azure restricts, see
 link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-reserved-resource-name[Resolve reserved resource name errors]
 in the Azure documentation.
 ====
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/nw-ingress-creating-a-reencrypt-route-with-a-custom-certificate.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.12+`

Issue:
[OSDOCS-5592](https://issues.redhat.com/browse/OSDOCS-5592)

Link to docs preview:
* [Forwarding Logs to GCP](https://57594--docspreview.netlify.app/openshift-rosa/latest/logging/cluster-logging-external.html#cluster-logging-collector-log-forward-gcp_cluster-logging-external)
   ![image](https://user-images.githubusercontent.com/16167833/227029112-016552f4-4c20-4f10-a409-4fd9d4b96123.png)
* [Service Mesh Across Clusters](https://57594--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/ossm-federation.html#exposing-the-federation-ingress-on-amazon-web-services-aws)
    ![image](https://user-images.githubusercontent.com/16167833/227032974-317dba9b-6f0c-4f9d-8951-35ee84feb0c9.png)
* [Secured Routes](https://57594--docspreview.netlify.app/openshift-rosa/latest/networking/routes/secured-routes.html)
    ![image](https://user-images.githubusercontent.com/16167833/227034091-a78c0f66-5176-4d37-a10e-7d7baf8fdb2d.png)
* Release Notes - two instances; [a section was modified to remove Azure](https://57594--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-2-0-7) from the header and body (1) and one reference from [the body of another section](https://57594--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/servicemesh-release-notes.html#service-mesh-federation) (2).
    1. ![image](https://user-images.githubusercontent.com/16167833/227036034-d4dbbac5-b795-451b-a083-5d4be9d48a9c.png)
    2. ![image](https://user-images.githubusercontent.com/16167833/227036212-da41a83e-5cc7-4f7f-9bed-b9b045f7a878.png)
* [Preparing to install Service Mesh](https://57594--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/preparing-ossm-installation.html#ossm-supported-configurations_preparing-ossm-installation)
    ![image](https://user-images.githubusercontent.com/16167833/227036829-a770a394-223d-49b8-afd4-5348c2df0ff1.png)
* [Custom domains for applications](https://57594--docspreview.netlify.app/openshift-rosa/latest/applications/deployments/osd-config-custom-domains-applications.html)
    ![image](https://user-images.githubusercontent.com/16167833/227037051-c75818b2-6b21-4a8a-9daa-6a6ce2df5f28.png)

Here are the same URLs for OCP - they should not have any of the Azure/GCP items removed.

* [Forwarding Logs to GCP](https://57594--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external.html#cluster-logging-collector-log-forward-gcp_cluster-logging-external)
* [Service Mesh Across Clusters](https://57594--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-federation.html#exposing-the-federation-ingress-on-amazon-web-services-aws)
* [Secured Routes](https://57594--docspreview.netlify.app/openshift-enterprise/latest/networking/routes/secured-routes.html)
* Release Notes 
  1. [Release Note section](https://57594--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-2-0-7) 
  1. [Separate Note](https://57594--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#service-mesh-federation).
* [Preparing to install Service Mesh](https://57594--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/preparing-ossm-installation.html#ossm-supported-configurations_preparing-ossm-installation)
* Custom domains for applications - does not exist?


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Removed references to Azure and GCP from the ROSA docs.