### PR TITLE
OSDOCS-3954: ROSA install command line reference updates

### DIFF
--- a/modules/rosa-checking-account-version-info-cli.adoc
+++ b/modules/rosa-checking-account-version-info-cli.adoc
@@ -31,9 +31,6 @@ $ rosa whoami [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v level
-|Log level for V logs.
 |===
 
 .Example
@@ -66,9 +63,6 @@ $ rosa version [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v level
-|Log level for V logs.
 |===
 
 .Example

--- a/modules/rosa-common-commands.adoc
+++ b/modules/rosa-common-commands.adoc
@@ -11,12 +11,12 @@ These common commands and arguments are available for the `rosa` CLI.
 [id="rosa-debug_{context}"]
 == debug
 
-Enables debug mode for the parent command.
+Enables debug mode for the parent command to help with troubleshooting.
 
 .Example
 [source,terminal]
 ----
-$ rosa create cluster --cluster=<cluster_name> --debug
+$ rosa create cluster --cluster-name=<cluster_name> --debug
 ----
 
 [id="rosa-download_{context}"]
@@ -56,7 +56,7 @@ Enables interactive mode.
 .Example
 [source,terminal]
 ----
-$ rosa create cluster --cluster=<cluster_name> --interactive
+$ rosa create cluster --cluster-name=<cluster_name> --interactive
 ----
 
 [id="rosa-profile-string_{context}"]
@@ -67,18 +67,7 @@ Specifies an AWS profile from your credential file.
 .Example
 [source,terminal]
 ----
-$ rosa create cluster --cluster=<cluster_name> --profile=myAWSprofile
-----
-
-[id="rosa-vlevel_{context}"]
-== v level
-
-Specifies the log level for V logs.
-
-.Example
-[source,terminal]
-----
-$ rosa create cluster --cluster=<cluster_name> --v <level>
+$ rosa create cluster --cluster-name=<cluster_name> --profile=myAWSprofile
 ----
 
 [id="rosa-version_{context}"]

--- a/modules/rosa-configure.adoc
+++ b/modules/rosa-configure.adoc
@@ -63,9 +63,6 @@ $ rosa login [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 [id="rosa-logout_{context}"]
@@ -92,9 +89,6 @@ $ rosa logout [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 [id="rosa-verify-permissions_{context}"]
@@ -129,9 +123,6 @@ This command verifies permissions only for clusters that do not use the AWS Secu
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples
@@ -175,9 +166,6 @@ $ rosa verify quota [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -11,7 +11,7 @@ This section describes the `create` commands for clusters and resources.
 [id="rosa-create-account-roles_{context}"]
 == create account-roles
 
-Create the needed account-wide role and policy resources for your cluster.
+Create the required account-wide role and policy resources for your cluster.
 
 .Syntax
 [source,terminal]
@@ -31,9 +31,10 @@ $ rosa create account-roles [flags]
 |Enable interactive mode.
 
 |-m, --mode string
-|How to perform the operation. Valid options are:
-    auto: Resource changes will be automatic applied using the current AWS account
-    manual: Commands necessary to modify AWS resources will be output to be run manually
+a|How to perform the operation. Valid options are:
+
+`auto`:: Resource changes will be automatically applied using the current AWS account.
+`manual`:: Commands necessary to modify AWS resources will be output to be run manually.
 
 |--path string
 |The ARN path for the account-wide roles and policies, including the Operator policies.
@@ -48,7 +49,7 @@ $ rosa create account-roles [flags]
 |Use a specific AWS profile from your credential file.
 
 |-y, --yes
-|Automatically answer yes to confirm operation.
+|Automatically answer yes to confirm operations.
 
 |===
 
@@ -60,7 +61,7 @@ Create a cluster administrator with an automatically generated password that can
 .Syntax
 [source,terminal]
 ----
-$ rosa create admin --cluster=<cluster_name> | <cluster_id>
+$ rosa create admin --cluster=<cluster_name>|<cluster_id>
 ----
 
 .Arguments
@@ -68,8 +69,8 @@ $ rosa create admin --cluster=<cluster_name> | <cluster_id>
 |===
 |Option |Definition
 
-|--cluster
-|Required: The name or ID (string) of the cluster to add to the identity provider (IDP).
+a|--cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID (string) of the cluster to add to the identity provider (IDP).
 |===
 
 .Optional arguments inherited from parent commands
@@ -86,11 +87,8 @@ $ rosa create admin --cluster=<cluster_name> | <cluster_id>
 |--interactive
 |Enables interactive mode.
 
-|--profile
-|Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
+|--profile string
+|Specifies an AWS profile from your credentials file.
 |===
 
 .Example
@@ -109,25 +107,26 @@ Create a new cluster.
 .Syntax
 [source,terminal]
 ----
-$ rosa create cluster --cluster=<cluster_name> | <cluster_id> [arguments]
+$ rosa create cluster --cluster-name=<cluster_name> [arguments]
 ----
+//Note to writers: The create cluster command specifically uses --cluster-name because a cluster ID does not exist yet. All other commands use --cluster because either the name or the ID can be used.
 
 .Arguments
 [cols="30,70"]
 |===
 |Option |Definition
 
-|--cluster
-|Required: The name or ID (string) of the cluster. When used with the `create cluster` command, this argument is used to generate a sub-domain for your cluster on `openshiftapps.com`.
+a|--cluster-name <cluster_name>
+|Required. The name of the cluster. When used with the `create cluster` command, this argument is used to set the cluster name and to generate a sub-domain for your cluster on `openshiftapps.com`. The value for this argument must be unique within your organization.
 
-|--compute-machine-type
-|The instance type (string) for the compute nodes. Determines the amount of memory and vCPU that are allocated to each compute node.
+|--compute-machine-type <instance_type>
+|The instance type for compute nodes in the cluster. This determines the amount of memory and vCPU that is allocated to each compute node. For more information on valid instance types, see _AWS Instance types_ in _{product-title} service definition_.
 
-|--compute-nodes
-|The number (integer) of worker nodes to provision per zone. Single-zone clusters require at least 2 nodes. Multi-zone clusters require at least 3 nodes. Default: `2` for single-az; `3` for multi-az
+|--compute-nodes n
+|The number of worker nodes to provision per availability zone. Single-zone clusters require at least 2 nodes. Multi-zone clusters require at least 3 nodes. Default: `2` for single-zone clusters; `3` for multi-zone clusters.
 
-|--controlplane-iam-role string
-|The Amazon Resource Name (ARN) of the IAM role that will be attached to control plane instances.
+|--controlplane-iam-role <arn>
+|The Amazon Resource Name (ARN) of the IAM role to attach to control plane instances.
 
 |--disable-scp-checks
 |Indicates whether cloud permission checks are disabled when attempting to install a cluster.
@@ -138,49 +137,70 @@ $ rosa create cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 |--enable-autoscaling
 |Enables autoscaling of compute nodes. By default, autoscaling is set to `2` nodes. To set non-default node limits, use this argument with the `--min-replicas` and `--max-replicas` arguments.
 
-|--host-prefix
-|The subnet prefix length (integer) to assign to each individual node. For example, if host prefix is set to `23`, then each node is assigned a `/23` subnet out of the given CIDR.
+|--host-prefix <subnet>
+|The subnet prefix length to assign to each individual node, as an integer. For example, if host prefix is set to `23`, then each node is assigned a `/23` subnet out of the given CIDR.
 
-|--machine-cidr
-|Block of IP addresses (ipNet) used by {product-title} while installing the cluster. Example: `10.0.0.0/16`
+|--machine-cidr <address_block>
+a|Block of IP addresses (ipNet) used by {product-title} while installing the cluster, for example, `10.0.0.0/16`.
 
-|--max-replicas
+[IMPORTANT]
+====
+OVN-Kubernetes, the default network provider in {product-title} 4.11 and later, uses the `100.64.0.0/16` IP address range internally. If your cluster uses OVN-Kubernetes, do not include the `100.64.0.0/16` IP address range in any other CIDR definitions in your cluster.
+====
+
+|--max-replicas <number_of_nodes>
 |Specifies the maximum number of compute nodes when enabling autoscaling. Default: `2`
 
-|--min-replicas
+|--min-replicas <number_of_nodes>
 |Specifies the minimum number of compute nodes when enabling autoscaling. Default: `2`
 
 |--multi-az
 |Deploys to multiple data centers.
 
-|--pod-cidr
-|Block of IP addresses (ipNet) from which pod IP addresses are allocated. Example: `10.128.0.0/14`
+|--operator-roles-prefix <string>
+|Prefix to use for all IAM roles used by the operators needed in the OpenShift installer. A prefix is generated automatically if you do not specify one.
+
+|--pod-cidr <address_block>
+a|Block of IP addresses (ipNet) from which pod IP addresses are allocated, for example, `10.128.0.0/14`.
+
+[IMPORTANT]
+====
+OVN-Kubernetes, the default network provider in {product-title} 4.11 and later, uses the `100.64.0.0/16` IP address range internally. If your cluster uses OVN-Kubernetes, do not include the `100.64.0.0/16` IP address range in any other CIDR definitions in your cluster.
+====
 
 |--private
 |Restricts primary API endpoint and application routes to direct, private connectivity.
 
 |--private-link
-| Specifies to use AWS PrivateLink to provide private connectivity between VPCs and services. The `--subnet-ids` argument is required when using `--private-link`.
+|Specifies to use AWS PrivateLink to provide private connectivity between VPCs and services. The `--subnet-ids` argument is required when using `--private-link`.
 
-|--region
-|The AWS region (string) where your worker pool will be located. This argument overrides the `AWS_REGION` environment variable.
+|--region <region_name>
+|The name of the AWS region where your worker pool will be located, for example, `us-east-1`. This argument overrides the `AWS_REGION` environment variable.
 
-|--role-arn string
-|The Amazon Resource Name (ARN) of the installer role that {cluster-manager} will assume to create the cluster.
+|--role-arn <arn>
+|The Amazon Resource Name (ARN) of the installer role that {cluster-manager} uses to create the cluster. This is required if you have not already created account roles.
 
-|--service-cidr
-|Block of IP addresses (ipNet) for services. Example: `172.30.0.0/16`
+|--service-cidr <address_block>
+a|Block of IP addresses (ipNet) for services, for example, `172.30.0.0/16`.
 
-|--subnet-ids
-|The subnet IDs (string) to use when installing the cluster. Subnet IDs must be in pairs with one private subnet ID and one public subnet ID per availability zone. Subnets are comma-delimited. Example: `--subnet-ids=subnet-1,subnet-2`. Leave the value empty for installer-provisioned subnet IDs.
+[IMPORTANT]
+====
+OVN-Kubernetes, the default network provider in {product-title} 4.11 and later, uses the `100.64.0.0/16` IP address range internally. If your cluster uses OVN-Kubernetes, do not include the `100.64.0.0/16` IP address range in any other CIDR definitions in your cluster.
+====
+
+a|--sts \| --non-sts
+|Specifies whether to use AWS Security Token Service (STS) or IAM credentials (non-STS) to deploy your cluster.
+
+|--subnet-ids <aws_subnet_id>
+|The AWS subnet IDs to use when installing the cluster, for example, `subnet-01abc234d5678ef9a`. Subnet IDs must be in pairs with one private subnet ID and one public subnet ID per availability zone. Subnets are comma-delimited, for example, `--subnet-ids=subnet-1,subnet-2`. Leave the value empty for installer-provisioned subnet IDs.
 
 When using `--private-link`, the `--subnet-ids` argument is required and only one private subnet is allowed per zone.
 
 |--support-role-arn string
 |The Amazon Resource Name (ARN) of the role used by Red Hat Site Reliabilty Engineers (SREs) to enable access to the cluster account to provide support.
 
-|--version
-|The version (string) of {product-title} that will be used to install the cluster or cluster resources, including `account-role`. Example: `4.13`
+|--version string
+|The version of {product-title} that will be used to install the cluster or cluster resources. For `cluster` use an `X.Y.Z` format, for example, `4.12.9`. For `account-role` use an `X.Y` format, for example, `4.12`.
 
 |--worker-iam-role string
 |The Amazon Resource Name (ARN) of the IAM role that will be attached to compute instances.
@@ -202,9 +222,6 @@ When using `--private-link`, the `--subnet-ids` argument is required and only on
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples
@@ -212,21 +229,22 @@ Create a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa create cluster --cluster=mycluster
+$ rosa create cluster --cluster-name=mycluster
 ----
+//Note to writers: The create cluster command specifically uses --cluster-name because a cluster ID does not exist yet. All other commands use --cluster because either the name or the ID can be used.
 
 Create a cluster with a specific AWS region.
 
 [source,terminal]
 ----
-$ rosa create cluster --cluster=mycluster --region=us-east-2
+$ rosa create cluster --cluster-name=mycluster --region=us-east-2
 ----
 
 Create a cluster with autoscaling enabled on the default worker machine pool.
 
 [source,terminal]
 ----
-$ rosa create cluster --cluster=mycluster -region=us-east-1 --enable-autoscaling --min-replicas=2 --max-replicas=5
+$ rosa create cluster --cluster-name=mycluster -region=us-east-1 --enable-autoscaling --min-replicas=2 --max-replicas=5
 ----
 
 [id="rosa-create-idp_{context}"]
@@ -245,11 +263,11 @@ $ rosa create idp --cluster=<cluster_name> | <cluster_id> [arguments]
 |===
 |Option |Definition
 
-|--cluster
-|Required: The name or ID (string) of the cluster to which the IDP will be added.
+a|--cluster <cluster_name>\|<cluster_id>
+|Required. The name or ID of the cluster to which the IDP will be added.
 
-|--ca
-|The path (string) to the PEM-encoded certificate file to use when making requests to the server.
+|--ca <path_to_file>
+|The path to the PEM-encoded certificate file to use when making requests to the server, for example, `/usr/share/cert.pem`.
 
 |--client-id
 |The client ID (string) from the registered application.
@@ -367,9 +385,6 @@ $ rosa create idp --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples
@@ -403,8 +418,8 @@ $ rosa create ingress --cluster=<cluster_name> | <cluster_id> [arguments]
 |===
 |Option |Definition
 
-|--cluster
-|Required: The name or ID (string) of the cluster to which the ingress will be added.
+a|--cluster <cluster_name>\|<cluster_id>
+|Required: The name or ID of the cluster to which the ingress will be added.
 
 |--label-match
 |The label match (string) for ingress. The format must be a comma-delimited list of key=value pairs. If no label is specified, all routes are exposed on both routers.
@@ -429,9 +444,6 @@ $ rosa create ingress --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples
@@ -472,8 +484,8 @@ $ rosa create machinepool --cluster=<cluster_name> | <cluster_id> --replicas=<nu
 |===
 |Option |Definition
 
-|--cluster
-|Required: The name or ID (string) of the cluster to which the machine pool will be added.
+a|--cluster <cluster_name>\|<cluster_id>
+|Required: The name or ID of the cluster to which the machine pool will be added.
 
 |--enable-autoscaling
 |Enable or disable autoscaling of compute nodes. To enable autoscaling, use this argument with the `--min-replicas` and `--max-replicas` arguments. To disable autoscaling, use `--enable-autoscaling=false` with the `--replicas` argument.
@@ -516,9 +528,6 @@ $ rosa create machinepool --cluster=<cluster_name> | <cluster_id> --replicas=<nu
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples
@@ -578,7 +587,7 @@ $ rosa create ocm-role [flags]
 |-m, --mode string
 a|How to perform the operation. Valid options are:
 
-* `auto`: Resource changes will be automatic applied using the current AWS account
+* `auto`: Resource changes will be automatically applied using the current AWS account
 * `manual`: Commands necessary to modify AWS resources will be output to be run manually
 
 |--path string
@@ -625,7 +634,7 @@ $ rosa create user-role [flags]
 |-m, --mode string
 a|How to perform the operation. Valid options are:
 
-* `auto`: Resource changes will be automatic applied using the current AWS account
+* `auto`: Resource changes will be automatically applied using the current AWS account
 * `manual`: Commands necessary to modify AWS resources will be output to be run manually
 
 |--path string

--- a/modules/rosa-delete-objects.adoc
+++ b/modules/rosa-delete-objects.adoc
@@ -44,9 +44,6 @@ $ rosa delete admin --cluster=<cluster_name> | <cluster_id>
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -97,9 +94,6 @@ $ rosa delete cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
 
-|--v <level>
-|The log level for V logs.
-
 |--yes
 |Automatically answers `yes` to confirm the operation.
 |===
@@ -149,9 +143,6 @@ $ rosa delete idp --cluster=<cluster_name> | <cluster_id> [arguments]
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
 
-|--v <level>
-|The log level for V logs.
-
 |--yes
 |Automatically answers `yes` to confirm the operation.
 |===
@@ -200,9 +191,6 @@ $ rosa delete ingress --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 
 |--yes
 |Automatically answers `yes` to confirm the operation.
@@ -259,9 +247,6 @@ $ rosa delete machinepool --cluster=<cluster_name> | <cluster_id> <machine_pool_
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 
 |--yes
 |Automatically answers `yes` to confirm the operation.

--- a/modules/rosa-edit-objects.adoc
+++ b/modules/rosa-edit-objects.adoc
@@ -49,9 +49,6 @@ $ rosa edit cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples
@@ -111,9 +108,6 @@ $ rosa edit ingress --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples
@@ -192,9 +186,6 @@ $ rosa edit machinepool --cluster=<cluster_name> | <cluster_id> <machinepool_ID>
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples
@@ -210,14 +201,14 @@ Enable autoscaling on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster-name=mycluster --enable-autoscaling --min-replicas=3 --max-replicas=5 --name=mp1
+$ rosa edit machinepool --cluster=mycluster --enable-autoscaling --min-replicas=3 --max-replicas=5 --name=mp1
 ----
 
 Disable autoscaling on a machine pool named `mp1` on a cluster named `mycluster`.
 
 [source,terminal]
 ----
-$ rosa edit machinepool --cluster-name=mycluster  --enable-autoscaling=false --replicas=3 --name=mp1
+$ rosa edit machinepool --cluster=mycluster  --enable-autoscaling=false --replicas=3 --name=mp1
 ----
 
 Modify the autoscaling range on a machine pool named `mp1` on a cluster named `mycluster`.

--- a/modules/rosa-enable-private-cluster-existing.adoc
+++ b/modules/rosa-enable-private-cluster-existing.adoc
@@ -24,7 +24,7 @@ Enter the following command to enable the `--private` option on an existing clus
 
 [source, terminal]
 ----
-$ rosa edit cluster --cluster-name=<cluster_name> --private
+$ rosa edit cluster --cluster=<cluster_name> --private
 ----
 
 [NOTE]

--- a/modules/rosa-initialize.adoc
+++ b/modules/rosa-initialize.adoc
@@ -73,9 +73,6 @@ $ rosa init [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples

--- a/modules/rosa-install-uninstall-addon.adoc
+++ b/modules/rosa-install-uninstall-addon.adoc
@@ -42,9 +42,6 @@ $ rosa install addon --cluster=<cluster_name> | <cluster_id> [arguments]
 |--profile
 |Uses a specific AWS profile (string) from your credentials file.
 
-|--v level
-|Log level for V logs.
-
 |--yes
 |Automatically answers `yes` to confirm the operation.
 |===
@@ -90,9 +87,6 @@ $ rosa uninstall addon --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Uses a specific AWS profile (string) from your credentials file.
-
-|--v level
-|Log level for V logs.
 
 |--yes
 |Automatically answers `yes` to confirm the operation.

--- a/modules/rosa-installing.adoc
+++ b/modules/rosa-installing.adoc
@@ -38,30 +38,40 @@ $ rosa
 .Example output
 [source,terminal]
 ----
-Command line tool for ROSA.
+Command line tool for Red Hat OpenShift Service on AWS.
+For further documentation visit https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws
 
 Usage:
   rosa [command]
 
 Available Commands:
-  completion  Generates bash completion scripts
+  completion  Generates completion scripts
   create      Create a resource from stdin
   delete      Delete a specific resource
   describe    Show details of a specific resource
+  download    Download necessary tools for using your cluster
   edit        Edit a specific resource
+  grant       Grant role to a specific resource
   help        Help about any command
-  init        Applies templates to support Managed OpenShift on AWS clusters
+  init        Applies templates to support Red Hat OpenShift Service on AWS
+  install     Installs a resource into a cluster
+  link        Link a ocm/user role from stdin
   list        List all resources of a specific type
   login       Log in to your Red Hat account
   logout      Log out
-  logs        Show logs of a specific resource
+  logs        Show installation or uninstallation logs for a cluster
+  revoke      Revoke role from a specific resource
+  uninstall   Uninstalls a resource from a cluster
+  unlink      UnLink a ocm/user role from stdin
+  upgrade     Upgrade a resource
   verify      Verify resources are configured correctly for cluster install
   version     Prints the version of the tool
+  whoami      Displays user account information
 
 Flags:
-      --debug     Enable debug mode.
-  -h, --help      help for rosa
-  -v, --v Level   log level for V logs
+      --color string   Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
+      --debug          Enable debug mode.
+  -h, --help           help for rosa
 
 Use "rosa [command] --help" for more information about a command.
 ----

--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -40,9 +40,6 @@ $ rosa list addons --cluster=<cluster_name> | <cluster_id>
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 [id="rosa-list-clusters_{context}"]
@@ -78,9 +75,6 @@ $ rosa list clusters [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 [id="rosa-list-idps_{context}"]
@@ -116,9 +110,6 @@ $ rosa list idps --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -162,9 +153,6 @@ $ rosa list ingresses --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -244,9 +232,6 @@ $ rosa list machinepools --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -290,9 +275,6 @@ $ rosa list regions [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -336,9 +318,6 @@ $ rosa list upgrades --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -381,9 +360,6 @@ $ rosa list users --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -418,9 +394,6 @@ $ rosa list versions [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -464,9 +437,6 @@ $ rosa describe admin --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -501,9 +471,6 @@ $ rosa describe addon <addon_id> | <addon_name> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example
@@ -547,9 +514,6 @@ $ rosa describe cluster --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example

--- a/modules/rosa-logs.adoc
+++ b/modules/rosa-logs.adoc
@@ -48,9 +48,6 @@ $ rosa logs install --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Examples
@@ -107,9 +104,6 @@ $ rosa logs uninstall --cluster=<cluster_name> | <cluster_id> [arguments]
 
 |--profile
 |Specifies an AWS profile (string) from your credentials file.
-
-|--v <level>
-|The log level for V logs.
 |===
 
 .Example

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -276,7 +276,8 @@ By enabling etcd encryption for the key values in etcd, you will incur a perform
 <7> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
 --
 +
-As an alternative to using the `--interactive` mode, you can specify the customization options directly when you run `rosa create cluster`. Run `rosa create cluster --help` to view a list of available CLI options.
+As an alternative to using the `--interactive` mode, you can specify the customization options directly when you run `rosa create cluster`. Run `rosa create cluster --help` to view a list of available CLI options, or see _create cluster_ in _Managing objects with the ROSA CLI_.
+
 +
 [IMPORTANT]
 ====

--- a/modules/rosa-sts-setting-up-environment.adoc
+++ b/modules/rosa-sts-setting-up-environment.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * rosa_planning/rosa-sts-setting-up-environment.adoc
+
 :_content-type: PROCEDURE
 [id="rosa-sts-setting-up-environment_{context}"]
 
@@ -76,30 +77,40 @@ $ rosa
 .Example output
 [source,terminal]
 ----
-Command line tool for ROSA.
+Command line tool for Red Hat OpenShift Service on AWS.
+For further documentation visit https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws
 
 Usage:
   rosa [command]
 
 Available Commands:
-  completion  Generates bash completion scripts
+  completion  Generates completion scripts
   create      Create a resource from stdin
   delete      Delete a specific resource
   describe    Show details of a specific resource
+  download    Download necessary tools for using your cluster
   edit        Edit a specific resource
+  grant       Grant role to a specific resource
   help        Help about any command
-  init        Applies templates to support Managed OpenShift on AWS clusters
+  init        Applies templates to support Red Hat OpenShift Service on AWS
+  install     Installs a resource into a cluster
+  link        Link a ocm/user role from stdin
   list        List all resources of a specific type
   login       Log in to your Red Hat account
   logout      Log out
-  logs        Show logs of a specific resource
+  logs        Show installation or uninstallation logs for a cluster
+  revoke      Revoke role from a specific resource
+  uninstall   Uninstalls a resource from a cluster
+  unlink      UnLink a ocm/user role from stdin
+  upgrade     Upgrade a resource
   verify      Verify resources are configured correctly for cluster install
   version     Prints the version of the tool
+  whoami      Displays user account information
 
 Flags:
-      --debug     Enable debug mode.
-  -h, --help      help for rosa
-  -v, --v Level   log level for V logs
+      --color string   Surround certain characters with escape sequences to display them in color on the terminal. Allowed options are [auto never always] (default "auto")
+      --debug          Enable debug mode.
+  -h, --help           help for rosa
 
 Use "rosa [command] --help" for more information about a command.
 ----

--- a/modules/rosa-upgrade-cluster-cli.adoc
+++ b/modules/rosa-upgrade-cluster-cli.adoc
@@ -98,9 +98,6 @@ $ rosa delete upgrade --cluster=<cluster_name> | <cluster_id>
 |--debug
 |Enables debug mode.
 
-|--v level
-|Log level for V logs.
-
 |--yes
 |Automatically answers `yes` to confirm the operation.
 |===

--- a/modules/rosa-using-bash-script.adoc
+++ b/modules/rosa-using-bash-script.adoc
@@ -31,6 +31,7 @@ $ rosa init --token=<token>
 ----
 $ rosa create cluster --cluster-name=<cluster_name>
 ----
+//Note to writers: The create cluster command specifically uses --cluster-name because a cluster ID does not exist yet. All other commands use --cluster because either the name or the ID can be used.
 
 . Add an identity provider (IDP):
 +

--- a/rosa_cli/rosa-manage-objects-cli.adoc
+++ b/rosa_cli/rosa-manage-objects-cli.adoc
@@ -14,6 +14,7 @@ include::modules/rosa-create-objects.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 == Additional resources
+* See xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-aws-instance-types_rosa-service-definition[AWS Instance types] for a list of supported instance types.
 * See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference] for a list of IAM roles needed for cluster creation.
 * See xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-understanding-aws-account-association_rosa-sts-creating-a-cluster-with-customizations[Understanding AWS account association] for more information about the OCM role and user role.
 

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -32,6 +32,11 @@ include::modules/rosa-sts-arn-path-customization-for-iam-roles-and-policies.adoc
 include::modules/rosa-sts-support-considerations.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-a-cluster-using-customizations.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster] in _Managing objects with the ROSA CLI_.
+
 include::modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc[leveloffset=+2]
 
 [id="next-steps_{context}"]


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-3954

Link to docs preview:
Create cluster CLI reference: https://57619--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli.html#rosa-create-cluster-command_rosa-managing-objects-cli
Install custom cluster (at the end of step 3): https://57619--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations

QE review:
- [x] QE has approved this change.
