### PR TITLE
Add token expiration information

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -154,6 +154,8 @@ Topics:
   File: monitor-acs
 - Name: Enabling audit logging
   File: configure-audit-logging
+- Name: Configuring API tokens
+  File: configure-api-token
 ---
 Name: Operating
 Dir: operating
@@ -211,7 +213,7 @@ Topics:
       - Name: Configuring OpenShift Container Platform OAuth server as an identity provider
         File: configure-ocp-oauth
       - Name: Connecting Azure AD to RHACS using SSO configuration
-        File: connecting-azure-ad-to-rhacs-using-sso-configuration    
+        File: connecting-azure-ad-to-rhacs-using-sso-configuration
 - Name: Using the system health dashboard
   File: use-system-health-dashboard
 ---

--- a/cli/getting-started-cli.adoc
+++ b/cli/getting-started-cli.adoc
@@ -1,4 +1,5 @@
 [id="cli-getting-started"]
+:_content-type: ASSEMBLY
 = Getting started with the roxctl CLI
 include::modules/common-attributes.adoc[]
 :context: cli-getting-started
@@ -29,7 +30,15 @@ include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
 include::modules/run-roxctl-from-container.adoc[leveloffset=+2]
 
 // Authenticating using CLI
-include::modules/cli-authentication.adoc[leveloffset=+1]
+
+[id="authenticating-cli"]
+== Authenticating using the roxctl CLI
+
+For authentication, you can use an authentication token or your administrator password.
+Use an authentication token in a production environment because each token is assigned specific access control permissions.
+
+include::modules/create-api-token.adoc[leveloffset=+2]
+include::modules/cli-authentication.adoc[leveloffset=+2]
 
 // Using the CLI
 include::modules/using-cli.adoc[leveloffset=+1]

--- a/configuration/configure-api-token.adoc
+++ b/configuration/configure-api-token.adoc
@@ -1,0 +1,14 @@
+:_content-type: ASSEMBLY
+[id="configure-api-token"]
+= Configuring API tokens
+include::modules/common-attributes.adoc[]
+:context: configure-api-token
+
+toc::[]
+
+[role="_abstract"]
+{rh-rhacs-first} requires API tokens for some system integrations, authentication processes, and system functions. You can configure tokens using the {product-title-short} web interface.
+
+include::modules/create-api-token.adoc[leveloffset=+1]
+include::modules/about-api-token-expiration.adoc[leveloffset=+1]
+

--- a/modules/about-api-token-expiration.adoc
+++ b/modules/about-api-token-expiration.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * configure/configure-api-token.adoc
+:_content-type: CONCEPT
+[id="about-api-token-expiration_{context}"]
+= About API token expiration
+
+API tokens expire one year from the creation date. {product-title-short} alerts you in the web interface and by sending log messages to Central when a token will expire in less than one week. The log message process runs once an hour. Once a day, the process lists the tokens that are expiring and creates a log message for each one. Log messages are issued once a day and appear in Central logs.
+
+Logs have the format as shown in the following example:
+
+[source,text]
+----
+Warn: API Token [token name] (ID [token ID]) will expire in less than X days.
+----
+
+You can change the default settings for the log message process by configuring the environment variables shown in the following table:
+
+[cols="1,1,1"]
+|===
+
+|Environment variable |Default value |Description
+
+| ROX_TOKEN_EXPIRATION_NOTIFIER_INTERVAL
+| 1h (1 hour)
+| The frequency at which the log message background loop that lists tokens and creates the logs will run.
+
+| ROX_TOKEN_EXPIRATION_NOTIFIER_BACKOFF_INTERVAL
+| 24h (1 day)
+| The frequency at which the loop lists tokens and issues notifications.
+
+| ROX_TOKEN_EXPIRATION_DETECTION_WINDOW
+| 168h (1 week)
+| The time period before expiration of the token that will cause the notification to be generated.
+
+|===

