### PR TITLE
CMA add TP note for the Kafka scaler

### DIFF
--- a/modules/nodes-pods-autoscaling-custom-trigger.adoc
+++ b/modules/nodes-pods-autoscaling-custom-trigger.adoc
@@ -8,10 +8,10 @@
 
 Triggers, also known as scalers, provide the metrics that the Custom Metrics Autoscaler Operator uses to scale your pods. 
 
-[NOTE]
-====
 The custom metrics autoscaler currently supports only the  Prometheus, CPU, memory, and Apache Kafka triggers.  
-====
+
+:FeatureName: Autoscaling based on Apache Kafka metrics
+include::snippets/technology-preview.adoc[leveloffset=+0]
 
 //You can specify a single trigger or multiple triggers. When using multiple triggers, the scaling is based on the greatest value from all the triggers. This section contains examples of the triggers supported for use with {product-title}. 
 
@@ -148,6 +148,9 @@ spec:
 == Understanding the Kafka trigger
 
 You can scale pods based on an Apache Kafka topic or other services that support the Kafka protocol. The custom metrics autoscaler does not scale higher than the number of Kafka partitions, unless you set the `allowIdleConsumers` parameter to `true` in the scaled object or scaled job.
+
+:FeatureName: Autoscaling based on Apache Kafka metrics
+include::snippets/technology-preview.adoc[leveloffset=+0]
 
 [NOTE]
 ====

--- a/nodes/pods/nodes-pods-autoscaling-custom.adoc
+++ b/nodes/pods/nodes-pods-autoscaling-custom.adoc
@@ -13,12 +13,12 @@ include::snippets/technology-preview.adoc[]
 
 The Custom Metrics Autoscaler Operator for Red Hat OpenShift is an optional operator, based on the Kubernetes Event Driven Autoscaler (KEDA), that allows workloads to be scaled using additional metrics sources other than pod metrics.
 
-[NOTE]
-====
 The custom metrics autoscaler currently supports only the Prometheus, CPU, memory, and Apache Kafka metrics.
-====
 
 // For example, you can scale a database application based on the number of tables in the database, scale another application based on the number of messages in a Kafka topic, or scale based on incoming HTTP requests collected by {product-title} monitoring.
+
+:FeatureName: Autoscaling based on Apache Kafka metrics
+include::snippets/technology-preview.adoc[leveloffset=+0]
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference


### PR DESCRIPTION
Support for scaling based on Apache Kafka metrics will be TP after the Cluster Metrics Autoscaler goes GA. The team decided to add the note to the CMA TP docs as an alert. 

Previews:
Added TP note to:
 [Automatically scaling pods based on custom metrics](https://58230--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html) 
[Understanding the custom metrics autoscaler triggers](https://58230--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-trigger_nodes-pods-autoscaling-custom)
[Understanding the Kafka trigger](https://58230--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-trigger_nodes-pods-autoscaling-custom)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

