### PR TITLE
Remove vSphere IPv6 from release

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -379,11 +379,6 @@ For more information, see xref:../networking/openshift_sdn/migrate-to-openshift-
 
 The cluster network can be expanded to support the addition of nodes to the cluster. For example, if you deployed a cluster and specified `10.128.0.0/19` as the cluster network range and a host prefix of `23`, you are limited to 16 nodes. You can expand that to 510 nodes by changing the CIDR mask on a cluster to `/14`. For more information, see xref:../networking/configuring-cluster-network-range.adoc#configuring-cluster-network-range[Configuring the cluster network range].
 
-[id="ocp-4-13-dual-stack-vmware-vsphere-clusters"]
-==== Dual-stack IPv4/IPv6 on VMware vSphere clusters
-
-On installer-provisioned vSphere clusters, you can use dual-stack networking with IPv4 as the primary IP family, and IPv6 as the secondary address family. For more information, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#installation-configuration-parameters-network_installing-vsphere-installer-provisioned-network-customizations[Network configuration parameters].
-
 [id="ocp-4-13-ipv6-primary-address-family-bare-metal-dual-stack-clusters"]
 ==== IPv6 as primary IP address family on bare metal dual-stack clusters
 


### PR DESCRIPTION
Per https://issues.redhat.com/browse/OPNET-198 this is no longer included in the release.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
