### PR TITLE
OSDOCS-5670: Removes references of Multicluster feature from 4.11 RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1292,6 +1292,11 @@ In the table, features are marked with the following statuses:
 |GA
 |REM
 
+|Multicluster console (Technology Preview)
+|-
+|REM
+|REM
+
 |====
 
 [id="ocp-4-11-deprecated-features"]
@@ -2199,10 +2204,10 @@ In the table below, features are marked with the following statuses:
 |GA
 |GA
 
-|Multicluster console
-|-
-|TP
-|TP
+//|Multicluster console
+//|-
+//|TP
+//|TP
 
 |Selectable Cluster Inventory
 |-


### PR DESCRIPTION
[OSDOCS-5670](https://issues.redhat.com//browse/OSDOCS-5670): Removes references of Multicluster feature from 4.11 RNs

Relates to https://github.com/openshift/openshift-docs/pull/58093

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-5670

Link to docs preview:
https://58284--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-technology-preview

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR will need CM acks
