### PR TITLE
OSDOCS-5277-rn: Document a vSphere deprecated release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -85,10 +85,13 @@ For more information, see xref:../installing/installing_ibm_z/installing-ibm-z-k
 ==== VMware vSphere region and zone enablement
 You can deploy an {product-title} cluster to multiple vSphere datacenters or regions that run in a single VMware vCenter. Each datacenter can run multiple clusters or zones. This configuration reduces the risk of a hardware failure or network outage causing your cluster to fail.
 
-You can also specify multiple regions and zones on a cluster after installation. You must upgrade your existing cluster to {product-title} {product-version} before you configure a multiple region and zone environment.
+[IMPORTANT]
+====
+The VMware vSphere region and zone enablement feature is only available with a newly installed cluster, because this feature requires the Container Storage Interface (CSI) storage class. A cluster that was upgraded from a previous release does not include the required CSI storage class.
+====
 
 [id="ocp-4-13-installation-vsphere-default-config-yaml"]
-==== Changes to the default `install-config.yaml` file
+==== Changes to the default vSphere `install-config.yaml` file
 After you run the installation program for {product-title} on vSphere, the default `install-config.yaml` file now includes `vcenters` and `failureDomains` fields, so that you can choose to specify multiple datacenters, region, and zone information for your cluster. You can leave these fields blank if you want to install an {product-title} cluster in a vSphere environment that consists of single datacenter running in a VMware vCenter.
 
 [id="ocp-4-13-installation-and-upgrade-three-node"]
@@ -673,6 +676,23 @@ The toolbox library is deprecated and support will be removed from a future {pro
 [id="ocp-4-13-rhel-9-device-driver-deprecation"]
 ==== {op-system-base} 9 driver deprecations
 {product-title} {product-version} introduces a {op-system-base} 9.2 based {op-system}. Some kernel device drivers are deprecated in {op-system-base} 9. See the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/considerations_in_adopting_rhel_9/assembly_hardware-enablement_considerations-in-adopting-rhel-9[{op-system-base} documentation] for more information.
+
+[id="ocp-4-13-vSphere-configuration-parameters"]
+==== VMware vSphere configuration parameters
+
+{product-title} {product-version} deprecates the following vSphere configuration parameters. You can continue to use these parameters, but the installation program does not automatically specify these parameters in the `install-config.yaml` file.
+
+* `platform.vsphere.vCenter`
+* `platform.vsphere.username`
+* `platform.vsphere.password`
+* `platform.vsphere.datacenter`
+* `platform.vsphere.defaultDatastore`
+* `platform.vsphere.cluster`
+* `platform.vsphere.folder`
+* `platform.vsphere.resourcePool`
+* `platform.vsphere.apiVIP`
+* `platform.vsphere.ingressVIP`
+* `platform.vsphere.network`
 
 [id="ocp-4-13-removed-features"]
 === Removed features


### PR DESCRIPTION
[OSDOCS-5277](https://issues.redhat.com/browse/OSDOCS-5277)

Version(s):
4.13

Link to docs preview:
[Installation and upgrade](https://57853--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-installation-and-upgrade)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs.

Additional resources: https://github.com/openshift/installer/blob/master/pkg/types/vsphere/platform.go#L35-L128
