### PR TITLE
Fixing YAML sample values

### DIFF
--- a/modules/machine-lifecycle-hook-deletion-etcd.adoc
+++ b/modules/machine-lifecycle-hook-deletion-etcd.adoc
@@ -41,7 +41,7 @@ After this transition is complete, it is safe for the old etcd pod and its data 
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
-kind: ControlPlaneMachineSet
+kind: Machine
 metadata:
   ...
 spec:

--- a/modules/machine-lifecycle-hook-deletion-format.adoc
+++ b/modules/machine-lifecycle-hook-deletion-format.adoc
@@ -12,7 +12,7 @@ The following YAML snippets demonstrate the format and placement of deletion lif
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
-kind: MachineSet
+kind: Machine
 metadata:
   ...
 spec:
@@ -29,7 +29,7 @@ spec:
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
-kind: MachineSet
+kind: Machine
 metadata:
   ...
 spec:
@@ -52,7 +52,7 @@ The following example demonstrates the implementation of multiple fictional life
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
-kind: MachineSet
+kind: Machine
 metadata:
   ...
 spec:


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[Per SME review](https://github.com/openshift/openshift-docs/pull/59032#pullrequestreview-1397653037)

Link to docs preview:
* [Deletion lifecycle hook configuration](https://59210--docspreview.netlify.app/openshift-enterprise/latest/machine_management/deleting-machine.html#machine-lifecycle-hook-deletion-format_deleting-machine)
* [Control plane deletion with quorum protection processing order](https://59210--docspreview.netlify.app/openshift-enterprise/latest/machine_management/deleting-machine.html#machine-lifecycle-hook-deletion-etcd-order_deleting-machine)

QE review:
- [ ] QE has approved this change.

Additional information:
Fixed the issue Joel found in that PR, but it applies to `main` and 4.12+ as well. Simple fix but needs QA ack from Milind.
