### PR TITLE
Release Note for TELCODOCS-782 - workload partitioning

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -495,6 +495,15 @@ This update adds the following features:
 
 For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-about-numa-aware-scheduling_numa-aware[Scheduling NUMA-aware workloads].
 
+[id="ocp-4-13-ran-workload-partitioning-three-node-standard-node"]
+==== Support for workload partitioning for three-node clusters and standard clusters 
+
+Before this update, workload partitioning was supported for {sno} clusters only.
+Now, you can also configure workload partitioning for three-node compact clusters and standard clusters.
+Use workload partitioning to isolate {product-title} services, cluster management workloads, and infrastructure pods to run on a reserved set of CPUs. 
+
+For more information, see xref:../scalability_and_performance/enabling-workload-partitioning.adoc#enabling-workload-partitioning[Workload partitioning].
+
 [id="ocp-4-13-configuring-power-states-using-ztp"]
 ==== Configuring power states using zero touch provisioning (ZTP)
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-782
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://58139--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-ran-workload-partitioning-three-node-standard-node
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
