### PR TITLE
[SRVCOM-2210] Add notes on restrictions for overriding probes

### DIFF
--- a/serverless/eventing/tuning/overriding-config-eventing.adoc
+++ b/serverless/eventing/tuning/overriding-config-eventing.adoc
@@ -6,7 +6,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeEventing` custom resource (CR).
+You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeEventing` custom resource (CR). Currently, overriding default configuration settings is supported for the `eventing-controller`, `eventing-webhook`, and `imc-controller` fields, as well as for the `readiness` and `liveness` fields for probes.
+
+[IMPORTANT]
+====
+The `replicas` spec cannot override the number of replicas for deployments that use the Horizontal Pod Autoscaler (HPA), and does not work for the `eventing-webhook` deployment.
+====
+
+[NOTE]
+====
+You can only override probes that are defined in the deployment by default.
+
+All Knative Serving deployments define a readiness and a liveness probe by default, with these exceptions:
+
+* `net-kourier-controller` and `3scale-kourier-gateway` only define a readiness probe.
+* `net-istio-controller` and `net-istio-webhook` define no probes.
+====
 
 include::modules/knative-eventing-CR-system-deployments.adoc[leveloffset=+1]
 

--- a/serverless/knative-serving/config-applications/overriding-config-serving.adoc
+++ b/serverless/knative-serving/config-applications/overriding-config-serving.adoc
@@ -6,6 +6,16 @@ include::_attributes/common-attributes.adoc[]
 
 You can override the default configurations for some specific deployments by modifying the `deployments` spec in the `KnativeServing` custom resources (CRs).
 
+[NOTE]
+====
+You can only override probes that are defined in the deployment by default.
+
+All Knative Serving deployments define a readiness and a liveness probe by default, with these exceptions:
+
+* `net-kourier-controller` and `3scale-kourier-gateway` only define a readiness probe.
+* `net-istio-controller` and `net-istio-webhook` define no probes.
+====
+
 include::modules/knative-serving-CR-system-deployments.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2210

Link to docs preview:
https://58237--docspreview.netlify.app/openshift-enterprise/latest/serverless/knative-serving/config-applications/overriding-config.html
https://58237--docspreview.netlify.app/openshift-enterprise/latest/serverless/eventing/tuning/override-config.html

QE review:
- [x] QE has approved this change.