### PR TITLE
OSDOCS-5667: microshift release notes about OS and container runtime support

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -30,8 +30,16 @@ Red Hat does not support an update path from the Technology Preview version to l
 This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s, for example:
-//[id="microshift-4-13-rhel-edge"]
-//=== {op-system-ostree-first} {op-system-version}
+[id="microshift-4-13-rhel-edge"]
+=== {op-system-ostree-first} {op-system-version}
+* {product-title} runs on {op-system-ostree} version {op-system-version} or later.
+
+// Some details of the next note are adapted from https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/
+* {product-title} uses crun and Control Group v2 (cgroup v2). {OCP} {ocp-version} defaults to Control Group v1. The divergence of control group versions is not anticipated to have a noticeable behavior difference on most workloads. If workloads rely on the cgroup file system layout, they may need to be updated to be compatible with cgroup v2.
+
+** If you run third-party monitoring and security agents that depend on the cgroup file system, update the agents to versions that support cgroup v2.
+** If you run cAdvisor as a standalone DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
+** If you deploy Java applications with the JDK, ensure you are using JDK 11.0.16 and later or JDK 15 and later, which fully support cgroup v2.
 
 //[id="microshift-4-13-new-feat-based-on-{op-system-ostree}"]
 //==== Placeholder for new feat bases on RHEL Edge


### PR DESCRIPTION
The versions of Control Group between OCP and MicroShift are different. We do not expect that to introduce any behavior changes, but workloads that make assumptions about the container runtime may be affected.

Version(s): 4.13

Issue: None

Link to docs preview:
https://58070--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes.html#microshift-4-13-rhel-edge

QE review:
- [ ] QE reviewed

/assign @ShaunaDiaz 
/cc @xsgordon 
/cc @DanielFroehlich 
/cc @mrunalp 