### PR TITLE
Updates broken xrefs and callouts build error

### DIFF
--- a/modules/cnf-about-ptp-fast-event-notifications-framework.adoc
+++ b/modules/cnf-about-ptp-fast-event-notifications-framework.adoc
@@ -21,16 +21,27 @@ The fast events notifications framework uses a REST API for communication. The R
 image::319_OpenShift_PTP_bare-metal_OCP_nodes_0323_4.13.png[Overview of PTP fast events]
 
 --
-<1> `linuxptp-daemon` in the PTP Operator-managed pod runs as a Kubernetes `DaemonSet` and manages the various `linuxptp` processes (`ptp4l`, `phc2sys`, and optionally for grandmaster clocks, `ts2phc`).
+image:darkcircle-1.png[20,20]
+`linuxptp-daemon` in the PTP Operator-managed pod runs as a Kubernetes `DaemonSet` and manages the various `linuxptp` processes (`ptp4l`, `phc2sys`, and optionally for grandmaster clocks, `ts2phc`).
 The `linuxptp-daemon` passes the event to the UNIX domain socket.
-<2> The PTP plugin reads the event from the UNIX domain socket and passes it to the `cloud-event-proxy` sidecar in the PTP Operator-managed pod.
+
+image:darkcircle-2.png[20,20]
+The PTP plugin reads the event from the UNIX domain socket and passes it to the `cloud-event-proxy` sidecar in the PTP Operator-managed pod.
 `cloud-event-proxy` delivers the event from the Kubernetes infrastructure to Cloud-Native Network Functions (CNFs) with low latency.
-<3> The `cloud-event-proxy` sidecar in the PTP Operator-managed pod persists the event and publishes the cloud native event using a REST API.
-<4> The message is transported to the `cloud-event-proxy` sidecar in the application pod over HTTP or AMQP 1.0 QPID.
-<5> The `cloud-event-proxy` sidecar in the Application pod processes the event and makes it available by using the REST API.
-<6> The consumer application sends an API request to the `cloud-event-proxy` sidecar in the application pod to create a PTP events subscription.
+
+image:darkcircle-3.png[20,20]
+The `cloud-event-proxy` sidecar in the PTP Operator-managed pod persists the event and publishes the cloud native event by using a REST API.
+
+image:darkcircle-4.png[20,20]
+The message is transported to the `cloud-event-proxy` sidecar in the application pod over HTTP or AMQP 1.0 QPID.
+
+image:darkcircle-5.png[20,20]
+The `cloud-event-proxy` sidecar in the Application pod processes the event and makes it available by using the REST API.
+
+image:darkcircle-6.png[20,20]
+The consumer application sends an API request to the `cloud-event-proxy` sidecar in the application pod to create a PTP events subscription.
 The `cloud-event-proxy` sidecar creates an AMQ or HTTP messaging listener protocol for the resource specified in the subscription.
-+
+
 The `cloud-event-proxy` sidecar in the application pod receives the event from the PTP Operator-managed pod, unwraps the cloud events object to retrieve the data, and posts the event to the consumer application.
 The consumer application listens to the address specified in the resource qualifier and receives and processes the PTP event.
 --

--- a/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
@@ -38,9 +38,9 @@ include::modules/ztp-using-pgt-to-configure-power-states.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref::../../../../scalability_and_performance/cnf-low-latency-tuning.html#cnf-understanding-workload-hints_cnf-master[Understanding workload hints]
+* xref:../../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-understanding-workload-hints_cnf-master[Understanding workload hints]
 
-* xref::../../../../scalability_and_performance/cnf-low-latency-tuning.html#configuring-workload-hints_cnf-master[Configuring workload hints manually]
+* xref:../../scalability_and_performance/cnf-low-latency-tuning.adoc#configuring-workload-hints_cnf-master[Configuring workload hints manually]
 
 include::modules/ztp-using-pgt-to-configure-performance-mode.adoc[leveloffset=+2]
 
@@ -51,11 +51,11 @@ include::modules/ztp-using-pgt-to-configure-power-saving-mode.adoc[leveloffset=+
 [role="_additional-resources"]
 .Additional resources
 
-* xref::../../../../scalability_and_performance/cnf-low-latency-tuning.html#node-tuning-operator-pod-power-saving-config_cnf-master[Enabling critical workloads for power saving configurations]
+* xref:../../scalability_and_performance/cnf-low-latency-tuning.adoc#node-tuning-operator-pod-power-saving-config_cnf-master[Enabling critical workloads for power saving configurations]
 
-* xref::../../../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.html#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu[Configuring host firmware for low latency and high performance]
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-du-configuring-host-firmware-requirements_sno-configure-for-vdu[Configuring host firmware for low latency and high performance]
 
-* xref::../../../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster[Preparing the GitOps ZTP site configuration repository]
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster[Preparing the GitOps ZTP site configuration repository]
 
 include::modules/ztp-using-pgt-to-maximize-power-saving-mode.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Fixes borked xrefs and callouts

Version(s):
main, enterprise-4.13

Link to docs preview:
* https://57906--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html#ztp-using-pgt-to-configure-power-saving-states_ztp-advanced-policy-config
* https://57906--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html#ztp-using-pgt-to-configure-power-saving-mode_ztp-advanced-policy-config
* https://57906--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-about-ptp-and-clock-synchronization_using-ptp

