### PR TITLE
CMP-1868: Compliance Operator 1.0.0 release notes

### DIFF
--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -15,6 +15,30 @@ For an overview of the Compliance Operator, see xref:../../security/compliance_o
 
 To access the latest release, see xref:../../security/compliance_operator/compliance-operator-updating.adoc#olm-preparing-upgrade_compliance-operator-updating[Updating the Compliance Operator].
 
+[id="compliance-operator-release-notes-1-0-0"]
+== OpenShift Compliance Operator 1.0.0
+
+The following advisory is available for the OpenShift Compliance Operator 1.0.0:
+
+* link:https://access.redhat.com/errata/RHBA-2023:1682[RHBA-2023:1682 - OpenShift Compliance Operator bug fix update]
+
+[id="compliance-operator-1-0-0-new-features-and-enhancements"]
+=== New features and enhancements
+
+* The Compliance Operator is now stable and the release channel is upgraded to `stable`. Future releases will follow link:https://semver.org/[Semantic Versioning]. To access the latest release, see xref:../../security/compliance_operator/compliance-operator-updating.adoc#olm-preparing-upgrade_compliance-operator-updating[Updating the Compliance Operator].
+
+[id="compliance-operator-1-0-0-bug-fixes"]
+=== Bug fixes
+
+// 4.13 only, commenting out for now
+// * Before this update, the `rhcos4-ensure-logrotate-activated` rule failed after auto-remediation was applied in {product-title} 4.13 environments. With this update, rules with auto-remediation available have a `PASS` result after the auto-remedations are applied. (link:https://issues.redhat.com/browse/OCPBUGS-10769[*OCPBUGS-10769*])
+
+* Before this update, the compliance_operator_compliance_scan_error_total metric had an ERROR label with a different value for each error message. With this update, the compliance_operator_compliance_scan_error_total metric does not increase in values. (link:https://issues.redhat.com/browse/OCPBUGS-1803[*OCPBUGS-1803*])
+
+* Before this update, the `ocp4-api-server-audit-log-maxsize` rule would result in a `FAIL` state. With this update, the error message has been removed from the metric, decreasing the cardinality of the metric in line with best practices. (link:https://issues.redhat.com/browse/OCPBUGS-7520[*OCPBUGS-7520*])
+
+* Before this update, the `rhcos4-enable-fips-mode` rule description was misleading that FIPS could be enabled after installation. With this update, the `rhcos4-enable-fips-mode` rule description clarifies that FIPS must be enabled at install time. (link:https://issues.redhat.com/browse/OCPBUGS-8358[*OCPBUGS-8358*])
+
 [id="compliance-operator-release-notes-0-1-61"]
 == OpenShift Compliance Operator 0.1.61
 
@@ -25,7 +49,7 @@ The following advisory is available for the OpenShift Compliance Operator 0.1.61
 [id="compliance-operator-0-1-61-new-features-and-enhancements"]
 === New features and enhancements
 
-* The Compliance Operator now supports timeout configuration for Scanner Pods. The timeout is specified in the `ScanSetting` object. If the scan is not completed within the timeout, the scan retries until the maximum number of retries is reached. See xref:../../security/compliance_operator/compliance-operator-troubleshooting.html#compliance-timeout_compliance-troubleshooting[Configuring ScanSetting timeout] for more information.
+* The Compliance Operator now supports timeout configuration for Scanner Pods. The timeout is specified in the `ScanSetting` object. If the scan is not completed within the timeout, the scan retries until the maximum number of retries is reached. See xref:../../security/compliance_operator/compliance-operator-troubleshooting.adoc#compliance-timeout_compliance-troubleshooting[Configuring ScanSetting timeout] for more information.
 
 [id="compliance-operator-0-1-61-bug-fixes"]
 === Bug fixes


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/CMP-1868

Link to docs preview (VPN required):
[OpenShift Compliance Operator 1.0.0](http://file.rdu.redhat.com/antaylor/CMP-1868/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-release-notes-1-0-0)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
