### PR TITLE
OCPBUGS-11249 v4.12: add rhel VG name info to 4.12 docs

### DIFF
--- a/modules/microshift-install-rpm-preparing.adoc
+++ b/modules/microshift-install-rpm-preparing.adoc
@@ -12,6 +12,8 @@ Before installing {product-title} from an RPM package, you must configure your {
 
 To configure a volume group (VG) that allows LVMS to create the LVs for your workload's PVs, adjust your root volume's size during the installation of {op-system}. Adjusting your root volume's size provides free space for additional LVs created by LVMS at runtime.
 
+The default name of the VG is `rhel`. You can change the VG name during your {op-system} configuration and use it during your {product-title} installation.
+
 .Prerequisites
 
 * The system requirements for installing {product-title} have been met.
@@ -21,7 +23,7 @@ To configure a volume group (VG) that allows LVMS to create the LVs for your wor
 
 . In the graphical installer under *Storage Configuration*, select *Custom* -> *Done* to open the dialog for configuring partitions and volumes.
 
-. Under *New Red Hat Enterprise Linux 9.x Installation*, select *Click here to create them automatically*.
+. Under *New Red Hat Enterprise Linux 8.x Installation*, select *Click here to create them automatically*.
 
 . Select the root partition, */*, reduce *Desired Capacity* so that the VG has sufficient capacity for your PVs, and then click *Update Settings*.
 


### PR DESCRIPTION
Version(s):
4.12 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-11249

Link to docs preview:
https://58374--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#microshift-install-rpm-preparing_microshift-install-rpm

QE review:
- No QE needed; Developer Preview docs.
- SME approval needed.

Additional information:
Additional information:
Decision to split this bug into two. This is the 4.12 PR.
See also https://github.com/openshift/openshift-docs/pull/58263 for 4.13.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
