### PR TITLE
Telcodocs 1205 Allowing the SR-IOV Network Operator to use an unsupported NIC

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -567,7 +567,7 @@ Topics:
 - Name: Configuring additional devices in an IBM zSystems or IBM LinuxONE environment
   File: ibmz-post-install
 - Name: Regions and zones for a VMware vCenter
-  File: post-install-vsphere-zones-regions-configuration 
+  File: post-install-vsphere-zones-regions-configuration
 - Name: Red Hat Enterprise Linux CoreOS image layering
   File: coreos-layering
   Distros: openshift-enterprise
@@ -1231,6 +1231,8 @@ Topics:
     File: installing-sriov-operator
   - Name: Configuring the SR-IOV Operator
     File: configuring-sriov-operator
+  - Name: Configuring unsupported devices for the SR-IOV Network Operator
+    File: configuring-unsupported-nic-sriov-operator
   - Name: Configuring an SR-IOV network device
     File: configuring-sriov-device
   - Name: Configuring an SR-IOV Ethernet network attachment
@@ -3858,7 +3860,7 @@ Topics:
     - Name: Resolving image tags to digests
       File: resolving-image-tags-to-digests
     - Name: Configuring TLS authentication
-      File: serverless-config-tls      
+      File: serverless-config-tls
     - Name: Restrictive network policies
       File: restrictive-network-policies
   - Name: Traffic splitting

--- a/modules/disable-sr-iov-admission-controller-webhook.adoc
+++ b/modules/disable-sr-iov-admission-controller-webhook.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-unsupported-nic-sriov-operator.adoc
+
+:_content-type: PROCEDURE
+[id="disable-sr-iov-operator-admission-control-webhook_{context}"]
+== Disabling the SR-IOV Network Operator admission controller webhook
+
+To disable the admission controller webhook, complete the following procedure.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* You must have installed the SR-IOV Network Operator.
+
+.Procedure
+
+- Set the `enableOperatorWebhook` field to `false` to disable the feature:
++
+[source,terminal]
+----
+$ oc patch sriovoperatorconfig default --type=merge \
+  -n openshift-sriov-network-operator \
+  --patch '{ "spec": { "enableOperatorWebhook": false } }'
+----
++
+[TIP]
+====
+You can alternatively apply the following YAML to update the Operator:
+
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovOperatorConfig
+metadata:
+  name: default
+  namespace: openshift-sriov-network-operator
+spec:
+  enableOperatorWebhook: false
+----
+====

--- a/modules/disable-sr-iov-subscription-update.adoc
+++ b/modules/disable-sr-iov-subscription-update.adoc
@@ -1,0 +1,91 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-unsupported-nic-sriov-operator.adoc
+
+:_content-type: PROCEDURE
+[id="disable-sr-iov-subscription-update_{context}"]
+= Enabling SR-IOV Network Operator developer mode
+
+Follow this procedure to enable SR-IOV Network Operator developer mode to allow the use of an unsupported NIC.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* You must have installed the SR-IOV Network Operator.
+
+.Procedure
+
+. Find the name of the Subscription CR for the SR-IOV Network Operator:
++
+[source,terminal]
+----
+$ oc get subscription -n openshift-sriov-network-operator
+----
+
+. Update the subscription by patching its spec field by using the following command:
++
+[source,terminal]
+----
+$ oc patch subscription sriov-network-operator -n openshift-sriov-network-operator --type=merge -p '{"spec": {"config": {"env": [{"name": "DEV_MODE", "value": "TRUE"}]}}}'
+----
+
+. Verify that the `sriov-network-operator` pods restarted by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-sriov-network-operator get po
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                                     READY   STATUS    RESTARTS   AGE
+network-resources-injector-6r49n         1/1     Running   0          22m
+network-resources-injector-skd5z         1/1     Running   0          22m
+network-resources-injector-wkr55         1/1     Running   0          22m
+sriov-network-config-daemon-cc24s        3/3     Running   0          22m
+sriov-network-config-daemon-hx5kd        3/3     Running   0          22m
+sriov-network-config-daemon-sb5xw        3/3     Running   0          22m
+sriov-network-operator-6dcf6f64f-4hf6d   1/1     Running   0          99s <1>
+----
++
+<1> The `sriov-network-operator-6dcf6f64f-4hf6d` pod has restarted.
+
+. Run the same command after a few minutes and verify the `sriov-network-config-daemon` has restarted:
++
+[source,terminal]
+----
+$ oc -n openshift-sriov-network-operator get po
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                                     READY   STATUS    RESTARTS   AGE
+network-resources-injector-6r49n         1/1     Running   0          24m
+network-resources-injector-skd5z         1/1     Running   0          24m
+network-resources-injector-wkr55         1/1     Running   0          24m
+sriov-network-config-daemon-6txht        3/3     Running   0          15s
+sriov-network-config-daemon-lclsr        3/3     Running   0          16s
+sriov-network-config-daemon-qhwvk        3/3     Running   0          13s
+sriov-network-operator-6dcf6f64f-4hf6d   1/1     Running   0          3m28s
+----
+
+. Verify that the `sriov-network-config-daemon` logs report `dev mode enabled` by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-sriov-network-operator logs -f -c sriov-network-config-daemon sriov-network-config-daemon-bbdbw
+----
++
+.Example output
+[source,text]
+----
+I0426 11:39:07.157483   35008 start.go:143] dev mode enabled
+I0426 11:39:07.157496   35008 start.go:146] starting node writer
+I0426 11:39:07.164103   35008 start.go:166] Running on platform: Baremetal
+I0426 11:39:07.167959   35008 writer.go:47] RunOnce()
+----

--- a/networking/hardware_networks/configuring-unsupported-nic-sriov-operator.adoc
+++ b/networking/hardware_networks/configuring-unsupported-nic-sriov-operator.adoc
@@ -1,0 +1,23 @@
+:_content-type: ASSEMBLY
+[id="configuring-unsupported-nic-sriov-operator"]
+= Configuring the SR-IOV Network Operator to use an unsupported NIC
+include::_attributes/common-attributes.adoc[]
+:context: configuring-unsupported-nic-sriov-operator
+
+toc::[]
+
+The Single Root I/O Virtualization (SR-IOV) Network operator defaults to a policy that restricts the configuration of network interface cards (NICs) to the list of supported devices only. Follow the described procedure to configure the SR-IOV Network Operator to use an unsupported NIC.
+
+[WARNING]
+====
+Enabling an unsupported NICs is not officially supported and any issues that arise from installing an unsupported NIC fall outside the Red Hat support contract.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref::../../../../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices]
+
+include::modules/disable-sr-iov-admission-controller-webhook.adoc[leveloffset=+1]
+
+include::modules/disable-sr-iov-subscription-update.adoc[leveloffset=+1]


### PR DESCRIPTION
[TELCODOCS-1205]: Allowing the SR-IOV Network Operator to use an unsupported NIC
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9, 4.10, 4.11, 4.12, 4.13 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1205
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://58524--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-unsupported-nic-sriov-operator.html
KB article https://access.redhat.com/articles/7010183

KB created and published and I believe this PR will not need to be merged as KD should suffice. 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
