### PR TITLE
[OSDOCS-3790]: Add note about ensuring node is completely shut down.

### DIFF
--- a/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
+++ b/modules/persistent-storage-csi-vol-detach-non-graceful-shutdown-procedure.adoc
@@ -24,7 +24,12 @@ To allow volumes to detach automatically from a node after a non-graceful node s
 oc get node <node name> <1>
 ----
 <1> <node name> = name of the non-gracefully shutdown node
-
++
+[IMPORTANT]
+====
+If the node is not completely shut down, do not proceed with tainting the node. If the node is still up and the taint is applied, filesystem corruption can occur.
+====
++
 . Taint the corresponding node object by running the following command:
 +
 [source, terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
main / 4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-3790

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
No current issues for this, but having the note should help prevent/warn customers about errantly tainting their nodes and causing FS corruption. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
