### PR TITLE
TELCODOCS-948: Merge PAO logs in OCP must-gather

### DIFF
--- a/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
+++ b/modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support.adoc
@@ -25,43 +25,16 @@ The `oc adm must-gather` CLI command collects the information from your cluster 
 You can specify one or more images when you run the command by including the `--image` argument. When you specify an image, the tool collects data related to that feature or product. When you run `oc adm must-gather`, a new pod is created on the cluster. The data is collected on that pod and saved in a new directory that starts with `must-gather.local`. This directory is created in your current working directory.
 
 [id="cnf-about-collecting-low-latency-data_{context}"]
-== About collecting low latency tuning data
+== Gathering low latency tuning data
 
 Use the `oc adm must-gather` CLI command to collect information about your cluster, including features and objects associated with low latency tuning, including:
 
 * The Node Tuning Operator namespaces and child objects.
 * `MachineConfigPool` and associated `MachineConfig` objects.
 * The Node Tuning Operator and associated Tuned objects.
-* Linux Kernel command line options.
+* Linux kernel command line options.
 * CPU and NUMA topology
 * Basic PCI device information and NUMA locality.
-
-To collect debugging information with `must-gather`, you must specify the Performance Addon Operator `must-gather` image:
-
-[source,terminal,subs="attributes+"]
-----
---image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8:v{product-version}.
-----
-
-[NOTE]
-====
-In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
-====
-
-[id="cnf-about-gathering-data_{context}"]
-== Gathering data about specific features
-
-You can gather debugging information about specific features by using the `oc adm must-gather` CLI command with the `--image` or `--image-stream` argument. The `must-gather` tool supports multiple images, so you can gather data about more than one feature by running a single command.
-
-[NOTE]
-====
-To collect the default `must-gather` data in addition to specific feature data, add the `--image-stream=openshift/must-gather` argument.
-====
-
-[NOTE]
-====
-In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11, these functions are part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
-====
 
 .Prerequisites
 
@@ -72,26 +45,55 @@ In earlier versions of {product-title}, the Performance Addon Operator provided 
 
 . Navigate to the directory where you want to store the `must-gather` data.
 
-. Run the `oc adm must-gather` command with one or more `--image` or `--image-stream` arguments. For example, the following command gathers both the default cluster data and information specific to the Node Tuning Operator:
+. Collect debugging information by running the following command:
 +
-[source,terminal,subs="attributes+"]
+[source,terminal]
 ----
-$ oc adm must-gather \
- --image-stream=openshift/must-gather \ <1>
+$ oc adm must-gather
+----
++
+.Example output
++
+[source,terminal]
+----
+[must-gather      ] OUT Using must-gather plug-in image: quay.io/openshift-release
+When opening a support case, bugzilla, or issue please include the following summary data along with any other requested information:
+ClusterID: 829er0fa-1ad8-4e59-a46e-2644921b7eb6
+ClusterVersion: Stable at "<cluster_version>"
+ClusterOperators:
+	All healthy and stable
 
- --image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8:v{product-version} <2>
+
+[must-gather      ] OUT namespace/openshift-must-gather-8fh4x created
+[must-gather      ] OUT clusterrolebinding.rbac.authorization.k8s.io/must-gather-rhlgc created
+[must-gather-5564g] POD 2023-07-17T10:17:37.610340849Z Gathering data for ns/openshift-cluster-version...
+[must-gather-5564g] POD 2023-07-17T10:17:38.786591298Z Gathering data for ns/default...
+[must-gather-5564g] POD 2023-07-17T10:17:39.117418660Z Gathering data for ns/openshift...
+[must-gather-5564g] POD 2023-07-17T10:17:39.447592859Z Gathering data for ns/kube-system...
+[must-gather-5564g] POD 2023-07-17T10:17:39.803381143Z Gathering data for ns/openshift-etcd...
+
+...
+
+Reprinting Cluster State:
+When opening a support case, bugzilla, or issue please include the following summary data along with any other requested information:
+ClusterID: 829er0fa-1ad8-4e59-a46e-2644921b7eb6
+ClusterVersion: Stable at "<cluster_version>"
+ClusterOperators:
+	All healthy and stable
 ----
-+
-<1> The default {product-title} `must-gather` image.
-<2> The `must-gather` image for low latency tuning diagnostics.
 
 . Create a compressed file from the `must-gather` directory that was created in your working directory. For example, on a computer that uses a Linux operating system, run the following command:
 +
 [source,terminal]
 ----
- $ tar cvaf must-gather.tar.gz must-gather.local.5421342344627712289/ <1>
+$ tar cvaf must-gather.tar.gz must-gather-local.5421342344627712289// <1>
 ----
 +
