### PR TITLE
CNV-24741: Typo fix

### DIFF
--- a/virt/virtual_machines/virt-managing-vms-openshift-pipelines.adoc
+++ b/virt/virtual_machines/virt-managing-vms-openshift-pipelines.adoc
@@ -36,7 +36,7 @@ include::modules/virt-supported-tekton-tasks.adoc[leveloffset=+1]
 
 The Tekton Tasks Operator includes the following example `Pipeline` manifests. You can run the example pipelines by using the web console or CLI.
 
-You might have to run more than one installer pipline if you need multiple versions of Windows. If you run more than one installer pipeline, each one requires unique parameters, such as the `autounattend` config map and base image name. For example, if you need Windows 10 and Windows 11 or Windows Server 2022 images, you have to run both the Windows efi installer pipeline and the Windows bios installer pipeline. However, if you need Windows 11 and Windows Server 2022 images, you have to run only the Windows efi installer pipeline.
+You might have to run more than one installer pipeline if you need multiple versions of Windows. If you run more than one installer pipeline, each one requires unique parameters, such as the `autounattend` config map and base image name. For example, if you need Windows 10 and Windows 11 or Windows Server 2022 images, you have to run both the Windows efi installer pipeline and the Windows bios installer pipeline. However, if you need Windows 11 and Windows Server 2022 images, you have to run only the Windows efi installer pipeline.
 
 Windows EFI installer pipeline:: This pipeline installs Windows 11 or Windows Server 2022 into a new data volume from a Windows installation image (ISO file). A custom answer file is used to run the installation process.
 


### PR DESCRIPTION
Version(s): 4.13


Issue: [CNV-24741](https://issues.redhat.com//browse/CNV-24741)


Link to docs preview: Fixed typo in second paragraph (from "pipline" to "pipeline")
https://59221--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-managing-vms-openshift-pipelines.html


QE review:
No QE review needed; typo fix only



