### PR TITLE
OSDOCS-5743-redo: Documented the 4.11.37 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3472,4 +3472,23 @@ $ oc adm release info 4.11.36 --pullspecs
 [id="ocp-4-11-36-updating"]
 ==== Updating
 
-All OpenShift Container Platform 4.11 users are advised that the only defect fixed in this release is limited to install time; therefore, there is no need to update previously installed clusters to this version.
+All {product-title} 4.11 users are advised that the only defect fixed in this release is limited to install time; therefore, there is no need to update previously installed clusters to this version.
+
+[id="ocp-4-11-37"]
+=== RHBA-2023:1760 - {product-title} 4.11.37 bug fix
+
+Issued: 2023-04-19
+
+{product-title} release 4.11.37 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1760[RHBA-2023:1760] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1759[RHBA-2023:1759] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.37 --pullspecs
+----
+
+[id="ocp-4-11-37-updating"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
**Note to merge:** Approvals on https://github.com/openshift/openshift-docs/pull/58905


Version(s):
4.11

Issue:
[OSDOCS-5743](https://issues.redhat.com/browse/OSDOCS-5743)

Link to docs preview:
[Preview](https://59053--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-37)

QE review:
- [ ] QE has approved this change.