### PR TITLE
OADP 1442 - resourceTimeouts

### DIFF
--- a/modules/oadp-installing-dpa.adoc
+++ b/modules/oadp-installing-dpa.adoc
@@ -54,40 +54,42 @@ spec:
       defaultPlugins:
         - openshift <1>
         - aws
+      resourceTimeout: 10m <2>
     restic:
-      enable: true <2>
+      enable: true <3>
       podConfig:
-        nodeSelector: <node selector> <3>
+        nodeSelector: <node_selector> <4>
   backupLocations:
     - name: default
       velero:
         provider: {provider}
         default: true
         objectStorage:
-          bucket: <bucket_name> <4>
-          prefix: <prefix> <5>
+          bucket: <bucket_name> <5>
+          prefix: <prefix> <6>
         config:
           region: <region>
           profile: "default"
         credential:
           key: cloud
-          name: {credentials} <6>
-  snapshotLocations: <7>
+          name: {credentials} <7>
+  snapshotLocations: <8>
     - name: default
       velero:
         provider: {provider}
         config:
-          region: <region> <8>
+          region: <region> <9>
           profile: "default"
 ----
 <1> The `openshift` plugin is mandatory.
-<2> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<3> Specify the node selector to be supplied to Restic podSpec.
-<4> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<5> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
-<6> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<7> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
-<8> The snapshot location must be in the same region as the PVs.
+<2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
+<3> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
+<5> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<6> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<7> Specify the name of the `Secret` object that you created. If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<8> Specify a snapshot location, unless you use CSI snapshots or Restic to back up PVs.
+<9> The snapshot location must be in the same region as the PVs.
 endif::[]
 ifdef::installing-oadp-azure[]
 +
@@ -104,26 +106,27 @@ spec:
       defaultPlugins:
         - azure
         - openshift <1>
+      resourceTimeout: 10m <2>
     restic:
-      enable: true <2>
+      enable: true <3>
       podConfig:
-        nodeSelector: <node selector> <3>
+        nodeSelector: <node_selector> <4>
   backupLocations:
     - velero:
         config:
-          resourceGroup: <azure_resource_group> <4>
-          storageAccount: <azure_storage_account_id> <5>
-          subscriptionId: <azure_subscription_id> <6>
+          resourceGroup: <azure_resource_group> <5>
+          storageAccount: <azure_storage_account_id> <6>
+          subscriptionId: <azure_subscription_id> <7>
           storageAccountKeyEnvVar: AZURE_STORAGE_ACCOUNT_ACCESS_KEY
         credential:
           key: cloud
-          name: {credentials}  <7>
+          name: {credentials}  <8>
         provider: {provider}
         default: true
         objectStorage:
-          bucket: <bucket_name> <8>
-          prefix: <prefix> <9>
-  snapshotLocations: <10>
+          bucket: <bucket_name> <9>
+          prefix: <prefix> <10>
+  snapshotLocations: <11>
     - velero:
         config:
           resourceGroup: <azure_resource_group>
@@ -133,15 +136,16 @@ spec:
         provider: {provider}
 ----
 <1> The `openshift` plugin is mandatory.
-<2> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<3> Specify the node selector to be supplied to Restic podSpec.
-<4> Specify the Azure resource group.
-<5> Specify the Azure storage account ID.
-<6> Specify the Azure subscription ID.
-<7> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<8> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<9> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
-<10> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
+<2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
+<3> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
+<5> Specify the Azure resource group.
+<6> Specify the Azure storage account ID.
+<7> Specify the Azure subscription ID.
+<8> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<9> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<10> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<11> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
 endif::[]
 ifdef::installing-oadp-gcp[]
 +
@@ -158,36 +162,38 @@ spec:
       defaultPlugins:
         - gcp
         - openshift <1>
+      resourceTimeout: 10m <2>
     restic:
-      enable: true <2>
+      enable: true <3>
       podConfig:
-        nodeSelector: <node selector> <3>
+        nodeSelector: <node_selector> <4>
   backupLocations:
     - velero:
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} <4>
+          name: {credentials} <5>
         objectStorage:
-          bucket: <bucket_name> <5>
-          prefix: <prefix> <6>
-  snapshotLocations: <7>
+          bucket: <bucket_name> <6>
+          prefix: <prefix> <7>
+  snapshotLocations: <8>
     - velero:
         provider: {provider}
         default: true
         config:
           project: <project>
-          snapshotLocation: us-west1 <8>
+          snapshotLocation: us-west1 <9>
 ----
 <1> The `openshift` plugin is mandatory.
-<2> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<3> Specify the node selector to be supplied to Restic podSpec.
-<4> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<5> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<6> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
-<7> You do not need to specify a snapshot location if you use CSI snapshots or Restic to back up PVs.
-<8> The snapshot location must be in the same region as the PVs.
+<2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
+<3> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
+<5> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<6> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<7> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<8> Specify a snapshot location, unless you use CSI snapshots or Restic to back up PVs.
+<9> The snapshot location must be in the same region as the PVs.
 endif::[]
 ifdef::installing-oadp-mcg[]
 +
