### PR TITLE
OSDOCS-5396: adds CoreDNS update to RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -346,6 +346,11 @@ If you are using the OVN-Kubernetes network plugin, you can migrate to the OpenS
 
 For more information, see xref:../networking/openshift_sdn/migrate-to-openshift-sdn.adoc#migrate-to-openshift-sdn[Migrating to the OpenShift SDN network plugin].
 
+[id="ocp-4-13-core-dns-update"]
+==== CoreDNS updated to 1.10.1
+
+{product-title} {product-version} updates CoreDNS to 1.10.1. CoreDNS now uses the DNSSEC DO Bit that was specified on the originating client query. This reduces the DNS response UDP packet size when a client is not requesting DNSSEC. Consequently, the smaller packet size reduces both the chance of DNS truncation decreasing by TCP connection retries as well as overall DNS bandwidth.
+
 [id="ocp-4-13-expand-cluster-network-ip-address-range"]
 ==== Expand cluster network IP address range
 


### PR DESCRIPTION
[OSDOCS-5396](https://issues.redhat.com//browse/OSDOCS-5396): adds C
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5396
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://58745--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-core-dns-update
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @gcs278 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
