### PR TITLE
OCPBUGS#12285: Update the operator library version

### DIFF
--- a/modules/osdk-operatorconditions.adoc
+++ b/modules/osdk-operatorconditions.adoc
@@ -13,7 +13,7 @@ To support Operator conditions, an Operator must be able to read the `OperatorCo
 * Get the specific condition.
 * Set the status of a specific condition.
 
-This can be accomplished by using the link:https://github.com/operator-framework/operator-lib/tree/v0.3.0[`operator-lib`] library. An Operator author can provide a link:https://github.com/kubernetes-sigs/controller-runtime/tree/master/pkg/client[`controller-runtime` client] in their Operator for the library to access the `OperatorCondition` CR owned by the Operator in the cluster.
+This can be accomplished by using the link:https://github.com/operator-framework/operator-lib/tree/v0.11.0[`operator-lib`] library. An Operator author can provide a link:https://github.com/kubernetes-sigs/controller-runtime/tree/master/pkg/client[`controller-runtime` client] in their Operator for the library to access the `OperatorCondition` CR owned by the Operator in the cluster.
 
 The library provides a generic `Conditions` interface, which has the following methods to `Get` and `Set` a `conditionType` in the `OperatorCondition` CR:
 
@@ -25,7 +25,7 @@ The Operator is allowed to modify only the `status` subresource of the CR. Opera
 
 [NOTE]
 ====
-Operator SDK v1.10.1 supports `operator-lib` v0.3.0.
+Operator SDK {osdk_ver} supports `operator-lib` v0.11.0.
 ====
 
 .Prerequisites


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-12285
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://59186--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-generating-csvs.html#osdk-operatorconditions_osdk-generating-csvs
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
