### PR TITLE
OSDOCS-5348: Module to Automate workaround for SELinux relabeling issue for large volumes

### DIFF
--- a/modules/nodes-pods-configuring-reducing.adoc
+++ b/modules/nodes-pods-configuring-reducing.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-pods-configuring.adoc
+// * nodes/nodes-cluster-pods-configuring
+
+:_content-type: REFERENCE
+[id="nodes-pods-configuring-reducing_{context}"]
+= Reducing pod timeouts when using persistent volumes with high file counts
+
+If a storage volume contains many files (~1,000,000 or greater), you might experience pod timeouts.
+
+This can occur because, when volumes are mounted, {product-title} recursively changes the ownership and permissions of the contents of each volume in order to match the `fsGroup` specified in a pod's `securityContext`. For large volumes, checking and changing the ownership and permissions can be time consuming, resulting in a very slow pod startup. 
+
+You can reduce this delay by applying one of the following workarounds:
+
+* Use a security context constraint (SCC) to skip the SELinux relabeling for a volume.
+
+* Use the `fsGroupChangePolicy` field inside an SCC to control the way that {product-title} checks and manages ownership and permissions for a volume.
+
+* Use a runtime class to skip the SELinux relabeling for a volume.
+
+For information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].

--- a/nodes/pods/nodes-pods-configuring.adoc
+++ b/nodes/pods/nodes-pods-configuring.adoc
@@ -28,6 +28,8 @@ include::modules/nodes-pods-pod-disruption-configuring.adoc[leveloffset=+2]
 
 include::modules/nodes-pods-configuring-pod-critical.adoc[leveloffset=+1]
 
+include::modules/nodes-pods-configuring-reducing.adoc[leveloffset=+1]
+
 // modules/nodes-pods-configuring-run-once.adoc[leveloffset=+1]
 
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5347

Preview: Nodes -> Pods ->  Configuring a cluster for pods -> [Reducing pod timeouts when using persistent volumes with high file counts](https://57595--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-reducing_nodes-pods-configuring): New module

**4.13+ only.** After merging, pull new PR to add  this 4.13-only bullet:
* Use the Cluster Resource Override Operator (CRO) to automatically apply an SCC to skip the SELinux relabeling.


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

