### PR TITLE
OSDOCS-4863 updating installing prep page

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -32,6 +32,7 @@ endif::openshift-origin[]
 * {ibmzProductName} or {linuxoneProductName}
 * {ibmzProductName} or {linuxoneProductName} for {op-system-base-full} KVM
 * {ibmpowerProductName}
+* {ibmpowerProductName} Virtual Server 
 * Nutanix
 * VMware vSphere
 * VMware Cloud (VMC) on AWS
@@ -128,7 +129,7 @@ Not all installation options are supported for all platforms, as shown in the fo
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS (x86_64) |AWS (arm64) |Azure (x86_64) |Azure (arm64)|Azure Stack Hub |GCP |Nutanix |{rh-openstack} |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |{ibmzProductName} |{ibmpowerProductName}
+||Alibaba |AWS (x86_64) |AWS (arm64) |Azure (x86_64) |Azure (arm64)|Azure Stack Hub |GCP |Nutanix |{rh-openstack} |RHV |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |{ibmzProductName} |{ibmpowerProductName} |{ibmpowerProductName} Virtual Server 
 
 |Default
 |xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[&#10003;]
@@ -146,6 +147,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc#installing-vsphere-installer-provisioned[&#10003;]
 |xref:../installing/installing_vmc/installing-vmc.adoc#installing-vmc[&#10003;]
 |xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[&#10003;]
+|
 |
 |
 
@@ -167,6 +169,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#installing-ibm-cloud-customizations[&#10003;]
 |
 |
+|xref:../installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc#installing-ibm-power-vs-customizations[&#10003;]
 
 
 |Network customization
@@ -185,6 +188,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installing-vsphere-installer-provisioned-network-customizations[&#10003;]
 |xref:../installing/installing_vmc/installing-vmc-network-customizations.adoc#installing-vmc-network-customizations[&#10003;]
 |xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.adoc#installing-ibm-cloud-network-customizations[&#10003;]
+|
 |
 |
 
@@ -206,6 +210,7 @@ ifndef::openshift-origin[]
 |
 |
 |
+|xref:../installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc#installing-restricted-networks-ibm-power-vs[&#10003;]
 
 |Private clusters
 |
@@ -225,6 +230,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-private.adoc#installing-ibm-cloud-private[&#10003;]
 |
 |
+|xref:../installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc#installing-ibm-power-vs-private-cluster[&#10003;]
 
 |Existing virtual private networks
 |
@@ -244,12 +250,14 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_ibm_cloud_public/installing-ibm-cloud-vpc.adoc#installing-ibm-cloud-vpc[&#10003;]
 |
 |
+|xref:../installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc#installing-ibm-powervs-vpc[&#10003;]
 
 |Government regions
 |
 |xref:../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-government-region[&#10003;]
 |
 |xref:../installing/installing_azure/installing-azure-government-region.adoc#installing-azure-government-region[&#10003;]
+|
 |
 |
 |
@@ -282,10 +290,12 @@ ifndef::openshift-origin[]
 |
 |
 |
+|
 
 |China regions
 |
 |xref:../installing/installing_aws/installing-aws-china.adoc#installing-aws-china-region[&#10003;]
+|
 |
 |
 |


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-4863

Link to docs preview:
https://bscott-rh.github.io/openshift-docs/OSDOCS-4863/installing/installing-preparing.html#supported-installation-methods-for-different-platforms

QE review:
- [ ] QE has approved this change.

Additional information:
Don't merge until after https://github.com/openshift/openshift-docs/pull/47558 merges