### PR TITLE
OSDOCS-5637-installer: Documented the installer bug fix release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1086,6 +1086,14 @@ With this release, replacement control plane nodes are assigned to the correct i
 [id="ocp-4-13-installer-bug-fixes"]
 ==== Installer
 
+* Previously, DNS records that the installation program created were not removed when uninstalling a private cluster. With this update, the installation program now correctly removes these DNS records. (link:https://issues.redhat.com/browse/OCPBUGS-7973[OCPBUGS-7973])
+
+* Previously, the bare-metal installer-provisioned infrastructure used port 80 for providing images to the Baseboard Management Controller (BMC) and the deployment agent. Security risks could exist with port 80, because this port is commonly chosen for internet communications. The bare metal installer-provisioned infrastructure now uses port 6180 for serving images that are used by the `metal3` pod on deployed clusters. (link:https://issues.redhat.com/browse/OCPBUGS-8511[*OCPBUGS-8511*])
+
+* Previously, SSH access to bootstrap and cluster nodes failed when the bastion host ran in the same VPC network as the cluster nodes. Additionally, this configuration caused SSH access from the temporary bootstrap node to the cluster nodes to fail. These issues are now fixed by updating the IBM Cloud security group rules to support SSH traffic between the temporary bootstrap node and cluster nodes, and to support SSH traffic from a bastion host to cluster nodes on the same VPC network. Log and debug information can be accurately collected for analysis during installer-provisioned infrastructure failure.(link:https://issues.redhat.com/browse/OCPBUGS-8035[*OCPBUGS-8035*])
+
+* Previously, if you configured the rendezvous IP to the IP address of the host that has a `role` parameter set to `worker` and you generated an ISO image, the Agent-based installer would fail to install the cluster. Now, when you attempt to generate an ISO image based on this configuration, you will receive a validation failure message. On receiving this message, you must update the `rendezvousIP` field in the `agent-config.yaml` file to use the IP of a host with the `master` role. (link:https://issues.redhat.com/browse/OCPBUGS-2088[*OCPBUGS-2088*]) 
+
 [discrete]
 [id="ocp-4-13-kube-controller-bug-fixes"]
 ==== Kubernetes Controller Manager


### PR DESCRIPTION
[OSDOCS-5637](https://issues.redhat.com/browse/OSDOCS-5637)

Version(s):
4.13

Link to docs preview:
[Preview](https://58496--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-bug-fixes)

QE review:
- [ ] QE has approved this change.
