### PR TITLE
Bump OMR version to 3.8.6

### DIFF
--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -11,6 +11,17 @@ These release notes track the development of the _mirror registry for Red Hat Op
 
 For an overview of the _mirror registry for Red Hat OpenShift_, see xref:../../installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-flags_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift].
 
+[id="mirror-registry-for-openshift-1-3-4"]
+== Mirror registry for Red Hat OpenShift 1.3.4
+
+Issued: 2023-04-25
+
+_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.6.
+
+The following advisory is available for the _mirror registry for Red Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2023:1914[RHBA-2023:1914 - mirror registry for Red Hat OpenShift 1.3.4]
+
 [id="mirror-registry-for-openshift-1-3-3"]
 == Mirror registry for Red Hat OpenShift 1.3.3
 


### PR DESCRIPTION
Bumps OMR version to 3.8.6

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-5823

Link to docs preview:
https://59257--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html#mirror-registry-for-openshift-1-3-4

QE not needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
