### PR TITLE
OSDOCS-5694-4-11:Documented a golang known issue for vSphere

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2504,6 +2504,8 @@ openshift.io/scc: hostmount-anyuid
 
 * If a cluster that was deployed through ZTP has policies that do not become compliant, and no `ClusterGroupUpdates` object is present, you must restart the {cgu-operator} pods. Restarting {cgu-operator} creates the proper `ClusterGroupUpdates` object, which enforces the policy compliance. (link:https://issues.redhat.com/browse/OCPBUGS-4065[*OCPBUGS-4065*])
 
+* Currently, a certificate compliance issue, specifically outputted as `x509: certificate is not standards compliant`, exists when you run the installation program on macOS for the purposes of installing an {product-title} cluster on VMware vSphere. This issue relates to a known issue with the `golang` compiler in that the compiler does not recognize newly supported macOS certificate standards. No workaround exists for this issue. (link:https://issues.redhat.com/browse/OSDOCS-5694[*OSDOCS-5694*])
+
 [id="ocp-4-11-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
[OSDOCS-5694](https://issues.redhat.com/browse/OSDOCS-5694)

Version(s):
4.11

Link to docs preview:
[Preview-see last note in Known Issues section](https://59123--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-known-issues)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->