### PR TITLE
GH53296 OKD Updating clusters section needs to be updated

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -585,8 +585,10 @@ Topics:
   File: index
 - Name: Understanding OpenShift updates
   File: understanding-openshift-updates
+  Distros: openshift-enterprise
 - Name: Understanding upgrade channels
   File: understanding-upgrade-channels-release
+  Distros: openshift-enterprise
 - Name: Understanding OpenShift update duration
   File: understanding-openshift-update-duration
 - Name: Preparing to update to OpenShift Container Platform 4.13
@@ -597,6 +599,7 @@ Topics:
   Distros: openshift-origin
 - Name: Preparing to perform an EUS-to-EUS update
   File: preparing-eus-eus-upgrade
+  Distros: openshift-enterprise
 - Name: Preparing to update a cluster with manually maintained credentials
   File: preparing-manual-creds-update
 - Name: Updating a cluster using the web console
@@ -612,7 +615,6 @@ Topics:
   Distros: openshift-enterprise
 - Name: Updating a cluster in a disconnected environment
   Dir: updating-restricted-network-cluster
-  Distros: openshift-enterprise
   Topics:
   - Name: About cluster updates in a disconnected environment
     File: index
@@ -620,10 +622,16 @@ Topics:
     File: mirroring-image-repository
   - Name: Updating a cluster in a disconnected environment using OSUS
     File: restricted-network-update-osus
+    Distros: openshift-enterprise
   - Name: Updating a cluster in a disconnected environment without OSUS
     File: restricted-network-update
+    Distros: openshift-enterprise
+  - Name: Updating a cluster in a disconnected environment by using the CLI
+    File: restricted-network-update
+    Distros: openshift-origin
   - Name: Uninstalling OSUS from a cluster
     File: uninstalling-osus
+    Distros: openshift-enterprise
 - Name: Updating hardware on nodes running on vSphere
   File: updating-hardware-on-nodes-running-on-vsphere
 - Name: Preflight validation for Kernel Module Management (KMM) Modules

--- a/modules/update-changing-update-server-web.adoc
+++ b/modules/update-changing-update-server-web.adoc
@@ -5,8 +5,12 @@
 :_content-type: PROCEDURE
 [id="update-changing-update-server-web_{context}"]
 = Changing the update server by using the web console
-
+ifndef::openshift-origin[]
 Changing the update server is optional. If you have an OpenShift Update Service (OSUS) installed and configured locally, you must set the URL for the server as the `upstream` to use the local server during updates.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+Changing the update server is optional. 
+endif::openshift-origin[]
 
 .Procedure
 

--- a/modules/update-upgrading-web.adoc
+++ b/modules/update-upgrading-web.adoc
@@ -24,12 +24,17 @@ link:https://access.redhat.com/downloads/content/290[in the errata section] of t
 
 . From the web console, click *Administration* -> *Cluster Settings* and review the contents of the *Details* tab.
 
+ifndef::openshift-origin[]
 . For production clusters, ensure that the *Channel* is set to the correct channel for the version that you want to update to, such as `stable-{product-version}`.
 +
 [IMPORTANT]
 ====
 For production clusters, you must subscribe to a `stable-\*`, `eus-*` or `fast-*` channel.
 ====
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+. For production clusters, ensure that the *Channel* is set to `stable-4`.
+endif::openshift-origin[]
 +
 [NOTE]
 ====

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -8,12 +8,15 @@ toc::[]
 
 You can update an {product-title} 4 cluster with a single operation by using the web console or the OpenShift CLI (`oc`).
 
+ifndef::openshift-origin[]
 [id="updating-clusters-overview-understanding-container-platform-updates"]
 == Understanding OpenShift Container Platform updates
 xref:../updating/understanding-openshift-updates.adoc#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]: For clusters with internet access, Red Hat provides over-the-air updates by using an {product-title} update service as a hosted service located behind public APIs.
+endif::openshift-origin[]
 
 [id="updating-clusters-overview-upgrade-channels-and-releases"]
 == Understanding upgrade channels and releases
+ifndef::openshift-origin[]
 xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Upgrade channels and releases]: With upgrade channels, you can choose an upgrade strategy. Upgrade channels are specific to a minor version of {product-title}. Upgrade channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version. For more information, see the following:
 
 * xref:../updating/understanding-upgrade-channels-release.adoc#upgrade-version-paths_understanding-upgrade-channels-releases[Upgrading version paths]
