### PR TITLE
[OCPBUGS-11019]: Update the version of a bare metal Operator command

### DIFF
--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -313,7 +313,7 @@ $ oc get clusteroperator baremetal
 [source,terminal]
 ----
 NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-baremetal   4.11.3    True        False         False      3d15h
+baremetal   4.10.x    True        False         False      3d15h
 ----
 
 . Remove the old `BareMetalHost` object by running the following command:


### PR DESCRIPTION
[OCPBUGS-11019](https://issues.redhat.com/browse/OCPBUGS-11019)


Version(s): 4.9 and CP to 4.10

Link to docs preview:
http://file.rdu.redhat.com/tlove/etcd-ocpbugs-11019-tlove-new/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-baremetal-etcd-member_replacing-unhealthy-etcd-member

QE review:
- [x ] QE has approved this change.

