### PR TITLE
[OSDOCS-5646]: Confidential Computing is Tech Preview

### DIFF
--- a/modules/machineset-gcp-confidential-vm.adoc
+++ b/modules/machineset-gcp-confidential-vm.adoc
@@ -15,6 +15,9 @@ By editing the machine set YAML file, you can configure the Confidential VM opti
 
 For more information about Confidential Compute features, functionality, and compatibility, see the GCP Compute Engine documentation about link:https://cloud.google.com/compute/confidential-vm/docs/about-cvm[Confidential VM].
 
+:FeatureName: Confidential Computing
+include::snippets/technology-preview.adoc[]
+
 .Procedure
 
 . In a text editor, open the YAML file for an existing machine set or create a new one.


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OSDOCS-5646](https://issues.redhat.com//browse/OSDOCS-5646) (update of [OSDOCS-5090](https://issues.redhat.com//browse/OSDOCS-5090) for [OCPCLOUD-1889](https://issues.redhat.com//browse/OCPCLOUD-1889))

Link to docs preview:
[Configuring Confidential VM by using machine sets](https://57925--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp.html#machineset-gcp-confidential-vm_creating-machineset-gcp)

QE review:
- [x] QE has approved this change.

Additional information:
[Citation of TP status](https://issues.redhat.com/browse/OCPBU-142?focusedId=21992690&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-21992690)