### PR TITLE
OCP 4.13/NetObserv 1.1, 1.2 release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -356,6 +356,10 @@ For more information, see xref:../security/encrypting-etcd.adoc#etcd-encryption-
 ==== Enhancements to networking alerts
 * OVN Kubernetes retries a claim up to 15 times before dropping it. With this update, if this failure happens, {product-title} alerts the cluster administrator. A description of each alert can be viewed in the console.
 
+[id="ocp-4-13-network-observability-1_1-1_2"]
+==== Network Observability Operator
+The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, rolling stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator can be found in the xref:../networking/network_observability/network-observability-operator-release-notes.adoc[Network Observability release notes].
+
 [id="ocp-4-13-noovnmasterleader"]
 ===== NoOvnMasterLeader
 * Summary: There is no ovn-kubernetes master leader.
@@ -1855,7 +1859,7 @@ In the following tables, features are marked with the following statuses:
 
 |Network Observability Operator
 |Not Available
-|Not Available
+|General Availability
 |General Availability
 
 |Platform Operators


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
OCP 4.13 Release Notes
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://59029--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-network-observability-1_1-1_2
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This PR creates a small announcement of Network Observability in the big OpenShift Container Platform documentation release notes. It doesn't include specifics, but rather points to the Operator release notes. 
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
