### PR TITLE
[OSDOCS-5532]: Manual creds YAML cleanup

### DIFF
--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_azure/manually-creating-iam-azure.adoc
 // * installing/installing_gcp/manually-creating-iam-gcp.adoc
 // * installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc
+// * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 
 ifeval::["{context}" == "manually-creating-iam-aws"]
 :aws:
@@ -42,10 +43,7 @@ endif::cco-manual-mode[]
 
 //For providers that support multiple modes of operation
 ifdef::cco-multi-mode[]
-The Cloud Credential Operator (CCO) can be put into manual mode prior to
-installation in environments where the cloud identity and access management
-(IAM) APIs are not reachable, or the administrator prefers not to store an
-administrator-level credential secret in the cluster `kube-system` namespace.
+The Cloud Credential Operator (CCO) can be put into manual mode prior to installation in environments where the cloud identity and access management (IAM) APIs are not reachable, or the administrator prefers not to store an administrator-level credential secret in the cluster `kube-system` namespace.
 endif::cco-multi-mode[]
 
 //For providers who only support manual mode
@@ -56,7 +54,7 @@ endif::cco-manual-mode[]
 .Procedure
 
 ifdef::cco-multi-mode[]
-. Change to the directory that contains the installation program and create the `install-config.yaml` file:
+. Change to the directory that contains the installation program and create the `install-config.yaml` file by running the following command:
 +
 [source,terminal]
 ----
@@ -88,11 +86,9 @@ endif::cco-multi-mode[]
 $ openshift-install create manifests --dir <installation_directory>
 ----
 +
-where:
+where `<installation_directory>` is the directory in which the installation program creates files.
 
-`<installation_directory>`:: Specifies the directory in which the installation program creates files.
-
-. From the directory that contains the installation program, obtain details of the {product-title} release image that your `openshift-install` binary is built to use:
+. From the directory that contains the installation program, obtain details of the {product-title} release image that your `openshift-install` binary is built to use by running the following command:
 +
 [source,terminal]
 ----
@@ -105,42 +101,38 @@ $ openshift-install version
 release image quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64
 ----
 
-. Locate all `CredentialsRequest` objects in this release image that target the cloud you are deploying on:
+. Locate all `CredentialsRequest` objects in this release image that target the cloud you are deploying on by running the following command:
 +
 [source,terminal]
+----
+$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 \
+  --credentials-requests \
 ifdef::aws[]
-----
-$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 --credentials-requests --cloud=aws
-----
+  --cloud=aws
 endif::aws[]
 ifdef::azure,ash[]
-----
-$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 --credentials-requests --cloud=azure
-----
+  --cloud=azure
 endif::azure,ash[]
 ifdef::google-cloud-platform[]
-----
-$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 --credentials-requests --cloud=gcp
-----
+  --cloud=gcp
 endif::google-cloud-platform[]
+----
 +
 This command creates a YAML file for each `CredentialsRequest` object.
 +
-ifdef::aws[]
 .Sample `CredentialsRequest` object
 [source,yaml]
 ----
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  name: cloud-credential-operator-iam-ro
+  name: <component-credentials-request>
   namespace: openshift-cloud-credential-operator
+  ...
 spec:
-  secretRef:
-    name: cloud-credential-operator-iam-ro-creds
-    namespace: openshift-cloud-credential-operator
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
+ifdef::aws[]
     kind: AWSProviderSpec
     statementEntries:
     - effect: Allow
@@ -149,108 +141,62 @@ spec:
       - iam:GetUserPolicy
       - iam:ListAccessKeys
       resource: "*"
-----
 endif::aws[]
 ifdef::azure,ash[]
-.Sample `CredentialsRequest` object
-[source,yaml]
-----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: openshift-image-registry-azure
-  namespace: openshift-cloud-credential-operator
-spec:
-  secretRef:
-    name: installer-cloud-credentials
-    namespace: openshift-image-registry
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
     kind: AzureProviderSpec
     roleBindings:
     - role: Contributor
-----
 endif::azure,ash[]
 ifdef::google-cloud-platform[]
-.Sample `CredentialsRequest` object
-[source,yaml]
-----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
-metadata:
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: openshift-image-registry-gcs
-  namespace: openshift-cloud-credential-operator
-spec:
-  secretRef:
-    name: installer-cloud-credentials
-    namespace: openshift-image-registry
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
     kind: GCPProviderSpec
     predefinedRoles:
     - roles/storage.admin
     - roles/iam.serviceAccountUser
     skipServiceCheck: true
-----
 endif::google-cloud-platform[]
+  ...
+----
 
 . Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object.
 +
