### PR TITLE
OSDOCS-5605: Added a module to detail AWS LZ cluster limitations

### DIFF
--- a/installing/installing_aws/installing-aws-localzone.adoc
+++ b/installing/installing_aws/installing-aws-localzone.adoc
@@ -40,6 +40,13 @@ Be sure to also review this site list if you are configuring a proxy.
 ====
 * If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-creating-iam-aws[manually create and maintain IAM credentials].
 
+include::modules/cluster-limitations-local-zone.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../storage/understanding-persistent-storage.html#pvc-storage-class_understanding-persistent-storage[Storage classes]
+
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/installation-aws-add-local-zone-locations.adoc[leveloffset=+1]

--- a/modules/cluster-limitations-local-zone.adoc
+++ b/modules/cluster-limitations-local-zone.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-aws-localzone.adoc
+
+:_content-type: CONCEPT
+
+[id="cluster-limitations-local-zone_{context}"]
+= Cluster limitations in AWS Local Zones
+
+Some limitations exist when you attempt to deploy a cluster with a default installation configuration in Amazon Web Services (AWS) Local Zones.
+
+[IMPORTANT]
+====
+The following list details limitations when deploying a cluster in AWS Local Zones:
+
+- The Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is `1300`. This causes the cluster-wide network MTU to change according to the network plugin that is used on the deployment.
+- Network resources such as Network Load Balancer (NLB), Classic Load Balancer, and Network Address Translation (NAT) Gateways are not supported in AWS Local Zones.
+- For an {product-title} cluster on AWS, the AWS Elastic Block Storage (EBS) `gp3` type volume is the default for node volumes and the default for the storage class. This volume type is not globally available on Local Zone locations. By default, the nodes running in Local Zones are deployed with the `gp2` EBS volume. The `gp2-csi` `StorageClass` must be set when creating workloads on Local Zone nodes.
+====


### PR DESCRIPTION
Change Management for 4.12 updates


[OSDOCS-5605](https://issues.redhat.com/browse/OSDOCS-5605)

Version(s):
4.12 and 4.13

Link to docs preview:
[Cluster limitations in AWS Local Zones](https://57736--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone.html#cluster-limitations-local-zone_installing-aws-localzone)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