--- a/modules/cli-authentication.adoc
+++ b/modules/cli-authentication.adoc
@@ -1,46 +1,30 @@
 // Module included in the following assemblies:
 //
-// * cli/using-roxctl-cli.adoc
-:_module-type: PROCEDURE
+// * cli/getting-started-cli.adoc
+:_content-type: PROCEDURE
 [id="cli-authentication_{context}"]
-= Authenticating using the `roxctl` CLI
+= Exporting and saving the authentication token
 
-For authentication, you can use an authentication token or your administrator password.
-Red Hat recommends using an authentication token in a production environment because each token is assigned specific access control permissions.
 //TODO: Add links to role based access control
-
-Use the following steps to generate an authentication token.
 
 .Procedure
 
-. Navigate to the RHACS portal.
-. Go to *Platform Configuration* -> *Integrations*.
-. Scroll down to the *Authentication Tokens* category, and click *API Token*.
-. Click *Generate Token*.
-. Enter a name for the token and select a role that provides the required level of access (for example, *Continuous Integration* or *Sensor Creator*).
-. Click *Generate*.
+. After you have generated the authentication token, export it as the `ROX_API_TOKEN` variable by entering the following command:
 +
-[IMPORTANT]
-====
-Copy the generated token and securely store it.
-You will not be able to view it again.
-====
-
-[NOTE]
-====
-After you have generated the authentication token, export it as `ROX_API_TOKEN` variable:
 [source,terminal]
 ----
 $ export ROX_API_TOKEN=<api_token>
 ----
-You can also save the token in a file and use it with the `--token-file` option.
-For example:
+. (Optional): You can also save the token in a file and use it with the `--token-file` option by entering the following command:
++
 [source,terminal]
 ----
 $ roxctl central debug dump --token-file <token_file>
 ----
 
+Note the following guidelines:
+
 * You cannot use both the `-password` (`-p`) and the `--token-file` options simultaneously.
-* If you have already set `ROX_API_TOKEN` variable, and specify the `--token-file` option, the `roxctl` CLI uses the specified token file for authentication.
-* If you have already set `ROX_API_TOKEN` variable, and specify the `--password` option, the `roxctl` CLI uses the specified password for authentication.
-====
+* If you have already set the `ROX_API_TOKEN` variable, and specify the `--token-file` option, the `roxctl` CLI uses the specified token file for authentication.
+* If you have already set the `ROX_API_TOKEN` variable, and specify the `--password` option, the `roxctl` CLI uses the specified password for authentication.
+

--- a/modules/create-api-token.adoc
+++ b/modules/create-api-token.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * configure/configure-api-token.adoc
+:_content-type: PROCEDURE
+[id="create-api-token_{context}"]
+= Creating an API token
+
+.Procedure
+
+. In the {product-title-short} portal, navigate to *Platform Configuration* -> *Integrations*.
+. Scroll to the *Authentication Tokens* category, and then click *API Token*.
+. Click *Generate Token*.
+. Enter a name for the token and select a role that provides the required level of access (for example, *Continuous Integration* or *Sensor Creator*).
+. Click *Generate*.
++
+[IMPORTANT]
+====
+Copy the generated token and securely store it.
+You will not be able to view it again.
+====


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.0`

[Issue](https://issues.redhat.com/browse/ROX-15837)

Link to docs preview:

- [API token configuration and expiration notice info](https://59001--docspreview.netlify.app/openshift-acs/latest/configuration/configure-api-token.html)
- [CLI section reusing API token configuration info
](https://59001--docspreview.netlify.app/openshift-acs/latest/cli/getting-started-cli.html#authenticating-cli)
QE review:
- [x] QE has approved this change. (**ACS has no QE, approved by SME**)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- Created new "Configuring API tokens" topic to reuse and link to from other parts of documentation.
- Added the token expiration section.
- Edited CLI section to use the new token module.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
