### PR TITLE
OSDOCS#5019: Add note to use kube config to add system-reserved parameter

### DIFF
--- a/modules/nodes-nodes-resources-configuring-setting.adoc
+++ b/modules/nodes-nodes-resources-configuring-setting.adoc
@@ -6,10 +6,15 @@
 [id="nodes-nodes-resources-configuring-setting_{context}"]
 = Manually allocating resources for nodes
 
-{product-title} supports the CPU and memory resource types for allocation. The `ephemeral-resource` resource type is supported as well. For the `cpu` type, the resource quantity is specified in units of cores, such as `200m`, `0.5`, or `1`. For `memory` and `ephemeral-storage`, it is specified in units of bytes, such as `200Ki`, `50Mi`, or `5Gi`. By default, the `system-reserved` CPU is `500m` and `system-reserved` memory is `1Gi`.
+{product-title} supports the CPU and memory resource types for allocation. The `ephemeral-resource` resource type is also supported. For the `cpu` type, you specify the resource quantity in units of cores, such as `200m`, `0.5`, or `1`. For `memory` and `ephemeral-storage`, you specify the resource quantity in units of bytes, such as `200Ki`, `50Mi`, or `5Gi`. By default, the `system-reserved` CPU is `500m` and `system-reserved` memory is `1Gi`.
 
-As an administrator, you can set these using a custom resource (CR) through a set of `<resource_type>=<resource_quantity>` pairs
+As an administrator, you can set these values by using a kubelet config custom resource (CR) through a set of `<resource_type>=<resource_quantity>` pairs
 (e.g., `cpu=200m,memory=512Mi`).
+
+[IMPORTANT]
+====
+You must use a kubelet config CR to manually set resource values. You cannot use a machine config CR.
+====
 
 For details on the recommended `system-reserved` values, refer to the link:https://access.redhat.com/solutions/5843241[recommended system-reserved values].
 

--- a/nodes/nodes/nodes-nodes-resources-configuring.adoc
+++ b/nodes/nodes/nodes-nodes-resources-configuring.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 To provide more reliable scheduling and minimize node resource overcommitment, reserve a portion of the CPU and memory resources for use by the underlying node components, such as `kubelet` and `kube-proxy`, and the remaining system components, such as `sshd` and `NetworkManager`. By specifying the resources to reserve, you provide the scheduler with more information about the remaining CPU and memory resources that a node has available for use by pods. You can allow {product-title} to xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-auto_nodes-nodes-resources-configuring[automatically determine the optimal `system-reserved` CPU and memory resources] for your nodes or you can xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring[manually determine and set the best resources] for your nodes. 
 
+[IMPORTANT]
+====
+To manually set resource values, you must use a kubelet config CR. You cannot use a machine config CR.
+====
+
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other


### PR DESCRIPTION
Per [Harshal in a private Slack](https://redhat-internal.slack.com/archives/GK6BJJ1J5/p1680097908061389) the system-reserved parameter must be set using the kubeletconfig. Adding a note to that effect.

https://issues.redhat.com/browse/OSDOCS-5019

Previews
[Allocating resources for nodes in an OpenShift Container Platform cluster ](https://58464--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html)
[Manually allocating resources for nodes](https://58464--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-setting_nodes-nodes-resources-configuring)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

