### PR TITLE
[SRVKS-957] Add section on resolving Serverless operator upgrade failure

### DIFF
--- a/modules/serverless-resolving-operator-upgrade-failure.adoc
+++ b/modules/serverless-resolving-operator-upgrade-failure.adoc
@@ -1,0 +1,51 @@
+// Module included in the following assemblies:
+//
+// * /serverless/admin_guide/serverless-upgrades.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-resolving-operator-upgrade-failure_{context}"]
+= Resolving an {ServerlessOperatorName} upgrade failure
+
+You might encounter an error when upgrading {ServerlessOperatorName}, for example, when performing manual uninstalls and reinstalls. If you encounter an error, you must manually reinstall {ServerlessOperatorName}.
+
+.Procedure
+
+. Identify the version of {ServerlessOperatorName} that was installed originally by searching in the {ServerlessProductName} Release Notes.
++
+For example, the error message during attempted upgrade might contain the following string:
++
+[source]
+----
+The installed KnativeServing version is v1.5.0.
+----
++
+In this example, the KnativeServing `MAJOR.MINOR` version is `1.5`, which is covered in the release notes for {ServerlessProductName} 1.26: _OpenShift Serverless now uses Knative Serving 1.5_.
+
+. Uninstall {ServerlessOperatorName} and all of its install plans.
+
+. Manually install the version of {ServerlessOperatorName} that you discovered in the first step. To install, first create a `serverless-subscription.yaml` file as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: serverless-operator
+  namespace: openshift-serverless
+spec:
+  channel: stable
+  name: serverless-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+  startingCSV: serverless-operator.v1.26.0
+----
+
+. Then, install the subscription by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f serverless-subscription.yaml
+----
+
+. Upgrade by manually approving the upgrade install plans as they appear.

--- a/serverless/admin_guide/serverless-upgrades.adoc
+++ b/serverless/admin_guide/serverless-upgrades.adoc
@@ -1,0 +1,18 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="serverless-upgrades"]
+= Serverless upgrades
+:context: serverless-upgrades
+
+toc::[]
+
+{ServerlessProductName} should be upgraded without skipping release versions. This section shows how to resolve problems with upgrading.
+
+include::modules/serverless-resolving-operator-upgrade-failure.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../serverless/serverless-release-notes.adoc#serverless-tech-preview-features_serverless-release-notes[{ServerlessProductName} Release Notes]
+* xref:../../serverless/removing/removing-serverless-operator.adoc#olm-deleting-operators-from-a-cluster-using-web-console_removing-serverless-operator[Deleting Operators from a cluster using the web console]
+* xref:../../serverless/install/install-serverless-operator.adoc#serverless-install-web-console_install-serverless-operator[Installing the OpenShift Serverless Operator from the web console]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVKS-957

Link to docs preview:
https://58238--docspreview.netlify.app/openshift-enterprise/latest/serverless/admin_guide/serverless-upgrades.html

QE review:
- [ ] QE has approved this change.