### PR TITLE
OCPBUG3826: Added a note under cluster-wide proxy installation related to wait-for command.

### DIFF
--- a/modules/installation-configure-proxy.adoc
+++ b/modules/installation-configure-proxy.adoc
@@ -236,6 +236,16 @@ bundle.
 ====
 The installation program does not support the proxy `readinessEndpoints` field.
 ====
++
+[NOTE]
+====
+If the installer times out, restart and then complete the deployment by using the `wait-for` command of the installer. For example:
+
+[source,terminal]
+----
+$ ./openshift-install wait-for install-complete --log-level debug
+----
+====
 
 . Save the file and reference it when installing {product-title}.
 

--- a/modules/installation-osp-deploying-bare-metal-machines.adoc
+++ b/modules/installation-osp-deploying-bare-metal-machines.adoc
@@ -126,7 +126,7 @@ If the installer times out, restart and then complete the deployment by using th
 
 [source,terminal]
 ----
-./openshift-install wait-for install-complete --log-level debug
+$ ./openshift-install wait-for install-complete --log-level debug
 ----
 ====
 


### PR DESCRIPTION
Version(s): 4.10+

Issue:
[OCPBUG-3826](https://issues.redhat.com/browse/OCPBUGS-3826)
Added a note when the installer times out under cluster-wide proxy installation.

Link to docs preview:
[Preview 1](https://58319--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-configure-proxy_installing-openstack-installer-custom)
[Preview 2](https://58319--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom.html#installation-osp-deploying-bare-metal-machines_installing-openstack-installer-custom)

QE review:
- [ ] QE has approved this change.


Additional information:
[Proxy](https://github.com/openshift/installer/blob/master/docs/user/customization.md#proxy)
[Deploying a cluster with bare metal machines](https://github.com/openshift/installer/blob/master/docs/user/openstack/deploy_baremetal_workers.md#considerations-when-deploying-bare-metal-workers)