### PR TITLE
[RHACS] Added instructions for Operator upgrade

### DIFF
--- a/modules/operator-upgrade-centraldb-cannot-be-scheduled.adoc
+++ b/modules/operator-upgrade-centraldb-cannot-be-scheduled.adoc
@@ -1,0 +1,35 @@
+// Module included in the following assemblies:
+//
+// * upgrade/upgrade-operator.adoc
+:_module-type: REFERENCE
+[id="operator-upgrade-centraldb-cannot-be-scheduled_{context}"]
+= Central DB cannot be scheduled
+
+[role="_abstract"]
+Follow the instructions here to troubleshoot a failing Central DB pod during an upgrade:
+
+. Check the status of the `central-db` pod:
++
+[source,terminal]
+----
+$ oc -n <namespace> get pod -l app=central-db <1>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+. If the status of the pod is `Pending`, use the describe command to get more details:
++
+[source,terminal]
+----
+$ oc -n <namespace> describe po/<central-db-pod-name> <1>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+. You might see the `FailedScheduling` warning message:
++
+[source,terminal]
+----
+Type     Reason            Age   From               Message
+----     ------            ----  ----               -------
+Warning  FailedScheduling  54s   default-scheduler  0/7 nodes are available: 1 Insufficient memory, 3 node(s) had untolerated taint {node-role.kubernetes.io/master: }, 4 Insufficient cpu. preemption: 0/7 nodes are available: 3 Preemption is not helpful for scheduling, 4 No preemption victims found for incoming pod.
+----
+. This warning message suggests that the scheduled node had insufficient memory to accommodate the pod's resource requirements. If you have a small environment, consider increasing resources on the nodes or adding a larger node that can support the database.
++
+Otherwise, consider decreasing the resource requirements for the `central-db` pod in the custom resource under `central` -> `db` -> `resources`. However, running central with fewer resources than the recommended minimum might lead to degraded performance for {product-title-short}.

--- a/modules/operator-upgrade-change-subscription-channel.adoc
+++ b/modules/operator-upgrade-change-subscription-channel.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-operator.adoc
+:_module-type: PROCEDURE
+[id="operator-upgrade-change-subscription-channel_{context}"]
+= Changing subscription channel
+
+[role="_abstract"]
+You can change the update channel for the {product-title-short} Operator by using the {ocp} web console or by using the command line. For upgrading to {product-title-short} 4.0 from {product-title-short} 3.74, you must change the update channel.
+
+[IMPORTANT]
+====
+You must change the subscription channel for all clusters where you have installed {product-title-short} Operator, including Central and all Secured clusters.
+====
+
+.Prerequisites
+* You must verify that you are using the latest {product-title-short} 3.74 Operator and there are no pending manual Operator upgrades.
+* You must verify that you have backed up your existing Central database.
+* You have access to an {ocp} cluster web console using an account with `cluster-admin` permissions.
+
+[discrete]
+== Changing the subscription channel by using the web console
+Use the following instructions for changing the subscription channel by using the web console:
+
+.Procedure
+. In the *Administrator* perspective of the {ocp} web console, go to *Operators* → *Installed Operators*.
+. Locate the {product-title-short} Operator and click on it.
+. Click the *Subscription* tab.
+. Click the name of the update channel under *Update Channel*.
+. Select *stable*, then click *Save*.
+. For subscriptions with an *Automatic* approval strategy, the update begins automatically. Navigate back to the *Operators* → *Installed Operators* page to monitor the progress of the update. When complete, the status changes to *Succeeded* and *Up to date*.
++
+For subscriptions with a *Manual* approval strategy, you can manually approve the update from the *Subscription* tab.
+
+[discrete]
+== Changing the subscription channel by using command line
+Use the following instructions for changing the subscription channel by using command line:
+
+.Procedure
+* Run the following command to change the subscription channel to `stable`:
++
+[source,terminal]
+----
+$ oc -n rhacs-operator \ <1>
+  patch subscriptions.operators.coreos.com rhacs-operator \
+  --type=merge --patch='{ "spec": { "channel": "stable" }}'
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+
+During the update the {product-title-short} Operator provisions a new deployment called `central-db` and your data begins migrating. It takes around 30 minutes and only happens once when you upgrade.

