### PR TITLE
Remove RHCOS Layering TP

### DIFF
--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -21,7 +21,7 @@ When you configure a custom layered image, {product-title} no longer automatical
 +
 [NOTE]
 ====
-You should use the same base {op-system} image that is installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos-8` command to obtain the base image being used in your cluster.
+You should use the same base {op-system} image that is installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos` command to obtain the base image being used in your cluster.
 ====
 +
 For example, the following Containerfile creates a custom layered image from an {product-title} 4.13 image and a Hotfix package:

--- a/post_installation_configuration/coreos-layering.adoc
+++ b/post_installation_configuration/coreos-layering.adoc
@@ -26,11 +26,8 @@ To apply a custom layered image, you create a Containerfile that references an {
 
 [NOTE]
 ====
-Use the same base {op-system} image installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos-8` command to obtain the base image used in your cluster.
+Use the same base {op-system} image installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos` command to obtain the base image used in your cluster.
 ====
-
-:FeatureName: Image layering
-include::snippets/technology-preview.adoc[]
 
 {op-system} image layering allows you to use the following types of images to create custom layered images:
 


### PR DESCRIPTION
Removing the Tech Preview snippet for RHCOS layering. Also, changed two references `rhel-coreos-8` to `rhel-coreos`. See https://issues.redhat.com/browse/OSDOCS-5139?focusedId=22154806&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-22154806 

Preview: [RHCOS image layering](https://59224--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html). Removed snippet after first note (see [current](https://docs.openshift.com/container-platform/4.12/post_installation_configuration/coreos-layering.html))

[Applying a RHCOS custom layered image](https://59224--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html#coreos-layering-configuring_coreos-layering) Edited note in the prereqs
