### PR TITLE
OSSM-3251: Add cluster-wide deployment to Service Mesh docs

### DIFF
--- a/modules/ossm-about-adding-namespace.adoc
+++ b/modules/ossm-about-adding-namespace.adoc
@@ -13,27 +13,12 @@ A project contains services; however, the services are only available if you add
 In {product-title}, a project is essentially a Kubernetes namespace with additional annotations, such as the range of user IDs that can be used in the project. Typically, the {product-title} web console uses the term project, and the CLI uses the term namespace, but the terms are essentially synonymous.
 ====
 
-You can add projects to an existing service mesh using either the {product-title} web console or the CLI. There are two methods to add a project to a service mesh:
+You can add projects to an existing service mesh using either the {product-title} web console or the CLI. There are three methods to add a project to a service mesh:
 
 * Specifying the project name in the `ServiceMeshMemberRoll` resource.
 
+* Configuring label selectors in the `spec.labelSelectors` field of the `ServiceMeshMemberRoll` resource.
+
 * Creating the `ServiceMeshMember` resource in the project.
 
-.ServiceMeshMemberRoll method
-
-This is the simplest way to add a project to a service mesh. To add a project, specify the project name in the `spec.members` field of the `ServiceMeshMemberRoll` resource. The `ServiceMeshMemberRoll` resource specifies which projects are controlled by the `ServiceMeshControlPlane` resource. 
-
-[NOTE]
-====
-Adding projects using this method requires the user to have the `update servicemeshmemberrolls` and the `update pods` privileges in the project that is being added.
-====
-
-* If you already have an application, workload, or service to add to the service mesh, see the instructions for adding or removing projects from the service mesh using the `ServiceMeshMemberRoll` resource with the xref:../../service_mesh/v2x/ossm-create-mesh.adoc#ossm-add-project-member-roll-recourse-console_ossm-create-mesh[web console] or with the xref:../../service_mesh/v2x/ossm-create-mesh.adoc#ossm-add-project-member-roll-resource-cli_ossm-create-mesh[CLI]. 
-
-* Alternatively, to install a sample application called Bookinfo and add it to a `ServiceMeshMemberRoll` resource, see xref:../../service_mesh/v2x/ossm-create-mesh.adoc#ossm-tutorial-bookinfo-overview_ossm-create-mesh[Bookinfo example application] tutorial.
-
-.ServiceMeshMember method
-
-A `ServiceMeshMember` resource provides a way to add a project to a service mesh without modifying the `ServiceMeshMemberRoll` resource. To add a project, create a `ServiceMeshMember` resource in the project that you want to add to the service mesh. When the {SMProductShortName} Operator processes the `ServiceMeshMember` object, the project appears in the `status.members` list of the `ServiceMeshMemberRoll` resource. Then, the services that reside in the project are made available to the mesh. For more information, see the instructions for adding projects to the service mesh using the `ServiceMeshMember` resource with the xref:../../service_mesh/v2x/ossm-create-mesh.adoc#ossm-adding-project-using-smm-resource-console_ossm-create-mesh[web console] or with the xref:../../service_mesh/v2x/ossm-create-mesh.adoc#ossm-adding-project-using-smm-resource-cli_ossm-create-mesh[CLI].
-
-The mesh administrator must grant each mesh user permission to reference the `ServiceMeshControlPlane` resource in the `ServiceMeshMember` resource. With this permission in place, this method of adding projects to a mesh can be used when the mesh user does not have direct access rights for the service mesh project or the `ServiceMeshMemberRoll` resource. For more information, see xref:../../service_mesh/v2x/ossm-profiles-users.html#ossm-members_ossm-profiles-users[Creating the {SMProductName} members].
+If you choose to use the first method, then you must create the `ServiceMeshMemberRoll` resource.

