### PR TITLE
OSDOCS#5597: Added regionalized AWS STS URLs to the allow list for PrivateLink (DRAFT)

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -146,7 +146,11 @@ Alternatively, if you choose to not use a wildcard for Amazon Web Services (AWS)
 
 |`sts.amazonaws.com`
 |443
-|Used to install and manage clusters in an AWS environment.
+|Used to install and manage clusters in an AWS environment, for clusters configured to use the global endpoint for AWS STS.
+
+|`sts.<aws_region>.amazonaws.com`
+|443
+|Used to install and manage clusters in an AWS environment, for clusters configured to use regionalized endpoints for AWS STS. See link:https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html[AWS STS regionalized endpoints] for more information.
 
 |`tagging.us-east-1.amazonaws.com`
 |443

--- a/modules/rosa-sts-oidc-provider-command.adoc
+++ b/modules/rosa-sts-oidc-provider-command.adoc
@@ -22,7 +22,7 @@ When using `manual` mode, the `aws` command is printed to the terminal for your 
 ----
 aws iam create-open-id-connect-provider \
 	--url https://rh-oidc.s3.<aws_region>.amazonaws.com/<cluster_id> \
-	--client-id-list openshift sts.amazonaws.com \
+	--client-id-list openshift sts.<aws_region>.amazonaws.com \
 	--thumbprint-list <thumbprint> <1>
 ----
 <1> The thumbprint is generated automatically when you run the `rosa create oidc-provider` command. For more information about using thumbprints with AWS Identity and Access Management (IAM) OpenID Connect (OIDC) identity providers, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html[the AWS documentation].


### PR DESCRIPTION
Version(s):
4.12, 4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5597

Link to docs preview:
https://58175--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites
https://58175--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-sts-oidc-provider-for-operators-aws-cli_rosa-sts-about-iam-resources

QE review:
- [x] QE has approved this change.

Additional information: None