### PR TITLE
Adds descheduler RN to 4.13 Rns

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -93,7 +93,7 @@ You can deploy an {product-title} cluster to multiple vSphere datacenters or reg
 ====
 The VMware vSphere region and zone enablement feature is only available with a newly installed cluster, because this feature requires the vSphere Container Storage Interface (CSI) driver as the default storage driver in the cluster.
 
-A cluster that was upgraded from a previous release defaults to using the in-tree vSphere driver. As a result, you must enable CSI automatic migration for the cluster to use this feature. You can then configure multiple regions and zones for the upgraded cluster. 
+A cluster that was upgraded from a previous release defaults to using the in-tree vSphere driver. As a result, you must enable CSI automatic migration for the cluster to use this feature. You can then configure multiple regions and zones for the upgraded cluster.
 ====
 
 [id="ocp-4-13-installation-vsphere-default-config-yaml"]
@@ -445,7 +445,7 @@ This release includes the following version updates for monitoring stack compone
 * prom-label-proxy to 0.6.0
 * Prometheus to 2.42.0
 * prometheus-operator to 0.63.0
-* Thanos to 0.30.2 
+* Thanos to 0.30.2
 
 [id="ocp-4-13-monitoring-changes-to-alerting-rules"]
 ==== Changes to alerting rules
@@ -459,13 +459,13 @@ Red Hat does not guarantee backward compatibility for recording rules or alertin
 
 [id="ocp-4-13-monitoring-new-option-to-add-secrets-to-the-alertmanager-configuration"]
 ==== New option to add secrets to the Alertmanager configuration
-With this release, you can add secrets to the Alertmanager configuration for core platform monitoring and for user-defined projects. 
+With this release, you can add secrets to the Alertmanager configuration for core platform monitoring and for user-defined projects.
 If you need to authenticate with a receiver so that Alertmanager can send alerts to it, you can now configure Alertmanager to use a secret that contains authentication credentials for the receiver.
 
 [id="ocp-4-13-monitoring-new-option-to-configure-node-exporter-collectors"]
 ==== New option to configure node-exporter collectors
 With this release, you can customize Cluster Monitoring Operator (CMO) config map settings for the following node-exporter collectors.
-The following node-exporter collectors are now optional and can be enabled or disabled: 
+The following node-exporter collectors are now optional and can be enabled or disabled:
 
 * `buddyinfo` collector
 * `cpufreq` collector
@@ -476,12 +476,12 @@ The following node-exporter collectors are now optional and can be enabled or di
 
 [id="ocp-4-13-monitoring-new-option-to-filter-node-related-dashboards-by-node-role"]
 ==== New option to filter node-related dashboards by node role
-In the {product-title} web console, you can now filter data in node-related monitoring dashboards based on node roles. 
+In the {product-title} web console, you can now filter data in node-related monitoring dashboards based on node roles.
 You can use this new filter to quickly select relevant node roles if you want to see dashboard data only for nodes with certain roles, such as worker nodes.
 
 [id="ocp-4-13-monitoring-new-option-to-enable-metrics-collection-profiles-technology-preview"]
 ==== New option to enable metrics collection profiles (Technology Preview)
-This release introduces a Technology Preview feature for default platform monitoring in which an administrator can set a metrics collection profile to collect either the default amount of metrics data or a minimal amount of metrics data. 
+This release introduces a Technology Preview feature for default platform monitoring in which an administrator can set a metrics collection profile to collect either the default amount of metrics data or a minimal amount of metrics data.
 When you enable the minimal profile, basic monitoring features such as alerting continue to work, but the CPU and memory resources required by Prometheus decrease.
 
 [id="ocp-4-13-scalability-and-performance"]
@@ -962,6 +962,8 @@ With this release, replacement control plane nodes are assigned to the correct i
 [discrete]
 [id="ocp-4-13-kube-scheduler-bug-fixes"]
 ==== Kubernetes Scheduler
+
+* Previously, when the `LifeCycleUtilization` profile was excluded to test namespace filtering, the following error was logged in the Descheduler Operator logs: `belowE0222 12:43:14.331258 1 target_config_reconciler.go:668] key failed with : only namespace exclusion supported with LowNodeUtilization`. Consequently, the Descheduler cluster pod would not start. This issue has been resolved and namespace exclusion now works with the `LifeCycleUtilization` profile. (link:https://issues.redhat.com/browse/OCPBUGS-7876[*OCPBUGS-7876*])
 
 [discrete]
 [id="ocp-4-13-machine-config-operator-bug-fixes"]


### PR DESCRIPTION
Descheduler RNs for 4.13. 

Version(s):
4.13 RNs 

Issue:
https://issues.redhat.com/browse/OCPBUGS-7876

Link to docs preview:
https://58463--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-bug-fixes

Qe not needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