--- a/modules/ossm-about-adding-projects-using-label-selectors.adoc
+++ b/modules/ossm-about-adding-projects-using-label-selectors.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/create-mesh.adoc
+
+:_content-type: CONCEPT
+[id="ossm-about-adding-projects-using-label-selectors_{context}"]
+= About adding projects using label selectors
+
+For cluster-wide deployments, you can use label selectors to add projects to the mesh. Label selectors specified in the `ServiceMeshMemberRoll` resource enable the {SMProductShortName} operator to add or remove namespaces to or from the mesh based on namespace labels. Unlike other standard {product-title} resources that you can use to specify a single label selector, you can use the `ServiceMeshMemberRoll` resource to specify multiple label selectors. If the labels for a namespace match any of the selectors specified in the `ServiceMeshMemberRoll` resource, then the namespace is included in the mesh.
+
+[NOTE]
+====
+In {product-title}, a project is essentially a Kubernetes namespace with additional annotations, such as the range of user IDs that can be used in the project. Typically, the {product-title} web console uses the term _project_, and the CLI uses the term _namespace_, but the terms are essentially synonymous.
+====

--- a/modules/ossm-about-control-plane-and-cluster-wide-deployment.adoc
+++ b/modules/ossm-about-control-plane-and-cluster-wide-deployment.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+// * service_mesh/v2x/ossm-create-smcp.adoc
+
+:_content-type: CONCEPT
+[id="ossm-about-control-plane-and-cluster-wide-deployment_{context}"]
+= About control plane and cluster-wide deployments
+
+A cluster-wide deployment contains a {SMProductShortName} Control Plane that monitors resources for an entire cluster. Monitoring resources for an entire cluster closely resembles Istio functionality in that the control plane uses a single query across all namespaces to monitor Istio and Kubernetes resources. As a result, cluster-wide deployments decrease the number of requests sent to the API server.
+
+You can configure the {SMProductShortName} Control Plane for cluster-wide deployments using either the {product-title} web console or the CLI.

--- a/modules/ossm-about-smcp.adoc
+++ b/modules/ossm-about-smcp.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+// * service_mesh/v2x/ossm-create-smcp.adoc
+
+:_content-type: CONCEPT
+[id="ossm-about-smcp_{context}"]
+= About ServiceMeshControlPlane
+
+The control plane includes Istiod, Ingress and Egress Gateways, and other components, such as Kiali and Jaeger. The control plane must be deployed in a separate namespace than the {SMProductShortName} Operators and the data plane applications and services. You can deploy a basic installation of the `ServiceMeshControlPlane`(SMCP) from the {product-title} web console or the command line using the `oc` client tool.
+
+[NOTE]
+====
+This basic installation is configured based on the default {product-title} settings and is not designed for production use. Use this default installation to verify your installation, and then configure your `ServiceMeshControlPlane` settings for your environment.
+====
+
+[NOTE]
+====
+Red Hat OpenShift Service on AWS (ROSA) places additional restrictions on where you can create resources, and as a result, the default deployment does not work. See Installing {SMProductShortName} on Red Hat OpenShift Service on AWS for additional requirements before deploying your SMCP in a ROSA environment.
+====
+
+[NOTE]
+====
+The {SMProductShortName} documentation uses `istio-system` as the example project, but you can deploy the service mesh to any project.
+====

--- a/modules/ossm-add-project-using-label-selectors-cli.adoc
+++ b/modules/ossm-add-project-using-label-selectors-cli.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/installing-ossm.adoc
+
+:_content-type: PROCEDURE
+[id="ossm-adding-project-using-label-selectors-cli_{context}"]
+= Adding a project to the {SMProductShortName} using label selectors with the CLI 
+
+You can use label selectors to add a project to the {SMProductShortName} with the CLI.
+
+.Prerequisites
+* The deployment has an installed, verified {SMProductName} Operator.
+* The deployment has an existing `ServiceMeshMemberRoll` resource.
+* You are logged in as a user with mesh admin privileges.
+
+.Procedure
+
+. Log in to the {product-title} CLI.
+
+. Edit the `ServiceMeshMemberRoll` resource.
++
+[source,terminal]
+----
+$ oc edit smmr -n <controlplane_project>
+----
++
+The previous example uses `<controlplane_project>` as an example. You can deploy the {SMProductShortName} control plane to any project as long as it is separate from the project that contains your services.
+
+. Modify the YAML file to include namespace label selectors in the `spec.memberSelectors` field of the `ServiceMeshMemberRoll` resource.
++
+[NOTE]
+====
+Instead of using the `matchLabels` field, you can also use the `matchExpressions` field in the selector.
+====
++
+[source,yaml]
+----
+apiVersion: maistra.io/v1
+kind: ServiceMeshMemberRoll
+metadata:
+  name: default
+  namespace: istio-system
+spec:
+  memberSelectors: <1>
+  - matchLabels: <2>                 
+      mykey: myvalue <2>            
+  - matchLabels: <3>               
+      myotherkey: myothervalue <3> 
+----
+<1> Contains the label selectors used to identify which project namespaces are included in the service mesh. If a project namespace has either label specified by the selectors, then the project namespace is included in the service mesh. The project namespace does not need both labels to be included.
+<2> Specifies all namespaces with the `mykey=myvalue` label. When the selector identifies a match, the project namespace is added to the service mesh.
+<3> Specifies all namespaces with the `myotherkey=myothervalue` label. When the selector identifies a match, the project namespace is added to the service mesh.

