### PR TITLE
Add note about 3.x to 4.x upgrades

### DIFF
--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -11,6 +11,11 @@ Upgrades through the {rh-rhacs-first} Operator are performed automatically or ma
 
 If you installed {product-title-short} using the Operator and selected *Automatic* in the *Update approval* field, {product-title-short} is automatically updated when a new software version is released. If you selected *Manual*, you must approve subsequent Operator updates by using Operator Lifecycle Manager (OLM). For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/administrator-tasks#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update].
 
+[NOTE]
+====
+It is not possible, even with manual approval, to upgrade from {product-title-short} version 3.74 and earlier to {product-title-short} 4.0 by using the standard OLM upgrade process. The custom upgrade procedure requires a manual intervention so that the system administrator can perform a database backup before database changes introduced in {product-title-short} 4.0 are applied. For that upgrade procedure, see "Upgrading from {product-title-short} 3.74 and earlier to {product-title-short 4.0 and later}" in the "Additional resources" section.
+====
+
 To roll back an Operator upgrade, you must perform the steps described in one of the following sections. You can roll back an Operator upgrade by using the CLI or the {ocp} web console.
 
 include::modules/rollback-operator-upgrades-cli.adoc[leveloffset=+1]
@@ -22,3 +27,4 @@ include::modules/rollback-operator-upgrades-console.adoc[leveloffset=+1]
 * xref:../installing/installing_ocp/install-central-ocp.adoc#install-central-operator_install-central-ocp[Installing Central using the Operator method]
 * link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/understanding-operators#olm-workflow[Operator Lifecycle Manager workflow]
 * link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/administrator-tasks#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update]
+* TODO: add link to Upgrading from {product-title-short} 3.74 and earlier to {product-title-short} 4.0 and later


### PR DESCRIPTION
Version(s):
- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.0`

Issue: 
- 4.0 changes from #57249 
- Related to [ROX-12509](https://issues.redhat.com//browse/ROX-12509) - which includes Operator instructions for upgrading from 3.x to 4.x

[Link to docs preview
](https://58643--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-operator.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
