### PR TITLE
OCPBUGS#8058: Rm opm index prune from disconnected install

### DIFF
--- a/installing/disconnected_install/installing-mirroring-installation-images.adoc
+++ b/installing/disconnected_install/installing-mirroring-installation-images.adoc
@@ -94,9 +94,6 @@ Mirroring Operator catalogs for use with disconnected clusters has the following
 
 * Workstation with unrestricted network access.
 * `podman` version 1.9.3 or later.
-* If you want to filter, or _prune_, the default catalog and selectively mirror only a subset of Operators, see the following sections:
-** xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[Installing the opm CLI]
-** xref:../../operators/admin/olm-restricted-networks.adoc#olm-pruning-index-image_olm-restricted-networks[Filtering a SQLite-based index image]
 ifndef::openshift-origin[]
 * If you want to mirror a Red Hat-provided catalog, run the following command on your workstation with unrestricted network access to authenticate with `registry.redhat.io`:
 +

--- a/modules/connected-to-disconnected-mirror-images.adoc
+++ b/modules/connected-to-disconnected-mirror-images.adoc
@@ -43,7 +43,7 @@ $ oc adm catalog mirror <index_image> <mirror_registry>:<port>/<namespace> -a <r
 --
 where:
 
-`index_image`:: Specifies the index image for the catalog you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
+`index_image`:: Specifies the index image for the catalog that you want to mirror.
 `mirror_registry`:: Specifies the FQDN for the target registry and namespace to mirror the Operator content to, where `<namespace>` is any existing namespace on the registry.
 `reg_creds`:: Optional: Specifies the location of your registry credentials file, if required.
 --

--- a/modules/olm-mirroring-catalog-airgapped.adoc
+++ b/modules/olm-mirroring-catalog-airgapped.adoc
@@ -28,7 +28,7 @@ $ oc adm catalog mirror \
     --insecure \ <4>
     --index-filter-by-os='<platform>/<arch>' <5>
 ----
-<1> Specify the index image for the catalog that you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
+<1> Specify the index image for the catalog that you want to mirror.
 <2> Specify the content to mirror to local files in your current directory.
 <3> Optional: If required, specify the location of your registry credentials file.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.

--- a/modules/olm-mirroring-catalog-colocated.adoc
+++ b/modules/olm-mirroring-catalog-colocated.adoc
@@ -38,13 +38,13 @@ $ oc adm catalog mirror \
     [--index-filter-by-os='<platform>/<arch>'] \ <5>
     [--manifests-only] <6>
 ----
-<1> Specify the index image for the catalog that you want to mirror. For example, this might be a pruned index image that you created previously, or one of the source index images for the default catalogs, such as `{index-image-pullspec}`.
+<1> Specify the index image for the catalog that you want to mirror.
 <2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
 <3> Optional: If required, specify the location of your registry credentials file.
 `{REG_CREDS}` is required for `registry.redhat.io`.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 <5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are passed as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, `linux/arm64`.
-<6> Optional: Generate only the manifests required for mirroring without actually mirroring the image content to a registry. This option can be useful for reviewing what will be mirrored, and lets you make any changes to the mapping list, if you require only a subset of packages. You can then use the `mapping.txt` file with the `oc image mirror` command to mirror the modified list of images in a later step. This flag is intended for only advanced selective mirroring of content from the catalog; the `opm index prune` command, if you used it previously to prune the index image, is suitable for most catalog management use cases.
+<6> Optional: Generate only the manifests required for mirroring without actually mirroring the image content to a registry. This option can be useful for reviewing what will be mirrored, and lets you make any changes to the mapping list, if you require only a subset of packages. You can then use the `mapping.txt` file with the `oc image mirror` command to mirror the modified list of images in a later step. This flag is intended for only advanced selective mirroring of content from the catalog.
 +
 .Example output
 [source,terminal,subs="attributes+"]

--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -45,7 +45,6 @@ Infrastructure features:: Disconnected
 == Prerequisites
 
 * Log in to your {product-title} cluster as a user with `cluster-admin` privileges.
-* If you want to prune the default catalog and selectively mirror only a subset of Operators, install the xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[`opm` CLI].
 
 [NOTE]
 ====
@@ -53,7 +52,6 @@ If you are using OLM in a restricted network on {ibmzProductName}, you must have
 ====
 
 include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
-include::modules/olm-pruning-index-image.adoc[leveloffset=+1]
 
 [id="olm-mirror-catalog_olm-restricted-networks"]
 == Mirroring an Operator catalog


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-8058

4.11+

The scope of this PR is to remove mention of using `opm index prune` to filter the official RH catalogs during a disconnected install, because starting in 4.11 they have been shipped in FBC format, which `prune` does not work with.

The `opm index prune` steps still exist in the [Managing custom catalogs](https://59236--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-pruning-index-image_olm-managing-custom-catalogs) topic, however, because SQLite-based catalogs are only [deprecated at this point](https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html#ocp-4-12-deprecated-removed-features), not yet fully removed.

Preview:

* [Using Operator Lifecycle Manager on restricted networks](https://59236--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html)
* [Mirroring images for a disconnected installation](https://59236--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirroring-catalog_installing-mirroring-installation-images)