### PR TITLE
OCPBUGS#4956:AWS_EFS

### DIFF
--- a/modules/storage-persistent-storage-block-volume.adoc
+++ b/modules/storage-persistent-storage-block-volume.adoc
@@ -28,6 +28,7 @@ The following table displays which volume plugins support block volumes.
 |===
 |Volume Plugin  |Manually provisioned  |Dynamically provisioned |Fully supported
 |AWS EBS  | ✅ | ✅ | ✅
+|AWS EFS | | |
 ifndef::openshift-dedicated,openshift-rosa[]
 |Azure Disk | ✅ | ✅ | ✅
 |Azure File | | |

--- a/modules/storage-persistent-storage-pv.adoc
+++ b/modules/storage-persistent-storage-pv.adoc
@@ -40,6 +40,9 @@ ifndef::microshift[]
 // - Ceph RBD
 // - OpenStack Cinder
 - AWS Elastic Block Store (EBS)
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa[]
+- AWS Elastic File Store (EFS)
+endif::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-aro[]
 - Azure Disk
 - Azure File
@@ -130,6 +133,7 @@ ifndef::microshift[]
 |===
 |Volume plugin  |ReadWriteOnce ^[1]^  |ReadOnlyMany  |ReadWriteMany
 |AWS EBS ^[2]^ | ✅ | - |  -
+|AWS EFS | ✅ | ✅ | ✅
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 |Azure File | ✅ | ✅ | ✅
 |Azure Disk | ✅ | - | -


### PR DESCRIPTION
The last several CSI storage drivers (AWS EFS, AliCloud, IBM) were not added in the following locations: Access mode, PV types, and Block volume support).
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-4956
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: PR for AliCloud & IBM https://github.com/openshift/openshift-docs/pull/58433
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**PTAL**: @gcharot, @jsafrane, @duanwei33 
