### PR TITLE
OCPBUGS#11673: Confirm that the default CNI network provider is Openshift SDN

### DIFF
--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -184,7 +184,7 @@ where `<config_name>` is the name of the machine config from the `machineconfigu
 
 . Confirm that the migration succeeded:
 
-.. To confirm that the default CNI network provider is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OpenShiftSDN`.
+.. To confirm that the default CNI network provider is OpenShift SDN, enter the following command.  The value of `status.networkType` must be `OpenShiftSDN`.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-11673
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://58694--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.html#nw-ovn-kubernetes-rollback_rollback-to-openshift-sdn
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The issue appears in 4.9, 4.10, and 4.11 only. I will open follow-up PRs for 4.9 and 4.10.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.---> 
