### PR TITLE
OSDOCS-3796: Private/Public Subnet

### DIFF
--- a/modules/ccs-aws-provisioned.adoc
+++ b/modules/ccs-aws-provisioned.adoc
@@ -64,7 +64,12 @@ Two buckets are required with a typical size of 2 TB each.
 Customers should expect to see one VPC per cluster. Additionally, the VPC needs the following configurations:
 
 * *Subnets*: Two subnets for a cluster with a single availability zone, or six subnets for a cluster with multiple availability zones.
-
++
+[NOTE]
+====
+A *public subnet* connects directly to the internet through an internet gateway. A *private subnet* connects to the internet through a network address translation (NAT) gateway.
+====
++ 
 * *Route tables*: One route table per private subnet, and one additional table per cluster.
 
 * *Internet gateways*: One Internet Gateway per cluster.

--- a/modules/osd-aws-privatelink-architecture.adoc
+++ b/modules/osd-aws-privatelink-architecture.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/rosa_architecture_sub/rosa-architecture-models.adoc
+
 [id="osd-aws-privatelink-architecture.adoc_{context}"]
 = AWS PrivateLink architecture
 
@@ -18,6 +22,11 @@ image::156_OpenShift_ROSA_Arch_0621_privatelink.svg[Multi-AZ AWS PrivateLink clu
 == AWS reference architectures
 
 AWS provides multiple reference architectures that can be useful to customers when planning how to set up a configuration that uses AWS PrivateLink. Here are three examples:
+
+[NOTE]
+====
+A *public subnet* connects directly to the internet through an internet gateway. A *private subnet* connects to the internet through a network address translation (NAT) gateway.
+====
 
 * VPC with a private subnet and AWS Site-to-Site VPN access.
 +

--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -67,7 +67,12 @@ Two buckets are required with a typical size of 2TB each.
 Customers should expect to see one VPC per cluster. Additionally, the VPC will need the following configurations:
 
 * *Subnets*: Two subnets for a cluster with a single availability zone, or six subnets for a cluster with multiple availability zones.
-
++
+[NOTE]
+====
+A *public subnet* connects directly to the internet through an internet gateway. A *private subnet* connects to the internet through a network address translation (NAT) gateway.
+====
++ 
 * *Route tables*: One route table per private subnet, and one additional table per cluster.
 
 * *Internet gateways*: One Internet Gateway per cluster.


### PR DESCRIPTION
[OSDOCS-3796](https://issues.redhat.com//browse/OSDOCS-3796)

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-3796

Link to docs preview:
Page 1: https://58047--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html
Page 2: https://58047--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_architecture_sub/rosa-architecture-models.html
Page 3: https://58047--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
