### PR TITLE
OSSM-3695: 2.3.3 Z Stream Release Notes, Known Issues and Bug Fixes for OSSM 

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -134,7 +134,7 @@ endif::[]
 :product-dedicated: Red Hat OpenShift Dedicated
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.3.2
+:SMProductVersion: 2.3.3
 :MaistraVersion: 2.3
 //Service Mesh v1
 :SMProductVersion1x: 1.1.18.2

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -19,6 +19,10 @@ The following issues been resolved in the current release:
 [id="ossm-rn-fixed-issues-ossm_{context}"]
 == {SMProductShortName} fixed issues
 
+* https://issues.redhat.com/browse/OSSM-3644[OSSM-3644] Previously, the federation egress-gateway received the wrong update of network gateway endpoints, causing extra endpoint entries. Now, the federation-egress gateway has been updated on the server side so it receives the correct network gateway endpoints.
+
+* https://issues.redhat.com/browse/OSSM-3595[OSSM-3595] Previously, the `istio-cni` plugin sometimes failed on {op-system-base} because SELinux did not allow the utility `iptables-restore` to open files in the `/tmp` directory. Now, SELinux passes `iptables-restore` via `stdin` input stream instead of via a file.
+
 * https://issues.redhat.com/browse/OSSM-3025[OSSM-3025] Istiod sometimes fails to become ready. Sometimes, when a mesh contained many member namespaces, the Istiod pod did not become ready due to a deadlock within Istiod. The deadlock is now resolved and the pod now starts as expected.
 
 * https://issues.redhat.com/browse/OSSM-2493[OSSM-2493] Default `nodeSelector` and `tolerations` in SMCP not passed to Kiali. The `nodeSelector` and `tolerations` you add to `SMCP.spec.runtime.defaults` are now passed to the Kiali resource.

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -15,6 +15,31 @@ Module included in the following assemblies:
 
 This release adds improvements related to the following components and concepts.
 
+== New features {SMProductName} version 2.3.3
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
+//only Envoy Proxy changed 04/17/2023
+//kiali and istio changed 04/19/2023
+//Jaeger updated 04/20/2023
+
+=== Component versions included in {SMProductName} version 2.3.3
+
+|===
+|Component |Version
+
+|Istio
+|1.14.5
+
+|Envoy Proxy
+|1.22.9
+
+|Jaeger
+|1.42.0
+
+|Kiali
+|1.57.7
+|===
+
 == New features {SMProductName} version 2.3.2
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
@@ -166,7 +191,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |1.39
 
 |Kiali
-|1.48.4
+|1.48.5
 |===
 
 == New features {SMProductName} version 2.2.5
@@ -399,7 +424,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |1.36
 
 |Kiali
-|1.36.15
+|1.36.16
 |===
 
 == New features {SMProductName} 2.1.5.2


### PR DESCRIPTION
[DOC] 2.3.3 Z Stream Release Notes, Known Issues and Bug Fixes for OSSM

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSSM-3695

Link to docs preview:

New features: https://58341--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#new-features-red-hat-openshift-service-mesh-version-2-3-3

Fix issues: https://58341--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-rn-fixed-issues-ossm_ossm-release-notes

Please review the following issues:

[OSSM-3644](https://issues.redhat.com//browse/OSSM-3644)
[OSSM-3595](https://issues.redhat.com//browse/OSSM-3595)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
