### PR TITLE
TELCODOCS-1210: Update ACM version for Telco RAN ZTP solution

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -21,7 +21,7 @@ The Red Hat Telco Radio Access Network (RAN) version {product-version} solution 
 |4.10, 4.11, or 4.12
 
 |{rh-rhacm-first}
-|2.6
+|2.6, 2.7
 
 |{gitops-title}
 |1.6


### PR DESCRIPTION
Updates ACM version for Telco RAN ZTP solution

Version(s):
main, enterprise-4.12, enterprise-4.13 

Issue:
https://issues.redhat.com/browse/TELCODOCS-1210

Link to docs preview:
https://58182--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-telco-ran-software-versions_ztp-preparing-the-hub-cluster


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
