### PR TITLE
OSDOCS-5387: add kubeconfig management

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -74,7 +74,6 @@ Topics:
 - Name: Network APIs
   Dir: network_apis
   Topics:
-    # FIXME: need to incorporate the supported k8s APIs
   - Name: Route [route.openshift.io/v1]
     File: route-route-openshift-io-v1
 - Name: Security APIs
@@ -106,14 +105,16 @@ Distros: microshift
 Topics:
 - Name: Using configuration tools
   File: microshift-using-config-tools
+- Name: Cluster access with kubeconfig
+  File: microshift-cluster-access-kubeconfig
 ---
 Name: Networking
 Dir: microshift_networking
 Distros: microshift
 Topics:
-- Name: Applying networking settings
+- Name: Networking settings
   File: microshift-networking
-- Name: Using a firewall
+- Name: Firewall configuration
   File: microshift-firewall
 ---
 Name: Storage
@@ -132,14 +133,6 @@ Topics:
   File: expanding-persistent-volumes-microshift
 - Name: Dynamic storage using the LVMS plugin
   File: microshift-storage-plugin-overview
-#- Name: Using container storage interface (CSI) for MicroShift
-#  Dir: container_storage_interface_microshift
-#  Distros: microshift
-#  Topics:
-#  - Name: Configuring CSI volumes for MicroShift
-#    File: microshift-persistent-storage-csi
-#- Name: Dynamic provisioning for MicroShift
-#  File: dynamic-provisioning-microshift
 ---
 Name: Running applications
 Dir: microshift_running_apps
@@ -151,37 +144,6 @@ Topics:
   File: microshift-operators
 - Name: Greenboot health check
   File: microshift-greenboot
-# ---
-# Name: Networking
-# Dir: networking
-# Distros: microshift
-# Topics:
-# - Name: Understanding the Ingress Operator
-#   File: ingress-operator-microshift
-# - Name: Configuring a cluster-wide proxy during installation
-#   File: configuring-cluster-wide-proxy
-# - Name: CIDR range definitions
-#   File: cidr-range-definitions
-# - Name: Network policy
-#   Dir: network_policy
-#   Topics:
-#   - Name: About network policy
-#     File: about-network-policy
-#   - Name: Creating a network policy
-#     File: creating-network-policy
-#   - Name: Viewing a network policy
-#     File: viewing-network-policy
-#   - Name: Deleting a network policy
-#     File: deleting-network-policy
-#   - Name: Configuring multitenant isolation with network policy
-#     File: multitenant-network-policy
-# ---
-# Name: Updating clusters
-# Dir: updating
-# Distros: microshift
-# Topics:
-# - Name: Updating MicroShift Clusters
-#   File: TBD
 ---
 Name: Troubleshooting
 Dir: microshift_troubleshooting

--- a/microshift_configuring/microshift-cluster-access-kubeconfig.adoc
+++ b/microshift_configuring/microshift-cluster-access-kubeconfig.adoc
@@ -1,0 +1,23 @@
+:_content-type: ASSEMBLY
+[id="microshift-kubeconfig"]
+= Cluster access with kubeconfig
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-kubeconfig
+
+toc::[]
+
+Learn about how `kubeconfig` files are used with {product-title} deployments. CLI tools use `kubeconfig` files to communicate with the API server of a cluster. These files provide cluster details, IP addresses, and other information needed for authentication.
+
+include::modules/microshift-kubeconfig-overview.adoc[leveloffset=+1]
+
+include::modules/microshift-kubeconfig-local-access.adoc[leveloffset=+1]
+
+include::modules/microshift-accessing-cluster-locally.adoc[leveloffset=+2]
+
+include::modules/microshift-kubeconfig-remote-con.adoc[leveloffset=+1]
+
+include::modules/microshift-kubeconfig-generating-remote-kcfiles.adoc[leveloffset=+1]
+
+include::modules/microshift-accessing-cluster-open-firewall.adoc[leveloffset=+2]
+
+include::modules/microshift-accessing-cluster-remotely.adoc[leveloffset=+2]

--- a/modules/microshift-accessing-cluster-locally.adoc
+++ b/modules/microshift-accessing-cluster-locally.adoc
@@ -2,6 +2,7 @@
 //
 // microshift/microshift_install/microshift-install-rpm.adoc
 // microshift/microshift_install/microshift-embed-in-rpm-ostree.adoc
