### PR TITLE
OSDOCS#5683: [4.12] Update the `osdk_ver_n1` attribute to 1.22.2

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -174,5 +174,5 @@ endif::[]
 //Operator SDK version
 :osdk_ver: 1.25.4
 //Operator SDK version that shipped with the previous OCP 4.x release
-:osdk_ver_n1: 1.22.0
+:osdk_ver_n1: 1.22.2
 :web-terminal-op: Web Terminal Operator

--- a/operators/operator_sdk/osdk-about.adoc
+++ b/operators/operator_sdk/osdk-about.adoc
@@ -28,7 +28,7 @@ Operator authors with cluster administrator access to a Kubernetes-based cluster
 
 [NOTE]
 ====
-{product-title} {product-version} supports Operator SDK {osdk_ver}.
+{product-title} {product-version} supports Operator SDK {osdk_ver} or later.
 ====
 
 [id="osdk-about-what-are-operators"]

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -1493,18 +1493,18 @@ For more information, see xref:../operators/admin/olm-managing-custom-catalogs.a
 
 [discrete]
 [id="ocp-4-12-operator-sdk-1-25-z"]
-=== Operator SDK 1.25.4
+=== Operator SDK {osdk_ver}
 
-{product-title} 4.12 supports Operator SDK 1.25.4. See xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Installing the Operator SDK CLI] to install or update to this latest version.
+{product-title} 4.12 supports Operator SDK {osdk_ver}. See xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Installing the Operator SDK CLI] to install or update to this latest version.
 
 [NOTE]
 ====
-Operator SDK 1.25.4 supports Kubernetes 1.25.
+Operator SDK {osdk_ver} supports Kubernetes 1.25.
 
 For more information, see xref:../release_notes/ocp-4-12-release-notes.adoc#ocp-4-12-removed-kube-1-25-apis[Beta APIs removed from Kubernetes 1.25] and xref:../release_notes/ocp-4-12-release-notes.adoc#ocp-4-12-osdk-bundle-validate-removed-kube-1-25-apis[Validating bundle manifests for APIs removed from Kubernetes 1.25].
 ====
 
-If you have Operator projects that were previously created or maintained with Operator SDK 1.22.0, update your projects to keep compatibility with Operator SDK 1.25.4.
+If you have Operator projects that were previously created or maintained with Operator SDK {osdk_ver_n1}, update your projects to keep compatibility with Operator SDK {osdk_ver}.
 
 * xref:../operators/operator_sdk/golang/osdk-golang-updating-projects.adoc#osdk-upgrading-projects_osdk-golang-updating-projects[Updating Go-based Operator projects]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-5683](https://issues.redhat.com//browse/OSDOCS-5683)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
* [Updating Go-based Operators](https://58289--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-updating-projects.html)
* [Updating Ansible-based Operators](https://58289--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-updating-projects.html)
* [Updating Helm-based Operators](https://58289--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-updating-projects.html)
* [Updating Hybrid Helm-based Operators](https://58289--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.html)
* [Updating Java-based Operators](https://58289--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/java/osdk-java-updating-projects.html)
* [Notable technical changes > Operator SDK](https://58289--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-notable-technical-changes) (scroll to Operator SDK update)

_Places where hard-coded OSDK 1.25.4 version was replaced with `osdk_ver` attribute_
* [Notable technical changes > Operator SDK](https://58289--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-notable-technical-changes)
* [About Operator SDK](https://58289--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-about.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The Operator SDK version was updated to 1.22.2 in OCP 4.11.34.

`enterprise-4.11` PR: #58106 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
