### PR TITLE
GH58576: Remove Support section from OKD docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -712,6 +712,7 @@ Topics:
     File: opting-out-of-remote-health-reporting
   - Name: Enabling remote health reporting
     File: enabling-remote-health-reporting
+    Distros: openshift-enterprise,openshift-online
   - Name: Using Insights to identify issues with your cluster
     File: using-insights-to-identify-issues-with-your-cluster
   - Name: Using the Insights Operator

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -717,8 +717,10 @@ Topics:
     File: using-insights-to-identify-issues-with-your-cluster
   - Name: Using the Insights Operator
     File: using-insights-operator
+# OKD users likely cannot upload files to support
   - Name: Using remote health reporting in a restricted network
     File: remote-health-reporting-from-restricted-network
+    Distros: openshift-enterprise,openshift-online
   - Name: Importing simple content access entitlements with Insights Operator
     File: insights-operator-simple-access
 - Name: Gathering data about your cluster

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -691,7 +691,7 @@ Topics:
 ---
 Name: Support
 Dir: support
-Distros: openshift-enterprise,openshift-online
+Distros: openshift-enterprise,openshift-online,openshift-origin
 Topics:
 - Name: Support overview
   File: index

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -691,7 +691,7 @@ Topics:
 ---
 Name: Support
 Dir: support
-Distros: openshift-enterprise,openshift-online,openshift-origin
+Distros: openshift-enterprise,openshift-online
 Topics:
 - Name: Support overview
   File: index

--- a/modules/accessing-windows-node-using-rdp.adoc
+++ b/modules/accessing-windows-node-using-rdp.adoc
@@ -13,7 +13,12 @@ You can access a Windows node by using a Remote Desktop Protocol (RDP).
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You have created a Windows compute machine set.
 * You have added the key used in the `cloud-private-key` secret and the key used when creating the cluster to the ssh-agent. For security reasons, remember to remove the keys from the ssh-agent after use.
+ifndef::openshift-origin[]
 * You have connected to the Windows node link:https://access.redhat.com/solutions/4073041[using an `ssh-bastion` pod].
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+* You have connected to the Windows node using an `ssh-bastion` pod.
+endif::openshift-origin[]
 
 .Procedure
 

--- a/modules/accessing-windows-node-using-ssh.adoc
+++ b/modules/accessing-windows-node-using-ssh.adoc
@@ -13,7 +13,12 @@ You can access a Windows node by using a secure shell (SSH).
 * You have installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You have created a Windows compute machine set.
 * You have added the key used in the `cloud-private-key` secret and the key used when creating the cluster to the ssh-agent. For security reasons, remember to remove the keys from the ssh-agent after use.
+ifndef::openshift-origin[]
 * You have connected to the Windows node link:https://access.redhat.com/solutions/4073041[using an `ssh-bastion` pod].
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+* You have connected to the Windows node using an `ssh-bastion` pod.
+endif::openshift-origin[]
 
 .Procedure
 

--- a/modules/installation-bootstrap-gather.adoc
+++ b/modules/installation-bootstrap-gather.adoc
@@ -72,5 +72,8 @@ INFO Pulling debug logs from the bootstrap machine
 INFO Bootstrap gather logs captured here "<installation_directory>/log-bundle-<timestamp>.tar.gz"
 ----
 +
+ifndef::openshift-origin[]
 If you open a Red Hat support case about your installation failure, include
 the compressed logs in the case.
+endif::openshift-origin[]
+

--- a/modules/upi-installation-considerations.adoc
+++ b/modules/upi-installation-considerations.adoc
@@ -9,7 +9,9 @@ The default installation method uses installer-provisioned infrastructure. With 
 
 You can alternatively install {product-title} {product-version} on infrastructure that you provide. If you use this installation method, follow user-provisioned infrastructure installation documentation carefully. Additionally, review the following considerations before the installation:
 
+ifndef::openshift-origin[]
 * Check the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux[{op-system-base-full} Ecosystem] to determine the level of {op-system-first} support provided for your chosen server hardware or virtualization technology.
+endif::openshift-origin[]
 
 * Many virtualization and cloud environments require agents to be installed on guest operating systems. Ensure that these agents are installed as a containerized workload deployed through a daemon set.
 

