### PR TITLE
Release notes for multi-arch compute machines on  4.13

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -154,6 +154,12 @@ If you need the virtual IP (VIP) addresses to run on the control plane nodes in 
 [id="ocp-4-13-post-installation"]
 === Post-installation configuration
 
+[id="ocp-4-13-multi-arch-compute-machines-ga"]
+==== {product-title} clusters with multi-architecture compute machines 
+
+{product-title} {product-version} clusters with multi-architecture compute machines is now generally available. As a Day 2 operation, you can now create a cluster with compute nodes of different architectures on AWS and Azure installer provisioned infrastructures. User-provisioned installation on bare metal are in Technology Preview. For more information on creating a cluster with multi-architecture compute machines, see xref:../post_installation_configuration/multi-architecture-configuration.adoc#multi-architecture-configuration[Configuring multi-architecture compute machines on an {product-title} cluster].
+
+
 [id="ocp-4-13-post-installation-vsphere-failure-domains"]
 ==== Specifying multiple failure domains for your cluster on VSphere
 As an administrator, you can specify multiple failure domains for your {product-title} cluster that runs on a VMware VSphere instance. This means that you can distribute key control planes and workload elements among varied hardware resources for a datacenter. Additionally, you can configure your cluster to use a multiple layer 2 network configuration, so that data transfer among nodes can span across multiple networks.


### PR DESCRIPTION
**For Version:** 4.13

**Description:** Cluster with multi-architecture compute machines are now generally available. Highlighting in 4.13 release notes 

**Preview:** 
[Release notes -> Post-installation configuration ](https://58844--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-post-installation)

**QE review:**
- [x] QE approval 