### PR TITLE
OSDOCS#5463: Rm go/v4 plugin note from OSDK upgrade

### DIFF
--- a/modules/osdk-updating-v125-to-v128.adoc
+++ b/modules/osdk-updating-v125-to-v128.adoc
@@ -33,13 +33,6 @@ endif::[]
 
 The following procedure updates an existing {type}-based Operator project for compatibility with {osdk_ver}.
 
-ifdef::golang[]
-[NOTE]
-====
-The `go/v3` plugin is being deprecated by Kubebuilder. As a result, the Operator SDK is planned to migrate to the `go/v4` plugin in a future release.
-====
-endif::[]
-
 .Prerequisites
 
 * Operator SDK {osdk_ver} installed


### PR DESCRIPTION
Follow-up to https://issues.redhat.com/browse/OSDOCS-5463.

4.13 only

Per PM chat

Preview: https://59049--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-updating-projects.html#osdk-upgrading-projects_osdk-golang-updating-projects 