### PR TITLE
OSDOCS#5690: Adds notes for MS 4.12.11 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -167,3 +167,12 @@ Issued: 2023-04-03
 {product-title} release 4.12.10 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1511[RHBA-2023:1511] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1508[RHBA-2023:1508] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-11-dp"]
+=== RHBA-2023:1648 - {product-title} 4.12.11 bug fix update
+
+Issued: 2023-04-10
+
+{product-title} release 4.12.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1648[RHBA-2023:1648] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1508[RHBA-2023:1645] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#5690: Adds notes for MS 4.12.11 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5690

Link to docs preview:
https://58475--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-11-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Images link will not work yet.
