### PR TITLE
SPLAT-1015: fix Labels for MachineSet on AWS Local Zone deployment page

### DIFF
--- a/modules/installation-localzone-generate-k8s-manifest.adoc
+++ b/modules/installation-localzone-generate-k8s-manifest.adoc
@@ -154,8 +154,8 @@ spec:
     spec:
       metadata:
         labels:
-          zone_type: local-zone
-          zone_group: ${LZ_ZONE_NAME:0:-1}
+          machine.openshift.com/zone-type: local-zone
+          machine.openshift.com/zone-group: ${ZONE_GROUP_NAME}
           node-role.kubernetes.io/edge: ""
       taints:
         - key: node-role.kubernetes.io/edge


### PR DESCRIPTION
Fixing the MachineSet labels added to the Local Zone nodes. The information is incorrect from the EP[1] on 4.12 documentation[2]

[1] https://github.com/openshift/enhancements/pull/1232/files#diff-f2590494c9138551ab5b3d5632d11170fe8742a128256f9e1d8ebc63baa19f41R242-R243
[2] https://docs.openshift.com/container-platform/4.12/installing/installing_aws/installing-aws-localzone.html#installation-localzone-generate-k8s-manifestinstalling-aws-localzone

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/SPLAT-1015
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

QE review:
- [x] QE has approved this change.

Additional information:
