### PR TITLE
Add europe-west12 GCP region as supported region

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -31,6 +31,7 @@ regions:
 * `europe-west6` (Zürich, Switzerland)
 * `europe-west8` (Milan, Italy)
 * `europe-west9` (Paris, France)
+* `europe-west12` (Turin, Italy)
 * `me-west1` (Tel Aviv, Israel)
 * `northamerica-northeast1` (Montréal, Québec, Canada)
 * `northamerica-northeast2` (Toronto, Ontario, Canada)


### PR DESCRIPTION
Version(s):
CP to 4.12+

Issue:
This PR address [osdocs-5648](https://issues.redhat.com/browse/OSDOCS-5648)/[CORS-2593](https://issues.redhat.com/browse/CORS-2593)

Link to doc preview:
[Supported GCP regions](https://57904--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-regions_installing-gcp-account)

QE review:
- [x] QE has tested the new region from 4.12.z+