### PR TITLE
[enterprise-4.9] Updating imagecontentsourcepolicy should not trigger a node drain

### DIFF
--- a/modules/troubleshooting-disabling-autoreboot-mco.adoc
+++ b/modules/troubleshooting-disabling-autoreboot-mco.adoc
@@ -7,17 +7,9 @@
 
 When configuration changes are made by the Machine Config Operator (MCO), {op-system-first} must reboot for the changes to take effect. Whether the configuration change is automatic or manual, an {op-system} node reboots automatically unless it is paused.
 
-[NOTE]
+[NOTE] 
 ====
-The following modifications do not trigger a node reboot:
-
-* When the MCO detects any of the following changes, it applies the update without draining or rebooting the node:
-
-** Changes to the SSH key in the `spec.config.passwd.users.sshAuthorizedKeys` parameter of a machine config.
-** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
-** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
-
-* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes. The node drain does not happen when there is a mirror configuration change in the `ImageContentSourcePolicy` (ICSP) object such as a new mirror added to an existing registry or a new registry added that has the setting `mirror-by-digest-only=true`.
+include::snippets/node-icsp-no-drain.adoc[]
 ====
 
 To avoid unwanted disruptions, you can modify the machine config pool (MCP) to prevent automatic rebooting after the Operator makes changes to the machine config.

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -47,13 +47,7 @@ When changes are made to a machine configuration, the Machine Config Operator (M
 
 To prevent the nodes from automatically rebooting after machine configuration changes, before making the changes, you must pause the autoreboot process by setting the `spec.paused` field to `true` in the corresponding machine config pool. When paused, machine configuration changes are not applied until you set the `spec.paused` field to `false` and the nodes have rebooted into the new configuration.
 
-The following modifications do not trigger a node reboot:
+Make sure the pools are unpaused when the CA certificate rotation happens. If the MCPs are paused, the MCO cannot push the newly rotated certificates to those nodes. This causes the cluster to become degraded and causes failure in multiple `oc` commands, including `oc debug`, `oc logs`, `oc exec`, and `oc attach`. You receive alerts in the Alerting UI of the {product-title} web console if an MCP is paused when the certificates are rotated.
 
-* When the MCO detects any of the following changes, it applies the update without draining or rebooting the node:
-
-** Changes to the SSH key in the `spec.config.passwd.users.sshAuthorizedKeys` parameter of a machine config.
-** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
-** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
-
-* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageContentSourcePolicy` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes. The node drain does not happen when there is a mirror configuration change in the `ImageContentSourcePolicy` (ICSP) object such as a new mirror added to an existing registry or a new registry added that has the setting `mirror-by-digest-only=true`.
+include::snippets/node-icsp-no-drain.adoc[]
 ====

--- a/snippets/node-icsp-no-drain.adoc
+++ b/snippets/node-icsp-no-drain.adoc
@@ -1,0 +1,20 @@
+// Text snippet included in the following modules:
+//
+// * modules/about-crio.adoc
+// * modules/nodes-containers-using.adoc
+
+:_content-type: SNIPPET
+
+The following modifications do not trigger a node reboot:
+
+* When the MCO detects any of the following changes, it applies the update without draining or rebooting the node:
+
+** Changes to the SSH key in the `spec.config.passwd.users.sshAuthorizedKeys` parameter of a machine config.
+** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
+** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
+
+* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageDigestMirrorSet` or `ImageTagMirrorSet` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes.The node drain does not happen for the following changes:
+** The addition of a registry with the `pull-from-mirror = "digest-only"` parameter set for each mirror.
+** The addition of a mirror with the `pull-from-mirror = "digest-only"` parameter set in a registry.
+** The addition of items to the `unqualified-search-registries` list.
+


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/57440