### PR TITLE
updating the copyright date on the legal notice

### DIFF
--- a/welcome/legal-notice.adoc
+++ b/welcome/legal-notice.adoc
@@ -5,7 +5,7 @@ include::_attributes/common-attributes.adoc[]
 :context: legal-notice
 
 [.lead]
-Copyright © 2022 Red Hat, Inc.
+Copyright © 2023 Red Hat, Inc.
 
 OpenShift documentation is licensed under the Apache License 2.0 (https://www.apache.org/licenses/LICENSE-2.0).
 


### PR DESCRIPTION
The remaining copyright dates have been set to automatically update.

4.9+

Preview: https://58507--docspreview.netlify.app/openshift-enterprise/latest/welcome/legal-notice.html