### PR TITLE
OCPBUG8885: Added  'available' definition in 'understanding how to use PDBs' section.

### DIFF
--- a/modules/nodes-pods-pod-disruption-about.adoc
+++ b/modules/nodes-pods-pod-disruption-about.adoc
@@ -30,6 +30,9 @@ parts:
 
 [NOTE]
 ====
+`Available` refers to the number of pods that has condition `Ready=True`.
+`Ready=True` refers to the pod that is able to serve requests and should be added to the load balancing pools of all matching services.
+
 A `maxUnavailable` of `0%` or `0` or a `minAvailable` of `100%` or equal to the number of replicas
 is permitted but can block nodes from being drained.
 ====


### PR DESCRIPTION
Version(s): 4.10+

Issue: [OCPBUG8885](https://issues.redhat.com/browse/OCPBUGS-8885)

Link to docs preview:
[Docs Preview](https://59241--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring)

QE review:

- [ x ]  QE has approved this change.


Additional information:
