### PR TITLE
RHDEVDOCS-5142: Document tainting nodes

### DIFF
--- a/cicd/gitops/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
+++ b/cicd/gitops/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.adoc
@@ -6,14 +6,19 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-With Red Hat OpenShift GitOps, you can configure Argo CD to recursively sync the content of a Git directory with an application that contains custom configurations for your cluster.
+With {gitops-title}, you can configure Argo CD to recursively sync the content of a Git directory with an application that contains custom configurations for your cluster.
 
 .Prerequisites
 
-* Red Hat OpenShift GitOps is installed in your cluster.
+* {gitops-title} is installed in your cluster.
 * Logged into Argo CD instance.
 
 include::modules/go-run-argo-cd-instance-on-infrastructure-nodes.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* To learn more about taints and tolerations, see xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
+* For more information on infrastructure machine sets, see xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets].
 
 include::modules/gitops-creating-an-application-by-using-the-argo-cd-dashboard.adoc[leveloffset=+1]
 

--- a/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.adoc
+++ b/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="run-gitops-control-plane-workload-on-infra-nodes"]
-= Running GitOps control plane workloads on infrastructure nodes
+= Running {gitops-shortname} control plane workloads on infrastructure nodes
 :context: run-gitops-control-plane-workload-on-infra-nodes
 include::_attributes/common-attributes.adoc[]
 
@@ -12,7 +12,13 @@ You can use the {product-title} to run certain workloads on infrastructure nodes
 
 [NOTE]
 ====
-Any other Argo CD instances installed to user namespaces are not eligible to run on Infrastructure nodes.
+Any other Argo CD instances installed to user namespaces are not eligible to run on infrastructure nodes.
 ====
 
 include::modules/go-add-infra-nodes.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_run-gitops-control-plane-workload-on-infra-nodes"]
+== Additional resources
+* To learn more about taints and tolerations, see xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
+* For more information on infrastructure machine sets, see xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets].

--- a/modules/go-add-infra-nodes.adoc
+++ b/modules/go-add-infra-nodes.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="add-infra-nodes_{context}"]
-= Moving GitOps workloads to infrastructure nodes
+= Moving {gitops-shortname} workloads to infrastructure nodes
 
 You can move the default workloads installed by the {gitops-title} to the infrastructure nodes. The workloads that can be moved are:
 
@@ -19,7 +19,6 @@ You can move the default workloads installed by the {gitops-title} to the infras
 * `openshift-gitops-application-controller statefulset`
 * `openshift-gitops-redis-server statefulset`
 
-
 .Procedure
 
 . Label existing nodes as infrastructure by running the following command:
@@ -28,7 +27,7 @@ You can move the default workloads installed by the {gitops-title} to the infras
 ----
 $ oc label node <node-name> node-role.kubernetes.io/infra=
 ----
-. Edit the `GitOpsService` Custom Resource (CR) to add the infrastructure node selector:
+. Edit the `GitOpsService` custom resource (CR) to add the infrastructure node selector:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: `enterprise-4.10` and later
• **JIRA issue**:  [RHDEVDOCS-5142](https://issues.redhat.com/browse/RHDEVDOCS-5142)
• **Preview pages**: [Configuring an OpenShift cluster by deploying an application with cluster configurations](https://58872--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html), [Running GitOps control plane workloads on infrastructure nodes](https://58872--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.html)
• **SME Review**: Completed by @iam-veeramalla 
• **QE review**: Completed by @varshab1210 
• **Peer-review**: Completed by @deerskindoll 