### PR TITLE
OSDOCS-5821: making corrections to install from RHEL team review

### DIFF
--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -18,12 +18,14 @@ include::modules/microshift-adding-repos-to-image-builder.adoc[leveloffset=+1]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-image-builder-system-requirements_setting-up-image-builder[Image Builder system requirements].
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/setting-up-image-builder_composing-installing-managing-rhel-for-edge-images#edge-installing-image-builder_setting-up-image-builder[Installing Image Builder].
 
-include::modules/microshift-adding-service-to-blueprint.adoc[leveloffset=+2]
+include::modules/microshift-adding-service-to-blueprint.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* For further customizations such as adding users, firewall rules, or kernel arguments to a blueprint, refer to link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images#image-customizations_composing-a-rhel-for-edge-image-using-image-builder-command-line[supported image customizations].
+* For more details on creating a blueprint, read link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images#proc_creating-a-rhel-for-edge-container-image-blueprint-using-image-builder-cli_composing-a-rhel-for-edge-image-using-image-builder-command-line[creating a RHEL for Edge Container blueprint using image builder CLI].
+* For further customizations such as adding users, firewall rules, or kernel arguments to a blueprint, read link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images#image-customizations_composing-a-rhel-for-edge-image-using-image-builder-command-line[supported image customizations].
+* For more about the composer cli, read https://www.osbuild.org/guides/user-guide/building-an-image-from-cli.html?highlight=push%20bluepring#blueprints-management-using-composer-cli[blueprint management using composer cli].
 
 //include::modules/microshift-adding-containers-to-blueprint.adoc[leveloffset=+2]
 include::modules/microshift-provisioning-ostree.adoc[leveloffset=+1]

--- a/modules/microshift-adding-repos-to-image-builder.adoc
+++ b/modules/microshift-adding-repos-to-image-builder.adoc
@@ -19,7 +19,7 @@ Use the following procedure to add the {product-title} repositories to Image Bui
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo subscription-manager repos
-    --enable rhocp-{ocp-version}-for-{rhel-major}-$(uname -i)-rpms
+$ sudo subscription-manager repos \
+    --enable rhocp-{ocp-version}-for-{rhel-major}-$(uname -i)-rpms \
     --enable fast-datapath-for-{rhel-major}-$(uname -i)-rpms
 ----

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: CONCEPT
 [id="adding-{product-title}-service_{context}"]
-= Adding the {product-title} service
+= Example Image Builder blueprint with {product-title}
 
-Add the {product-title} RPM package to a blueprint and enable the {product-title} service to build an {op-system-ostree} image with {product-title}.
+Adding the {product-title} RPM package to an Image Builder blueprint enables the build of a {op-system-ostree} image with {product-title} embedded.
 
 .Image Builder blueprint example
 

--- a/modules/microshift-configuration.adoc
+++ b/modules/microshift-configuration.adoc
@@ -26,11 +26,15 @@ etcd:
 .Verification
 
 . After modifying the `memoryLimitMB` value in `/etc/microshift/config.yaml`, restart {product-title} by running the following command:
++
+[source, terminal]
 ----
 $ sudo systemctl restart microshift
 ----
 
 . Verify the new `memoryLimitMB` value is in use by running the following command:
++
+[source, terminal]
 ----
-$ systemctl status microshift
+$ systemctl show --property=MemoryHigh microshift-etcd.scope
 ----

--- a/modules/microshift-install-rpms.adoc
+++ b/modules/microshift-install-rpms.adoc
@@ -38,7 +38,7 @@ $ sudo dnf install -y microshift
 $ sudo dnf install -y microshift-greenboot
 ----
 
