### PR TITLE
ML-RHDEVDOCS-5097:Added OCP v4.13 to GitOps v1.8.2 RN for the upcoming OCP v4.13 release.

### DIFF
--- a/modules/gitops-release-notes-1-8-2.adoc
+++ b/modules/gitops-release-notes-1-8-2.adoc
@@ -5,7 +5,7 @@
 [id="gitops-release-notes-1-8-2_{context}"]
 = Release notes for {gitops-title} 1.8.2
 
-{gitops-title} 1.8.2 is now available on {product-title} 4.10, 4.11, and 4.12.
+{gitops-title} 1.8.2 is now available on {product-title} 4.10, 4.11, 4.12, and 4.13.
 
 [id="fixed-issues-1-8-2_{context}"]
 == Fixed issues


### PR DESCRIPTION
• JIRA issue: [RHDEVDOCS-5097](https://issues.redhat.com/browse/RHDEVDOCS-5097)
• Aligned team: DevTools
• OCP version for cherry-picking: enterprise-4.10 and later
• Preview page: [gitops-release-notes-1-8-2](https://59284--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-8-2_gitops-release-notes)
• SME Review: @jaideepr97
• QE review: @varshab1210 
• Peer-review: @Srivaralakshmi and @ekristova 