+// microshift/microshift_configuring/microshift-cluster-access-kubeconfig.adoc
 
 :_content-type: PROCEDURE
 [id="accessing-microshift-cluster-locally_{context}"]

--- a/modules/microshift-accessing-cluster-open-firewall.adoc
+++ b/modules/microshift-accessing-cluster-open-firewall.adoc
@@ -2,6 +2,7 @@
 //
 // microshift/microshift_install/microshift-install-rpm.adoc
 // microshift/microshift_install/microshift-embed-in-rpm-ostree.adoc
+// microshift/microshift_configuring/microshift-cluster-access-kubeconfig.adoc
 
 :_content-type: PROCEDURE
 [id="microshift-accessing-cluster-open-firewall_{context}"]

--- a/modules/microshift-accessing-cluster-remotely.adoc
+++ b/modules/microshift-accessing-cluster-remotely.adoc
@@ -2,6 +2,7 @@
 //
 // microshift/microshift_install/microshift-install-rpm.adoc
 // microshift/microshift_install/microshift-embed-in-rpm-ostree.adoc
+// microshift/microshift_configuring/microshift-cluster-access-kubeconfig.adoc
 
 :_content-type: PROCEDURE
 [id="accessing-microshift-cluster-remotely_{context}"]

--- a/modules/microshift-kubeconfig-generating-remote-kcfiles.adoc
+++ b/modules/microshift-kubeconfig-generating-remote-kcfiles.adoc
@@ -1,0 +1,89 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift_configuring/microshift-cluster-access-kubeconfig.adoc
+
+:_content-type: PROCEDURE
+[id="generating-additional-kubeconfig-files_{context}"]
+= Generating additional kubeconfig files for remote access
+
+You can generate additional `kubeconfig` files to use if you need more host names or IP addresses than the default remote access file provides.
+
+[IMPORTANT]
+====
+You must restart {product-title} for configuration changes to be implemented.
+====
+
+.Prerequisites
+
+* You have created a `config.yaml` for {product-title}.
+
+.Procedure
+
+. (Optional) You can show the contents of the `config.yaml` by running the following command:
++
+[source,terminal]
+----
+$ cat /etc/microshift/config.yaml
+----
+
+. (Optional) You can show the contents of the remote-access `kubeconfig` file, by running the following command:
++
+[source,terminal]
+----
+$ cat /var/lib/microshift/resources/kubeadmin/<hostname>/kubeconfig
+----
++
+[IMPORTANT]
+====
+Additional remote access `kubeconfig` files must include one of the server names listed in the {product-title} `config.yaml` file. Additional `kubeconfig` files must also use the same CA for validation.
+====
+
+. To generate additional `kubeconfig` files for additional DNS names SANs or external IP addresses, add the entries you need to the `apiServer.subjectAltNames` field. In the following example, the DNS name used is `alt-name-1` and the IP address is `1.2.3.4`.
++
+.Example `config.yaml` with additional authentication values
+[source,yaml]
+----
+dns:
+  baseDomain: example.com
+node:
+  hostnameOverride: "microshift-rhel9" <1>
+  nodeIP: 10.0.0.1
+apiServer:
+  subjectAltNames:
+  - alt-name-1 <2>
+  - 1.2.3.4 <3>
+----
+<1> Hostname
+<2> DNS name
+<3> IP address or range
+
+. Restart {product-title} to apply configuration changes and auto-generate the `kubeconfig` files you need by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl restart microshift
+----
+
+. To check the contents of additional remote-access `kubeconfig` files, insert the name or IP address as listed in the `config.yaml` into the `cat` command. For example, `alt-name-1` is used in the following example command:
++
+[source,terminal]
+----
+$ cat /var/lib/microshift/resources/kubeadmin/alt-name-1/kubeconfig
+----
+
+. Choose the `kubeconfig` file to use that contains the SAN or IP address you want to use to connect your cluster. In this example, the `kubeconfig` containing`alt-name-1` in the `cluster.server` field is the correct file.
++
+.Example contents of an additional `kubeconfig` file
+[source,yaml]
+----
+clusters:
+- cluster:
+    certificate-authority-data: <base64 CA>
+    server: https://alt-name-1:6443 <1>
+----
+<1> The `/var/lib/microshift/resources/kubeadmin/alt-name-1/kubeconfig` file values are from the `apiServer.subjectAltNames` configuration values.
+
+[NOTE]
+====
+All of these parameters are included as common names (CN) and subject alternative names (SAN) in the external serving certificates for the API server.
+====

