### PR TITLE
OSDOCS#5578: Added `oc adm upgrade --to-multi-arch` to 4.13 release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -146,6 +146,10 @@ For more information, see xref:../updating/updating-cluster-prepare.adoc#updatin
 ==== Minimum required permissions for Microsoft Azure to install and delete an {product-title} cluster
 In {product-title} {product-version}, instead of using the built-in roles, you can now define your custom roles to include the minimum required permissions for Microsoft Azure to install and delete an {product-title} cluster. These permissions are available for installer-provisioned infrastructure and user-provisioned infrastructure.
 
+[id="ocp-4-13-updating-clusters-migrating-cluster-to-multi-arch"]
+==== Single-architecture to multi-architecture payload migration
+{product-title} {product-version} introduces the `oc adm upgrade --to-multi-arch` command, which lets you migrate a cluster with single-architecture compute machines to a cluster with multi-architecture compute machines. By updating to a multi-architecture, manifest-listed payload, you can add mixed architecture compute machines to your cluster.
+
 [id="ocp-4-13-install-configure-vips-to-run-on-control-plane"]
 ==== Configuring network components to run on the control plane in vSphere
 


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5578

Link to docs preview:
https://59009--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-updating-clusters-migrating-cluster-to-multi-arch

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
