### PR TITLE
Fixed RHDE preview link

### DIFF
--- a/scripts/ocpdocs/_previewpage
+++ b/scripts/ocpdocs/_previewpage
@@ -124,7 +124,7 @@
                 <a
                   role="button"
                   class="btn btn-primary"
-                  href="/rhde-docs/overview/rhde-overview.html"
+                  href="/openshift-rhde/latest/overview/rhde-overview.html"
                 >
                   <i class="fa fa-arrow-circle-o-right"></i> RHDE </a
                 >


### PR DESCRIPTION
> Netlify isn’t working right for the rhde-docs branch. (https://github.com/openshift/openshift-docs/pull/58617) Do you have suggestions for troubleshooting this?

The link in the preview page was pointing to a different page. To fix this, I built a local AsciiBinder preview, and checked the link of the overview page. By comparing it with the link in preview page I found the mismatch.

This PR fixes the issue. In future, if we modify the Overview page, we should make sure that we update the link in the preview page as well.