### PR TITLE
OSDOCS-5594: Removed references to IBM from ROSA docs

### DIFF
--- a/modules/cluster-logging-feature-reference.adoc
+++ b/modules/cluster-logging-feature-reference.adoc
@@ -159,8 +159,10 @@ $ oc -n openshift-logging edit ClusterLogging instance
 | Global proxy support  | &#10003; | &#10003;
 | x86 support           | &#10003; | &#10003;
 | ARM support           | &#10003; | &#10003;
+ifndef::openshift-rosa[]
 | {ibmpowerProductName} support       | &#10003; | &#10003;
 | {ibmzProductName} support         | &#10003; | &#10003;
+endif::openshift-rosa[]
 | IPv6 support          | &#10003; | &#10003;
 | Log event buffering   | &#10003; |
 | Disconnected Cluster  | &#10003; | &#10003;

--- a/modules/distr-tracing-rn-known-issues.adoc
+++ b/modules/distr-tracing-rn-known-issues.adoc
@@ -17,8 +17,10 @@ Result - If the workaround does not completely address the problem.
 These limitations exist in {DTProductName}:
 
 * Apache Spark is not supported.
+ifndef::openshift-rosa[]
 
 * The streaming deployment via AMQ/Kafka is unsupported on IBM Z and IBM Power Systems.
+endif::openshift-rosa[]
 
 These are the known issues for {DTProductName}:
 

--- a/modules/ossm-federation-across-cluster.adoc
+++ b/modules/ossm-federation-across-cluster.adoc
@@ -14,11 +14,13 @@ The service must be exposed through a load balancer that operates at Layer4 of t
 If the cluster runs on bare metal and fully supports `LoadBalancer` services, the IP address found in the `.status.loadBalancer.ingress.ip` field of the ingress gateway `Service` object should be specified as one of the entries in the `.spec.remote.addresses` field of the `ServiceMeshPeer` object.
 
 If the cluster does not support `LoadBalancer` services, using a `NodePort` service could be an option if the nodes are accessible from the cluster running the other mesh. In the `ServiceMeshPeer` object, specify the IP addresses of the nodes in the `.spec.remote.addresses` field and the service's node ports in the `.spec.remote.discoveryPort` and `.spec.remote.servicePort` fields.
+ifndef::openshift-rosa[]
 
 == Exposing the federation ingress on clusters running on {ibmpowerProductName} and {ibmzProductName}
 If the cluster runs on {ibmpowerProductName} or {ibmzProductName} infrastructure and fully supports `LoadBalancer` services, the IP address found in the `.status.loadBalancer.ingress.ip` field of the ingress gateway `Service` object should be specified as one of the entries in the `.spec.remote.addresses` field of the `ServiceMeshPeer` object.
 
 If the cluster does not support `LoadBalancer` services, using a `NodePort` service could be an option if the nodes are accessible from the cluster running the other mesh. In the `ServiceMeshPeer` object, specify the IP addresses of the nodes in the `.spec.remote.addresses` field and the service's node ports in the `.spec.remote.discoveryPort` and `.spec.remote.servicePort` fields.
+endif::openshift-rosa[]
 
 == Exposing the federation ingress on Amazon Web Services (AWS)
 By default, LoadBalancer services in clusters running on AWS do not support L4 load balancing. In order for {SMProductName} federation to operate correctly, the following annotation must be added to the ingress gateway service:

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -21,12 +21,14 @@ These limitations exist in {SMProductName}:
 
 * The first time you access related services such as {JaegerShortName} and Grafana, from the Kiali console, you must accept the certificate and re-authenticate using your {product-title} login credentials. This happens due to an issue with how the framework displays embedded pages in the console.
 
+ifndef::openshift-rosa[]
 * The Bookinfo sample application cannot be installed on IBM Z and IBM Power.
 
 * WebAssembly extensions are not supported on IBM Z and IBM Power.
 
 * LuaJIT is not supported on IBM Power.
 
+endif::openshift-rosa[]
 [id="ossm-rn-known-issues-ossm_{context}"]
 == {SMProductShortName} known issues
 
@@ -83,6 +85,7 @@ For example, if you create a namespace called 'akube-a' and add it to the Servic
 +
 Workaround: Change the Kiali Custom Resource setting so it prefixes the setting with a carat (^). For example:
 +
+ifndef::openshift-rosa[]
 [source,yaml]
 ----
 api:
@@ -94,10 +97,26 @@ api:
     - "^ibm.*"
     - "^kiali-operator"
 ----
+endif::openshift-rosa[]
+
+ifdef::openshift-rosa[]
+[source,yaml]
+----
+api:
+  namespaces:
+    exclude:
+    - "^istio-operator"
+    - "^kube-.*"
+    - "^openshift.*"
+    - "^kiali-operator"
+----
+endif::openshift-rosa[]
 +
 * link:https://issues.redhat.com/browse/MAISTRA-2692[MAISTRA-2692] With Mixer removed, custom metrics that have been defined in {SMProductShortName} 2.0.x cannot be used in 2.1. Custom metrics can be configured using `EnvoyFilter`. Red Hat is unable to support `EnvoyFilter` configuration except where explicitly documented. This is due to tight coupling with the underlying Envoy APIs, meaning that backward compatibility cannot be maintained.
