### PR TITLE
GH53988: Add missing node label

### DIFF
--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -61,8 +61,9 @@ metadata:
     kubernetes.io/hostname: ip-10-0-131-14
     beta.kubernetes.io/arch: amd64
     region: east <1>
+    type: user-node
 ----
-<1> Label to match the pod node selector.
+<1> Labels to match the pod node selector.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
 .Sample `Node` object with a label
@@ -87,8 +88,9 @@ metadata:
     kubernetes.io/hostname: ip-10-0-131-14
     beta.kubernetes.io/arch: amd64
     region: east <1>
+    type: user-node
 ----
-<1> Label to match the pod node selector.
+<1> Labels to match the pod node selector.
 endif::openshift-origin[]
 +
 A pod has the `type: user-node,region: east` node selector:
@@ -106,7 +108,7 @@ spec:
     region: east
     type: user-node
 ----
-<1> Node selectors to match the node label.
+<1> Node selectors to match the node label. The node must have a label for each node selector.
 +
 When you create the pod using the example pod spec, it can be scheduled on the example node.
 


### PR DESCRIPTION
The example yaml code with the title: "Sample Node object with a label" is missing the label "type: user-node", because the next yaml code "Sample Pod object with node selectors" uses that nodeSelector.

https://github.com/openshift/openshift-docs/issues/53988

Preview:  Nodes -> Scheduling -> Placing pods on specific nodes using node selectors -> [About node selectors](https://58296--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-about_nodes-scheduler-node-selectors). Two code blocks under _Node selectors on specific pods and nodes_

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
