### PR TITLE
OSDOCS-5670: Remove multicluster references

### DIFF
--- a/applications/working_with_helm_charts/understanding-helm.adoc
+++ b/applications/working_with_helm_charts/understanding-helm.adoc
@@ -26,10 +26,10 @@ Helm provides the ability to:
 * Create your own charts with {product-title} or Kubernetes resources.
 * Package and share your applications as charts.
 
-[NOTE]
-====
-In {product-title} 4.10 and 4.11, Helm is disabled for the xref:../../web_console/web-console.adoc#multi-cluster-about_web-console[Multicluster Console] (Technology Preview).
-====
+//[NOTE]
+//====
+// In {product-title} 4.10 and 4.11, Helm is disabled for the xref:../../web_console/web-console.adoc#multi-cluster-about_web-console[Multicluster Console] (Technology Preview).
+//====
 
 == Red Hat Certification of Helm charts for OpenShift
 

--- a/web_console/web-console.adoc
+++ b/web_console/web-console.adoc
@@ -21,8 +21,8 @@ Platform 4.x Tested Integrations] page before you create the supporting
 infrastructure for your cluster.
 
 include::modules/web-console-overview.adoc[leveloffset=+1]
-include::modules/multi-cluster-about.adoc[leveloffset=+1]
-include::modules/enabling-multi-cluster-console.adoc[leveloffset=+2]
+// include::modules/multi-cluster-about.adoc[leveloffset=+1]
+//include::modules/enabling-multi-cluster-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
[OSDOCS-5670](https://issues.redhat.com//browse/OSDOCS-5670): Remove multicluster references

Version(s):
4.13
Need to check if backporting all the way to 4.10 (I think we will need to).

Issue:
https://issues.redhat.com/browse/OSDOCS-5670>

Link to docs preview:
https://58093--docspreview.netlify.app/openshift-enterprise/latest/web_console/web-console.html
https://docs.openshift.com/container-platform/4.12/applications/working_with_helm_charts/understanding-helm.html#additional-resources

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Release notes will be updated in follow-up PRs.