--- a/modules/ossm-add-project-using-label-selectors-console.adoc
+++ b/modules/ossm-add-project-using-label-selectors-console.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-create-mesh.adoc
+
+:_content-type: PROCEDURE
+[id="ossm-adding-project-using-label-selectors-console_{context}"]
+= Adding a project to the {SMProductShortName} using label selectors with the web console
+
+You can use labels selectors to add a project to the {SMProductShortName} with the {product-title} web console.
+
+.Prerequisites
+* The deployment has an installed, verified {SMProductName} Operator.
+* The deployment has an existing `ServiceMeshMemberRoll` resource.
+* You are logged in as a user with mesh admin privileges.
+
+.Procedure
+
+. Log in to the {product-title} web console.
+
+. Navigate to *Operators* -> *Installed Operators*.
+
+. Click the *Project* menu, and from the drop-down list, select the project where your `ServiceMeshMemberRoll` resource is deployed. For example, *istio-system*.
+
+. Click the {SMProductName} Operator.
+
+. Click the *Istio Service Mesh Member Roll* tab.
+
+. Click *Create ServiceMeshMember Roll*.
+
+. Accept the default name for the `ServiceMeshMemberRoll`.
+
+. In the *Labels* field, enter key-value pairs to define the labels that identify which namespaces to include in the service mesh. If a project namespace has either label specified by the selectors, then the project namespace is included in the service mesh. You do not need to include both labels.
++
+For example, entering `mykey=myvalue` includes all namespaces with this label as part of the mesh. When the selector identifies a match, the project namespace is added to the service mesh.
++
+Entering `myotherkey=myothervalue` includes all namespaces with this label as part of the mesh. When the selector identifies a match, the project namespace is added to the service mesh.
+
+. Click *Create*.

--- a/modules/ossm-adding-project-using-smm-resource-console.adoc
+++ b/modules/ossm-adding-project-using-smm-resource-console.adoc
@@ -6,7 +6,7 @@
 [id="ossm-adding-project-using-smm-resource-console_{context}"]
 = Adding a project to the service mesh using the ServiceMeshMember resource with the web console
 
-You can add one or more projects to the {SMProductShortName} from the web console.
+You can add one or more projects to the {SMProductShortName} from the {product-title} web console.
 
 .Prerequisites
 * An installed, verified {SMProductName} Operator.

