### PR TITLE
OCPBUGS 11488: Adding pod security admission enforcement to the TechPr…

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -10,7 +10,7 @@ You can use the `FeatureGate` custom resource (CR) to enable specific feature se
 
 You can activate the following feature set by using the `FeatureGate` CR:
 
-* `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these tech preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters. Enabling this feature set cannot be undone and prevents minor version updates. This feature set is not recommended on production clusters.
+* `TechPreviewNoUpgrade`. This feature set is a subset of the current Technology Preview features. This feature set allows you to enable these Technology Preview features on test clusters, where you can fully test them, while leaving the features disabled on production clusters.
 +
 [WARNING]
 ====
@@ -23,14 +23,20 @@ The following Technology Preview features are enabled by this feature set:
 ** CSI automatic migration. Enables automatic migration for supported in-tree volume plugins to their equivalent Container Storage Interface (CSI) drivers. Supported for:
 *** Azure File (`CSIMigrationAzureFile`)
 *** VMware vSphere (`CSIMigrationvSphere`)
-** Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds. Enables the Container Storage Interface (CSI) (`CSIDriverSharedResource`).
-** CSI volumes. Enables CSI volume support for the {product-title} build system (`BuildCSIVolumes`).
-** Swap memory on nodes. Enables swap memory use for {product-title} workloads on a per-node basis (`NodeSwap`).
-** cgroups v2. Enables cgroup v2, the next version of the Linux cgroup API (`CGroupsV2`).
-** crun. Enables the crun container runtime (`Crun`).
-** Insights Operator. Enables the Insights Operator, which gathers {product-title} configuration data and sends it to Red Hat (`InsightsConfigAPI`).
+** Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds. Enables the Container Storage Interface (CSI). (`CSIDriverSharedResource`)
+** CSI volumes. Enables CSI volume support for the {product-title} build system. (`BuildCSIVolumes`)
+** Swap memory on nodes. Enables swap memory use for {product-title} workloads on a per-node basis. (`NodeSwap`)
+** cgroups v2. Enables cgroup v2, the next version of the Linux cgroup API. (`CGroupsV2`)
+** crun. Enables the crun container runtime. (`Crun`)
+** Insights Operator. Enables the Insights Operator, which gathers {product-title} configuration data and sends it to Red Hat. (`InsightsConfigAPI`)
 ** External cloud providers. Enables support for external cloud providers for clusters on vSphere, AWS, Azure, and GCP. Support for OpenStack is GA. (`ExternalCloudProvider`)
-** Pod topology spread constraints. Enables the `matchLabelKeys` parameter for pod topology contraints. The parameter is list of pod label keys to select the pods over which spreading will be calculated (`MatchLabelKeysInPodTopologySpread`).
+** Pod topology spread constraints. Enables the `matchLabelKeys` parameter for pod topology constraints. The parameter is list of pod label keys to select the pods over which spreading will be calculated. (`MatchLabelKeysInPodTopologySpread`)
+** Pod security admission enforcement. Enables restricted enforcement for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)
++
+[NOTE]
+====
+Pod security admission restricted enforcement is only activated if you enable the `TechPreviewNoUpgrade` feature set after your {product-title} cluster is installed. It is not activated if you enable the `TechPreviewNoUpgrade` feature set during cluster installation.
+====
 --
 
 ////

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -17,17 +17,15 @@ For more information about the features activated by the `TechPreviewNoUpgrade` 
 ** xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[Using Container Storage Interface (CSI)]
 ** xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-s2i[Source-to-image (S2I) build volumes] and xref:../../cicd/builds/build-strategies.adoc#builds-using-build-volumes_build-strategies-docker[Docker build volumes]
 ** xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-jobs[Swap memory on nodes]
-** xref:../../machine_management/capi-machine-management.adoc#capi-machine-management[Managing machines with the Cluster API] 
+** xref:../../machine_management/capi-machine-management.adoc#capi-machine-management[Managing machines with the Cluster API]
 ** xref:../../nodes/clusters/nodes-cluster-cgroups-2.adoc#nodes-cluster-cgroups-2[Enabling Linux control group version 2 (cgroup v2)]
 ** xref:../../nodes/containers/nodes-containers-using.adoc#nodes-containers-runtimes[About the container engine and container runtime]
 ** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
 ** xref:../../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Controlling pod placement by using pod topology spread constraints]
+** link:https://kubernetes.io/docs/concepts/security/pod-security-admission/[Pod Security Admission] in the Kubernetes documentation and xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
 
 include::modules/nodes-cluster-enabling-features-install.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-console.adoc[leveloffset=+1]
 
 include::modules/nodes-cluster-enabling-features-cli.adoc[leveloffset=+1]
-
-
-


### PR DESCRIPTION
…eviewNoUpgrade feature set

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-11488

Link to docs preview:
https://58381--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
 - peer review was done as part of #55880

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
