### PR TITLE
OSDOCS-5686: Added a note about OVN-Kubernetes migration

### DIFF
--- a/modules/nw-ovn-kubernetes-migration-about.adoc
+++ b/modules/nw-ovn-kubernetes-migration-about.adoc
@@ -18,6 +18,11 @@ A migration to the OVN-Kubernetes network plugin is supported on the following p
 * {rh-virtualization-first}
 * VMware vSphere
 
+[IMPORTANT]
+====
+Migrating to or from the OVN-Kubernetes network plugin is not supported for managed OpenShift cloud services such as OpenShift Dedicated and Red Hat OpenShift Service on AWS (ROSA).
+====
+
 [id="considerations-migrating-ovn-kubernetes-network-provider_{context}"]
 == Considerations for migrating to the OVN-Kubernetes network plugin
 


### PR DESCRIPTION
Version(s):
`enterprise-4.8+`

Issue:
[OSDOCS-5686](https://issues.redhat.com/browse/OSDOCS-5686)

Link to docs preview:
* [OCP](https://58384--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration-about_migrate-from-openshift-sdn)
    ![image](https://user-images.githubusercontent.com/16167833/230466272-3ab43401-a34d-4c87-86b5-ef056fac9f08.png)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a note that there is no way to migrate to OVN-Kubernetes on OSD or ROSA.