### PR TITLE
Bug OCPBUGS#9139: Document limitations of bare metal workers with OSP

### DIFF
--- a/modules/installation-osp-deploying-bare-metal-machines.adoc
+++ b/modules/installation-osp-deploying-bare-metal-machines.adoc
@@ -21,7 +21,6 @@ Bare-metal compute machines are not supported on clusters that use Kuryr.
 [NOTE]
 ====
 Be sure that your `install-config.yaml` file reflects whether the {rh-openstack} network that you use for bare metal workers supports floating IP addresses or not.
-
 ====
 
 .Prerequisites
@@ -29,6 +28,9 @@ Be sure that your `install-config.yaml` file reflects whether the {rh-openstack}
 * The {rh-openstack} link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/bare_metal_provisioning/index[Bare Metal service (Ironic)] is enabled and accessible via the {rh-openstack} Compute API.
 
 * Bare metal is available as link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.1/html/bare_metal_provisioning/configuring-the-bare-metal-provisioning-service-after-deployment#creating-the-bare-metal-flavor_bare-metal-post-deployment[a {rh-openstack} flavor].
+
+* If your cluster runs on an {rh-openstack} version that is more than 16.1.6 and less than 16.2.4, bare metal workers do not function due to a link:https://bugzilla.redhat.com/show_bug.cgi?id=2033953[known issue] that causes the metadata service to be unavailable for services on {product-title} nodes.
+
 
 * The {rh-openstack} network supports both VM and bare metal server attachment.
 


### PR DESCRIPTION
Detail the current state of bare metal works in the docs for:
- https://bugzilla.redhat.com/show_bug.cgi?id=2033953

Version(s): support for bm workers was added in 4.7, so probably docs need to be update until that version

/cc @maxwelldb @imatza-rh @mandre 
