### PR TITLE
OCPBUGS#10339: When using OVN-Kubernetes, changing the default gateway interface is not supported

### DIFF
--- a/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc
@@ -13,4 +13,9 @@ include::snippets/technology-preview.adoc[]
 
 Before you can use NMState with {product-title}, you must install the Kubernetes NMState Operator.
 
+[WARNING]
+====
+When using OVN-Kubernetes, changing the default gateway interface is not supported.
+====
+
 include::modules/k8s-nmstate-installing-the-kubernetes-nmstate-operator.adoc[leveloffset=+1]

--- a/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc
@@ -9,6 +9,11 @@ toc::[]
 
 You can update the node network configuration, such as adding or removing interfaces from nodes, by applying `NodeNetworkConfigurationPolicy` manifests to the cluster.
 
+[WARNING]
+====
+When using OVN-Kubernetes, changing the default gateway interface is not supported.
+====
+
 include::modules/virt-about-nmstate.adoc[leveloffset=+1]
 
 include::modules/virt-creating-interface-on-nodes.adoc[leveloffset=+1]


### PR DESCRIPTION
This PR adds the warning - When using OVN-Kubernetes, changing the default gateway interface is not supported.

Version(s): 4.9

Issue: https://issues.redhat.com/browse/OCPBUGS-10339

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Preview: http://file.rdu.redhat.com/sdudhgao/49-ovnk8s/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html

http://file.rdu.redhat.com/sdudhgao/49-ovnk8s/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html


QE review:
- [x] QE has approved this change.
