### PR TITLE
OCPBUGS-8096:removes typo from 4.10.13 RNs

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -2917,11 +2917,6 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.10.13 --pullspecs
 ----
 
-[id="ocp-4-10-13-known-issues"]
-==== Known issues
-* When installing {product-title} 4.10.13, the HPE nodes fail and are unable to start the inspection. Upgrade to {product-title} 4.9.28 or 4.10.9 to help mitigate the issue. Currently, there are plans to resolve this issue in a future version of {product-title}. For more information, see the following Knowledgebase solution:
-** link:https://access.redhat.com/solutions/6849521[Potential etcd data inconsistency issue in OCP 4.9 and 4.10]
-
 [id="ocp-4-10-13-bug-fixes"]
 ==== Bug fixes
 * Previously, when creating an Ingress Object in {product-title} 4.8, the API restrictions prevented users from defining routes with hostnames and installing numeric clusters. This fix removes the API's number restriction, allowing users to create clusters with numbers and define routes using hostnames. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2072739#[*BZ#2072739*])


### PR DESCRIPTION
OCPBUGS #8096: removes a `Known issue` typo from 4.10.13 RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-8096
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview](https://joealdinger.github.io/openshift-docs/OCPBUGS-8096/release_notes/ocp-4-10-release-notes.html#ocp-4-10-13)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is a `Known issue` that was accidentally pasted into the 4.10 RNs from the 4.9.28 RNs.
PTAL @sunilcio @sferich888 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
