### PR TITLE
OSDOCS-5348: 4.13 Module to Automate workaround for SELinux relabeling issue for large volumes

### DIFF
--- a/modules/nodes-pods-configuring-reducing.adoc
+++ b/modules/nodes-pods-configuring-reducing.adoc
@@ -17,6 +17,8 @@ You can reduce this delay by applying one of the following workarounds:
 
 * Use the `fsGroupChangePolicy` field inside an SCC to control the way that {product-title} checks and manages ownership and permissions for a volume.
 
+* Use the Cluster Resource Override Operator to automatically apply an SCC to skip the SELinux relabeling.
+
 * Use a runtime class to skip the SELinux relabeling for a volume.
 
 For information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5347

Add the [4.13+ workaround from Ryan P](https://docs.google.com/document/d/1u96QZUdAZmurhPBjMue_ieyURsrM57p8gS8KqvJSvrE/edit#heading=h.rk0d81h4r775).

Preview: [Reducing pod timeouts when using persistent volumes with high file counts](https://58056--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-reducing_nodes-pods-configuring)