### PR TITLE
GH57499:[OKD] Broken link to install service mesh

### DIFF
--- a/post_installation_configuration/network-configuration.adoc
+++ b/post_installation_configuration/network-configuration.adoc
@@ -95,6 +95,7 @@ include::modules/modifying-template-for-new-projects.adoc[leveloffset=+2]
 include::modules/nw-networkpolicy-project-defaults.adoc[leveloffset=+3]
 endif::[]
 
+ifndef::openshift-origin[]
 include::modules/ossm-supported-configurations.adoc[leveloffset=+1]
 
 include::modules/ossm-installation-activities.adoc[leveloffset=+2]
@@ -102,6 +103,7 @@ include::modules/ossm-installation-activities.adoc[leveloffset=+2]
 .Next steps
 
 * xref:../service_mesh/v2x/installing-ossm.adoc#installing-ossm[Install {SMProductName}] in your {product-title} environment.
+endif::openshift-origin[]
 
 [id="post-installationrouting-optimization"]
 == Optimizing routing


### PR DESCRIPTION
For OKD, remove OSSM from Post-install -> Network configuration

Link to docs preview (VPN needed):
OKD: Post-install -> [Network configuration](http://file.rdu.redhat.com/mburke/okd-remove-ossm/post_installation_configuration/network-configuration.html)

OCP : Post-install -> [Network configuration](https://docs.openshift.com/container-platform/4.12/post_installation_configuration/network-configuration.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

