### PR TITLE
OCPBUG#10383: Added a note to clarify the time taken during the start of an upgrade.

### DIFF
--- a/modules/upgrade.adoc
+++ b/modules/upgrade.adoc
@@ -19,6 +19,11 @@ You can also set a grace period for how long `PodDisruptionBudget` protected wor
 All Kubernetes objects and PVs in each {product-title} cluster are backed up as part of the {product-title} service. Application and application data backups are not a part of the {product-title} service. Ensure you have a backup policy in place for your applications and application data prior to scheduling upgrades.
 ====
 
+[NOTE]
+====
+The upgrade starting time might be later than the scheduled time. It could be sometimes an hour or longer.
+====
+
 [id="upgrade-automatic_{context}"]
 == Recurring upgrades
 

--- a/upgrading/rosa-upgrading.adoc
+++ b/upgrading/rosa-upgrading.adoc
@@ -26,6 +26,11 @@ There are three methods to upgrade {product-title} (ROSA) clusters:
 For steps to upgrade a ROSA cluster that uses the AWS Security Token Service (STS), see xref:../upgrading/rosa-upgrading-sts.adoc#rosa-upgrading-sts[Upgrading ROSA clusters with STS].
 ====
 
+[NOTE]
+====
+The upgrade starting time might be later than the scheduled time. It could be sometimes an hour or longer.
+====
+
 include::modules/rosa-upgrading-cli-tutorial.adoc[leveloffset=+2]
 include::modules/rosa-upgrading-manual-ocm.adoc[leveloffset=+2]
 include::modules/rosa-upgrading-automatic-ocm.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): 4.10+

Issue:
[OCPBUG-10383](https://issues.redhat.com/browse/OCPBUGS-10383)

Scope: Added a note to mention the delay during the start of clusters upgrade in RCOS and OSD.

Link to docs preview:
[Preview 1](https://57999--docspreview.netlify.app/openshift-dedicated/latest/upgrading/osd-upgrades.html#upgrade_osd-upgrades)
[Preview 2](https://57999--docspreview.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading.html#rosa-sts-upgrading-a-cluster)

QE review:
- [ ] QE has approved this change.


Additional information:
