### PR TITLE
OSDOCS-5577: oc-mirror tarball release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -578,6 +578,24 @@ If you are receiving pod security violations, see the following resources:
 
 * If necessary, you can set a custom admission profile on the namespace or pod by setting the `pod-security.kubernetes.io/enforce` label.
 
+[discrete]
+[id="ocp-4-13-oc-mirror-openshift-endpoint"]
+=== The oc-mirror plugin now retrieves graph data container images from an OpenShift API endpoint
+
+The oc-mirror OpenShift CLI (`oc`) plugin now downloads the graph data tarball from an OpenShift API endpoint instead of downloading the entire graph data repository from GitHub. Retrieving this data from Red Hat instead of an external vendor is more suitable for users with stringent security and compliance restrictions on external content.
+
+The data that the oc-mirror plugin downloads now excludes content that is in the graph data repository but not needed by the OpenShift Update Service. The container also uses UBI Micro as the base image instead of UBI, resulting in a container image that is significantly smaller than before.
+
+These changes do not affect the user workflow for the oc-mirror plugin.
+
+[discrete]
+[id="ocp-4-13-graph-data-openshift-endpoint"]
+=== The Dockerfile for the graph data container image is now retrieved from an OpenShift API endpoint
+
+If you are creating a graph data container image for the OpenShift Update Service by using the Dockerfile, note that the graph data tarball is now downloaded from an OpenShift API endpoint instead of GitHub.
+
+For more information, see xref:../updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc#update-service-graph-data_updating-restricted-network-cluster-osus[Creating the OpenShift Update Service graph data container image].
+
 [id="ocp-4-13-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
[OSDOCS-5577](https://issues.redhat.com/browse/OSDOCS-5577)

Version: 4.13

This PR adds a release note entry of a notable technical change, where the oc-mirror plugin retrieves the graph-data tarball from a RedHat hosted API endpoint instead of a GitHub repository.

QE review:
- [x] QE has approved this change.

Preview: 
https://58085--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-notable-technical-changes:~:text=ca.crt.-,The,-oc%2Dmirror%20plugin