### PR TITLE
[RHDEVDOCS-5161]: Move Kafka sink docs and create new section

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3960,6 +3960,8 @@ Topics:
     Topics:
     - Name: Event sinks overview
       File: serverless-event-sinks
+    - Name: Creating event sinks
+      File: serverless-creating-sinks
     - Name: Kafka sink
       File: serverless-kafka-developer-sink
   - Name: Brokers

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -538,6 +538,8 @@ Topics:
     Topics:
     - Name: Event sinks overview
       File: serverless-event-sinks
+    - Name: Creating event sinks
+      File: serverless-creating-sinks
     - Name: Kafka sink
       File: serverless-kafka-developer-sink
   - Name: Brokers

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -733,6 +733,8 @@ Topics:
     Topics:
     - Name: Event sinks overview
       File: serverless-event-sinks
+    - Name: Creating event sinks
+      File: serverless-creating-sinks
     - Name: Kafka sink
       File: serverless-kafka-developer-sink
   - Name: Brokers

--- a/modules/serverless-creating-a-kafka-event-sink.adoc
+++ b/modules/serverless-creating-a-kafka-event-sink.adoc
@@ -1,20 +1,20 @@
 // Module included in the following assemblies:
 //
-// * serverless/develop/serverless-event-sinks.adoc
+// * serverless/eventing/event-sinks/serverless-kafka-developer-sink.adoc
 
 :_content-type: PROCEDURE
 [id="serverless-creating-a-kafka-event-sink_{context}"]
+= Creating a Kafka sink by using the {product-title} web console
 
-= Creating a Kafka event sink
-
-As a developer, you can create an event sink to receive events from a particular source and send them to a Kafka topic. 
+You can create a Kafka sink that sends events to a Kafka topic by using the *Developer* perspective in the {product-title} web console. By default, a Kafka sink uses the binary content mode, which is more efficient than the structured mode.
 
 .Prerequisites
-* You have installed the Red Hat OpenShift Serverless operator, with Knative Serving, Knative Eventing, and Knative Kafka APIs, from the Operator Hub.
 
+* You have installed the {ServerlessOperatorName}, with Knative Serving, Knative Eventing, and Knative Kafka APIs, from the OperatorHub.
 * You have created a Kafka topic in your Kafka environment.
 
 .Procedure
+
 . In the *Developer* perspective, navigate to the *+Add* view.
 . Click *Event Sink* in the *Eventing catalog*.
 . Search for `KafkaSink` in the catalog items and click it.
@@ -28,5 +28,6 @@ image::create-event-sink.png[]
 . Click *Create*. 
 
 .Verification
+
 . In the *Developer* perspective, navigate to the *Topology* view.
 . Click the created event sink to view its details in the right panel.

--- a/modules/serverless-kafka-sink.adoc
+++ b/modules/serverless-kafka-sink.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="serverless-kafka-sink_{context}"]
-= Using a Kafka sink
+= Creating a Kafka sink by using YAML
 
-You can create an event sink called a Kafka sink that sends events to a Kafka topic. Creating Knative resources by using YAML files uses a declarative API, which enables you to describe applications declaratively and in a reproducible manner. By default, a Kafka sink uses the binary content mode, which is more efficient than the structured mode. To create a Kafka sink by using YAML, you must create a YAML file that defines a `KafkaSink` object, then apply it by using the `oc apply` command.
+You can create a Kafka sink that sends events to a Kafka topic. By default, a Kafka sink uses the binary content mode, which is more efficient than the structured mode. To create a Kafka sink by using YAML, you must create a YAML file that defines a `KafkaSink` object, then apply it by using the `oc apply` command.
 
 .Prerequisites
 

