### PR TITLE
OSDOCS-5454: remove irrelevant OCP APIs from tier table

### DIFF
--- a/modules/api-support-tiers-mapping.adoc
+++ b/modules/api-support-tiers-mapping.adoc
@@ -28,6 +28,7 @@ API groups that end with the suffix `*.k8s.io` or have the form `version.<name>`
 
 |===
 
+ifndef::microshift[]
 [id="mapping-support-tiers-to-openshift-api-groups_{context}"]
 == Support for OpenShift API groups
 
@@ -87,7 +88,28 @@ API groups that end with the suffix `*.openshift.io` are governed by the {produc
 |Tier 2
 
 |===
+endif::microshift[]
 
+ifdef::microshift[]
+[id="microshift-mapping-support-tiers-to-openshift-api-groups_{context}"]
+== Support for OpenShift API groups
+API groups that end with the suffix `*.openshift.io` are governed by the {product-title} deprecation policy and follow a general mapping between API version exposed and corresponding compatibility level unless otherwise specified.
+
+[cols="2",options="header"]
+|===
+|API version example
+|API tier
+
+|`route.openshift.io/v1`
+|Tier 1
+
+|`security.openshift.io/v1`
+|Tier 1 except for `RangeAllocation` (tier 4) and `*Reviews` (tier 2)
+
+|===
+endif::microshift[]
+
+ifndef::microshift[]
 [id="mapping-support-tiers-to-monitoring-api-groups_{context}"]
 == Support for Monitoring API groups
 
@@ -102,3 +124,4 @@ API groups that end with the suffix `monitoring.coreos.com` have the following m
 |Tier 1
 
 |===
+endif::microshift[]


### PR DESCRIPTION
Version(s):
4.12, 4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-8095

Link to docs preview:
https://58254--docspreview.netlify.app/microshift/latest/microshift_rest_api/understanding-api-support-tiers.html#microshift-mapping-support-tiers-to-openshift-api-groups_understanding-api-tiers (MicroShift, edited table)

http://file.rdu.redhat.com/shdiaz/OCPBUGS8095/rest_api/understanding-api-support-tiers.html#mapping-support-tiers-to-openshift-api-groups_understanding-api-tiers (OCP, no change)

QE review:
- [x] QE has approved this change.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
