### PR TITLE
[enterprise-4.11] bump up folder versions for 1.10 release

### DIFF
--- a/modules/op-installing-pipelines-as-code-cli.adoc
+++ b/modules/op-installing-pipelines-as-code-cli.adoc
@@ -9,13 +9,13 @@
 [role="_abstract"]
 Cluster administrators can use the `tkn pac` and `opc` CLI tools on local machines or as containers for testing. The `tkn pac` and `opc` CLI tools are installed automatically when you install the `tkn` CLI for {pipelines-title}.
 
-You can install the `tkn pac` and `opc` version `1.9.1` binaries for the supported platforms:
+You can install the `tkn pac` and `opc` version `1.10.0` binaries for the supported platforms:
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-linux-s390x.tar.gz[Linux on IBM Z and LinuxONE (s390x)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-linux-ppc64le.tar.gz[Linux on IBM Power (ppc64le)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-macos-amd64.tar.gz[macOS]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-windows-amd64.zip[Windows]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-macos-amd64.tar.gz[macOS]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-windows-amd64.zip[Windows]
 
 // In addition, you can install `tkn pac` using the following methods:
 

--- a/modules/op-installing-tkn-on-linux-using-rpm.adoc
+++ b/modules/op-installing-tkn-on-linux-using-rpm.adoc
@@ -51,28 +51,28 @@ For {op-system-base-full} version 8, you can install the {pipelines-title} CLI a
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="pipelines-1.9-for-rhel-8-x86_64-rpms"
+# subscription-manager repos --enable="pipelines-1.10-for-rhel-8-x86_64-rpms"
 ----
 +
-* Linux on IBM Z and LinuxONE (s390x)
-+
-[source,terminal]
-----
-# subscription-manager repos --enable="pipelines-1.9-for-rhel-8-s390x-rpms"
-----
-+
-* Linux on IBM Power (ppc64le)
+* Linux on {ibmzProductName} and {linuxoneProductName} (s390x)
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="pipelines-1.9-for-rhel-8-ppc64le-rpms"
+# subscription-manager repos --enable="pipelines-1.10-for-rhel-8-s390x-rpms"
+----
++
+* Linux on {ibmpowerProductName} (ppc64le)
++
+[source,terminal]
+----
+# subscription-manager repos --enable="pipelines-1.10-for-rhel-8-ppc64le-rpms"
 ----
 +
 * Linux on ARM (arm64)
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="pipelines-1.9-for-rhel-8-arm64-rpms"
+# subscription-manager repos --enable="pipelines-1.10-for-rhel-8-arm64-rpms"
 ----
 . Install the `openshift-pipelines-client` package:
 +

--- a/modules/op-installing-tkn-on-linux.adoc
+++ b/modules/op-installing-tkn-on-linux.adoc
@@ -14,13 +14,13 @@ For Linux distributions, you can download the CLI as a `tar.gz` archive.
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-linux-s390x.tar.gz[Linux on IBM Z and LinuxONE (s390x)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-linux-ppc64le.tar.gz[Linux on IBM Power (ppc64le)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-linux-arm64.tar.gz[Linux on ARM (arm64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-linux-arm64.tar.gz[Linux on ARM (arm64)]
 
 // Binaries also need to be updated in the following modules:
 // op-installing-pipelines-as-code-cli.adoc

--- a/modules/op-installing-tkn-on-macos.adoc
+++ b/modules/op-installing-tkn-on-macos.adoc
@@ -14,9 +14,9 @@ For macOS, you can download the CLI as a `tar.gz` archive.
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-macos-amd64.tar.gz[macOS]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-macos-amd64.tar.gz[macOS]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-macos-arm64.tar.gz[macOS on ARM]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-macos-arm64.tar.gz[macOS on ARM]
 
 . Unpack and extract the archive.
 

--- a/modules/op-installing-tkn-on-windows.adoc
+++ b/modules/op-installing-tkn-on-windows.adoc
@@ -12,7 +12,7 @@ For Windows, you can download the CLI as a `zip` archive.
 
 .Procedure
 
-.  Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.0/tkn-windows-amd64.zip[CLI tool].
+.  Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.10.0/tkn-windows-amd64.zip[CLI tool].
 
 . Extract the archive with a ZIP program.
 


### PR DESCRIPTION
Manual CP from https://github.com/openshift/openshift-docs/pull/58250 to 4.11

Aligned team: Dev Tools

Purpose: To resolve the following issue:
https://issues.redhat.com/browse/RHDEVDOCS-5040

OCP version this PR applies to: enterprise 4.11