### PR TITLE
OSDOCS-5277: Document deprecated release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -66,7 +66,7 @@ You can deploy an {product-title} cluster to multiple vSphere datacenters or reg
 You can also specify multiple regions and zones on a cluster after installation. You must upgrade your existing cluster to {product-title} {product-version} before you configure a multiple region and zone environment.
 
 [id="ocp-4-13-installation-vsphere-default-config-yaml"]
-==== Changes to the default `install-config.yaml` file
+==== Changes to the default vSphere `install-config.yaml` file 
 After you run the installation program for {product-title} on vSphere, the default `install-config.yaml` file now includes `vcenters` and `failureDomains` fields, so that you can choose to specify multiple datacenters, region, and zone information for your cluster. You can leave these fields blank if you want to install an {product-title} cluster in a vSphere environment that consists of single datacenter running in a VMware vCenter.
 
 [id="ocp-4-13-installation-and-upgrade-three-node"]
@@ -575,6 +575,23 @@ The `ImageContentSourcePolicy` (ICSP) object is now deprecated. You can now use 
 For more information on these new objects, see xref:../post_installation_configuration/preparing-for-users.adoc#images-configuration-registry-mirror_post-install-preparing-for-users[Configuring image registry repository mirroring].
 
 For more information on converting existing ICSP YAML files to IDMS YAML files, see xref:../post_installation_configuration/preparing-for-users.adoc#images-configuration-registry-mirror-convert_post-install-preparing-for-users[Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring].
+
+[id="ocp-4-13-vSphere-configuration-parameters"]
+==== VMware vSphere configuration parameters
+
+{product-title} {product-version} deprecates the following vSphere configuration parameters. You can continue to use these parameters, but the installation program does not automatically specify these parameters in the `install-config.yaml` file.
+
+* `platform.vsphere.vCenter`
+* `platform.vsphere.username`
+* `platform.vsphere.password`
+* `platform.vsphere.datacenter`
+* `platform.vsphere.defaultDatastore`
+* `platform.vsphere.cluster`
+* `platform.vsphere.folder`
+* `platform.vsphere.resourcePool`
+* `platform.vsphere.apiVIP`
+* `platform.vsphere.ingressVIP`
+* `platform.vsphere.network`
 
 [id="ocp-4-13-removed-features"]
 === Removed features


### PR DESCRIPTION
[OSDOCS-5277](https://issues.redhat.com/browse/OSDOCS-5277)

Version(s):
4.13

Link to docs preview: [Deprecated VMware vSphere configuration parameters](https://57624--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-deprecated-features)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs.

Additional resources: https://github.com/openshift/installer/blob/master/pkg/types/vsphere/platform.go#L35-L128