### PR TITLE
OCPBUGS#11576: Update the operator SDK version in OCP 4.12

### DIFF
--- a/cli_reference/osdk/cli-osdk-install.adoc
+++ b/cli_reference/osdk/cli-osdk-install.adoc
@@ -14,7 +14,7 @@ See xref:../../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Oper
 
 [NOTE]
 ====
-{product-title} 4.9 and later supports Operator SDK v1.16.0.
+{product-title} {product-version} supports Operator SDK {osdk_ver}.
 ====
 
 include::modules/osdk-installing-cli-linux-macos.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-11576
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://58970--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/osdk/cli-osdk-install.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
