### PR TITLE
Telcodocs 992: deploying modules and creating a multiloader image

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -4,7 +4,6 @@
 include::_attributes/common-attributes.adoc[]
 :context: kernel-module-management-operator
 
-
 toc::[]
 
 Learn about the Kernel Module Management (KMM) Operator and how you can use it to deploy out-of-tree kernel modules and device plugins on {product-title} clusters.
@@ -16,6 +15,47 @@ include::modules/kmm-installation.adoc[leveloffset=+1]
 include::modules/kmm-installing-using-web-console.adoc[leveloffset=+2]
 include::modules/kmm-installing-using-cli.adoc[leveloffset=+2]
 include::modules/kmm-installing-older-versions.adoc[leveloffset=+2]
+include::modules/kmm-deploying-modules.adoc[leveloffset=+1]
+include::modules/kmm-creating-module-cr.adoc[leveloffset=+2]
+include::modules/kmm-security.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission].
+
+include::modules/kmm-example-module-cr.adoc[leveloffset=+2]
+include::modules/kmm-creating-moduleloader-image.adoc[leveloffset=+1]
+include::modules/kmm-running-depmod.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../hardware_enablement/psap-driver-toolkit.adoc#driver-toolkit[Driver Toolkit].
+
+include::modules/kmm-building-in-cluster.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../cicd/builds/build-configuration.adoc#build-configuration[Build configuration resources].
+
+include::modules/kmm-using-driver-toolkit.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../hardware_enablement/psap-driver-toolkit.adoc#driver-toolkit[Driver Toolkit].
+
+//Deploying kernel modules (Might just leave this short intro in the assembly and put further module below it)
+//    * Running ModuleLoader images (CONCEPT, or could be included in the assembly with the intro)
+//    * Using the device plugin (CONCEPT, or could be included in the assembly with the intro)
+//  * Creating the Module Custom Resource (PROCEDURE? Seems like not a process the user does after reading it. Maybe a REFERENCE)
+//  * Security and permissions (CONCEPT or REFERENCE)
+//    * ServiceAccounts and SecurityContextConstraints (can include in Security and permissions)
+//    * Pod Security Standards (can include in Security and permissions)
+//  * Example Module CR (REFERENCE)
+
 // Added for TELCODOCS-1065
 include::modules/kmm-using-signing-with-kmm.adoc[leveloffset=+1]
 include::modules/kmm-adding-the-keys-for-secureboot.adoc[leveloffset=+1]

--- a/modules/kmm-building-in-cluster.adoc
+++ b/modules/kmm-building-in-cluster.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-building-in-cluster_{context}"]
+
+= Building in the cluster
+
+KMM can build module loader images in the cluster. Follow these guidelines:
+
+* Provide build instructions using the `build` section of a kernel mapping.
+* Copy the `Dockerfile` for your container image into a `ConfigMap` resource, under the `dockerfile` key.
+* Ensure that the `ConfigMap` is located in the same namespace as the `Module`.
+
+KMM checks if the image name specified in the `containerImage` field exists. If it does, the build is skipped.
+
+Otherwise, KMM creates a `Build` resource to build your image. After the image is built, KMM proceeds with the `Module` reconciliation. See the following example.
+
+[source,yaml]
+----
+# ...
+- regexp: '^.+$'
+  containerImage: "some.registry/org/<my_kmod>:${KERNEL_FULL_VERSION}"
+  build:
+    buildArgs:  <1>
+      - name: ARG_NAME
+        value: <some_value>
+    secrets: <2>
+      - name: <some_kubernetes_secret> <3>
+    baseImageRegistryTLS:
+      insecure: false <4>
+      insecureSkipTLSVerify: false <5>
+    dockerfileConfigMap:  <6>
+      name: <my_kmod_dockerfile>
+  registryTLS:
+    insecure: false <7>
+    insecureSkipTLSVerify: false <8>
+----
+<1> Optional.
+<2> Optional.
+<3> Will be mounted in the build pod as `/run/secrets/some-kubernetes-secret`.
+<4> Optional: Avoid using this parameter. If set to `true`, the build will be allowed to pull the image in the Dockerfile `FROM` instruction using plain HTTP.
+<5> Optional: Avoid using this parameter. If set to `true`, the build will skip any TLS server certificate validation when pulling the image in the Dockerfile `FROM` instruction using plain HTTP.
+<6> Required.
+<7> Optional: Avoid using this parameter. If set to `true`, KMM will be allowed to check if the container image already exists using plain HTTP.
+<8> Optional: Avoid using this parameter. If set to `true`, KMM will skip any TLS server certificate validation when checking if the container image already exists.

