### PR TITLE
OCPBUGS-9238: moving must-gather note

### DIFF
--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -178,7 +178,7 @@ $ oc image mirror -a ${LOCAL_SECRET_JSON} --from-dir=${REMOVABLE_MEDIA_PATH}/mir
 +
 [IMPORTANT]
 ====
-Running `oc image mirror` might result in the following error: `error: unable to retrieve source image`. This error occurs when image indexes include references to images that no longer exist on the image registry. Image indexes might retain older references to allow users running those images an upgrade path to newer points on the upgrade graph. As a temporary workaround, you can use the `--skip-missing` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed]. 
+Running `oc image mirror` might result in the following error: `error: unable to retrieve source image`. This error occurs when image indexes include references to images that no longer exist on the image registry. Image indexes might retain older references to allow users running those images an upgrade path to newer points on the upgrade graph. As a temporary workaround, you can use the `--skip-missing` option to bypass the error and continue downloading the image index. For more information, see link:https://access.redhat.com/solutions/6975305[Service Mesh Operator mirroring failed].
 ====
 
 ** If the local container registry is connected to the mirror host, take the following actions:
@@ -244,8 +244,6 @@ that you selected, you must extract the installation program from the mirrored
 content.
 
 You must perform this step on a machine with an active internet connection.
-
-If you are in a disconnected environment, use the `--image` flag as part of must-gather and point to the payload image.
 ====
 +
 . For clusters using installer-provisioned infrastructure, run the following command:

--- a/modules/support-gather-data.adoc
+++ b/modules/support-gather-data.adoc
@@ -20,7 +20,7 @@ You can gather debugging information about your cluster by using the `oc adm mus
 
 [NOTE]
 ====
-If your cluster is using a restricted network, you must take additional steps. If your mirror registry has a trusted CA, you must first add the trusted CA to the cluster. For all clusters on restricted networks, you must import the default `must-gather` image as an image stream.
+If your cluster is in a disconnected environment, you must take additional steps. If your mirror registry has a trusted CA, you must first add the trusted CA to the cluster. For all clusters in disconnected environments, you must import the default `must-gather` image as an image stream.
 
 [source,terminal]
 ----
@@ -36,13 +36,17 @@ $ oc import-image is/must-gather -n openshift
 $ oc adm must-gather
 ----
 +
-
+[IMPORTANT]
+====
+If you are in a disconnected environment, use the `--image` flag as part of must-gather and point to the payload image.
+====
++
 [NOTE]
 ====
 Because this command picks a random control plane node by default, the pod might be scheduled to a control plane node that is in the `NotReady` and `SchedulingDisabled` state.
 ====
 
-.. If this command fails, for example, if you cannot schedule a pod on your cluster, then use the `oc adm inspect` command to gather information for particular resources. 
+.. If this command fails, for example, if you cannot schedule a pod on your cluster, then use the `oc adm inspect` command to gather information for particular resources.
 +
 [NOTE]
 ====


### PR DESCRIPTION
[OCPBUGS-9238](https://issues.redhat.com/browse/OCPBUGS-9238)

Version(s):
4.10+

This PR moves a note about must gather out of mirroring documentation for disconnected installs, and into documentation for gathering data to provide to red hat support.

Link to docs preview:
https://59230--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#support_gathering_data_gathering-cluster-data

QE review:
- [ ] QE has approved this change.
