### PR TITLE
OADP 1178 - featureFlags

### DIFF
--- a/modules/oadp-enabling-csi-dpa.adoc
+++ b/modules/oadp-enabling-csi-dpa.adoc
@@ -31,5 +31,7 @@ spec:
       defaultPlugins:
       - openshift
       - csi <1>
+      featureFlags:
+      - EnableCSI
 ----
 <1> Add the `csi` default plugin.


### PR DESCRIPTION
https://github.com/openshift/openshift-docs/pull/57763

Preview: [Enabling CSI in the DataProtectionApplication CR](https://59062--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-enabling-csi-dpa_installing-oadp-aws)

Current version: [Enabling CSI in the DataProtectionApplication CR](https://docs.openshift.com/container-platform/4.12/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-enabling-csi-dpa_installing-oadp-aws)