@@ -204,34 +210,36 @@ spec:
       defaultPlugins:
         - aws
         - openshift <1>
+      resourceTimeout: 10m <2>
     restic:
-      enable: true <2>
+      enable: true <3>
       podConfig:
-        nodeSelector: <node selector> <3>
+        nodeSelector: <node_selector> <4>
   backupLocations:
     - velero:
         config:
           profile: "default"
           region: minio
-          s3Url: <url> <4>
+          s3Url: <url> <5>
           insecureSkipTLSVerify: "true"
           s3ForcePathStyle: "true"
         provider: {provider}
         default: true
         credential:
           key: cloud
-          name: {credentials} <5>
+          name: {credentials} <6>
         objectStorage:
-          bucket: <bucket_name> <6>
-          prefix: <prefix> <7>
+          bucket: <bucket_name> <7>
+          prefix: <prefix> <8>
 ----
 <1> The `openshift` plugin is mandatory.
-<2> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<3> Specify the node selector to be supplied to Restic podSpec.
-<4> Specify the URL of the S3 endpoint.
-<5> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
-<6> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<7> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
+<3> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
+<5> Specify the URL of the S3 endpoint.
+<6> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
+<7> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<8> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 ifdef::installing-oadp-ocs[]
 +
@@ -250,31 +258,33 @@ spec:
         - gcp <2>
         - csi <3>
         - openshift <4>
+      resourceTimeout: 10m <5>
     restic:
-      enable: true <5>
+      enable: true <6>
       podConfig:
-        nodeSelector: <node selector> <6>
+        nodeSelector: <node_selector> <7>
   backupLocations:
     - velero:
-        provider: {provider} <7>
+        provider: {provider} <8>
         default: true
         credential:
           key: cloud
-          name: <default_secret> <8>
+          name: <default_secret> <9>
         objectStorage:
-          bucket: <bucket_name> <9>
-          prefix: <prefix> <10>
+          bucket: <bucket_name> <10>
+          prefix: <prefix> <11>
 ----
 <1> Optional: The `kubevirt` plugin is used with {VirtProductName}.
 <2> Specify the default plugin for the backup provider, for example, `gcp`, if appropriate.
 <3> Specify the `csi` default plugin if you use CSI snapshots to back up PVs. The `csi` plugin uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
 <4> The `openshift` plugin is mandatory.
-<5> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<6> Specify the node selector to be supplied to Restic podSpec
-<7> Specify the backup provider.
-<8> If you use a default plugin for the backup provider, you must specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`. If you specify a custom name, the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
-<9> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<10> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<5> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
+<6> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<7> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
+<8> Specify the backup provider.
+<9> Specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`, if you use a default plugin for the backup provider. If specifying a custom name, then the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
+<10> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<11> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 ifdef::virt-installing-configuring-oadp[]
 +
@@ -293,31 +303,33 @@ spec:
         - gcp <2>
         - csi <3>
         - openshift <4>
+      resourceTimeout: 10m <5>
     restic:
-      enable: true <5>
+      enable: true <6>
       podConfig:
-        nodeSelector: <node selector> <6>
+        nodeSelector: <node_selector> <7>
   backupLocations:
     - velero:
-        provider: {provider} <7>
+        provider: {provider} <8>
         default: true
         credential:
           key: cloud
-          name: <default_secret> <8>
+          name: <default_secret> <9>
         objectStorage:
-          bucket: <bucket_name> <9>
-          prefix: <prefix> <10>
+          bucket: <bucket_name> <10>
+          prefix: <prefix> <11>
 ----
 <1> The `kubevirt` plugin is mandatory for {VirtProductName}.
 <2> Specify the plugin for the backup provider, for example, `gcp`, if it exists.
 <3> The `csi` plugin is mandatory for backing up PVs with CSI snapshots. The `csi` plugin uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
 <4> The `openshift` plugin is mandatory.
-<5> Set to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
-<6> Specify the node selector to be supplied to Restic podSpec
-<7> Specify the backup provider.
-<8> If you use a default plugin for the backup provider, you must specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`. If you specify a custom name, the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
-<9> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
-<10> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
+<5> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
+<6> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<7> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
+<8> Specify the backup provider.
+<9> Specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`, if you use a default plugin for the backup provider. If specifying a custom name, then the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
+<10> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
+<11> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
 endif::[]
 
 . Click *Create*.


### PR DESCRIPTION
OADP - 1.2.0 
OCP - 4.10 +

Resolves - https://issues.redhat.com/browse/OADP-1442

Deploy preview - 

resourceTimeout has been updated in the "Installing the Data Protection Application section" in the following sections:

 https://58111--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html

https://58111--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.html

https://58111--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.html

https://58111--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.html













