### PR TITLE
OCPBUGS-7536: no csr generated in multi-node-cluster (3 master) per 4.12. step 10 Approving CSRs

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -203,6 +203,11 @@ $ sudo systemctl restart kubelet.service
 .. Repeat this step on all other control plane hosts.
 
 . Approve the pending CSRs:
++
+[NOTE]
+====
+Clusters with no worker nodes, such as single-node clusters or clusters consisting of three schedulable control plane nodes, will not have any pending CSRs to approve. In those scenarios, you can skip this step.
+====
 
 .. Get the list of current CSRs:
 +


### PR DESCRIPTION
Added a note indicating that certain clusters will not have CSRs to approve.

Fixes: OCPBUGS-7536
See https://issues.redhat.com/browse/OCPBUGS-7536 for additional details.
Preview URL: http://jowilkin.com:8080/OCPBUGS-7536/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html


For release(s): 4.13, 4.12

QE Review:
- [x] QE has approved this change.

Signed-off-by: John Wilkins <jowilkin@redhat.com>