### PR TITLE
OSDOCS5736: Document CMA metrics

### DIFF
--- a/modules/nodes-pods-autoscaling-custom-metrics-access.adoc
+++ b/modules/nodes-pods-autoscaling-custom-metrics-access.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-autoscaling-custom.adoc
+// Modeled after migration-accessing-performance-metrics.adoc
+
+:_content-type: PROCEDURE
+[id="nodes-pods-autoscaling-custom-metrics-access_{context}"]
+= Accessing performance metrics
+
+The Custom Metrics Autoscaler Operator exposes ready-to-use metrics that it pulls from the on-cluster monitoring component. You can query the metrics by using the Prometheus Query Language (PromQL) to analyze and diagnose issues. All metrics are reset when the controller pod restarts.
+
+You can access the metrics and run queries by using the {product-title} web console.
+
+.Procedure
+
+. Select the *Administrator* perspective in the {product-title} web console.
+
+. Select *Observe* -> *Metrics*.
+
+. To create a custom query, add your PromQL query to the *Expression* field.
+
+. To add multiple queries, select *Add Query*.
+
+// Procedure copied from monitoring-querying-metrics-for-all-projects-as-an-administrator

--- a/modules/nodes-pods-autoscaling-custom-metrics.adoc
+++ b/modules/nodes-pods-autoscaling-custom-metrics.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-autoscaling-custom.adoc
+
+:_content-type: REFERENCE
+[id="nodes-pods-autoscaling-custom-metrics_{context}"]
+= Provided metrics
+
+The Custom Metrics Autoscaler Operator exposes the following metrics, which you can view by using the {product-title} web console.
+
+.Custom Metric Autoscaler Operator metrics
+
+[cols="3,7",options="header"]
+|===
+|Metric name
+|Description
+
+|`keda_scaler_activity`
+|Whether the particular scaler is active or inactive. A value of `1` indicates the scaler is active; a value of `0` indicates the scaler is inactive.
+
+|`keda_scaler_metrics_value`
+|The current value for each scaler’s metric, which is used by the Horizontal Pod Autoscaler (HPA) in computing the target average.
+
+|`keda_scaler_metrics_latency`
+|The latency of retrieving the current metric from each scaler.
+
+|`keda_scaler_errors`
+|The number of errors that have occurred for each scaler.
+
+|`keda_scaler_errors_total`
+|The total number of errors encountered for all scalers.
+
+|`keda_scaled_object_errors`
+|The number of errors that have occurred for each scaled obejct.
+
+|`keda_resource_totals`
+|The total number of Custom Metrics Autoscaler custom resources in each namespace for each custom resource type.
+
+|`keda_trigger_totals`
+|The total number of triggers by trigger type.
+
+|===
+
+.Custom Metrics Autoscaler Admission webhook metrics
+
+The Custom Metrics Autoscaler Admission webhook also exposes the following Prometheus metrics.
+
+[cols="3,7"options="header"]
+|===
+|Metric name
+|Description
+
+|`keda_scaled_object_validation_total`
+|The number of scaled object validations.
+
+|`keda_scaled_object_validation_errors`
+|The number of validation errors.
+
+|===

--- a/nodes/pods/nodes-pods-autoscaling-custom.adoc
+++ b/nodes/pods/nodes-pods-autoscaling-custom.adoc
@@ -67,6 +67,10 @@ include::modules/nodes-pods-autoscaling-custom-pausing.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-autoscaling-custom-audit.adoc[leveloffset=+1]
 
+.Additional resources
+
+* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-audit_nodes-pods-autoscaling-custom[Configuring audit logging]
+
 include::modules/nodes-pods-autoscaling-custom-gather.adoc[leveloffset=+1]
 
 .Additional resources
@@ -75,6 +79,10 @@ include::modules/nodes-pods-autoscaling-custom-gather.adoc[leveloffset=+1]
 ifndef::openshift-origin[]
 * xref:../../support/gathering-cluster-data.adoc#support-get-cluster-id_gathering-cluster-data[Obtaining your cluster ID]
 endif::openshift-origin[]
+
+include::modules/nodes-pods-autoscaling-custom-metrics-access.adoc[leveloffset=+1]
+
+include::modules/nodes-pods-autoscaling-custom-metrics.adoc[leveloffset=+2]
 
 include::modules/nodes-pods-autoscaling-custom-adding.adoc[leveloffset=+1]
 
@@ -85,7 +93,6 @@ include::modules/nodes-pods-autoscaling-custom-creating-workload.adoc[leveloffse
 * xref:../../nodes/pods/nodes-pods-autoscaling.adoc#nodes-pods-autoscaling-policies_nodes-pods-autoscaling[Scaling policies]
 * xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-trigger_nodes-pods-autoscaling-custom[Understanding the custom metrics autoscaler triggers]
 * xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-trigger-auth_nodes-pods-autoscaling-custom[Understanding custom metrics autoscaler trigger authentications]
-* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-audit_nodes-pods-autoscaling-custom[Configuring audit logging]
 
 include::modules/nodes-pods-autoscaling-custom-creating-job.adoc[leveloffset=+2]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5736

 document describing various stats and metrics available.

Upstream doc:  https://keda.sh/docs/2.10/operate/prometheus/

Preview: Nodes -> Pods -> Cluster Metrics Autoscaler -> [Accessing performance metrics](https://59040--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-metrics-access_nodes-pods-autoscaling-custom) and [Provided metrics](https://59040--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-metrics_nodes-pods-autoscaling-custom).

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

