### PR TITLE
OCPBUG#10412: Corrected the command related to mirror host while mirroring the OCP.

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -220,7 +220,7 @@ mirrored, extract it and pin it to the release:
 +
 [source,terminal]
 ----
-$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --icsp-file=<file> \ --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}"
 ----
 ** If the local container registry is connected to the mirror host, run the following command:
 +


### PR DESCRIPTION
Version(s): 4.10+


Issue: [OCPBUG-10412](https://issues.redhat.com/browse/OCPBUGS-10412)

Scope: Changed the command syntax that was partially valid according to the information provided.

Link to docs preview:
[Preview](https://57991--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-installation-images.html#installation-mirror-repository_installing-mirroring-installation-images)

QE review:
- [ ] QE has approved this change.
@dmoessne ptal

Additional information:
[Getting error when trying to extract `openshift-install` in fully disconnected environment](https://access.redhat.com/solutions/7003109)