### PR TITLE
OSDOCS-3976: Add NodeTuning capability and Capability set v4.13

### DIFF
--- a/installing/cluster-capabilities.adoc
+++ b/installing/cluster-capabilities.adoc
@@ -62,6 +62,12 @@ include::modules/operator-marketplace.adoc[leveloffset=+2]
 .Additional resources
 * xref:../operators/understanding/olm-rh-catalogs.adoc#olm-rh-catalogs[Red Hat-provided Operator catalogs]
 
+include::modules/node-tuning-operator.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator]
+
 include::modules/cluster-samples-operator.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -10,6 +10,10 @@ endif::[]
 ifeval::["{context}" == "node-tuning-operator"]
 :perf:
 endif::[]
+ifeval::["{context}" == "cluster-capabilities"]
+:cluster-caps:
+endif::[]
+
 
 :_content-type: CONCEPT
 [id="about-node-tuning-operator_{context}"]
@@ -19,12 +23,24 @@ endif::operators[]
 ifdef::perf[]
 = About the Node Tuning Operator
 endif::perf[]
-ifdef::operators[]
+ifdef::cluster-caps[= Node Tuning capability]
+
+ifndef::perf[]
 [discrete]
 == Purpose
-endif::operators[]
+endif::perf[]
+
+ifdef::cluster-caps[]
+The Node Tuning Operator provides features for the `NodeTuning` capability.
+endif::cluster-caps[]
+
 The Node Tuning Operator helps you manage node-level tuning by orchestrating the TuneD daemon and achieves low latency performance by using the Performance Profile controller. The majority of high-performance applications require some level of kernel tuning. The Node Tuning Operator provides a unified management interface to users of node-level sysctls and more flexibility to add custom tuning specified by user needs.
 
+ifdef::cluster-caps[]
+If you disable the NodeTuning capability, some default tuning settings will not be applied to the control-plane nodes. This might limit the scalability and performance of large clusters with over 900 nodes or 900 routes.
+endif::[]
+
+ifndef::cluster-caps[]
 The Operator manages the containerized TuneD daemon for {product-title} as a Kubernetes daemon set. It ensures the custom tuning specification is passed to all containerized TuneD daemons running in the cluster in the format that the daemons understand. The daemons run on all nodes in the cluster, one per node.
 
 Node-level settings applied by the containerized TuneD daemon are rolled back on an event that triggers a profile change or when the containerized TuneD daemon is terminated gracefully by receiving and handling a termination signal.
@@ -41,6 +57,7 @@ The Node Tuning Operator is part of a standard {product-title} installation in v
 ====
 In earlier versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator.
 ====
+endif::cluster-caps[]
 
 ifdef::operators[]
 [discrete]

--- a/snippets/capabilities-table.adoc
+++ b/snippets/capabilities-table.adoc
@@ -16,6 +16,9 @@ The following table describes the `baselineCapabilitySet` values.
 |`v4.12`
 |Specify when you want the capabilities recommended in {product-title} 4.12 and not automatically enable capabilities, which might be introduced in later versions. The capabilities recommended in {product-title} 4.12 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage` and `CSISnapshot`. 
 
+|`v4.13`
+|Specify when you want the capabilities recommended in {product-title} 4.13 and not automatically enable capabilities, which might be introduced in later versions. The capabilities recommended in {product-title} 4.12 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot` and `NodeTuning`. 
+
 |`None`
 |Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via `additionalEnabledCapabilities`.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
[OSDOCS-3976
](https://issues.redhat.com/browse/OSDOCS-3976)
[PSAP-741](https://issues.redhat.com/browse/PSAP-741)

Link to docs preview:
https://57602--docspreview.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities.html#about-node-tuning-operator_cluster-capabilities


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