--- a/modules/operator-upgrade-fail-to-deploy.adoc
+++ b/modules/operator-upgrade-fail-to-deploy.adoc
@@ -1,0 +1,67 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-operator.adoc
+:_module-type: REFERENCE
+[id="operator-upgrade-fail-to-deploy_{context}"]
+= Central or Secured cluster fails to deploy
+
+[role="_abstract"]
+When {product-title-short} Operator:
+
+* fails to deploy Central or Secured Cluster.
+* fails to apply CR changes to actual resources.
+
+You must check the custom resource conditions to find the issue.
+
+* For Central, run the following command to check the conditions:
++
+[source,terminal]
+----
+$ oc -n rhacs-operator describe centrals.platform.stackrox.io <1>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+
+* For Secured clusters, run the following command to check the conditions:
++
+[source,terminal]
+----
+$ oc -n rhacs-operator describe securedclusters.platform.stackrox.io <1>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+
+You can identify configuration errors from the conditions output:
+
+.Example output
+[source,terminal]
+----
+ Conditions:
+    Last Transition Time:  2023-04-19T10:49:57Z
+    Status:                False
+    Type:                  Deployed
+    Last Transition Time:  2023-04-19T10:49:57Z
+    Status:                True
+    Type:                  Initialized
+    Last Transition Time:  2023-04-19T10:59:10Z
+    Message:               Deployment.apps "central" is invalid: spec.template.spec.containers[0].resources.requests: Invalid value: "50": must be less than or equal to cpu limit
+    Reason:                ReconcileError
+    Status:                True
+    Type:                  Irreconcilable
+    Last Transition Time:  2023-04-19T10:49:57Z
+    Message:               No proxy configuration is desired
+    Reason:                NoProxyConfig
+    Status:                False
+    Type:                  ProxyConfigFailed
+    Last Transition Time:  2023-04-19T10:49:57Z
+    Message:               Deployment.apps "central" is invalid: spec.template.spec.containers[0].resources.requests: Invalid value: "50": must be less than or equal to cpu limit
+    Reason:                InstallError
+    Status:                True
+    Type:                  ReleaseFailed
+----
+
+Additionally, you can view {product-title-short} pod logs to find more information about the issue. Run the following command to view the logs:
+
+[source,terminal]
+----
+oc -n rhacs-operator logs deploy/rhacs-operator-controller-manager manager <1>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.

--- a/modules/operator-upgrade-modify-central-custom-resource.adoc
+++ b/modules/operator-upgrade-modify-central-custom-resource.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-operator.adoc
+:_module-type: PROCEDURE
+[id="operator-upgrade-modify-central-custom-resource_{context}"]
+= Modifying Central custom resource
+
+[role="_abstract"]
+The Central DB service requires persistent storage. If you have not configured a default storage class for the Central cluster that is an SSD or is high performance, you must update the `Central` custom resource to configure the storage class for the Central DB persistent volume claim (PVC).
+
+[NOTE]
+====
+Skip this section if you have already configured a default storage class for Central.
+====
+
+.Procedure
+* Update the central custom resource with the following configuration:
+[source,terminal]
+----
+spec:
+  central:
+    db:
+      isEnabled: Default <1>
+      persistence:
+        persistentVolumeClaim: <2>
+          claimName: central-db
+          size: 100Gi
+          storageClassName: <storage-class-name>
+----
+<1> You must not change the value of `IsEnabled` to `Enabled`.
+<2> If this claim exists, your cluster uses the existing claim, otherwise it creates a new claim.

--- a/modules/prepare-operator-upgrades.adoc
+++ b/modules/prepare-operator-upgrades.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-operator.adoc
+:_module-type: CONCEPT
+[id="prepare-operator-upgrades_{context}"]
+= Preparing to upgrade
+
+[role="_abstract"]
+Before you upgrade {rh-rhacs-first} version, you must:
+
+* Verify that you are running the latest patch release version of the {product-title-short} Operator 3.74.
+* Backup your existing Central database.

--- a/modules/rollback-operator-upgrades-cli.adoc
+++ b/modules/rollback-operator-upgrades-cli.adoc
@@ -148,4 +148,4 @@ $ kubectl set image -n <central namespace> deploy/central central=registry.redha
 ----
 Clone to Migrate ".previous", ""
 ----
