### PR TITLE
OSDOCS-5641: RN Update docs to reflect MCO's new bahavior around cert rotation

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -405,6 +405,16 @@ To manage the cloud controller manager and cloud node manager deployments and li
 
 For more information, see the xref:../operators/operator-reference.adoc#cluster-cloud-controller-manager-operator_cluster-operators-ref[Cluster Cloud Controller Manager Operator] entry in the _Platform Operators reference_.
 
+[discrete]
+[id="ocp-4-13-mco-certificate-changes"]
+==== The MCO now syncs kubelet CA certificates on paused pools
+
+Previously, the Machine Config Operator (MCO) updated the kubelet client certificate authority (CA) certificate, `/etc/kubernetes/kubelet-ca.crt`, as a part of the regular machine config update. Starting with {product-title} (product-version}, the `kubelet-ca.crt` no longer gets updated as a part of the regular machine config update. As a result of this change, the Machine Config Daemon (MCD) automatically keeps the `kubelet-ca.crt` up to date whenever changes to the certificate occur. 
+
+Also, if a machine config pool is paused, the MCD is now able to push the newly rotated certificates to those nodes. A new rendered machine config, which contains the changes to the certificate, is generated for the pool, like in previous versions. The pool will indicate that an update is required; this condition will be removed in a future release of this product. However, because the certificate is updated separately, it is safe to keep the pool paused, assuming there are no further updates.
+
+Also, the `MachineConfigControllerPausedPoolKubeletCA` alert has been removed, because the nodes should always have the most up-to-date `kubelet-ca.crt`.
+
 [id="ocp-4-13-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5641
https://redhat-internal.slack.com/archives/C02CZNQHGN8/p1679510610718179

[Notable technical changes > The MCO now syncs kubelet CA certificates on paused pools
](https://57901--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-notable-technical-changes)
