### PR TITLE
OSDOCS-5723: Adding known issue to Compliance Operator 0.1.57+

### DIFF
--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -39,6 +39,21 @@ The following advisory is available for the OpenShift Compliance Operator 1.0.0:
 
 * Before this update, the `rhcos4-enable-fips-mode` rule description was misleading that FIPS could be enabled after installation. With this update, the `rhcos4-enable-fips-mode` rule description clarifies that FIPS must be enabled at install time. (link:https://issues.redhat.com/browse/OCPBUGS-8358[*OCPBUGS-8358*])
 
+[id="compliance-operator-1-0-0-known-issue"]
+=== Known issue
+
+In Compliance Operator 0.1.61, the `eventRecordQPS` variable is set to `10` by default, an increase from `5` in previous releases.
+
+If necessary, apply a tailored profile to set the `ocp4-var-event-record-qps` variable to match the output from the following command:
+
+[source,terminal]
+----
+$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); \
+     do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | \
+     jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' | \
+     grep eventRecordQPS; done
+----
+
 [id="compliance-operator-release-notes-0-1-61"]
 == OpenShift Compliance Operator 0.1.61
 
@@ -81,6 +96,21 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.61
 
 * Before this update, the `selinux_confinement_of_daemons` rule failed running on the kubelet because of the permissions necessary for the kubelet to run. With this update, the `selinux_confinement_of_daemons` rule is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-6968[*OCPBUGS-6968*])
 
+[id="compliance-operator-0-1-61-known-issue"]
+=== Known issue
+
+In Compliance Operator 0.1.61, the `eventRecordQPS` variable is set to `10` by default, an increase from `5` in previous releases.
+
+If necessary, apply a tailored profile to set the `ocp4-var-event-record-qps` variable to match the output from the following command:
+
+[source,terminal]
+----
+$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); \
+     do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | \
+     jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' | \
+     grep eventRecordQPS; done
+----
+
 [id="compliance-operator-release-notes-0-1-59"]
 == OpenShift Compliance Operator 0.1.59
 
@@ -101,6 +131,22 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.59
 * Previously, after the recent update to version 0.1.57, the `rerunner` service account (SA) was no longer owned by the cluster service version (CSV), which caused the SA to be removed during the Operator upgrade. Now, the CSV owns the `rerunner` SA in 0.1.59, and upgrades from any previous version will not result in a missing SA. (link:https://issues.redhat.com/browse/OCPBUGS-3452[*OCPBUGS-3452*])
 
 * In 0.1.57, the Operator started the controller metrics endpoint listening on port `8080`. This resulted in `TargetDown` alerts since cluster monitoring expected port is `8383`. With 0.1.59, the Operator starts the endpoint listening on port `8383` as expected. (link:https://issues.redhat.com/browse/OCPBUGS-3097[*OCPBUGS-3097*])
+
+[id="compliance-operator-0-1-59-known-issue"]
+=== Known issue
+
+In Compliance Operator 0.1.59, the `eventRecordQPS` variable is set to `10` by default, an increase from `5` in previous releases.
+
+If necessary, apply a tailored profile to set the `ocp4-var-event-record-qps` variable to match the output from the following command:
+
+[source,terminal]
+----
+$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); \
+     do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | \
+     jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' | \
+     grep eventRecordQPS; done
+----
+
 
 [id="compliance-operator-release-notes-0-1-57"]
 == OpenShift Compliance Operator 0.1.57
@@ -142,6 +188,22 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.57
 * Previously, the Compliance Operator would fail to fetch API resources when parsing machine configurations without Ignition specifications, which caused the `api-check-pods` processes to crash loop. Now, the Compliance Operator handles Machine Config Pools that do not have Ignition specifications correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2117268[*BZ#2117268*])
 
 * Previously, rules evaluating the `modprobe` configuration would fail even after applying remediations due to a mismatch in values for the `modprobe` configuration. Now, the same values are used for the `modprobe` configuration in checks and remediations, ensuring consistent results. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2117747[*BZ#2117747*])
+
+[id="compliance-operator-0-1-57-known-issue"]
+=== Known issue
+
+In Compliance Operator 0.1.57, the `eventRecordQPS` variable is set to `10` by default, an increase from `5` in previous releases.
+
+If necessary, apply a tailored profile to set the `ocp4-var-event-record-qps` variable to match the output from the following command:
+
+[source,terminal]
+----
+$ for NODE_NAME in $(oc get nodes -ojsonpath='{.items[*].metadata.name}'); \
+     do oc get --raw /api/v1/nodes/$NODE_NAME/proxy/configz | \
+     jq '.kubeletconfig|.kind="KubeletConfiguration"|.apiVersion="kubelet.config.k8s.io/v1beta1"' | \
+     grep eventRecordQPS; done
+----
+
 
 [id="compliance-operator-0-1-57-deprecations"]
 === Deprecations


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-5723

Link to docs preview (VPN required):
[Compliance Operator known issue](http://file.rdu.redhat.com/antaylor/co-known-issue/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-0-1-61-known-issue)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Adds a known issue to the release notes.