### PR TITLE
OCPBUGS-11651 fixing content for IBM-Z and IBM power

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -207,6 +207,7 @@ nameserver=8.8.8.8
 ----
 ifndef::ibm-z-kvm[]
 
+
 [discrete]
 === Bonding multiple network interfaces to a single interface
 
@@ -248,6 +249,7 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 Always set the `fail_over_mac=1` option in active-backup mode, to avoid problems when shared OSA/RoCE cards are used.
 endif::ibm-z[]
 
+ifdef::ibm-z[]
 [discrete]
 === Bonding multiple network interfaces to a single interface
 
@@ -268,6 +270,9 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0.100:none
 bond=bond0:em1,em2:mode=active-backup
 vlan=bond0.100:bond0
 ----
+endif::ibm-z[]
+
+ifndef::ibm-z[]
 
 [id="bonding-multiple-sriov-network-interfaces-to-dual-port_{context}"]
 [discrete]
@@ -301,23 +306,12 @@ ip=bond0:dhcp
 ----
 
 ** To configure the bonded interface to use a static IP address, enter the specific IP address you want and related information. For example:
-ifndef::ibm-z[]
 +
 [source,terminal]
 ----
 bond=bond0:eno1f0,eno2f0:mode=active-backup
 ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 ----
-endif::ibm-z[]
-ifdef::ibm-z[]
-
-[source,terminal]
-----
-bond=bond0:eno1f0,eno2f0:mode=active-backup,fail_over_mac=1
-ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
-----
-
-Always set the `fail_over_mac=1` option in active-backup mode, to avoid problems when shared OSA/RoCE cards are used.
 endif::ibm-z[]
 
 [discrete]


### PR DESCRIPTION
[OCPBUGS-11651]: SR-IOV section included in IBM zSystems install docs in error

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-11651

Link to docs preview:
https://58568--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/preparing-to-install-on-bare-metal.html#nw-sriov-dual-nic-con_preparing-to-install-on-bare-metal

https://58568--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#bonding-multiple-sriov-network-interfaces-to-dual-port_installing-bare-metal

for Z:
https://58568--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z.html#installation-user-infra-machines-routing-bonding_installing-ibm-z

KVM-Link https://58568--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z-kvm.html

for Power:

https://58568--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power.html#installation-user-infra-machines-routing-bonding_installing-ibm-power

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updating documentation where a section accidentally leaked into Z docs due to my misunderstanding. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
