### PR TITLE
Add new coreos layering example

### DIFF
--- a/post_installation_configuration/coreos-layering.adoc
+++ b/post_installation_configuration/coreos-layering.adoc
@@ -56,7 +56,7 @@ RUN rpm-ostree override replace https://example.com/myrepo/haproxy-1.0.16-5.el8.
 
 * *{op-system-base} packages*. You can download {op-system-base-full} packages from the link:https://access.redhat.com/downloads/content/479/ver=/rhel---9/9.1/x86_64/packages[Red Hat Customer Portal], such as chrony, firewalld, and iputils.
 +
-.Example Containerfile to apply a RHEL package
+.Example Containerfile to apply the firewalld utility
 [source,yaml]
 ----
 FROM quay.io/openshift-release-dev/ocp-release@sha256:6499bc69a0707fcad481c3cb73225b867d
@@ -65,6 +65,12 @@ RUN rpm-ostree install firewalld ansible && \
     ansible-playbook configure-firewall-playbook.yml && \
     rpm -e ansible && \
     ostree container commit
+----
++
+.Example Containerfile to apply the libreswan utility
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift/rhcos-image-layering-examples/master/libreswan/Containerfile[]
 ----
 
 * *Third-party packages*. You can download and install RPMs from third-party organizations, such as the following types of packages:
@@ -82,6 +88,14 @@ RUN rpm-ostree install firewalld ansible && \
 ----
 include::https://raw.githubusercontent.com/openshift/rhcos-image-layering-examples/master/htop/Containerfile[]
 ----
++
+.Example Containerfile to apply a third-party package that has {op-system-base} dependencies
+[source,yaml]
+----
+include::https://raw.githubusercontent.com/openshift/rhcos-image-layering-examples/master/fish/Containerfile[]
+----
++
+This Containerfile installs the Linux fish program. Because fish requires additional RHEL packages, the image must be built on an entitled {op-system-base} host.
 
 After you create the machine config, the Machine Config Operator (MCO) performs the following steps:
 


### PR DESCRIPTION
Adding a  [new coreos layering example](https://github.com/openshift/rhcos-image-layering-examples/blob/master/fish/Containerfile) to the layering docs. 

**No QE Required** The code example is QE reviewed and approved. This PR adds a link to pull in that example.

Preview: [RHCOS image layering ](https://58156--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html), a few screens down on the page:
Reworded: _Example Containerfile to apply the firewalld utility_
Added: _Example Containerfile to apply the libreswan utility_
Added: _Example Containerfile to apply a third-party package that has RHEL dependencies_