### PR TITLE
Updates OMR docs to provide links to both Quay API and the specific c…

### DIFF
--- a/installing/disconnected_install/installing-mirroring-creating-registry.adoc
+++ b/installing/disconnected_install/installing-mirroring-creating-registry.adoc
@@ -23,7 +23,7 @@ If you already have a container image registry, such as Red Hat Quay, you can sk
 +
 [IMPORTANT]
 ====
-These requirements are based on local testing results with only release images and Operator images. Storage requirements can vary based on your organization's needs. You might require more space, for example, when you mirror multiple z-streams. You can use standard Red Hat Quay functionality to remove unnecessary images and free up space.
+These requirements are based on local testing results with only release images and Operator images. Storage requirements can vary based on your organization's needs. You might require more space, for example, when you mirror multiple z-streams. You can use standard link:https://access.redhat.com/documentation/en-us/red_hat_quay/3[Red Hat Quay functionality] or the proper link:https://access.redhat.com/documentation/en-us/red_hat_quay/3/html-single/red_hat_quay_api_guide/index#deletefulltag[API callout] to remove unnecessary images and free up space.
 ====
 
 include::modules/mirror-registry-introduction.adoc[leveloffset=+1]


### PR DESCRIPTION
…allout to delete images

Slight updates to OMR docs.

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-4209

Link to docs preview:
https://59096--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#prerequisites_installing-mirroring-creating-registry

QE not needed. Seeking SME approval. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
