### PR TITLE
Updated EUS module to be version-agnostic

### DIFF
--- a/modules/updating-eus-to-eus-upgrade.adoc
+++ b/modules/updating-eus-to-eus-upgrade.adoc
@@ -6,12 +6,12 @@
 [id="updating-eus-to-eus-upgrade_{context}"]
 = EUS-to-EUS update
 
-The following procedure pauses all non-master machine config pools and performs updates from {product-title} 4.10 to 4.11 to 4.12, then unpauses the previously paused machine config pools.
+The following procedure pauses all non-master machine config pools and performs updates from {product-title} <4.y> to <4.y+1> to <4.y+2>, then unpauses the previously paused machine config pools.
 Following this procedure reduces the total update duration and the number of times worker nodes are restarted.
 
 .Prerequisites
 
-* Review the release notes for {product-title} 4.11 and 4.12
+* Review the release notes for {product-title} <4.y+1> and <4.y+2>
 * Review the release notes and product lifecycles for any layered products and Operator Lifecycle Manager (OLM) Operators. Some may require updates either before or during an EUS-to-EUS update.
-* Ensure that you are familiar with version-specific prerequisites, such as link:https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-prepare.html#update-preparing-migrate_updating-cluster-prepare[administrator acknowledgement] that is required prior to updating from {product-title} 4.11 to 4.12.
+* Ensure that you are familiar with version-specific prerequisites, such as the removal of deprecated APIs, that are required prior to updating from {product-title} <4.y+1> to <4.y+2>.
 


### PR DESCRIPTION
Missed a small module related to the version-agnostic EUS initiative :) 

Version(s):
4.10+

Link to docs preview:
https://58091--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing-eus-eus-upgrade.html#updating-eus-to-eus-upgrade_eus-to-eus-upgrade

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
