### PR TITLE
OSDOCS-5817

### DIFF
--- a/adding_service_cluster/rosa-available-services.adoc
+++ b/adding_service_cluster/rosa-available-services.adoc
@@ -24,12 +24,15 @@ include::modules/osd-rhoam.adoc[leveloffset=+1]
 .Additional resources
 * link:https://access.redhat.com/documentation/en-us/red_hat_openshift_api_management[Red Hat OpenShift API Management] documentation
 
+////
 include::modules/rosa-rhoda.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * link:https://www.redhat.com/en/technologies/cloud-computing/openshift/openshift-database-access[Red Hat OpenShift Database Access] product page
+////
+// This module and additional resource are no longer included in the document due to OSDOCS-5817.
 
 include::modules/rosa-rhods.adoc[leveloffset=+1]
 

--- a/modules/rosa-rhoda.adoc
+++ b/modules/rosa-rhoda.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * adding_service_cluster/rosa-available-services.adoc
+// This module is no longer included in the document due to OSDOCS-5817.
 :_content-type: CONCEPT
 [id="rosa-rhoda_{context}"]
 = Red Hat OpenShift Database Access


### PR DESCRIPTION
[OSDOCS-5817](https://issues.redhat.com/browse/OSDOCS-5817): Remove RHODA from ROSA docs

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.12 and enterprise-4.13
JIRA issues: [OSDOCS-5817](https://issues.redhat.com/browse/OSDOCS-5817)
Preview pages: [Click to see the build preview in your browser](https://59251--docspreview.netlify.app/openshift-rosa/latest/adding_service_cluster/rosa-available-services.html)
SME Review **completed**: @tchughesiv
QE review **completed**: @yuwang-RH / @xueli181114 
CS review **completed**: @laujohns89
DPM review **completed**: @karanthshashank
PM review **completed**: @arendej 
Product experience review **completed**: @arendej / @davemulford
Peer-review **completed**: @aldiazRH 