### PR TITLE
OADP 1440 - Data Mover

### DIFF
--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -7,32 +7,68 @@
 = Using Data Mover for CSI snapshots
 
 :FeatureName: Data Mover for CSI snapshots
-include::snippets/technology-preview.adoc[]
 
-The OADP 1.1.2 Data Mover enables customers to back up container storage interface (CSI) volume snapshots to a remote object store. When Data Mover is enabled, you can restore stateful applications from the store if a failure, accidental deletion, or corruption of the cluster occurs. The OADP 1.1.2 Data Mover solution uses the Restic option of VolSync.
+The OADP Data Mover enables customers to back up Container Storage Interface (CSI) volume snapshots to a remote object store. When Data Mover is enabled, you can restore stateful applications, using CSI volume snapshots pulled from the object store if a failure, accidental deletion, or corruption of the cluster occurs.
 
-[NOTE]
-=====
+The Data Mover solution uses the Restic option of VolSync.
+
 Data Mover supports backup and restore of CSI volume snapshots only.
 
-Currently, Data Mover does not support Google Cloud Storage (GCS) buckets.
-=====
+In OADP 1.2 Data Mover `VolumeSnapshotBackups` (VSBs) and `VolumeSnapshotRestores` (VSRs) are queued using the VolumeSnapshotMover (VSM). The VSM's performance is improved by specifying a concurrent number of VSBs and VSRs simultaneously `InProgress`. After all async plugin operations are complete, the backup is marked as complete.
+
+
+[NOTE]
+====
+The OADP 1.1 Data Mover is a Technology Preview feature.
+
+The OADP 1.2 Data Mover has significantly improved features and performances, but is still a Technology Preview feature.
+====
+:FeatureName: The OADP Data Mover
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+[NOTE]
+====
+Red Hat recommends that customers who use OADP 1.2 Data Mover in order to back up and restore ODF CephFS volumes, upgrade or install {product-title} version 4.12 or later for improved performance. OADP Data Mover can leverage CephFS shallow volumes in {product-title} version 4.12 or later, which based on our testing, can improve the performance of backup times.
+
+* https://issues.redhat.com/browse/RHSTOR-4287[CephFS ROX details]
+//* https://github.com/ceph/ceph-csi/blob/devel/docs/cephfs-snapshot-backed-volumes.md[Provisioning and mounting CephFS snapshot-backed volumes]
+
+
+//For more information about OADP 1.2 with CephS [name of topic], see ___.
+
+====
 
 .Prerequisites
 
 * You have verified that the `StorageClass` and `VolumeSnapshotClass` custom resources (CRs) support CSI.
 
 * You have verified that only one `volumeSnapshotClass` CR has the annotation `snapshot.storage.kubernetes.io/is-default-class: true`.
++
+[NOTE]
+====
+In {product-title} version 4.12 or later, verify that this is the only default `volumeSnapshotClass`.
+====
+
+* You have verified that `deletionPolicy` of the `VolumeSnapshotClass` CR is set to `Retain`.
 
 * You have verified that only one `storageClass` CR has the annotation `storageclass.kubernetes.io/is-default-class: true`.
 
 * You have included the label `{velero-domain}/csi-volumesnapshot-class: 'true'` in your `VolumeSnapshotClass` CR.
 
+* You have verified that the `OADP namespace` has the annotation `oc annotate --overwrite namespace/openshift-adp volsync.backube/privileged-movers='true'`.
++
+[NOTE]
+====
+In OADP 1.1 the above setting is mandatory.
+
+In OADP 1.2 the `privileged-movers` setting is not required in most scenarios. The restoring container permissions should be adequate for the Volsync copy. In some user scenarios, there may be permission errors that the `privileged-mover`= `true` setting should resolve.
+====
+
 * You have installed the VolSync Operator by using the Operator Lifecycle Manager (OLM).
 +
 [NOTE]
 ====
-The VolSync Operator is required only for use with the Technology Preview Data Mover. The Operator is not required for using OADP production features.
+The VolSync Operator is required for using OADP Data Mover.
 ====
 
 * You have installed the OADP operator by using OLM.
@@ -69,10 +105,6 @@ metadata:
   name: velero-sample
   namespace: openshift-adp
 spec:
-  features:
-    dataMover:
-      enable: true
-      credentialName: <secret_name> <1>
   backupLocations:
     - velero:
         config:
@@ -84,18 +116,47 @@ spec:
         default: true
         objectStorage:
           bucket: <bucket_name>
-          prefix: <bucket_prefix>
+          prefix: <bucket-prefix>
         provider: aws
   configuration:
     restic:
       enable: <true_or_false>
     velero:
-      defaultPlugins:
+       itemOperationSyncFrequency: "10s"
+       defaultPlugins:
         - openshift
         - aws
         - csi
+        - vsm <1>
+  features:
+    dataMover:
+      credentialName: restic-secret
+      enable: true
+      maxConcurrentBackupVolumes: "3" <2>
+      maxConcurrentRestoreVolumes: "3" <3>
+      pruneInterval: "14" <4>
+      volumeOptions: <5>
+      sourceVolumeOptions:
+          accessMode: ReadOnlyMany
+          cacheAccessMode: ReadWriteOnce
+          cacheCapacity: 2Gi
+      destinationVolumeOptions:
+          storageClass: other-storageclass-name
+          cacheAccessMode: ReadWriteMany
+  snapshotLocations:
+    - velero:
+        config:
+          profile: default
+          region: us-west-2
+        provider: aws
+
 ----
-<1> Add the Restic secret name from the previous step. If this is not done, the default secret name `dm-credential` is used.
+<1> OADP 1.2 only.
+<2> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for backup. The default value is 10.
+<3> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for restore. The default value is 10.
+<4> OADP 1.2 only. Optional: Specify the number of days, between running Restic pruning on the repository. The prune operation repacks the data to free space, but it can also generate significant I/O traffic as a part of the process. Setting this option allows a trade-off between storage consumption, from no longer referenced data, and access costs.
+<5> OADP 1.2 only. Optional: Specify VolumeSync volume options for backup and restore.
+
 +
 The OADP Operator installs two custom resource definitions (CRDs), `VolumeSnapshotBackup` and `VolumeSnapshotRestore`.
 +


### PR DESCRIPTION
OADP Version - 1.2.0

OCP Version - 4.10, 4.11, 4.12 & 4.13

Resolves - https://issues.redhat.com/browse/OADP-1440,  https://issues.redhat.com/browse/OADP-1441,  https://issues.redhat.com/browse/OADP-1148 & https://issues.redhat.com/browse/OADP-1681

Deploy preview - https://57854--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html   in the "Using Data Mover for CSI snapshots" section.
