### PR TITLE
OSDOCS-4972-RN: adds OVN-K as secondary network to RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -399,6 +399,18 @@ For more information, refer to the following sources:
 * Installer-provisioned infrastructure: xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow[Deploying with dual-stack networking]
 * User-provisioned infastructure: xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-configuration-parameters-network_installing-bare-metal-network-customizations[Network configuration parameters]
 
+[id="ocp-4-13-ovn-kubernetes-plugin-secondary-network"]
+==== OVN-Kubernetes is available as a secondary network
+
+You can configure the OVN-Kubernetes network plugin as a Multus additional network attachment definition. As a secondary network, OVN-Kubernetes supports the following configurations:
+
+- Layer 3, routed topology
+- Layer 2, switched topology
+
+// TODO add link
+//For more information on OVN-Kubernetes as a secondary network, see
+For more information on Multus, see xref:../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[Understanding multiple networks].
+
 [id="ocp-4-13-storage"]
 === Storage
 
@@ -1304,6 +1316,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Multi-network policies for SR-IOV networks
+|Not Available
+|Not Available
+|Technology Preview
+
+|OVN-Kubernetes network plugin as secondary network
 |Not Available
 |Not Available
 |Technology Preview


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-4972
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
