### PR TITLE
OSDOCS-5890 Zstream release notes for 4.11.39

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3511,3 +3511,26 @@ $ oc adm release info 4.11.38 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-11-39"]
+=== RHSA-2023:2014 - {product-title} 4.11.39 bug fix and security update
+
+Issued: 2023-05-02
+
+{product-title} release 4.11.39, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:2014[RHSA-2023:2014] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2056[RHBA-2023:2056] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.39 --pullspecs
+----
+
+[id="ocp-4-11-39-bug-fixes"]
+==== Bug fixes
+* Previously, the Ingress Operator failed to publish the `router-certs` secret on a cluster with a high number of Ingress Controllers because of the secret size limit of 1 MB. Consequently, the Authentication Operator, which uses the `router-certs` secret to access the cluster Ingress domain, might not have had the latest certificate to use for OAuth purposes. With this update, the Ingress Operator publishes the certificate and key only for the Ingress Controller that owns the cluster Ingress domain, so that the secret does not exceed the size limit. This update ensures that the Authentication Operator can read and use an up-to-date certificate for OAuth authentication. (link:https://issues.redhat.com/browse/OCPBUGS-8000[*OCPBUGS-8000*])
+
+[id="ocp-4-11-39-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OSDOCS-5890

Link to docs preview:
[Preview](https://59329--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-39)

Additional information:
Z-stream release notes for 4.11.39. [OSDOCS-5890](https://issues.redhat.com/browse/OSDOCS-5890)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
