### PR TITLE
OCPBUGS#7068: Filestore CSI driver does not support clone

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -22,7 +22,7 @@ endif::openshift-dedicated,openshift-rosa[]
 |AWS EFS | - | - | -
 ifndef::openshift-rosa[]
 |Google Compute Platform (GCP) persistent disk (PD)| ✅ | - | ✅
-|GCP Filestore | ✅ | ✅  | ✅
+|GCP Filestore | ✅ | - | ✅
 endif::openshift-rosa[]
 ifndef::openshift-dedicated,openshift-rosa[]
 |IBM VPC Block | ✅^[3]^ | - | ✅^[3]^


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-7068
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://58470--docspreview.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi.html#csi-drivers-supported_persistent-storage-csi
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**PTAL**: @gcharot, @duanwei33, @bertinatto, @sferich888, @mawerner
