### PR TITLE
OCPBUGS-6875: Clarified the Compliance Operator supported profiles table

### DIFF
--- a/modules/compliance-profiles.adoc
+++ b/modules/compliance-profiles.adoc
@@ -46,6 +46,8 @@ $ oc get -n openshift-compliance -oyaml profiles.compliance rhcos4-e8
 ----
 +
 .Example output
+[%collapsible]
+====
 [source,yaml]
 ----
 apiVersion: compliance.openshift.io/v1alpha1
@@ -129,6 +131,7 @@ rules:
 - rhcos4-sysctl-net-core-bpf-jit-harden
 title: Australian Cyber Security Centre (ACSC) Essential Eight
 ----
+====
 
 * Run the following command to view the details of the `rhcos4-audit-rules-login-events` rule:
 +
@@ -138,6 +141,8 @@ $ oc get -n openshift-compliance -oyaml rules rhcos4-audit-rules-login-events
 ----
 +
 .Example output
+[%collapsible]
+====
 [source,yaml]
 ----
 apiVersion: compliance.openshift.io/v1alpha1
@@ -186,4 +191,18 @@ title: Record Attempts to Alter Logon and Logout Events
 warning: Manual editing of these files may indicate nefarious activity, such as an
   attacker attempting to remove evidence of an intrusion.
 ----
+====
 
+[id="compliance_profile_types{context}"]
+== Compliance Operator profile types
+
+There are two types of compliance profiles available: Platform and Node.
+
+Platform:: Platform scans target your {product-title} cluster.
+
+Node:: Node scans target the nodes of the cluster.
+
+[IMPORTANT]
+====
+For compliance profiles that have Node and Platform applications, such as `pci-dss` compliance profiles, you must run both in your {product-title} environment.
+====

--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -2,87 +2,100 @@
 //
 // * security/compliance_operator/
 
+:_content-type: CONCEPT
 [id="compliance-supported-profiles_{context}"]
 = Compliance profiles
 
 The Compliance Operator provides the following compliance profiles:
 
 .Supported compliance profiles
-[cols="10%,40%,10%,40%,10%", options="header"]
+[cols="10%,40%,10%,10%,40%,10%", options="header"]
 
 |===
 |Profile
 |Profile title
+|Application
 |Compliance Operator version
 |Industry compliance benchmark
 |Supported architectures
 
 |ocp4-cis
 |CIS Red Hat OpenShift Container Platform 4 Benchmark
+|Platform
 |0.1.39+
-|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] footnote:cisbenchmark[To locate the CIS RedHat OpenShift Container Platform v4 Benchmark, go to  link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks] and type `Kubernetes` in the search box. Click on *Kubernetes* and then *Download Latest CIS Benchmark*, where you can then register to download the benchmark.]
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] ^[1]^
 |`x86_64`
  `ppc64le`
  `s390x`
 
 |ocp4-cis-node
 |CIS Red Hat OpenShift Container Platform 4 Benchmark
+|Node ^[2]^
 |0.1.39+
-|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] footnote:cisbenchmark[]
+|link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks &#8482;] ^[1]^
 |`x86_64`
  `ppc64le`
  `s390x`
 
 |ocp4-e8
 |Australian Cyber Security Centre (ACSC) Essential Eight
+|Platform
 |0.1.39+
 |link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[ACSC Hardening Linux Workstations and Servers]
 |`x86_64`
 
 |ocp4-moderate
 |NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Platform level
+|Platform
 |0.1.39+
 |link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 |`x86_64`
 
 |rhcos4-e8
 |Australian Cyber Security Centre (ACSC) Essential Eight
+|Node
 |0.1.39+
 |link:https://www.cyber.gov.au/acsc/view-all-content/publications/hardening-linux-workstations-and-servers[ACSC Hardening Linux Workstations and Servers]
 |`x86_64`
 
 |rhcos4-moderate
 |NIST 800-53 Moderate-Impact Baseline for Red Hat Enterprise Linux CoreOS
+|Node
 |0.1.39+
 |link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 |`x86_64`
 
 |ocp4-moderate-node
 |NIST 800-53 Moderate-Impact Baseline for Red Hat OpenShift - Node level
+|Node ^[2]^
 |0.1.44+
 |link:https://nvd.nist.gov/800-53/Rev4/impact/moderate[NIST SP-800-53 Release Search]
 |`x86_64`
 
 |ocp4-nerc-cip
 |North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Platform level
