### PR TITLE
OSDOCS-5159 updating xrefs to reference storage content

### DIFF
--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -153,4 +153,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * Optional: xref:../../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#vsphere-problem-detector-viewing-events_vsphere-problem-detector[View the events from the vSphere Problem Detector Operator] to determine if the cluster has permission or storage configuration issues.
-* Optional: if you created encrypted virtual machines, xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[create an encrypted storage class].
+* Optional: if you created encrypted virtual machines, xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[create an encrypted storage class].

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -56,7 +56,7 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-vsphere-encrypted-vms.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[Creating an encrypted storage class]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[Creating an encrypted storage class]
 
 include::modules/csr-management.adoc[leveloffset=+2]
 
@@ -140,4 +140,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Set up your registry and configure registry storage].
 * Optional: xref:../../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#vsphere-problem-detector-viewing-events_vsphere-problem-detector[View the events from the vSphere Problem Detector Operator] to determine if the cluster has permission or storage configuration issues.
-* Optional: if you created encrypted virtual machines, xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[create an encrypted storage class].
+* Optional: if you created encrypted virtual machines, xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[create an encrypted storage class].

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -56,7 +56,7 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-vsphere-encrypted-vms.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[Creating an encrypted storage class]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[Creating an encrypted storage class]
 
 include::modules/csr-management.adoc[leveloffset=+2]
 
@@ -143,4 +143,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 * xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Set up your registry and configure registry storage].
 * Optional: xref:../../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#vsphere-problem-detector-viewing-events_vsphere-problem-detector[View the events from the vSphere Problem Detector Operator] to determine if the cluster has permission or storage configuration issues.
-* Optional: if you created encrypted virtual machines, xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[create an encrypted storage class].
+* Optional: if you created encrypted virtual machines, xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[create an encrypted storage class].

--- a/post_installation_configuration/vsphere-post-installation-encryption.adoc
+++ b/post_installation_configuration/vsphere-post-installation-encryption.adoc
@@ -14,5 +14,5 @@ include::modules/vsphere-encrypting-vms.adoc[leveloffset=+1]
 [id="additional-resources_enabling-encryption-installation"]
 == Additional resources
 * xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-evacuating_nodes-nodes-working[Working with nodes]
-* xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-encryption[vSphere encryption]
+* xref:../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#vsphere-pv-encryption[vSphere encryption]
 * xref:../installing/installing_vsphere/installing-vsphere.adoc#installation-vsphere-encrypted-vms_installing-vsphere[Installing a cluster on vSphere with user-provisioned infrastructure]


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-5159](https://issues.redhat.com//browse/OSDOCS-5159)

Link to docs preview:
https://58675--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-encrypted-vms_installing-vsphere
https://58675--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/vsphere-post-installation-encryption.html

QE review:
QE not required, only xrefs are changing

Additional information:
Referencing the storage content added in https://github.com/openshift/openshift-docs/pull/56655. The links will not go to the correct heading until https://github.com/openshift/openshift-docs/pull/56655 merges.