### PR TITLE
Adds OVNK secondary network release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -399,6 +399,13 @@ For more information, refer to the following sources:
 * Installer-provisioned infrastructure: xref:../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow[Deploying with dual-stack networking]
 * User-provisioned infastructure: xref:../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-configuration-parameters-network_installing-bare-metal-network-customizations[Network configuration parameters]
 
+[id="ocp-4-13-ovn-kubernetes-plugin-secondary-network"]
+==== OVN-Kubernetes is available as a secondary network (Technology Preview)
+
+With this release, the {openshift-networking} OVN-Kubernetes network plug-in allows the configuration of secondary network interfaces for pods. As a secondary network, OVN-Kubernetes supports a layer 2 (switched) topology network. This is available as a Technology Preview feature.
+
+For more information about OVN-Kubernetes as a secondary network, see xref:../networking/multiple_networks/configuring-additional-network.html#configuration-ovnk-additional-networks_configuring-additional-network[Configuration for an OVN-Kubernetes additional network].
+
 [id="ocp-4-13-storage"]
 === Storage
 
@@ -1304,6 +1311,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Multi-network policies for SR-IOV networks
+|Not Available
+|Not Available
+|Technology Preview
+
+|OVN-Kubernetes network plugin as secondary network
 |Not Available
 |Not Available
 |Technology Preview


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5892

Link to docs preview:
https://59330--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-ovn-kubernetes-plugin-secondary-network

QE not needed. Release note follow up to https://github.com/openshift/openshift-docs/pull/56657

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
