### PR TITLE
[OSDOCS-5554]: UPI VMware MachineSet reqs/proc

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2066,7 +2066,7 @@ Distros: openshift-origin,openshift-enterprise
 Topics:
 - Name: Overview of machine management
   File: index
-- Name: Creating compute machine sets
+- Name: Managing compute machines with the Machine API
   Dir: creating_machinesets
   Distros: openshift-origin,openshift-enterprise
   Topics:
@@ -2110,14 +2110,14 @@ Topics:
 - Name: Adding more RHEL compute machines
   File: more-rhel-compute
   Distros: openshift-enterprise
-- Name: User-provisioned infrastructure
+- Name: Managing user-provisioned infrastructure manually
   Dir: user_infra
   Topics:
-  - Name: Adding compute machines to user-provisioned infrastructure clusters
+  - Name: Adding compute machines to clusters with user-provisioned infrastructure manually
     File: adding-compute-user-infra-general
   - Name: Adding compute machines to AWS using CloudFormation templates
     File: adding-aws-compute-user-infra
-  - Name: Adding compute machines to vSphere
+  - Name: Adding compute machines to vSphere manually
     File: adding-vsphere-compute-user-infra
   - Name: Adding compute machines to a cluster on RHV
     File: adding-rhv-compute-user-infra

--- a/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-vsphere.adoc
@@ -10,8 +10,30 @@ You can create a different compute machine set to serve a specific purpose in yo
 
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
 
+//Sample YAML for a compute machine set custom resource on vSphere
 include::modules/machineset-yaml-vsphere.adoc[leveloffset=+1]
 
+//Minimum required vCenter privileges for compute machine set management
 include::modules/machineset-vsphere-required-permissions.adoc[leveloffset=+1]
 
+//Requirements for clusters with user-provisioned infrastructure to use compute machine sets
+include::modules/compute-machineset-upi-reqs.adoc[leveloffset=+1]
+
+//Obtaining the infrastructure ID
+[discrete]
+include::modules/machineset-upi-reqs-infra-id.adoc[leveloffset=+2]
+
+//Satisfying vSphere credentials requirements
+[discrete]
+include::modules/machineset-upi-reqs-vsphere-creds.adoc[leveloffset=+2]
+
+//Satisfying ignition configuration requirements
+[discrete]
+include::modules/machineset-upi-reqs-ignition-config.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../post_installation_configuration/machine-configuration-tasks.adoc#understanding-the-machine-config-operator[Understanding the Machine Config Operator]
+* xref:../../installing/installing_vsphere/installing-vsphere.adoc#installation-vsphere-machines_installing-vsphere[Installing {op-system} and starting the {product-title} bootstrap process]
+
+//Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]

--- a/machine_management/user_infra/adding-compute-user-infra-general.adoc
+++ b/machine_management/user_infra/adding-compute-user-infra-general.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="adding-compute-user-infra-general"]
-= Adding compute machines to clusters with user-provisioned infrastructure
+= Adding compute machines to clusters with user-provisioned infrastructure manually
 include::_attributes/common-attributes.adoc[]
 :context: adding-compute-user-infra-general
 
@@ -31,7 +31,9 @@ To add more compute machines to your {product-title} cluster on Google Cloud Pla
 [id="upi-adding-compute-vsphere"]
 == Adding compute machines to vSphere
 
-To add more compute machines to your {product-title} cluster on vSphere, see xref:../../machine_management/user_infra/adding-vsphere-compute-user-infra.adoc#adding-vsphere-compute-user-infra[Adding compute machines to vSphere].
+You can xref:../../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere[use compute machine sets] to automate the creation of additional compute machines for your {product-title} cluster on vSphere.
+
+To manually add more compute machines to your cluster, see xref:../../machine_management/user_infra/adding-vsphere-compute-user-infra.adoc#adding-vsphere-compute-user-infra[Adding compute machines to vSphere manually].
 
 [id="upi-adding-compute-rhv"]
 == Adding compute machines to {rh-virtualization}

--- a/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
+++ b/machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
@@ -1,12 +1,17 @@
 :_content-type: ASSEMBLY
 [id="adding-vsphere-compute-user-infra"]
