### PR TITLE
CNV-23499: 4.12 RN fix

### DIFF
--- a/virt/virt-4-12-release-notes.adoc
+++ b/virt/virt-4-12-release-notes.adoc
@@ -149,7 +149,7 @@ Deprecated features are included in the current release and supported. However, 
 Removed features are not supported in the current release.
 
 // CNV-23499_412RN
-* Support for the legacy HPP custom resource, and the associated storage class, has been removed for all new deployments. In {VirtProductName} {VirtVersion}, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. Only in the case of an upgrade will a previously installed legacy HPP custom resource still be supported.
+* Support for the legacy HPP custom resource, and the associated storage class, has been removed for all new deployments. In {VirtProductName} {VirtVersion}, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. A legacy HPP custom resource is supported only if it had been installed on a previous version of {VirtProductName}.
 
 //CNV-16317 NMState is no longer part of CNV
 * {VirtProductName} 4.11 removed support for link:https://nmstate.io/[nmstate], including the following objects:


### PR DESCRIPTION
Version(s): 4.12


Issue: [CNV-23499](https://issues.redhat.com//browse/CNV-23499): 4.10+ HPP CSI only (4.12 RN fix)


Link to docs preview: https://59065--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-12-release-notes.html#virt-4-12-removed 

In the first note under Removed features, the last sentence has changed from "Only in the case of an upgrade will a previously installed legacy HPP custom resource still be supported" to "Legacy HPP custom resource is supported only if it had been installed on a previous version of OpenShift Virtualization."


QE review:
- [x] QE has approved this change.
This PR fixes an update already approved by QE but not pushed to enterprise-4.12 after commit (https://github.com/openshift/openshift-docs/pull/57355).


