### PR TITLE
TELCODOCS-1067: Create KMMO doc: Firmware support

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -66,3 +66,17 @@ include::modules/kmm-building-and-signing-a-moduleloader-container-image.adoc[le
 For information on creating a service account, see xref:https://docs.openshift.com/container-platform/4.12/authentication/understanding-and-creating-service-accounts.html#service-accounts-managing_understanding-service-accounts[Creating service accounts].
 
 include::modules/kmm-debugging-and-troubleshooting.adoc[leveloffset=+1]
+
+// Added for TELCODOCS-1067
+include::modules/kmm-firmware-support.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* xref:../hardware_enablement/kmm-kernel-module-management.adoc#kmm-creating-moduleloader-image_kernel-module-management-operator[Creating a ModuleLoader image].
+
+include::modules/kmm-configuring-the-lookup-path-on-nodes.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../post_installation_configuration/machine-configuration-tasks.adoc#understanding-the-machine-config-operator[Machine Config Operator].
+
+include::modules/kmm-building-a-moduleloader-image.adoc[leveloffset=+2]
+include::modules/kmm-tuning-the-module-resource.adoc[leveloffset=+2]

--- a/modules/kmm-building-a-moduleloader-image.adoc
+++ b/modules/kmm-building-a-moduleloader-image.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-building-a-moduleloader-image_{context}"]
+= Building a ModuleLoader image
+
+.Procedure
+
+* In addition to building the kernel module itself, include the binary firmware in the builder image:
++
+[source,dockerfile]
+----
+FROM registry.redhat.io/ubi8/ubi-minimal as builder
+
+# Build the kmod
+
+RUN ["mkdir", "/firmware"]
+RUN ["curl", "-o", "/firmware/firmware.bin", "https://artifacts.example.com/firmware.bin"]
+
+FROM registry.redhat.io/ubi8/ubi-minimal
+
+# Copy the kmod, install modprobe, run depmod
+
+COPY --from=builder /firmware /firmware
+----

--- a/modules/kmm-configuring-the-lookup-path-on-nodes.adoc
+++ b/modules/kmm-configuring-the-lookup-path-on-nodes.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-configuring-the-lookup-path-on-nodes_{context}"]
+= Configuring the lookup path on nodes
+
+On {product-title} nodes, the set of default lookup paths for firmwares does not include the `/var/lib/firmware` path.
+
+.Procedure
+
+. Use the Machine Config Operator to create a `MachineConfig` custom resource (CR) that contains the `/var/lib/firmware` path:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker <1>
+  name: 99-worker-kernel-args-firmware-path
+spec:
+  kernelArguments:
+    - 'firmware_class.path=/var/lib/firmware'
+----
+<1> You can configure the label based on your needs. In the case of {sno}, use either `control-pane` or `master` objects.
+
+
+. By applying the `MachineConfig` CR, the nodes are automatically rebooted.

--- a/modules/kmm-firmware-support.adoc
+++ b/modules/kmm-firmware-support.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-firmware-support_{context}"]
+= KMM firmware support
+
+Kernel modules sometimes need to load firmware files from the file system. KMM supports copying firmware files from the ModuleLoader image to the node's file system.
+
+The contents of `.spec.moduleLoader.container.modprobe.firmwarePath` are copied into the `/var/lib/firmware` path on the node before running the `modprobe` command to insert the kernel module.
+
+All files and empty directories are removed from that location before running the `modprobe -r` command to unload the kernel module, when the pod is terminated.

--- a/modules/kmm-tuning-the-module-resource.adoc
+++ b/modules/kmm-tuning-the-module-resource.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-tuning-the-module-resource_{context}"]
+= Tuning the Module resource
+
+.Procedure
+
+* Set `.spec.moduleLoader.container.modprobe.firmwarePath` in the `Module` custom resource (CR):
++
+[source,yaml]
+----
+apiVersion: kmm.sigs.x-k8s.io/v1beta1
+kind: Module
+metadata:
+  name: my-kmod
+spec:
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: my-kmod  # Required
+
+        firmwarePath: /firmware <1>
+----
+<1> Optional: Copies `/firmware/*` into `/var/lib/firmware/` on the node.


### PR DESCRIPTION
Create KMMO doc:  Firmware support

Jira: https://issues.redhat.com/browse/TELCODOCS-1067?src=confmacro

Version: openshift-4.12.z

Preview: https://58256--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management.html#kmm-firmware-support_kernel-module-management-operator

Dev:[ @qbarrand](https://github.com/qbarrand) 
@chr15p
T&PS:[ @slovern](https://github.com/slovern)
QE:[ @cdvultur](https://github.com/cdvultur) Approved