### PR TITLE
OCPBUGS:9933 - Updated procedure for changing log_level to debug for CRI-O in OSC

### DIFF
--- a/modules/sandboxed-containers-enable-debug-crio.adoc
+++ b/modules/sandboxed-containers-enable-debug-crio.adoc
@@ -6,68 +6,36 @@
 [id="sandboxed-containers-enable-debug-logs_{context}"]
 = Enabling debug logs for {sandboxed-containers-first}
 
-As a cluster administrator, you can collect a more detailed level of logs for {sandboxed-containers-first}. Enhance logging by changing the `log_level` in the CRI-O runtime for the worker nodes running {sandboxed-containers-first}.
+As a cluster administrator, you can collect a more detailed level of logs for {sandboxed-containers-first}. You can also enhance logging by changing the `logLevel` field in the `KataConfig` CR. This changes the `log_level` in the CRI-O runtime for the worker nodes running {sandboxed-containers-first}.
 
 .Procedure
 
-. Create a YAML file for the `ContainerRuntimeConfig` CR with the following manifest:
-+
-[source,yaml]
-----
-apiVersion: machineconfiguration.openshift.io/v1
-kind: ContainerRuntimeConfig
-metadata:
- name: crio-debug
-spec:
- machineConfigPoolSelector:
-  matchLabels:
-    pools.operator.machineconfiguration.openshift.io/worker: '' <1>
- containerRuntimeConfig:
-    logLevel: debug
-----
-<1> Specify a label for the machine config pool that you want you want to modify.
+. Change the `logLevel` field in your existing `KataConfig` CR to `debug`:
 
-. Create the `ContainerRuntimeConfig` CR:
-+
 [source,terminal]
 ----
-$ oc create -f ctrcfg.yaml
+$ oc patch kataconfig <name_of_kataconfig_file> --type merge --patch '{"spec":{"logLevel":"debug"}}'
 ----
 
-+
 [NOTE]
 ====
-The file name listed above is a suggestion. You can create this file using another name.
+When running this command, reference the name of your `KataConfig` CR. This is the name you used to create the CR when setting up {sandboxed-containers-first}.
 ====
-
-. Verify the CR is created:
-+
-[source,terminal]
-----
-$ oc get ctrcfg
-----
-+
-.Example output
-[source,terminal]
-----
-NAME           AGE
-crio-debug   3m19s
-----
 
 .Verification
 
-. Monitor the machine config pool until the `UPDATED` field for all worker nodes appears as `True`:
+. Monitor the `kata-oc` machine config pool until the `UPDATED` field appears as `True`, meaning all worker nodes are updated:
 +
 [source,terminal]
 ----
-$ oc get mcp worker
+$ oc get mcp kata-oc
 ----
 +
 .Example output
 [source,terminal]
 ----
-NAME    CONFIG               UPDATED  UPDATING  DEGRADED  MACHINECOUNT  READYMACHINECOUNT  UPDATEDMACHINECOUNT  DEGRADEDMACHINECOUNT  AGE
-worker  rendered-worker-169  False    True      False     3             1                  1                    0                     9h
+NAME     CONFIG                 UPDATED  UPDATING  DEGRADED  MACHINECOUNT  READYMACHINECOUNT  UPDATEDMACHINECOUNT  DEGRADEDMACHINECOUNT  AGE
+kata-oc  rendered-kata-oc-169   False    True      False     3             1                  1                    0                     9h
 ----
 
 . Verify that the `log_level` was updated in CRI-O:


### PR DESCRIPTION
Version(s):
Main, 4.11, 4.12, 4.13

Issue:
[OCPBUGS-9933](https://issues.redhat.com/browse/OCPBUGS-9933)

[Link to docs preview](https://58144--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/troubleshooting-sandboxed-containers.html#sandboxed-containers-enable-debug-logs_troubleshooting-sandboxed-containers)

QE review:
- [x] QE has approved this change.
