### PR TITLE
OSDOCS-5692 Z-stream release notes 4.11.35

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3423,3 +3423,26 @@ $ oc adm release info 4.11.34 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-35"]
+=== RHBA-2023:1650 - {product-title} 4.11.35 bug fix
+
+Issued: 2023-04-12
+
+{product-title} release 4.11.35 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1650[RHBA-2023:1650] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1649[RHBA-2023:1649] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.35 --pullspecs
+----
+
+[id="ocp-4-11-35-bug-fixes"]
+==== Bug fixes
+* Previously, if the OpenStack `clouds.yaml` file was rotated, you needed to restart `machine-api-provider-openstack` to pick up  new cloud credentials. As a result, the ability of a `MachineSet` to scale to zero could be affected. With this change, cloud credentials are no longer cached and `machine-api-provider-openstack` reads the corresponding secret when it is needed. (link:https://issues.redhat.com/browse/OCPBUGS-10954[*OCPBUGS-10954*])
+
+[id="ocp-4-11-35-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-5692](https://issues.redhat.com/browse/OSDOCS-5692)

Link to docs preview:
[Preview](https://58436--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-35)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Z-stream release notes for 4.11.35.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
