### PR TITLE
OCPBUGS-3388: updates OVN-K configs

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -477,6 +477,11 @@ This update benefits highly specialized installations and applications that rely
 This enhancement has an interaction with the Open vSwitch hardware offloading feature.
 With this update, when the `gatewayConfig.routingViaHost` field is set to `true`, you do not receive the performance benefits of the offloading because egress traffic is processed by the host networking stack.
 
+[IMPORTANT]
+====
+To set egress traffic, use `gatewayConfig.routingViaHost` and delete the `gateway-mode-config` config map if you have set it up in the `openshift-network-operator` namespace. For more information regarding the `gateway-mode-config` solution and setting OVN-Kubernetes gateway mode in {product-title} 4.10 and higher, see the link:https://access.redhat.com/solutions/7008996[soultion].
+====
+
 For configuration information, see xref:../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration for the OVN-Kubernetes CNI cluster network provider].
 
 [id="ocp-4-10-networking-metrics"]


### PR DESCRIPTION
OCPBUGS-338: clarifies OVN-K egress traffic 
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-3388
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Preview](https://joealdinger.github.io/openshift-docs/OCPBUGS-3388/release_notes/ocp-4-10-release-notes.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @CFields651 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