--- a/support/index.adoc
+++ b/support/index.adoc
@@ -8,9 +8,11 @@ toc::[]
 
 Red Hat offers cluster administrators tools for gathering data for your cluster, monitoring, and troubleshooting.
 
+ifndef::openshift-origin[]
 [id='support-overview-get-support']
 == Get support
 xref:../support/getting-support.adoc#getting-support[Get support]: Visit the Red Hat Customer Portal to review knowledge base articles, submit a support case, and review additional product documentation and resources.
+endif::openshift-origin[]
 
 ifndef::openshift-rosa,openshift-dedicated[]
 [id='support-overview-remote-health-monitoring']

--- a/support/index.adoc
+++ b/support/index.adoc
@@ -127,11 +127,14 @@ endif::openshift-rosa,openshift-dedicated[]
 ** Investigate why user-defined metrics are unavailable.
 ** Determine why Prometheus is consuming a lot of disk space.
 
+ifndef::openshift-origin[]
+// Replace in OKD if Logging is added
 * xref:../logging/cluster-logging.adoc#cluster-logging[Logging issues]: A cluster administrator can follow the procedures in the "Support" and "Troubleshooting logging" sections to resolve logging issues:
 
 ** xref:../logging/troubleshooting/cluster-logging-cluster-status.adoc#cluster-logging-clo-status_cluster-logging-cluster-status[Viewing the status of the {clo}].
 ** xref:../logging/troubleshooting/cluster-logging-cluster-status.adoc#cluster-logging-clo-status-comp_cluster-logging-cluster-status[Viewing the status of {logging} components].
 ** xref:../logging/troubleshooting/troubleshooting-logging-alerts.adoc#troubleshooting-logging-alerts[Troubleshooting logging alerts].
 ** xref:../logging/cluster-logging-support.adoc#cluster-logging-must-gather-collecting_cluster-logging-support[Collecting information about your logging environment by using the `oc adm must-gather` command].
+endif::openshift-origin[]
 
 * xref:../support/troubleshooting/diagnosing-oc-issues.adoc#diagnosing-oc-issues[{oc-first} issues]: Investigate {oc-first} issues by increasing the log level.

--- a/support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc
+++ b/support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc
@@ -26,7 +26,9 @@ include::modules/telemetry-consequences-of-disabling-telemetry.adoc[leveloffset=
 
 include::modules/insights-operator-new-pull-secret-disabled.adoc[leveloffset=+1]
 
+ifndef::openshift-origin[]
 include::modules/insights-operator-register-disconnected-cluster.adoc[leveloffset=+1]
+endif::openshift-origin[]
 
 [role="_additional-resources"]
 .Additional resources
@@ -35,4 +37,4 @@ include::modules/insights-operator-register-disconnected-cluster.adoc[leveloffse
 
 include::modules/images-update-global-pull-secret.adoc[leveloffset=+1]
 
-endif::[]
+endif::openshift-enterprise,openshift-webscale,openshift-origin[]

--- a/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+++ b/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
@@ -9,6 +9,7 @@ endif::[]
 
 toc::[]
 
+ifndef::openshift-origin[]
 Insights repeatedly analyzes the data Insights Operator sends. Users of {product-title} can display the report in the {insights-advisor-url} service on {hybrid-console}.
 
 include::modules/insights-operator-advisor-overview.adoc[leveloffset=+1]
@@ -21,3 +22,10 @@ include::modules/removing-filters-from-insights-advisor-recommendations.adoc[lev
 include::modules/disabling-insights-advisor-recommendations.adoc[leveloffset=+1]
 include::modules/enabling-insights-advisor-recommendations.adoc[leveloffset=+1]
 include::modules/displaying-the-insights-status-in-the-web-console.adoc[leveloffset=+1]
+endif::openshift-origin[]
+
+ifdef::openshift-origin[]
+Insights repeatedly analyzes the data Insights Operator sends.
+
+include::modules/displaying-the-insights-status-in-the-web-console.adoc[leveloffset=+1]
+endif::openshift-origin[]


### PR DESCRIPTION
Please remove the "Support" section of the OKD Product Docs.
4.9+

Product docs issue: https://github.com/openshift/openshift-docs/issues/58576

Preview: https://file.rdu.redhat.com/mburke/okd-remove-support/support/index.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