--- a/modules/kmm-creating-module-cr.adoc
+++ b/modules/kmm-creating-module-cr.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-creating-module-cr_{context}"]
+
+= The Module custom resource definition
+
+The `Module` custom resource definition (CRD) represents a kernel module that can be loaded on all or select nodes in the cluster, through a module loader image.
+A `Module` custom resource (CR) specifies one or more kernel versions with which it is compatible, and a node selector.
+
+The compatible versions for a `Module` resource are listed under `.spec.moduleLoader.container.kernelMappings`.
+A kernel mapping can either match a `literal` version, or use `regexp` to match many of them at the same time.
+
+The reconciliation loop for the `Module` resource runs the following steps:
+
+. List all nodes matching `.spec.selector`.
+. Build a set of all kernel versions running on those nodes.
+. For each kernel version:
+ .. Go through `.spec.moduleLoader.container.kernelMappings` and find the appropriate container image name. If the kernel mapping has `build` or `sign` defined and the container image does not already exist, run the build, the signing job, or both, as needed.
+.. Create a module loader daemon set with the container image determined in the previous step.
+.. If `.spec.devicePlugin` is defined, create a device plugin daemon set using the configuration specified under `.spec.devicePlugin.container`.
+. Run `garbage-collect` on:
+ .. Existing daemon set resources targeting kernel versions that are not run by any node in the cluster.
+ .. Successful build jobs.
+ .. Successful signing jobs.

--- a/modules/kmm-creating-moduleloader-image.adoc
+++ b/modules/kmm-creating-moduleloader-image.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-creating-moduleloader-image_{context}"]
+= Using a ModuleLoader image
+
+Kernel Module Management (KMM) works with purpose-built module loader images.
+These are standard OCI images that must satisfy the following requirements:
+
+* `.ko` files must be located in `+/opt/lib/modules/${KERNEL_VERSION}+`.
+* `modprobe` and `sleep` binaries must be defined in the `$PATH` variable.

--- a/modules/kmm-deploying-modules.adoc
+++ b/modules/kmm-deploying-modules.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-deploy-kernel-modules_{context}"]
+= Kernel module deployment
+
+For each `Module` resource, Kernel Module Management (KMM) can create a number of `DaemonSet` resources:
+
+* One ModuleLoader `DaemonSet` per compatible kernel version running in the cluster.
+* One device plugin `DaemonSet`, if configured.
+
+The module loader daemon set resources run ModuleLoader images to load kernel modules.
+A module loader image is an OCI image that contains the `.ko` files and both the `modprobe` and `sleep` binaries.
+
+When the module loader pod is created, the pod runs `modprobe` to insert the specified module into the kernel.
+It then enters a sleep state until it is terminated.
+When that happens, the `ExecPreStop` hook runs `modprobe -r` to unload the kernel module.
+
+If the `.spec.devicePlugin` attribute is configured in a `Module` resource, then KMM creates a link:https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/[device plugin]
+daemon set in the cluster.
+That daemon set targets:
+
+* Nodes that match the `.spec.selector` of the `Module` resource.
+* Nodes with the kernel module loaded (where the module loader pod is in the `Ready` condition).

