### PR TITLE
CNV-23499: RN 4.13 fix

### DIFF
--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -122,8 +122,7 @@ Removed features are not supported in the current release.
 * Red Hat Enterprise Linux 6 is no longer supported on {VirtProductName}.
 
 //CNV-23499: Carry over/repeat removed feature from version 4.12 
-* Support for the legacy HPP custom resource, and the associated storage class, has been removed for all new deployments. In {VirtProductName} 4.13, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. Only in the case of an upgrade will a previously installed legacy HPP custom resource still be supported.
-
+* Support for the legacy HPP custom resource, and the associated storage class, has been removed for all new deployments. In {VirtProductName} 4.13, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. A legacy HPP custom resource is supported only if it had been installed on a previous version of {VirtProductName}.
 
 
 //NOTE: Removed features for 4.13 are above this line.


### PR DESCRIPTION
Version(s): 4.13

Issue: [CNV-23499](https://issues.redhat.com//browse/CNV-23499): 4.10+ HPP CSI only (4.13 RN fix)


Link to docs preview: https://59082--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-13-release-notes.html#virt-4-13-removed

In the second note under Removed features, the last sentence has changed from "Only in the case of an upgrade will a previously installed legacy HPP custom resource still be supported" to "Legacy HPP custom resource is supported only if it had been installed on a previous version of OpenShift Virtualization."

QE review:
- [x] QE has approved this change.
This PR fixes an update already approved by QE (and peer reviewed) but not pushed to enterprise-4.13 after commit (https://github.com/openshift/openshift-docs/pull/57514).