--- a/modules/microshift-kubeconfig-local-access.adoc
+++ b/modules/microshift-kubeconfig-local-access.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift_configuring/microshift-cluster-access-kubeconfig.adoc
+
+:_content-type: CONCEPT
+[id="microshift-kubeconfig-local-access_{context}"]
+= Local access kubeconfig file
+
+The local access `kubeconfig` file is written to`/var/lib/microshift/resources/kubeadmin/kubeconfig`. This `kubeconfig` file provides access to the API server using `localhost`. Choose this file when you are connecting the cluster locally.
+
+.Example contents of `kubeconfig` for local access
+[source,yaml]
+----
+clusters:
+- cluster:
+    certificate-authority-data: <base64 CA>
+    server: https://localhost:6443
+----
+
+The `localhost` `kubeconfig` file can only be used from a client connecting to the API server from the same host. The certificates in the file do not work for remote connections.

--- a/modules/microshift-kubeconfig-overview.adoc
+++ b/modules/microshift-kubeconfig-overview.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift_configuring/microshift-cluster-access-kubeconfig.adoc
+
+:_content-type: CONCEPT
+[id="kubeconfig-files-overview_{context}"]
+= Kubeconfig files for configuring cluster access
+
+The two categories of `kubeconfig` files used in {product-title} are local access and remote access. Every time {product-title} starts, a set of `kubeconfig` files for local and remote access to the API server are generated. These files are generated in the `/var/lib/microshift/resources/kubeadmin/` directory using preexisting configuration information.
+
+Each access type requires a different authentication certificate signed by different Certificate Authorities (CAs). The generation of multiple `kubeconfig` files accommodates this need.
+
+You can use the appropriate `kubeconfig` file for the access type needed in each case to provide authentication details. The contents of {product-title} `kubeconfig` files are determined by either default built-in values or a `config.yaml` file.
+
+[NOTE]
+====
+A `kubeconfig` file must exist for the cluster to be accessible. The values are applied from built-in default values or a `config.yaml`, if one was created.
+====
+
+.Example contents of the kubeconfig files
+[source,terminal]
+----
+/var/lib/microshift/resources/kubeadmin/
+├── kubeconfig <1>
+├── alt-name-1 <2>
+│   └── kubeconfig
+├── 1.2.3.4 <3>
+│   └── kubeconfig
+└── microshift-rhel9 <4>
+    └── kubeconfig
+----
+<1> Local host name. The main IP address of the host is always the default.
+<2> Subject Alternative Names for API server certificates.
+<3> DNS name.
+<4> {product-title} host name.

--- a/modules/microshift-kubeconfig-remote-con.adoc
+++ b/modules/microshift-kubeconfig-remote-con.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * microshift/microshift_configuring/microshift-cluster-access-kubeconfig.adoc
+
+:_content-type: CONCEPT
+[id="remote-access-con_{context}"]
+= Remote access kubeconfig files
+
+When a {product-title} cluster connects to the API server from an external source, a certificate with all of the alternative names in the SAN field is used for validation. {product-title} generates a default `kubeconfig` for external access using the `hostname` value. The defaults are set in the `<node.hostnameOverride>`, `<node.nodeIP>` and `api.<dns.baseDomain>` parameter values of the default `kubeconfig` file.
+
+The `/var/lib/microshift/resources/kubeadmin/<hostname>/kubeconfig` file uses the `hostname` of the machine, or `node.hostnameOverride` if that option is set, to reach the API server. The CA of the `kubeconfig` file is able to validate certificates when accessed externally.
+
+.Example contents of a default `kubeconfig` file for remote access
+[source,yaml]
+----
+clusters:
+- cluster:
+    certificate-authority-data: <base64 CA>
+    server: https://microshift-rhel9:6443
+----
+
+[id="remote-access-customization_{context}"]
+== Remote access customization
+Multiple remote access `kubeconfig` file values can be generated for accessing the cluster with different IP addresses or host names. An additional `kubeconfig` file generates for each entry in the `apiServer.subjectAltNames` parameter. You can copy remote access `kubeconfig` files from the host during times of IP connectivity and then use them to access the API server from other workstations.


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5387

Link to docs preview:
https://57834--docspreview.netlify.app/microshift/latest/microshift_configuring/microshift-kubeconfig.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
