### PR TITLE
OSDOCS-4976: Add release note for cluster network expansion

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -219,6 +219,11 @@ If you are using the OVN-Kubernetes network plugin, you can migrate to the OpenS
 
 For more information, see xref:../networking/openshift_sdn/migrate-to-openshift-sdn.adoc#migrate-to-openshift-sdn[Migrating to the OpenShift SDN network plugin].
 
+[id="ocp-4-13-expand-cluster-network-ip-address-range"]
+==== Expand cluster network IP address range
+
+The cluster network can be expanded to support the addition of nodes to the cluster. For example, if you deployed a cluster and specified `10.128.0.0/19` as the cluster network range and a host prefix of `23`, you are limited to 16 nodes. You can expand that to 510 nodes by changing the CIDR mask on a cluster to `/14`. For more information, see xref:../networking/configuring-cluster-network-range.adoc#configuring-cluster-network-range[Configuring the cluster network range].
+
 [id="ocp-4-13-storage"]
 === Storage
 


### PR DESCRIPTION
Adds a release note for this feature.

- https://issues.redhat.com/browse/OSDOCS-4976

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57737--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-expand-cluster-network-ip-address-range
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
