### PR TITLE
Document GitOps RN 1.7.4 and 1.6.7

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -29,11 +29,15 @@ include::modules/gitops-release-notes-1-8-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-8-0.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-7-4.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-7-3.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-7-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-7-0.adoc[leveloffset=+1]
+
+include::modules/gitops-release-notes-1-6-7.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-6-6.adoc[leveloffset=+1]
 

--- a/modules/gitops-release-notes-1-6-7.adoc
+++ b/modules/gitops-release-notes-1-6-7.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-6-7_{context}"]
+= Release notes for {gitops-title} 1.6.7
+
+{gitops-title} 1.6.7 is now available on {product-title} 4.8, 4.9, 4.10, and 4.11.
+
+[id="fixed-issues-1-6-7_{context}"]
+== Fixed issues
+The following issue has been resolved in the current release:
+
+* Before this update, all versions of the Argo CD Operator, starting with v0.5.0 were vulnerable to an information disclosure flaw. As a result, unauthorized users could enumerate application names by inspecting API error messages and use the discovered application names as the starting point of another attack. For example, the attacker might use their knowledge of an application name to convince an administrator to grant higher privileges. This update fixes the CVE-2022-41354 error. link:https://issues.redhat.com/browse/GITOPS-2635[GITOPS-2635], link:https://access.redhat.com/security/cve/CVE-2022-41354[CVE-2022-41354]

--- a/modules/gitops-release-notes-1-7-4.adoc
+++ b/modules/gitops-release-notes-1-7-4.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-7-4_{context}"]
+= Release notes for {gitops-title} 1.7.4
+
+{gitops-title} 1.7.4 is now available on {product-title} 4.10, 4.11, and 4.12.
+
+[id="errata-updates-1-7-4_{context}"]
+== Errata updates
+
+=== RHSA-2023:1454 - {gitops-title} 1.7.4 security update advisory 
+
+Issued: 2023-03-23
+
+The list of security fixes that are included in this release is documented in the link:https://access.redhat.com/errata/RHSA-2023:1454[RHSA-2023:1454] advisory. 
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----


### PR DESCRIPTION
**NOTE**: From GitOps 1.7.0 onwards, we are documenting security issues in a new advisory format as part of errata updates.

**Aligned team**: Dev Tools

**Purpose**: To resolve the following issues:
https://issues.redhat.com/browse/RHDEVDOCS-5219
https://issues.redhat.com/browse/RHDEVDOCS-5218


**OCP version this PR applies to**: enterprise-`4.10`

**Link to docs preview**: 

- [Release notes for Red Hat OpenShift GitOps 1.7.4](https://59016--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-7-4_gitops-release-notes)
- [Release notes for Red Hat OpenShift GitOps 1.6.7](https://59016--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-6-7_gitops-release-notes)


**SME review**: @reginapizza, @iam-veeramalla 
**QE review**: @varshab1210 
**Peer-review**:  