### PR TITLE
OSDOCS-5647 z-stream release notes 4.11.34

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3404,3 +3404,22 @@ $ oc adm release info 4.11.33 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-34"]
+=== RHSA-2023:1504 - {product-title} 4.11.34 bug fix and security update
+
+Issued: 2023-04-04
+
+{product-title} release 4.11.34 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1504[RHSA-2023:1504] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1503[RHSA-2023:1503] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.34 --pullspecs
+----
+
+[id="ocp-4-11-34-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-5647](https://issues.redhat.com/browse/OSDOCS-5647)

Link to docs preview:
[preview](https://57954--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-34)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Release notes for z-stream release 4.11.34.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
