### PR TITLE
[Enterprise-4.9] OCPBUGS#5852 specify control plane machines for the minimums

### DIFF
--- a/modules/installation-azure-limits.adoc
+++ b/modules/installation-azure-limits.adoc
@@ -107,10 +107,7 @@ endif::ash[]
 ifndef::ash[]
 |
 endif::ash[]
-|VM OS disk must be able to sustain a tested and recommended minimum throughput of 5000 IOPS / 200MBps. This throughput can be provided by having a minimum of 1 TiB Premium SSD (P30). In {cp}, disk performance is directly dependent on SSD disk sizes, so to achieve the throughput supported by
-ifndef::ash[`Standard_D8s_v3`,]
-ifdef::ash[`Standard_DS4_v2`,]
-or other similar machine types available, and the target of 5000 IOPS, at least a P30 disk is required.
+|VM OS disk must be able to sustain a tested and recommended minimum throughput of 5000 IOPS / 200MBps for control plane machines. This throughput can be provided by having a minimum of 1 TiB Premium SSD (P30). In {cp}, disk performance is directly dependent on SSD disk sizes, so to achieve the throughput supported by `Standard_D8s_v3`, or other similar machine types available, and the target of 5000 IOPS, at least a P30 disk is required.
 
 Host caching must be set to `ReadOnly` for low read latency and high read IOPS and throughput. The reads performed from the cache, which is present either in the VM memory or in the local SSD disk, are much faster than the reads from the data disk, which is in the blob storage.
 


### PR DESCRIPTION
Version(s):
4.9

Cherry-picked from: a108ec8f355285e63a86ac5f344b8e72f8d52bec

xref: https://github.com/openshift/openshift-docs/pull/58441

