### PR TITLE
OSDOCS-3976: NTO release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -277,6 +277,11 @@ With this release, Operator authors can set a default node selector on the sugge
 
 For more information, see xref:../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-suggested-namespace-default-node_osdk-generating-csvs[Setting a suggested namespace with default node selector].
 
+[id="ocp-4-13-nto"]
+==== Node Tuning Operator
+
+The Node Tuning Operator (NTO) can now be enabled/disabled using the `NodeTuning` cluster capability. If disabled at cluster install, it can be re-enabled later. For more information, see xref:../installing/cluster-capabilities.adoc#about-node-tuning-operator_cluster-capabilities[Node Tuning capability].
+
 [id="ocp-4-13-machine-api"]
 === Machine API
 


### PR DESCRIPTION
Version(s):
4.13 only

Issue:
https://issues.redhat.com/browse/OSDOCS-3976

Link to docs preview:
[Node Tuning Operator](https://57816--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-nto)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Release notes information regarding NTO content, which has been previously merged to 4.13+.
