### PR TITLE
[enterprise-4.12] [OSDOCS-5511]: Misc loose ends for CPMS in 4.13

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2106,13 +2106,13 @@ Topics:
 - Name: Managing control plane machines
   Dir: control_plane_machine_management
   Topics:
-  - Name: About the Control Plane Machine Set Operator
+  - Name: About control plane machine sets
     File: cpmso-about
-  - Name: Getting started
+  - Name: Getting started with control plane machine sets
     File: cpmso-getting-started
-  - Name: Control Plane Machine Set Operator configuration
+  - Name: Control plane machine set configuration
     File: cpmso-configuration
-  - Name: Using the Control Plane Machine Set Operator
+  - Name: Using control plane machine sets
     File: cpmso-using
   - Name: Control plane resiliency and recovery
     File: cpmso-resiliency

--- a/machine_management/control_plane_machine_management/cpmso-about.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-about.adoc
@@ -1,19 +1,18 @@
 :_content-type: ASSEMBLY
 [id="cpmso-about"]
-= About the Control Plane Machine Set Operator
+= About control plane machine sets
 include::_attributes/common-attributes.adoc[]
 :context: cpmso-about
 
 toc::[]
 
-With the Control Plane Machine Set Operator, you can automate management of the control plane machine resources within your {product-title} cluster. 
+With control plane machine sets, you can automate management of the control plane machine resources within your {product-title} cluster.
 
 [IMPORTANT]
 ====
 Control plane machine sets cannot manage compute machines, and compute machine sets cannot manage control plane machines.
 ====
 
-//Trying to balance the two being analogous (so, familiar to admins), but not the same (so, not conflated by admins). I think this language needs a lot of careful scrutiny and consideration.
 Control plane machine sets provide for control plane machines similar management capabilities as compute machine sets provide for compute machines. However, these two types of machine sets are separate custom resources defined within the Machine API and have several fundamental differences in their architecture and functionality.
 
 //Control Plane Machine Set Operator overview
@@ -24,7 +23,7 @@ include::modules/cpmso-overview.adoc[leveloffset=+1]
 
 The Control Plane Machine Set Operator has the following limitations:
 
-* The Operator requires the Machine API to be operational and is therefore not supported on clusters with manually provisioned machines. When installing a {product-title} cluster with manually provisioned machines for a platform that creates an active generated `ControlPlaneMachineSet` custom resource (CR), you must remove the Kubernetes manifest files that define the control plane machine set as instructed in the installation process.
+* The Operator requires the Machine API Operator to be operational and is therefore not supported on clusters with manually provisioned machines. When installing a {product-title} cluster with manually provisioned machines for a platform that creates an active generated `ControlPlaneMachineSet` custom resource (CR), you must remove the Kubernetes manifest files that define the control plane machine set as instructed in the installation process.
 
 * Only Amazon Web Services (AWS), Microsoft Azure, and VMware vSphere clusters are supported.
 

--- a/machine_management/control_plane_machine_management/cpmso-configuration.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-configuration.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="cpmso-configuration"]
-= Control Plane Machine Set Operator configuration
+= Control plane machine set configuration
 include::_attributes/common-attributes.adoc[]
 :context: cpmso-configuration
 
@@ -13,7 +13,7 @@ include::modules/cpmso-yaml-sample-cr.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with the Control Plane Machine Set Operator]
+* xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with control plane machine sets]
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-feat-config-update_cpmso-using[Updating the control plane configuration]
 
@@ -21,7 +21,7 @@ include::modules/cpmso-yaml-sample-cr.adoc[leveloffset=+1]
 [id="cpmso-sample-yaml-provider-specific_{context}"]
 === Provider-specific configuration
 
-The `<platform_failure_domains>` and `<platform_provider_spec>` sections of the control plane machine set resources are provider-specific. Refer to the example YAML for your cluster:
+The `<platform_provider_spec>` and `<platform_failure_domains>` sections of the control plane machine set resources are provider-specific. Refer to the example YAML for your cluster:
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-aws_cpmso-configuration[Sample YAML snippets for configuring Amazon Web Services clusters]
 

--- a/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
@@ -1,14 +1,14 @@
 :_content-type: ASSEMBLY
 [id="cpmso-getting-started"]
-= Getting started with the Control Plane Machine Set Operator
+= Getting started with control plane machine sets
 include::_attributes/common-attributes.adoc[]
 :context: cpmso-getting-started
 
 toc::[]
 
