### PR TITLE
OSDOCS-5670: Removes references of Multicluster feature from 4.10 RNs

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -253,9 +253,9 @@ Starting with {product-title} {product-version}, the ability to create OpenShift
 
 For more information about the dynamic plug-in, see xref:../web_console/dynamic-plug-ins.adoc#dynamic-plug-ins_dynamic-plug-ins[Adding a dynamic plug-in to the {product-title} web console].
 
-[id="ocp-4-10-multicluster-console-technology-preview"]
-==== Multicluster console (Technology Preview)
-Starting with {product-title} 4.10, the multicluster console is now available as a Technology Preview feature. By enabling this feature, you can connect to remote clusters' API servers from a single {product-title} console. You must have Red Hat Advanced Cluster Management (ACM) or the multicluster engine (MCE) Operator installed to enable this feature.
+//[id="ocp-4-10-multicluster-console-technology-preview"]
+//==== Multicluster console (Technology Preview)
+//Starting with {product-title} 4.10, the multicluster console is now available as a Technology Preview feature. By enabling this feature, you can connect to remote clusters' API servers from a single {product-title} console. You must have Red Hat Advanced Cluster Management (ACM) or the multicluster engine (MCE) Operator installed to enable this feature.
 
 [id="pod-debug-mode-web-console"]
 ==== Running a pod in debug mode
@@ -1447,6 +1447,11 @@ In the table, features are marked with the following statuses:
 |
 |DEP
 
+|Multicluster console (Technology Preview)
+|
+|
+|REM
+
 |====
 
 [id="ocp-4-10-deprecated-features"]
@@ -2426,10 +2431,10 @@ In the table below, features are marked with the following statuses:
 |GA
 |GA
 
-|Multicluster console
-|-
-|-
-|TP
+//|Multicluster console
+//|-
+//|-
+//|TP
 
 |Selectable Cluster Inventory
 |-
@@ -3601,7 +3606,7 @@ $ oc adm release info 4.10.40 --pullspecs
 [id="ocp-4-10-40-notable-technical-changes"]
 ==== Notable technical changes
 
-* The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices. 
+* The Cloud Credential Operator utility (`ccoctl`) now creates secrets that use regional endpoints for the xref:../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc[AWS Security Token Service (AWS STS)]. This approach aligns with AWS recommended best practices.
 
 [id="ocp-4-10-40-upgrading"]
 ==== Updating
@@ -3625,7 +3630,7 @@ $ oc adm release info 4.10.41 --pullspecs
 [id="ocp-4-10-41-notable-technical-changes"]
 ==== Notable technical changes
 
-* With this release, when you xref:../installing/installing_gcp/uninstalling-cluster-gcp.adoc#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp[delete GCP resources with the Cloud Credential Operator utility], you must specify the directory containing the files for the component `CredentialsRequest` objects. 
+* With this release, when you xref:../installing/installing_gcp/uninstalling-cluster-gcp.adoc#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp[delete GCP resources with the Cloud Credential Operator utility], you must specify the directory containing the files for the component `CredentialsRequest` objects.
 
 [id="ocp-4-10-41-upgrading"]
 ==== Updating


### PR DESCRIPTION
[OSDOCS-5670](https://issues.redhat.com//browse/OSDOCS-5670): Removes references of Multicluster feature from 4.10 RNs

Relates to https://github.com/openshift/openshift-docs/pull/58093

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OSDOCS-5670

Link to docs preview:
http://file.rdu.redhat.com/opayne/OSDOCS-5670-4/release_notes/ocp-4-10-release-notes.html#ocp-4-10-web-console
http://file.rdu.redhat.com/opayne/OSDOCS-5670-4/release_notes/ocp-4-10-release-notes.html#ocp-4-10-technology-preview

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR will need to go through CM
