### PR TITLE
correction for wrong xref

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -275,7 +275,7 @@ With this update, {product-title} cluster can be deployed on a bond interface wi
 * Installer-provisioned infrastructure installation
 * User-provisioned infrastructure installation
 
-For more information about installing {product-title} on nodes with dual-port NICs, see xref:../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adocl#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal[NIC partitioning for SR-IOV devices].
+For more information about installing {product-title} on nodes with dual-port NICs, see xref:../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal[NIC partitioning for SR-IOV devices].
 
 [id="ocp-4-13-bf2-switching-dpu-nic"]
 ==== Support for switching the BlueField-2 network device from data processing unit (DPU) mode to network interface controller (NIC) mode is now GA


### PR DESCRIPTION
[TELCODOCS-1123]: Document new features and fixing mistake with xref

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-1123

Link to docs preview:
https://58022--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/preparing-to-install-on-bare-metal.html#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I noticed a small typo in https://github.com/openshift/openshift-docs/pull/57258 which broke the xref so this PR addresses that typo. Should be OK to merge as no substantial content change. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
