### PR TITLE
[enterprise-4.9] CNV-22554_49: Removing hostname from cloud-init field

### DIFF
--- a/modules/virt-cloud-init-fields-web.adoc
+++ b/modules/virt-cloud-init-fields-web.adoc
@@ -9,9 +9,6 @@
 |===
 |Name | Description
 
-|Hostname
-|Sets a specific hostname for the virtual machine.
-
 |Authorized SSH Keys
 |The user's public key that is copied to *_~/.ssh/authorized_keys_* on the virtual machine.
 

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -34,7 +34,7 @@ include::modules/virt-vm-wizard-fields-web.adoc[leveloffset=+2]
 
 Enable the xref:../../scalability_and_performance/using-cpu-manager.adoc#using-cpu-manager[CPU Manager] to use the high-performance workload profile.
 
-include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
+include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+3]
 
 include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
 

--- a/virt/virtual_machines/virt-edit-vms.adoc
+++ b/virt/virtual_machines/virt-edit-vms.adoc
@@ -9,6 +9,7 @@ toc::[]
 You can update a virtual machine configuration using either the YAML editor in the web console or the OpenShift CLI on the command line. You can also update a subset of the parameters in the *Virtual Machine Details* screen.
 
 include::modules/virt-editing-vm-web.adoc[leveloffset=+1]
+
 include::modules/virt-editing-vm-yaml-web.adoc[leveloffset=+1]
 include::modules/virt-editing-vm-cli.adoc[leveloffset=+1]
 include::modules/virt-add-disk-to-vm.adoc[leveloffset=+1]


### PR DESCRIPTION
**Version(s):**
4.9 only

**Issue:**
https://issues.redhat.com/browse/CNV-22554

**Link to docs preview:**


**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
* Main PR https://github.com/openshift/openshift-docs/pull/56152 failed to merge for 4.11 and earlier
* Manually cherrypicking for [4.9](https://github.com/openshift/openshift-docs/pull/57830), [4.10](https://github.com/openshift/openshift-docs/pull/57801), and [4.11](https://github.com/openshift/openshift-docs/pull/57675)
* Cherrypicked from 59d1d495d01b1b07ed193029906d52ee257988d9