### PR TITLE
[enterprise-4.11] CNV-22554_411-REV: This reverts the changes made in CNV-22554_411

### DIFF
--- a/modules/virt-cloud-init-fields-web.adoc
+++ b/modules/virt-cloud-init-fields-web.adoc
@@ -2,12 +2,13 @@
 //
 // * virt/virtual_machines/virt-create-vms.adoc
 // * virt/vm_templates/virt-creating-vm-template.adoc
-
 [id="virt-cloud-init-fields-web_{context}"]
 = Cloud-init fields
-
 |===
 |Name | Description
+
+|Hostname
+|Sets a specific hostname for the virtual machine.
 
 |Authorized SSH Keys
 |The user's public key that is copied to *_~/.ssh/authorized_keys_* on the virtual machine.

--- a/modules/virt-vm-fields-web.adoc
+++ b/modules/virt-vm-fields-web.adoc
@@ -1,0 +1,126 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-create-vms.adoc
+// * virt/vm_templates/virt-creating-vm-template.adoc
+// * virt/vm_templates/virt-editing-vm-template.adoc
+
+// VM wizard includes additional options to VM template wizard
+// Call appropriate attribute in the assembly
+
+ifeval::["{context}" == "virt-editing-vm-template"]
+:object: virtual machine template
+:object-title: Virtual machine template
+endif::[]
+ifeval::["{context}" == "virt-edit-vms"]
+:object: virtual machine
+:object-title: Virtual machine
+endif::[]
+ifeval::["{context}" == "virt-create-vms"]
+:object: virtual machine
+:object-title: Virtual machine
+endif::[]
+
+:_content-type: REFERENCE
+[id="virt-vm-fields-web_{context}"]
+= {object-title} fields
+
+The following table lists the {object} fields that you can edit in the {product-title} web console:
+
+[cols="1,1a", options="header"]
+.{object-title} fields
+|===
+|Tab |Fields or functionality
+
+ifdef::virtualmachine[]
+|Overview
+endif::[]
+ifdef::virt-edit-vms,virt-editing-vm-template[]
+|Details
+endif::[]
+|
+ifdef::virt-edit-vms,virt-editing-vm-template[]
+* Labels
+* Annotations
+endif::[]
+ifdef::virt-editing-vm-template[]
+* Display name
+endif::[]
+* Description
+ifdef::virt-editing-vm-template[]
+* Workload profile
+endif::[]
+* CPU/Memory
+* Boot mode
+ifdef::virt-edit-vms[]
+* Boot order
+endif::[]
+* GPU devices
+* Host devices
+ifdef::virt-edit-vms[]
+* SSH access
+endif::[]
+
+|YAML
+|
+* View, edit, or download the custom resource.
+
+|Scheduling
+|
+* Node selector
+* Tolerations
+* Affinity rules
+* Dedicated resources
+* Eviction strategy
+* Descheduler setting
+
+ifdef::virtualmachine[]
+|Environment
+|* Add, edit, or delete a config map, secret, or service account.
+endif::[]
+
+|Network Interfaces
+|
+* Add, edit, or delete a network interface.
+
+|Disks
+|
+* Add, edit, or delete a disk.
+
+|Scripts
+|
+* cloud-init settings
+ifdef::virtualmachine[]
+* Authorized SSH key
+* Sysprep answer files
+endif::[]
+
+ifdef::virtualmachine[]
+|Metadata
+|
+* Labels
+* Annotations
+endif::[]
+ifdef::virt-editing-vm-template[]
+|Parameters (optional)
+|
+* Virtual machine name
+* cloud-user password
+endif::[]
+ifdef::virt-edit-vms[]
+|Snapshots
+|
+* Add, restore, or delete a virtual machine snapshot.
+endif::[]
+|===
+
+ifeval::["{context}" == "virt-editing-vm-template"]
+:virt-editing-vm-template!:
+endif::[]
+ifeval::["{context}" == "virt-edit-vms"]
+:virt-edit-vms!:
+endif::[]
+ifeval::["{context}" == "virtualmachine"]
+:virtualmachine!:
+endif::[]
+:object!:
+:object-title!:

--- a/virt/virt-4-11-release-notes.adoc
+++ b/virt/virt-4-11-release-notes.adoc
@@ -87,7 +87,7 @@ The SVVP Certification applies to:
 //CNV-18319 UI can switch between BIOS and UEFI
 * You can set the xref:../virt/virtual_machines/virt-edit-vms.adoc#virt-editing-vm-web_virt-edit-vms[boot mode] of templates and virtual machines to *BIOS*, *UEFI*, or *UEFI (secure)* by using the web console.
 
-* You can now enable and disable the descheduler from the web console on the *Scheduling* tab of the xref:../virt/virtual_machines/virt-create-vms.adoc#virt-create-vms[*VirtualMachine details*] page.
+* You can now enable and disable the descheduler from the web console on the *Scheduling* tab of the xref:../virt/virtual_machines/virt-create-vms.adoc#virt-vm-fields-web_virt-create-vms[*VirtualMachine details*] page.
 
 //CNV-17805 Single VM Overview page
 * You can access virtual machines by navigating to *Virtualization* -> *VirtualMachines* in the side menu. Each virtual machine now has an xref:../virt/logging_events_monitoring/virt-viewing-information-about-vm-workloads.adoc#virt-about-the-vm-dashboard_virt-viewing-information-about-vm-workloads[updated *Overview* tab] that provides information about the virtual machine configuration, alerts, snapshots, network interfaces, disks, usage data, and hardware devices.

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -37,6 +37,8 @@ include::modules/virt-creating-vm-custom-template.adoc[leveloffset=+1]
 Refer to the virtual machine fields section when creating a VM from the web console.
 
 :virtualmachine:
+include::modules/virt-vm-fields-web.adoc[leveloffset=+2]
+
 include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+3]
 
 include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+3]

--- a/virt/virtual_machines/virt-edit-vms.adoc
+++ b/virt/virtual_machines/virt-edit-vms.adoc
@@ -10,6 +10,10 @@ You can update a virtual machine configuration using either the YAML editor in t
 
 include::modules/virt-editing-vm-web.adoc[leveloffset=+1]
 
+:virt-edit-vms:
+include::modules/virt-vm-fields-web.adoc[leveloffset=+2]
+:virt-edit-vms!:
+
 include::modules/virt-editing-vm-yaml-web.adoc[leveloffset=+1]
 
 include::modules/virt-editing-vm-cli.adoc[leveloffset=+1]

--- a/virt/vm_templates/virt-editing-vm-template.adoc
+++ b/virt/vm_templates/virt-editing-vm-template.adoc
@@ -15,6 +15,10 @@ You cannot edit a template provided by the Red Hat Virtualization Operator. If y
 
 include::modules/virt-editing-vm-web.adoc[leveloffset=+1]
 
+:virt-editing-vm-template:
+include::modules/virt-vm-fields-web.adoc[leveloffset=+2]
+:virt-editing-vm-template!:
+
 include::modules/virt-add-nic-to-vm.adoc[leveloffset=+2]
 
 include::modules/virt-add-disk-to-vm.adoc[leveloffset=+2]


### PR DESCRIPTION
**Version(s):**
4.11 only

**Issue:**
https://issues.redhat.com/browse/CNV-22554

**Link to docs preview:**
* https://57978--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-11-release-notes.html
* https://57978--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html#virt-cloud-init-fields-web_virt-create-vms
* https://57978--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-edit-vms.html
* https://57978--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-create-vms.html

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
This reverts the changes in PR https://github.com/openshift/openshift-docs/pull/57675