### PR TITLE
RHDEVDOCS-5060: Pipelines: deprecation notes for cluster task function

### DIFF
--- a/cicd/pipelines/managing-nonversioned-and-versioned-cluster-tasks.adoc
+++ b/cicd/pipelines/managing-nonversioned-and-versioned-cluster-tasks.adoc
@@ -6,13 +6,17 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, installing the {pipelines-title} Operator creates variants of each default cluster task known as _versioned cluster tasks_ (VCT) and _non-versioned cluster tasks_ (NVCT). For example, installing the {pipelines-title} Operator v1.7 creates a `buildah-1-7-0` VCT and a `buildah` NVCT. 
+As a cluster administrator, installing the {pipelines-title} Operator creates variants of each default cluster task known as _versioned cluster tasks_ (VCT) and _non-versioned cluster tasks_ (NVCT). For example, installing the {pipelines-title} Operator v1.7 creates a `buildah-1-7-0` VCT and a `buildah` NVCT.
 
-Both NVCT and VCT have the same metadata, behavior, and specifications, including `params`, `workspaces`, and `steps`. However, they behave differently when you disable them or upgrade the Operator.  
+Both NVCT and VCT have the same metadata, behavior, and specifications, including `params`, `workspaces`, and `steps`. However, they behave differently when you disable them or upgrade the Operator.
+
+[IMPORTANT]
+====
+In {pipelines-title} 1.10, cluster task functionality is deprecated and is planned to be removed in a future release.
+====
 
 include::modules/op-differences-between-non-versioned-and-versioned-cluster-tasks.adoc[leveloffset=+1]
 
 include::modules/op-advantages-and-disadvantages-of-non-versioned-and-versioned-cluster-tasks.adoc[leveloffset=+1]
 
 include::modules/op-disabling-non-versioned-and-versioned-cluster-tasks.adoc[leveloffset=+1]
-

--- a/modules/op-constructing-pipelines-using-pipeline-builder.adoc
+++ b/modules/op-constructing-pipelines-using-pipeline-builder.adoc
@@ -11,6 +11,12 @@ In the *Developer* perspective of the console, you can use the *+Add* -> *Pipeli
 
 * Configure pipelines using either the *Pipeline builder* or the *YAML view*.
 * Construct a pipeline flow using existing tasks and cluster tasks. When you install the OpenShift Pipelines Operator, it adds reusable pipeline cluster tasks to your cluster.
+
+[IMPORTANT]
+====
+In {pipelines-title} 1.10, cluster task functionality is deprecated and is planned to be removed in a future release.
+====
+
 * Specify the type of resources required for the pipeline run, and if required, add additional parameters to the pipeline.
 * Reference these pipeline resources in each of the tasks in the pipeline as input and output resources.
 * If required, reference any additional parameters added to the pipeline in the task. The parameters for a task are prepopulated based on the specifications of the task.

--- a/modules/op-creating-pipeline-tasks.adoc
+++ b/modules/op-creating-pipeline-tasks.adoc
@@ -55,3 +55,8 @@ git-clone                                1 day ago
 s2i-python                               1 day ago
 tkn                                      1 day ago
 ----
+
+[IMPORTANT]
+====
+In {pipelines-title} 1.10, cluster task functionality is deprecated and is planned to be removed in a future release.
+====

--- a/modules/op-tkn-clustertask-management.adoc
+++ b/modules/op-tkn-clustertask-management.adoc
@@ -5,6 +5,11 @@
 [id="op-tkn-clustertask-management-commands_{context}"]
 = ClusterTask management commands
 
+[IMPORTANT]
+====
+In {pipelines-title} 1.10, ClusterTask functionality of the `tkn` command line utility is deprecated and is planned to be removed in a future release.
+====
+
 == clustertask
 Manage ClusterTasks.
 


### PR DESCRIPTION
Version(s): 4.11, 4,12, 4.13
Issue: https://issues.redhat.com/browse/RHDEVDOCS-5060

Link to docs preview:

https://57988--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/tkn_cli/op-tkn-reference.html

https://57988--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/creating-applications-with-cicd-pipelines.html

https://57988--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/managing-nonversioned-and-versioned-cluster-tasks.html

https://57988--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.html

SME review: Completed by @piyush-garg  
QE review: Completed by @ppitonak 
Peer-review: Completed by @libander 

Additional information:

This came out of https://issues.redhat.com/browse/SRVKP-2804 . While the original issue is a version bump of the CLI utility, I looked at the changes in that CLI utility version at https://github.com/tektoncd/cli/releases/tag/v0.30.0 and it turned out that ClusterTask was getting deprtecated. 

Note that documenting resolvers, which are the repacement, is not in scope as I could not do it for 1.10. https://issues.redhat.com/browse/RHDEVDOCS-5106 was created to track documenting resolvers.
