### PR TITLE
OSDOCS-5637-batch2:adds bug batch to RNs for 4.13.0

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -820,6 +820,14 @@ With this release, replacement control plane nodes are assigned to the correct i
 [id="ocp-4-13-networking-bug-fixes"]
 ==== Networking
 
+* Previously, the Ingress Operator displayed a success message for the `updateIngressClass` function logs when an error message should be displayed. With this update, the log message for Ingress Operator is accurate. (link:https://issues.redhat.com/browse/OCPBUGS-6700[*OCPBUGS-6700*])
+
+* Previously, the Ingress Operator did not specify `ingressClass.spec.parameters.scope`, while the Ingress Class API object specifies type `cluster` by default. This caused unnecessary updates to all Ingress Classes when the Operator starts. With this update, the Ingress Operator specifies `ingressClass.spec.parameters.scope` of type `cluster`. (link:https://issues.redhat.com/browse/OCPBUGS-6701[*OCPBUGS-6701*])
+
+* Previously, the Ingress Operator had the wrong service name in `ensureNodePortService` log message causing incorrect information to be logged. With this update, the Ingress Operator accurately logs the service in `ensureNodePortService`. (link:https://issues.redhat.com/browse/OCPBUGS-6698[*OCPBUGS-6698*])
+
+* Previously, in {product-title} 4.7.0 and 4.6.20, the Ingress Operator used an annotation for router pods that was specific for {product-title}. This was a temporary way to configure the liveness probe's grace period in order to fix a bug. As a result, {product-title} was required to carry a patch to implement the fix. With this update, the Ingress Operator uses `terminationGracePeriodSeconds` API field making the previous patch removable in future releases. (link:https://issues.redhat.com/browse/OCPBUGS-4703[*OCPBUGS-4703*])
+
 [discrete]
 [id="ocp-4-13-node-bug-fixes"]
 ==== Node


### PR DESCRIPTION
[OSDOCS-5637](https://issues.redhat.com//browse/OSDOCS-5637): Bug batch 2 for 4.13.0 GA
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5637
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://58087--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-bug-fixes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
batch 1 https://github.com/openshift/openshift-docs/pull/57943
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
