### PR TITLE
OSDOCS-5797: adds 4.11.38 to RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3492,3 +3492,22 @@ $ oc adm release info 4.11.37 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-38"]
+=== RHBA-2023:1863 - {product-title} 4.11.38 bug fix update
+
+Issued: 2023-04-26
+
+{product-title} release 4.11.38 is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:1863[RHBA-2023:1863] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1862[RHBA-2023:1862] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.38 --pullspecs
+----
+
+[id="ocp-4-11-38-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5797](https://issues.redhat.com//browse/OSDOCS-5797): adds 4.11.38 to RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5797
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://59220--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-38
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
