### PR TITLE
Adds .jsx to doc guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1036,6 +1036,7 @@ syntax highlighting. For example:
 ** `[source,yaml]`
 ** `[source,go]`
 ** `[source,javascript]`
+** `[source,jsx]`
 
 * Do not use more than one command per code block. For example, the following must
 be split up into three separate code blocks:


### PR DESCRIPTION
Adds .jsx to doc guidelines

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://github.com/openshift/openshift-docs/pull/58553/files?short_path=719cf3b#diff-719cf3b36e5cfdc45393ebde8ff09fd9a56c239b5671fe1cea5b7f364d647125

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