--- a/modules/ossm-customize-smmr-cluster-wide.adoc
+++ b/modules/ossm-customize-smmr-cluster-wide.adoc
@@ -1,0 +1,24 @@
+//
+This module is included in the following assemblies:
+* service_mesh/v2x/ossm-create-smcp.adoc
+//
+
+:_content-type: CONCEPT
+[id="ossm-customize-smrr-cluster-wide_{context}"]
+= Customizing the member roll for a cluster-wide mesh
+
+In cluster-wide mode, when you create the `ServiceMeshControlPlane` resource, the `ServiceMeshMemberRoll` resource is also created. You can modify the `ServiceMeshMemberRoll` resource after it gets created. After you modify the resource, the {SMProductShortName} operator no longer changes it. If you modify the `ServiceMeshMemberRoll` resource by using the {product-title} web console, accept the prompt to overwrite the modifications.
+
+Alternatively, you can create a `ServiceMeshMemberRoll` resource before deploying the `ServiceMeshControlPlane` resource. When you create the `ServiceMeshControlPlane` resource, the {SMProductShortName} Operator will not modify the `ServiceMeshMemberRoll`.
+
+[NOTE]
+====
+The `ServiceMeshMemberRoll` resource name must be named `default` and must be created in the same project namespace as the `ServiceMeshControlPlane` resource.
+====
+
+There are two ways to add a namespace to the mesh. You can either add the namespace by specifying its name in the `spec.members` list, or configure a set of namespace label selectors to include or exclude namespaces based on their labels.
+
+[NOTE]
+====
+Regardless of how members are specified in the `ServiceMeshMemberRoll` resource, you can also add members to the mesh by creating the `ServiceMeshMember` resource in each namespace.
+====

--- a/modules/ossm-deploy-cluster-wide-control-plane-cli.adoc
+++ b/modules/ossm-deploy-cluster-wide-control-plane-cli.adoc
@@ -1,0 +1,74 @@
+//
+This module is included in the following assemblies:
+* service_mesh/v2x/ossm-create-smcp.adoc
+//
+:_content-type: PROCEDURE
+[id="ossm-deploy-cluster-wide-control-plane-cli_{context}"]
+= Configuring the control plane for cluster-wide deployment with the CLI
+
+You can configure the `ServiceMeshControlPlane` resource for cluster-wide deployment using the CLI. In this example, `istio-system` is the name of the Service Mesh control plane namespace.
+
+.Prerequisites
+
+* The {SMProductName} Operator is installed.
+* You have access to the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Log in to the {product-title} CLI as a user with the `cluster-admin` role. If you use {product-dedicated}, you must have an account with the `dedicated-admin` role.
++
+[source,terminal]
+----
+$ oc login --username=<NAMEOFUSER> https://<HOSTNAME>:6443
+----
++
+. Create a project named `istio-system`.
++
+[source,terminal]
+----
+$ oc new-project istio-system
+----
+
+. Create a `ServiceMeshControlPlane` file named `istio-installation.yaml` using the following example. 
++
+.Example version {MaistraVersion} istio-installation.yaml
+[source,yaml, subs="attributes,verbatim"]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+  namespace: istio-system
+spec:
+  version: v{MaistraVersion}
+  mode: ClusterWide
+----
+
+. Run the following command to deploy the {SMProductShortName} control plane, where `<istio_installation.yaml>` includes the full path to your file.
++
+[source,terminal]
+----
+$ oc create -n istio-system -f <istio_installation.yaml>
+----
++
+. To monitor the progress of the pod deployment, run the following command:
++
+[source,terminal]
+----
+$ oc get pods -n istio-system -w
+----
++
+You should see output similar to the following example:
++
+.Example output
+[source,terminal]
+----
+NAME                                   READY   STATUS    RESTARTS   AGE
+grafana-b4d59bd7-mrgbr                 2/2     Running   0          65m
+istio-egressgateway-678dc97b4c-wrjkp   1/1     Running   0          108s
+istio-ingressgateway-b45c9d54d-4qg6n   1/1     Running   0          108s
+istiod-basic-55d78bbbcd-j5556          1/1     Running   0          108s
+jaeger-67c75bd6dc-jv6k6                2/2     Running   0          65m
+kiali-6476c7656c-x5msp                 1/1     Running   0          43m
+prometheus-58954b8d6b-m5std            2/2     Running   0          66m
+----