--- a/modules/kmm-example-module-cr.adoc
+++ b/modules/kmm-example-module-cr.adoc
@@ -1,0 +1,97 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: REFERENCE
+[id="kmm-example-cr_{context}"]
+
+= Example Module CR
+
+The following is an annotated `Module` example:
+
+[source,yaml]
+----
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: <my_kmod>
+spec:
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: <my_kmod> <1>
+        dirName: /opt <2>
+        firmwarePath: /firmware <3>
+        parameters:  <4>
+          - param=1
+      kernelMappings:  <5>
+        - literal: 6.0.15-300.fc37.x86_64
+          containerImage: some.registry/org/my-kmod:6.0.15-300.fc37.x86_64
+        - regexp: '^.+\fc37\.x86_64$' <6>
+          containerImage: "some.other.registry/org/<my_kmod>:${KERNEL_FULL_VERSION}"
+        - regexp: '^.+$' <7>
+          containerImage: "some.registry/org/<my_kmod>:${KERNEL_FULL_VERSION}"
+          build:
+            buildArgs:  <8>
+              - name: ARG_NAME
+                value: <some_value>
+            secrets:
+              - name: <some_kubernetes_secret>  <9>
+            baseImageRegistryTLS: <10>
+              insecure: false
+              insecureSkipTLSVerify: false <11>
+            dockerfileConfigMap:  <12>
+              name: <my_kmod_dockerfile>
+          sign:
+            certSecret:
+              name: <cert_secret>  <13>
+            keySecret:
+              name: <key_secret>  <14>
+            filesToSign:
+              - /opt/lib/modules/${KERNEL_FULL_VERSION}/<my_kmod>.ko
+          registryTLS: <15>
+            insecure: false <16>
+            insecureSkipTLSVerify: false
+    serviceAccountName: <sa_module_loader>  <17>
+  devicePlugin:  <18>
+    container:
+      image: some.registry/org/device-plugin:latest  <19>
+      env:
+        - name: MY_DEVICE_PLUGIN_ENV_VAR
+          value: SOME_VALUE
+      volumeMounts:  <20>
+        - mountPath: /some/mountPath
+          name: <device_plugin_volume>
+    volumes:  <21>
+      - name: <device_plugin_volume>
+        configMap:
+          name: <some_configmap>
+    serviceAccountName: <sa_device_plugin> <22>
+  imageRepoSecret:  <23>
+    name: <secret_name>
+  selector:
+    node-role.kubernetes.io/worker: ""
+----
+<1> Required.
+<2> Optional.
+<3> Optional: Copies `/firmware/*` into `/var/lib/firmware/` on the node.
+<4> Optional.
+<5> At least one kernel item is required.
+<6> For each node running a kernel matching the regular expression, KMM creates a `DaemonSet` resource running the image specified in `containerImage` with `${KERNEL_FULL_VERSION}` replaced with the kernel version.
+<7> For any other kernel, build the image using the Dockerfile in the `my-kmod` ConfigMap.
+<8> Optional.
+<9> Optional: A value for `some-kubernetes-secret` can be obtained from the build environment at `/run/secrets/some-kubernetes-secret`.
+<10> Optional: Avoid using this parameter. If set to `true`, the build is allowed to pull the image in the Dockerfile `FROM` instruction using plain HTTP.
+<11> Optional: Avoid using this parameter. If set to `true`, the build will skip any TLS server certificate validation when pulling the image in the Dockerfile `FROM` instruction using plain HTTP.
+<12> Required.
+<13> Required: A secret holding the public secureboot key with the key 'cert'.
+<14> Required: A secret holding the private secureboot key with the key 'key'.
+<15> Optional: Avoid using this parameter. If set to `true`, KMM will be allowed to check if the container image already exists using plain HTTP.
+<16> Optional: Avoid using this parameter. If set to `true`, KMM will skip any TLS server certificate validation when checking if the container image already exists.
+<17> Optional.
+<18> Optional.
+<19> Required: If the device plugin section is present.
+<20> Optional.
+<21> Optional.
+<22> Optional.
+<23> Optional: Used to pull module loader and device plugin images.

--- a/modules/kmm-running-depmod.adoc
+++ b/modules/kmm-running-depmod.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-running-depmod_{context}"]
+
+= Running depmod
+
+If your module loader image contains several kernel modules and if one of the modules depends on another module, it is best practice to run `depmod` at the end of the build process to generate dependencies and map files.
+
+[NOTE]
+====
+You must have a Red Hat subscription to download the `kernel-devel` package.
+====
+
+.Procedure
+
+. To generate `modules.dep` and `.map` files for a specific kernel version, run `+depmod -b /opt ${KERNEL_VERSION}+`.
+
+[id="example-dockerfile_{context}"]
+== Example Dockerfile
+
+If you are building your image on {product-title}, consider using the Driver Tool Kit (DTK).
+
+For further information, see link:https://cloud.redhat.com/blog/how-to-use-entitled-image-builds-to-build-drivercontainers-with-ubi-on-openshift[using an entitled build].
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kmm-ci-dockerfile
+data:
+  dockerfile: |
+    ARG DTK_AUTO
+    FROM ${DTK_AUTO} as builder
+    ARG KERNEL_VERSION
+    WORKDIR /usr/src
+    RUN ["git", "clone", "https://github.com/rh-ecosystem-edge/kernel-module-management.git"]
+    WORKDIR /usr/src/kernel-module-management/ci/kmm-kmod
+    RUN KERNEL_SRC_DIR=/lib/modules/${KERNEL_VERSION}/build make all
+    FROM registry.redhat.io/ubi8/ubi-minimal
+    ARG KERNEL_VERSION
+    RUN microdnf install kmod
+    COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_a.ko /opt/lib/modules/${KERNEL_VERSION}/
+    COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_b.ko /opt/lib/modules/${KERNEL_VERSION}/
+    RUN depmod -b /opt ${KERNEL_VERSION}
+----

