### PR TITLE
fix indentation for pod creation steps

### DIFF
--- a/modules/rollback-operator-upgrades-console.adoc
+++ b/modules/rollback-operator-upgrades-console.adoc
@@ -23,7 +23,7 @@ You can roll back the Operator version by using the {ocp} web console.
 ----
 $ curl -k -s -u <user>:<password> https://<central hostname>/v1/centralhealth/upgradestatus | jq -r .upgradeStatus.forceRollbackTo
 ----
-* You can create a pod to extract the previous version by performing the following steps:
+* You can create a pod and extract the previous version by performing the following steps:
 +
 [NOTE]
 ====
@@ -57,8 +57,8 @@ spec:
     persistentVolumeClaim:
       claimName: stackrox-db
 ----
-. Click *Create*.
-. After the pod is created, click the *Logs* tab to get the version string.
+.. Click *Create*.
+.. After the pod is created, click the *Logs* tab to get the version string.
 . Update the rollback configuration by performing the following steps:
 .. Navigate to *Workloads* -> *ConfigMaps* -> *central-config* and select *Edit ConfigMap* from the *Actions* list.
 .. Find the `forceRollbackVersion` line in the value of the `central-config.yaml` key.


### PR DESCRIPTION
Version(s):

- Merge to rhacs-docs
- Cherry pick to `rhacs-docs-4.0`
- Cherry pick to `rhacs-docs-3.74`
- Cherry pick to `rhacs-docs-3.73`
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: Updates to #57249 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview
](https://58511--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-operator.html#rollback-operator-upgrades-console_upgrade-operator)

QE review:
- [x] QE has approved this change. (**N/A - ACS has no QE, approved by SME**)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- Add in change to all versions
- Cherry pick to 4.0 docs in progress (forgot to include in original PR) - OK to merge to 4.0 since 4.0 docs won't go "live" until the page that controls them being visible is published at GA.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
