### PR TITLE
RHDEVDOCS-5034-dist-tracing-2.8-RNs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -113,13 +113,16 @@ endif::[]
 //distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing
 :DTShortName: distributed tracing
-:DTProductVersion: 2.7
+:DTProductVersion: 2.8
 :JaegerName: Red Hat OpenShift distributed tracing platform
 :JaegerShortName: distributed tracing platform
-:JaegerVersion: 1.39.0
+:JaegerVersion: 1.42.0
 :OTELName: Red Hat OpenShift distributed tracing data collection
 :OTELShortName: distributed tracing data collection
-:OTELVersion: 0.63.1
+:OTELVersion: 0.74.0
+:TempoName: Tempo Operator
+:TempoShortName: Tempo
+:TempoVersion: 0.1.0
 //logging
 :logging-title: logging subsystem for Red Hat OpenShift
 :logging-title-uc: Logging subsystem for Red Hat OpenShift

--- a/modules/distr-tracing-rn-new-features.adoc
+++ b/modules/distr-tracing-rn-new-features.adoc
@@ -13,6 +13,28 @@ Result – If changed, describe the current user experience.
 
 This release adds improvements related to the following components and concepts.
 
+== New features and enhancements {DTProductName} 2.8
+
+This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.
+
+=== Component versions supported in {DTProductName} version 2.8
+
+[options="header"]
+|===
+|Operator |Component |Version
+|{JaegerName}
+|Jaeger
+|1.42
+
+|{OTELName}
+|OpenTelemetry
+|0.74.0
+
+|{TempoName}
+|{TempoShortName}
+|0.1.0
+|===
+
 == New features and enhancements {DTProductName} 2.7
 
 This release of {DTProductName} addresses Common Vulnerabilities and Exposures (CVEs) and bug fixes.

--- a/modules/distr-tracing-rn-technology-preview.adoc
+++ b/modules/distr-tracing-rn-technology-preview.adoc
@@ -18,6 +18,25 @@ Technology Preview features are not supported with Red Hat production service le
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====
 
+== {DTProductName} 2.8.0 Technology Preview
+
+This release introduces support for {TempoName} as a Technology Preview feature for {DTProductName}.
+The feature uses version 0.1.0 of {TempoName} and version 2.0.1 of the upstream {TempoShortName} components.
+
+You can use {TempoName} to replace Jaeger so that you can use S3-compatible storage instead of ElasticSearch.
+Most users who use {TempoName} instead of Jaeger will not notice any difference in functionality because {TempoShortName} supports the same ingestion and query protocols as Jaeger and uses the same user interface.
+
+If you enable this Technology Preview feature, note the following limitations of the current implementation:
+
+* {TempoName} currently does not support disconnected installations. (link:https://issues.redhat.com/browse/TRACING-3145[TRACING-3145])
+
+* When you use the Jaeger user interface (UI) with {TempoName}, the Jaeger UI lists only services that have sent traces within the last 15 minutes.
+For services that have not sent traces within the last 15 minutes, those traces are still stored even though they are not visible in the Jaeger UI. (link:https://issues.redhat.com/browse/TRACING-3139[TRACING-3139])
+
+Expanded support for the Tempo Operator is planned for future releases of {DTProductName}.
+Possible additional features might include support for TLS authentication, multitenancy, and multiple clusters.
+For more information about the Tempo Operator, see link:https://tempo-operator.netlify.app[the Tempo community documentation].
+
 == {DTProductName} 2.4.0 Technology Preview
 
 This release also adds support for auto-provisioning certificates using the Red Hat Elasticsearch Operator.


### PR DESCRIPTION
Summary: This PR adds release notes content for the 2.8 release of distributed tracing.

- Aligned team: DevTools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-5034
- Direct link to doc previews:
- - https://59141--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distributed-tracing-release-notes.html#new-features-and-enhancements-red-hat-openshift-distributed-tracing-2-8
- - https://59141--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distributed-tracing-release-notes.html#red-hat-openshift-distributed-tracing-2-8-0-technology-preview

- SME review: @pavolloffay (approved) @rubenvp8510 (approved)
- PM review: @mwringe (approved)
- QE review: @iblancasa (approved)
- Peer review: @gwynnemonahan (approved)