### PR TITLE
OCPBUGS#793: Replace "base64-encoded certificate"

### DIFF
--- a/modules/images-configuration-cas.adoc
+++ b/modules/images-configuration-cas.adoc
@@ -17,7 +17,7 @@ The `image.config.openshift.io/cluster` custom resource can contain a reference 
 
 You can create a config map in the `openshift-config` namespace and use its name in `AdditionalTrustedCA` in the `image.config.openshift.io` custom resource to provide additional CAs that should be trusted when contacting external registries.
 
-The config map key is the hostname of a registry with the port for which this CA is to be trusted, and the base64-encoded certificate is the value, for each additional registry CA to trust.
+The config map key is the hostname of a registry with the port for which this CA is to be trusted, and the PEM certificate content is the value, for each additional registry CA to trust.
 
 .Image registry CA config map example
 [source,yaml]


### PR DESCRIPTION
The previous description was technically inaccurate.

Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/OCPBUGS-793

Link to docs preview:
https://58457--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users.html#images-configuration-cas_post-install-preparing-for-users

QE review:
- [x] QE has approved this change.

Additional information:
N/A
