### PR TITLE
[OCPBUGS-10654]: Fix a typo and remove a list item

### DIFF
--- a/modules/network-observability-flowcollector-view.adoc
+++ b/modules/network-observability-flowcollector-view.adoc
@@ -47,7 +47,6 @@ spec:
   loki:                                       <3>
     url: 'http://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network'
     statusUrl: 'https://loki-query-frontend-http.netobserv.svc:3100/'
-    tenantID: network
     authToken: FORWARD
     tls:
       enable: true

--- a/modules/network-observability-operator-install.adoc
+++ b/modules/network-observability-operator-install.adoc
@@ -22,7 +22,6 @@ You can install the Network Observability Operator using the {product-title} web
 * *spec.agent.ebpf.Sampling* : Specify a sampling size for flows. Lower sampling sizes will have higher impact on resource utilization. For more information, see the `FlowCollector` API reference, under spec.agent.ebpf. 
 * *spec.deploymentModel*: If you are using Kafka, verify Kafka is selected.
 * *loki.url*: Since authentication is specified separately, this URL needs to be updated to `https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network`. The first part of the URL, "loki", should match the name of your LokiStack.
-* *loki.tenantID*: Set this to `network`.
 * *loki.statusUrl*: Set this to `https://loki-query-frontend-http.netobserv.svc:3100/`.
 * *loki.authToken*: Select the `FORWARD` value.
 * *tls.enable*: Verify that the box is checked so it is enabled.

--- a/modules/network-observability-roles-create.adoc
+++ b/modules/network-observability-roles-create.adoc
@@ -9,7 +9,7 @@ Specify authentication and authorization configurations by defining `ClusterRole
 
 .Procedure
 
-. Using the web console, click the Imoport icon, *+*. 
+. Using the web console, click the Import icon, *+*. 
 . Drop your YAML file into the editor and click *Create*: 
 +
 [source, yaml]


### PR DESCRIPTION
[OCPBUGS-10654](https://issues.redhat.com/browse/OCPBUGS-10654)

Version(s): 4.10 +

Link to docs preview: (March 24)
[Installing the Network Observability Operator](http://file.rdu.redhat.com/tlove/netobserv-ocpbugs-10654-tlove/networking/network_observability/installing-operators.html#network-observability-operator-installation_network_observability)
[Create roles for Authentication and authorization module](http://file.rdu.redhat.com/tlove/netobserv-ocpbugs-10654-tlove/networking/network_observability/installing-operators.html#network-observability-roles-create_network_observability)
[View the FlowCollector resource](http://file.rdu.redhat.com/tlove/netobserv-ocpbugs-10654-tlove/networking/network_observability/configuring-operator.html#network-observability-flowcollector-view_network_observability)

QE review:
- [ x] QE has approved this change.
