### PR TITLE
[WIP] OCPBUGS#10352: EUS-to-EUS upgrade content mentions the unsupported version

### DIFF
--- a/modules/updating-eus-to-eus-upgrade.adoc
+++ b/modules/updating-eus-to-eus-upgrade.adoc
@@ -6,12 +6,12 @@
 [id="updating-eus-to-eus-upgrade_{context}"]
 = EUS-to-EUS update
 
-The following procedure pauses all non-master machine config pools and performs updates from {product-title} 4.10 to 4.11 to 4.12, then unpauses the previously paused machine config pools.
+The following procedure pauses all non-master machine config pools and performs updates from {product-title} 4.10 to 4.12, then unpauses the previously paused machine config pools.
 Following this procedure reduces the total update duration and the number of times worker nodes are restarted.
 
 .Prerequisites
 
-* Review the release notes for {product-title} 4.11 and 4.12
+* Review the release notes for {product-title} 4.10 and 4.12
 * Review the release notes and product lifecycles for any layered products and Operator Lifecycle Manager (OLM) Operators. Some may require updates either before or during an EUS-to-EUS update.
 * Ensure that you are familiar with version-specific prerequisites, such as link:https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-prepare.html#update-preparing-migrate_updating-cluster-prepare[administrator acknowledgement] that is required prior to updating from {product-title} 4.11 to 4.12.
 


### PR DESCRIPTION

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:  https://issues.redhat.com/browse/OCPBUGS-10352
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://56055--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing-eus-eus-upgrade.html#updating-eus-to-eus-upgrade_eus-to-eus-upgrade
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
