### PR TITLE
OCPBUG#11043: Corrected the command related to oc-mirror.

### DIFF
--- a/modules/oc-mirror-installing-plugin.adoc
+++ b/modules/oc-mirror-installing-plugin.adoc
@@ -53,5 +53,5 @@ $ sudo mv oc-mirror /usr/local/bin/.
 +
 [source,terminal]
 ----
-$ oc mirror help
+$ oc-mirror help
 ----


### PR DESCRIPTION
Version(s): 4.10+

`$oc mirror help` command corrected to `$oc-mirror help` in the section 'Installing the oc-mirror OpenShift CLI plugin'

Issue:
[OCPBUG-11043](https://issues.redhat.com/browse/OCPBUGS-11043)

Link to docs preview:
[Preview](https://58034--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#installation-oc-mirror-installing-plugin_installing-mirroring-disconnected)

QE review:
- [ ] QE has approved this change.
