### PR TITLE
OCPBUGS-11816: Removing typo that added iPXE for ZTP reference

### DIFF
--- a/modules/ztp-installation-crs.adoc
+++ b/modules/ztp-installation-crs.adoc
@@ -22,7 +22,7 @@ The following table lists the installation CRs that are automatically applied by
 
 |`BareMetalHost`
 |Contains the connection information for the Baseboard Management Controller (BMC) of the target bare-metal host.
-|Provides access to the BMC to load and boot the discovery image on the target server by using the Redfish protocol. ZTP supports iPXE and virtual media network booting.
+|Provides access to the BMC to load and boot the discovery image on the target server by using the Redfish protocol.
 
 |`InfraEnv`
 |Contains information for installing {product-title} on the target bare-metal host.

--- a/snippets/ztp-example-siteconfig.adoc
+++ b/snippets/ztp-example-siteconfig.adoc
@@ -80,7 +80,7 @@ spec:
 <5> Optional. The CR specifed under `KlusterletAddonConfig` is used to override the default `KlusterletAddonConfig` that is created for the cluster.
 <6> For single-node deployments, define a single host. For three-node deployments, define three hosts. For standard deployments, define three hosts with `role: master` and two or more hosts defined with `role: worker`.
 <7> Optional. Use `biosConfigRef` to configure desired firmware for the host.
-<8> Applies to all cluster types. Specifies the BMC address. ZTP supports iPXE and virtual media booting by using Redfish or IPMI protocols.
+<8> Applies to all cluster types. Specifies the BMC address.
 <9> Create the `bmh-secret` CR that specifies the BMC credentials. Use the same namespace as the `SiteConfig` CR.
 <10> Use `UEFISecureBoot` to enable secure boot on the host.
 <11> Specifies the network settings for the node.


### PR DESCRIPTION
Removing typo that added iPXE for ZTP reference to versions of OCP earlier than 4.12, This occured in a re-org of the content. 

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OCPBUGS-11816

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Typo, no QE required.
