### PR TITLE
RHDEVDOCS-5095: Adding 4.13 version to GitOps v1.8.1 RN after OCP 4.1…

### DIFF
--- a/modules/gitops-release-notes-1-8-1.adoc
+++ b/modules/gitops-release-notes-1-8-1.adoc
@@ -7,7 +7,7 @@
 [id="gitops-release-notes-1-8-1_{context}"]
 = Release notes for {gitops-title} 1.8.1
 
-{gitops-title} 1.8.1 is now available on {product-title} 4.10, 4.11, and 4.12.
+{gitops-title} 1.8.1 is now available on {product-title} 4.10, 4.11, 4.12, and 4.13.
 
 [id="errata-updates-1-8-1_{context}"]
 == Errata updates


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: enterprise-4.10 and later
• **JIRA issue**: [RHDEVDOCS-5095](https://issues.redhat.com/browse/RHDEVDOCS-5095)
• **Preview page**: [Release notes for Red Hat OpenShift GitOps 1.8.1](https://58114--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-8-1_gitops-release-notes)
• **SME Review**: Completed by @jaideepr97
• **QE review**: Completed by @varshab1210
• **Peer-review**: Completed by @abrennan89