### PR TITLE
OSDOCS-5540: Updating missing package in microshift

### DIFF
--- a/modules/microshift-adding-repos-to-image-builder.adoc
+++ b/modules/microshift-adding-repos-to-image-builder.adoc
@@ -28,7 +28,7 @@ $ sudo subscription-manager repos
 +
 [source,terminal]
 ----
-$ sudo yum install -y yum-utils
+$ sudo yum install -y yum-utils createrepo
 ----
 
 . Sync the {product-title} RPM packages to your build host by running the following command:


### PR DESCRIPTION
**For Version**: 4.12
**Issue:** [OSDOCS-5540](https://issues.redhat.com//browse/OSDOCS-5540)

**Preview:** 
[Adding MicroShift repositories to Image builder](https://59012--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#adding-MicroShift-repos-image-builder_microshift-embed-in-rpm-ostree)

**QE review** 

- [x] QE approved 

