### PR TITLE
OCPBUG#11403: Corrected the note related to the cluster upgrade.

### DIFF
--- a/modules/upgrade.adoc
+++ b/modules/upgrade.adoc
@@ -21,7 +21,7 @@ All Kubernetes objects and PVs in each {product-title} cluster are backed up as 
 
 [NOTE]
 ====
-The upgrade starting time might be later than the scheduled time. It could be sometimes an hour or longer.
+When following a scheduled upgrade policy, there might be a delay of an hour or more before the upgrade process begins, even if it is an immediate upgrade. Additionally, the duration of the upgrade might vary based on your workload configuration.
 ====
 
 [id="upgrade-automatic_{context}"]

--- a/upgrading/rosa-upgrading.adoc
+++ b/upgrading/rosa-upgrading.adoc
@@ -28,7 +28,7 @@ For steps to upgrade a ROSA cluster that uses the AWS Security Token Service (ST
 
 [NOTE]
 ====
-The upgrade starting time might be later than the scheduled time. It could be sometimes an hour or longer.
+When following a scheduled upgrade policy, there might be a delay of an hour or more before the upgrade process begins, even if it is an immediate upgrade. Additionally, the duration of the upgrade might vary based on your workload configuration.
 ====
 
 include::modules/rosa-upgrading-cli-tutorial.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s): 4.10+

Issue:
[OCPBUG-11403](https://issues.redhat.com/browse/OCPBUGS-11403)

Link to docs preview:
[Preview 1](https://58316--docspreview.netlify.app/openshift-dedicated/latest/upgrading/osd-upgrades.html#upgrade_osd-upgrades)
[Preview 2](https://58316--docspreview.netlify.app/openshift-rosa/latest/upgrading/rosa-upgrading.html#rosa-sts-upgrading-a-cluster)

QE review:
- [ ] QE has approved this change.
@xueli181114 ptal

Additional information:
Related to [OCPBUG-10383](https://issues.redhat.com/browse/OCPBUGS-10383).