+ifndef::openshift-rosa[]
 
 * link:https://issues.redhat.com/browse/MAISTRA-2648[MAISTRA-2648] `ServiceMeshExtensions` are currently not compatible with meshes deployed on IBM Z Systems.
+endif::openshift-rosa[]
 
 * link:https://issues.jboss.org/browse/MAISTRA-1959[MAISTRA-1959] _Migration to 2.0_ Prometheus scraping (`spec.addons.prometheus.scrape` set to `true`) does not work when mTLS is enabled. Additionally, Kiali displays extraneous graph data when mTLS is disabled.
 +

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -1026,7 +1026,12 @@ In addition, this release has the following new features:
 
 == New features {SMProductName} 2.0.2
 
+ifndef::openshift-rosa[]
 This release of {SMProductName} adds support for IBM Z and IBM Power Systems. It also addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+endif::openshift-rosa[]
 
 == New features {SMProductName} 2.0.1
 

--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -42,9 +42,14 @@ Explicitly unsupported cases include:
 [id="ossm-supported-configurations-sm_{context}"]
 == Supported configurations for Service Mesh
 
+ifndef::openshift-rosa[]
 * This release of {SMProductName} is only available on {product-title} x86_64, {ibmzProductName}, and {ibmpowerProductName}.
 ** {ibmzProductName} is only supported on {product-title} 4.6 and later.
 ** {ibmpowerProductName} is only supported on {product-title} 4.6 and later.
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+* This release of {SMProductName} is only available on {product-title} x86_64.
+endif::openshift-rosa[]
 * Configurations where all {SMProductShortName} components are contained within a single {product-title} cluster.
 * Configurations that do not integrate external services such as virtual machines.
 * {SMProductName} does not support `EnvoyFilter` configuration except where explicitly documented.

--- a/modules/ossm-tutorial-bookinfo-install.adoc
+++ b/modules/ossm-tutorial-bookinfo-install.adoc
@@ -17,11 +17,13 @@ This tutorial walks you through how to create a sample application by creating a
 * Access to the OpenShift CLI (`oc`).
 * An account with the `cluster-admin` role.
 
+ifndef::openshift-rosa[]
 [NOTE]
 ====
 The Bookinfo sample application cannot be installed on {ibmzProductName} and {ibmpowerProductName}.
 ====
 
+endif::openshift-rosa[]
 [NOTE]
 ====
 The commands in this section assume the {SMProductShortName} control plane project is `istio-system`.  If you installed the control plane in another namespace, edit each command before you run it.

--- a/modules/serverless-gpu-resources-kn.adoc
+++ b/modules/serverless-gpu-resources-kn.adoc
@@ -15,11 +15,13 @@ After GPU resources are enabled for your {product-title} cluster, you can specif
 * GPU resources are enabled for your {product-title} cluster.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 
+ifndef::openshift-rosa[]
 [NOTE]
 ====
 Using NVIDIA GPU resources is not supported for {ibmzProductName} and {ibmpowerProductName}.
 ====
 
+endif::openshift-rosa[]
 .Procedure
 
 . Create a Knative service and set the GPU resource requirement limit to `1` by using the `--limit nvidia.com/gpu=1` flag:

--- a/modules/serverless-installing-cli-linux-rpm-package-manager.adoc
+++ b/modules/serverless-installing-cli-linux-rpm-package-manager.adoc
@@ -45,6 +45,7 @@ For {op-system-base-full}, you can install the Knative (`kn`) CLI as an RPM by u
 ----
 # subscription-manager repos --enable="openshift-serverless-1-for-rhel-8-x86_64-rpms"
 ----
+ifndef::openshift-rosa[]
 +
 * Linux on {ibmzProductName} and {linuxoneProductName} (s390x)
 +
@@ -59,6 +60,7 @@ For {op-system-base-full}, you can install the Knative (`kn`) CLI as an RPM by u
 ----
 # subscription-manager repos --enable="openshift-serverless-1-for-rhel-8-ppc64le-rpms"
 ----
+endif::openshift-rosa[]
 
 . Install the Knative (`kn`) CLI as an RPM by using a package manager:
 +

--- a/modules/serverless-installing-cli-linux.adoc
+++ b/modules/serverless-installing-cli-linux.adoc
@@ -28,10 +28,12 @@ $ kn: No such file or directory
 +
 --
 * link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
+ifndef::openshift-rosa[]
 
 * link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
 
 * link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/latest/kn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
+endif::openshift-rosa[]
 --
 +
 You can also download any version of `kn` by navigating to that version's corresponding directory in the link:https://mirror.openshift.com/pub/openshift-v4/clients/serverless/[Serverless client download mirror].

--- a/service_mesh/v2x/ossm-extensions.adoc
+++ b/service_mesh/v2x/ossm-extensions.adoc
@@ -8,10 +8,13 @@ toc::[]
 
 You can use WebAssembly extensions to add new features directly into the {SMProductName} proxies. This lets you move even more common functionality out of your applications, and implement them in a single language that compiles to WebAssembly bytecode.
 