-. Download your installation pull secret from the Red Hat Hybrid Cloud Console to a temporary folder, for example, `$HOME/openshift-pull-secret`. This pull secret allows you to authenticate with the container registries that serve the container images used by {product-title}.
+. Download your installation pull secret from the https://console.redhat.com/openshift/install/pull-secret[Red Hat Hybrid Cloud Console] to a temporary folder, for example, `$HOME/openshift-pull-secret`. This pull secret allows you to authenticate with the container registries that serve the container images used by {product-title}.
 
 . To copy the pull secret to the `/etc/crio` folder of your {op-system} machine, run the following command:
 +

--- a/modules/microshift-provisioning-ostree.adoc
+++ b/modules/microshift-provisioning-ostree.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="provisioning-a-machine_{context}"]
-= Provisioning for {product-title}
+= Provisioning a machine for {product-title}
 
 Provision a machine with your {op-system-ostree} image by using the procedures from the {op-system-ostree} documentation.
 
@@ -12,17 +12,18 @@ To use {product-title}, you must provision the system so that it meets the follo
 
 * The machine you are provisioning must meet the system requirements for installing {product-title}.
 * The file system must have a logical volume manager (LVM) volume group (VG) with sufficient capacity for the persistent volumes (PVs) of your workload.
-* A pull secret from the Red Hat Hybrid Cloud Console must be present as `/etc/crio/openshift-pull-secret` and have root user-only read/write permissions.
+* A pull secret from the https://console.redhat.com/openshift/install/pull-secret[Red Hat Hybrid Cloud Console] must be present as `/etc/crio/openshift-pull-secret` and have root user-only read/write permissions.
 * The firewall must be configured with {product-title}'s required firewall settings.
 
 [NOTE]
 ====
-If you are using a Kickstart such as the {op-system-ostree} Installer (iso) image, you can update your Kickstart file to meet the above requirements.
+If you are using a Kickstart such as the {op-system-ostree} Installer (ISO) image, you can update your Kickstart file to meet the provisioning requirements.
 ====
 
 .Prerequisites
 
 . You have created an {op-system-ostree} Installer (ISO) image containing your {op-system-ostree} commit with {product-title}.
+.. This requirement includes the steps of composing an RFE Container image, creating the RFE Installer blueprint, starting the RFE container, and composing the RFE Installer image.
 . Create a Kickstart file or use an existing one. In the Kickstart file, you must include:
 .. Detailed instructions about how to create a user.
 .. How to fetch and deploy the {op-system-ostree} image.
@@ -49,6 +50,8 @@ For more information, see "Additional resources."
 # └─sda2          8:2    0  19G  0 part
 #  └─rhel-root  253:0    0  10G  0 lvm  /sysroot
 #
+ostreesetup --nogpg --osname=rhel --remote=edge
+--url=file:///run/install/repo/ostree/repo --ref=rhel/<RHEL VERSION NUMBER>/x86_64/edge
 zerombr
 clearpart --all --initlabel
 part /boot/efi --fstype=efi --size=200
@@ -58,6 +61,10 @@ part /boot --fstype=xfs --asprimary --size=800
 part pv.01 --grow
 volgroup rhel pv.01
 logvol / --vgname=rhel --fstype=xfs --size=10000 --name=root
+# To add users, use a line such as the following
+user --name=user \
+--password=$6$HFVVV521NB4kOKVG$0.hM652uIOBNsC45kvFpMuRVkfNGHToMdQ6PDTU8DcEF30Gz/3DUwW153Gc9EvNMkH50qYfBO5os/FJsXTLLt. \
+--iscrypted --groups=wheel
 ----
 
 . In the `%post` section of the Kickstart file, add your pull secret and the mandatory firewall rules.


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5821

Link to docs preview:
https://59282--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#adding-MicroShift-repos-image-builder_microshift-embed-in-rpm-ostree
https://59282--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#provisioning-a-machine_microshift-embed-in-rpm-ostree
https://59282--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#installing-microshift-from-rpm-package_microshift-install-rpm

QE review:
- [x] QE has approved this change.


Additional information:
Go to the Jira issue to read the linked Google doc for the background of this PR.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
