### PR TITLE
Fixes various asciidoctor errors and warnings

### DIFF
--- a/modules/adding-tls-termination.adoc
+++ b/modules/adding-tls-termination.adoc
@@ -21,14 +21,13 @@ You can route the traffic for the domain to pods of a service and add TLS termin
 apiVersion: networking.olm.openshift.io/v1
 kind: AWSLoadBalancerController
 metadata:
-  name: cluster <2>
+  name: cluster <1>
 spec:
   subnetTagging: auto
-  ingressClass: tls-termination <3>
+  ingressClass: tls-termination <2>
 ----
-<1> Defines the API group of the `aws-load-balancer-controller` resource.
-<2> Defines the `aws-load-balancer-controller` instance.
-<3> Defines the name of an `ingressClass` resource reconciled by the AWS Load Balancer Controller. This `ingressClass` resource gets created if it is not present. You can add additional `ingressClass` values. The controller reconciles the `ingressClass` values if the `spec.controller` is set to `ingress.k8s.aws/alb`.
+<1> Defines the `aws-load-balancer-controller` instance.
+<2> Defines the name of an `ingressClass` resource reconciled by the AWS Load Balancer Controller. This `ingressClass` resource gets created if it is not present. You can add additional `ingressClass` values. The controller reconciles the `ingressClass` values if the `spec.controller` is set to `ingress.k8s.aws/alb`.
 
 . Create an `Ingress` resource:
 +

--- a/modules/network-observability-operator-uninstall.adoc
+++ b/modules/network-observability-operator-uninstall.adoc
@@ -1,10 +1,11 @@
 // Module included in the following assemblies:
-
+//
 // * networking/network_observability/installing-operators.adoc
 
 :_content-type: PROCEDURE
 [id="network-observability-operator-uninstall_{context}"]
 = Uninstalling the Network Observability Operator
+
 You can uninstall the Network Observability Operator using the {product-title} web console Operator Hub, working in the *Operators* -> *Installed Operators* area.
 
 .Procedure

--- a/networking/network_observability/installing-operators.adoc
+++ b/networking/network_observability/installing-operators.adoc
@@ -26,5 +26,6 @@ include::modules/network-observability-operator-install.adoc[leveloffset=+1]
 * For more information about Flow Collector specifications, see the xref:../network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference] and the xref:../network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource].
 
 * For more information about exporting flow data to Kafka for third party processing consumption, see xref:../../networking/network_observability/configuring-operator.adoc#network-observability-enriched-flows-kafka_network_observability[Export enriched network flow data].
+
 include::modules/network-observability-operator-uninstall.adoc[leveloffset=+1]
 

--- a/virt/virtual_machines/virt-create-vms.adoc
+++ b/virt/virtual_machines/virt-create-vms.adoc
@@ -39,11 +39,11 @@ Refer to the virtual machine fields section when creating a VM from the web cons
 include::modules/virt-creating-vm-instancetype.adoc[leveloffset=+1]
 
 :virtualmachine:
-include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+3]
+include::modules/virt-networking-wizard-fields-web.adoc[leveloffset=+2]
 
-include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+3]
+include::modules/virt-storage-wizard-fields-web.adoc[leveloffset=+2]
 
-include::modules/virt-cloud-init-fields-web.adoc[leveloffset=+3]
+include::modules/virt-cloud-init-fields-web.adoc[leveloffset=+2]
 
 To configure storage class defaults, use storage profiles. For more information, see xref:../../virt/virtual_machines/virtual_disks/virt-creating-data-volumes.adoc#virt-customizing-storage-profile_virt-creating-data-volumes[Customizing the storage profile].
 


### PR DESCRIPTION
Version(s):
4.10+

Issue:


Link to docs preview:
[Creating a virtual machine from an instance type](http://file.rdu.redhat.com/antaylor/asciidoc-fixes/virt/virtual_machines/virt-create-vms.html#virt-creating-vm-instancetype_virt-create-vms)
[Uninstalling the Network Observability Operator](http://file.rdu.redhat.com/antaylor/asciidoc-fixes/networking/network_observability/installing-operators.html#network-observability-operator-uninstall_network_observability)

Additional information:
Fixes the following asciidoctor errors and warnings:
```
asciidoctor: WARNING: modules/adding-tls-termination.adoc: line 29: no callout found for <1>
asciidoctor: ERROR: modules/network-observability-operator-uninstall.adoc: line 7: level 0 sections can only be used when doctype is book
asciidoctor: WARNING: modules/virt-networking-wizard-fields-web.adoc: line 9: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: modules/virt-storage-wizard-fields-web.adoc: line 7: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: modules/virt-cloud-init-fields-web.adoc: line 7: section title out of sequence: expected level 2, got level 3
```
