### PR TITLE
OSDOCS-5689:adds 4.12.11 to RNs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3423,3 +3423,41 @@ $ oc adm release info 4.12.10 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-12-11"]
+=== RHSA-2023:1645 - {product-title} 4.12.11 bug fix and security update
+
+Issued: 2023-04-11
+
+{product-title} release 4.12.11, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1645[RHBA-2023:1645] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1644[RHBA-2023:1644] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.11 --pullspecs
+----
+[id="ocp-4-12-11-features"]
+==== Features
+
+[id="ocp-4-12-11-oc-mirror-max-nested-paths"]
+===== New flag for the oc-mirror plugin: --max-nested-paths
+
+With this update, you can now use the `--max-nested-paths` flag for the oc-mirror plugin to specify the maximum number of nested paths for destination registries that limit nested paths. The default is `2`.
+
+[id="ocp-4-12-11-oc-mirror-skip-pruning"]
+===== New flag for the oc-mirror plugin: --skip-pruning
+
+With this update, you can now use the `--skip-pruning` flag for the oc-mirror plugin to disable automatic pruning of images from the target mirror registry.
+
+[id="ocp-4-12-11-bug-fixes"]
+==== Bug fixes
+
+* Previously, the `openshift-install agent create cluster-manifests` command required a non-empty list of `imageContentSources` in the `install-config.yaml` file. If no image content sources were supplied, the command generated the error `failed to write asset (Mirror Registries Config) to disk: failed to write file: open .: is a directory`. With this update, the command works whether or not the `imageContentSources` section of `install-config.yaml` file contains anything. (link:https://issues.redhat.com/browse/OCPBUGS-8384[*OCPBUGS-8384*])
+
+* Previously, the OpenStack Machine API provider had to be restarted so that new cloud credentials were used in the event of a rotation of the OpenStack `clouds.yaml` file. Consequently, the ability of a MachineSet to scale to zero was affected. With this update, cloud credentials are no longer cached and the OpenStack Machine API provider reads the corresponding secret on demand. (link:https://issues.redhat.com/browse/OCPBUGS-10603[*OCPBUGS-10603*])
+
+[id="ocp-4-12-11-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5689](https://issues.redhat.com//browse/OSDOCS-5689): adds 4.12.11 to release notes
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5689
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://58393--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-11
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
