### PR TITLE
Fix bad ifdef in OKD

### DIFF
--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -41,6 +41,7 @@ The `candidate-{product-version}` channel offers unsupported early access to rel
 may not contain the full feature set of eventual GA releases or features may be removed prior to GA. Additionally, these releases have not been subject to full
 Red Hat Quality Assurance and may not offer update paths to later GA releases. Given these caveats, the candidate channel is only suitable for testing purposes
 where destroying and recreating a cluster is acceptable.
+endif::openshift-origin[]
 
 ifdef::openshift-origin[]
 [id="stable-4-channel_{context}"]
@@ -49,7 +50,7 @@ Releases are added to the `stable-4` channel after passing all tests and stable-
 endif::openshift-origin[]
 
 
-
+ifndef::openshift-origin[]
 [id="upgrade-version-paths_{context}"]
 == Update recommendations in the channel
 


### PR DESCRIPTION
Noticed a missing `endif` causing problems in OKD

Current OKD docs -- [Update channels](https://docs.okd.io/latest/updating/understanding-upgrade-channels-release.html)
Previews
OKD -- [Update channels](http://file.rdu.redhat.com/mburke/okd-fix-upgrade-channels/updating/understanding-upgrade-channels-release.html). Fixed endif to display the OKD channel and hid all assemblies starting with _Update recommendations in the channel_.
OCP -- [Update channels](https://57745--docspreview.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html#understanding-upgrade-channels_understanding-upgrade-channels-releases)