--- a/modules/ossm-deploy-cluster-wide-control-plane-console.adoc
+++ b/modules/ossm-deploy-cluster-wide-control-plane-console.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-create-smcp.adoc
+
+:_content-type: PROCEDURE
+[id="ossm-deploy-cluster-wide-control-plane-console_{context}"]
+= Configuring the control plane for cluster-wide deployment with the web console
+
+You can configure the `ServiceMeshControlPlane` resource for cluster-wide deployment using the {product-title} web console. In this example, `istio-system` is the name of the {SMProductShortName} control plane project.
+
+.Prerequisites
+
+* The {SMProductName} Operator is installed.
+* You are logged in using an account with the `cluster-admin` role, or if you use {product-dedicated} with the `dedicated-admin` role.
+
+.Procedure
+
+. Create a project named `istio-system`.
++
+.. Navigate to *Home* -> *Projects*.
++
+.. Click *Create Project*.
++
+.. In the *Name* field, enter `istio-system`. The `ServiceMeshControlPlane` resource must be installed in a project that is separate from your microservices and Operators.
++
+These steps use `istio-system` as an example. You can deploy the {SMProductShortName} control plane to any project as long as it is separate from the project that contains your services.
++
+.. Click *Create*.
+
+. Navigate to *Operators* -> *Installed Operators*.
+
+. Click the {SMProductName} Operator, then click *Istio Service Mesh Control Plane*.
+
+. On the *Istio Service Mesh Control Plane* tab, click *Create ServiceMeshControlPlane*.
+
+. Click *YAML view*. The version of the {SMProductShortName} control plane determines the features available regardless of the version of the Operator.
+
+. Modify the `spec.mode` field of the YAML file to specify `ClusterWide`.
++
+.Example version {MaistraVersion} istio-installation.yaml
++
+[source,yaml]
+----
+apiVersion: maistra.io/v2
+kind: ServiceMeshControlPlane
+metadata:
+  name: basic
+  namespace: istio-system
+spec:
+  version: v{MaistraVersion}
+  mode: ClusterWide
+----
+
+. Click *Create*. The Operator creates pods, services, and {SMProductShortName} control plane components based on your configuration parameters. The operator also creates the `ServiceMeshMemberRoll` if it does not exist as part of the default configuration.
+
+. To verify that the control plane installed correctly, click the *Istio Service Mesh Control Plane* tab.
++
+.. Click the name of the new `ServiceMeshControlPlane` object.
++
+.. Click the *Resources* tab to see the {SMProductName} control plane resources that the Operator created and configured.

--- a/modules/ossm-deploy-cluster-wide-mesh.adoc
+++ b/modules/ossm-deploy-cluster-wide-mesh.adoc
@@ -1,0 +1,10 @@
+// Module included in the following assemblies:
+// * service_mesh/v2x/ossm-deployment-models.adoc
+
+:_content-type: CONCEPT
+[id="ossm-deploy-cluster-wide-mesh_{context}"]
+= Cluster-Wide (Single Tenant) mesh deployment model
+
+A cluster-wide deployment contains a Service Mesh Control Plane that monitors resources for an entire cluster. Monitoring resources for an entire cluster closely resembles Istio functionality in that the control plane uses a single query across all namespaces to monitor Istio and Kubernetes resources. As a result, cluster-wide deployments decrease the number of requests sent to the API server.
+
+Similar to Istio, a cluster-wide mesh includes namespaces with the `istio-injection=enabled` namespace label by default. You can change this label by modifying the `spec.labelSelectors` field of the `ServiceMeshMemberRoll` resource. 

