### PR TITLE
OSDOCS-5637-RHCOS: adds bug to RHCOS RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -78,8 +78,8 @@ For more information, see xref:../installing/installing_ibm_z/installing-ibm-z-k
 ==== {op-system} now includes lsof
 {product-title} {product-version} now includes the `lsof` command in {op-system}.
 
-[id="ocp-4-13-installation-and-upgrade"]
-=== Installation and upgrade
+[id="ocp-4-13-installation-and-update"]
+=== Installation and update
 
 [id="ocp-4-13-installation-vsphere-8-support"]
 ==== Support for VMware vSphere version 8.0
@@ -1164,6 +1164,8 @@ With this release, replacement control plane nodes are assigned to the correct i
 [discrete]
 [id="ocp-4-13-rhcos-bug-fixes"]
 ==== {op-system-first}
+
+* Previously, on Azure, the SR-IOV interface was configured by NetworkManager during boot because the udev rule that marks it as `NM_UNMANAGED` wasn't in the `initramfs` file. With this update, the udev rule is now in the `initramfs` file and the SR-IOV interface should always be unmanaged by NetworkManager. (link:https://issues.redhat.com/browse/OCPBUGS-7173[*OCPBUGS-7173*])
 
 [discrete]
 [id="ocp-4-13-scalability-and-performance-bug-fixes"]


### PR DESCRIPTION
[OSDOCS-5637](https://issues.redhat.com//browse/OSDOCS-5637): adds bug RHCOS in RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5637
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://59033--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-bug-fixes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