-The process for getting started with the Control Plane Machine Set Operator depends on the state of the `ControlPlaneMachineSet` custom resource (CR) in your cluster.
+The process for getting started with control plane machine sets depends on the state of the `ControlPlaneMachineSet` custom resource (CR) in your cluster.
 
-Clusters with an active generated CR:: Clusters that have a generated CR with an active state use the Operator by default. No administrator action is required.
+Clusters with an active generated CR:: Clusters that have a generated CR with an active state use the control plane machine set by default. No administrator action is required.
 
 Clusters with an inactive generated CR:: For clusters that include an inactive generated CR, you must review the CR configuration and xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[activate the CR].
 
@@ -19,9 +19,9 @@ If you are uncertain about the state of the `ControlPlaneMachineSet` CR in your 
 [id="cpmso-platform-matrix_{context}"]
 == Supported cloud providers
 
-In {product-title} {product-version}, the Control Plane Machine Set Operator is supported for Amazon Web Services (AWS), Microsoft Azure, and VMware vSphere clusters.
+In {product-title} {product-version}, the control plane machine sets are supported for Amazon Web Services (AWS), Microsoft Azure, and VMware vSphere clusters.
 
-The status of the Operator after installation depends on your cloud provider and the version of {product-title} that you installed on your cluster.
+The status of the control plane machine set after installation depends on your cloud provider and the version of {product-title} that you installed on your cluster.
 
 .Control plane machine set implementation for {product-title} {product-version}
 [cols="<.^5,^.^4,^.^4,^.^4"]

--- a/machine_management/control_plane_machine_management/cpmso-resiliency.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-resiliency.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use the Control Plane Machine Set Operator to improve the resiliency of the control plane for your {product-title} cluster. 
+You can use the control plane machine set to improve the resiliency of the control plane for your {product-title} cluster.
 
 [id="cpmso-failure-domains_{context}"]
 == High availability and fault tolerance with failure domains

--- a/machine_management/control_plane_machine_management/cpmso-using.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-using.adoc
@@ -1,12 +1,12 @@
 :_content-type: ASSEMBLY
 [id="cpmso-using"]
-= Managing control plane machines with the Control Plane Machine Set Operator
+= Managing control plane machines with control plane machine sets
 include::_attributes/common-attributes.adoc[]
 :context: cpmso-using
 
 toc::[]
 
-The Control Plane Machine Set Operator automates several essential aspects of control plane management.
+Control plane machine sets automate several essential aspects of control plane management.
 
 //Vertical resizing of the control plane
 //include::modules/cpmso-feat-vertical-resize.adoc[leveloffset=+1]

--- a/machine_management/deleting-machine.adoc
+++ b/machine_management/deleting-machine.adoc
@@ -15,4 +15,4 @@ include::modules/machine-delete.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc[Replacing an unhealthy etcd member]
-* xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-using[Managing control plane machines with the Control Plane Machine Set Operator]
+* xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-using[Managing control plane machines with control plane machine sets]

--- a/modules/cpmso-activating.adoc
+++ b/modules/cpmso-activating.adoc
@@ -6,11 +6,11 @@
 [id="cpmso-activating_{context}"]
 = Activating the control plane machine set custom resource
 
-To use the Control Plane Machine Set Operator, you must ensure that a `ControlPlaneMachineSet` custom resource (CR) with the correct settings for your cluster exists. On a cluster with a generated CR, you must verify that the configuration in the CR is correct for your cluster and activate it.
+To use the control plane machine set, you must ensure that a `ControlPlaneMachineSet` custom resource (CR) with the correct settings for your cluster exists. On a cluster with a generated CR, you must verify that the configuration in the CR is correct for your cluster and activate it.
 
 [NOTE]
 ====
-For more information about the parameters in the CR, see "Control Plane Machine Set Operator configuration".
+For more information about the parameters in the CR, see "Control plane machine set configuration".
 ====
 
 .Procedure
@@ -28,5 +28,5 @@ $ oc --namespace openshift-machine-api edit controlplanemachineset.machine.opens
 +
 [IMPORTANT]
 ====
-To activate the CR, you must change the `.spec.state` field to `Active` in the same `oc edit` session that you use to update the CR configuration. If the CR is saved with the state left as `Inactive`, the control plane machine set generator resets the CR to its original settings. 
+To activate the CR, you must change the `.spec.state` field to `Active` in the same `oc edit` session that you use to update the CR configuration. If the CR is saved with the state left as `Inactive`, the control plane machine set generator resets the CR to its original settings.
 ====

