### PR TITLE
Bump OMR version to 385

### DIFF
--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -11,6 +11,17 @@ These release notes track the development of the _mirror registry for Red Hat Op
 
 For an overview of the _mirror registry for Red Hat OpenShift_, see xref:../../installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-flags_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift].
 
+[id="mirror-registry-for-openshift-1-3-3"]
+== Mirror registry for Red Hat OpenShift 1.3.3
+
+Issued: 2023-04-05
+
+_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.5.
+
+The following advisory is available for the _mirror registry for Red Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2023:1528[RHBA-2023:1528 - mirror registry for Red Hat OpenShift 1.3.3]
+
 [id="mirror-registry-for-openshift-1-3-2"]
 == Mirror registry for Red Hat OpenShift 1.3.2
 


### PR DESCRIPTION
Document OMR 1.3.3. release notes 

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-5682

Link to docs preview:
https://58249--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-for-openshift-1-3-3

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
