### PR TITLE
Document GitOpsRN-1.7.4

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -29,6 +29,8 @@ include::modules/gitops-release-notes-1-8-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-8-0.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-7-4.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-7-3.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-7-1.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-7-4.adoc
+++ b/modules/gitops-release-notes-1-7-4.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-7-4_{context}"]
+= Release notes for {gitops-title} 1.7.4
+
+{gitops-title} 1.7.4 is now available on {product-title} 4.10, 4.11, and 4.12.
+
+[id="errata-updates-1-7-4_{context}"]
+== Errata updates
+
+=== RHSA-2023:1454 - {gitops-title} 1.7.4 security update advisory 
+
+Issued: 2023-03-23
+
+The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2023:1454[RHSA-2023:1454] advisory. 
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----


### PR DESCRIPTION
**NOTE**: From GitOps 1.7.0 onwards, we are documenting security issues in a new advisory format as part of errata updates.

**Aligned team**: Dev Tools

**Purpose**: To resolve the following issues:
https://issues.redhat.com/browse/RHDEVDOCS-5219


**OCP version this PR applies to**: enterprise- `4.12`

**Link to docs preview**: 
- [Release notes for Red Hat OpenShift GitOps 1.7.4](https://59014--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-7-4_gitops-release-notes)


**SME review**: @reginapizza, @iam-veeramalla 
**QE review**: @varshab1210 
**Peer-review**:  