### PR TITLE
OCPBUGS#11948: Clarify catalog source pod image pull policy

### DIFF
--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -62,7 +62,7 @@ spec:
 <1> If you mirrored content to local files before uploading to a registry, remove any backslash (`/`) characters from the `metadata.name` field to avoid an "invalid resource name" error when you create the object.
 <2> If you want the catalog source to be available globally to users in all namespaces, specify the `{namespace}` namespace. Otherwise, you can specify a different namespace for the catalog to be scoped and available only for that namespace.
 <3> Specify the value of `legacy` or `restricted`. If the field is not set, the default value is `legacy`. In a future {product-title} release, it is planned that the default value will be `restricted`. If your catalog cannot run with `restricted` permissions, it is recommended that you manually set this field to `legacy`.
-<4> Specify your index image.
+<4> Specify your index image. If you specify a tag after the image name, for example `:{tag}`, the catalog source pod uses an image pull policy of `Always`, meaning the pod always pulls the image prior to starting the container. If you specify a digest, for example `@sha256:<id>`, the image pull policy is `IfNotPresent`, meaning the pod pulls the image only if it does not already exist on the node.
 <5> Specify your name or an organization name publishing the catalog.
 <6> Catalog sources can automatically check for new versions to keep up to date.
 endif::[]
@@ -91,7 +91,7 @@ spec:
 <1> If you want the catalog source to be available globally to users in all namespaces, specify the `{namespace}` namespace. Otherwise, you can specify a different namespace for the catalog to be scoped and available only for that namespace.
 <2> Optional: Set the `olm.catalogImageTemplate` annotation to your index image name and use one or more of the Kubernetes cluster version variables as shown when constructing the template for the image tag.
 <3> Specify the value of `legacy` or `restricted`. If the field is not set, the default value is `legacy`. In a future {product-title} release, it is planned that the default value will be `restricted`. If your catalog cannot run with `restricted` permissions, it is recommended that you manually set this field to `legacy`.
-<4> Specify your index image.
+<4> Specify your index image. If you specify a tag after the image name, for example `:{tag}`, the catalog source pod uses an image pull policy of `Always`, meaning the pod always pulls the image prior to starting the container. If you specify a digest, for example `@sha256:<id>`, the image pull policy is `IfNotPresent`, meaning the pod pulls the image only if it does not already exist on the node.
 <5> Specify your name or an organization name publishing the catalog.
 <6> Catalog sources can automatically check for new versions to keep up to date.
 endif::[]

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -73,8 +73,9 @@ include::modules/olm-creating-catalog-from-index.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource_olm-understanding-olm[Operator Lifecycle Manager concepts and resources -> Catalog source] for more details on the `CatalogSource` object spec.
-* If your index image is hosted on a private registry and requires authentication, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries].
+* xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource_olm-understanding-olm[Operator Lifecycle Manager concepts and resources -> Catalog source]
+* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries]
+* xref:../../openshift_images/managing_images/image-pull-policy.adoc#image-pull-policy[Image pull policy]
 
 include::modules/olm-accessing-images-private-registries.adoc[leveloffset=+1]
 

--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -74,8 +74,9 @@ include::modules/olm-creating-catalog-from-index.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* If your index image is hosted on a private registry and requires authentication, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries].
-* If you want your catalogs to be able to automatically update their index image version after cluster upgrades by using Kubernetes version-based image tags, see xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource-image-template_olm-understanding-olm[Image template for custom catalog sources].
+* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries]
+* xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource-image-template_olm-understanding-olm[Image template for custom catalog sources]
+* xref:../../openshift_images/managing_images/image-pull-policy.adoc#image-pull-policy[Image pull policy]
 
 include::modules/olm-updating-index-image.adoc[leveloffset=+1]
 

--- a/post_installation_configuration/preparing-for-users.adoc
+++ b/post_installation_configuration/preparing-for-users.adoc
@@ -146,8 +146,12 @@ If you mirrored Operator catalogs for use with disconnected clusters, you can po
 
 include::modules/olm-mirroring-catalog-icsp.adoc[leveloffset=+2]
 include::modules/olm-creating-catalog-from-index.adoc[leveloffset=+2]
-* If your index image is hosted on a private registry and requires authentication, see xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries].
-* If you want your catalogs to be able to automatically update their index image version after cluster upgrades by using Kubernetes version-based image tags, see xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource-image-template_olm-understanding-olm[Image template for custom catalog sources].
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries]
+* xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource-image-template_olm-understanding-olm[Image template for custom catalog sources]
+* xref:../openshift_images/managing_images/image-pull-policy.adoc#image-pull-policy[Image pull policy]
 
 include::modules/olm-installing-operators-from-operatorhub.adoc[leveloffset=+1]
 ifdef::openshift-origin[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-11948

4.10+

Preview for the 3 assemblies where this module is included:

* Operators: [Using OLM on restricted networks](https://58949--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html#olm-creating-catalog-from-index_olm-restricted-networks)
* Operators: [Managing custom catalogs](https://58949--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-creating-catalog-from-index_olm-managing-custom-catalogs)
* Post-install config: [Preparing for users](https://58949--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users.html#olm-creating-catalog-from-index_post-install-preparing-for-users)