### PR TITLE
RHDEVDOCS-5199: Correct the tile name in modules/op-uninstalling-the-…

### DIFF
--- a/modules/op-uninstalling-the-pipelines-operator.adoc
+++ b/modules/op-uninstalling-the-pipelines-operator.adoc
@@ -6,10 +6,13 @@
 [id='op-uninstalling-the-pipelines-operator_{context}']
 = Uninstalling the {pipelines-title} Operator
 
+You can uninstall the {pipelines-title} Operator by using the *Administrator* perspective in the web console.
+
 [discrete]
 .Procedure
-. From the *Operators* -> *OperatorHub* page, use the *Filter by keyword* box to search for `{pipelines-title} Operator`.
 
-. Click the *{pipelines-shortname} Operator* tile. The Operator tile indicates it is installed.
+. From the *Operators* -> *OperatorHub* page, use the *Filter by keyword* box to search for the *{pipelines-title}* Operator.
 
-. In the *{pipelines-shortname} Operator* descriptor page, click *Uninstall*.
+. Click the *{pipelines-title}* Operator tile. The Operator tile indicates that the Operator is installed.
+
+. In the *{pipelines-title}* Operator description page, click *Uninstall*.


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: `enterprise-4.10` and later
• **JIRA issue**:  [RHDEVDOCS-5199](https://issues.redhat.com/browse/RHDEVDOCS-5199)
• **Preview page**: [Uninstalling the Red Hat OpenShift Pipelines Operator](https://59194--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/uninstalling-pipelines.html#op-uninstalling-the-pipelines-operator_uninstalling-pipelines)
• **QE review**: Completed by @ppitonak 
• **Peer-review**: Completed by @shipsing 