--- a/modules/kmm-security.adoc
+++ b/modules/kmm-security.adoc
@@ -1,0 +1,46 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: REFERENCE
+[id="kmm-security_{context}"]
+= Security and permissions
+
+[IMPORTANT]
+====
+Loading kernel modules is a highly sensitive operation.
+After they are loaded, kernel modules have all possible permissions to do any kind of operation on the node.
+====
+
+[id="serviceaccounts-and-securitycontextconstraint_{context}"]
+== ServiceAccounts and SecurityContextConstraints
+
+Kernel Module Management (KMM) creates a privileged workload to load the kernel modules on nodes.
+That workload needs `ServiceAccounts` allowed to use the `privileged` `SecurityContextConstraint` (SCC) resource.
+
+The authorization model for that workload depends on the namespace of the `Module` resource, as well as its spec.
+
+* If the `.spec.moduleLoader.serviceAccountName` or `.spec.devicePlugin.serviceAccountName` fields are set, they are always used.
+* If those fields are not set, then:
+ ** If the `Module` resource is created in the operator's namespace (`openshift-kmm` by default), then KMM uses its default, powerful `ServiceAccounts` to run the daemon sets.
+ ** If the `Module` resource is created in any other namespace, then KMM runs the daemon sets as the namespace's `default` `ServiceAccount`. The `Module` resource cannot run a privileged workload unless you manually enable it to use the `privileged` SCC.
+
+[IMPORTANT]
+====
+`openshift-kmm` is a trusted namespace.
+
+When setting up RBAC permissions, remember that any user or `ServiceAccount` creating a `Module` resource in the `openshift-kmm` namespace results in KMM automatically running privileged workloads on potentially all nodes in the cluster.
+====
+
+To allow any `ServiceAccount` to use the `privileged` SCC and therefore to run module loader or device plugin pods, use the following command:
+
+[source,terminal]
+----
+$ oc adm policy add-scc-to-user privileged -z "${serviceAccountName}" [ -n "${namespace}" ]
+----
+
+[id="pod-security-standards_{context}"]
+== Pod security standards
+
+OpenShift runs a synchronization mechanism that sets the namespace Pod Security level automatically based on
+the security contexts in use. No action is needed.

--- a/modules/kmm-using-driver-toolkit.adoc
+++ b/modules/kmm-using-driver-toolkit.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-using-driver-toolkit_{context}"]
+
+= Using the Driver Toolkit
+
+The Driver Toolkit (DTK) is a convenient base image for building build module loader images.
+It contains tools and libraries for the OpenShift version currently running in the cluster.
+
+.Procedure
+
+Use DTK as the first stage of a multi-stage `Dockerfile`.
+
+. Build the kernel modules.
+
+. Copy the `.ko` files into a smaller end-user image such as https://catalog.redhat.com/software/containers/ubi8/ubi-minimal[`ubi-minimal`].
+
+. To leverage DTK in your in-cluster build, use the `DTK_AUTO` build argument.
+The value is automatically set by KMM when creating the `Build` resource. See the following example.
++
+[source,dockerfile]
+----
+ARG DTK_AUTO
+FROM ${DTK_AUTO} as builder
+ARG KERNEL_VERSION
+WORKDIR /usr/src
+RUN ["git", "clone", "https://github.com/rh-ecosystem-edge/kernel-module-management.git"]
+WORKDIR /usr/src/kernel-module-management/ci/kmm-kmod
+RUN KERNEL_SRC_DIR=/lib/modules/${KERNEL_VERSION}/build make all
+FROM registry.redhat.io/ubi8/ubi-minimal
+ARG KERNEL_VERSION
+RUN microdnf install kmod
+COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_a.ko /opt/lib/modules/${KERNEL_VERSION}/
+COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_b.ko /opt/lib/modules/${KERNEL_VERSION}/
+RUN depmod -b /opt ${KERNEL_VERSION}
+----

--- a/modules/virt-prerequisites-mediated-devices.adoc
+++ b/modules/virt-prerequisites-mediated-devices.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: CONCEPT
 [id="prerequisites_{context}"]
-== Prerequisites
+= Prerequisites
 
 * If your hardware vendor provides drivers, you installed them on the nodes where you want to create mediated devices.
 ** If you use NVIDIA cards, you link:https://access.redhat.com/solutions/6738411[installed the NVIDIA GRID driver].


### PR DESCRIPTION
Telcodocs 992: deploying modules and creating a multiloader image

Version(s):
4.12 and onwards.

Issue: https://issues.redhat.com/browse/TELCODOCS-992

Link to docs preview: https://58024--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html

QE review:

    QE has approved this change.

Additional information:
This is a new PR created from the old PR https://github.com/openshift/openshift-docs/pull/56120. Peer review was completed in the old PR. Merge conflict fixed.