--- a/modules/cpmso-checking-status.adoc
+++ b/modules/cpmso-checking-status.adoc
@@ -20,7 +20,8 @@ You can verify the existence and state of the `ControlPlaneMachineSet` custom re
 +
 [source,terminal]
 ----
-$ oc get controlplanemachineset.machine.openshift.io cluster --namespace openshift-machine-api
+$ oc get controlplanemachineset.machine.openshift.io cluster \
+  --namespace openshift-machine-api
 ----
 
 ** A result of `Active` indicates that the `ControlPlaneMachineSet` CR exists and is activated. No administrator action is required.
@@ -32,7 +33,7 @@ $ oc get controlplanemachineset.machine.openshift.io cluster --namespace openshi
 ifndef::cpmso-disabling[]
 .Next steps
 
-To use the control plane machine set, you must ensure that a `ControlPlaneMachineSet` CR with the correct settings for your cluster exists. 
+To use the control plane machine set, you must ensure that a `ControlPlaneMachineSet` CR with the correct settings for your cluster exists.
 
 * If your cluster has an existing CR, you must verify that the configuration in the CR is correct for your cluster.
 

--- a/modules/cpmso-creating-cr.adoc
+++ b/modules/cpmso-creating-cr.adoc
@@ -6,11 +6,11 @@
 [id="cpmso-creating-cr_{context}"]
 = Creating a control plane machine set custom resource
 
-To use the Control Plane Machine Set Operator, you must ensure that a `ControlPlaneMachineSet` custom resource (CR) with the correct settings for your cluster exists. On a cluster without a generated CR, you must create the CR manually and activate it.
+To use the control plane machine set, you must ensure that a `ControlPlaneMachineSet` custom resource (CR) with the correct settings for your cluster exists. On a cluster without a generated CR, you must create the CR manually and activate it.
 
 [NOTE]
 ====
-For more information about the structure and parameters of the CR, see "Control Plane Machine Set Operator configuration".
+For more information about the structure and parameters of the CR, see "Control plane machine set configuration".
 ====
 
 .Procedure
@@ -58,15 +58,15 @@ spec:
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
-<2> Specify the state of the Operator. When the state is `Inactive`, the Operator is not operational. You can activate the Operator by setting the value to `Active`. 
+<2> Specify the state of the Operator. When the state is `Inactive`, the Operator is not operational. You can activate the Operator by setting the value to `Active`.
 +
 [IMPORTANT]
 ====
 Before you activate the CR, you must ensure that its configuration is correct for your cluster requirements.
 ====
-<3> Specify the update strategy for the cluster. The allowed values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`. 
+<3> Specify the update strategy for the cluster. The allowed values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`.
 //Todo: For more information about update strategies, see "Updating the control plane configuration".
