### PR TITLE
[OSDOCS-5672]: Deprecated k8s topo labels

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -794,6 +794,16 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Deprecated
 
+|Kubernetes topology label `failure-domain.beta.kubernetes.io/zone`
+|General Availability
+|General Availability
+|Deprecated
+
+|Kubernetes topology label `failure-domain.beta.kubernetes.io/region`
+|General Availability
+|General Availability
+|Deprecated
+
 |====
 
 [id="ocp-4-13-deprecated-features"]
@@ -847,6 +857,13 @@ The toolbox script is deprecated and support will be removed from a future {prod
 * `platform.vsphere.apiVIP`
 * `platform.vsphere.ingressVIP`
 * `platform.vsphere.network`
+
+[id="ocp-4-13-node-dep-topology-labels"]
+==== Kubernetes topology labels
+
+Two commonly used Kubernetes topology labels are being replaced. The `failure-domain.beta.kubernetes.io/zone` label is replaced with `topology.kubernetes.io/zone`. The `failure-domain.beta.kubernetes.io/region` label is replaced with `topology.kubernetes.io/region`. The replacement labels are available starting with Kubernetes 1.17 and {product-title} version 4.4.
+
+Currently, both the deprecated and replacement labels are supported, but support for the deprecated labels is planned to be removed in a future release. To prepare for the removal, you can modify any resources (such as volumes, deployments, or other workloads) that reference the deprecated labels to use the replacement labels instead.
 
 [id="ocp-4-13-removed-features"]
 === Removed features


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-5672](https://issues.redhat.com//browse/OSDOCS-5672)

Link to docs preview:
* [Node deprecated and removed features](https://58098--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#node-deprecated-and-removed-features)
* Deprecated features > [Kubernetes topology labels](https://58098--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-node-dep-topology-labels)

QE review:
- [x] QE has approved this change.

