### PR TITLE
OCPBUGS-11688: Explained that adding new users is not supported

### DIFF
--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -50,7 +50,7 @@ The kinds of components that MCO can change include:
 
 [IMPORTANT]
 ====
-Changing SSH keys via machine configs is only supported for the `core` user.
+Changing SSH keys via machine configs is only supported for the `core` user. It is not supported to add any other user via machine configs.
 ====
 * **kernelArguments**: Add arguments to the kernel command line when {product-title} nodes boot.
 * **kernelType**: Optionally identify a non-standard kernel to use instead of the standard kernel. Use `realtime` to use the RT kernel (for RAN). This is only supported on select platforms.


### PR DESCRIPTION
Version(s):
All the OCP 4.y versions, from 4.1 to the latest development version.

Issue:
https://issues.redhat.com/browse/OCPBUGS-11688

Link to docs preview:
https://58569--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks.html#what-can-you-change-with-machine-configs

QE review:
- [x] QE has approved this change.

Additional information:
It is not supported to add any user other than `core`, but we have not specified it in the docs. We only specified that it is possible to edit SSH keys only for `core` user, but the wording was not clear enough about adding other users.
