### PR TITLE
[OSDOCS-5476]: Cherry picking etcd restore doc update to 4.9

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc
@@ -13,9 +13,13 @@ include::modules/dr-restoring-cluster-state-about.adoc[leveloffset=+1]
 
 // Restoring to a previous cluster state
 include::modules/dr-restoring-cluster-state.adoc[leveloffset=+1]
-include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
-.Additional resources
+[id="additional-resources_dr-restoring-cluster-state"]
+== Additional resources
 
-* See xref:../../../networking/accessing-hosts.adoc#accessing-hosts[Accessing the hosts] for how to create a bastion host to access {product-title} instances and the control plane nodes with SSH.
+* xref:../../../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Installing a user-provisioned cluster on bare metal]
+* xref:../../../networking/accessing-hosts.adoc#accessing-hosts[Creating a bastion host to access {product-title} instances and the control plane nodes with SSH]
+* xref:../../../installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc#replacing-a-bare-metal-control-plane-node_ipi-install-expanding[Replacing a bare-metal control plane node] 
+
+include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+1]

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -336,13 +336,22 @@ $ oc get pods -n openshift-ovn-kubernetes -o name | grep ovnkube-node | while re
 $ oc get  pods -n openshift-ovn-kubernetes | grep ovnkube-node
 ----
 
-. Delete and recreate other non-recovery, control plane machines, one by one. After these machines are recreated, a new revision is forced and etcd scales up automatically.
+. Delete and re-create other non-recovery, control plane machines, one by one. After the machines are re-created, a new revision is forced and etcd automatically scales up.
 +
-If you are running installer-provisioned infrastructure, or you used the Machine API to create your machines, follow these steps. Otherwise, you must create the new control plane node using the same method that was used to originally create it.
+** If you use a user-provisioned bare metal installation, you can re-create a control plane machine by using the same method that you used to originally create it. For more information, see "Installing a user-provisioned cluster on bare metal". 
 +
 [WARNING]
 ====
-Do not delete and recreate the machine for the recovery host.
+Do not delete and re-create the machine for the recovery host.
+====
++
+** If you are running installer-provisioned infrastructure, or you used the Machine API to create your machines, follow these steps:
++
+[WARNING]
+====
+Do not delete and re-create the machine for the recovery host.
+
+For bare metal installations on installer-provisioned infrastructure, control plane machines are not re-created. For more information, see "Replacing a bare-metal control plane node".
 ====
 .. Obtain the machine for one of the lost control plane hosts.
 +

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -622,6 +622,13 @@ include::modules/disabling-etcd-encryption.adoc[leveloffset=+2]
 include::modules/backup-etcd.adoc[leveloffset=+2]
 include::modules/etcd-defrag.adoc[leveloffset=+2]
 include::modules/dr-restoring-cluster-state.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installing-bare-metal[Installing a user-provisioned cluster on bare metal]
+* xref:../installing/index.adoc#replacing-a-bare-metal-control-plane-node_ipi-install-expanding[Replacing a bare-metal control plane node]
+
 include::modules/dr-scenario-cluster-state-issues.adoc[leveloffset=+2]
 
 [id="post-install-pod-disruption-budgets"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.9 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5476
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

This PR cherry picks the updates from PR https://github.com/openshift/openshift-docs/pull/58758 to 4.9.
