### PR TITLE
OCPBUGS#7842: [graph-data] use the new osus endpoint

### DIFF
--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -15,9 +15,11 @@ The OpenShift Update Service requires a graph-data container image, from which t
 ----
 FROM registry.access.redhat.com/ubi8/ubi:8.1
 
-RUN curl -L -o cincinnati-graph-data.tar.gz https://github.com/openshift/cincinnati-graph-data/archive/master.tar.gz
+RUN curl -L -o cincinnati-graph-data.tar.gz https://api.openshift.com/api/upgrades_info/graph-data
 
-CMD exec /bin/bash -c "tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati/graph-data/ --strip-components=1"
+RUN mkdir -p /var/lib/cincinnati-graph-data && tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati-graph-data/ --no-overwrite-dir
+
+CMD ["/bin/bash", "-c" ,"exec cp -rp /var/lib/cincinnati-graph-data/* /var/lib/cincinnati/graph-data"]
 ----
 
 . Use the docker file created in the above step to build a graph-data container image, for example, `registry.example.com/openshift/graph-data:latest`:


### PR DESCRIPTION
use the new `/graph-data` endpoint on upstream update service to download the tar ball for creating graph data container
Follows up on https://github.com/openshift/cincinnati-operator/pull/168

Version(s): 4.9+

Issue: [OCPBUGS-7842](https://issues.redhat.com/browse/OCPBUGS-7842)

Link to docs preview:
https://57827--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/restricted-network-update-osus.html#update-service-graph-data_updating-restricted-network-cluster-osus

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