-<4> Specify your cloud provider platform name. The allowed values are `AWS`, `Azure`, and `VSphere`. 
+<4> Specify your cloud provider platform name. The allowed values are `AWS`, `Azure`, and `VSphere`.
 <5> Add the `<platform_failure_domains>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample failure domain configuration for your cloud provider.
 +
 [NOTE]

--- a/modules/cpmso-deleting.adoc
+++ b/modules/cpmso-deleting.adoc
@@ -14,7 +14,8 @@ To stop managing control plane machines with the control plane machine set on yo
 +
 [source,terminal]
 ----
-$ oc delete controlplanemachineset.machine.openshift.io cluster --namespace openshift-machine-api
+$ oc delete controlplanemachineset.machine.openshift.io cluster \
+  -n openshift-machine-api
 ----
 
 .Verification

--- a/modules/cpmso-failure-domains-provider.adoc
+++ b/modules/cpmso-failure-domains-provider.adoc
@@ -6,7 +6,7 @@
 [id="cpmso-failure-domains-provider_{context}"]
 = Failure domain platform support and configuration
 
-The control plane machine set concept of a failure domain is analogous to existing concepts on cloud providers. Not all platforms support the use of failure domains. 
+The control plane machine set concept of a failure domain is analogous to existing concepts on cloud providers. Not all platforms support the use of failure domains.
 
 .Failure domain support matrix
 [cols="<.^,^.^,^.^"]

--- a/modules/cpmso-feat-config-update.adoc
+++ b/modules/cpmso-feat-config-update.adoc
@@ -12,7 +12,7 @@ The Control Plane Machine Set Operator monitors the control plane machines and c
 
 [NOTE]
 ====
-For more information about the parameters in the CR, see "Control Plane Machine Set Operator configuration".
+For more information about the parameters in the CR, see "Control plane machine set configuration".
 ====
 
 .Prerequisites
@@ -25,7 +25,8 @@ For more information about the parameters in the CR, see "Control Plane Machine 
 +
 [source,terminal]
 ----
-$ oc --namespace openshift-machine-api edit controlplanemachineset.machine.openshift.io cluster
+$ oc edit controlplanemachineset.machine.openshift.io cluster \
+  -n openshift-machine-api
 ----
 
 . Change the values of any fields that you want to update in your cluster configuration.
@@ -34,6 +35,6 @@ $ oc --namespace openshift-machine-api edit controlplanemachineset.machine.opens
 
 .Next steps
 
-* For clusters that use the default `RollingUpdate` update strategy, the Operator automatically propagates the changes to your control plane configuration.
+* For clusters that use the default `RollingUpdate` update strategy, the changes to your control plane configuration are propagated automatically.
 
 * For clusters that are configured to use the `OnDelete` update strategy, you must replace your control plane machines manually.

--- a/modules/cpmso-overview.adoc
+++ b/modules/cpmso-overview.adoc
@@ -6,8 +6,8 @@
 [id="cpmso-overview_{context}"]
 = Control Plane Machine Set Operator overview
 
-The Control Plane Machine Set Operator uses the `ControlPlaneMachineSet` custom resource (CR) to automate management of the control plane machine resources within your {product-title} cluster. 
+The Control Plane Machine Set Operator uses the `ControlPlaneMachineSet` custom resource (CR) to automate management of the control plane machine resources within your {product-title} cluster.
 
 When the state of the cluster control plane machine set is set to `Active`, the Operator ensures that the cluster has the correct number of control plane machines with the specified configuration. This allows the automated replacement of degraded control plane machines and rollout of changes to the control plane.
 
-A cluster has only one control plane machine set, and the Operator only manages objects in the `openshift-machine-api` namespace. 
+A cluster has only one control plane machine set, and the Operator only manages objects in the `openshift-machine-api` namespace.

--- a/modules/cpmso-ts-ilb-missing.adoc
+++ b/modules/cpmso-ts-ilb-missing.adoc
@@ -16,7 +16,9 @@ For more information about where this parameter is located in the Azure provider
 +
 [source,terminal]
 ----
-$ oc get machines -l machine.openshift.io/cluster-api-machine-role==master -n openshift-machine-api
+$ oc get machines \
+  -l machine.openshift.io/cluster-api-machine-role==master \
+  -n openshift-machine-api
 ----
 
 . For each control plane machine, edit the CR by running the following command:
@@ -32,7 +34,8 @@ $ oc edit machine <control_plane_machine_name>
 +
 [source,terminal]
 ----
-$ oc --namespace openshift-machine-api edit controlplanemachineset.machine.openshift.io cluster
+$ oc edit controlplanemachineset.machine.openshift.io cluster \
+  -n openshift-machine-api
 ----
 
 . Add the `internalLoadBalancer` parameter with the correct details for your cluster and save your changes.

--- a/modules/cpmso-ts-mhc-etcd-degraded.adoc
+++ b/modules/cpmso-ts-mhc-etcd-degraded.adoc
@@ -6,9 +6,9 @@
 [id="cpmso-ts-etcd-degraded_{context}"]
 = Recovering a degraded etcd Operator
 
-Certain situations can cause the etcd Operator to become degraded. 
+Certain situations can cause the etcd Operator to become degraded.
 
-For example, while performing remediation, the machine health check might delete a control plane machine that is hosting etcd. If the etcd member is not reachable at that time, the etcd Operator becomes degraded. 
+For example, while performing remediation, the machine health check might delete a control plane machine that is hosting etcd. If the etcd member is not reachable at that time, the etcd Operator becomes degraded.
 
 When the etcd Operator is degraded, manual intervention is required to force the Operator to remove the failed member and restore the cluster state.
 
@@ -18,7 +18,10 @@ When the etcd Operator is degraded, manual intervention is required to force the
 +
 [source,terminal]
 ----
-$ oc get machines -l machine.openshift.io/cluster-api-machine-role==master -n openshift-machine-api -o wide
+$ oc get machines \
+  -l machine.openshift.io/cluster-api-machine-role==master \
+  -n openshift-machine-api \
+  -o wide
 ----
 +
 Any of the following conditions might indicate a failed control plane machine:

--- a/modules/cpmso-yaml-sample-cr.adoc
+++ b/modules/cpmso-yaml-sample-cr.adoc
@@ -50,11 +50,11 @@ spec:
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
-<4> Specifies the state of the Operator. When the state is `Inactive`, the Operator is not operational. You can activate the Operator by setting the value to `Active`. 
+<4> Specifies the state of the Operator. When the state is `Inactive`, the Operator is not operational. You can activate the Operator by setting the value to `Active`.
 +
 [IMPORTANT]
 ====
-Before you activate the Operator, you must ensure that the `ControlPlaneMachineSet` CR configuration is correct for your cluster requirements. For more information about activating the Control Plane Machine Set Operator, see "Getting started with the Control Plane Machine Set Operator".
+Before you activate the Operator, you must ensure that the `ControlPlaneMachineSet` CR configuration is correct for your cluster requirements. For more information about activating the Control Plane Machine Set Operator, see "Getting started with control plane machine sets".
 ====
 <5> Specifies the update strategy for the cluster. The allowed values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`. For more information about update strategies, see "Updating the control plane configuration".
 <6> Specifies the cloud provider platform name. Do not change this value.

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -77,7 +77,7 @@ include::modules/control-plane-machine-set-operator.adoc[leveloffset=+1]
 [id="additional-resources_cluster-op-ref-cpmso"]
 === Additional resources
 
-* xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[About the Control Plane Machine Set Operator]
+* xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[About control plane machine sets]
 * xref:../rest_api/machine_apis/controlplanemachineset-machine-openshift-io-v1.adoc#controlplanemachineset-machine-openshift-io-v1[`ControlPlaneMachineSet` custom resource]
 
 include::modules/cluster-dns-operator.adoc[leveloffset=+1]

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -556,7 +556,7 @@ include::modules/nodes-cluster-worker-latency-profiles-using.adoc[leveloffset=+2
 [id="post-install-cpms-setup"]
 == Managing control plane machines
 
-xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[Control plane machine sets] provide management capabilities for control plane machines that are similar to what compute machine sets provide for compute machines. The availability and initial status of control plane machine sets on your cluster depend on your cloud provider and the version of {product-title} that you installed. For more information, see xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with the Control Plane Machine Set Operator].
+xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[Control plane machine sets] provide management capabilities for control plane machines that are similar to what compute machine sets provide for compute machines. The availability and initial status of control plane machine sets on your cluster depend on your cloud provider and the version of {product-title} that you installed. For more information, see xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with control plane machine sets].
 
 [id="post-install-creating-infrastructure-machinesets-production"]
 == Creating infrastructure machine sets for production environments

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -65,7 +65,7 @@ include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+2]
 include::modules/machine-health-checks-about.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[About the Control Plane Machine Set Operator]
+* xref:../machine_management/control_plane_machine_management/cpmso-about.adoc#cpmso-about[About control plane machine sets]
 
 include::modules/machine-health-checks-resource.adoc[leveloffset=+2]
 include::modules/machine-health-checks-creating.adoc[leveloffset=+2]

--- a/scalability_and_performance/recommended-host-practices.adoc
+++ b/scalability_and_performance/recommended-host-practices.adoc
@@ -19,7 +19,7 @@ If the control plane machines in an Amazon Web Services (AWS) cluster require mo
 
 [NOTE]
 ====
-The procedure for clusters that use a control plane machine set is different than the procedure for clusters that do not use a control plane machine set. 
+The procedure for clusters that use a control plane machine set is different than the procedure for clusters that do not use a control plane machine set.
 
 If you are uncertain about the state of the `ControlPlaneMachineSet` CR in your cluster, you can xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-checking-status_cpmso-getting-started[verify the CR status].
 ====
@@ -29,7 +29,7 @@ include::modules/cpms-changing-aws-instance-type.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-using[Managing control plane machines with the Control Plane Machine Set Operator]
+* xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-using[Managing control plane machines with control plane machine sets]
 
 //Changing the Amazon Web Services instance type by using the AWS console
 include::modules/aws-console-changing-aws-instance-type.adoc[leveloffset=+3]


### PR DESCRIPTION
Cherrypicked from e734b79555bae65b9ea8ed3bbf2371eebf7c1458 xref: #57077 

This is a manual cherrypick of #57077 because no references to GCP can be ported into 4.12