### PR TITLE
[OCPBUGS-9060]: Adding warning to etcd encryption docs

### DIFF
--- a/modules/enabling-etcd-encryption.adoc
+++ b/modules/enabling-etcd-encryption.adoc
@@ -11,7 +11,13 @@ You can enable etcd encryption to encrypt sensitive resources in your cluster.
 
 [WARNING]
 ====
-It is not recommended to take a backup of etcd until the initial encryption process is complete. If the encryption process has not completed, the backup might be only partially encrypted.
+Do not back up etcd resources until the initial encryption process is completed. If the encryption process is not completed, the backup might be only partially encrypted.
+
+After you enable etcd encryption, several changes can occur:
+
+* The etcd encryption might affect the memory consumption of a few resources.
+* You might notice a transient affect on backup performance because the leader must serve the backup.
+* A disk I/O can affect the node that receives the backup state.
 ====
 
 .Prerequisites


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.8
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-9060
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds a warning about performance issues that can occur after you enable etcd encryption.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
