### PR TITLE
Adds errata links to 4.13 MS release notes

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -86,7 +86,10 @@ For more information, see xref:../microshift_support/microshift-etcd.html#micros
 [id="microshift-4-13-storage"]
 === Storage
 
-* {product-title} configures LVMS dynamically based on the Volume Groups present. For more details, read the xref:../microshift_storage/microshift-storage-plugin-overview.adoc#lvms-volume-group-name_microshift-storage-plugin-overview[LVMS system requirements] section of this documentation.
+[id="microshift-4-13-lvms-system-requirements"]
+==== LVMS system requirements
+
+{product-title} configures LVMS dynamically based on the Volume Groups present. For more details, read the xref:../microshift_storage/microshift-storage-plugin-overview.adoc#lvms-volume-group-name_microshift-storage-plugin-overview[LVMS system requirements] section of this documentation.
 
 //[id="microshift-4-13-deprecated-removed-features"]
 //== Deprecated and removed features
@@ -96,7 +99,7 @@ For more information, see xref:../microshift_support/microshift-etcd.html#micros
 
 * Previously, {product-title} generated `kubeconfig` files using certificate authorities (CA) shared by all embedded components. With this update, the CAs and certificates are reconfigured to ensure the `kubeconfig` files are independent. (link:https://issues.redhat.com/browse/OCPBUGS-10223[*OCPBUGS#10223*])
 
-* Previously, the `systemd-resolved` configuration was used by kubelet as an alternative DNS resolver, but the DNS Corefile configuration did not use the same `systemd-resolved` configuration. With this update, {product-title} uses the network name resolution provided by `systemd-resolved` for both kublet and cluster DNS when the `systemd-resolved.service` is enabled. (link:https://issues.redhat.com/browse/OCPBUGS-6786[*OCPBUGS-6786*])
+* Previously, the `systemd-resolved` configuration was used by kubelet as an alternative DNS resolver, but the DNS Corefile configuration did not use the same `systemd-resolved` configuration. With this update, {product-title} uses the network name resolution provided by `systemd-resolved` for both kubelet and cluster DNS when the `systemd-resolved.service` is enabled. (link:https://issues.redhat.com/browse/OCPBUGS-6786[*OCPBUGS-6786*])
 
 //etc
 
@@ -109,7 +112,7 @@ For more information, see xref:../microshift_support/microshift-etcd.html#micros
 +
 [source, terminal]
 ----
-$ iptables-save | grep NODEPORT
+$ sudo iptables-save | grep NODEPORT
 ----
 +
 .Example output
@@ -118,7 +121,7 @@ $ iptables-save | grep NODEPORT
 -A OUTPUT -j OVN-KUBE-NODEPORT
 -A OVN-KUBE-NODEPORT -p tcp -m addrtype --dst-type LOCAL -m tcp --dport 30326 -j DNAT --to-destination 10.43.95.170:80
 ----
-OVN-Kubernetes configures the `OVN-KUBE-NODEPORT` iptable chain in the NAT table to match the destination port and Destination Network Address Translates (DNATs) the packet to the `clusterIP` service. The packet is then routed to the OVN network through the gateway bridge `br-ex` using routing rules on the host.
+OVN-Kubernetes configures the `OVN-KUBE-NODEPORT` iptable chain in the NAT table to match the packet with the destination port and Destination Network Address Translates (DNATs) the packet to the `clusterIP` service. The packet is then routed to the OVN network through the gateway bridge `br-ex` using routing rules on the host.
 +
 . View the hosts routing table by running the following command:
 +
@@ -147,3 +150,12 @@ Red Hat Customer Portal user accounts must have systems registered and consuming
 ====
 
 This section will continue to be updated over time to provide notes on enhancements and bug fixes for future asynchronous errata releases of {product-title} {ocp-version}. Versioned asynchronous releases, for example with the form {product-title} {ocp-version}.z, will be detailed in subsections. In addition, releases in which the errata text cannot fit in the space provided by the advisory will be detailed in subsections that follow.
+
+[id="microshift-4-13-0-dp"]
+=== RHSA-2023:1329 - {product-title} 4.13.0 bug fix and security update
+
+Issued: 2023-05-17
+
+{product-title} release 4.13.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1329[RHSA-2023:1329] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1326[RHSA-2023:1326] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
OSDOCS#5564:Adds errata links to 4.13 MS release notes 

includes other formatting and tweaks

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5564

Link to docs preview:
https://59244--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes.html#microshift-4-13-0-dp

QE review:
Probably still need to get a QE review with the addition of `sudo` to a command in the KI section.


Additional information:
Links will not work until the release date


