### PR TITLE
Omit IPv6 for vSphere as this is unsupported

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -335,7 +335,7 @@ ifndef::bare,vsphere[]
 Only IPv4 addresses are supported.
 endif::[]
 
-ifdef::bare,vsphere[]
+ifdef::bare[]
 * If you use the {openshift-networking} OVN-Kubernetes network plugin, both IPv4 and IPv6 address families are supported.
 
 * If you use the {openshift-networking} OpenShift SDN network plugin, only the IPv4 address family is supported.
@@ -346,19 +346,6 @@ ifdef::ibm-cloud[]
 IBM Cloud VPC does not support IPv6 address families.
 ====
 endif::ibm-cloud[]
-
-ifdef::vsphere[]
-[NOTE]
-====
-On VMware vSphere, dual-stack networking must specify IPv4 as the primary address family.
-
-The following additional limitations apply to dual-stack networking:
-
-* Nodes report only their IPv6 IP address in `node.status.addresses`
-* Nodes with only a single NIC are supported
-* Pods configured for host networking report only their IPv6 addresses in `pod.status.IP`
-====
-endif::vsphere[]
 
 If you configure your cluster to use both IP address families, review the following requirements:
 


### PR DESCRIPTION
This is not currently supported.

- https://issues.redhat.com/browse/OPNET-198

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
