### PR TITLE
OSDOCS#5564:Adds errata links to 4.13 MS release notes

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -147,3 +147,12 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 ====
 
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {ocp-version}. Versioned asynchronous releases, for example with the form {product-title} {ocp-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
+
+[id="microshift-4-13-0-dp"]
+=== RHSA-2023:1329 - {product-title} 4.13.0 bug fix and security update
+
+Issued: 2023-05-17
+
+{product-title} release 4.13.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1329[RHSA-2023:1329] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1326[RHSA-2023:1326] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
OSDOCS#5564:Adds errata links to 4.13 MS release notes

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5564

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Links will not work until the release date
