### PR TITLE
Added even number of CPUs to the podman command for oslat test - issues 58468

### DIFF
--- a/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
+++ b/modules/cnf-performing-end-to-end-tests-running-oslat.adoc
@@ -31,7 +31,7 @@ When executing `podman` commands as a non-root or non-privileged user, mounting 
 ----
 $ podman run -v $(pwd)/:/kubeconfig:Z -e KUBECONFIG=/kubeconfig/kubeconfig \
 -e LATENCY_TEST_RUN=true -e DISCOVERY_MODE=true -e FEATURES=performance -e ROLE_WORKER_CNF=worker-cnf \
--e LATENCY_TEST_CPUS=7 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
+-e LATENCY_TEST_CPUS=10 -e LATENCY_TEST_RUNTIME=600 -e MAXIMUM_LATENCY=20 \
 registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version} \
 /usr/bin/test-run.sh -ginkgo.v -ginkgo.focus="oslat"
 ----


### PR DESCRIPTION
…es/58468

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
PR applies to the in-development version (e.g. 4.12) and future versions: 4.12+

Issue: 58468
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
fixes https://github.com/openshift/openshift-docs/issues/58468

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://github.com/rameshsahoo111/openshift-docs/blob/oslat-even-cpus-58468/scalability_and_performance/modules/cnf-performing-end-to-end-tests-running-oslat.adoc

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
