### PR TITLE
CNV-21839: Jumbo frames support

### DIFF
--- a/modules/virt-jumbo-frames-vm-pod-nw.adoc
+++ b/modules/virt-jumbo-frames-vm-pod-nw.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc              
+
+:_content-type: CONCEPT                                            
+[id="virt-jumbo-frames-vm-pod-nw_{context}"]                                   
+= About jumbo frames support          
+
+When using the OVN-Kubernetes CNI plugin, you can send unfragmented jumbo frame packets between two virtual machines (VMs) that are connected on the default pod network. Jumbo frames have a maximum transmission unit (MTU) value greater than 1500 bytes.
+
+The VM automatically gets the MTU value of the cluster network, set by the cluster administrator, in one of the following ways:
+
+* `libvirt`: If the guest OS has the latest version of the VirtIO driver that can interpret incoming data via a Peripheral Component Interconnect (PCI) config register in the emulated device. 
+
+* DHCP: If the guest DHCP client can read the MTU value from the DHCP server response.
+
+[NOTE]
+====
+For Windows VMs that do not have a VirtIO driver, you must set the MTU manually by using `netsh` or a similar tool. This is because the Windows DHCP client does not read the MTU value.
+====

--- a/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+++ b/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
@@ -6,8 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can connect a virtual machine to the default internal pod network by configuring its network interface to use the `masquerade` binding mode
+You can connect a virtual machine to the default internal pod network by configuring its network interface to use the `masquerade` binding mode.
 
 include::modules/virt-configuring-masquerade-mode-cli.adoc[leveloffset=+1]
 
 include::modules/virt-configuring-masquerade-mode-dual-stack.adoc[leveloffset=+1]
+
+include::modules/virt-jumbo-frames-vm-pod-nw.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the MTU for the cluster network]
+* xref:../../../scalability_and_performance/optimizing-networking.adoc#optimizing-mtu_optimizing-networking[Optimizing the MTU for your network]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-21839](https://issues.redhat.com//browse/CNV-21839)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://57936--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html#virt-jumbo-frames-vm-pod-nw_virt-using-the-default-pod-network-with-virt
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!---Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
