### PR TITLE
OSDOCS-5544: documenting signature digest extraction

### DIFF
--- a/modules/update-restricted-image-digests.adoc
+++ b/modules/update-restricted-image-digests.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * updating/updating-restricted-network-cluster/restricted-network-update.adoc
+
+:_content-type: PROCEDURE
+[id="update-restricted-image-digests_{context}"]
+= Retrieving a release image digest
+
+In order to update a cluster in a disconnected environment using the `oc adm upgrade` command with the `--to-image` option, you must reference the sha256 digest that corresponds to your targeted release image.
+
+.Procedure
+
+. Run the following command on a device that is connected to the internet:
++
+[source,terminal]
+----
+$ oc adm release info -o 'jsonpath={.digest}{"\n"}' quay.io/openshift-release-dev/ocp-release:${OCP_RELEASE_VERSION}-${ARCHITECTURE}
+----
++
+For `{OCP_RELEASE_VERSION}`, specify the version of {product-title} to which you want to update, such as `4.10.16`.
++
+For `{ARCHITECTURE}`, specify the architecture of the cluster, such as `x86_64`, `aarch64`, `s390x`, or `ppc64le`.
++
+.Example output
+[source,terminal]
+----
+sha256:a8bfba3b6dddd1a2fbbead7dac65fe4fb8335089e4e7cae327f3bad334add31d
+----
+
+. Copy the sha256 digest for use when updating your cluster.

--- a/modules/update-restricted.adoc
+++ b/modules/update-restricted.adoc
@@ -19,9 +19,9 @@ If you have a local OpenShift Update Service, you can update by using the connec
 
 * You mirrored the images for the new release to your registry.
 * You applied the release image signature ConfigMap for the new release to your cluster.
-* You obtained the sha256 sum value for the release from the image signature ConfigMap.
-* Install the OpenShift CLI (`oc`).
-* Pause all `MachineHealthCheck` resources.
+* You obtained the sha256 digest for your targeted release image.
+* You installed the OpenShift CLI (`oc`).
+* You paused all `MachineHealthCheck` resources.
 
 .Procedure
 
@@ -29,9 +29,9 @@ If you have a local OpenShift Update Service, you can update by using the connec
 +
 [source,terminal]
 ----
-$ oc adm upgrade --allow-explicit-upgrade --to-image ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}<sha256_sum_value> <1>
+$ oc adm upgrade --allow-explicit-upgrade --to-image ${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}@<digest> <1>
 ----
-<1> The `<sha256_sum_value>` value is the sha256 sum value for the release from the image signature ConfigMap, for example, `@sha256:81154f5c03294534e1eaf0319bef7a601134f891689ccede5d705ef659aa8c92`
+<1> The `<digest>` value is the sha256 digest for the targeted release image, for example, `sha256:81154f5c03294534e1eaf0319bef7a601134f891689ccede5d705ef659aa8c92`
 +
 If you use an `ImageContentSourcePolicy` for the mirror registry, you can use the canonical registry name instead of `LOCAL_REGISTRY`.
 +

--- a/updating/updating-restricted-network-cluster/restricted-network-update.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update.adoc
@@ -26,6 +26,8 @@ If you run an Operator or you have configured any application with the pod disru
 
 include::modules/machine-health-checks-pausing.adoc[leveloffset=+1]
 
+include::modules/update-restricted-image-digests.adoc[leveloffset=+1]
+
 include::modules/update-restricted.adoc[leveloffset=+1]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-5544](https://issues.redhat.com/browse/OSDOCS-5544)

Version(s): 4.10+

This PR adds documentation on how users can acquire the sha256 digest that corresponds to a given release image, which is necessary for users who want to update their disconnected clusters without using an update service.

QE review:
- [x] QE has approved this change.

Preview: https://59341--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-restricted-network-cluster/restricted-network-update.html#update-restricted-signature-digests_updating-restricted-network-cluster
