### PR TITLE
TELCODOCS-1036: Expanding an AWS cluster with on-premise bare metal nodes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -184,6 +184,8 @@ Topics:
     File: installing-aws-outposts-remote-workers
   - Name: Installing a three-node cluster on AWS
     File: installing-aws-three-node
+  - Name: Expanding a cluster with on-premise bare metal nodes
+    File: installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes
   - Name: Uninstalling a cluster on AWS
     File: uninstalling-cluster-aws
 - Name: Installing on Azure

--- a/installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
+++ b/installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
@@ -1,0 +1,24 @@
+:_content-type: ASSEMBLY
+[id="expanding-a-cluster-with-on-premise-bare-metal-nodes"]
+= Expanding a cluster with on-premise bare metal nodes
+include::_attributes/common-attributes.adoc[]
+:context: expanding-a-cluster-with-on-premise-bare-metal-nodes
+
+toc::[]
+
+You can expand an {product-title} cluster deployed with virtual media on AWS by adding bare metal nodes to the cluster. By default, a cluster deployed with virtual media on AWS with {product-title} 4.11 or earlier has the Baremetal Operator (BMO) disabled. In {product-title} 4.12 and later releases, the BMO is enabled to support a hybrid cloud consisting of AWS control plane nodes and worker nodes with additional on-premise bare metal worker nodes.
+
+Expanding a {product-title} cluster deployed on AWS requires using virtual media with bare metal nodes that meet the xref:../installing_bare_metal_ipi/ipi-install-prerequisites.adoc#node-requirements_ipi-install-prerequisites[node requirements] and xref:../installing_bare_metal_ipi/ipi-install-prerequisites.adoc#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites[firmware requirements] for installing with virtual media. A `provisioning` network is not required, and  if present, should be xref:../installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#modifying-install-config-for-no-provisioning-network_ipi-install-installation-workflow[disabled].
+
+include::modules/installation-aws_con_connecting-the-vpc-to-the-on-premise-network.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources-aws-vpc"]
+.Additional resources
+
+* link:https://docs.aws.amazon.com/vpc/?icmpid=docs_homepage_featuredsvcs[Amazon VPC]
+* link:https://docs.aws.amazon.com/vpc/latest/peering/what-is-vpc-peering.html[VPC peering]
+
+include::modules/installation-aws_proc_creating-firewall-rules-for-port-6183.adoc[leveloffset=+1]
+
+After you have the networking configured, you can proceed with xref:../installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc#ipi-install-expanding-the-cluster[expanding the cluster].

--- a/modules/installation-aws_con_connecting-the-vpc-to-the-on-premise-network.adoc
+++ b/modules/installation-aws_con_connecting-the-vpc-to-the-on-premise-network.adoc
@@ -1,0 +1,18 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
+
+:_content-type: CONCEPT
+[id="connecting-the-vpc-to-the-on-premise-network_{context}"]
+= Connecting the VPC to the on-premise network
+
+To expand the {product-title} cluster deployed on AWS with on-premise bare metal nodes, you must establish network connectivity between them. You will need to configure the networking using a virtual private network or AWS Direct Connect between the AWS VPC and your on-premise network. This allows traffic to flow between the on-premise nodes and the AWS nodes.
+
+Additionally, you need to ensure secure access to the Baseboard Management Controllers (BMCs) of the bare metal nodes. When expanding the cluster with the Baremetal Operator, access to the BMCs is required for remotely managing and monitoring the hardware of your on-premise nodes.
+
+To securely access the BMCs, you can create a separate, secure network segment or use a dedicated VPN connection specifically for BMC access. This way, you can isolate the BMC traffic from other network traffic, reducing the risk of unauthorized access or potential vulnerabilities.
+
+[WARNING]
+====
+Misconfiguration of the network connection between the AWS and on-premise environments can expose the on-premise network and bare metal nodes to the internet.
+====

--- a/modules/installation-aws_proc_creating-firewall-rules-for-port-6183.adoc
+++ b/modules/installation-aws_proc_creating-firewall-rules-for-port-6183.adoc
@@ -1,0 +1,59 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
+
+:_content-type: PROCEDURE
+[id="creating-firewall-rules-for-port-6183_{context}"]
+= Creating firewall rules for port 6183
+
+Port `6183` is open by default on the control plane. However, you must create a firewall rule for the VPC connection and for the on-premise network for the bare metal nodes to allow inbound and outbound traffic on that port.
+
+.Procedure
+
+. Modify the AWS VPC security group to open port `6183`:
+
+.. Navigate to the Amazon VPC console in the AWS Management Console.
+.. In the left navigation pane, click on **Security Groups**.
+.. Find and select the security group associated with the {product-title} cluster.
+.. In the **Inbound rules** tab, click **Edit inbound rules**.
+.. Click **Add rule** and select **Custom UDP Rule** as the rule type.
+.. In the **Port range** field, enter `6183`.
+.. In the **Source** field, specify the CIDR block for the on-premise network or the security group ID of the peered VPC (if you have VPC peering) to allow traffic only from the desired sources.
+.. Click **Save rules**.
+
+. Modify the AWS VPC network access control lists to open port `6183`:
+
+.. In the Amazon VPC console, click on **Network ACLs** in the left navigation pane.
+.. Find and select the network ACL associated with your {product-title} cluster's VPC.
+.. In the **Inbound rules** tab, click **Edit inbound rules**.
+.. Click **Add rule** and enter a rule number in the **Rule #** field. Choose a number that doesn't conflict with existing rules.
+.. Select `UDP` as the protocol.
+.. In the **Port range** field, enter `6183`.
+.. In the **Source** field, specify the CIDR block for the on-premise network to allow traffic only from the desired sources.
+.. Click **Save** to save the new rule.
+.. Repeat the same process for the **Outbound rules** tab to allow outbound traffic on port `6183`.
+
+. Modify the on-premise network to allow traffic on port `6183`:
+
+.. Execute the following command to identify the zone you want to modify:
++
+[source,terminal]
+----
+$ sudo firewall-cmd --list-all-zones
+----
+
+.. To open port `6183` for UDP traffic in the desired zone execute the following command:
++
+[source,terminal]
+----
+$ sudo firewall-cmd --zone=<zone> --add-port=6183/udp --permanent
+----
++
+Replace `<zone>` with the appropriate zone name.
+
+.. Reload `firewalld` to apply the new rule:
++
+[source,terminal]
+----
+$ sudo firewall-cmd --reload
+----


### PR DESCRIPTION
Provides information for expanding an AWS cluster with on-premise bare metal worker nodes. 

Version(s): 4.13

Issue: https://issues.redhat.com/browse/TELCODOCS-1036

Link to docs preview: http://jowilkin.com:8080/TELCODOCS-1036/installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->