### PR TITLE
OSDOCS-5435: Fixed some AWS Prereq URLs

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -41,7 +41,11 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides core container images.
 
-|`cm-quay-production-s3.s3.amazonaws.com`
+|`ocm-quay-production-s3.s3.amazonaws.com`
+|443
+|Provides core container images.
+
+|`quayio-production-s3.s3.amazonaws.com`
 |443
 |Provides core container images.
 


### PR DESCRIPTION
Version(s):
`enterprise-4.12+`
Issue:
[OSDOCS-5435](https://issues.redhat.com/browse/OSDOCS-5435)

Link to docs preview:

- [ROSA STS Prereq](https://57875--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs)
- [ROSA IAM Prereq](https://57875--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I changed a miswritten URL and added a missing one.