### PR TITLE
OCPBUG10401: Added Notes related to baselineCapabilitySet

### DIFF
--- a/modules/selecting-cluster-capabilities.adoc
+++ b/modules/selecting-cluster-capabilities.adoc
@@ -12,11 +12,22 @@ During a customized installation, you create an `install-config.yaml` file that 
 [source,yaml]
 ----
 capabilities:
-  baselineCapabilitySet: v4.13 <1>
+  baselineCapabilitySet: v4.11 <1>
   additionalEnabledCapabilities: <2>
   - CSISnapshot
   - Console
   - Storage
 ----
-<1> Defines a baseline set of capabilities to install. Valid values are `None`, `v4.12`, `v4.13`, and `vCurrent`. If you select `None`, all optional capabilities will be disabled. The default value is `vCurrent`, which enables all optional capabilities.
+<1> Defines a baseline set of capabilities to install. Valid values are `None`, `vCurrent` and `v4.x`. If you select `None`, all optional capabilities will be disabled. The default value is `vCurrent`, which enables all optional capabilities.
++
+[NOTE]
+====
+`v4.x` refers to any value up to and including the current cluster version. 
+For example, valid values for a {product-title} 4.12 cluster are `v4.11` and `v4.12`. 
+====
 <2> Defines a list of capabilities to explicitly enable. These will be enabled in addition to the capabilities specified in `baselineCapabilitySet`.
++
+[NOTE]
+====
+In this example, the default capability is set to `v4.11`. The `additionalEnabledCapabilities` field enables additional capabilities over the default `v4.11` capability set.
+====


### PR DESCRIPTION
Version(s): 4.12+

Issue: [OCPBUG10401](https://issues.redhat.com/browse/OCPBUGS-10401)

Scope: Added note related to baseline capabilities set in selecting cluster capabilities section.

Link to docs preview:
[Doc Preview](https://59010--docspreview.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities.html#selecting-cluster-capabilities_cluster-capabilities)

QE review:
- [ ] QE has approved this change.

Additional information:
