### PR TITLE
CNV-24741: Fix DV/PVC terminology in storage modules

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3676,8 +3676,8 @@ Topics:
       File: virt-cloning-vm-disk-into-new-datavolume
     - Name: Cloning a virtual machine by using a data volume template
       File: virt-cloning-vm-using-datavolumetemplate
-    - Name: Cloning a virtual machine disk into a new block storage data volume
-      File: virt-cloning-vm-disk-into-new-datavolume-block
+    - Name: Cloning a virtual machine disk into a new block storage persistent volume claim
+      File: virt-cloning-vm-disk-into-new-block-storage-pvc
 # Virtual machine networking
   - Name: Virtual machine networking
     Dir: vm_networking
@@ -3724,7 +3724,7 @@ Topics:
       File: virt-uploading-local-disk-images-web
     - Name: Uploading local disk images by using the virtctl tool
       File: virt-uploading-local-disk-images-virtctl
-    - Name: Uploading a local disk image to a block storage data volume
+    - Name: Uploading a local disk image to a block storage persistent volume claim
       File: virt-uploading-local-disk-images-block
     - Name: Managing virtual machine snapshots
       File: virt-managing-vm-snapshots

--- a/modules/virt-about-block-pvs.adoc
+++ b/modules/virt-about-block-pvs.adoc
@@ -1,8 +1,9 @@
 // Module included in the following assemblies:
 //
-// * virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-block.adoc
 // * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
 // * virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
+// * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-pvc.adoc
+
 
 :_content-type: CONCEPT
 [id="virt-about-block-pvs_{context}"]

--- a/modules/virt-about-datavolumes.adoc
+++ b/modules/virt-about-datavolumes.adoc
@@ -8,7 +8,7 @@
 // * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc
 // * virt/virtual_machines/cloning_vms/virt-cloning-vm-using-datavolumetemplate.adoc
 // * virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc
-// * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
+// * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-pvc.adoc
 // * virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
 
 

--- a/modules/virt-cdi-supported-operations-matrix.adoc
+++ b/modules/virt-cdi-supported-operations-matrix.adoc
@@ -5,7 +5,7 @@
 // * virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.adoc
 // * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc
 // * virt/virtual_machines/cloning_vms/virt-cloning-vm-using-datavolumetemplate.adoc
-// * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
+// * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-pvc.adoc
 // * virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
 // * virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes-block.adoc
 // * virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-web.adoc

--- a/modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc
+++ b/modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume.adoc
-// * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
+// * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-pvc.adoc
 
 // `blockstorage` conditionals are used (declared in the "*-block" assembly) to separate content 
 

--- a/modules/virt-creating-local-block-pv.adoc
+++ b/modules/virt-creating-local-block-pv.adoc
@@ -1,8 +1,9 @@
 // Module included in the following assemblies:
 //
 // * virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-block.adoc
-// * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-datavolume-block.adoc
 // * virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.adoc
+// * virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-pvc.adoc
+
 
 :_content-type: PROCEDURE
 [id="virt-creating-local-block-pv_{context}"]

--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-PVC.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-PVC.adoc
@@ -1,13 +1,13 @@
 :_content-type: ASSEMBLY
-[id="virt-cloning-vm-disk-into-new-datavolume-block"]
-= Cloning a virtual machine disk into a new block storage data volume
+[id="virt-cloning-vm-disk-into-new-block-storage-pvc"]
+= Cloning a virtual machine disk into a new block storage persistent volume claim
 include::_attributes/common-attributes.adoc[]
-:context: virt-cloning-vm-disk-into-new-datavolume-block
+:context: virt-cloning-vm-disk-into-new-block-storage-pvc
 
 toc::[]
 
 You can clone the persistent volume claim (PVC) of a virtual machine disk into
-a new block data volume by referencing the source PVC in your data volume configuration
+a new block PVC by referencing the source PVC in your clone target data volume configuration
 file.
 
 [WARNING]

