### PR TITLE
TELCODOCS-903: Graceful node shutdown

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2209,6 +2209,8 @@ Topics:
     File: nodes-nodes-working
   - Name: Managing nodes
     File: nodes-nodes-managing
+  - Name: Managing graceful node shutdown
+    File: nodes-nodes-graceful-shutdown
   - Name: Managing the maximum number of pods per node
     File: nodes-nodes-managing-max-pods
   - Name: Using the Node Tuning Operator

--- a/modules/nodes-nodes-cluster-timeout-graceful-shutdown.adoc
+++ b/modules/nodes-nodes-cluster-timeout-graceful-shutdown.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assembly:
+// * nodes/nodes-nodes-graceful-shutdown
+
+:_content-type: CONCEPT
+[id="nodes-nodes-cluster-timeout-graceful-shutdown_{context}"]
+= About graceful node shutdown
+
+During a graceful node shutdown, the kubelet sends a termination signal to pods running on the node and postpones the node shutdown until all the pods evicted. If a node unexpectedly shuts down, the graceful node shutdown feature minimizes interruption to workloads running on these pods. 
+
+During a graceful node shutdown, the kubelet stops pods in two phases:
+
+* Regular pod termination
+* Critical pod termination
+
+You can define shutdown grace periods for regular and critical pods by configuring the following specifications in the `KubeletConfig` custom resource:
+
+* `shutdownGracePeriod`: Specifies the total duration for pod termination for regular and critical pods.
+* `shutdownGracePeriodCriticalPods`: Specifies the duration for critical pod termination. This value must be less than the `shutdownGracePeriod` value.
+
+For example, if the `shutdownGracePeriod` value is `30s`, and the `shutdownGracePeriodCriticalPods` value is `10s`, the kubelet delays the node shutdown by 30 seconds. During the shutdown, the first 20 (30-10) seconds are reserved for gracefully shutting down regular pods, and the last 10 seconds are reserved for gracefully shutting down critical pods. 
+
+To define a critical pod, assign a pod priority value greater than or equal to `2000000000`. To define a regular pod, assign a pod priority value of less than `2000000000`. 
+
+For more information about how to define a priority value for pods, see the _Additional resources_ section. 
+

