### PR TITLE
[enterprise-4.10] [OSDOCS-4789]: Machine deletion hooks

### DIFF
--- a/modules/machine-delete.adoc
+++ b/modules/machine-delete.adoc
@@ -7,12 +7,12 @@
 [id="machine-delete_{context}"]
 = Deleting a specific machine
 
-You can delete a specific machine. 
+You can delete a specific machine.
 
 [NOTE]
 ====
 You cannot delete a control plane machine.
-====  
+====
 
 .Prerequisites
 
@@ -22,24 +22,29 @@ You cannot delete a control plane machine.
 
 .Procedure
 
-. View the machines that are in the cluster and identify the one to delete:
+. View the machines that are in the cluster by running the following command:
 +
 [source,terminal]
 ----
 $ oc get machine -n openshift-machine-api
 ----
 +
-The command output contains a list of machines in the `<clusterid>-worker-<cloud_region>` format.
+The command output contains a list of machines in the `<clusterid>-<role>-<cloud_region>` format.
 
-. Delete the machine:
+. Identify the machine that you want to delete.
+
+. Delete the machine by running the following command:
 +
 [source,terminal]
 ----
 $ oc delete machine <machine> -n openshift-machine-api
 ----
-
 +
 [IMPORTANT]
 ====
-By default, the machine controller tries to drain the node that is backed by the machine until it succeeds. In some situations, such as with a misconfigured pod disruption budget, the drain operation might not be able to succeed in preventing the machine from being deleted. You can skip draining the node by annotating "machine.openshift.io/exclude-node-draining" in a specific machine. If the machine being deleted belongs to a machine set, a new machine is immediately created to satisfy the specified number of replicas.
+By default, the machine controller tries to drain the node that is backed by the machine until it succeeds. In some situations, such as with a misconfigured pod disruption budget, the drain operation might not be able to succeed. If the drain operation fails, the machine controller cannot proceed removing the machine.
+
+You can skip draining the node by annotating `machine.openshift.io/exclude-node-draining` in a specific machine.
 ====
++
+If the machine that you delete belongs to a machine set, a new machine is immediately created to satisfy the specified number of replicas.

--- a/modules/machineset-manually-scaling.adoc
+++ b/modules/machineset-manually-scaling.adoc
@@ -42,15 +42,7 @@ $ oc get machine -n openshift-machine-api
 $ oc annotate machine/<machine_name> -n openshift-machine-api machine.openshift.io/cluster-api-delete-machine="true"
 ----
 
-. Cordon and drain the node that you want to delete:
-+
-[source,terminal]
-----
-$ oc adm cordon <node_name>
-$ oc adm drain <node_name>
-----
-
-. Scale the machine set:
+. Scale the compute machine set by running one of the following commands:
 +
 [source,terminal]
 ----
@@ -80,7 +72,14 @@ spec:
 ----
 ====
 +
-You can scale the machine set up or down. It takes several minutes for the new machines to be available.
+You can scale the compute machine set up or down. It takes several minutes for the new machines to be available.
++
+[IMPORTANT]
+====
+By default, the machine controller tries to drain the node that is backed by the machine until it succeeds. In some situations, such as with a misconfigured pod disruption budget, the drain operation might not be able to succeed. If the drain operation fails, the machine controller cannot proceed removing the machine.
+
+You can skip draining the node by annotating `machine.openshift.io/exclude-node-draining` in a specific machine.
+====
 
 .Verification
 


### PR DESCRIPTION
Cherrypicked from 7962d98ff32c9f4d0575bbf777112d51089d3b3d xref: #55175

Selective manual cherrypick because 4.10 only needs the delete update.

@miyadav PTAL, this should resolve https://issues.redhat.com/browse/OCPBUGS-6257 for version 4.10. 

~~If this is correct, I can port it into 4.9 as well.~~ 4.9 is EOL as of a few days ago, no backports

Previews (VPN required):
- [Deleting a specific machine](http://file.rdu.redhat.com/~jrouth/OSDOCS-4789-cp-410/machine_management/deleting-machine.html#machine-delete_deleting-machine)
- [Scaling a machine set manually](http://file.rdu.redhat.com/~jrouth/OSDOCS-4789-cp-410/machine_management/manually-scaling-machineset.html#machineset-manually-scaling_manually-scaling-machineset)