+ifndef::openshift-rosa[]
 [NOTE]
 ====
 WebAssembly extensions are not supported on {ibmzProductName} and {ibmpowerProductName}.
 ====
+
+endif::openshift-rosa[]
 
 include::modules/ossm-extensions-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.12+`

Issue:
[OSDOCS-5594](https://issues.redhat.com/browse/OSDOCS-5594)

Link to docs preview:
1. About Logging - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/logging/cluster-logging.html#collector-features) and [Dedicated](https://57658--docspreview.netlify.app/openshift-dedicated/latest/logging/cluster-logging.html#collector-features)
    ![image](https://user-images.githubusercontent.com/16167833/227283170-f5a26578-c3f2-46d4-93c7-1fdecdca1436.png)
2. Service Mesh Federations - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/ossm-federation.html#exposing-the-federation-ingress-on-amazon-web-services-aws) and [Enterprise](https://57658--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-federation.html#exposing-the-federation-ingress-on-amazon-web-services-aws)
    ![image](https://user-images.githubusercontent.com/16167833/227283389-265b935c-b34a-4b8c-9c6c-cc52b4b9320a.png)
3. Service Mesh Release Notes 
    * Known Issues 1 - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-rn-known-issues_ossm-release-notes) and [Enterprise](https://57658--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-rn-known-issues_ossm-release-notes) 
        ![image](https://user-images.githubusercontent.com/16167833/227283544-12f62258-a505-4428-9891-28855c9c9b1c.png)
    * Known Issues 2 - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-rn-known-issues-ossm_ossm-release-notes) vs. [Enterprise](https://57658--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-rn-known-issues-ossm_ossm-release-notes)
        ![image](https://user-images.githubusercontent.com/16167833/227307465-ac8a7d3c-df30-4eed-804f-b6f71bdc35ac.png)
    * Known Issue 3 - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/servicemesh-release-notes.html#distr-tracing-rn-known-issues_ossm-release-notes) and [Enterprise](https://57658--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#distr-tracing-rn-known-issues_ossm-release-notes)
        ![image](https://user-images.githubusercontent.com/16167833/227308446-2e685d75-e335-417b-8f57-d96f952f3376.png)
    * New Issue - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-2-0-2) and [Enterprise](https://57658--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-2-0-2)
        ![image](https://user-images.githubusercontent.com/16167833/227283788-7309c185-48c9-4def-904f-554a64757b15.png)
6. Supported Configurations for Service Mesh - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/preparing-ossm-installation.html#ossm-supported-configurations-sm_preparing-ossm-installation) and [Enterprise](https://57658--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/preparing-ossm-installation.html#ossm-supported-configurations-sm_preparing-ossm-installation)
    ![image](https://user-images.githubusercontent.com/16167833/227284016-41c97ecc-0b98-491d-b94e-d2aae2f2deb8.png)
7. Workloads to Service Mesh - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/ossm-create-mesh.html#ossm-tutorial-bookinfo-install_ossm-create-mesh) and [Enterprise](https://57658--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-mesh.html#ossm-tutorial-bookinfo-install_ossm-create-mesh)
    ![image](https://user-images.githubusercontent.com/16167833/227284309-0c7d5326-b433-4351-b39d-953b91f84996.png)
8. Serverless GPU - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/serverless/integrations/gpu-resources.html#serverless-gpu-resources-kn_gpu-resources) and [Enterprise](https://57658--docspreview.netlify.app/openshift-enterprise/latest/serverless/integrations/gpu-resources.html#serverless-gpu-resources-kn_gpu-resources)
    ![image](https://user-images.githubusercontent.com/16167833/227284575-9bf04d4d-99e8-4e50-a8e9-ff1a11bf6379.png)
9. Installing Knative CLI  
    * [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/serverless/install/installing-kn.html#installing-cli-linux_installing-kn) and [Dedicated](https://57658--docspreview.netlify.app/openshift-dedicated/latest/serverless/install/installing-kn.html#installing-cli-linux_installing-kn)
        ![image](https://user-images.githubusercontent.com/16167833/227284809-7caf36f8-6f75-420b-a897-87abe275bd69.png)
    * [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/serverless/install/installing-kn.html#serverless-installing-cli-linux-rpm-package-manager_installing-kn) and [Dedicated](https://57658--docspreview.netlify.app/openshift-dedicated/latest/serverless/install/installing-kn.html#serverless-installing-cli-linux-rpm-package-manager_installing-kn)
        ![image](https://user-images.githubusercontent.com/16167833/227309167-7bc60359-5546-45ac-8b36-81542b280424.png)
10. Service Mesh Extensions - [ROSA](https://57658--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/ossm-extensions.html) and [Enterprise](https://57658--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-extensions.html)
    ![image](https://user-images.githubusercontent.com/16167833/227284939-67b6be30-22d1-4a6b-a2ea-e0ddd69156be.png)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Removed all references to IBM from the ROSA docs.