### PR TITLE
OCPBUGS8700: correct kustomize language

### DIFF
--- a/modules/microshift-applying-manifests-example.adoc
+++ b/modules/microshift-applying-manifests-example.adoc
@@ -28,7 +28,7 @@ $ sudo mkdir -p ${MANIFEST_DIR}
 +
 [source,terminal]
 ----
-$ sudo cat << EOF > ${MANIFEST_DIR}/busybox.yaml
+$ sudo tee ${MANIFEST_DIR}/busybox.yaml &>/dev/null <<EOF
 
 apiVersion: v1
 kind: Namespace
@@ -63,7 +63,7 @@ EOF
 +
 [source,terminal]
 ----
-$ sudo cat << EOF > ${MANIFEST_DIR}/kustomization.yaml
+$ sudo tee ${MANIFEST_DIR}/kustomization.yaml &>/dev/null <<EOF
 ---
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization

--- a/modules/microshift-manifests-overview.adoc
+++ b/modules/microshift-manifests-overview.adoc
@@ -6,12 +6,7 @@
 [id="microshift-manifests-overview_{context}"]
 = How manifests work with kustomize
 
-Providing multiple directories allows a flexible method of managing {product-title} workloads. When you run the `kustomize` configuration management tool, {product-title} searches the `/etc/microshift/manifests` and `/usr/lib/microshift/` manifest directories for a `kustomization.yaml` file. If it finds one, {product-title} automatically runs the `kubectl apply -k` command to apply the manifests to the cluster.
-
-[IMPORTANT]
-====
-The `kustomize` tool must be either running as a separate step in the boot process, or it must be part of the {product-title} image.
-====
+The `kustomize` configuration management tool is integrated with {product-title}. At every start, {product-title} searches the `/etc/microshift/manifests` and `/usr/lib/microshift/` manifest directories for a `kustomization.yaml` file. If it finds one, {product-title} automatically runs the equivalent of the `kubectl apply -k` command to apply the identified manifests to the cluster.
 
 [cols="2",options="header"]
 |===


### PR DESCRIPTION
Version(s):
4.12, 4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-8700

Link to docs preview:
https://58375--docspreview.netlify.app/microshift/latest/microshift_running_apps/microshift-applications.html#microshift-manifests-overview_applications-microshift

QE review:
- [x] QE has approved this change.

Additional info: Bug filed on 4.12, but 4.13 docs read the same and the same corrections apply.
