### PR TITLE
OSDOCS-5670: Removes references of Multicluster feature from 4.12 RNs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -319,7 +319,7 @@ With this release, there are several updates to the *Administrator* perspective 
 
 * The {product-title} web console displays a `ConsoleNotification` if the cluster is upgrading. Once the upgrade is done, the notification is removed.
 * A *_restart rollout_* option for the `Deployment` resource and a *_retry rollouts_* option for the `DeploymentConfig` resource are available on the *Action* and *Kebab* menus.
-* You can view a list of supported clusters on the *All Clusters* dropdown list. The supported clusters include {product-title}, {product-title} Service on AWS (ROSA), Azure Red Hat OpenShift (ARO), ROKS, and {product-dedicated}.
+//* You can view a list of supported clusters on the *All Clusters* dropdown list. The supported clusters include {product-title}, {product-title} Service on AWS (ROSA), Azure Red Hat OpenShift (ARO), ROKS, and {product-dedicated}.
 
 [id="ocp-4-12-multi-arch-console"]
 ===== Multi-architecture compute machines on the {product-title} web console
@@ -1747,6 +1747,21 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
+[discrete]
+=== Web console deprecated and removed features
+
+.Web console deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.10 |4.11 | 4.12
+
+|Multicluster console (Technology Preview)
+|REM
+|REM
+|REM
+
+|====
+
 [id="ocp-4-12-deprecated-features"]
 === Deprecated features
 
@@ -2651,10 +2666,10 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.10 |4.11 | 4.12
 
-|Multicluster console
-|Technology Preview
-|Technology Preview
-|Technology Preview
+//|Multicluster console
+//|Technology Preview
+//|Technology Preview
+//|Technology Preview
 
 |Dynamic Plugins
 |Technology Preview


### PR DESCRIPTION
[OSDOCS-5670](https://issues.redhat.com//browse/OSDOCS-5670): Removes references of Multicluster feature from 4.12 RNs

Relates to https://github.com/openshift/openshift-docs/pull/58093

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5670

Link to docs preview:
https://58281--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-web-console
https://58281--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-technology-preview

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR will need CM acks

Need to know if this will be removed at 4.13 release or should be removed now.
