### PR TITLE
OSDOCS#5800: Adds notes for MS 4.12.14 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -185,3 +185,12 @@ Issued: 2023-04-18
 {product-title} release 4.12.13 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1753[RHBA-2023:1753] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1750[RHBA-2023:1750] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-14-dp"]
+=== RHBA-2023:1861 - {product-title} 4.12.14 bug fix update
+
+Issued: 2023-04-24
+
+{product-title} release 4.12.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1861[RHBA-2023:1861] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1858[RHBA-2023:1858] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#5800: Adds notes for MS 4.12.14 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5800

Link to docs preview:
https://59162--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-14-dp

QE review:
- [ ] QE has approved this change.
no qe needed for this PR

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
