### PR TITLE
OSDOCS-5499: Removing TP version of cert-manager for 4.13

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -73,32 +73,3 @@ Using the `unsupportedConfigOverrides` section to modify the configuration of an
 * The {cert-manager-operator} does not support using Google workload identity federation. (link:https://issues.redhat.com/browse/OCPBUGS-9998[*OCPBUGS-9998*])
 
 * When uninstalling the {cert-manager-operator}, if you select the *Delete all operand instances for this operator* checkbox in the {product-title} web console, the Operator is not uninstalled properly. As a workaround, do not select this checkbox when uninstalling the {cert-manager-operator}. (link:https://issues.redhat.com/browse/OCPBUGS-9960[*OCPBUGS-9960*])
-
-[id="cert-manager-operator-release-notes-1.7.1-1"]
-== Release notes for {cert-manager-operator} 1.7.1-1 (Technology Preview)
-
-Issued: 2022-04-11
-
-The following advisory is available for the {cert-manager-operator} 1.7.1-1:
-
-* link:https://access.redhat.com/errata/RHEA-2022:1273[RHEA-2022:1273]
-
-For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.7/#v1-7-1[cert-manager project release notes for v1.7.1].
-
-[id="cert-manager-operator-1.7.1-1-new-features-and-enhancements"]
-=== New features and enhancements
-
-* This is the initial, Technology Preview release of the {cert-manager-operator}.
-
-////
-// No bug fixes in the initial release
-[id="cert-manager-operator-1.7.1-1-bug-fixes"]
-=== Bug fixes
-
-* TODO
-////
-
-[id="cert-manager-operator-1.7.1-1-known-issues"]
-=== Known issues
-
-* Using `Route` objects is not fully supported. Currently, {cert-manager-operator} integrates with `Route` objects by creating `Ingress` objects through the Ingress Controller. (link:https://issues.redhat.com/browse/CM-16[*CM-16*])


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5499

Link to docs preview:
https://57649--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
