### PR TITLE
OSDOCS-5782 Z-stream release notes for 4.12.14

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3545,3 +3545,30 @@ For more information, see xref:../nodes/clusters/nodes-cluster-enabling-features
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-12-14"]
+=== RHBA-2023:1858 - {product-title} 4.12.14 bug fix update
+
+Issued: 2023-04-24
+
+{product-title} release 4.12.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1858[RHBA-2023:1858] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1857[RHBA-2023:1857] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.14 --pullspecs
+----
+
+[id="ocp-4-12-14-features"]
+==== Features
+
+[id="ocp-4-12-14-cloud-provider-openstack-1.25"]
+===== Cloud provider OpenStack is updated to 1.25
+
+With this release, Cloud Provider {rh-openstack-first} is updated to 1.25.5. The update includes the addition of an annotation for real load balancer IP addresses and the global source for `math/rand` packages are seeded in `main.go`.
+
+[id="ocp-4-12-14-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5782

Link to docs preview:
[Preview](https://59110--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-14)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Z-stream release notes for 4.12.14. [OSDOCS-5782](https://issues.redhat.com/browse/OSDOCS-5782)

