### PR TITLE
Updates misleading example on ONVK additional network config

### DIFF
--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -15,7 +15,10 @@ The following table describes the configuration parameters for the OVN-Kubernete
 
 |`name`
 |`string`
-|The name of the network. This value must be unique across all `NetworkAttachmentDefinitions`. Failure to make this attribute unique might result in the merging of two networks with the same name. Merging two networks by sharing similar names is unsupported.
+|The name of the network. These networks are not namespaced. For example, you can have a network named
+`l2-network` referenced from two different `NetworkAttachmentDefinitions` that exist on two different
+namespaces. This ensures that pods making use of the `NetworkAttachmentDefinition` on their own different
+namespaces can communicate over the same secondary network. However, those two different `NetworkAttachmentDefinitions` must also share the same network specific parameters such as `topology`, `subnets`, `mtu`, and `excludeSubnets`.
 
 |`type`
 |`string`
@@ -37,7 +40,8 @@ For `"topology":"layer2"` deployments, IPv6 (`2001:DBB::/64`) and dual-stack (`1
 
 |`netAttachDefName`
 |`string`
-| The namespace and the network attachment name. The value must match the values specified for `namespace` and `name` when defining the network attachment definition object. For example, `ns1/l2-network` refers to the `ns1` namespace and the `l2-network` network attachment definition name.
+|The metadata `namespace` and `name` of the network attachment definition object where this
+configuration is included. For example, if this configuration is defined in a `NetworkAttachmentDefinition` in namespace `ns1` named `l2-network`, this should be set to `ns1/l2-network`.
 
 |`excludeSubnets`
 |`string`

--- a/modules/configuring-layer-two-switched-topology.adoc
+++ b/modules/configuring-layer-two-switched-topology.adoc
@@ -19,7 +19,7 @@ The following `NetworkAttachmentDefinition` custom resource definition (CRD) YAM
 ----
     {
             "cniVersion": "0.3.1",
-            "name": "ns1-l2-network",
+            "name": "l2-network",
             "type": "ovn-k8s-cni-overlay",
             "topology":"layer2",
             "subnets": "10.100.200.0/24",


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5818

Link to docs preview:
https://59219--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#configuration-ovnk-network-plugin-json-object_configuring-additional-network

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
