### PR TITLE
[SRVKS-869] Document gRPC over HTTP2 for 4.10+

### DIFF
--- a/modules/interacting-serverless-apps-http2-gRPC-up-to-4-9.adoc
+++ b/modules/interacting-serverless-apps-http2-gRPC-up-to-4-9.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// serverless/knative-serving/external-ingress-routing/using-http2-gRPC.adoc
+
+:_content-type: PROCEDURE
+[id="interacting-serverless-apps-http2-grpc-up-to-4-9_{context}"]
+= Interacting with a serverless application using HTTP2 and gRPC in {product-title} 4.9 and older
+
+[IMPORTANT]
+====
+This method needs to expose Kourier Gateway using the `LoadBalancer` service type. You can configure this by adding the following YAML to your `KnativeServing` custom resource definition (CRD):
+
+[source,yaml]
+----
+...
+spec:
+  ingress:
+    kourier:
+      service-type: LoadBalancer
+...
+----
+====
+
+.Prerequisites
+
+* Install {ServerlessOperatorName} and Knative Serving on your cluster.
+* Install the OpenShift CLI (`oc`).
+* Create a Knative service.
+
+.Procedure
+
+. Find the application host. See the instructions in _Verifying your serverless application deployment_.
+
+. Find the ingress gateway's public address:
++
+[source,terminal]
+----
+$ oc -n knative-serving-ingress get svc kourier
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP                                                             PORT(S)                                                                                                                                      AGE
+kourier   LoadBalancer   172.30.51.103   a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com   80:31380/TCP,443:31390/TCP   67m
+----
++
+The public address is surfaced in the `EXTERNAL-IP` field, and in this case is `a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com`.
+
+. Manually set the host header of your HTTP request to the application's host, but direct the request itself against the public address of the ingress gateway.
++
+[source,terminal]
+----
+$ curl -H "Host: hello-default.example.com" a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com
+----
++
+.Example output
+[source,terminal]
+----
+Hello Serverless!
+----
++
+You can also make a direct gRPC request against the ingress gateway:
++
+[source,golang]
+----
+import "google.golang.org/grpc"
+
+grpc.Dial(
+    "a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com:80",
+    grpc.WithAuthority("hello-default.example.com:80"),
+    grpc.WithInsecure(),
+)
+----
++
+[NOTE]
+====
+Ensure that you append the respective port, 80 by default, to both hosts as shown in the previous example.
+====

--- a/modules/interacting-serverless-apps-http2-gRPC.adoc
+++ b/modules/interacting-serverless-apps-http2-gRPC.adoc
@@ -3,76 +3,55 @@
 // serverless/knative-serving/external-ingress-routing/using-http2-gRPC.adoc
 
 :_content-type: PROCEDURE
-[id="interacting-serverless-apps-http2-gRPC_{context}"]
+[id="interacting-serverless-apps-http2-grpc_{context}"]
 = Interacting with a serverless application using HTTP2 and gRPC
 
 [IMPORTANT]
 ====
-This method needs to expose Kourier Gateway using the `LoadBalancer` service type. You can configure this by adding the following YAML to your `KnativeServing` custom resource definition (CRD):
-
-[source,yaml]
-----
-...
-spec:
-  ingress:
-    kourier:
-      service-type: LoadBalancer
-...
-----
+This method applies to {product-title} 4.10 and later. For older versions, see the following section.
 ====
 
 .Prerequisites
 
-* {ServerlessOperatorName} and Knative Serving are installed on your cluster.
+* Install {ServerlessOperatorName} and Knative Serving on your cluster.
 * Install the OpenShift CLI (`oc`).
-* You have created a Knative service.
+* Create a Knative service.
+* Upgrade {product-title} 4.10 or later.
+* Enable HTTP/2 on OpenShift Ingress controller.
 
 .Procedure
 
-. Find the application host. See the instructions in _Verifying your serverless application deployment_.
-
-. Find the ingress gateway's public address:
+. Add the `serverless.openshift.io/default-enable-http2=true` annotation to the `KnativeServing` Custom Resource:
 +
 [source,terminal]
 ----
-$ oc -n knative-serving-ingress get svc kourier
+$ oc annotate knativeserving <your_knative_CR> -n knative-serving serverless.openshift.io/default-enable-http2=true
+----
+
+. After the annotation is added, you can verify that the `appProtocol` value of the Kourier service is `h2c`:
++
+[source,terminal]
+----
+$ oc get svc -n knative-serving-ingress kourier -o jsonpath="{.spec.ports[0].appProtocol}"
 ----
 +
 .Example output
 +
 [source,terminal]
 ----
-NAME                   TYPE           CLUSTER-IP      EXTERNAL-IP                                                             PORT(S)                                                                                                                                      AGE
-kourier   LoadBalancer   172.30.51.103   a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com   80:31380/TCP,443:31390/TCP   67m
+h2c
 ----
-+
-The public address is surfaced in the `EXTERNAL-IP` field, and in this case is `a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com`.
 
-. Manually set the host header of your HTTP request to the application's host, but direct the request itself against the public address of the ingress gateway.
+. Now you can use the gRPC framework over the HTTP/2 protocol for external traffic, for example:
 +
-[source,terminal]
+[source,golang]
 ----
-$ curl -H "Host: hello-default.example.com" a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com
-----
-+
-.Example output
-[source,terminal]
-----
-Hello Serverless!
-----
-+
-You can also make a gRPC request by setting the authority to the application's host, while directing the request against the ingress gateway directly:
-+
-[source,yaml]
-----
+import "google.golang.org/grpc"
+
 grpc.Dial(
-    "a83e86291bcdd11e993af02b7a65e514-33544245.us-east-1.elb.amazonaws.com:80",
-    grpc.WithAuthority("hello-default.example.com:80"),
-    grpc.WithInsecure(),
+   YOUR_URL, <1>
+   grpc.WithTransportCredentials(insecure.NewCredentials())), <2>
 )
 ----
-+
-[NOTE]
-====
-Ensure that you append the respective port, 80 by default, to both hosts as shown in the previous example.
-====
+<1> Your `ksvc` URL.
+<2> Your certificate.

--- a/serverless/knative-serving/external-ingress-routing/using-http2-gRPC.adoc
+++ b/serverless/knative-serving/external-ingress-routing/using-http2-gRPC.adoc
@@ -7,3 +7,9 @@ include::_attributes/common-attributes.adoc[]
 {ServerlessProductName} supports only insecure or edge-terminated routes. Insecure or edge-terminated routes do not support HTTP2 on {product-title}. These routes also do not support gRPC because gRPC is transported by HTTP2. If you use these protocols in your application, you must call the application using the ingress gateway directly. To do this you must find the ingress gateway's public address and the application's specific host.
 
 include::modules/interacting-serverless-apps-http2-gRPC.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../../networking/ingress-operator.adoc#nw-http2-haproxy_configuring-ingress[Enabling HTTP/2 Ingress connectivity]
+
+include::modules/interacting-serverless-apps-http2-gRPC-up-to-4-9.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/SRVKS-869

Link to docs preview:
https://58177--docspreview.netlify.app/openshift-dedicated/latest/serverless/knative-serving/external-ingress-routing/using-http2-grpc

QE review:
- [x] QE has approved this change.