### PR TITLE
OCPBUGS-10985: Adding the --max-nested-paths flag

### DIFF
--- a/modules/oc-mirror-command-reference.adoc
+++ b/modules/oc-mirror-command-reference.adoc
@@ -68,6 +68,9 @@ The following tables describe the `oc mirror` subcommands and flags:
 |`--manifests-only`
 |Generate manifests for `ImageContentSourcePolicy` objects to configure a cluster to use the mirror registry, but do not actually mirror any images.
 
+|`--max-nested-paths <int>`
+|Specify the maximum number of nested paths for destination registries that limit nested paths. The default is `2`.
+
 |`--max-per-registry <int>`
 |Specify the number of concurrent requests allowed per registry. The default is `6`.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-10985

Link to docs preview:
https://57878--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-command-reference_installing-mirroring-disconnected

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
**This should not be merged to 4.12 until 3 April, when 4.12.10 goes out**