--- a/serverless/eventing/event-sinks/serverless-creating-sinks.adoc
+++ b/serverless/eventing/event-sinks/serverless-creating-sinks.adoc
@@ -1,0 +1,16 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="serverless-creating-sinks"]
+= Creating event sinks
+:context: serverless-creating-sinks
+
+toc::[]
+
+include::snippets/serverless-about-event-sinks.adoc[]
+
+For information about creating resources that can be used as event sinks, see the following documentation:
+
+* xref:../../../serverless/knative-serving/getting-started/serverless-applications.adoc#serverless-applications[Serverless applications]
+* xref:../../../serverless/eventing/brokers/serverless-using-brokers.adoc#serverless-using-brokers[Creating brokers]
+* xref:../../../serverless/eventing/channels/serverless-creating-channels.adoc#serverless-creating-channels[Creating channels]
+* xref:../../../serverless/eventing/event-sinks/serverless-kafka-developer-sink.adoc#serverless-kafka-developer-sink[Kafka sink]

--- a/serverless/eventing/event-sinks/serverless-event-sinks.adoc
+++ b/serverless/eventing/event-sinks/serverless-event-sinks.adoc
@@ -6,14 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-When you create an event source, you can specify a sink where events are sent to from the source. A sink is an addressable or a callable resource that can receive incoming events from other resources. Knative services, channels and brokers are all examples of sinks.
+include::snippets/serverless-about-event-sinks.adoc[]
 
 Addressable objects receive and acknowledge an event delivered over HTTP to an address defined in their `status.address.url` field. As a special case, the core Kubernetes `Service` object also fulfills the addressable interface.
 
 Callable objects are able to receive an event delivered over HTTP and transform the event, returning `0` or `1` new events in the HTTP response. These returned events may be further processed in the same way that events from an external event source are processed.
-
-//Creating a Kafka event sink
-include::modules/serverless-creating-a-kafka-event-sink.adoc[leveloffset=+1]
 
 // Using --sink flag with kn (generic)
 include::modules/specifying-sink-flag-kn.adoc[leveloffset=+1]

--- a/serverless/eventing/event-sinks/serverless-kafka-developer-sink.adoc
+++ b/serverless/eventing/event-sinks/serverless-kafka-developer-sink.adoc
@@ -8,9 +8,11 @@ toc::[]
 
 Kafka sinks are a type of xref:../../../serverless/eventing/event-sinks/serverless-event-sinks.adoc#serverless-event-sinks[event sink] that are available if a cluster administrator has enabled Kafka on your cluster. You can send events directly from an xref:../../../serverless/eventing/event-sources/knative-event-sources.adoc#knative-event-sources[event source] to a Kafka topic by using a Kafka sink.
 
-// Kafka sink
+// Kafka sink via YAML
 include::modules/serverless-kafka-sink.adoc[leveloffset=+1]
 
+// Creating a Kafka sink via ODC
+include::modules/serverless-creating-a-kafka-event-sink.adoc[leveloffset=+1]
 
 // kafka sink security config
 include::modules/serverless-kafka-sink-security-config.adoc[leveloffset=+1]

--- a/snippets/serverless-about-event-sinks.adoc
+++ b/snippets/serverless-about-event-sinks.adoc
@@ -1,0 +1,8 @@
+// Text snippet included in the following modules and assemblies:
+//
+// * /serverless/eventing/event-sinks/serverless-event-sinks
+// * /serverless/eventing/event-sinks/serverless-creating-sinks
+
+:_content-type: SNIPPET
+
+When you create an event source, you can specify an event sink where events are sent to from the source. An event sink is an addressable or a callable resource that can receive incoming events from other resources. Knative services, channels, and brokers are all examples of event sinks. There is also a specific Apache Kafka sink type available.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-5161

Link to docs preview:
- https://58532--docspreview.netlify.app/openshift-enterprise/latest/serverless/eventing/event-sinks/serverless-creating-sinks.html
- https://58532--docspreview.netlify.app/openshift-enterprise/latest/serverless/eventing/event-sinks/serverless-kafka-developer-sink.html

QE review:
- [x] QE approved