@@ -21,16 +24,27 @@ xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgra
 * xref:../updating/understanding-upgrade-channels-release.adoc#restricted-network-clusters_understanding-upgrade-channels-releases[Understanding restricted network clusters]
 * xref:../updating/understanding-upgrade-channels-release.adoc#switching-between-channels_understanding-upgrade-channels-releases[Switching between channels]
 * xref:../updating/understanding-upgrade-channels-release.adoc#conditional-updates-overview_understanding-upgrade-channels-releases[Understanding conditional updates]
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+With upgrade channels, you can choose an upgrade strategy. Upgrade channels are specific to a minor version of {product-title}. Upgrade channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version.
+
+{product-title} {product-version} offers the following update channel:
+
+* `stable-4`
+endif::openshift-origin[]
+
 
 include::modules/determining-upgrade-viability-conditiontype.adoc[leveloffset=+1]
 
 include::modules/determining-upgrade-viability-cv-conditiontype.adoc[leveloffset=+1]
 
+ifndef::openshift-origin[]
 [id="updating-clusters-overview-prepare-eus-to-eus-update"]
 == Preparing to perform an EUS-to-EUS update
 xref:../updating/preparing-eus-eus-upgrade.adoc#preparing-eus-eus-upgrade[Preparing to perform an EUS-to-EUS update]: Due to fundamental Kubernetes design, all {product-title} updates between minor versions must be serialized. You must update from {product-title} 4.10 to 4.11, and then to 4.12. You cannot update from {product-title} 4.10 to 4.12 directly. However, if you want to update between two Extended Update Support (EUS) versions, you can do so by incurring only a single reboot of non-control plane hosts. For more information, see the following:
 
 * xref:../updating/preparing-eus-eus-upgrade.adoc#updating-eus-to-eus-upgrade_eus-to-eus-upgrade[Updating EUS-to-EUS]
+endif::openshift-origin[]
 
 [id="updating-clusters-overview-update-cluster-using-web-console"]
 == Updating a cluster using the web console
@@ -61,6 +75,7 @@ xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-cust
 * xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-unpause_update-using-custom-machine-config-pools[Unpausing the machine configuration pools]
 * xref:../updating/update-using-custom-machine-config-pools.adoc#update-using-custom-machine-config-pools-mcp-remove_update-using-custom-machine-config-pools[Moving a node to the original machine configuration pool]
 
+ifndef::openshift-origin[]
 [id="updating-clusters-overview-update-cluster-with-rhel-compute-machines"]
 == Updating a cluster that includes {op-system-base} compute machines
 xref:../updating/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-compute[Updating a cluster that includes {op-system-base} compute machines]: If your cluster contains {op-system-base-full} machines, you must perform additional steps to update those machines. You can perform the following procedures:
@@ -68,6 +83,7 @@ xref:../updating/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-comput
 * xref:../updating/updating-cluster-rhel-compute.adoc#update-upgrading-web_updating-cluster-rhel-compute[Updating a cluster by using the web console]
 * xref:../updating/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-compute-hooks[Optional: Adding hooks to perform Ansible tasks on {op-system-base} machines]
 * xref:../updating/updating-cluster-rhel-compute.adoc#rhel-compute-updating-minor_updating-cluster-rhel-compute[Updating {op-system-base} compute machines in your cluster]
+endif::openshift-origin[]
 
 [id="updating-clusters-overview-update-restricted-network-cluster"]
 == Updating a cluster in a disconnected environment

--- a/updating/understanding-openshift-update-duration.adoc
+++ b/updating/understanding-openshift-update-duration.adoc
@@ -39,9 +39,11 @@ include::modules/update-duration-mco.adoc[leveloffset=+2]
 
 include::modules/update-duration-estimate-cluster-update-time.adoc[leveloffset=+1]
 
+ifndef::openshift-origin[]
 include::modules/update-duration-rhel-nodes.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../updating/updating-cluster-rhel-compute.adoc#updating-cluster-rhel-compute[Updating RHEL compute machines]
+endif::openshift-origin[]

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -55,9 +55,12 @@ include::modules/update-upgrading-cli.adoc[leveloffset=+1]
 
 include::modules/update-conditional-updates.adoc[leveloffset=+1]
 
