### PR TITLE
OSDOCS#5326: Added warning regarding rollbacks specific to TALM/SNO

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-backup-recovery.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-backup-recovery.adoc
@@ -9,6 +9,12 @@
 If an upgrade of a cluster fails, you can manually log in to the cluster and use the backup to return the cluster to its preupgrade state. There are two stages:
 
 Rollback:: If the attempted upgrade included a change to the platform OS deployment, you must roll back to the previous version before running the recovery script.
+
+[IMPORTANT]
+====
+A rollback is only applicable to upgrades from TALM and single-node OpenShift. This process does not apply to rollbacks from any other upgrade type.
+====
+
 Recovery:: The recovery shuts down containers and uses files from the backup partition to relaunch containers and restore clusters.
 
 .Prerequisites


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-5326

Link to docs preview:
https://59332--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-talm-for-cluster-upgrades.html#talo-backup-recovery_cnf-topology-aware-lifecycle-manager

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
