### PR TITLE
OCPBUGS#11673: Confirm that the default CNI network provider is Openshift SDN

### DIFF
--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -184,7 +184,7 @@ where `<config_name>` is the name of the machine config from the `machineconfigu
 
 . Confirm that the migration succeeded:
 
-.. To confirm that the default CNI network provider is OVN-Kubernetes, enter the following command.  The value of `status.networkType` must be `OpenShiftSDN`.
+.. To confirm that the default CNI network provider is OpenShift SDN, enter the following command. The value of `status.networkType` must be `OpenShiftSDN`.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s): 4.10 only

Issue: https://issues.redhat.com/browse/OCPBUGS-11673

Link to docs preview: http://file.rdu.redhat.com/sdudhgao/410-rollback/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn.html#nw-ovn-kubernetes-rollback_rollback-to-openshift-sdn

QE review: [QE ack](https://github.com/openshift/openshift-docs/pull/58694#issuecomment-1515771638) is in the 4.11 PR
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
