### PR TITLE
Remove unnecessary looping symlink

### DIFF
--- a/_attributes/_attributes
+++ b/_attributes/_attributes
@@ -1,1 +1,0 @@
-../_attributes/


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

This removes a symlink that loops to itself (creating an infinite loop) from the `_attributes/` directory.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
