### PR TITLE
Update availability zone with Europe

### DIFF
--- a/modules/cloud-create-instance-steps.adoc
+++ b/modules/cloud-create-instance-steps.adoc
@@ -10,7 +10,7 @@
 toc::[]
 
 [role="_abstract"]
-In the {cloud-console}, create an *ACS instance* to connect to your secured clusters. 
+In the {cloud-console}, create an *ACS instance* to connect to your secured clusters.
 
 .Procedure
 
@@ -20,9 +20,11 @@ To create an *ACS instance*:
 . From the navigation menu, select *Advanced Cluster Security* -> *ACS Instances*.
 . Select *Create ACS instance* and enter information into the displayed fields or select the appropriate option from the drop-down list:
 * *Name*: Enter the name of your *ACS instance*. An *ACS instance* contains the {product-title-short} Central component, also referred to as "Central," which includes the {product-title-managed-short} management interface and services that are configured and managed by Red Hat. You manage your secured clusters that communicate with Central. You can connect multiple secured clusters to one instance.
-* *Cloud provider*: The cloud provider where Central is located. Select *AWS*. 
-* *Cloud region*: The region for your cloud provider where Central is located. Select *AWS*.
-* *Availability zones*: Use the default value.
+* *Cloud provider*: The cloud provider where Central is located. Select *AWS*.
+* *Cloud region*: The region for your cloud provider where Central is located. Select one of the following regions:
+** US-East, N. Virginia
+** Europe, Ireland
+* *Availability zones*: Use the default value (*Multi*).
 . Click *Create instance*.
 
 .Next step


### PR DESCRIPTION
Version(s):
- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.0`

[Issue](https://issues.redhat.com/browse/ROX-15869)

Link to docs preview:

- OCP: https://57970--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_ocp/cloud-create-instance-ocp.html
- non-OCP: https://57970--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_other/cloud-create-instance-other.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
