### PR TITLE
RHDEVDOCS-5178-remove-metering-refs-from-monitoring-docs

### DIFF
--- a/modules/monitoring-common-terms.adoc
+++ b/modules/monitoring-common-terms.adoc
@@ -50,9 +50,6 @@ Kubernetes scheduler allocates pods to nodes.
 labels::
 Labels are key-value pairs that you can use to organize and select subsets of objects such as a pod.
 
-Metering::
-Metering is a general purpose data analysis tool that enables you to write reports to process data from different data sources.
-
 node::
 A worker machine in the {product-title} cluster. A node is either a virtual machine (VM) or a physical machine.
 

--- a/modules/monitoring-default-monitoring-targets.adoc
+++ b/modules/monitoring-default-monitoring-targets.adoc
@@ -18,7 +18,6 @@ In addition to the components of the stack itself, the default monitoring stack 
 * Kubernetes API server
 * Kubernetes controller manager
 * Kubernetes scheduler
-* Metering (if Metering is installed)
 * OpenShift API server
 * OpenShift Controller Manager
 * Operator Lifecycle Manager (OLM)


### PR DESCRIPTION
Summary: This PR removes references to the metering feature in the OCP monitoring docs. The feature was removed starting in OCP 4.9

- Aligned team: DevTools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-5178
- Direct link to doc previews: 
- - https://59099--docspreview.netlify.app/openshift-enterprise/latest/monitoring/monitoring-overview.html#default-monitoring-targets_monitoring-overview
- - https://59099--docspreview.netlify.app/openshift-enterprise/latest/monitoring/monitoring-overview.html#openshift-monitoring-common-terms_monitoring-overview
- SME review: @ tbd
- QE review: @juzhao 
- Peer review: @rh-tokeefe 