### PR TITLE
layering: Use `rhel-coreos` now

### DIFF
--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -21,7 +21,7 @@ When you configure a custom layered image, {product-title} no longer automatical
 +
 [NOTE]
 ====
-You should use the same base {op-system} image that is installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos-8` command to obtain the base image being used in your cluster.
+You should use the same base {op-system} image that is installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos` command to obtain the base image being used in your cluster.  In {product-title} 4.12, use `rhel-coreos-8` instead of `rhel-coreos`.
 ====
 +
 For example, the following Containerfile creates a custom layered image from an {product-title} 4.13 image and a Hotfix package:


### PR DESCRIPTION
This changed in https://github.com/openshift/machine-config-operator/pull/3485
