### PR TITLE
CORS-2383: Update permissions for GCP shared VPC installs.

### DIFF
--- a/installing/installing_gcp/installing-gcp-account.adoc
+++ b/installing/installing_gcp/installing-gcp-account.adoc
@@ -28,6 +28,8 @@ include::modules/installation-gcp-permissions.adoc[leveloffset=+2]
 
 include::modules/minimum-required-permissions-ipi-gcp.adoc[leveloffset=+2]
 
+include::modules/minimum-required-permissions-ipi-gcp-xpn.adoc[leveloffset=+2]
+
 include::modules/installation-gcp-regions.adoc[leveloffset=+1]
 
 == Next steps

--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -20,7 +20,7 @@ The installation program provisions the rest of the required infrastructure, whi
 * If the cloud identity and access management (IAM) APIs are not accessible in your environment, or if you do not want to store an administrator-level credential secret in the `kube-system` namespace, you can xref:../../installing/installing_gcp/manually-creating-iam-gcp.adoc#manually-creating-iam-gcp[manually create and maintain IAM credentials].
 * You have a GCP host project which contains a shared VPC network.
 * You xref:../../installing/installing_gcp/installing-gcp-account.adoc#installing-gcp-account[configured a GCP project] to host the cluster. This project, known as the service project, must be attached to the host project. For more information, see link:https://cloud.google.com/vpc/docs/provisioning-shared-vpc#create-shared[Attaching service projects in the GCP documentation].
-* You have a GCP service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#installation-gcp-permissions_installing-gcp-account[required GCP permissions] in the host project.
+* You have a GCP service account that has the xref:../../installing/installing_gcp/installing-gcp-account.adoc#minimum-required-permissions-ipi-gcp-xpn[required GCP permissions] in both the host and service projects.
 
 include::modules/cluster-entitlements.adoc[leveloffset=+1]
 

--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_gcp/installing-gcp-account.adoc
+
+[id="minimum-required-permissions-ipi-gcp-xpn"]
+= Required GCP permissions for shared VPC installations
+
+When you are installing a cluster to a link:https://cloud.google.com/vpc/docs/shared-vpc[shared VPC], you must configure the service account for both the host project and the service project. If you are not installing to a shared VPC, you can skip this section.
+
+You must apply the minimum roles required for a standard installation as listed above, to the service project. Note that custom roles, and therefore fine-grained permissions, cannot be used in shared VPC installations because GCP does not support adding the required permission `compute.organizations.administerXpn` to custom roles.
+
+In addition, the host project must apply one of the following configurations to the service account:
+
+.Required permissions for creating firewalls in the host project
+[%collapsible]
+====
+* `projects/<host-project>/roles/dns.networks.bindPrivateDNSZone`
+* `roles/compute.networkAdmin`
+* `roles/compute.securityAdmin`
+====
+
+.Required minimal permissions
+[%collapsible]
+====
+* `projects/<host-project>/roles/dns.networks.bindPrivateDNSZone`
+* `roles/compute.networkUser`
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[CORS-2383](https://issues.redhat.com/browse/CORS-2383)

Link to docs preview:
https://58474--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#minimum-required-permissions-ipi-gcp-xpn
https://58474--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-shared-vpc.html#installation-gcp-shared-vpc-prerequisites_installing-gcp-shared-vpc

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Builds on #54885 & #58172

This takes the ideas of #54885 and applies them to the new organizational structure of #58172. Particularly, adds a new section specifically for Shared VPC in the GCP Account Configuration doc.

cc @bscott-rh @jianli-wei 