### PR TITLE
CNF-6351 updating agent based install

### DIFF
--- a/modules/nw-sriov-dual-nic-con.adoc
+++ b/modules/nw-sriov-dual-nic-con.adoc
@@ -23,7 +23,16 @@ Only one LACP can be declared by physical NIC.
 
 An {product-title} cluster can be deployed on a bond interface with 2 VFs on 2 physical functions (PFs) using the following methods:
 
-* Agent based installer
+* Agent-based installer
++
+[NOTE]
+====
+The minimum required version of `nmstate` is:
+
+* `1.4.2-4` for RHEL 8 versions
+* `2.2.7` for RHEL 9 versions
+====
+
 * Installer-provisioned infrastructure installation
 * User-provisioned infrastructure installation
 


### PR DESCRIPTION
[CNF-6351](https://issues.redhat.com//browse/CNF-6351): Updating guidance about nmstate versions required.

Version(s): 4.13

Issue:
https://issues.redhat.com/browse/CNF-6351

Link to docs preview: https://58492--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/preparing-to-install-on-bare-metal.html#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal/



QE review:

 QE has approved this change.
