### PR TITLE
OSDOCS-5691: Documented the 4.10.56 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3908,3 +3908,22 @@ $ oc adm release info 4.10.55 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-56"]
+=== RHSA-2023:1656 - {product-title} 4.10.56 bug fix and security update
+
+Issued: 2023-04-12
+
+{product-title} release 4.10.56, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:1656[RHSA-2023:1656] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1655[RHSA-2023:1655] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.56 --pullspecs
+----
+
+[id="ocp-4-10-56-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5691](https://issues.redhat.com/browse/OSDOCS-5691)

Version(s):
4.10

Issue:
[Preview link](http://file.emea.redhat.com/dfitzmau/OSDOCS-5691/release_notes/ocp-4-10-release-notes.html#ocp-4-10-56)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