-<1> Replace `must-gather-local.5421342344627712289/` with the actual directory name.
+<1> Replace `must-gather-local.5421342344627712289//` with the directory name created by the `must-gather` tool. 
++
+[NOTE]
+====
+Create a compressed file to attach the data to a support case or to use with the Performance Profile Creator wrapper script when you create a performance profile.
+====
 
 . Attach the compressed file to your support case on the link:https://access.redhat.com/[Red Hat Customer Portal].

--- a/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
+++ b/modules/cnf-gathering-data-about-cluster-using-must-gather.adoc
@@ -8,15 +8,9 @@
 
 The Performance Profile Creator (PPC) tool requires `must-gather` data. As a cluster administrator, run the `must-gather` command to capture information about your cluster.
 
-[NOTE]
-====
-In earlier versions of {product-title}, the Performance Addon Operator provided automatic, low latency performance tuning for applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator. However, you must still use the `performance-addon-operator-must-gather` image when running the `must-gather` command.
-====
-
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
-* Access to the Performance Addon Operator `must gather` image.
 * The OpenShift CLI (`oc`) installed.
 
 .Procedure
@@ -45,27 +39,21 @@ $ oc label mcp <mcp_name> <mcp_name>=""
 
 . Navigate to the directory where you want to store the `must-gather` data.
 
-. Run `must-gather` on your cluster:
+. Collect cluster information by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm must-gather --image=<PAO_must_gather_image> --dest-dir=<dir>
+$ oc adm must-gather
 ----
-+
-[NOTE]
-====
-The `must-gather` command must be run with the `performance-addon-operator-must-gather` image. The output can optionally be compressed. Compressed output is required if you are running the Performance Profile Creator wrapper script.
-====
-+
-.Example
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc adm must-gather --image=registry.redhat.io/openshift4/performance-addon-operator-must-gather-rhel8:v{product-version} --dest-dir=<path_to_must-gather>/must-gather
-----
-. Create a compressed file from the `must-gather` directory:
+
+. Optional: Create a compressed file from the `must-gather` directory:
 +
 [source,terminal]
 ----
 $ tar cvaf must-gather.tar.gz must-gather/
 ----
++
+[NOTE]
+====
+Compressed output is required if you are running the Performance Profile Creator wrapper script.
+====

--- a/modules/cnf-understanding-low-latency.adoc
+++ b/modules/cnf-understanding-low-latency.adoc
@@ -6,8 +6,7 @@
 [id="cnf-understanding-low-latency_{context}"]
 = Understanding low latency
 
-The emergence of Edge computing in the area of Telco / 5G plays a key role in
-reducing latency and congestion problems and improving application performance.
+The emergence of Edge computing in the area of Telco / 5G plays a key role in reducing latency and congestion problems and improving application performance.
 
 Simply put, latency determines how fast data (packets) moves from the sender to receiver and returns to the sender after processing by the receiver. Maintaining a network architecture with the lowest possible delay of latency speeds is key for meeting the network performance requirements of 5G. Compared to 4G technology, with an average latency of 50 ms, 5G is targeted to reach latency numbers of 1 ms or less. This reduction in latency boosts wireless throughput by a factor of 10.
 
@@ -38,4 +37,3 @@ In an ideal world, all of those would be prioritized: in real life, some come at
 
 The environment in which an application is operating influences its behavior. For a typical data center with no strict latency requirements, only minimal default tuning is needed that enables CPU partitioning for some high performance workload pods. For data centers and workloads where latency is a higher priority, measures are still taken to optimize power consumption. The most complicated cases are clusters close to latency-sensitive equipment such as manufacturing machinery and software-defined radios. This last class of deployment is often referred to as Far edge. For Far edge deployments, ultra-low latency is the ultimate priority, and is achieved at the expense of power management.
 
-In {product-title} version 4.10 and previous versions, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance. Now this functionality is part of the Node Tuning Operator.

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -81,6 +81,8 @@ include::modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-su
 [role="_additional-resources"]
 .Additional resources
 
+* For more information about the `must-gather` tool, see xref:../support/gathering-cluster-data.adoc#gathering-cluster-data[Gathering data about your cluster]
+
 * For more information about MachineConfig and KubeletConfig,
 see xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[Managing nodes].
 


### PR DESCRIPTION
[TELCODOCS-948](https://issues.redhat.com//browse/TELCODOCS-948): PAO had a separate must-gather to aid debugging. This will be merged into the OCP must-gather so all PAO and low latency info for nodes will be included in the OCP must-gather. Removing/refactoring instances referring to the old PAO must-gather

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-948

Link to docs preview:
- https://59307--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support_cnf-master
- https://59307--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-create-performance-profiles.html#gathering-data-about-your-cluster-using-must-gather_cnf-create-performance-profiles

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

