### PR TITLE
OCPBUGS-10717 removing RHV warning that does not apply to generic

### DIFF
--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -253,14 +253,6 @@ ifdef::ibm-z,ibm-z-kvm[{ibmzProductName} infrastructure.]
 ifdef::ibm-power[{ibmpowerProductName} infrastructure.]
 ifdef::rhv[RHV infrastructure.]
 ifndef::openshift-origin[]
-+
-[WARNING]
-====
-Red Hat Virtualization does not currently support installation with user-provisioned infrastructure on the oVirt platform. Therefore, you must set the platform to `none`, allowing {product-title} to identify each node as a bare-metal node and the cluster as a bare-metal cluster. This is the same as xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[installing a cluster on any platform], and has the following limitations:
-
-. There will be no cluster provider so you must manually add each machine and there will be no node scaling capabilities.
-. The oVirt CSI driver will not be installed and there will be no CSI capabilities.
-====
 <12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]


### PR DESCRIPTION
 [OCPBUGS-10717](https://issues.redhat.com/browse/OCPBUGS-10717)

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): enterprise-4.13, enterprise-4.12, enterprise-4.10, enterprise-4.9
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: remove RHV specific warning displayed in generic version of installation example of YAML file configuration - in callout #11 description
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  https://57659--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_platform_agnostic/installing-platform-agnostic.html#installation-initializing-manual_installing-platform-agnostic
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
