### PR TITLE
Document GitOps 1.8.1. RN and GitOps 1.7.3 RN

### DIFF
--- a/cicd/gitops/configuring-sso-on-argo-cd-using-dex.adoc
+++ b/cicd/gitops/configuring-sso-on-argo-cd-using-dex.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 After the {gitops-title} Operator is installed, Argo CD automatically creates a user with `admin` permissions. To manage multiple users, cluster administrators can use Argo CD to configure Single Sign-On (SSO).
 
+[IMPORTANT]
+====
+The `spec.dex` parameter in the ArgoCD CR is deprecated. In a future release of {gitops-title} v1.9, configuring Dex using the `spec.dex` parameter in the ArgoCD CR is planned to be removed. Consider using the `.spec.sso` parameter instead.
+====
+
 include::modules/gitops-creating-a-new-client-in-dex.adoc[leveloffset=+1]
 
 include::modules/gitops-dex-role-mappings.adoc[leveloffset=+2]

--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,7 +23,11 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-8-1.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-8-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-7-3.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-7-1.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-7-3.adoc
+++ b/modules/gitops-release-notes-1-7-3.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-7-3_{context}"]
+= Release notes for {gitops-title} 1.7.3
+
+{gitops-title} 1.7.3 is now available on {product-title} 4.10, 4.11, and 4.12.
+
+[id="errata-updates-1-7-3_{context}"]
+== Errata updates
+
+=== RHSA-2023:1454 - {gitops-title} 1.7.3 security update advisory 
+
+Issued: 2023-03-23
+
+The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2023:1454[RHSA-2023:1454] advisory. 
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----

--- a/modules/gitops-release-notes-1-8-0.adoc
+++ b/modules/gitops-release-notes-1-8-0.adoc
@@ -8,7 +8,7 @@
 
 {gitops-title} 1.8.0 is now available on {product-title} 4.10, 4.11, and 4.12.
 
-[id="errata-updates-1-8-0_{context}"]
+[id="new-features-1-8-0_{context}"]
 == New features
 
 The current release adds the following improvements:

--- a/modules/gitops-release-notes-1-8-1.adoc
+++ b/modules/gitops-release-notes-1-8-1.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-8-1_{context}"]
+= Release notes for {gitops-title} 1.8.1
+
+{gitops-title} 1.8.1 is now available on {product-title} 4.10, 4.11, and 4.12.
+
+[id="errata-updates-1-8-1_{context}"]
+== Errata updates
+
+=== RHSA-2023:1452 - {gitops-title} 1.8.1 security update advisory 
+
+Issued: 2023-03-23
+
+The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2023:1452[RHSA-2023:1452] advisory. 
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----


### PR DESCRIPTION
**NOTE**: From GitOps 1.7.0 onwards, we are documenting security issues in a new advisory format as part of errata updates.

**Aligned team**: Dev Tools

**Purpose**: To resolve the following issues:
https://issues.redhat.com/browse/RHDEVDOCS-5086
https://issues.redhat.com/browse/RHDEVDOCS-5087


**OCP version this PR applies to**: enterprise-`4.10` and later

**Link to docs preview**: 
- [Release notes for Red Hat OpenShift GitOps 1.8.1](https://57800--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-8-1_gitops-release-notes)
- [Release notes for Red Hat OpenShift GitOps 1.7.3](https://57800--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-7-3_gitops-release-notes)


**SME review**: Completed by @reginapizza 
**QE review**: Completed by @varshab1210
**Peer-review**:  Completed by @mramendi 