### PR TITLE
docs: fix typo in 'adding-tab-pods-page'

### DIFF
--- a/modules/adding-tab-pods-page.adoc
+++ b/modules/adding-tab-pods-page.adoc
@@ -26,7 +26,7 @@ Custom plugin code is not supported by Red Hat. Only link:https://access.redhat.
 
 . Re-name the new repository with the name of your plugin.
 
-. Clone your copied repositury to your local machine so you can edit the code.
+. Clone your copied repository to your local machine so you can edit the code.
 
 . Edit the plugin metadata in the `consolePlugin` declaration of `package.json`.
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57851--docspreview.netlify.app/openshift-enterprise/latest/web_console/dynamic-plug-in/dynamic-plug-in-example.html ([original](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html-single/web_console/index#adding-tab-to-pods-page_dynamic-plug-in-example))
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
