### PR TITLE
OSDOCS#ROX-14480 

### DIFF
--- a/files/ca-setup.sh
+++ b/files/ca-setup.sh
@@ -28,7 +28,7 @@ function usage {
 	echo
 	echo "The argument may be:"
 	echo "  - a single file"
-	echo "  - a directory (all files ending in .crt will be added)"
+	echo "  - a directory (all files ending in .crt and .pem will be added)"
 	echo "Each file must contain exactly one PEM-encoded certificate."
 	echo
 	echo "If the -u (update) argument is passed, the existing additional CAs will be"
@@ -50,14 +50,14 @@ function create_directory {
 	local dir="$1"
 	echo "The following certificates will be used as additional CAs:"
 	from_file_args=()
-	for f in $dir/*.crt; do
+	for f in $dir/*.crt $dir/*.pem; do
     	if [ -f "$f" ] ; then
     		from_file_args+=("--from-file=$(basename "$f")=$f")
 			echo "  - $f"
 		fi
 	done
 	if [ "${#from_file_args[@]}" -eq 0 ]; then
-		echo "Error: No filenames ending in \".crt\" in $dir. Please add some."
+		echo "Error: No filenames ending in \".crt\" or \".pem\" in $dir. Please add some."
 		exit 2
 	fi
 	create_or_replace secret -n "stackrox" generic "additional-ca" "${from_file_args[@]}"

--- a/modules/configure-additional-cas.adoc
+++ b/modules/configure-additional-cas.adoc
@@ -44,7 +44,7 @@ $ ./ca-setup.sh -d <directory_name>
 +
 [NOTE]
 ====
-* You must use PEM-encoded certificate files with a `.crt` extension.
+* You must use PEM-encoded certificate files with a `.crt` or `.pem` extension.
 * Each file must only contain a single certificate.
 * You can also use the `-u` (update) option along with the `-d` option to update any previously added certificates.
 ====


### PR DESCRIPTION
Allow .PEM files for additional CAs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
merge to `rhacs-docs` and cherry pick to `rhacs-docs-4.0`

Issue:
https://issues.redhat.com/browse/ROX-14480

Link to docs preview:
https://58775--docspreview.netlify.app/openshift-acs/latest/configuration/add-trusted-ca.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
https://github.com/stackrox/stackrox/pull/5574

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
