### PR TITLE
Document GitOps 1.8.2 Release Notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-8-2.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-8-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-8-0.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-8-2.adoc
+++ b/modules/gitops-release-notes-1-8-2.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+:_content-type: REFERENCE
+[id="gitops-release-notes-1-8-2_{context}"]
+= Release notes for {gitops-title} 1.8.2
+
+{gitops-title} 1.8.2 is now available on {product-title} 4.10, 4.11, and 4.12.
+
+[id="fixed-issues-1-8-2_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, when you configured Dex using the `.spec.dex` parameter and tried to log in to the Argo CD UI by using the *LOG IN VIA OPENSHIFT* option, you were not able to log in. This update fixes the issue. 
++
+[IMPORTANT]
+====
+The `spec.dex` parameter in the ArgoCD CR is deprecated. In a future release of {gitops-title} v1.9, configuring Dex using the `spec.dex` parameter in the ArgoCD CR is planned to be removed. Consider using the `.spec.sso` parameter instead. See "Enabling or disabling Dex using .spec.sso".  link:https://issues.redhat.com/browse/GITOPS-2761[GITOPS-2761]
+====
+
+* Before this update, the cluster and `kam` CLI pods failed to start with a new installation of {gitops-title} v1.8.0 on the {product-title} 4.10 cluster. This update fixes the issue and now all pods run as expected. link:https://issues.redhat.com/browse/GITOPS-2762[GITOPS-2762] 


### PR DESCRIPTION
**NOTE**: From GitOps 1.7.0 onwards, we are documenting security issues in a new advisory format as part of errata updates.

**Aligned team**: Dev Tools

**Purpose**: To resolve the following issues:
https://issues.redhat.com/browse/RHDEVDOCS-5089

**OCP version this PR applies to**: enterprise-`4.10` and later

**Link to docs preview**: 
- [Release notes for Red Hat OpenShift GitOps 1.8.2](https://58017--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-8-2_gitops-release-notes)


**SME review**: Completed by @reginapizza 
**QE review**: Completed by @varshab1210
**Peer-review**:  Completed by @mramendi 