### PR TITLE
OSDOCS-5745 Updates RNs for z-stream release 4.10.57

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3922,3 +3922,22 @@ $ oc adm release info 4.10.56 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-57"]
+=== RHBA-2023:1782 - {product-title} 4.10.57 bug fix update
+
+Issued: 2023-04-19
+
+{product-title} release 4.10.57 is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:1782[RHBA-2023:1782] advisory. There are no RPM packages for this update.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.57 --pullspecs
+----
+
+[id="ocp-4-10-57-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OSDOCS-5745

Link to docs preview:
[Preview](http://file.rdu.redhat.com/~cbippley/OSDOCS-5745/release_notes/ocp-4-10-release-notes.html#ocp-4-10-57)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Z-stream release notes for 4.10.57.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
