### PR TITLE
OSDOCS-4336: Content audit for Requesting CRI-O and Kubelet profiling data by using the Node Observability Operator

### DIFF
--- a/modules/node-observability-install-cli.adoc
+++ b/modules/node-observability-install-cli.adoc
@@ -48,8 +48,7 @@ metadata:
   name: node-observability-operator
   namespace: node-observability-operator
 spec:
-  targetNamespaces:
-  - node-observability-operator
+  targetNamespaces: []
 EOF
 ----
 

--- a/modules/node-observability-run-profiling-query.adoc
+++ b/modules/node-observability-run-profiling-query.adoc
@@ -44,7 +44,7 @@ $ oc apply -f nodeobservabilityrun.yaml
 +
 [source,terminal]
 ----
-$ oc get nodeobservabilityrun -o yaml  | yq '.status.conditions'
+$ oc get nodeobservabilityrun nodeobservabilityrun -o yaml  | yq '.status.conditions'
 ----
 
 +


### PR DESCRIPTION
Issue:
https://issues.redhat.com/browse/OSDOCS-4336

Version(s):
4.11+

Link to docs preview:
https://58208--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/node-observability-operator.html