### PR TITLE
OSDOCS-5664: Adds notes for 4.12.10 MS release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -158,3 +158,12 @@ Issued: 2023-03-27
 * Previously, installing and starting {product-title} using an 4.12.7 RPM failed with an error. With this update, {product-title} starts successfully. (link:https://issues.redhat.com/browse/OCPBUGS-10347[*OCPBUGS-10347*])
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-10-dp"]
+=== RHBA-2023:1511 - {product-title} 4.12.10 bug fix update
+
+Issued: 2023-04-03
+
+{product-title} release 4.12.10 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1511[RHBA-2023:1511] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1508[RHBA-2023:1508] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
[OSDOCS-5664](https://issues.redhat.com//browse/OSDOCS-5664): Adds notes for 4.12.10 MS release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5664

Link to docs preview:
https://58068--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-10-dp

QE review:
Qe not required for this update

Additional information:
Links will not work yet
