### PR TITLE
CNV-25573: UI - Ability to make a hot-plug disk part of the VM

### DIFF
--- a/modules/virt-about-hot-plugging-virtual-disks.adoc
+++ b/modules/virt-about-hot-plugging-virtual-disks.adoc
@@ -13,3 +13,5 @@ When you _hot unplug_ a virtual disk, you detach a virtual disk from a virtual m
 Only data volumes and persistent volume claims (PVCs) can be hot plugged and hot unplugged. You cannot hot plug or hot unplug container disks.
 
 After you hot plug a virtual disk, it remains attached until you detach it, even if you restart the virtual machine.
+
+In the web console, hot-plugged volumes are marked by a "persistent hotplug" label on the disk in the disk list (*VirtualMachine Details* -> *Configuration* -> *Disks* tab). To change a hot-plug volume to a persistent volume, click the *Options* menu {kebab} and select *Make persistent*. The "persistent hotplug" label is removed and the change is applied after the next reboot.

--- a/virt/virt-web-console-overview.adoc
+++ b/virt/virt-web-console-overview.adoc
@@ -777,7 +777,7 @@ You can manage disks on the *Disks* tab.
 |*Disks* table
 |List of VirtualMachine disks
 
-Click the Options menu {kebab} beside a disk to select *Edit* or *Detach*.
+Click the *Options* menu {kebab} beside a disk to select *Edit*, *Detach*, or *Make persistent*.
 
 |*File systems* table
 |List of VirtualMachine file systems if QEMU guest agent is installed


### PR DESCRIPTION
**Version(s):**
4.13+

**Issue:**
https://issues.redhat.com/browse/CNV-25573

**Link to docs preview:**
* https://58012--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-hot-plugging-virtual-disks.html#virt-about-hot-plugging-virtual-disks_virt-hot-plugging-virtual-disks
* https://58012--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-web-console-overview.html#ui-virtualmachine-details-disks_virt-web-console-overview

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
Some of the sentence casing included in these docs have not yet been made on the actual kubevirt-plugin (https://github.com/kubevirt-ui/kubevirt-plugin/pull/1042), but have been requested.