### PR TITLE
OSDOCS#5628: Removed multi as cluster arch option

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
@@ -46,7 +46,7 @@ $ OCP_RELEASE_NUMBER=<release_version>
 ----
 $ ARCHITECTURE=<cluster_architecture> <1>
 ----
-<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
 
 
 .. Get the release image digest from Quay by running the following command

--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -114,7 +114,7 @@ ifndef::openshift-origin[]
 ----
 $ ARCHITECTURE=<cluster_architecture> <1>
 ----
-<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
 
 endif::[]
 

--- a/modules/ipi-install-mirroring-for-disconnected-registry.adoc
+++ b/modules/ipi-install-mirroring-for-disconnected-registry.adoc
@@ -109,7 +109,7 @@ ifndef::openshift-origin[]
 ----
 $ ARCHITECTURE=<cluster_architecture> <1>
 ----
-<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
 
 endif::[]
 

--- a/modules/update-configuring-image-signature.adoc
+++ b/modules/update-configuring-image-signature.adoc
@@ -32,7 +32,7 @@ to update the cluster, such as `4.4.0`.
 ----
 $ ARCHITECTURE=<cluster_architecture> <1>
 ----
-<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
 
 . Get the release image digest from link:https://quay.io/[Quay]:
 +

--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -90,7 +90,7 @@ For a production release, you must specify `ocp-release`.
 ----
 $ ARCHITECTURE=<cluster_architecture> <1>
 ----
-<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, `ppc64le`, or `multi`.
+<1> Specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
 
 .. Export the path to the directory to host the mirrored images:
 +


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5628

Link to docs preview:
https://57797--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/mirroring-image-repository.html#update-mirror-repository-adm-release-mirror_mirroring-ocp-image-repository

https://57797--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-installation-images.html

https://57797--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.html

https://57797--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/samples-operator-alt-registry.html

https://57797--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
