### PR TITLE
TELCODOCS-1307 - Adding crun CR to GitOps ZTP docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -173,3 +173,5 @@ endif::[]
 :osdk_ver_n1: 1.25.4
 :ztp-first: GitOps Zero Touch Provisioning (ZTP)
 :ztp: GitOps ZTP
+:3no: three-node OpenShift
+:3no-caps: Three-node OpenShift

--- a/modules/ztp-deploying-a-site.adoc
+++ b/modules/ztp-deploying-a-site.adoc
@@ -76,6 +76,17 @@ For more information about BMC addressing, see the "Additional resources" sectio
 .. You can inspect the default set of extra-manifest `MachineConfig` CRs in `out/argocd/extra-manifest`. It is automatically applied to the cluster when it is installed.
 
 .. Optional: To provision additional install-time manifests on the provisioned cluster, create a directory in your Git repository, for example, `sno-extra-manifest/`, and add your custom manifest CRs to this directory. If your `SiteConfig.yaml` refers to this directory in the `extraManifestPath` field, any CRs in this referenced directory are appended to the default set of extra manifests.
++
+.Enabling the crun OCI container runtime
+[IMPORTANT]
+====
+For optimal cluster performance, enable crun for master and worker nodes in {sno}, {sno} with additional worker nodes, {3no}, and standard clusters.
+
+Enable crun in a `ContainerRuntimeConfig` CR as an additional day-0 install-time manifest to avoid the cluster having to reboot.
+
+The `enable-crun-master.yaml` and `enable-crun-worker.yaml` CR files are in the `out/source-crs/optional-extra-manifest/` folder that you can extract from the `ztp-site-generate` container.
+For more information, see "Customizing extra installation manifests in the {ztp} pipeline".
+====
 
 . Add the `SiteConfig` CR to the `kustomization.yaml` file in the `generators` section, similar to the example shown in `out/argocd/example/siteconfig/kustomization.yaml`.
 

--- a/modules/ztp-sno-du-configuring-crun-container-runtime.adoc
+++ b/modules/ztp-sno-du-configuring-crun-container-runtime.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+
+:_content-type: CONCEPT
+[id="ztp-sno-du-configuring-crun-container-runtime_{context}"]
+= Configuring crun as the default container runtime
+
+The following `ContainerRuntimeConfig` custom resources (CRs) configure crun as the default OCI container runtime for control plane and worker nodes.
+The crun container runtime is fast and lightweight and has a low memory footprint.
+
+[IMPORTANT]
+====
+For optimal performance, enable crun for master and worker nodes in {sno}, {3no}, and standard clusters.
+To avoid the cluster rebooting when the CR is applied, apply the change as a {ztp} additional day-0 install-time manifest.
+====
+
+include::snippets/ztp-07-ztp-sno-du-configuring-crun-container-runtime-master.adoc[]
+
+include::snippets/ztp-08-ztp-sno-du-configuring-crun-container-runtime-worker.adoc[]

--- a/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
@@ -26,6 +26,8 @@ include::modules/ztp-deploying-a-site.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.adoc#ztp-customizing-the-install-extra-manifests_ztp-advanced-install-ztp[Customizing extra installation manifests in the {ztp} pipeline]
+
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster[Preparing the {ztp} site configuration repository]
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-configuring-hub-cluster-with-argocd_ztp-preparing-the-hub-cluster[Configuring the hub cluster with ArgoCD]

--- a/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
@@ -52,6 +52,8 @@ include::modules/ztp-sno-du-accelerating-container-startup.adoc[leveloffset=+2]
 
 include::modules/ztp-sno-du-enabling-kdump.adoc[leveloffset=+2]
 
+include::modules/ztp-sno-du-configuring-crun-container-runtime.adoc[leveloffset=+2]
+
 [id="ztp-sno-post-install-time-cluster-config"]
 == Recommended post-installation cluster configurations
 

--- a/snippets/ztp-07-ztp-sno-du-configuring-crun-container-runtime-master.adoc
+++ b/snippets/ztp-07-ztp-sno-du-configuring-crun-container-runtime-master.adoc
@@ -1,0 +1,15 @@
+:_content-type: SNIPPET
+.Recommended `ContainerRuntimeConfig` CR for control plane nodes
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+ name: enable-crun-master
+spec:
+ machineConfigPoolSelector:
+   matchLabels:
+     pools.operator.machineconfiguration.openshift.io/master: ""
+ containerRuntimeConfig:
+   defaultRuntime: crun
+----

--- a/snippets/ztp-08-ztp-sno-du-configuring-crun-container-runtime-worker.adoc
+++ b/snippets/ztp-08-ztp-sno-du-configuring-crun-container-runtime-worker.adoc
@@ -1,0 +1,15 @@
+:_content-type: SNIPPET
+.Recommended `ContainerRuntimeConfig` CR for worker nodes
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: ContainerRuntimeConfig
+metadata:
+ name: enable-crun-worker
+spec:
+ machineConfigPoolSelector:
+   matchLabels:
+     pools.operator.machineconfiguration.openshift.io/worker: ""
+ containerRuntimeConfig:
+   defaultRuntime: crun
+----


### PR DESCRIPTION
Adds docs for `ContainerRuntimeConfig` CR to configure crun as the the default container runtime for control plane and worker nodes.

Version(s):
openshift-4.13+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1307 

Link to docs preview:
* http://file.emea.redhat.com/aireilly/TELCODOCS-1307-CRUN-ZTP/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-du-configuring-crun-container-runtime_sno-configure-for-vdu
* http://file.emea.redhat.com/aireilly/TELCODOCS-1307-CRUN-ZTP/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.html#ztp-deploying-a-site_ztp-deploying-far-edge-sites

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