-= Adding compute machines to vSphere
+= Adding compute machines to vSphere manually
 include::_attributes/common-attributes.adoc[]
 :context: adding-vsphere-compute-user-infra
 
 toc::[]
 
-You can add more compute machines to your {product-title} cluster on VMware vSphere.
+You can add more compute machines to your {product-title} cluster on VMware vSphere manually.
+
+[NOTE]
+====
+You can also xref:../../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere[use compute machine sets] to automate the creation of additional VMware vSphere compute machines for your cluster.
+====
 
 == Prerequisites
 

--- a/modules/compute-machineset-upi-reqs.adoc
+++ b/modules/compute-machineset-upi-reqs.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+//
+// Currently only in the vSphere compute machine set content, but we will want this for other platforms such as AWS and GCP.
+
+ifeval::["{context}" == "creating-machineset-vsphere"]
+:vsphere:
+endif::[]
+
+:_content-type: CONCEPT
+[id="compute-machineset-upi-reqs_{context}"]
+= Requirements for clusters with user-provisioned infrastructure to use compute machine sets
+
+To use compute machine sets on clusters that have user-provisioned infrastructure, you must ensure that you cluster configuration supports using the Machine API.
+
+ifeval::["{context}" == "creating-machineset-vsphere"]
+:!vsphere:
+endif::[]

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -252,6 +252,11 @@ ifndef::ibm-z,ibm-z-kvm,ibm-power,rhv[your platform.]
 ifdef::ibm-z,ibm-z-kvm[{ibmzProductName} infrastructure.]
 ifdef::ibm-power[{ibmpowerProductName} infrastructure.]
 ifdef::rhv[RHV infrastructure.]
++
+[IMPORTANT]
+====
+Clusters that are installed with the platform type `none` are unable to use some features, such as managing compute machines with the Machine API. This limitation applies even if the compute machines that are attached to the cluster are installed on a platform that would normally support the feature. This parameter cannot be changed after installation.
+====
 ifndef::openshift-origin[]
 <12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +

--- a/modules/machine-user-provisioned-limitations.adoc
+++ b/modules/machine-user-provisioned-limitations.adoc
@@ -15,5 +15,14 @@
 
 [IMPORTANT]
 ====
-This process is not applicable for clusters with manually provisioned machines. You can use the advanced machine management and scaling capabilities only in clusters where the Machine API is operational.
+You can use the advanced machine management and scaling capabilities only in clusters where the Machine API is operational. Clusters with user-provisioned infrastructure require additional validation and configuration to use the Machine API.
+
+Clusters with the infrastructure platform type `none` cannot use the Machine API. This limitation applies even if the compute machines that are attached to the cluster are installed on a platform that supports the feature. This parameter cannot be changed after installation.
+
+To view the platform type for your cluster, run the following command:
+
+[source,terminal]
+----
+$ oc get infrastructure cluster -o jsonpath='{.status.platform}'
+----
 ====

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -33,7 +33,14 @@ endif::[]
 [id="machineset-creating_{context}"]
 = Creating a compute machine set
 
-In addition to the ones created by the installation program, you can create your own compute machine sets to dynamically manage the machine compute resources for specific workloads of your choice.
+In addition to the compute machine sets created by the installation program, you can create your own to dynamically manage the machine compute resources for specific workloads of your choice.
+
+ifdef::vsphere[]
+[NOTE]
+====
+Clusters that are installed with user-provisioned infrastructure have a different networking stack than clusters with infrastructure that is provisioned by the installation program. As a result of this difference, automatic load balancer management is unsupported on clusters that have user-provisioned infrastructure. For these clusters, a compute machine set can only create `worker` and `infra` type machines.
+====
+endif::vsphere[]
 
 .Prerequisites
 
@@ -41,8 +48,8 @@ In addition to the ones created by the installation program, you can create your
 * Install the OpenShift CLI (`oc`).
 * Log in to `oc` as a user with `cluster-admin` permission.
 ifdef::vsphere[]
