### PR TITLE
OSDOCS-5641: Update docs to reflect MCO's new bahavior around cert rotation

### DIFF
--- a/modules/compliance-applying.adoc
+++ b/modules/compliance-applying.adoc
@@ -18,11 +18,6 @@ After the Compliance Operator processes the applied remediation, the `status.App
 
 Note that when the Machine Config Operator applies a new `MachineConfig` object to nodes in a pool, all the nodes belonging to the pool are rebooted. This might be inconvenient when applying multiple remediations, each of which re-renders the composite `75-$scan-name-$suite-name` `MachineConfig` object. To prevent applying the remediation immediately, you can pause the machine config pool by setting the `.spec.paused` attribute of a `MachineConfigPool` object to `true`.
 
-[NOTE]
-====
-Make sure the pools are unpaused when the CA certificate rotation happens. If the MCPs are paused, the MCO cannot push the newly rotated certificates to those nodes. This causes the cluster to become degraded and causes failure in multiple `oc` commands, including `oc debug`, `oc logs`, `oc exec`, and `oc attach`. You receive alerts in the Alerting UI of the {product-title} web console if an MCP is paused when the certificates are rotated.
-====
-
 The Compliance Operator can apply remediations automatically. Set `autoApplyRemediations: true` in the `ScanSetting` top-level object.
 
 [WARNING]

--- a/modules/understanding-machine-config-operator.adoc
+++ b/modules/understanding-machine-config-operator.adoc
@@ -46,8 +46,6 @@ When changes are made to a machine configuration, the Machine Config Operator (M
 
 To prevent the nodes from automatically rebooting after machine configuration changes, before making the changes, you must pause the autoreboot process by setting the `spec.paused` field to `true` in the corresponding machine config pool. When paused, machine configuration changes are not applied until you set the `spec.paused` field to `false` and the nodes have rebooted into the new configuration.
 
-Make sure the pools are unpaused when the CA certificate rotation happens. If the MCPs are paused, the MCO cannot push the newly rotated certificates to those nodes. This causes the cluster to become degraded and causes failure in multiple `oc` commands, including `oc debug`, `oc logs`, `oc exec`, and `oc attach`. You receive alerts in the Alerting UI of the {product-title} web console if an MCP is paused when the certificates are rotated.
-
 include::snippets/node-icsp-no-drain.adoc[]
 ====
 

--- a/modules/update-using-custom-machine-config-pools-about.adoc
+++ b/modules/update-using-custom-machine-config-pools-about.adoc
@@ -23,13 +23,6 @@ Do not remove the default worker label from the nodes. The nodes *must* have a r
 ====
 
 . Pause the MCPs you do not want to update as part of the update process.
-+
-[NOTE]
-====
-Pausing the MCP also pauses the `kube-apiserver-to-kubelet-signer` automatic CA certificates rotation. New CA certificates are generated at 292 days from the installation date and old certificates are removed 365 days from the installation date. See the link:https://access.redhat.com/articles/5651701[Understand CA cert auto renewal in Red Hat OpenShift 4] to find out how much time you have before the next automatic CA certificate rotation. 
-
-Make sure the pools are unpaused when the CA certificate rotation happens. If the MCPs are paused, the MCO cannot push the newly rotated certificates to those nodes. This causes the cluster to become degraded and causes failure in multiple `oc` commands, including `oc debug`, `oc logs`, `oc exec`, and `oc attach`. You receive alerts in the Alerting UI of the {product-title} web console if an MCP is paused when the certificates are rotated.
-====
 
 . Perform the cluster update. The update process updates the MCPs that are not paused, including the control plane nodes.
 

--- a/modules/update-using-custom-machine-config-pools-canary.adoc
+++ b/modules/update-using-custom-machine-config-pools-canary.adoc
@@ -26,11 +26,7 @@ The rolling update process described in this topic involves:
 
 [NOTE]
 ====
-Pausing an MCP prevents the Machine Config Operator from applying any configuration changes on the associated nodes. Pausing an MCP also prevents any automatically rotated certificates from being pushed to the associated nodes, including the automatic CA rotation of the `kube-apiserver-to-kubelet-signer` CA certificate. 
-
-If the MCP is paused when the `kube-apiserver-to-kubelet-signer` CA certificate expires and the MCO attempts to automatically renew the certificate, the new certificate is created but not applied across the nodes in the respective machine config pool. This causes failure in multiple `oc` commands, including `oc debug`, `oc logs`, `oc exec`, and `oc attach`. You receive alerts in the Alerting UI of the {product-title} web console if an MCP is paused when the certificates are rotated.
-
-Pausing an MCP should be done with careful consideration about the `kube-apiserver-to-kubelet-signer` CA certificate expiration and for short periods of time only.
+Pausing an MCP should be done with careful consideration and for short periods of time only.
 ====
 
 //link that follows is in the assembly: updating-cluster-between-minor

--- a/modules/update-using-custom-machine-config-pools-pause.adoc
+++ b/modules/update-using-custom-machine-config-pools-pause.adoc
@@ -7,13 +7,6 @@
 
 In this canary rollout update process, after you label the nodes that you do not want to update with the rest of your {product-title} cluster and create the machine config pools (MCPs), you pause those MCPs. Pausing an MCP prevents the Machine Config Operator (MCO) from updating the nodes associated with that MCP.
 
-[NOTE]
-====
-Pausing the MCP also pauses the `kube-apiserver-to-kubelet-signer` automatic CA certificates rotation. New CA certificates are generated at 292 days from the installation date and old certificates are removed 365 days from the installation date. See the link:https://access.redhat.com/articles/5651701[Understand CA cert auto renewal in Red Hat OpenShift 4] to find out how much time you have before the next automatic CA certificate rotation. 
-
-Make sure the pools are unpaused when the CA certificate rotation happens. If the MCPs are paused, the MCO cannot push the newly rotated certificates to those nodes. This causes the cluster to become degraded and causes failure in multiple `oc` commands, including `oc debug`, `oc logs`, `oc exec`, and `oc attach`. You receive alerts in the Alerting UI of the {product-title} web console if an MCP is paused when the certificates are rotated.
-====
-
 To pause an MCP:
 
 . Patch the MCP that you want paused:

--- a/modules/updating-eus-to-eus-upgrade-cli.adoc
+++ b/modules/updating-eus-to-eus-upgrade-cli.adoc
@@ -125,7 +125,7 @@ $ oc patch mcp/worker --type merge --patch '{"spec":{"paused":false}}'
 +
 [IMPORTANT]
 ====
-If pools are not unpaused, the cluster is not permitted to update to any future minor versions, and maintenance tasks such as certificate rotation are inhibited. This puts the cluster at risk for future degradation.
+If pools are not unpaused, the cluster is not permitted to update to any future minor versions, and some maintenance tasks are inhibited. This puts the cluster at risk for future degradation.
 ====
 
 . Verify that your previously paused pools are updated and that the update to version <4.y+2> is complete by running the following command:

--- a/modules/updating-eus-to-eus-upgrade-console.adoc
+++ b/modules/updating-eus-to-eus-upgrade-console.adoc
@@ -44,7 +44,7 @@ To set your channel, click *Administration* -> *Cluster Settings* -> *Channel*. 
 +
 [IMPORTANT]
 ====
-If pools are not unpaused, the cluster is not permitted to upgrade to any future minor versions, and maintenance tasks such as certificate rotation are inhibited. This puts the cluster at risk for future degradation.
+If pools are paused, the cluster is not permitted to upgrade to any future minor versions, and some maintenance tasks are inhibited. This puts the cluster at risk for future degradation.
 ====
 
 . Verify that your previously paused pools are updated and that your cluster has completed the update to version <4.y+2>. 

--- a/updating/preparing-eus-eus-upgrade.adoc
+++ b/updating/preparing-eus-eus-upgrade.adoc
@@ -20,7 +20,7 @@ There are a number of caveats to consider when attempting an EUS-to-EUS update.
 * EUS-to-EUS updates are only offered after updates between all versions involved have been made available in `stable` channels.
 * If you encounter issues during or after upgrading to the odd-numbered minor version but before upgrading to the next even-numbered version, then remediation of those issues may require that non-control plane hosts complete the update to the odd-numbered version before moving forward.
 * You can do a partial update by updating the worker or custom pool nodes to accommodate the time it takes for maintenance.
-* You can complete the update process during multiple maintenance windows by pausing at intermediate steps. However, plan to complete the entire update within 60 days. This is critical to ensure that normal cluster automation processes are completed including those associated with certificate rotation.
+* You can complete the update process during multiple maintenance windows by pausing at intermediate steps. However, plan to complete the entire update within 60 days. This is critical to ensure that normal cluster automation processes are completed.
 
 * Until the machine config pools are unpaused and the update is complete, some features and bugs fixes in <4.y+1> and <4.y+2> of {product-title} are not available.
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5641

Previews:
Security > Compliance operator > Compliance operator remediation > [Applying a remediation](https://57971--docspreview.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-remediation.html#compliance-applying_compliance-remediation)  Removed note after 3rd paragraph.

Architecture > Control plane architecture > [About the Machine Config Operator](https://57971--docspreview.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#about-machine-config-operator_control-plane ) Removed the _Make sure the pools are unpaused_ paragraph  from the Important admonition

Updating clusters > Performing a canary rollout update > [About performing a canary rollout update](https://57971--docspreview.netlify.app/openshift-enterprise/latest/updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-about_update-using-custom-machine-config-pools) Removed the note in Step 3 

Updating > Updating a cluster using the web console > [Performing a canary rollout update](https://57971--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-within-minor.html#update-using-custom-machine-config-pools-canary_updating-cluster-within-minor)  Edited the note to remove the first two paragraphs

Updating > Performing update using canary rollout strategy > [Pausing the machine config pools](https://57971--docspreview.netlify.app/openshift-enterprise/latest/updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools)  Removed the note

Updating > Preparing to perform an EUS-to-EUS update  > [EUS-to-EUS update using the CLI](https://57971--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing-eus-eus-upgrade.html#updating-eus-to-eus-upgrade-cli_eus-to-eus-upgrade) In important note: s/ maintenance tasks such as certificate rotation are inhibited/ maintenance tasks such as certificate rotation are inhibited/some maintenance tasks are inhibited

Updating > Preparing to perform an EUS-to-EUS update  > [EUS-to-EUS update using the web console](https://57971--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing-eus-eus-upgrade.html#updating-eus-to-eus-upgrade-console_eus-to-eus-upgrade) In important note: s/ maintenance tasks such as certificate rotation are inhibited/ maintenance tasks such as certificate rotation are inhibited/some maintenance tasks are inhibited

Updating > [Preparing to perform an EUS-to-EUS update](https://57971--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing-eus-eus-upgrade.html). Removed _ including those associated with certificate rotation_ from the end of the You can complete the update process during multiple maintenance windows by pausing at intermediate steps. bullet.

Current:
[Applying a remediation](https://docs.openshift.com/container-platform/4.12/security/compliance_operator/compliance-operator-remediation.html#compliance-applying_compliance-remediation)
[About the Machine Config Operator](https://docs.openshift.com/container-platform/4.12/architecture/control-plane.html#about-machine-config-operator_control-plane )
[About performing a canary rollout update](https://docs.openshift.com/container-platform/4.12/updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-about_update-using-custom-machine-config-pools)
[Performing a canary rollout update](https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-within-minor.html#update-using-custom-machine-config-pools-canary_updating-cluster-within-minor)  
[Pausing the machine config pools](https://docs.openshift.com/container-platform/4.12/updating/update-using-custom-machine-config-pools.html#update-using-custom-machine-config-pools-pause_update-using-custom-machine-config-pools)
[EUS-to-EUS update using the CLI](https://docs.openshift.com/container-platform/4.12/updating/preparing-eus-eus-upgrade.html#updating-eus-to-eus-upgrade-cli_eus-to-eus-upgrade)
[EUS-to-EUS update using the web console](https://docs.openshift.com/container-platform/4.12/updating/preparing-eus-eus-upgrade.html#updating-eus-to-eus-upgrade-console_eus-to-eus-upgrade)
[Preparing to perform an EUS-to-EUS update](https://docs.openshift.com/container-platform/4.12/updating/preparing-eus-eus-upgrade.html). 
 
[See also the associated release note](https://github.com/openshift/openshift-docs/pull/57901)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
