### PR TITLE
OSDOCS-5595:updates install and uninstall for NW observability Operator

### DIFF
--- a/modules/network-observability-operator-install.adoc
+++ b/modules/network-observability-operator-install.adoc
@@ -5,37 +5,38 @@
 :_content-type: PROCEDURE
 [id="network-observability-operator-installation_{context}"]
 = Installing the Network Observability Operator
-You can install the Network Observability Operator using the {product-title} web console Operator Hub. When you install the Operator,  it provides the `FlowCollector` custom resource definition (CRD). You can set specifications in the web console when you create the  `FlowCollector`.  
+You can install the Network Observability Operator using the {product-title} web console Operator Hub. When you install the Operator,  it provides the `FlowCollector` custom resource definition (CRD). You can set specifications in the web console when you create the  `FlowCollector`.
 
 .Prerequisites
 
-* Installed Loki. It is recommended to install Loki using the link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel8-operator/622b46bcae289285d6fcda39[Loki Operator version 5.6]. 
+* Installed Loki. It is recommended to install Loki using the link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel8-operator/622b46bcae289285d6fcda39[Loki Operator version 5.6].
 
 .Procedure
 
 .. In the {product-title} web console, click *Operators* -> *OperatorHub*.
-//In the Operator Hub on the test console Julian provided perms for, its NetObserv Operator, with a capital O. 
+//In the Operator Hub on the test console Julian provided perms for, its NetObserv Operator, with a capital O.
 .. Choose  *Network Observability Operator* from the list of available Operators in the *OperatorHub*, and click *Install*.
+.. Select the checkbox `Enable Operator recommended cluster monitoring on this Namespace`.
 .. Navigate to *Operators* -> *Installed Operators*. Under Provided APIs for Network Observability, select the *Flow Collector* link.
 . Navigate to the *Flow Collector* tab, and click *Create FlowCollector*. Make the following selections in the form view:
 +
-* *spec.agent.ebpf.Sampling* : Specify a sampling size for flows. Lower sampling sizes will have higher impact on resource utilization. For more information, see the `FlowCollector` API reference, under spec.agent.ebpf. 
+* *spec.agent.ebpf.Sampling* : Specify a sampling size for flows. Lower sampling sizes will have higher impact on resource utilization. For more information, see the `FlowCollector` API reference, under spec.agent.ebpf.
 * *spec.deploymentModel*: If you are using Kafka, verify Kafka is selected.
 * *loki.url*: Since authentication is specified separately, this URL needs to be updated to `https://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network`. The first part of the URL, "loki", should match the name of your LokiStack.
 * *loki.tenantID*: Set this to `network`.
 * *loki.statusUrl*: Set this to `https://loki-query-frontend-http.netobserv.svc:3100/`.
 * *loki.authToken*: Select the `FORWARD` value.
 * *tls.enable*: Verify that the box is checked so it is enabled.
-. Click *Create*. 
+. Click *Create*.
 
 .Verification
 
-To confirm this was successful, when you navigate to *Observe* you should see *Network Traffic* listed in the options. 
+To confirm this was successful, when you navigate to *Observe* you should see *Network Traffic* listed in the options.
 
-In the absence of *Application Traffic* within the {product-title} cluster, default filters might show that there are "No results", which results in no visual flow. Beside the filter selections, select *Clear all filters* to see the flow. 
+In the absence of *Application Traffic* within the {product-title} cluster, default filters might show that there are "No results", which results in no visual flow. Beside the filter selections, select *Clear all filters* to see the flow.
 
 [IMPORTANT]
 ====
-If you installed Loki using the Loki Operator, it is advised not to use `querierUrl`, as it can break the console access to Loki. If you installed Loki using another type of Loki installation, this does not apply. 
+If you installed Loki using the Loki Operator, it is advised not to use `querierUrl`, as it can break the console access to Loki. If you installed Loki using another type of Loki installation, this does not apply.
 ====
 

--- a/modules/network-observability-operator-uninstall.adoc
+++ b/modules/network-observability-operator-uninstall.adoc
@@ -10,17 +10,19 @@ You can uninstall the Network Observability Operator using the {product-title} w
 .Procedure
 
 . Remove the `FlowCollector` custom resource.
-.. Click *Flow Collector*, which is next to the *Network Observability Operator* in the *Provided APIs* column. 
+.. Click *Flow Collector*, which is next to the *Network Observability Operator* in the *Provided APIs* column.
 .. Click the options menu {kebab} for the *cluster* and select *Delete FlowCollector*.
 . Uninstall the Network Observability Operator.
-.. Navigate back to the *Operators* -> *Installed Operators* area. 
+.. Navigate back to the *Operators* -> *Installed Operators* area.
 .. Click the options menu {kebab} next to the  *Network Observability Operator* and select *Uninstall Operator*.
+.. *Home* -> *Projects* and select `openshift-netobserv-operator`
+.. Navigate to *Actions* and select *Delete Project*
 . Remove the `FlowCollector` custom resource definition (CRD).
-.. Navigate to *Administration* -> *CustomResourceDefinitions*. 
-.. Look for *FlowCollector* and click the options menu {kebab}. 
+.. Navigate to *Administration* -> *CustomResourceDefinitions*.
+.. Look for *FlowCollector* and click the options menu {kebab}.
 .. Select *Delete CustomResourceDefinition*.
 +
 [IMPORTANT]
 ====
-The Loki Operator and Kafka remain if they were installed and must be removed separately. Additionally, you might have remaining data stored in an object store, and a persistent volume that must be removed. 
+The Loki Operator and Kafka remain if they were installed and must be removed separately. Additionally, you might have remaining data stored in an object store, and a persistent volume that must be removed.
 ====


### PR DESCRIPTION
[OSDOCS-5595](https://issues.redhat.com//browse/OSDOCS-5595): updates install and uninstall for Network Observability Operator
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5595
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://57748--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/installing-operators.html#network-observability-operator-installation_network_observability
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @memodi and @OlivierCazade 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