-* Create a tag inside your vCenter instance based on the cluster API name. This tag is utilized by the compute machine set to associate the {product-title} nodes to the provisioned virtual machines (VM). For directions on creating tags in vCenter, see the VMware documentation for link:https://docs.vmware.com/en/VMware-vSphere/6.7/com.vmware.vsphere.vcenterhost.doc/GUID-E8E854DD-AA97-4E0C-8419-CE84F93C4058.html[vSphere Tags and Attributes].
 * Have the necessary permissions to deploy VMs in your vCenter instance and have the required access to the datastore specified.
+* If your cluster uses user-provisioned infrastructure, you have satisfied the specific Machine API requirements for that configuration.
 endif::vsphere[]
 ifdef::ash[]
 * Create an availability set in which to deploy Azure Stack Hub compute machines.
@@ -59,7 +66,9 @@ ifdef::ash[]
 Ensure that you set the `<availabilitySet>`, `<clusterID>`, and `<role>` parameter values.
 endif::ash[]
 
-.. If you are not sure which value to set for a specific field, you can check an existing compute machine set from your cluster:
+. Optional: If you are not sure which value to set for a specific field, you can check an existing compute machine set from your cluster.
+
+.. To list the compute machine sets in your cluster, run the following command:
 +
 [source,terminal]
 ----
@@ -78,37 +87,108 @@ agl030519-vplxk-worker-us-east-1e   0         0                             55m
 agl030519-vplxk-worker-us-east-1f   0         0                             55m
 ----
 
-.. Check values of a specific compute machine set:
+.. To view values of a specific compute machine set custom resource (CR), run the following command:
 +
 [source,terminal]
 ----
-$ oc get machineset <machineset_name> -n \
-     openshift-machine-api -o yaml
+$ oc get machineset <machineset_name> \
+  -n openshift-machine-api -o yaml
 ----
 +
+--
 .Example output
 [source,yaml]
 ----
-...
-template:
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+  name: <infrastructure_id>-<role> <2>
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
+  template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: agl030519-vplxk <1>
-        machine.openshift.io/cluster-api-machine-role: worker <2>
-        machine.openshift.io/cluster-api-machine-type: worker
-        machine.openshift.io/cluster-api-machineset: agl030519-vplxk-worker-us-east-1a
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
+    spec:
+      providerSpec: <3>
+        ...
 ----
-<1> The cluster ID.
+<1> The cluster infrastructure ID.
 <2> A default node label.
++
+[NOTE]
+====
+For clusters that have user-provisioned infrastructure, a compute machine set can only create `worker` and `infra` type machines.
+====
+<3> The values in the `<providerSpec>` section of the compute machine set CR are platform-specific. For more information about `<providerSpec>` parameters in the CR, see the sample compute machine set CR configuration for your provider.
+--
 
-. Create the new `MachineSet` CR:
+ifdef::vsphere[]
+.. If you are creating a compute machine set for a cluster that has user-provisioned infrastructure, note the following important values:
++
+.Example vSphere `providerSpec` values
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+...
+template:
+  ...
+  spec:
+    providerSpec:
+      value:
+        apiVersion: machine.openshift.io/v1beta1
+        credentialsSecret:
+          name: vsphere-cloud-credentials <1>
+        diskGiB: 120
+        kind: VSphereMachineProviderSpec
+        memoryMiB: 16384
+        network:
+          devices:
+            - networkName: "<vm_network_name>"
+        numCPUs: 4
+        numCoresPerSocket: 4
+        snapshot: ""
+        template: <vm_template_name> <2>
+        userDataSecret:
+          name: worker-user-data <3>
+        workspace:
+          datacenter: <vcenter_datacenter_name>
+          datastore: <vcenter_datastore_name>
+          folder: <vcenter_vm_folder_path>
+          resourcepool: <vsphere_resource_pool>
+          server: <vcenter_server_address> <4>
+----
+<1> The name of the secret in the `openshift-machine-api` namespace that contains the required vCenter credentials.
+<2> The name of the {op-system} VM template for your cluster that was created during installation.
+<3> The name of the secret in the `openshift-machine-api` namespace that contains the required Ignition configuration credentials.
+<4> The IP address or fully qualified domain name (FQDN) of the vCenter server.
+endif::vsphere[]
+
+. Create a `MachineSet` CR by running the following command:
 +
 [source,terminal]
 ----
 $ oc create -f <file_name>.yaml
 ----
 
