### PR TITLE
OCPBUG10593: Corrected command syntax for 'opm migrate'.

### DIFF
--- a/modules/opm-cli-ref-migrate.adoc
+++ b/modules/opm-cli-ref-migrate.adoc
@@ -10,7 +10,7 @@ Migrate a SQLite database format index image or database file to a file-based ca
 .Command syntax
 [source,terminal]
 ----
-$ opm  <index_ref> <output_dir> [<flags>]
+$ opm migrate <index_ref> <output_dir> [<flags>]
 ----
 
 .`migrate` flags


### PR DESCRIPTION
Version: 4.10+

Scope: Corrected command syntax for 'opm migrate' under opm CLI reference.

Issue: [OCPBUG#10593](https://issues.redhat.com/browse/OCPBUGS-10593)

Links to Doc Preview:
[Preview](https://57633--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/opm/cli-opm-ref.html#opm-cli-ref-migrate_cli-opm-ref)

@Xia-Zhao-rh ptal