+// OKD removed the section that this link points to.
+ifndef::openshift-origin
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Upgrade channels and release paths]
+endif::openshift-origin
 
 include::modules/update-changing-update-server-cli.adoc[leveloffset=+1]

--- a/updating/updating-restricted-network-cluster/restricted-network-update.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update.adoc
@@ -1,6 +1,12 @@
 :_content-type: ASSEMBLY
+ifndef::openshift-origin[]
 [id="updating-restricted-network-cluster"]
 = Updating a cluster in a disconnected environment without the OpenShift Update Service
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+[id="updating-restricted-network-cluster"]
+= Updating a cluster in a disconnected environment by using the CLI
+endif::openshift-origin[]
 include::_attributes/common-attributes.adoc[]
 :context: updating-restricted-network-cluster
 


### PR DESCRIPTION
Editing updating docs for OKD.

Mostly structural changes, ifdef, and a few changes to the text.

**Hidden assemblies** 
[Understanding OpenShift updates](https://docs.openshift.com/container-platform/4.12/updating/understanding-openshift-updates.html) (Mostly about OSUS, not in [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/index.html))

[Updating a cluster that includes RHEL compute machines](https://docs.openshift.com/container-platform/4.12/updating/updating-cluster-rhel-compute.html). N/A in [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/updating-restricted-network-cluster/index.html)

[Updating a cluster in a disconnected environment using the OpenShift Update Service](https://docs.openshift.com/container-platform/4.12/updating/updating-restricted-network-cluster/restricted-network-update-osus.html) 

[Uninstalling the OpenShift Update Service from a cluster](https://docs.openshift.com/container-platform/4.12/updating/updating-restricted-network-cluster/uninstalling-osus.html) N/A in [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/updating-restricted-network-cluster/index.html)

[Preparing to perform an EUS-to-EUS update](https://docs.openshift.com/container-platform/4.12/updating/preparing-eus-eus-upgrade.html) N/A in [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/index.html)

**Modified:**
[index/Understanding upgrade channels and releases](https://docs.openshift.com/container-platform/4.12/updating/index.html#updating-clusters-overview-upgrade-channels-and-releases). Removed link and references in [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates//updating/index.html#updating-clusters-overview-upgrade-channels-and-releases).

[Understanding upgrade channel](https://docs.openshift.com/container-platform/4.12/updating/understanding-upgrade-channels-release.html). Only one channel for [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/index.html).

Updating a cluster by using the web console. Added ifdef to switch between `stable-Branch Build` ([OCD](https://58413--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-within-minor.html#update-upgrading-web_updating-cluster-within-minor)) and `stable-4` ([OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/updating-cluster-within-minor.html#update-upgrading-web_updating-cluster-within-minor)) 

Changing the update server by using the web console, Added ifdefs to remove [the second sentence on OSUS](https://58413--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-within-minor.html#update-changing-update-server-web_updating-cluster-within-minor) from [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/updating-cluster-within-minor.html#update-changing-update-server-web_updating-cluster-within-minor).

Understanding OpenShift Container Platform update duration. Added ifdefs to remove [Red Hat Enterprise Linux (RHEL) compute nodes module](https://58413--docspreview.netlify.app/openshift-enterprise/latest/updating/understanding-openshift-update-duration.html#redhat-enterprise-linux-nodes_openshift-update-duration) from [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates//updating/understanding-openshift-update-duration.html#redhat-enterprise-linux-nodes_openshift-update-duration).

[Updating a cluster in a disconnected environment without the OpenShift Update Service](https://58413--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/restricted-network-update.html). Used ifdefs to remove _without the OpenShift Update Service_ from [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/updating-restricted-network-cluster/restricted-network-update.html)  

[Updating a cluster in a disconnected environment without the OpenShift Update Service](https://docs.openshift.com/container-platform/4.12/updating/updating-restricted-network-cluster/restricted-network-update.html) Changed [name of assembly in OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/updating-restricted-network-cluster/restricted-network-update.html).

**Added:** 
[Updating a cluster in a disconnected environment](https://58413--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/index.html). Was not included in [OKD](http://file.rdu.redhat.com/mburke/GH53296-OKD-updating-section-updates/updating/updating-restricted-network-cluster/index.html) upon initial publication.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

