### PR TITLE
OSDOCS-5735: Added note about OCI feature not supporting pruning

### DIFF
--- a/modules/oc-mirror-oci-format.adoc
+++ b/modules/oc-mirror-oci-format.adoc
@@ -12,6 +12,8 @@ You can use the oc-mirror plugin to mirror Operators in the Open Container Initi
 :FeatureName: Using the oc-mirror plugin to mirror Operator images in OCI format
 include::snippets/technology-preview.adoc[]
 
+When using the OCI feature, images are not automatically pruned from the target mirror registry.
+
 .Prerequisites
 
 * You have access to the internet to obtain the necessary container images.

--- a/modules/oc-mirror-updating-registry-about.adoc
+++ b/modules/oc-mirror-updating-registry-about.adoc
@@ -32,7 +32,12 @@ If there are {product-title} releases or Operator versions that you no longer ne
 
 [IMPORTANT]
 ====
-If there are no new or updated images to mirror, the excluded images are not pruned from the target mirror registry. Additionally, if an Operator publisher removes an Operator version from a channel, the removed versions are pruned from the target mirror registry.
+Images are not automatically pruned from the target mirror registry in the following situations:
+
+* If there are no new or updated images to mirror
+* If you are using the Technology Preview OCI feature
+
+Additionally, if an Operator publisher removes an Operator version from a channel, the removed versions are pruned from the target mirror registry.
 ====
 
 To disable automatic pruning of images from the target mirror registry, pass the `--skip-pruning` flag to the `oc mirror` command.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12 only

Issue:
https://issues.redhat.com/browse/OSDOCS-5735

Link to docs preview:
* https://58855--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-oci-format_installing-mirroring-disconnected
* https://58855--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-updating-registry-about_installing-mirroring-disconnected

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