-. View the list of compute machine sets:
+ifeval::["{context}" == "creating-machineset-aws"]
+. If you need compute machine sets in other availability zones, repeat this process to create more compute machine sets.
+endif::[]
+
+.Verification
+
+* View the list of compute machine sets by running the following command:
 +
 [source,terminal]
 ----
@@ -141,82 +221,6 @@ endif::win[]
 ----
 +
 When the new compute machine set is available, the `DESIRED` and `CURRENT` values match. If the compute machine set is not available, wait a few minutes and run the command again.
-
-////
-This step is not needed. No machines at this point.
-
-. After the new compute machine set is available, check status of the machine and the node that it references:
-+
-[source,terminal]
-----
-$ oc describe machine <name> -n openshift-machine-api
-----
-+
-For example:
-+
-[source,terminal]
-----
-ifdef::win[]
-$ oc describe machine agl030519-vplxk-windows-worker-us-east-1a -n openshift-machine-api
-endif::win[]
-ifndef::win[]
-$ oc describe machine agl030519-vplxk-infra-us-east-1a -n openshift-machine-api
-endif::win[]
-----
-+
-.Example output
-[source,terminal]
-----
-status:
-  addresses:
-  - address: 10.0.133.18
-    type: InternalIP
-  - address: ""
-    type: ExternalDNS
-  - address: ip-10-0-133-18.ec2.internal
-    type: InternalDNS
-  lastUpdated: "2019-05-03T10:38:17Z"
-  nodeRef:
-    kind: Node
-    name: ip-10-0-133-18.ec2.internal
-    uid: 71fb8d75-6d8f-11e9-9ff3-0e3f103c7cd8
-  providerStatus:
-    apiVersion: awsproviderconfig.openshift.io/v1beta1
-    conditions:
-    - lastProbeTime: "2019-05-03T10:34:31Z"
-      lastTransitionTime: "2019-05-03T10:34:31Z"
-      message: machine successfully created
-      reason: MachineCreationSucceeded
-      status: "True"
-      type: MachineCreation
-    instanceId: i-09ca0701454124294
-    instanceState: running
-    kind: AWSMachineProviderStatus
-----
-////
-
-////
-This step is not needed. I have not labeled a node yet.
-
-. View the node you want to assign as the infra node to confirm that the node has the label that you specified:
-+
-[source,terminal]
-----
-$ oc get node <node_name> --show-labels
-----
-+
-Review the command output and confirm that `node-role.kubernetes.io/<your_label>` is in the `LABELS` list.
-
-[NOTE]
-====
-Any change to a compute machine set is not applied to existing machines owned by the compute machine set. For example, labels edited or added to an existing compute machine set are not propagated to existing machines and nodes associated with the compute machine set.
-====
-////
-
-ifeval::["{context}" == "creating-machineset-aws"]
-.Next steps
-If you need compute machine sets in other availability zones, repeat this process to create more compute machine sets.
-endif::[]
 
 ifeval::["{context}" == "creating-machineset-vsphere"]
 :!vsphere:

--- a/modules/machineset-upi-reqs-ignition-config.adoc
+++ b/modules/machineset-upi-reqs-ignition-config.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+//
+// Currently only in the vSphere compute machine set content, but we will want this for other platforms such as AWS and GCP.
+
+ifeval::["{context}" == "creating-machineset-vsphere"]
+:vsphere:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="machineset-upi-reqs-ignition-config_{context}"]
+= Satisfying Ignition configuration requirements
+
+Provisioning virtual machines (VMs) requires a valid Ignition configuration. The Ignition configuration contains the `machine-config-server` address and a system trust bundle for obtaining further Ignition configurations from the Machine Config Operator.
+
+By default, this configuration is stored in the `worker-user-data` secret in the the `machine-api-operator` namespace. Compute machine sets reference the secret during the machine creation process.
+
+.Procedure
+
+. To determine whether the required secret exists, run the following command:
++
+[source,terminal]
+----
+$ oc get secret \
+  -n openshift-machine-api worker-user-data \
+  -o go-template='{{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'
+----
++
+.Sample output
+[source,terminal]
+----
+disableTemplating: false
+userData: <1>
+  {
+    "ignition": {
+      ...
+      },
+    ...
+  }
+----
+<1> The full output is omitted here, but should have this format.
+
+. If the secret does not exist, create it by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic worker-user-data \
+  -n openshift-machine-api \
+  --from-file=<installation_directory>/worker.ign
+----
++
+where `<installation_directory>` is the directory that was used to store your installation assets during cluster installation.
+
+ifeval::["{context}" == "creating-machineset-vsphere"]
+:!vsphere:
+endif::[]

