### PR TITLE
TELCODOCS-1242: [Doc Bug] Short secret name while following worker scale-up for agent-based clusters

### DIFF
--- a/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
+++ b/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
@@ -41,7 +41,7 @@ $ ARCH=<architecture> <1>
 +
 [source,terminal]
 ----
-$ oc extract -n openshift-machine-api secret/worker-user-data --keys=userData --to=- > worker.ign
+$ oc extract -n openshift-machine-api secret/worker-user-data-managed --keys=userData --to=- > worker.ign
 ----
 
 . Host the `worker.ign` file on a web server accessible from your network.
@@ -90,7 +90,8 @@ $ curl -L $ISO_URL -o rhcos-live.iso
 [source,terminal]
 ----
 $ nmcli con mod <network_interface> ipv4.method manual /
-ipv4.addresses <static_ip> ipv4.gateway <network_gateway> ipv4.dns <dns_server>
+ipv4.addresses <static_ip> ipv4.gateway <network_gateway> ipv4.dns <dns_server> /
+802-3-ethernet.mtu 9000
 ----
 +
 where:


### PR DESCRIPTION
Fixed the secret name and added MTU 9000 to the interface.

Fixes: [TELCODOCS-1242](https://issues.redhat.com//browse/TELCODOCS-1242)

See https://issues.redhat.com/browse/TELCODOCS-1242 for additional details.

Preview URL: http://jowilkin.com:8080/TELCODOCS-1242/nodes/nodes/nodes-sno-worker-nodes.html#sno-adding-worker-nodes-to-single-node-clusters-manually_add-workers

For release(s): 4.13, 4.12, 4.11
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
