### PR TITLE
OCPBUGS-10984: Document the --skip-pruning oc-mirror flag

### DIFF
--- a/modules/oc-mirror-command-reference.adoc
+++ b/modules/oc-mirror-command-reference.adoc
@@ -92,6 +92,9 @@ The following tables describe the `oc mirror` subcommands and flags:
 |`--skip-missing`
 |If an image is not found, skip it instead of reporting an error and aborting execution. Does not apply to custom images explicitly specified in the image set configuration.
 
+|`--skip-pruning`
+|Disable automatic pruning of images from the target mirror registry.
+
 |`--skip-verification`
 |Skip digest verification.
 

--- a/modules/oc-mirror-updating-registry-about.adoc
+++ b/modules/oc-mirror-updating-registry-about.adoc
@@ -34,3 +34,5 @@ If there are {product-title} releases or Operator versions that you no longer ne
 ====
 If there are no new or updated images to mirror, the excluded images are not pruned from the target mirror registry. Additionally, if an Operator publisher removes an Operator version from a channel, the removed versions are pruned from the target mirror registry.
 ====
+
+To disable automatic pruning of images from the target mirror registry, pass the `--skip-pruning` flag to the `oc mirror` command.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-10984

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
**This should not be merged to 4.12 until the 4.12 z-stream goes out that it's included with**

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
