### PR TITLE
[SRVCOM-2222] Add Serverless 1.28.0 release notes, update feature tables

### DIFF
--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -13,18 +13,20 @@ For the most recent list of major functionality deprecated and removed within {S
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Deprecated and removed features tracker
-[cols="3,1,1,1,1",options="header"]
+[cols="3,1,1,1,1,1",options="header"]
 |====
-|Feature |1.20|1.21|1.22 to 1.26|1.27
+|Feature |1.20|1.21|1.22 to 1.26|1.27|1.28
 
 |`KafkaBinding` API
 |Deprecated
 |Deprecated
 |Removed
 |Removed
+|Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |Deprecated
+|Removed
 |Removed
 |Removed
 |Removed
@@ -34,12 +36,14 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |-
 |-
 |Deprecated
+|Deprecated
 
-// |`enable-secret-informer-filtering` annotation
-// |-
-// |-
-// |-
-// |Deprecated
+|`enable-secret-informer-filtering` annotation
+|-
+|-
+|-
+|-
+|Deprecated
 
 |====
 endif::[]
@@ -47,20 +51,23 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Deprecated and removed features tracker
-[cols="3,1,1",options="header"]
+[cols="3,1,1,1",options="header"]
 |====
-|Feature |1.23 to 1.26|1.27
+|Feature |1.23 to 1.26|1.27|1.28
 
 |`KafkaBinding` API
+|Removed
 |Removed
 |Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
 |Removed
 |Removed
+|Removed
 
 |Serving and Eventing `v1alpha1` API
 |-
+|Deprecated
 |Deprecated
 
 |====

--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -24,14 +24,14 @@ You can use the Knative (`kn`) CLI to initiate a function project build and then
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.27.0/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.28.0/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
 ----
 
 .. Create the `kn func` deploy Tekton task to be able to deploy the function in the pipeline:
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.27.0/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.28.0/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
 ----
 
 . Create a function:

--- a/modules/serverless-rn-1-28-0.adoc
+++ b/modules/serverless-rn-1-28-0.adoc
@@ -16,13 +16,15 @@
 * {ServerlessProductName} now uses Kourier 1.7.
 * {ServerlessProductName} now uses Knative (`kn`) CLI 1.7.
 * {ServerlessProductName} now uses Knative Kafka 1.7.
-* The `kn func` CLI plug-in now uses `func` FIXME version.
+* The `kn func` CLI plug-in now uses `func` 1.9.1 version.
 
 * Node.js and TypeScript runtimes for {ServerlessProductName} Functions are now Generally Available (GA).
 
+* Python runtime for {ServerlessProductName} Functions is now available as a Technology Preview.
+
 * Multi-container support for Knative Serving is now available as a Technology Preview. This feature allows you to use a single Knative service to deploy a multi-container pod.
 
-* In a future release, the following components of Knative Eventing will be scaled down from two pods to one:
+* In {ServerlessProductName} 1.29 or later, the following components of Knative Eventing will be scaled down from two pods to one:
 +
 --
 * `imc-controller`

--- a/modules/serverless-rn-1-28-0.adoc
+++ b/modules/serverless-rn-1-28-0.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-28-0_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.28
+
+{ServerlessProductName} 1.28 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-1-28-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.7.
+* {ServerlessProductName} now uses Knative Eventing 1.7.
+* {ServerlessProductName} now uses Kourier 1.7.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.7.
+* {ServerlessProductName} now uses Knative Kafka 1.7.
+* The `kn func` CLI plug-in now uses `func` FIXME version.
+
+* Node.js and TypeScript runtimes for {ServerlessProductName} Functions are now Generally Available (GA).
+
+* Multi-container support for Knative Serving is now available as a Technology Preview. This feature allows you to use a single Knative service to deploy a multi-container pod.
+
+* In a future release, the following components of Knative Eventing will be scaled down from two pods to one:
++
+--
+* `imc-controller`
+* `imc-dispatcher`
+* `mt-broker-controller`
+* `mt-broker-filter`
+* `mt-broker-ingress`
+--
+
+* The `serverless.openshift.io/enable-secret-informer-filtering` annotation for the Serving CR is now deprecated. The annotation is valid only for Istio, and not for Kourier.
++
+With {ServerlessProductName} 1.28, the {ServerlessOperatorName} allows injecting the environment variable `ENABLE_SECRET_INFORMER_FILTERING_BY_CERT_UID` for both `net-istio` and `net-kourier`.
++
+To prevent problems when upgrading from {ServerlessProductName} 1.28 to some future version, users must annotate their secrets with `networking.internal.knative.dev/certificate-uid:some_cuid`.
+
+[id="known-issues-1-28-0_{context}"]
+== Known issues
+
+* Currently, runtimes for Python are not supported for {ServerlessProductName} Functions on IBM Power, IBM zSystems, and IBM(R) LinuxONE.
++
+Node.js, TypeScript, and Quarkus functions are supported on these architectures.
+
+* On the Windows platform, Python functions cannot be locally built, run, or deployed using the Source-to-Image builder due to the `app.sh` file permissions.
++
+To work around this problem, use the Windows Subsystem for Linux.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,9 +13,9 @@ The following table provides information about which {ServerlessProductName} fea
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1,1,1,1",options="header"]
+[cols="4,1,1,1,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24|1.25|1.26|1.27
+|Feature |1.23|1.24|1.25|1.26|1.27|1.28
 
 |`kn func`
 |TP
@@ -23,8 +23,10 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |TP
 |GA
 |GA
+|GA
 
 |Service Mesh mTLS
+|GA
 |GA
 |GA
 |GA
@@ -37,8 +39,10 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |GA
 |GA
 |GA
+|GA
 
 |HTTPS redirection
+|GA
 |GA
 |GA
 |GA
@@ -51,6 +55,7 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |GA
 |GA
 |GA
+|GA
 
 |Kafka sink
 |TP
@@ -58,9 +63,11 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |GA
 |GA
 |GA
+|GA
 
 |Init containers support for Knative services
 |TP
+|GA
 |GA
 |GA
 |GA
@@ -72,10 +79,12 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |TP
 |GA
 |GA
+|GA
 
 |TLS for internal traffic
 |-
 |-
+|TP
 |TP
 |TP
 |TP
@@ -86,7 +95,15 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |-
 |-
 |TP
+|TP
 
+|`multi-container support`
+|-
+|-
+|-
+|-
+|-
+|TP
 
 |====
 endif::[]
@@ -94,7 +111,7 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Generally Available and Technology Preview features tracker
-[cols="3,1,1,1,1,1",options="header"]
+[cols="4,1,1,1,1,1,1",options="header"]
 |====
 |Feature |1.23|1.24|1.25|1.26|1.27
 
@@ -104,8 +121,10 @@ ifdef::openshift-rosa[]
 |TP
 |GA
 |GA
+|GA
 
 |Service Mesh mTLS
+|GA
 |GA
 |GA
 |GA
@@ -118,8 +137,10 @@ ifdef::openshift-rosa[]
 |GA
 |GA
 |GA
+|GA
 
 |HTTPS redirection
+|GA
 |GA
 |GA
 |GA
@@ -132,8 +153,10 @@ ifdef::openshift-rosa[]
 |GA
 |GA
 |GA
+|GA
 
 |Kafka sink
+|TP
 |TP
 |TP
 |TP
@@ -146,11 +169,13 @@ ifdef::openshift-rosa[]
 |GA
 |GA
 |GA
+|GA
 
 |PVC support for Knative services
 |TP
 |TP
 |TP
+|GA
 |GA
 |GA
 
@@ -160,8 +185,18 @@ ifdef::openshift-rosa[]
 |TP
 |TP
 |TP
+|TP
 
 |Namespace-scoped brokers
+|-
+|-
+|-
+|-
+|TP
+|TP
+
+|`multi-container support`
+|-
 |-
 |-
 |-

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,7 +13,7 @@ The following table provides information about which {ServerlessProductName} fea
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Generally Available and Technology Preview features tracker
-[cols="4,1,1,1",options="header"]
+[cols="2,1,1,1",options="header"]
 |====
 |Feature |1.26|1.27|1.28
 
@@ -98,7 +98,7 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Generally Available and Technology Preview features tracker
-[cols="4,1,1,1",options="header"]
+[cols="2,1,1,1",options="header"]
 |====
 |Feature |1.26|1.27|1.28
 

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -13,22 +13,36 @@ The following table provides information about which {ServerlessProductName} fea
 // OCP + OSD table
 ifdef::openshift-enterprise,openshift-dedicated[]
 .Generally Available and Technology Preview features tracker
-[cols="4,1,1,1,1,1,1",options="header"]
+[cols="4,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24|1.25|1.26|1.27|1.28
+|Feature |1.26|1.27|1.28
 
 |`kn func`
-|TP
-|TP
-|TP
 |GA
 |GA
 |GA
 
+|Quarkus functions
+|GA
+|GA
+|GA
+
+|Node.js functions
+|TP
+|TP
+|GA
+
+|TypeScript functions
+|TP
+|TP
+|GA
+
+|Python functions
+|-
+|-
+|TP
+
 |Service Mesh mTLS
-|GA
-|GA
-|GA
 |GA
 |GA
 |GA
@@ -37,70 +51,43 @@ ifdef::openshift-enterprise,openshift-dedicated[]
 |GA
 |GA
 |GA
-|GA
-|GA
-|GA
 
 |HTTPS redirection
 |GA
 |GA
 |GA
-|GA
-|GA
-|GA
 
 |Kafka broker
-|TP
-|TP
-|GA
 |GA
 |GA
 |GA
 
 |Kafka sink
-|TP
-|TP
-|GA
 |GA
 |GA
 |GA
 
 |Init containers support for Knative services
-|TP
-|GA
-|GA
 |GA
 |GA
 |GA
 
 |PVC support for Knative services
-|TP
-|TP
-|TP
 |GA
 |GA
 |GA
 
 |TLS for internal traffic
-|-
-|-
-|TP
 |TP
 |TP
 |TP
 
 |Namespace-scoped brokers
 |-
-|-
-|-
-|-
 |TP
 |TP
 
 |`multi-container support`
-|-
-|-
-|-
 |-
 |-
 |TP
@@ -111,14 +98,11 @@ endif::[]
 // ROSA table
 ifdef::openshift-rosa[]
 .Generally Available and Technology Preview features tracker
-[cols="4,1,1,1,1,1,1",options="header"]
+[cols="4,1,1,1",options="header"]
 |====
-|Feature |1.23|1.24|1.25|1.26|1.27
+|Feature |1.26|1.27|1.28
 
 |`kn func`
-|TP
-|TP
-|TP
 |GA
 |GA
 |GA
@@ -127,14 +111,8 @@ ifdef::openshift-rosa[]
 |GA
 |GA
 |GA
-|GA
-|GA
-|GA
 
 |`emptyDir` volumes
-|GA
-|GA
-|GA
 |GA
 |GA
 |GA
@@ -143,14 +121,8 @@ ifdef::openshift-rosa[]
 |GA
 |GA
 |GA
-|GA
-|GA
-|GA
 
 |Kafka broker
-|TP
-|TP
-|GA
 |GA
 |GA
 |GA
@@ -159,46 +131,28 @@ ifdef::openshift-rosa[]
 |TP
 |TP
 |TP
-|TP
-|TP
-|TP
 
 |Init containers support for Knative services
-|TP
-|GA
-|GA
 |GA
 |GA
 |GA
 
 |PVC support for Knative services
-|TP
-|TP
-|TP
 |GA
 |GA
 |GA
 
 |TLS for internal traffic
-|-
-|-
-|TP
 |TP
 |TP
 |TP
 
 |Namespace-scoped brokers
 |-
-|-
-|-
-|-
 |TP
 |TP
 
 |`multi-container support`
-|-
-|-
-|-
 |-
 |-
 |TP

--- a/serverless/functions/serverless-developing-nodejs-functions.adoc
+++ b/serverless/functions/serverless-developing-nodejs-functions.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {FunctionsProductName} with NodeJS
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a Node.js function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-nodejs-functions"]

--- a/serverless/functions/serverless-developing-typescript-functions.adoc
+++ b/serverless/functions/serverless-developing-typescript-functions.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: {FunctionsProductName} with TypeScript
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 After you have xref:../../serverless/functions/serverless-functions-getting-started.adoc#serverless-create-func-kn_serverless-functions-getting-started[created a TypeScript function project], you can modify the template files provided to add business logic to your function. This includes configuring function invocation and the returned headers and status codes.
 
 [id="prerequisites_serverless-developing-typescript-functions"]

--- a/serverless/serverless-release-notes.adoc
+++ b/serverless/serverless-release-notes.adoc
@@ -28,6 +28,9 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-28-0.adoc[leveloffset=+1]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-27-0.adoc[leveloffset=+1]
 
 // OCP + OSD + ROSA


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2222

Link to docs preview:
* GA/TP table, Deprecated & removed table, and the release notes for the current release: https://58140--docspreview.netlify.app/openshift-enterprise/latest/serverless/serverless-release-notes.html#serverless-rn-1-28-0_serverless-release-notes
* Also, Tech Preview notes for Node.js and TypeScript have been removed in the main docs

QE review:
- [ ] QE has approved this change.