### PR TITLE
OSDOCS-4696: Added Optimizations for network policy with OVN module

### DIFF
--- a/modules/nw-networkpolicy-optimize-ovn.adoc
+++ b/modules/nw-networkpolicy-optimize-ovn.adoc
@@ -1,0 +1,98 @@
+// Module included in the following assemblies:
+//
+// * networking/network_policy/about-network-policy.adoc
+
+[id="nw-networkpolicy-optimize-ovn_{context}"]
+= Optimizations for network policy with OpenShift OVN
+
+When designing your network policy, refer to the following guidelines:
+
+* For network policies with the same `spec.podSelector` spec,  it is more efficient to use one network policy with multiple `ingress` or `egress` rules, than multiple network policies with subsets of `ingress` or `egress` rules.
+
+* Every `ingress` or `egress` rule based on the `podSelector` or `namespaceSelector` spec generates the number of OVS flows proportional to `number of pods selected by network policy + number of pods selected by ingress or egress rule`. Therefore, it is preferable to use the `podSelector` or `namespaceSelector` spec that can select as many pods as you need in one rule, instead of creating individual rules for every pod.
++
+For example, the following policy contains two rules:
++
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: test-network-policy
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+       - podSelector:
+           matchLabels:
+             role: frontend
+    - from:
+       - podSelector:
+           matchLabels:
+             role: backend
+----
++
+The following policy expresses those same two rules as one:
++
+[source,yaml]
+----
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+ name: test-network-policy
+spec:
+  podSelector: {}
+  ingress:
+    - from:
+       - podSelector:
+           matchExpressions:
+             - {key: role, operator: In, values: [frontend, backend]}
+----
++
+The same guideline applies to the `spec.podSelector` spec. If you have the same `ingress` or `egress` rules for different network policies, it might be more efficient to create one network policy with a common `spec.podSelector` spec. For example, the following two policies have different rules:
++
+[source,yaml]
+----
+metadata:
+ name: policy1
+spec:
+ podSelector:
+   matchLabels:
+     role: db
+  ingress:
+    - from:
+       - podSelector:
+           matchLabels:
+             role: frontend
+
+metadata:
+ name: policy2
+spec:
+ podSelector:
+   matchLabels:
+     role: client
+  ingress:
+    - from:
+       - podSelector:
+           matchLabels:
+             role: frontend
+----
++
+The following network policy expresses those same two rules as one:
++
+[source,yaml]
+----
+metadata:
+ name: policy3
+spec:
+ podSelector:
+   matchExpressions:
+     - {key: role, operator: In, values: [db, client]}
+  ingress:
+    - from:
+       - podSelector:
+           matchLabels:
+             role: frontend
+----
++
+You can apply this optimization when only multiple selectors are expressed as one. In cases where selectors are based on different labels, it may not be possible to apply this optimization. In those cases, consider applying some new labels for network policy optimization specifically.

--- a/modules/nw-networkpolicy-optimize.adoc
+++ b/modules/nw-networkpolicy-optimize.adoc
@@ -2,15 +2,10 @@
 //
 // * networking/network_policy/about-network-policy.adoc
 
-[id="nw-networkpolicy-optimize_{context}"]
-= Optimizations for network policy
+[id="nw-networkpolicy-optimize-sdn_{context}"]
+= Optimizations for network policy with OpenShift SDN
 
 Use a network policy to isolate pods that are differentiated from one another by labels within a namespace.
-
-[NOTE]
-====
-The guidelines for efficient use of network policy rules applies to only the OpenShift SDN network plugin.
-====
 
 It is inefficient to apply `NetworkPolicy` objects to large numbers of individual pods in a single namespace. Pod labels do not exist at the IP address level, so a network policy generates a separate Open vSwitch (OVS) flow rule for every possible link between every pod selected with a `podSelector`.
 

--- a/networking/network_policy/about-network-policy.adoc
+++ b/networking/network_policy/about-network-policy.adoc
@@ -16,10 +16,11 @@ As a cluster administrator, you can define network policies that restrict traffi
 Configured network policies are ignored in IPv6 networks.
 ====
 
-
 include::modules/nw-networkpolicy-about.adoc[leveloffset=+1]
 
 include::modules/nw-networkpolicy-optimize.adoc[leveloffset=+1]
+
+include::modules/nw-networkpolicy-optimize-ovn.adoc[leveloffset=+1]
 
 [id="about-network-policy-next-steps"]
 == Next steps


### PR DESCRIPTION
Version(s):
4.12+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-4696

Link to docs preview:
https://58394--docspreview.netlify.app/openshift-enterprise/latest/networking/network_policy/about-network-policy.html#nw-networkpolicy-optimize-ovn_about-network-policy
