### PR TITLE
OCPBUGS-10695: Forbid IPv4-mapped IPv6 addresses in dual-stack

### DIFF
--- a/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
+++ b/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
@@ -14,5 +14,10 @@ After converting to dual-stack, all newly created pods are dual-stack enabled.
 A dual-stack network is supported on clusters provisioned on bare metal, IBM Power, {ibmzProductName} infrastructure, and single node OpenShift clusters.
 ====
 
+[NOTE]
+====
+While using dual-stack networking, you cannot use IPv4-mapped IPv6 addresses, such as `::FFFF:198.51.100.1`, where IPv6 is required.
+====
+
 include::modules/nw-dual-stack-convert.adoc[leveloffset=+1]
 include::modules/nw-dual-stack-convert-back-single-stack.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

OCP 4.8 and later

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

OCPBUGS-10695

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://57993--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
