### PR TITLE
doc-guide-yaml-rules: Updated OCP doc guidelines with additional YAML…

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1317,7 +1317,7 @@ spec:
 ----
 
 ==== Formatting
-Use the following conventions govern the layout of YAML for API objects.
+The following conventions govern the layout of YAML for API objects.
 
 - Begin YAML at the beginning of the left margin.
 - Use two-space indentation.
@@ -1330,7 +1330,8 @@ fieldName: |-
   This is a string.
   And it can be on multiple lines.
 ----
-- When truncating YAML, always precede an ellipsis with a pound so that the YAML is valid.
+- When truncating YAML, use an ellipsis (`...`) to indicate where content is omitted. Precede the ellipsis with a pound (`#`) so that the YAML is valid.
+- Use three hyphens (`---`) to separate YAML definitions in a single YAML file.
 
 .Example with array indentation flush with parent field
 ----


### PR DESCRIPTION
PR contains a proposed update for the in-house [OCP guidelines GitHub](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#yaml-formatting-for-kubernetes-and-openshift-api-objects) page.
