### PR TITLE
OCPBUGS#5852 specify control plane machines for the minimums

### DIFF
--- a/modules/installation-azure-limits.adoc
+++ b/modules/installation-azure-limits.adoc
@@ -106,7 +106,7 @@ ifndef::ash[]
 |OS Disk
 |7
 |
-|VM OS disk must be able to sustain a tested and recommended minimum throughput of 5000 IOPS / 200MBps. This throughput can be provided by having a minimum of 1 TiB Premium SSD (P30). In {cp}, disk performance is directly dependent on SSD disk sizes, so to achieve the throughput supported by `Standard_D8s_v3`, or other similar machine types available, and the target of 5000 IOPS, at least a P30 disk is required.
+|VM OS disk must be able to sustain a tested and recommended minimum throughput of 5000 IOPS / 200MBps for control plane machines. This throughput can be provided by having a minimum of 1 TiB Premium SSD (P30). In {cp}, disk performance is directly dependent on SSD disk sizes, so to achieve the throughput supported by `Standard_D8s_v3`, or other similar machine types available, and the target of 5000 IOPS, at least a P30 disk is required.
 
 Host caching must be set to `ReadOnly` for low read latency and high read IOPS and throughput. The reads performed from the cache, which is present either in the VM memory or in the local SSD disk, are much faster than the reads from the data disk, which is in the blob storage.
 endif::ash[]


### PR DESCRIPTION
Version(s):
4.9+

Issue:
[OCPBUGS-5852](https://issues.redhat.com/browse/OCPBUGS-5852)

Link to docs preview:
[Preview](https://58441--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra.html#installation-azure-limits_installing-azure-user-infra)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Clarification to [this PR. ](https://github.com/openshift/openshift-docs/pull/55263)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
