### PR TITLE
Updates attr that were erroneously changed in a CP conflict

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,9 +4,9 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.13
+:ocp-version: 4.12
 :product-registry: OpenShift image registry
-:rhel-major: rhel-9
+:rhel-major: rhel-8
 :op-system-base-full: Red Hat Enterprise Linux (RHEL)
 :op-system: RHEL
 :op-system-ostree-first: Red Hat Enterprise Linux (RHEL) for Edge


### PR DESCRIPTION
Somehow my CP into 4.12 from https://github.com/openshift/openshift-docs/commit/af9abc5c2d78ca11242c18f7b30bb4d2ff80ee1c picked up attribute changes. This PR reverts those changes of the attributes. 

Version 4.12 only

QE not needed. 