### PR TITLE
[SRVCOM-2105] Serverless: s/v1alpha/v1beta1 in examples

### DIFF
--- a/modules/knative-serving-CR-system-deployments.adoc
+++ b/modules/knative-serving-CR-system-deployments.adoc
@@ -25,7 +25,7 @@ The `KnativeServing` CR label and annotation settings override the deployment's 
 .KnativeServing CR example
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: ks

--- a/modules/knative-serving-controller-custom-certs-secrets.adoc
+++ b/modules/knative-serving-controller-custom-certs-secrets.adoc
@@ -35,7 +35,7 @@ $ oc -n knative-serving create secret generic custom-secret --from-file=<secret_
 .Example KnativeServing CR
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/modules/serverless-admin-init-containers.adoc
+++ b/modules/serverless-admin-init-containers.adoc
@@ -25,7 +25,7 @@ endif::[]
 .Example KnativeServing CR
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/modules/serverless-channel-default.adoc
+++ b/modules/serverless-channel-default.adoc
@@ -18,7 +18,7 @@
 +
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 metadata:
   name: knative-eventing

--- a/modules/serverless-config-emptydir.adoc
+++ b/modules/serverless-config-emptydir.adoc
@@ -12,7 +12,7 @@ The `kubernetes.podspec-volumes-emptydir` extension controls whether `emptyDir` 
 .Example KnativeServing CR
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/modules/serverless-config-replicas-eventing.adoc
+++ b/modules/serverless-config-replicas-eventing.adoc
@@ -42,7 +42,7 @@ image::eventing-YAML-HA.png[Knative Eventing YAML]
 .Example YAML
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 metadata:
   name: knative-eventing

--- a/modules/serverless-config-replicas-serving.adoc
+++ b/modules/serverless-config-replicas-serving.adoc
@@ -38,7 +38,7 @@ image::serving-YAML-HA.png[Knative Serving YAML]
 .Example YAML
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/modules/serverless-enable-scale-to-zero.adoc
+++ b/modules/serverless-enable-scale-to-zero.adoc
@@ -29,7 +29,7 @@ endif::[]
 .Example KnativeServing CR
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/modules/serverless-https-redirect-global.adoc
+++ b/modules/serverless-https-redirect-global.adoc
@@ -9,7 +9,7 @@
 .Example `KnativeServing` CR that enables HTTPS redirection
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/modules/serverless-install-eventing-yaml.adoc
+++ b/modules/serverless-install-eventing-yaml.adoc
@@ -28,7 +28,7 @@ endif::[]
 +
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 metadata:
     name: knative-eventing

--- a/modules/serverless-install-serving-yaml.adoc
+++ b/modules/serverless-install-serving-yaml.adoc
@@ -27,7 +27,7 @@ endif::[]
 +
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
     name: knative-serving

--- a/modules/serverless-jaeger-config.adoc
+++ b/modules/serverless-jaeger-config.adoc
@@ -42,7 +42,7 @@ metadata:
 .Tracing YAML example for Serving
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving
@@ -66,7 +66,7 @@ spec:
 .Tracing YAML example for Eventing
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 metadata:
   name: knative-eventing

--- a/modules/serverless-open-telemetry.adoc
+++ b/modules/serverless-open-telemetry.adoc
@@ -86,7 +86,7 @@ These services are used to configure Jaeger, Knative Serving, and Knative Eventi
 .Example KnativeServing CR
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
     name: knative-serving
@@ -106,7 +106,7 @@ spec:
 .Example KnativeEventing CR
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 metadata:
     name: knative-eventing

--- a/modules/serverless-ossm-secret-filtering.adoc
+++ b/modules/serverless-ossm-secret-filtering.adoc
@@ -30,7 +30,7 @@ endif::[]
 .Example KnativeServing CR
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/modules/serverless-ossm-setup.adoc
+++ b/modules/serverless-ossm-setup.adoc
@@ -154,7 +154,7 @@ $ oc apply -f <filename>
 +
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/modules/serverless-rn-1-23-0.adoc
+++ b/modules/serverless-rn-1-23-0.adoc
@@ -42,7 +42,7 @@ not identified yet
 +
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/modules/serverless-rn-1-26-0.adoc
+++ b/modules/serverless-rn-1-26-0.adoc
@@ -28,7 +28,7 @@ To enable new trigger filters, add the `new-trigger-filters: enabled` entry in t
 +
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 ...
 ...

--- a/modules/serverless-scale-to-zero-grace-period.adoc
+++ b/modules/serverless-scale-to-zero-grace-period.adoc
@@ -29,7 +29,7 @@ endif::[]
 .Example KnativeServing CR
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeServing
 metadata:
   name: knative-serving

--- a/serverless/eventing/brokers/serverless-broker-backing-channel-default.adoc
+++ b/serverless/eventing/brokers/serverless-broker-backing-channel-default.adoc
@@ -19,7 +19,7 @@ If you are using a channel-based broker, you can set the default backing channel
 +
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 metadata:
   name: knative-eventing

--- a/serverless/eventing/brokers/serverless-global-config-broker-class-default.adoc
+++ b/serverless/eventing/brokers/serverless-global-config-broker-class-default.adoc
@@ -19,7 +19,7 @@ You can use the `config-br-defaults` config map to specify default broker class 
 +
 [source,yaml]
 ----
-apiVersion: operator.knative.dev/v1alpha1
+apiVersion: operator.knative.dev/v1beta1
 kind: KnativeEventing
 metadata:
   name: knative-eventing


### PR DESCRIPTION
Version(s):
4.8+

Issue:
https://issues.redhat.com/browse/SRVCOM-2105

Link to docs preview:
Same string substitution across many files, no need to look at the preview, source review is enough.

QE review:
- [x] QE has approved this change.