### PR TITLE
OSDOCS-5694-feature: Dropped macOS reference and added a note about golang

### DIFF
--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -68,6 +68,24 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :private:
 endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vmc"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:vmc:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-obtaining-installer_{context}"]
@@ -90,8 +108,17 @@ endif::restricted[]
 
 .Prerequisites
 
-ifdef::ibm-z,ibm-z-kvm,private[* You have a machine that runs Linux, for example Red Hat Enterprise Linux 8, with 500 MB of local disk space.]
-ifndef::ibm-z,ibm-z-kvm,private[* You have a computer that runs Linux or macOS, with 500 MB of local disk space.]
+ifdef::ibm-z,ibm-z-kvm,private,vsphere,vmc[]
+* You have a machine that runs Linux, for example Red Hat Enterprise Linux 8, with 500 MB of local disk space.
+endif::ibm-z,ibm-z-kvm,private,vsphere,vmc[]
+ifdef::vsphere,vmc[]
++
+[IMPORTANT]
+====
+If you attempt to run the installation program on macOS, a known issue related to the `golang` compiler causes the installation of the {product-title} cluster to fail. For more information about this issue, see the section named "Known Issues" in the _{product-title} {product-version} release notes_ document.
+====
+endif::vsphere,vmc[]
+ifndef::ibm-z,ibm-z-kvm,private,vsphere,vmc[* You have a computer that runs Linux or macOS, with 500 MB of local disk space.]
 
 .Procedure
 


### PR DESCRIPTION
[OSDOCS-5694](https://issues.redhat.com/browse/OSDOCS-5694)

Version(s):
4.13, 4.12, & 4.11

Link to docs preview:
* [Installing a cluster on vSphere](https://59121--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned.html#installation-obtaining-installer_installing-vsphere-installer-provisioned)
* [Installing a cluster on vSphere with customizations](https://59121--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-obtaining-installer_installing-vsphere-installer-provisioned-customizations)
* [Installing a cluster on vSphere with network customizations](https://59121--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-obtaining-installer_installing-vsphere-installer-provisioned-network-customizations)
* [Installing a cluster on VMC](https://59121--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc.html#installation-obtaining-installer_installing-vmc)
* [Installing a cluster on VMC with customizations](https://59121--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-customizations.html#installation-obtaining-installer_installing-vmc-customizations)
* [Installing a cluster on VMC with network customizations](https://59121--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vmc/installing-vmc-network-customizations.html#installation-obtaining-installer_installing-vmc-network-customizations)

QE review:
- [ ] QE has approved this change.
