### PR TITLE
OSDOCS-3606: Add IPv6 family first bare metal support

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -318,11 +318,12 @@ You can customize your installation configuration based on the requirements of y
 // But only for installer-provisioned
 // https://bugzilla.redhat.com/show_bug.cgi?id=2020416
 // Once BM UPI supports dual-stack, uncomment all the following conditionals and blocks
-ifndef::bare[]
-Only IPv4 addresses are supported.
-endif::bare[]
 
-ifdef::bare[]
+ifndef::bare,vsphere[]
+Only IPv4 addresses are supported.
+endif::[]
+
+ifdef::bare,vsphere[]
 * If you use the {openshift-networking} OVN-Kubernetes network plugin, both IPv4 and IPv6 address families are supported.
 
 * If you use the {openshift-networking} OpenShift SDN network plugin, only the IPv4 address family is supported.
@@ -333,6 +334,19 @@ ifdef::ibm-cloud[]
 IBM Cloud VPC does not support IPv6 address families.
 ====
 endif::ibm-cloud[]
+
+ifdef::vsphere[]
+[NOTE]
+====
+On VMware vSphere, dual-stack networking must specify IPv4 as the primary address family.
+
+The following additional limitations apply to dual-stack networking:
+
+* Nodes report only their IPv6 IP address in `node.status.addresses`
+* Nodes with only a single NIC are supported
+* Pods configured for host networking report only their IPv6 addresses in `pod.status.IP`
+====
+endif::vsphere[]
 
 If you configure your cluster to use both IP address families, review the following requirements:
 
@@ -354,7 +368,7 @@ networking:
   - 172.30.0.0/16
   - fd00:172:16::/112
 ----
-endif::bare[]
+endif::[]
 
 [NOTE]
 ====

--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -6,7 +6,7 @@
 [id='modifying-install-config-for-dual-stack-network_{context}']
 = Optional: Deploying with dual-stack networking
 
-For dual-stack networking in {product-title} clusters, you can configure IPv4 and IPv6 address endpoints for cluster nodes. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. Ensure the first CIDR entry is the IPv4 setting and the second CIDR entry is the IPv6 setting.
+For dual-stack networking in {product-title} clusters, you can configure IPv4 and IPv6 address endpoints for cluster nodes. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `machineNetwork`, `clusterNetwork`, and `serviceNetwork` configuration settings in the `install-config.yaml` file. Each setting must have two CIDR entries each. For a cluster with the IPv4 family as the primary address family, specify the IPv4 setting first. For a cluster with the IPv6 family as the primary address family, specify the IPv6 setting first.
 
 [source,yaml]
 ----
@@ -22,11 +22,6 @@ serviceNetwork:
 - 172.30.0.0/16
 - fd03::/112
 ----
-
-[IMPORTANT]
-====
-The API VIP IP address and the Ingress VIP address must be of the primary IP address family when using dual-stack networking. Currently, Red Hat does not support dual-stack VIPs or dual-stack networking with IPv6 as the primary IP address family. However, Red Hat does support dual-stack networking with IPv4 as the primary IP address family. Therefore, the IPv4 entries must go *before* the IPv6 entries.
-====
 
 To provide an interface to the cluster for applications that use IPv4 and IPv6 addresses, configure IPv4 and IPv6 virtual IP (VIP) address endpoints for the Ingress VIP and API VIP services. To configure IPv4 and IPv6 address endpoints, edit the `apiVIPs` and `ingressVIPs` configuration settings in the `install-config.yaml` file . The `apiVIPs` and `ingressVIPs` configuration settings use a list format. The order of the list indicates the primary and secondary VIP address for each service.
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-3606

Adds support for IPv6 primary dual stack for bare metal, and IPv4/IPv6 dual stack for vSphere.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [vSphere: Network configuration parameters](https://57903--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-configuration-parameters-network_installing-vsphere-installer-provisioned-network-customizations)
- [IPI bare metal: Optional: Deploying with dual-stack networking](https://57903--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