-. Reinstall the Operator on the rolled back channel. For example, `3.71.3` is installed on the `rhacs-3.71` channel.
+. Reinstall the Operator on the rolled back channel. For example, `3.74.2` is installed on the `rhacs-3.74` channel.

--- a/modules/rollback-operator-upgrades-console.adoc
+++ b/modules/rollback-operator-upgrades-console.adoc
@@ -74,4 +74,4 @@ spec:
 ----
 Clone to Migrate ".previous", ""
 ----
-. Reinstall the Operator on the rolled back channel. For example, `3.71.3` is installed on the `rhacs-3.71` channel.
+. Reinstall the Operator on the rolled back channel. For example, `3.74.2` is installed on the `rhacs-3.74` channel.

--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -9,16 +9,52 @@ toc::[]
 [role="_abstract"]
 Upgrades through the {rh-rhacs-first} Operator are performed automatically or manually, depending on the *Update approval* option you chose at installation.
 
-If you installed {product-title-short} using the Operator and selected *Automatic* in the *Update approval* field, {product-title-short} is automatically updated when a new software version is released. If you selected *Manual*, you must approve subsequent Operator updates by using Operator Lifecycle Manager (OLM). For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/administrator-tasks#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update].
+{product-title-short} 4.0 includes a significant architectural change, moving Central’s database to PostgreSQL. Because of this change, {product-title-short} 4.0 Operator is published by a new subscription channel. Therefore, as part of the upgrade instructions, you must manually change the subscription channel to upgrade from {product-title-short} 3.74 to {product-title-short} 4.0.
+
+//If you installed {product-title-short} using the Operator and selected *Automatic* in the *Update approval* field, {product-title-short} is automatically updated when a new software version is released. If you selected *Manual*, you must approve subsequent Operator updates by using Operator Lifecycle Manager (OLM). For more information, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/administrator-tasks#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update].
+
+[IMPORTANT]
+====
+* Because of the database related changes introduced in {product-title-short} 4.0, even if you have selected *Automatic* in the *Update approval* field, you must manually upgrade to {product-title-short} 4.0.
+* You must be using {product-title-short} 3.74 to upgrade to {product-title-short} 4.0. If you are using a version older than 3.74, you must first upgrade to {product-title-short} 3.74 and then upgrade to {product-title-short} 4.0.
+====
+
+include::modules/prepare-operator-upgrades.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-upgrading-operators.html[Updating installed Operators]
+* xref:../backup_and_restore/backing-up-acs.adoc[Backing up {product-title}]
+
+include::modules/operator-upgrade-modify-central-custom-resource.adoc[leveloffset=+1]
+
+include::modules/operator-upgrade-change-subscription-channel.adoc[leveloffset=+1]
+
+[id="rollback-operator-upgrade"]
+== Rolling back an Operator upgrade
 
 To roll back an Operator upgrade, you must perform the steps described in one of the following sections. You can roll back an Operator upgrade by using the CLI or the {ocp} web console.
 
-include::modules/rollback-operator-upgrades-cli.adoc[leveloffset=+1]
-include::modules/rollback-operator-upgrades-console.adoc[leveloffset=+1]
+[NOTE]
+====
+If you are rolling back from {product-title-short} 4.0, you can only rollback to the latest patch release version of {product-title-short} 3.74.
+====
+
+include::modules/rollback-operator-upgrades-cli.adoc[leveloffset=+2]
+include::modules/rollback-operator-upgrades-console.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
-== Additional resources
-
+.Additional resources
 * xref:../installing/installing_ocp/install-central-ocp.adoc#install-central-operator_install-central-ocp[Installing Central using the Operator method]
 * link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/understanding-operators#olm-workflow[Operator Lifecycle Manager workflow]
 * link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/operators/administrator-tasks#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update]
+
+[id="operator-upgrade-troubleshooting_{context}"]
+== Troubleshooting Operator upgrade issues
+
+[role="_abstract"]
+Follow the instructions in this section to investigate and resolve upgrade-related issues for the {product-title-short} Operator.
+
+include::modules/operator-upgrade-centraldb-cannot-be-scheduled.adoc[leveloffset=+2]
+
+include::modules/operator-upgrade-fail-to-deploy.adoc[leveloffset=+2]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-12515

Added instructions for upgrading to 4.0 using RHACS Operator

Preview:https://58684--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-operator.html

Cherrypick into `rhacs-docs-4.0`