+|Platform
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
 |`x86_64`
 
 |ocp4-nerc-cip-node
 |North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for the Red Hat OpenShift Container Platform - Node level
+|Node ^[2]^
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
 |`x86_64`
 
 |rhcos4-nerc-cip
 |North American Electric Reliability Corporation (NERC) Critical Infrastructure Protection (CIP) cybersecurity standards profile for Red Hat Enterprise Linux CoreOS
+|Node
 |0.1.44+
 |link:https://www.nerc.com/pa/Stand/Pages/CIPStandards.aspx[NERC CIP Standards]
 |`x86_64`
 
 |ocp4-pci-dss
 |PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
+|Platform
 |0.1.47+
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
@@ -90,26 +103,33 @@ The Compliance Operator provides the following compliance profiles:
 
 |ocp4-pci-dss-node
 |PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
+|Node ^[2]^
 |0.1.47+
 |link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
 |`x86_64`
  `ppc64le`
- 
+
 |ocp4-high
 |NIST 800-53 High-Impact Baseline for Red Hat OpenShift - Platform level
+|Platform
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
 |`x86_64`
 
 |ocp4-high-node
 |NIST 800-53 High-Impact Baseline for Red Hat OpenShift - Node level
+|Node ^[2]^
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
 |`x86_64`
 
 |rhcos4-high
 |NIST 800-53 High-Impact Baseline for Red Hat Enterprise Linux CoreOS
+|Node
 |0.1.52+
 |link:https://csrc.nist.gov/Projects/risk-management/sp800-53-controls/release-search#!/800-53[NIST SP-800-53 Release Search]
 |`x86_64`
 |===
+[.small]
+1. To locate the CIS {product-title} v4 Benchmark, go to  link:https://www.cisecurity.org/cis-benchmarks/[CIS Benchmarks] and type `Kubernetes` in the search box. Click on *Kubernetes* and then *Download Latest CIS Benchmark*, where you can then register to download the benchmark.
+2. Node profiles must be used with the relevant Platform profile. For more information, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#compliance_profile_typesunderstanding-compliance[Compliance Operator profile types].

--- a/security/compliance_operator/compliance-operator-supported-profiles.adoc
+++ b/security/compliance_operator/compliance-operator-supported-profiles.adoc
@@ -17,4 +17,6 @@ include::modules/compliance-supported-profiles.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information about viewing the compliance profiles available in your system, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#compliance_profiles_understanding-compliance[Compliance Operator profiles] in Understanding the Compliance Operator.
+* xref:../../security/compliance_operator/compliance-operator-understanding.adoc#compliance_profiles_understanding-compliance[Compliance Operator profiles]
+
+* xref:../../security/compliance_operator/compliance-operator-understanding.adoc#compliance_profile_typesunderstanding-compliance[Compliance Operator profile types]

--- a/security/compliance_operator/compliance-operator-understanding.adoc
+++ b/security/compliance_operator/compliance-operator-understanding.adoc
@@ -14,3 +14,9 @@ The Compliance Operator is available for {op-system-first} deployments only.
 ====
 
 include::modules/compliance-profiles.adoc[leveloffset=+1]
+
+[id="additional-resources_compliance-operator-understanding"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../security/compliance_operator/compliance-operator-supported-profiles.html#compliance-operator-supported-profiles[Supported compliance profiles]


### PR DESCRIPTION
Version(s):
4.9+

Issue:
https://issues.redhat.com/browse/OCPBUGS-6875

Link to docs preview (VPN required) :
[Compliance profiles](http://file.rdu.redhat.com/antaylor/OCPBUGS-6875/security/compliance_operator/compliance-operator-supported-profiles.html)
[Compliance Operator profile types](http://file.rdu.redhat.com/antaylor/OCPBUGS-6875/security/compliance_operator/compliance-operator-understanding.html#compliance_profile_typesunderstanding-compliance)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This pull request attempts to clarify how to use the Node- and Platform-specific compliance profiles, while also cleaning up footnote formatting. Currently, footnote [1] is below Additional resources in [published content](https://docs.openshift.com/container-platform/4.12/security/compliance_operator/compliance-operator-supported-profiles.html#additional-resources-compliance-operator-).
