### PR TITLE
OSDOCS-4818 Removes a fixed known issue from 4.11 RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2399,8 +2399,6 @@ For more information, see xref:../networking/metallb/metallb-upgrading-operator.
 
 * There is currently a known issue. If you create an instance of `ProjectHelmChartRepository` custom resource (CR) that uses TLS verification, you cannot list the repositories and perform Helm-related operations. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/HELM-343[*HELM-343*])
 
-* If the pruner fails, the Image Registry Operator is degraded until the pruner successfully runs. By default, the pruner runs once a day. As a workaround, you can give it more opportunities to run successfully by configuring it to run more often. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1990125[*BZ#1990125*])
-
 * When running {product-title} on bare-metal IBM Power, there is a known issue that the Petitboot bootloader is unable to populate boot configurations for some {op-system} live images. In such cases, after booting nodes with PXE to install {op-system}, the expected live image disk configuration might not be visible.
 +
 As a workaround, you can boot manually with `kexec` from the Petitboot shell.


### PR DESCRIPTION
Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-4818

Link to docs preview:[
Preview](https://58522--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[OSDOCS-4818](https://issues.redhat.com/browse/OSDOCS-4818) This is a `Known issue` that has been fixed. [(BZ1990125)](https://bugzilla.redhat.com/show_bug.cgi?id=1990125)
Acks from PX via slack.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
