### PR TITLE
TELCODOCS-903: release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -597,6 +597,15 @@ Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone
 
 For more information, see xref:../nodes/pods/nodes-pods-configuring.adoc#pod-disruption-eviction-policy_nodes-pods-configuring[Specifying the eviction policy for unhealthy pods].
 
+[id="ocp-4-13-graceful-node-shutdown"]
+==== Support for graceful node shutdown
+
+A graceful node shutdown delays the eviction of pods during a node shutdown. In {product-title} {product-version}, you can configure the kubelet to enable a graceful node shutdown so that pods running critical workloads are not interrupted.
+
+To configure graceful node shutdowns, you can specify a termination grace period for regular and critical pods in the `KubeletConfig` custom resource. A termination grace period defines a time period for the pod to complete any ongoing tasks before terminating. You can also add priority classes to pods to specify the order of termination.
+
+For further information see xref:../nodes/nodes/nodes-nodes-graceful-shutdown.adoc#nodes-nodes-graceful-shutdown[Managing graceful node shutdown].
+
 [id="ocp-4-13-monitoring"]
 === Monitoring
 The monitoring stack for this release includes the following new and modified features.


### PR DESCRIPTION
[TELCODOCS-903](https://issues.redhat.com//browse/TELCODOCS-903): Release note for graceful node shutdown

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-903

Link to docs preview:
https://58197--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-graceful-node-shutdown

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Related content update is here:https://github.com/openshift/openshift-docs/pull/58198

Picking up this issue from #55869 as  previous writer left the company