### PR TITLE
Removed command formatting from heading per style guidelines

### DIFF
--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="gathering-data-about-your-cluster-using-must-gather_{context}"]
-= Gathering data about your cluster using `must-gather`
+= Gathering data about your cluster using the must-gather command
 
-The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run `must-gather` to capture information about your cluster.
+The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run the `must-gather` command to capture information about your cluster.
 
 [NOTE]
 ====
@@ -32,7 +32,7 @@ $ oc adm must-gather --image=<PAO_must_gather_image> --dest-dir=<dir>
 +
 [NOTE]
 ====
-`must-gather` must be run with the `performance-addon-operator-must-gather` image. The output can optionally be compressed. Compressed output is required if you are running the Performance Profile Creator wrapper script.
+The `must-gather` command must be run with the `performance-addon-operator-must-gather` image. The output can optionally be compressed. Compressed output is required if you are running the Performance Profile Creator wrapper script.
 ====
 +
 .Example


### PR DESCRIPTION
Version(s):
4.8+

Issue:
None; found this style error when conducting a content audit

Link to docs preview:
https://58752--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-create-performance-profiles.html#gathering-data-about-your-cluster-using-must-gather_cnf-create-performance-profiles

No QE review needed