### PR TITLE
OSDOCS-5731: puts scalability and performance heading back into RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -992,6 +992,9 @@ Before this release, you could not configure this setting.
 You can now configure the retention time period for Thanos Ruler data in user-defined projects.
 Before this release, you could not change the default value of `24h`.
 
+[id="ocp-4-11-scalability-and-performance"]
+=== Scalability and performance
+
 [id=ocp-4-11-workload-hints-for-nto]
 ==== Workload hints for the Node Tuning Operator
 {product-title} 4.11 supports a hinting mechanism for the Node Tuning Operator that can tune `PerformanceProfile` to meet the demands of different industry environments. In this release, workload hints are available for `highPowerConsumption` (very low latency at the cost of increased power consumption) and `realtime` (priority given to optimum latency). A combination of true/false settings for these hints can be used to deal with application-specific workload profiles and requirements.


### PR DESCRIPTION
[OSDOCS-5731](https://issues.redhat.com//browse/OSDOCS-5731): puts the scalability and performance heading back into the RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5731?filter=12403435
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://58802--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-scalability-and-performance
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
