### PR TITLE
OCPBUGS#10828: Update uninstalling the cert-manager Operator section

### DIFF
--- a/modules/cert-manager-remove-resources-cli.adoc
+++ b/modules/cert-manager-remove-resources-cli.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-operator-uninstall.adoc
+
+:_content-type: PROCEDURE
+[id="cert-manager-uninstall-cli_{context}"]
+= Removing the {cert-manager-operator} resources by using the CLI
+
+You must remove the {cert-manager-operator} resources by using the CLI.
+
+.Prerequisites
+
+* You have access to the cluster with `cluster-admin` privileges.
+* You have installed the OpenShift CLI (`oc`).
+* You have installed the {cert-manager-operator}.
+
+.Procedure
+
+. Get a list of deployments that were installed by the {cert-manager-operator} by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment -n cert-manager
+----
++
+.Example output
+[source,terminal]
+----
+NAME                        READY   UP-TO-DATE   AVAILABLE   AGE
+cert-manager                1/1     1            1           73s
+cert-manager-cainjector     1/1     1            1           67s
+cert-manager-webhook        1/1     1            1           44s
+----
+
+. Remove the cert-manager deployments by running the following command:
++
+[source,terminal]
+----
+$ oc delete deployment -n cert-manager -l app.kubernetes.io/instance=cert-manager
+----
+
+.Verification
+
+. Verify that no pods are available in the `cert-manager` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n cert-manager
+----
++
+.Example output
+[source,terminal]
+----
+No resources found in openshift-storage namespace.
+----
+
+. Verify that no deployments are available in the `cert-manager` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get deployment -n cert-manager
+----
++
+.Example output
+[source,terminal]
+----
+No resources found in openshift-storage namespace.
+----

--- a/security/cert_manager_operator/cert-manager-operator-uninstall.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-uninstall.adoc
@@ -11,5 +11,8 @@ You can remove the {cert-manager-operator} from {product-title} by uninstalling 
 // Uninstalling the {cert-manager-operator}
 include::modules/cert-manager-uninstall-console.adoc[leveloffset=+1]
 
-// Removing {cert-manager-operator} resources
+// Removing {cert-manager-operator} resources by using the CLI
+include::modules/cert-manager-remove-resources-cli.adoc[leveloffset=+1]
+
+// Removing {cert-manager-operator} resources by using the web console
 include::modules/cert-manager-remove-resources-console.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-10828
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://59057--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html#cert-manager-uninstall-console_cert-manager-operator-uninstall
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
