### PR TITLE
OCPBUGS#11133: Updating FW for 14th generation

### DIFF
--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -28,7 +28,7 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 | Model | Management | Firmware versions
 
 | 15th Generation | iDRAC 9 | v6.10.30.00
-| 14th Generation | iDRAC 9 | v5.10.00.00 - v5.10.50.00 only
+| 14th Generation | iDRAC 9 | v6.10.30.00
 
 | 13th Generation .2+| iDRAC 8 | v2.75.75.75 or later
 


### PR DESCRIPTION
OCPBUGS-11133: Updating firmware for 14th gen servers

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-11133

Link to docs preview:
https://58115--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