-ifdef::ash[] 
-.Sample `CredentialsRequest` object
+.Sample `CredentialsRequest` object with secrets
 [source,yaml]
 ----
 apiVersion: cloudcredential.openshift.io/v1
 kind: CredentialsRequest
 metadata:
-  annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: openshift-image-registry-azure
+  name: <component-credentials-request>
   namespace: openshift-cloud-credential-operator
+  ...
 spec:
   providerSpec:
     apiVersion: cloudcredential.openshift.io/v1
+ifdef::aws[]
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - s3:CreateBucket
+      - s3:DeleteBucket
+      resource: "*"
+endif::aws[]
+ifdef::ash,azure[]
     kind: AzureProviderSpec
     roleBindings:
     - role: Contributor
+endif::ash,azure[]
+ifdef::gcp[]
+    kind: GCPProviderSpec
+      predefinedRoles:
+      - roles/iam.securityReviewer
+      - roles/iam.roleViewer
+      skipServiceCheck: true
+endif::gcp[]
+      ...
   secretRef:
-    name: installer-cloud-credentials
-    namespace: openshift-image-registry
-----
-+
-endif::ash[] 
-
-.Sample `CredentialsRequest` object
-[source,yaml]
-----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
-metadata:
-  annotations:
-    include.release.openshift.io/ibm-cloud-managed: "true"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
-  labels:
-    controller-tools.k8s.io: "1.0"
-  name: openshift-image-registry-azure
-  namespace: openshift-cloud-credential-operator
-spec:
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
-    kind: AzureProviderSpec
-    roleBindings:
-    - role: Contributor
-  secretRef:
-    name: installer-cloud-credentials
-    namespace: openshift-image-registry
+    name: <component-secret>
+    namespace: <component-namespace>
+  ...
 ----
 +
 .Sample `Secret` object
@@ -259,16 +205,27 @@ spec:
 apiVersion: v1
 kind: Secret
 metadata:
-  namespace: openshift-image-registry
-  name: installer-cloud-credentials
+  name: <component-secret>
+  namespace: <component-namespace>
+ifdef::aws[]
 data:
-  azure_subscription_id: <base64_encrypted_azure_subscription_id>
-  azure_client_id: <base64_encrypted_azure_client_id>
-  azure_client_secret: <base64_encrypted_azure_client_secret>
-  azure_tenant_id: <base64_encrypted_azure_tenant_id>
-  azure_resource_prefix: <base64_encrypted_azure_resource_prefix>
-  azure_resourcegroup: <base64_encrypted_azure_resourcegroup>
-  azure_region: <base64_encrypted_azure_region>
+  aws_access_key_id: <base64_encoded_aws_access_key_id>
+  aws_secret_access_key: <base64_encoded_aws_secret_access_key>
+endif::aws[]
+ifdef::azure,ash[]
+data:
+  azure_subscription_id: <base64_encoded_azure_subscription_id>
+  azure_client_id: <base64_encoded_azure_client_id>
+  azure_client_secret: <base64_encoded_azure_client_secret>
+  azure_tenant_id: <base64_encoded_azure_tenant_id>
+  azure_resource_prefix: <base64_encoded_azure_resource_prefix>
+  azure_resourcegroup: <base64_encoded_azure_resourcegroup>
+  azure_region: <base64_encoded_azure_region>
+endif::azure,ash[]
+ifdef::google-cloud-platform[]
+data:
+  service_account.json: <base64_encoded_gcp_service_account_file>
+endif::google-cloud-platform[]
 ----
 +
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.9+

Issue:
[OCPBUGS-10870](https://issues.redhat.com/browse/OCPBUGS-10870), [OSDOCS-5532](https://issues.redhat.com//browse/OSDOCS-5532)

Link to docs preview:
* [Manually create IAM (AWS)](https://58206--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/manually-creating-iam.html#manually-create-iam_manually-creating-iam-aws)
* [Manually create IAM (global Azure)](https://58206--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/manually-creating-iam-azure.html#manually-create-iam_manually-creating-iam-azure)
* [Manually manage cloud credentials (ASH default)](https://58206--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.html#manually-create-iam_installing-azure-stack-hub-default)
* [Manually manage cloud credentials (ASH custom network)](https://58206--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.html#manually-create-iam_installing-azure-stack-hub-network-customizations)
* [Manually create IAM (GCP)](https://58206--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/manually-creating-iam-gcp.html#manually-create-iam_manually-creating-iam-gcp)

QE review:
- [x] QE has approved this change.

Additional information:
4.9 will likely need a manual cherrypick anyway, but note that it is **required** since ASH is 4.10+