### PR TITLE
OCPBUG7145: Deleted the step.11(c) in 'Restoring to a previous cluster state'

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -282,8 +282,6 @@ etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          
 ----
 +
 If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
-
-.. Repeat this step for each lost control plane host that is not the recovery host.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version: 4.10

Cherry Picked from [commit_ID](498555580e1c7a78fb81c63204a0e36429703fea)  https://github.com/openshift/openshift-docs/pull/56658

Scope: Modified the steps in 'Restoring to a previous cluster state'.
Removed the step 11.c: Repeat this step for each lost control plane host that is not the recovery host.

ISSUE: [OCPBUG-7145](https://issues.redhat.com/browse/OCPBUGS-7145)

- [ ] QE approved

- [ ] Peer Reviewed