### PR TITLE
OSDOCS#5750: Adjust disabled CSVs admonition for fixed console behavior

### DIFF
--- a/modules/olm-disabling-copied-csvs.adoc
+++ b/modules/olm-disabling-copied-csvs.adoc
@@ -6,22 +6,25 @@
 [id="olm-disabling-copied-csvs_{context}"]
 = Disabling copied CSVs
 
-When an Operator is installed by Operator Lifecycle Manager (OLM), a simplified copy of its cluster service version (CSV) is created in every namespace that the Operator is configured to watch. These CSVs are known as _copied CSVs_ and communicate to users which controllers are actively reconciling resource events in a given namespace.
+When an Operator is installed by Operator Lifecycle Manager (OLM), a simplified copy of its cluster service version (CSV) is created by default in every namespace that the Operator is configured to watch. These CSVs are known as _copied CSVs_ and communicate to users which controllers are actively reconciling resource events in a given namespace.
 
-When Operators are configured to use the `AllNamespaces` install mode, versus targeting a single or specified set of namespaces, a copied CSV is created in every namespace on the cluster. On especially large clusters, with namespaces and installed Operators potentially in the hundreds or thousands, copied CSVs consume an untenable amount of resources, such as OLM's memory usage, cluster etcd limits, and networking.
+When an Operator is configured to use the `AllNamespaces` install mode, versus targeting a single or specified set of namespaces, a copied CSV for the Operator is created in every namespace on the cluster. On especially large clusters, with namespaces and installed Operators potentially in the hundreds or thousands, copied CSVs consume an untenable amount of resources, such as OLM's memory usage, cluster etcd limits, and networking.
 
-To support these larger clusters, cluster administrators can disable copied CSVs for Operators installed with the `AllNamespaces` mode.
+To support these larger clusters, cluster administrators can disable copied CSVs for Operators globally installed with the `AllNamespaces` mode.
 
-[WARNING]
+[NOTE]
 ====
-If you disable copied CSVs, a user's ability to discover Operators in the OperatorHub and CLI is limited to Operators installed directly in the user's namespace.
+If you disable copied CSVs, an Operator installed in `AllNamespaces` mode has their CSV copied only to the `openshift` namespace, instead of every namespace on the cluster. In disabled copied CSVs mode, the behavior differs between the web console and CLI:
 
-If an Operator is configured to reconcile events in the user's namespace but is installed in a different namespace, the user cannot view the Operator in the OperatorHub or CLI. Operators affected by this limitation are still available and continue to reconcile events in the user's namespace.
-
-This behavior occurs for the following reasons:
-
-* Copied CSVs identify the Operators available for a given namespace.
-* Role-based access control (RBAC) scopes the user's ability to view and discover Operators in the OperatorHub and CLI.
+* In the web console, the default behavior is modified to show copied CSVs from the `openshift` namespace in every namespace, even though the CSVs are not actually copied to every namespace. This allows regular users to still be able to view the details of these Operators in their namespaces and create related custom resources (CRs).
+* In the OpenShift CLI (`oc`), regular users can view Operators installed directly in their namespaces by using the `oc get csvs` command, but the copied CSVs from the `openshift` namespace are not visible in their namespaces. Operators affected by this limitation are still available and continue to reconcile events in the user's namespace.
++
+To view a full list of installed global Operators, similar to the web console behavior, all authenticated users can run the following command:
++
+[source,terminal]
+----
+$ oc get csvs -n openshift
+----
 ====
 
 .Procedure


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5750

4.13

Update the Operators guide `[NOTE]` box to describe the modified/fixed behavior for the web console when copied CSVs is disabled, and remove mention of the previous limitation.

Preview: https://58768--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-config.html#olm-disabling-copied-csvs_olm-config