### PR TITLE
OSDOCS-5616: Adds notes for the 4.12.9 MS release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -144,3 +144,17 @@ Issued: 2023-03-21
 {product-title} release 4.12.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1272[RHBA-2023:1272] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1269[RHBA-2023:1269] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-9-dp"]
+=== RHBA-2023:1412 - {product-title} 4.12.9 bug fix and security update
+
+Issued: 2023-03-27
+
+{product-title} release 4.12.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1412[RHBA-2023:1412] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1409[RHSA-2023:1409] advisory.
+
+[id="microshift-4-12-9-bug-fixes"]
+==== Bug Fixes
+
+* Previously, installing and starting {product-title} using an 4.12.7 RPM failed with an error. With this update, {product-title} starts successfully. (link:https://issues.redhat.com/browse/OCPBUGS-10347[*OCPBUGS-10347*])
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
[OSDOCS-5616](https://issues.redhat.com//browse/OSDOCS-5616): Adds notes for the 4.12.9 MS release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5616

Link to docs preview:
https://57795--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-9-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
