### PR TITLE
[OSDOCS-4318]: Adds steps to use STS for 3rd-party Operators (rebased)

### DIFF
--- a/modules/olm-configuring-aws-sts.adoc
+++ b/modules/olm-configuring-aws-sts.adoc
@@ -1,0 +1,224 @@
+// Module included in the following assemblies:
+//
+// * operators/admin/olm-adding-operators-to-cluster.adoc
+// * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+// * storage/container_storage_interface/rosa-persistent-storage-aws-efs-csi.adoc
+
+ifeval::["{context}" == "olm-adding-operators-to-a-cluster"]
+:olm-generic:
+endif::[]
+ifeval::["{context}" == "persistent-storage-csi-aws-efs"]
+:csi-efs-sts:
+endif::[]
+ifeval::["{context}" == "osd-persistent-storage-aws-efs-csi"]
+:csi-efs-sts:
+endif::[]
+ifeval::["{context}" == "persistent-storage-csi-aws-efs"]
+:csi-efs-sts:
+endif::[]
+
+////
+:README:
+
+The 'olm-generic' version of this procedure is for Operators that are not known to create a `CredentialsRequest` custom resource that the user can simply copy and apply.
+
+For Operators that do create an appropriate CR, the `ifndef::olm-generic[]` steps apply.
+
+For Operators with additional special considerations, add an `ifeval` condition and include that content in a corresponding `ifdef` block (for example, the `ifdef::csi-efs-sts[]` statement below about drivers).
+////
+
+:_content-type: PROCEDURE
+[id="olm-configuring-aws-sts_{context}"]
+= Providing credentials for an Operator to use Amazon Web Services Security Token Service
+
+You can use the CCO utility (`ccoctl`) to create resources for Operators on Amazon Web Services (AWS) clusters that use the AWS Security Token Service (STS). Operators that use STS assign components IAM roles that provide short-term, limited-privilege security credentials. For more information, see "About manual mode with AWS Security Token Service".
+
+//Special considerations for the AWS EFS CSI Driver Operator
+ifdef::csi-efs-sts[]
+Perform this procedure after installing the AWS EFS CSI Operator, but before installing the AWS EFS CSI driver as part of _Installing the AWS EFS CSI Driver Operator_ procedure. If you perform this procedure after installing the driver and creating volumes, your volumes will fail to mount into pods.
+
+During installation, the AWS EFS CSI Driver Operator creates a `CredentialsRequest` custom resource (CR) named `openshift-aws-efs-csi-driver` in the `openshift-cloud-credential-operator` namespace. When you run `oc get credentialsrequest` in this procedure, use these values for `<operator_cr_name>` and `<operator_cr_namespace>`, respectively.
+endif::[]
+
+[NOTE]
+====
+By default, `ccoctl` creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this directory.
+
+Some `ccoctl` commands make AWS API calls to create or modify AWS resources. You can use the `--dry-run` flag to avoid making API calls. Using this flag creates JSON files on the local file system instead. You can review and modify the JSON files and then apply them with the AWS CLI tool using the `--cli-input-json` parameters.
+====
+
+.Prerequisites
+
+* You have an AWS cluster that is configured to use STS.
+
+* You have installed an Operator that can use STS.
+
+* You have access to the OpenShift CLI (`oc`) that matches your {product-title} version.
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Configure the `ccoctl` utility:
+
+.. Obtain the CCO container image from the {product-title} release image by running the following command:
++
+[source,terminal]
+----
+$ CCO_IMAGE=$(oc adm release info --image-for='cloud-credential-operator')
+----
+
+.. Save the contents of the cluster pull secret as a JSON file by running the following command:
++
+[source,terminal]
+----
+$ oc get secret installation-pull-secrets -n openshift-image-registry \
+  -o jsonpath="{.data.\.dockerconfigjson}" \
+  | base64 -d > pull-secret.json
+----
+
+.. Extract the `ccoctl` binary from the CCO container image by running the following command:
++
+[source,terminal]
+----
+$ oc image extract $CCO_IMAGE --file="/usr/bin/ccoctl" -a ./pull-secret.json
+----
+
+.. Change the permissions to make `ccoctl` executable by running the following command:
++
+[source,terminal]
+----
+$ chmod 775 ccoctl
+----
+
+.. Optional: Delete the pull secret file by running the following command:
++
+[source,terminal]
+----
+$ rm ./pull-secret.json
+----
+
+ifndef::olm-generic[]
+. Extract the `CredentialsRequest` custom resource (CR) that the Operator generated during installation by running the following command:
++
+[source,terminal]
+----
+$ oc get credentialsrequest \
+  -n <operator_cr_namespace> <operator_cr_name> \
+  -o yaml > <path_to_directory_with_list_of_credentials_requests>/credrequests/<operator_cr_name>.yaml
+----
+where:
++
+--
+** `<operator_cr_namespace>` is the namespace in which the Operator generates the CR.
+** `<operator_cr_name>` is the name of the CR the Operator generates.
+--
+endif::[]
+
+ifdef::olm-generic[]
+. Create a `CredentialsRequest` custom resource (CR) YAML file, such as shown in the following example. Save the file in a `credrequests` directory to be processed by `ccoctl` in a subsequent step.
++
+.Example `CredentialsRequest` custom resource
++
+[source, yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: <operator_cr_name> <1>
+  namespace: <operator_cr_namespace> <2>
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries: <3>
+    - action:
+      - iam:ListAccessKeys:*
+      effect: Allow
+      resource: 'arn:aws:s3:::*'
+  secretRef:
+    name: <operator_secret_name> <4>
+    namespace: <operator_secret_namespace> <5>
+  serviceAccountNames:
+  - <service_account_name> <6>
+----
+<1> Specify a name for the CR. For easier reference, choose a name related to the name of the Operator.
+<2> Specify a namespace for the CR. For easier reference, choose a name related to the name of the Operator.
+<3> Specify IAM JSON policy statement entries. The values in this example are provided for formatting clarification only and must be updated for the requirements of the Operator. For more information, see AWS documentation about link:https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_statement.html[IAM JSON policy elements: Statement].
+<4> Specify a name for the secret that will be used by the Operator. For easier reference, choose a name related to the name of the Operator.
+<5> Specify the namespace in which the Operator that consumes the AWS credentials is deployed. For easier reference, choose a name related to the name of the Operator.
+<6> Specify the name of the service account that is used by the Operator.
+endif::[]
+
+. Retrieve the `serviceAccountIssuer` value for your cluster by running the following command:
++
+[source, terminal]
+----
+$ oc get authentication cluster -o jsonpath --template='{ .spec.serviceAccountIssuer }'
+----
++
+.Example output
++
+[source, terminal]
+----
+https://<cluster_name>-oidc.s3.<aws_region>.amazonaws.com <1>
+----
+<1> In this example, the issuer URL is `<cluster_name>-oidc.s3.<aws_region>.amazonaws.com`, without the `https://` prefix.
+
+. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory by running the following command:
++
+[source, terminal]
+----
+$ ccoctl aws create-iam-roles \
+  --name=<name> \ //<1>
+  --region=<aws_region> \ //<2>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \ //<3>
+  --identity-provider-arn=arn:aws:iam::<aws_account_id>:oidc-provider/<issuer_URL> \ //<4>
+  --output-dir=<path_to_ccoctl_output_dir> \ //<5>
+----
+<1> Specify the name used to tag any cloud resources that are created for tracking.
+<2> Specify the AWS region in which cloud resources will be created.
+<3> Specify the path to the public key file that the `ccoctl aws create-key-pair` command generated.
+<4> Specify  your AWS account ID for `<aws_account_id>` and the `serviceAccountIssuer` value for your cluster for `<issuer_URL>`. These are standard elements of the Amazon Resource Name (ARN) for your cluster, provided here to illustrate the format of an ARN. You can obtain the ARN for your cluster's identity provider from the *Identity Providers* menu in the link:https://console.aws.amazon.com/iam/[AWS IAM console].
+<5> Optional: Specify the directory in which you want  the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
++
+The command creates an IAM role in AWS for the Operator and a corresponding `<operator_secret_namespace>-<operator_secret_name>-credentials.yaml` file in the `<path_to_ccoctl_output_dir>/manifests/` directory of the local file system.
+
+. Optional: To verify that the manifests with cloud credentials exist, list the contents of the `<path_to_ccoctl_output_dir>/manifests` directory by running the following command:
++
+[source,terminal]
+----
+$ ll <path_to_ccoctl_output_dir>/manifests
+----
++
+.Example output:
++
+[source,terminal]
+----
+-rw-------. 1 <user> <user> 306 Oct 13 16:14 <operator_secret_namespace>-<operator_secret_name>-credentials.yaml
+----
+
+. Apply the secrets to your cluster by running the following command:
++
+[source,terminal]
+----
+$ ls <path_to_ccoctl_output_dir>/manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
+----
+
+.Verification
+
+You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.
+
+ifeval::["{context}" == "olm-adding-operators-to-a-cluster"]
+:!olm-generic:
+endif::[]
+ifeval::["{context}" == "persistent-storage-csi-aws-efs"]
+:!csi-efs-sts:
+endif::[]
+ifeval::["{context}" == "osd-persistent-storage-aws-efs-csi"]
+:!csi-efs-sts:
+endif::[]
+ifeval::["{context}" == "persistent-storage-csi-aws-efs"]
+:!csi-efs-sts:
+endif::[]

--- a/modules/persistent-storage-csi-efs-sts.adoc
+++ b/modules/persistent-storage-csi-efs-sts.adoc
@@ -1,6 +1,9 @@
 // Module included in the following assemblies:
 //
 // * storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+// * storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc
+//
+// There is also an OSD version of this, modules/osd-persistent-storage-csi-efs-sts.adoc. I am updating OCP and ROSA to point to the newer procedure (Providing credentials for an Operator to use Amazon Web Services Security Token Service, modules/olm-configuring-aws-sts.adoc). I am not sure what should be done for OSD.
 
 :_content-type: PROCEDURE
 [id="efs-sts_{context}"]
@@ -8,7 +11,7 @@
 
 This procedure explains how to configure the AWS EFS CSI Driver Operator with {product-title} on AWS Security Token Service (STS).
 
-Perform this procedure before you have installed the AWS EFS CSI Operator, but not yet installed the AWS EFS CSI driver as part of the _Installing the AWS EFS CSI Driver Operator_ procedure. 
+Perform this procedure before you have installed the AWS EFS CSI Operator, but not yet installed the AWS EFS CSI driver as part of the _Installing the AWS EFS CSI Driver Operator_ procedure.
 
 [IMPORTANT]
 ====

--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -69,6 +69,13 @@ When you initiate the Operator installation, if the Operator has dependencies, t
 
 * xref:../../operators/understanding/olm/olm-understanding-dependency-resolution.adoc#olm-colocation-namespaces_olm-understanding-dependency-resolution[Colocation of Operators in a namespace]
 
+//Providing credentials for an Operator to use Amazon Web Services Security Token Service
+include::modules/olm-configuring-aws-sts.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-about[About manual mode with AWS Security Token Service]
+
 include::modules/olm-pod-placement.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+++ b/storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
@@ -39,7 +39,7 @@ include::modules/persistent-storage-efs-csi-driver-operator-setup.adoc[leveloffs
 include::modules/persistent-storage-csi-olm-operator-install.adoc[leveloffset=+2]
 .Next steps
 ifdef::openshift-rosa[]
-* If you are using {FeatureName} with AWS Secure Token Service (STS), you must configure the {FeatureName} CSI Driver with STS. For more information, see xref:../../storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc#efs-sts_osd-persistent-storage-aws-efs-csi[Configuring {FeatureName} CSI Driver with STS].
+* If you are using {FeatureName} with AWS Security Token Service (STS), you must configure the {FeatureName} CSI Driver with STS. For more information, see xref:../../storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc#efs-sts_osd-persistent-storage-aws-efs-csi[Configuring {FeatureName} CSI Driver with STS].
 endif::openshift-rosa[]
 ifdef::openshift-dedicated[]
 * xref:../../storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc#persistent-storage-csi-efs-driver-install_osd-persistent-storage-aws-efs-csi[Installing the {FeatureName} CSI Driver]

--- a/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc
@@ -34,13 +34,14 @@ include::modules/persistent-storage-efs-csi-driver-operator-setup.adoc[leveloffs
 
 include::modules/persistent-storage-csi-olm-operator-install.adoc[leveloffset=+2]
 .Next steps
-* If you are using {FeatureName} with AWS Secure Token Service (STS), you must configure the {FeatureName} CSI Driver with STS. For more information, see xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#efs-sts_persistent-storage-csi-aws-efs[Configuring AWS EFS CSI Driver with STS].
+* If you are using {FeatureName} with AWS Security Token Service (STS), you must configure the {FeatureName} CSI Driver with STS. For more information, see xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#olm-configuring-aws-sts_persistent-storage-csi-aws-efs[Providing credentials for an Operator to use Amazon Web Services Security Token Service].
 
-include::modules/persistent-storage-csi-efs-sts.adoc[leveloffset=+2]
+//Providing credentials for an Operator to use Amazon Web Services Security Token Service
+include::modules/olm-configuring-aws-sts.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-olm-operator-install_persistent-storage-csi-aws-efs[Installing the AWS EFS CSI Driver Operator]
-* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-about[About manual mode with AWS Security Token Service]
 * xref:../../storage/container_storage_interface/persistent-storage-csi-aws-efs.adoc#persistent-storage-csi-efs-driver-install_persistent-storage-csi-aws-efs[Installing the {FeatureName} CSI Driver]
 
 include::modules/persistent-storage-csi-efs-driver-install.adoc[leveloffset=+2]

--- a/storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc
+++ b/storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc
@@ -40,9 +40,10 @@ include::modules/persistent-storage-csi-olm-operator-install.adoc[leveloffset=+1
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc#efs-sts_rosa-persistent-storage-aws-efs-csi[Configuring AWS EFS CSI Driver with STS]
+* xref:../../storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc#olm-configuring-aws-sts_rosa-persistent-storage-aws-efs-csi[Providing credentials for an Operator to use Amazon Web Services Security Token Service]
 
-include::modules/persistent-storage-csi-efs-sts.adoc[leveloffset=+1]
+//Providing credentials for an Operator to use Amazon Web Services Security Token Service
+include::modules/olm-configuring-aws-sts.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
@@ -51,7 +52,7 @@ include::modules/persistent-storage-csi-efs-sts.adoc[leveloffset=+1]
 * xref:../../storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc#persistent-storage-csi-olm-operator-install_rosa-persistent-storage-aws-efs-csi[Installing the AWS EFS CSI Driver Operator]
 
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/authentication_and_authorization/index#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/authentication_and_authorization/index#sts-mode-about[About manual mode with AWS Security Token Service]
 
 :StorageClass: AWS EFS
 :Provisioner: efs.csi.aws.com


### PR DESCRIPTION
Version(s):
4.10+ for EFS-specific content (to #44136)

Issue:
[OSDOCS-4318](https://issues.redhat.com//browse/OSDOCS-4318)

Link to docs preview:
- [Configuring an Operator to use Amazon Web Services Secure Token Service](https://59158--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster.html#olm-configuring-aws-sts_olm-adding-operators-to-a-cluster) (OLM book)
- [Configuring an Operator to use Amazon Web Services Secure Token Service](https://59158--docspreview.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-aws-efs.html#olm-configuring-aws-sts_persistent-storage-csi-aws-efs) (AWS EFS CSI section)
- [Configuring an Operator to use Amazon Web Services Secure Token Service](https://59158--docspreview.netlify.app/openshift-rosa/latest/storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.html#efs-sts_osd-persistent-storage-aws-efs-csi) (ROSA AWS EFS CSI section)

QE review:
- [ ] QE has approved this change.

Additional information:
- Replaces #51541, which became too messy to rebase due to content changes.
- Since my initial attempt at this, OSD has gained a diverged version of the topic I am replacing here. Leaving OSD alone for now.