### PR TITLE
[RHDEVDOCS-3624] Move export app docs to higher level for findability

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1985,6 +1985,8 @@ Topics:
     File: creating-applications-using-cli
 - Name: Viewing application composition using the Topology view
   File: odc-viewing-application-composition-using-topology-view
+- Name: Exporting applications
+  File: odc-exporting-applications
 - Name: Connecting applications to services
   Dir: connecting_applications_to_services
   Topics:

--- a/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
+++ b/applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
@@ -78,8 +78,6 @@ include::modules/odc-using-the-devfile-registry.adoc[leveloffset=+1]
 
 include::modules/odc-using-the-developer-catalog-to-add-services-or-components.adoc[leveloffset=+1]
 
-include::modules/odc-exporting-an-application-to-another-project-or-cluster.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 [id="additional-resources_odc-creating-applications-using-developer-perspective"]
 == Additional resources

--- a/applications/odc-exporting-applications.adoc
+++ b/applications/odc-exporting-applications.adoc
@@ -1,25 +1,28 @@
-// Module included in the following assemblies:
-//
-// * applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc
+:_content-type: ASSEMBLY
+[id="odc-exporting-applications"]
+= Exporting applications
+include::_attributes/common-attributes.adoc[]
+:context: odc-exporting-applications
 
-:_content-type: PROCEDURE
-[id="odc-exporting-an-application-to-another-project-or-cluster_{context}"]
-
-= Exporting an application to another project or cluster
+toc::[]
 
 As a developer, you can export your application in the ZIP file format. Based on your needs, import the exported application to another project in the same cluster or a different cluster by using the *Import YAML* option in the *+Add* view. Exporting your application helps you to reuse your application resources and saves your time.
 
-.Prerequisites
-* You have installed the gitops-primer operator from the Operator Hub.
+[id="prerequisites_odc-exporting-applications"]
+== Prerequisites
+
+* You have installed the gitops-primer Operator from the OperatorHub.
 +
 [NOTE]
 ====
-The *Export application* option is disabled in the *Topology* view even after installing the gitops-primer operator.
+The *Export application* option is disabled in the *Topology* view even after installing the gitops-primer Operator.
 ====
 
 * You have created an application in the *Topology* view to enable *Export application*.
 
-.Procedure
+[id="odc-exporting-applications-procedure"]
+== Procedure
+
 . In the developer perspective, perform one of the following steps:
 .. Navigate to the *+Add* view and click *Export application* in the *Application portability* tile.
 .. Navigate to the *Topology* view and click *Export application*.

--- a/applications/odc-viewing-application-composition-using-topology-view.adoc
+++ b/applications/odc-viewing-application-composition-using-topology-view.adoc
@@ -37,4 +37,4 @@ include::modules/odc-labels-and-annotations-used-for-topology-view.adoc[leveloff
 
 * See xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-importing-codebase-from-git-to-create-application_odc-creating-applications-using-developer-perspective[Importing a codebase from Git to create an application] for more information on creating an application from Git.
 * See xref:../applications/connecting_applications_to_services/odc-connecting-an-application-to-a-service-using-the-developer-perspective.adoc#odc-connecting-an-application-to-a-service-using-the-developer-perspective[Connecting an application to a service using the Developer perspective].
-* See xref:../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-exporting-an-application-to-another-project-or-cluster_odc-creating-applications-using-developer-perspective[Exporting an application to another project or cluster]
+* See xref:../applications/odc-exporting-applications.adoc#odc-exporting-applications[Exporting applications]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-3624

Link to docs preview:
https://58214--docspreview.netlify.app/openshift-enterprise/latest/applications/odc-exporting-applications.html

QE review:
Not required
