### PR TITLE
OSDOCS#5522: Add release notes for the AWS Load Balancer Operator

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1196,6 +1196,8 @@ Topics:
   Dir: aws_load_balancer_operator
   Distros: openshift-enterprise,openshift-origin
   Topics:
+  - Name: AWS Load Balancer Operator release notes
+    File: aws-load-balancer-operator-release-notes
   - Name: Understanding the AWS Load Balancer Operator
     File: understanding-aws-load-balancer-operator
   - Name: Installing the AWS Load Balancer Operator

--- a/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
+++ b/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
@@ -1,0 +1,48 @@
+// AWS Load Balancer Operator Release Notes
+:_content-type: ASSEMBLY
+[id="aws-load-balancer-operator-release-notes"]
+= AWS Load Balancer Operator release notes
+:context: aws-load-balancer-operator-release-notes
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+The AWS Load Balancer (ALB) Operator deploys and manages an instance of the `AWSLoadBalancerController` resource.
+
+These release notes track the development of the AWS Load Balancer Operator in {product-title}.
+
+For an overview of the AWS Load Balancer Operator, see xref:../../networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc#aws-load-balancer-operator[AWS Load Balancer Operator in {product-title}].
+
+[id="aws-load-balancer-operator-release-notes-1.0.0"]
+== AWS Load Balancer Operator 1.0.0
+
+The following advisory is available for the AWS Load Balancer Operator version 1.0.0:
+
+* link:https://access.redhat.com/errata/RHEA-2023:1954[RHEA-2023:1954 Release of AWS Load Balancer Operator on OperatorHub Enhancement Advisory Update]
+
+[id="aws-load-balancer-operator-1.0.0-notable-changes"]
+=== Notable changes
+
+* This release uses the new `v1` API version.
+
+[id="aws-load-balancer-operator-1.0.0-bug-fixes"]
+=== Bug fixes
+
+* Previously, the controller provisioned by the AWS Load Balancer Operator did not properly use the configuration for the cluster-wide proxy.
+These settings are now applied appropriately to the controller.
+(link:https://issues.redhat.com/browse/OCPBUGS-4052[*OCPBUGS-4052*], link:https://issues.redhat.com/browse/OCPBUGS-5295[*OCPBUGS-5295*])
+
+[id="aws-load-balancer-operator-release-notes-earlier-versions"]
+== Earlier versions
+
+The two earliest versions of the AWS Load Balancer Operator are available as a Technology Preview.
+These versions should not be used in a production cluster.
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+
+The following advisory is available for the AWS Load Balancer Operator version 0.2.0:
+
+* link:https://access.redhat.com/errata/RHEA-2022:9084[RHEA-2022:9084 Release of AWS Load Balancer Operator on OperatorHub Enhancement Advisory Update]
+
+The following advisory is available for the AWS Load Balancer Operator version 0.0.1:
+
+* link:https://access.redhat.com/errata/RHEA-2022:5780[RHEA-2022:5780 Release of AWS Load Balancer Operator on OperatorHub Enhancement Advisory Update]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-5522

Link to docs preview:
https://57751--docspreview.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.html

QE review:
- [x] QE has approved this change.

Additional information:

~~The AWS Load Balancer Operator release erratum that we need to link to in this page does not exist yet. The link is currently a placeholder.~~ The link is now live. :slightly_smiling_face: 