### PR TITLE
OSDOCS-5637-monitoring: Documented the monitoring bug fix release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1119,6 +1119,9 @@ With this release, replacement control plane nodes are assigned to the correct i
 [id="ocp-4-13-monitoring-bug-fixes"]
 ==== Monitoring
 
+* Previously, the Kubernetes scheduler could skip scheduling certain pods for a node that received multiple restart operations. {product-title} {product-version} counteracts this issue by including the `KubePodNotScheduled` alert for pods that cannot be scheduled within 30 minutes. (link:https://issues.redhat.com/browse/OCPBUGS-2260[*OCPBUGS-2260*])
+
+
 [discrete]
 [id="ocp-4-13-networking-bug-fixes"]
 ==== Networking


### PR DESCRIPTION
[OSDOCS-5637](https://issues.redhat.com/browse/OSDOCS-5637)

Version(s):
4.13

Link to docs preview:
[Preview](https://58585--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-bug-fixes)

QE review:
- [ ] QE has approved this change.
