### PR TITLE
OCPBUGS#10339: When using OVN-Kubernetes, changing the default gateway interface is not supported

### DIFF
--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -14,6 +14,11 @@ The Kubernetes NMState Operator provides a Kubernetes API for performing state-d
 Red Hat supports the Kubernetes NMState Operator in production environments on bare-metal, IBM Power, IBM Z, and LinuxONE installations.
 ====
 
+[WARNING]
+====
+When using OVN-Kubernetes, changing the default gateway interface is not supported.
+====
+
 Before you can use NMState with {product-title}, you must install the Kubernetes NMState Operator.
 
 [id="installing-the-kubernetes-nmstate-operator-cli"]

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 You can update the node network configuration, such as adding or removing interfaces from nodes, by applying `NodeNetworkConfigurationPolicy` manifests to the cluster.
 
+[WARNING]
+====
+When using OVN-Kubernetes, changing the default gateway interface is not supported.
+====
+
 include::modules/virt-about-nmstate.adoc[leveloffset=+1]
 
 include::modules/virt-creating-interface-on-nodes.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR adds the warning - When using OVN-Kubernetes, changing the default gateway interface is not supported.

Version(s): 4.10

Issue: https://issues.redhat.com/browse/OCPBUGS-10339

Link to docs preview:

 http://file.rdu.redhat.com/sdudhgao/410-ovnk8s/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html

http://file.rdu.redhat.com/sdudhgao/410-ovnk8s/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