--- a/modules/nodes-nodes-configuring-graceful-shutdown.adoc
+++ b/modules/nodes-nodes-configuring-graceful-shutdown.adoc
@@ -1,0 +1,143 @@
+// Module included in the following assembly:
+// * nodes/nodes-nodes-graceful-shutdown
+
+:_content-type: PROCEDURE
+[id="nodes-nodes-activating-graceful-shutdown_{context}"]
+= Configuring graceful node shutdown
+
+To configure graceful node shutdown, create a `KubeletConfig` custom resource (CR) to specify a shutdown grace period for pods on a set of nodes. The graceful node shutdown feature minimizes interruption to workloads that run on these pods.
+
+[NOTE]
+====
+If you do not configure graceful node shutdown, the default grace period is `0` and the pod is forcefully evicted from the node.
+====
+
+.Prerequisites
+
+* You have access to the cluster with the `cluster-admin` role.
+* You have defined priority classes for pods that require critical or regular classification.
+
+.Procedure
+
+. Define shutdown grace periods in the `KubeletConfig` CR by saving the following YAML in the `kubelet-gns.yaml` file:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: graceful-shutdown
+  namespace: openshift-machine-config-operator
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      pools.operator.machineconfiguration.openshift.io/worker: "" <1>
+  kubeletConfig:
+    shutdownGracePeriod: "3m" <2>
+    shutdownGracePeriodCriticalPods: "2m" <3>
+----
+<1> This example applies shutdown grace periods to nodes with the `worker` role. 
+<2> Define a time period for regular pods to shut down.
+<3> Define a time period for critical pods to shut down. 
+
+. Create the `KubeletConfig` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f kubelet-gns.yaml
+----
++
+.Example output
+[source,terminal]
+----
+kubeletconfig.machineconfiguration.openshift.io/graceful-shutdown created
+----
+
+.Verification
+
+. View the kubelet logs for a node to verify the grace period configuration by using the command line or by viewing the `kublet.conf` file.
++
+[NOTE]
+====
+Ensure that the log messages for `shutdownGracePeriodRequested` and `shutdownGracePeriodCriticalPods` match the values set in the `KubeletConfig` CR. 
+====
+
+.. To view the logs by using the command line, run the following command, replacing `<node_name>` with the name of the node:
++
+[source,bash]
+----
+$ oc adm node-logs <node_name> -u kubelet
+----
++
+.Example output
+[source,terminal]
+----
+Sep 12 22:13:46
+ci-ln-qv5pvzk-72292-xvkd9-worker-a-dmbr4
+hyperkube[22317]: I0912 22:13:46.687472
+22317 nodeshutdown_manager_linux.go:134]
+"Creating node shutdown manager"
+shutdownGracePeriodRequested="3m0s" <1>
+shutdownGracePeriodCriticalPods="2m0s"
+shutdownGracePeriodByPodPriority=[
+{Priority:0
+ShutdownGracePeriodSeconds:1200}
+{Priority:2000000000
+ShutdownGracePeriodSeconds:600}]
+...
+----
++
+<1> Ensure that the log messages for `shutdownGracePeriodRequested` and `shutdownGracePeriodCriticalPods` match the values set in the `KubeletConfig` CR. 
++
+.. To view the logs in the `kublet.conf` file on a node, run the following commands to enter a debug session on the node:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
++
+[source,terminal]
+----
+$ chroot /host
+----
++
+[source,terminal]
+----
+$ cat /etc/kubernetes/kubelet.conf 
+----
++
+.Example output
+[source,terminal]
+----
+...
+“memorySwap”: {},
+ “containerLogMaxSize”: “50Mi”,
+ “logging”: {
+  “flushFrequency”: 0,
+  “verbosity”: 0,
+  “options”: {
+   “json”: {
+    “infoBufferSize”: “0”
+   }
+  }
+ },
+ “shutdownGracePeriod”: “10m0s”, <1>
+ “shutdownGracePeriodCriticalPods”: “3m0s”
+}
+----
++
+<1> Ensure that the log messages for `shutdownGracePeriodRequested` and `shutdownGracePeriodCriticalPods` match the values set in the `KubeletConfig` CR.
+
+. During a graceful node shutdown, you can verify that a pod was gracefully shut down by running the following command, replacing `<pod_name>` with the name of the pod:
++
+[source,terminal]
+----
+$ oc describe pod <pod_name>
+----
++
+.Example output
+[source,terminal]
+----
+Reason:         Terminated
+Message:        Pod was terminated in response to imminent node shutdown.
+----

--- a/nodes/nodes/nodes-nodes-graceful-shutdown.adoc
+++ b/nodes/nodes/nodes-nodes-graceful-shutdown.adoc
@@ -1,0 +1,20 @@
+:_content-type: ASSEMBLY
+[id="nodes-nodes-graceful-shutdown"]
+= Managing graceful node shutdown
+include::_attributes/common-attributes.adoc[]
+:context: nodes-nodes-graceful-shutdown
+
+toc::[]
+
+Graceful node shutdown enables the kubelet to delay forcible eviction of pods during a node shutdown. When you configure a graceful node shutdown, you can define a time period for pods to complete running workloads before shutting down. This grace period minimizes interruption to critical workloads during unexpected node shutdown events. Using priority classes, you can also specify the order of pod shutdown. 
+
+// concept topic: how it works
+include::modules/nodes-nodes-cluster-timeout-graceful-shutdown.adoc[leveloffset=+1]
+
+// procedure topic: configuring Graceful node shutdown
+include::modules/nodes-nodes-configuring-graceful-shutdown.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../nodes/pods/nodes-pods-priority.adoc#nodes-pods-priority[Understanding pod priority]


### PR DESCRIPTION
[TELCODOCS-903](https://issues.redhat.com//browse/TELCODOCS-903): Graceful node shutdown allows you to define a time period for workloads to complete on pods on a node before shutting down.

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/TELCODOCS-903

Link to docs preview:
https://58198--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-graceful-shutdown.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Taking over from #56770 as the previous writer left the company.