### PR TITLE
OCPBUGS#11440:  Removing invalid fields from the SMCP reference documentation

### DIFF
--- a/modules/ossm-cr-general.adoc
+++ b/modules/ossm-cr-general.adoc
@@ -43,12 +43,6 @@ spec:
 |N/A
 
 |logging:
- logLevels:
-|Possible values: `trace`, `debug`, `info`, `warning`, `error`, `fatal`, `panic`.
-|
-|N/A
-
-|logging:
  logAsJSON:
 |Use to enable or disable JSON logging.
 |`true`/`false`


### PR DESCRIPTION
Improving the documentation to remove the invalid fields. 

The following fields are not present in the API and are invalid:

```
logging:
 logLevels:

```

```
$ oc explain servicemeshcontrolplane.spec.general.logging 
KIND:     ServiceMeshControlPlane
VERSION:  maistra.io/v2

RESOURCE: logging <Object>

DESCRIPTION:
     <empty>

FIELDS:
   componentLevels    <map[string]string>   

   logAsJSON    <boolean>
```


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
