### PR TITLE
TELCODOCS-1267: Clarifying out-of-band management network access 

### DIFF
--- a/modules/ipi-install-out-of-band-management.adoc
+++ b/modules/ipi-install-out-of-band-management.adoc
@@ -6,8 +6,18 @@
 [id="out-of-band-management_{context}"]
 = Out-of-band management
 
-Nodes will typically have an additional NIC used by the baseboard management controllers (BMCs). These BMCs must be accessible from the provisioner node.
+Nodes typically have an additional NIC used by the baseboard management controllers (BMCs). These BMCs must be accessible from the provisioner node.
 
 Each node must be accessible via out-of-band management. When using an out-of-band management network, the provisioner node requires access to the out-of-band management network for a successful {product-title} installation.
 
-The out-of-band management setup is out of scope for this document. We recommend setting up a separate management network for out-of-band management. However, using the provisioning network or the baremetal network are valid options.
+The out-of-band management setup is out of scope for this document. Using a separate management network for out-of-band management can enhance performance and improve security. However, using the provisioning network or the bare metal network are valid options.
+
+[NOTE]
+====
+The bootstrap VM features a maximum of two network interfaces. If you configure a separate management network for out-of-band management, and you are using a provisioning network, the bootstrap VM requires routing access to the management network through one of the network interfaces. In this scenario, the bootstrap VM can then access three networks:
+
+* the bare metal network
+* the provisioning network
+* the management network routed through one of the network interfaces
+====
+


### PR DESCRIPTION
[TELCODOCS-1267](https://issues.redhat.com//browse/TELCODOCS-1267): The bootstrap VM in IPI installations features two network interfaces. In the case where you have a BM network, a provisioning network, and a separate out-of-band management network, you need to ensure the management network is routable through the BM network interface due to the bootstrap VM limitation on interfaces. 

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1267

Link to docs preview:
https://58242--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#out-of-band-management_ipi-install-prerequisites

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