--- a/modules/machineset-upi-reqs-infra-id.adoc
+++ b/modules/machineset-upi-reqs-infra-id.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+//
+// Currently only in the vSphere compute machine set content, but we will want this for other platforms such as AWS and GCP.
+
+ifeval::["{context}" == "creating-machineset-vsphere"]
+:vsphere:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="machineset-upi-reqs-infra-id_{context}"]
+= Obtaining the infrastructure ID
+
+To create compute machine sets, you must be able to supply the infrastructure ID for your cluster.
+
+.Procedure
+
+* To obtain the infrastructure ID for your cluster, run the following command:
++
+[source,terminal]
+----
+$ oc get infrastructure cluster -o jsonpath='{.status.infrastructureName}'
+----
+
+ifeval::["{context}" == "creating-machineset-vsphere"]
+:!vsphere:
+endif::[]

--- a/modules/machineset-upi-reqs-vsphere-creds.adoc
+++ b/modules/machineset-upi-reqs-vsphere-creds.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
+
+:_content-type: PROCEDURE
+[id="machineset-upi-reqs-vsphere-creds_{context}"]
+= Satisfying vSphere credentials requirements
+
+To use compute machine sets, the Machine API must be able to interact with vCenter. Credentials that authorize the Machine API components to interact with vCenter must exist in a secret in the `openshift-machine-api` namespace.
+
+.Procedure
+
+. To determine whether the required credentials exist, run the following command:
++
+[source,terminal]
+----
+$ oc get secret \
+  -n openshift-machine-api vsphere-cloud-credentials \
+  -o go-template='{{range $k,$v := .data}}{{printf "%s: " $k}}{{if not $v}}{{$v}}{{else}}{{$v | base64decode}}{{end}}{{"\n"}}{{end}}'
+----
++
+.Sample output
+[source,terminal]
+----
+<vcenter-server>.password=<openshift-user-password>
+<vcenter-server>.username=<openshift-user>
+----
++
+where `<vcenter-server>` is the IP address or fully qualified domain name (FQDN) of the vCenter server and `<openshift-user>` and `<openshift-user-password>` are the {product-title} administrator credentials to use.
+
+. If the secret does not exist, create it by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic vsphere-cloud-credentials \
+  -n openshift-machine-api \
+  --from-literal=<vcenter-server>.username=<openshift-user> --from-literal=<vcenter-server>.password=<openshift-user-password>
+----


### PR DESCRIPTION
Version(s):
4.9+

Issue:
[OSDOCS-5554](https://issues.redhat.com//browse/OSDOCS-5554)

Link to docs preview:
* [Sample install-config.yaml file for bare metal](https://57600--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-bare-metal-config-yaml_installing-bare-metal) (callout 11)
* [Creating a compute machine set on vSphere](https://57600--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere.html)
  * [Requirements for clusters with user-provisioned infrastructure to use compute machine sets](https://57600--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere.html#compute-machineset-upi-reqs_creating-machineset-vsphere)
  * [Creating a compute machine set](https://57600--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-vsphere.html#machineset-creating_creating-machineset-vsphere)
* [Adding compute machines to vSphere](https://57600--docspreview.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-compute-user-infra-general.html#upi-adding-compute-vsphere)
* [Adding compute machines to vSphere manually
](https://57600--docspreview.netlify.app/openshift-enterprise/latest/machine_management/user_infra/adding-vsphere-compute-user-infra.html#adding-vsphere-compute-user-infra)

QE review:
- [ ] QE has approved this change.

Additional information:
**Note** 
The update to `modules/machine-user-provisioned-limitations.adoc` means that the updated admonition appears in all compute machine set pages. I think this is right, but wanted to make sure it was called out. Here is an example: 
[Creating a compute machine set on AWS](https://57600--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws.html)