### PR TITLE
SRVKE-1215 FIPS issue in Knative Broker for Apache Kafka is fixed

### DIFF
--- a/snippets/serverless-about-kafka-broker.adoc
+++ b/snippets/serverless-about-kafka-broker.adoc
@@ -7,11 +7,6 @@
 
 For production-ready Knative Eventing deployments, Red Hat recommends using the Knative Kafka broker implementation. The Kafka broker is an Apache Kafka native implementation of the Knative broker, which sends CloudEvents directly to the Kafka instance.
 
-[IMPORTANT]
-====
-The Federal Information Processing Standards (FIPS) mode is disabled for Kafka broker.
-====
-
 The Kafka broker has a native integration with Kafka for storing and routing events. This allows better integration with Kafka for the broker and trigger model over other broker types, and reduces network hops. Other benefits of the Kafka broker implementation include:
 
 * At-least-once delivery guarantees


### PR DESCRIPTION
Jira: https://issues.redhat.com/browse/SRVKE-1215
fixVersion: 1.26


Version(s): 4.9+


Issue: https://issues.redhat.com/browse/SRVKE-1215


Link to docs preview:
https://58382--docspreview.netlify.app/openshift-enterprise/latest/serverless/eventing/brokers/kafka-broker.html
![Screenshot from 2023-04-06 23-31-56](https://user-images.githubusercontent.com/75261888/230505701-ab4e5cb0-068f-4c7d-8260-f1514ecc428a.png)

Previously, this showed an Important warning:
https://docs.openshift.com/container-platform/4.12/serverless/eventing/brokers/kafka-broker.html

![Screenshot from 2023-04-06 23-30-47](https://user-images.githubusercontent.com/75261888/230505632-6045c8b3-76b0-47f2-9932-964b7063cb03.png)

QE review:
- [x] QE has approved this change.


