### PR TITLE
OCPBUGS-7842: add --no-same-owner for extracting graph-data tar

### DIFF
--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -17,7 +17,7 @@ FROM registry.access.redhat.com/ubi8/ubi:8.1
 
 RUN curl -L -o cincinnati-graph-data.tar.gz https://api.openshift.com/api/upgrades_info/graph-data
 
-RUN mkdir -p /var/lib/cincinnati-graph-data && tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati-graph-data/ --no-overwrite-dir
+RUN mkdir -p /var/lib/cincinnati-graph-data && tar xvzf cincinnati-graph-data.tar.gz -C /var/lib/cincinnati-graph-data/ --no-overwrite-dir --no-same-owner
 
 CMD ["/bin/bash", "-c" ,"exec cp -rp /var/lib/cincinnati-graph-data/* /var/lib/cincinnati/graph-data"]
 ----


### PR DESCRIPTION
add the --no-same-owner flag while extracting the graph-data tarball in order to avoid permission issues while extracting if the user does not have permissions


Version(s): 4.9+

Issue: [OCPBUGS-7842](https://issues.redhat.com/browse/OCPBUGS-7842)

Link to docs preview:
https://58611--docspreview.netlify.app//openshift-enterprise/latest/updating/updating-restricted-network-cluster/restricted-network-update-osus.html#update-service-graph-data_updating-restricted-network-cluster-osus


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
