### PR TITLE
OSDOCS-3908-RN: adds node selector as enhancement to 4.13 RN

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -406,6 +406,11 @@ With this release, the {openshift-networking} OVN-Kubernetes network plug-in all
 
 For more information about OVN-Kubernetes as a secondary network, see xref:../networking/multiple_networks/configuring-additional-network.html#configuration-ovnk-additional-networks_configuring-additional-network[Configuration for an OVN-Kubernetes additional network].
 
+[id="ocp-4-13-nodeselector-egressfirewall-enhancement"]
+==== Node selector added to egress firewall for OVN-Kubernetes network plugin
+
+In {product-title} {product-version}, `nodeSelector` has been added to the egress firewall destination spec in OVN-Kubernetes network plug-in. This feature allows users to add a label to one or multiple nodes and the IP addresses of the selected nodes are included in the associated rule. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.adoc#configuringNodeSelector-example_configuring-egress-firewall-ovn[Example nodeSelector for EgressFirewall]
+
 [id="ocp-4-13-storage"]
 === Storage
 


### PR DESCRIPTION
[OSDOCS-3908](https://issues.redhat.com//browse/OSDOCS-3908): adds node selector as enhancement to 4.13 RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-3908
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://58842--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-networking
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
