### PR TITLE
[OSDOCS-5742]: Updating links to ACM content

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
@@ -11,7 +11,7 @@ The following procedure is partially automated and requires manual steps after t
 
 == Prerequisites
 * You have read the following documentation:
-** link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/multicluster_engine/multicluster_engine_overview[multicluster engine for Kubernetes].
+** link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview[Cluster lifecycle with multicluster engine operator overview].
 ** xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-local.adoc#persistent-storage-using-local-volume[Persistent storage using local volumes].
 ** xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc#about-ztp_ztp-deploying-far-edge-clusters-at-scale[Using ZTP to provision clusters at the network far edge].
 ** xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer].

--- a/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
+++ b/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
@@ -13,7 +13,7 @@
 
 * You have logged in to the hub cluster as a user with `cluster-admin` privileges.
 
-* You have enabled the assisted service on the hub cluster. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/multicluster_engine/multicluster_engine_overview#enable-cim[Enabling CIM].
+* You have enabled the assisted service on the hub cluster. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#enable-cim[Enabling the Central Infrastructure Management Service].
 
 .Procedure
 

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -201,7 +201,7 @@ For clusters managed by the Assisted Installer, you can add worker nodes by usin
 
 For clusters managed by the multicluster engine for Kubernetes, you can add worker nodes by using the dedicated multicluster engine console.
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/multicluster_engine/multicluster_engine_overview#scale-hosts-infrastructure-env[Adding worker nodes for clusters managed by the multicluster engine for Kubernetes]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#scale-hosts-infrastructure-env[Scaling hosts to an infrastructure environment]
 
 ////
 [id="default-crds_{context}"]

--- a/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
@@ -45,7 +45,7 @@ include::modules/ztp-site-cleanup.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For information about removing a cluster, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/multicluster_engine/multicluster_engine_overview#remove-managed-cluster[Removing a cluster from management].
+* For information about removing a cluster, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management].
 
 include::modules/ztp-removing-obsolete-content.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
@@ -45,7 +45,7 @@ include::modules/ztp-precaching-downloading-artifacts.adoc[leveloffset=+1]
 
 * To access the online Red Hat registries, see link:https://console.redhat.com/openshift/downloads#tool-pull-secret[OpenShift installation customization tools].
 
-* For more information about using the multicluster engine, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.6/html/multicluster_engine/multicluster_engine_overview#mce-intro[About the multicluster engine for Kubernetes operator].
+* For more information about using the multicluster engine, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with the multicluster engine operator].
 
 include::modules/ztp-precaching-ztp-config.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5742
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://58679--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.html
- https://58679--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#enabling-assisted-installer-service-on-bare-metal_ztp-preparing-the-hub-cluster
- https://58679--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#adding-worker-nodes-to-clusters-managed-by-the-multicluster-engine-for-kubernetes
- https://58679--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.html#ztp-site-cleanup_ztp-deploying-far-edge-sites
- https://58679--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-precaching-tool.html#ztp-custom-pre-caching-in-disconnected-environment_pre-caching
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR updates several links in the OCP docs that point to the ACM docs. The previous links were pointing to ACM 2.6, which correlates with the OCP 4.11 release. This PR changes the links to point to the ACM 2.7 docs, which align with OCP 4.12. Note: I'll need to do this exercise again for the 4.13 docs after ACM 2.8 is released.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
