### PR TITLE
PTP typo fix

### DIFF
--- a/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
+++ b/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
@@ -46,7 +46,7 @@ spec:
     storageType: "example-storage-class" <2>
 ----
 <1> Set `enableEventPublisher` to `true` to enable PTP fast event notifications.
-<2> Use the value you set for `storageType` to populate the `StorageClassName` field for the `PersistentVolumeClaim` (`PVC`) resource that the PTP Operator automatically deploys.
+<2> Use the value that you set for `storageType` to populate the `StorageClassName` field for the `PersistentVolumeClaim` (`PVC`) resource that the PTP Operator automatically deploys.
 The `PVC` resource is used to persist consumer event subscriptions.
 +
 [NOTE]


### PR DESCRIPTION
AMQ is EOL in 2024. HTTP Transport replaces AMQP in PTP events infrastructure.

Version(s):
Merge to main, CP to 4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-834