--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-pvc.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-pvc.adoc
@@ -1,0 +1,40 @@
+:_content-type: ASSEMBLY
+[id="virt-cloning-vm-disk-into-new-block-storage-pvc"]
+= Cloning a virtual machine disk into a new block storage persistent volume claim
+include::_attributes/common-attributes.adoc[]
+:context: virt-cloning-vm-disk-into-new-block-storage-pvc
+
+toc::[]
+
+You can clone the persistent volume claim (PVC) of a virtual machine disk into
+a new block PVC by referencing the source PVC in your clone target data volume configuration
+file.
+
+[WARNING]
+====
+Cloning operations between different volume modes are supported, such as cloning from a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`.
+
+However, you can only clone between different volume modes if they are of the `contentType: kubevirt`.
+====
+
+[TIP]
+====
+When you enable preallocation globally, or for a single data volume, the Containerized Data Importer (CDI) preallocates disk space during cloning. Preallocation enhances write performance. For more information, see xref:../../../virt/virtual_machines/virtual_disks/virt-using-preallocation-for-datavolumes.adoc#virt-using-preallocation-for-datavolumes[Using preallocation for data volumes].
+====
+
+== Prerequisites
+
+* Users need xref:../../../virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.
+
+:blockstorage:
+include::modules/virt-about-datavolumes.adoc[leveloffset=+1]
+
+include::modules/virt-about-block-pvs.adoc[leveloffset=+1]
+
+include::modules/virt-creating-local-block-pv.adoc[leveloffset=+1]
+
+include::modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc[leveloffset=+1]
+
+include::modules/virt-cdi-supported-operations-matrix.adoc[leveloffset=+1]
+
+:blockstorage!:

--- a/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-block.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-block.adoc
@@ -1,27 +1,26 @@
 :_content-type: ASSEMBLY
 [id="virt-uploading-local-disk-images-block"]
-= Uploading a local disk image to a block storage data volume
+= Uploading a local disk image to a block storage persistent volume claim
 include::_attributes/common-attributes.adoc[]
 :context: virt-uploading-local-disk-images-block
 
 toc::[]
 
-You can upload a local disk image into a block data volume by using the
+You can upload a local disk image into a block persistent volume claim (PVC) by using the
 `virtctl` command-line utility.
 
 In this workflow, you create a local block device to use as a persistent volume,
 associate this block volume with an `upload` data volume, and use `virtctl`
-to upload the local disk image into the data volume.
+to upload the local disk image into the PVC.
 
 == Prerequisites
 
 * xref:../../../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl[Install `virtctl`].
-* If you require scratch space according to the
-xref:#virt-cdi-supported-operations-matrix_virt-uploading-local-disk-images-block[CDI supported operations matrix], you must first
-xref:../../../virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.adoc#virt-defining-storageclass_virt-preparing-cdi-scratch-space[define a storage class or prepare CDI scratch space]
+
+* You might need to xref:../../../virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.adoc#virt-defining-storageclass_virt-preparing-cdi-scratch-space[define a storage class or prepare CDI scratch space]
 for this operation to complete successfully.
 
-:blockstorage:
+
 include::modules/virt-about-datavolumes.adoc[leveloffset=+1]
 
 include::modules/virt-about-block-pvs.adoc[leveloffset=+1]

--- a/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-virtctl.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-virtctl.adoc
@@ -6,16 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can upload a locally stored disk image to a new or existing data volume by using the
-`virtctl` command-line utility.
+You can upload a locally stored disk image to a new or existing persistent volume claim (PVC) by using the `virtctl` command-line utility.
 
 == Prerequisites
 
 * xref:../../../virt/install/virt-installing-virtctl.adoc#virt-installing-virtctl[Install `virtctl`].
 
-* If you require scratch space according to the
-xref:#virt-cdi-supported-operations-matrix_virt-cloning-vm-disk-into-new-datavolume-block[CDI supported operations matrix], you must first
-xref:../../../virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.adoc#virt-defining-storageclass_virt-preparing-cdi-scratch-space[define a storage class or prepare CDI scratch space]
+* You might need to xref:../../../virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space.adoc#virt-defining-storageclass_virt-preparing-cdi-scratch-space[define a storage class or prepare CDI scratch space]
 for this operation to complete successfully.
 
 include::modules/virt-about-datavolumes.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.13

Issue: [CNV-24741](https://issues.redhat.com/browse/CNV-24741)


Link to docs preview: https://58657--docspreview.netlify.app/

https://58657--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-managing-vms-openshift-pipelines.html (topic had been revised recently; text to be updated is longer included)

https://58657--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-pvc

https://58657--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-importing-virtual-machine-images-datavolumes.html

https://58657--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/importing_vms/virt-tls-certificates-for-dv-imports.html

https://58657--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-block.html

https://58657--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-uploading-local-disk-images-virtctl.html




QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
