### PR TITLE
OCPBUGS#11363: Expose the node port for the application

### DIFF
--- a/modules/nw-exposing-service.adoc
+++ b/modules/nw-exposing-service.adoc
@@ -72,18 +72,28 @@ HTTP/1.1 200 OK
 
 endif::nodeport[]
 ifdef::nodeport[]
-. To expose a node port for the application, enter the following command. {product-title} automatically selects an available port in the `30000-32767` range.
+. To expose a node port for the application, modify the custom resource definition (CRD) of a service by entering the following command:
 +
 [source,terminal]
 ----
-$ oc expose service nodejs-ex  --type=NodePort --name=nodejs-ex-nodeport --generator="service/v2"
+$ oc edit svc <service_name>
 ----
 +
 .Example output
-[source,terminal]
+[source,yaml]
 ----
-service/nodejs-ex-nodeport exposed
+spec:
+  ports:
+  - name: 8443-tcp
+    nodePort: 30327 <1>
+    port: 8443
+    protocol: TCP
+    targetPort: 8443
+  sessionAffinity: None
+  type: NodePort <2>
 ----
+<1> Optional: Specify the node port range for the application. By default, {product-title} selects an available port in the `30000-32767` range.
+<2> Define the service type.
 
 . Optional: To confirm the service is available with a node port exposed, enter the following command:
 +
@@ -105,6 +115,24 @@ nodejs-ex-ingress   NodePort    172.30.107.72    <none>        3306:31345/TCP   
 [source,terminal]
 ----
 $ oc delete svc nodejs-ex
+----
+
+.Verification
+
+* To check that the service node port is updated with a port in the `30000-32767` range, enter the following command:
++
+[source,terminal]
+----
+$ oc get svc
+----
++
+In the following example output, the updated port is `30327`:
++
+.Example output
+[source,terminal]
+----
+NAME    TYPE       CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+httpd   NodePort   172.xx.xx.xx    <none>        8443:30327/TCP   109s
 ----
 endif::nodeport[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-11363
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://58232--docspreview.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.html#nw-exposing-service_configuring-ingress-cluster-traffic-nodeport
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
