### PR TITLE
OCPBUGS#5449: Change the cluster MTU

### DIFF
--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -91,126 +91,22 @@ where:
 `<node_name>`:: Specifies the name of a node in your cluster.
 --
 
-... To find the connection profile that NetworkManager created for the interface name returned from the previous command, enter the following command:
-+
-[source,terminal]
-----
-$ oc debug node/<node_name> -- chroot /host nmcli c | grep <interface>
-----
-+
---
-where:
-
-`<interface>`:: Specifies the name of the primary network interface.
---
-+
-.Example output for OpenShift SDN
-[source,text]
-----
-Wired connection 1  46da4a6a-xxxx-xxxx-xxxx-ac0ca900f213  ethernet  ens3
-----
-+
-.Example output for OVN-Kubernetes without an original connection configuration
-[source,text]
-----
-ovs-if-phys0        353774d3-0d3d-4ada-b14e-cd4d8824e2a8  ethernet       ens4
-ovs-port-phys0      332ef950-b2e5-4991-a0dc-3158977c35ca  ovs-port       ens4
-----
-+
---
-For the OVN-Kubernetes cluster network provider, two or three connection manager profiles are returned.
-
-* If the previous command returns only two profiles, then you must use a default NetworkManager connection configuration as a template.
-* If the previous command returns three profiles, use the profile that is not named `ovs-if-phys0` or `ovs-port-phys0` as a template for the following modifications.
---
-
-... To get the file name of the NetworkManager connection configuration for the primary network interface, enter the following command:
-+
-[source,terminal]
-----
-$ oc debug node/<node_name> -- chroot /host nmcli -g UUID,FILENAME c show | grep <uuid> | cut -d: -f2
-----
-+
---
-where:
-
-`<node_name>`:: Specifies the name of a node in your cluster.
-`<uuid>`:: Specifies the UUID of the NetworkManager connection profile.
---
-+
-.Example output
-[source,text]
-----
-/run/NetworkManager/system-connections/Wired connection 1.nmconnection
-----
-
-... To copy the NetworkManager connection configuration from the node, enter the following command:
-+
-[source,terminal]
-----
-$ oc debug node/<node_name> -- chroot /host cat "<profile_path>" > config.nmconnection
-----
-+
---
-where:
-
-`<node_name>`:: Specifies the name of a node in your cluster.
-`<profile_path>`:: Specifies the file system path of the NetworkManager connection from the previous step.
---
+... Create the following NetworkManager configuration in the `<interface>-mtu.conf` file:
 +
 .Example NetworkManager connection configuration
 [source,ini]
 ----
-[connection]
-id=Wired connection 1
-uuid=3e96a02b-xxxx-xxxx-ad5d-61db28678130
-type=ethernet
-autoconnect-priority=-999
-interface-name=enp1s0
-permissions=
-timestamp=1644109633
-
-[ethernet]
-mac-address-blacklist=
-
-[ipv4]
-dns-search=
-method=auto
-
-[ipv6]
-addr-gen-mode=stable-privacy
-dns-search=
-method=auto
-
-[proxy]
-
-[.nmmeta]
-nm-generated=true
+[connection-<interface>-mtu]
+match-device=interface-name:<interface>
+ethernet.mtu=<mtu>
 ----
-
-... Edit the NetworkManager configuration file saved in the `config.nmconnection` file from the previous step:
 +
 --
-**** Set the following values:
-***** `802-3-ethernet.mtu`: Specify the MTU for the primary network interface of the system.
-***** `connection.interface-name`: Optional: Specify the network interface name that this configuration applies to.
-***** `connection.autoconnect-priority`: Optional: Consider specifying an integer priority value above `0` to ensure this profile is used over other profiles for the same interface. If you are using the OVN-Kubernetes cluster network provider, this value must be less than `100`.
-**** Remove the `connection.uuid` field.
-**** Change the following values:
-***** `connection.id`: Optional: Specify a different NetworkManager connection profile name.
+where:
+
+`<mtu>`:: Specifies the new hardware MTU value.
+`<interface>`:: Specifies the primary network interface name.
 --
-+
-.Example NetworkManager connection configuration
-[source,ini]
-----
-[connection]
-id=Primary network interface
-type=ethernet
-autoconnect-priority=10
-interface-name=enp1s0
-[802-3-ethernet]
-mtu=8051
-----
 
 ... Create two `MachineConfig` objects, one for the control plane nodes and another for the worker nodes in your cluster:
 
@@ -226,9 +122,9 @@ metadata:
     machineconfiguration.openshift.io/role: master
 storage:
   files:
-    - path: /etc/NetworkManager/system-connections/<connection_name> <1>
+    - path: /etc/NetworkManager/conf.d/99-<interface>-mtu.conf <1>
       contents:
-        local: config.nmconnection <2>
+        local: <interface>-mtu.conf <2>
       mode: 0600
 ----
 <1> Specify the NetworkManager connection name for the primary network interface.
@@ -246,10 +142,10 @@ metadata:
     machineconfiguration.openshift.io/role: worker
 storage:
   files:
-    - path: /etc/NetworkManager/system-connections/<connection_name> <1>
+    - path: /etc/NetworkManager/conf.d/99-<interface>-mtu.conf <1>
       contents:
-        local: config.nmconnection <2>
-      mode: 0644
+        local: <interface>-mtu.conf <2>
+      mode: 0600
 ----
 <1> Specify the NetworkManager connection name for the primary network interface.
 <2> Specify the local filename for the updated NetworkManager configuration file from the previous step.


### PR DESCRIPTION
Version(s): 4.11

Issue: https://issues.redhat.com/browse/OCPBUGS-5449

Link to docs preview: https://57998--docspreview.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu.html#nw-cluster-mtu-change_changing-cluster-network-mtu

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
