### PR TITLE
SRVOCF-501 reinstate TP python functions

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4051,6 +4051,8 @@ Topics:
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
+  - Name: Developing Python functions
+    File: serverless-developing-python-functions
   - Name: Using functions with Knative Eventing
     File: serverless-functions-eventing
   - Name: Function project configuration in func.yaml

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -630,6 +630,8 @@ Topics:
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
+  - Name: Developing Python functions
+    File: serverless-developing-python-functions
   - Name: Using functions with Knative Eventing
     File: serverless-functions-eventing
   - Name: Function project configuration in func.yaml

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -825,6 +825,8 @@ Topics:
     File: serverless-developing-nodejs-functions
   - Name: Developing TypeScript functions
     File: serverless-developing-typescript-functions
+  - Name: Developing Python functions
+    File: serverless-developing-python-functions
   - Name: Using functions with Knative Eventing
     File: serverless-functions-eventing
   - Name: Function project configuration in func.yaml


### PR DESCRIPTION
Version(s):
4.9+

Issue:
[SRVOCF-501](https://issues.redhat.com//browse/SRVOCF-501)

Link to docs preview:
https://58320--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-developing-python-functions.html

QE review: Not requires - restoring previously approved content