--- a/service_mesh/v2x/ossm-create-mesh.adoc
+++ b/service_mesh/v2x/ossm-create-mesh.adoc
@@ -20,6 +20,12 @@ include::modules/ossm-adding-project-using-smm-resource-console.adoc[leveloffset
 
 include::modules/ossm-adding-project-using-smm-resource-cli.adoc[leveloffset=+1]
 
+include::modules/ossm-about-adding-projects-using-label-selectors.adoc[leveloffset=+1]
+
+include::modules/ossm-add-project-using-label-selectors-console.adoc[leveloffset=+2]
+
+include::modules/ossm-add-project-using-label-selectors-cli.adoc[leveloffset=+2]
+
 include::modules/ossm-tutorial-bookinfo-overview.adoc[leveloffset=+1]
 
 include::modules/ossm-tutorial-bookinfo-install.adoc[leveloffset=+2]

--- a/service_mesh/v2x/ossm-create-smcp.adoc
+++ b/service_mesh/v2x/ossm-create-smcp.adoc
@@ -6,34 +6,27 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-The control plane includes Istiod, Ingress and Egress Gateways, and other components, such as Kiali and Jaeger. The control plane must be deployed in a separate namespace than the {SMProductShortName} Operators and the data plane applications and services. You can deploy a basic installation of the `ServiceMeshControlPlane`(SMCP) from the {product-title} web console or the command line using the `oc` client tool.
+include::modules/ossm-about-smcp.adoc[leveloffset=+1]
 
-[NOTE]
-====
-This basic installation is configured based on the default OpenShift settings and is not designed for production use. Use this default installation to verify your installation, and then configure your `ServiceMeshControlPlane` for your environment.
-====
+include::modules/ossm-control-plane-web.adoc[leveloffset=+2]
 
-[NOTE]
-====
-Red Hat OpenShift Service on AWS (ROSA) places additional restrictions on where you can create resources and as a result the default deployment does not work. See xref:../../service_mesh/v2x/ossm-create-smcp.adoc#ossm-install-rosa_ossm-create-smcp[Installing Service Mesh on Red Hat OpenShift Service on AWS] for additional requirements before deploying your SMCP in a ROSA environment.
-====
+include::modules/ossm-control-plane-cli.adoc[leveloffset=+2]
 
-[NOTE]
-====
-The {SMProductShortName} documentation uses `istio-system` as the example project, but you can deploy the service mesh to any project.
-====
-
-include::modules/ossm-control-plane-web.adoc[leveloffset=+1]
-
-include::modules/ossm-control-plane-cli.adoc[leveloffset=+1]
-
-include::modules/ossm-validate-smcp-cli.adoc[leveloffset=+1]
+include::modules/ossm-validate-smcp-cli.adoc[leveloffset=+2]
 
 include::modules/ossm-config-control-plane-infrastructure-node.adoc[leveloffset=+1]
 
 include::modules/ossm-config-individual-control-plane-infrastructure-node.adoc[leveloffset=+1]
 
 include::modules/ossm-confirm-smcp-infrastructure-node.adoc[leveloffset=+1]
+
+include::modules/ossm-about-control-plane-and-cluster-wide-deployment.adoc[leveloffset=+1]
+
+include::modules/ossm-deploy-cluster-wide-control-plane-console.adoc[leveloffset=+2]
+
+include::modules/ossm-deploy-cluster-wide-control-plane-cli.adoc[leveloffset=+2]
+
+include::modules/ossm-customize-smmr-cluster-wide.adoc[leveloffset=+2]
 
 include::modules/ossm-validate-smcp-kiali.adoc[leveloffset=+1]
 

--- a/service_mesh/v2x/ossm-deployment-models.adoc
+++ b/service_mesh/v2x/ossm-deployment-models.adoc
@@ -8,9 +8,9 @@ toc::[]
 
 {SMProductName} supports several different deployment models that can be combined in different ways to best suit your business requirements.
 
-include::modules/ossm-deploy-single-mesh.adoc[leveloffset=+1]
+In Istio, a tenant is a group of users that share common access and privileges for a set of deployed workloads. You can use tenants to provide a level of isolation between different teams. You can segregate access to different tenants using `NetworkPolicies`, `AuthorizationPolicies`, and `exportTo` annotations on istio.io or service resources.
 
-include::modules/ossm-deploy-single-tenant.adoc[leveloffset=+1]
+include::modules/ossm-deploy-cluster-wide-mesh.adoc[leveloffset=+1]
 
 include::modules/ossm-deploy-multitenant.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-3251
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- Cluster-Wider deployment model conceptual topic: https://58539--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-deployment-models.html#ossm-deploy-cluster-wide-mesh_ossm-deployment-models
- Deploying cluster-wide control plane: https://58539--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-smcp.html#ossm-about-control-plane-and-cluster-wide-deployment_ossm-create-smcp
- Adding project using label selectors: https://58539--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-mesh.html#ossm-about-adding-projects-using-label-selectors_ossm-create-mesh

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
