### PR TITLE
OCPBUG#10564: Corrected a command related to Subnet_ID.

### DIFF
--- a/modules/installation-localzone-generate-k8s-manifest.adoc
+++ b/modules/installation-localzone-generate-k8s-manifest.adoc
@@ -113,9 +113,8 @@ $ export AMI_ID=$(grep ami
 +
 [source,terminal]
 ----
-$ export SUBNET_ID=$(aws cloudformation describe-stacks \
-  --stack-name "<subnet_stack_name>" \ <1>
-  | jq -r .Stacks[0].Outputs[0].OutputValue)
+$ export SUBNET_ID=$(aws cloudformation describe-stacks --stack-name "<subnet_stack_name>" \ <1>
+  | jq -r '.Stacks[0].Outputs[0].OutputValue') 
 ----
 <1> For `<subnet_stack_name>`, specify the name of the subnet stack that you created.
 


### PR DESCRIPTION
Version(s):4.12+

Issue:
[OCPBUG-10564](https://issues.redhat.com/browse/OCPBUGS-10564)

Scope: Corrected the command related to Subnet_ID under "Creating the Kubernetes Manifest files".

Link to docs preview:
[Doc Preview](https://58315--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone.html#installation-localzone-generate-k8s-manifestinstalling-aws-localzone)

QE review:
- [ ] QE has approved this change.


Additional information:
