### PR TITLE
OCPBUGS#11576: Update the operator SDK version in OCP 4.13

### DIFF
--- a/cli_reference/osdk/cli-osdk-install.adoc
+++ b/cli_reference/osdk/cli-osdk-install.adoc
@@ -14,7 +14,7 @@ See xref:../../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Oper
 
 [NOTE]
 ====
-{product-title} 4.9 and later supports Operator SDK v1.16.0.
+{product-title} {product-version} supports Operator SDK {osdk_ver}.
 ====
 
 include::modules/osdk-installing-cli-linux-macos.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.13 only

Issue: https://issues.redhat.com/browse/OCPBUGS-11576

Link to docs preview: https://58971--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/osdk/cli-osdk-install.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
