### PR TITLE
CMA Adding 2.10.1 Release Notes

### DIFF
--- a/modules/nodes-pods-autoscaling-custom-rn-210.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn-210.adoc
@@ -1,0 +1,86 @@
+// Module included in the following assemblies:
+//
+// * nodes/nodes-pods-autoscaling-custom.adoc
+
+:_content-type: CONCEPT
+[id="nodes-pods-autoscaling-custom-rn_{context}"]
+= Custom Metrics Autoscaler Operator release notes
+
+The release notes for the Custom Metrics Autoscaler Operator for Red Hat OpenShift describe new features and enhancements, deprecated features, and known issues.
+
+The Custom Metrics Autoscaler Operator uses the Kubernetes-based Event Driven Autoscaler (KEDA) and is built on top of the {product-title} horizontal pod autoscaler (HPA).
+
+[NOTE]
+====
+The Custom Metrics Autoscaler Operator for Red Hat OpenShift is provided as an installable component, with a distinct release cycle from the core {product-title}. The link:https://access.redhat.com/support/policy/updates/openshift#cma[Red Hat OpenShift Container Platform Life Cycle Policy] outlines release compatibility.
+====
+
+[id="nodes-pods-autoscaling-custom-rn-versions_{context}"]
+== Supported versions
+
+The following table defines the Custom Metrics Autoscaler Operator versions for each {product-title} version.
+
+[cols="3,7,3",options="header"]
+|===
+|Version
+|{product-title} version
+|General availability
+
+|2.10
+|4.13
+|General availability
+
+|2.10
+|4.12
+|General availability
+
+|2.10
+|4.11
+|General availability
+
+|2.10
+|4.10
+|General availability
+|===
+
+[id="nodes-pods-autoscaling-custom-rn-210_{context}"]
+== Custom Metrics Autoscaler Operator 2.10 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.10 provides new features and bug fixes for running the Operator in an {product-title} cluster. The components of the Custom Metrics Autoscaler Operator 2.10 were released in link:https://access.redhat.com/errata/RHEA-:[RHEA-:].
+
+[id="nodes-pods-autoscaling-custom-rn-210-new_{context}"]
+=== New features and enhancements
+
+[id="nodes-pods-autoscaling-custom-rn-210-ga_{context}"]
+==== Custom Metrics Autoscaler Operator general availability 
+
+The Custom Metrics Autoscaler Operator is now generally available as of Custom Metrics Autoscaler Operator version 2.10. 
+
+:FeatureName: Scaling by using a scaled job
+include::snippets/technology-preview.adoc[]
+
+[id="nodes-pods-autoscaling-custom-rn-210-metrics_{context}"]
+==== Custom Metrics Autoscaler Operator metrics
+
+You can now use the Prometheus Query Language (PromQL) to query metrics from the Custom Metrics Autoscaler Operator. 
+
+[id="nodes-pods-autoscaling-custom-rn-210-pause_{context}"]
+==== Pausing the custom metrics autoscaling for scaled objects
+
+You can now pause the autoscaling of a scaled object, as needed, and resume autoscaling when ready.
+
+[id="nodes-pods-autoscaling-custom-rn-210-fall-back_{context}"]
+==== Replica fall back for scaled objects
+
+You can now specify the number of replicas to fall back to if a scaled object fails to get metrics from the source.
+
+[id="nodes-pods-autoscaling-custom-rn-210-hpa-name_{context}"]
+==== Customizable HPA naming for scaled objects
+
+You can now specify a custom name for the horizontal pod autoscaler in scaled objects.
+
+[id="nodes-pods-autoscaling-custom-rn-210-activation_{context}"]
+==== Activation and scaling thresholds
+
+Because the horizontal pod autoscaler (HPA) cannot scale to or from 0 replicas, the Custom Metrics Autoscaler Operator does that scaling, after which the HPA performs the scaling. You can now specify when the HPA takes over autoscaling, based on the number of replicas. This allows for more flexibility with your scaling policies.
+

--- a/modules/nodes-pods-autoscaling-custom-rn.adoc
+++ b/modules/nodes-pods-autoscaling-custom-rn.adoc
@@ -3,44 +3,8 @@
 // * nodes/nodes-pods-autoscaling-custom.adoc
 
 :_content-type: CONCEPT
-[id="nodes-pods-autoscaling-custom-rn_{context}"]
-= Custom Metrics Autoscaler Operator release notes
-
-The release notes for the Custom Metrics Autoscaler Operator for Red Hat Openshift describe new features and enhancements, deprecated features, and known issues.
-
-The Custom Metrics Autoscaler Operator uses the Kubernetes-based Event Driven Autoscaler (KEDA) and is built on top of the {product-title} horizontal pod autoscaler (HPA).
-
-[NOTE]
-====
-The Custom Metrics Autoscaler Operator for Red Hat OpenShift is provided as an installable component, with a distinct release cycle from the core {product-title}. The link:https://access.redhat.com/support/policy/updates/openshift#cma[Red Hat OpenShift Container Platform Life Cycle Policy] outlines release compatibility.
-====
-
-[id="nodes-pods-autoscaling-custom-rn-versions_{context}"]
-== Supported versions
-
-The following table defines the Custom Metrics Autoscaler Operator versions for each {product-title} version.
-
-[cols="3,7,3",options="header"]
-|===
-|Version
-|{product-title} version
-|General availability
-
-|2.8.2-174
-|4.12
-|Technology Preview
-
-|2.8.2-174
-|4.11
-|Technology Preview
-
-|2.8.2-174
-|4.10
-|Technology Preview
-|===
-
 [id="nodes-pods-autoscaling-custom-rn-282-174_{context}"]
-== Custom Metrics Autoscaler Operator 2.8.2-174 release notes
+= Custom Metrics Autoscaler Operator 2.8.2-174 release notes
 
 This release of the Custom Metrics Autoscaler Operator 2.8.2-174 provides new features and bug fixes for running the Operator in an {product-title} cluster. The components of the Custom Metrics Autoscaler Operator 2.8.2-174 were released in link:https://access.redhat.com/errata/RHEA-2023:1683[RHEA-2023:1683].
 
@@ -50,20 +14,20 @@ The Custom Metrics Autoscaler Operator is currently a link:https://access.redhat
 ====
 
 [id="nodes-pods-autoscaling-custom-rn-282-174-new_{context}"]
-=== New features and enhancements
+== New features and enhancements
 
 [id="autoscaling-custom-2-8-2-upgrade-operator"]
-==== Operator upgrade support
+=== Operator upgrade support
 
 You can now upgrade from a prior version of the Custom Metrics Autoscaler Operator. See "Changing the update channel for an Operator" in the "Additional resources" for information on upgrading an Operator.
 
 [id="autoscaling-custom-2-8-2-must-gather"]
-==== must-gather support
+=== must-gather support
 
 You can now collect data about the Custom Metrics Autoscaler Operator and its components by using the {product-title} `must-gather` tool. Currently, the process for using the `must-gather` tool with the Custom Metrics Autoscaler is different than for other operators. See "Gathering debugging data in the "Additional resources" for more information.
 
 [id="nodes-pods-autoscaling-custom-rn-282_{context}"]
-== Custom Metrics Autoscaler Operator 2.8.2 release notes
+= Custom Metrics Autoscaler Operator 2.8.2 release notes
 
 This release of the Custom Metrics Autoscaler Operator 2.8.2 provides new features and bug fixes for running the Operator in an {product-title} cluster. The components of the Custom Metrics Autoscaler Operator 2.8.2 were released in link:https://access.redhat.com/errata/RHSA-2023:1042[RHSA-2023:1042].
 
@@ -73,15 +37,15 @@ The Custom Metrics Autoscaler Operator is currently a link:https://access.redhat
 ====
 
 [id="nodes-pods-autoscaling-custom-rn-282-new_{context}"]
-=== New features and enhancements
+== New features and enhancements
 
 [id="autoscaling-custom-2-8-2-audit-log"]
-==== Audit Logging
+=== Audit Logging
 
 You can now gather and view audit logs for the Custom Metrics Autoscaler Operator and its associated components. Audit logs are security-relevant chronological sets of records that document the sequence of activities that have affected the system by individual users, administrators, or other components of the system.  
 
 [id="autoscaling-custom-2-8-2-kafka-metrics"]
-==== Scale applications based on Apache Kafka metrics
+=== Scale applications based on Apache Kafka metrics
 
 You can now use the KEDA Apache kafka trigger/scaler to scale deployments based on an Apache Kafka topic.
 
@@ -93,11 +57,11 @@ Technology Preview features are not supported with Red Hat production service le
 ====
 
 [id="autoscaling-custom-2-8-2-cpu-metrics"]
-==== Scale applications based on CPU metrics
+=== Scale applications based on CPU metrics
 
 You can now use the KEDA CPU trigger/scaler to scale deployments based on CPU metrics.
 
 [id="autoscaling-custom-2-8-2-memory-metrics"]
-==== Scale applications based on memory metrics
+=== Scale applications based on memory metrics
 
 You can now use the KEDA memory trigger/scaler to scale deployments based on memory metrics.

--- a/nodes/pods/nodes-pods-autoscaling-custom.adoc
+++ b/nodes/pods/nodes-pods-autoscaling-custom.adoc
@@ -8,16 +8,13 @@ toc::[]
 
 As a developer, you can use the custom metrics autoscaler to specify how {product-title} should automatically increase or decrease the number of pods for a deployment, stateful set, custom resource, or job based on custom metrics that are not based only on CPU or memory.
 
-:FeatureName: Scaling by using a scaled job
-include::snippets/technology-preview.adoc[]
-
 The Custom Metrics Autoscaler Operator for Red Hat OpenShift is an optional operator, based on the Kubernetes Event Driven Autoscaler (KEDA), that allows workloads to be scaled using additional metrics sources other than pod metrics.
 
 The custom metrics autoscaler currently supports only the Prometheus, CPU, memory, and Apache Kafka metrics.
 
 // For example, you can scale a database application based on the number of tables in the database, scale another application based on the number of messages in a Kafka topic, or scale based on incoming HTTP requests collected by {product-title} monitoring.
 
-:FeatureName: Autoscaling based on Apache Kafka metrics
+:FeatureName: The custom metrics autoscaler
 include::snippets/technology-preview.adoc[leveloffset=+0]
 
 // The following include statements pull in the module files that comprise
@@ -25,7 +22,17 @@ include::snippets/technology-preview.adoc[leveloffset=+0]
 // modules required to cover the user story. You can also include other
 // assemblies.
 
-include::modules/nodes-pods-autoscaling-custom-rn.adoc[leveloffset=+1]
+include::modules/nodes-pods-autoscaling-custom-rn-210.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-metrics-access_nodes-pods-autoscaling-custom[Accessing performance metrics]
+* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-pausing_nodes-pods-autoscaling-custom[Pausing the custom metrics autoscaler for a workload]
+* For information on using fallback and HPA naming, see xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-creating-workload_nodes-pods-autoscaling-custom[Adding a custom metrics autoscaler to a workload].
+* For information on activation and scaling thresholds, see xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-about_nodes-pods-autoscaling-custom[Understanding the custom metrics autoscaler].
+
+
+include::modules/nodes-pods-autoscaling-custom-rn.adoc[leveloffset=+2]
 
 .Additional resources
 
@@ -67,10 +74,6 @@ include::modules/nodes-pods-autoscaling-custom-pausing.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-autoscaling-custom-audit.adoc[leveloffset=+1]
 
-.Additional resources
-
-* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-audit_nodes-pods-autoscaling-custom[Configuring audit logging]
-
 include::modules/nodes-pods-autoscaling-custom-gather.adoc[leveloffset=+1]
 
 .Additional resources
@@ -82,8 +85,6 @@ endif::openshift-origin[]
 
 include::modules/nodes-pods-autoscaling-custom-metrics-access.adoc[leveloffset=+1]
 
-include::modules/nodes-pods-autoscaling-custom-metrics.adoc[leveloffset=+2]
-
 include::modules/nodes-pods-autoscaling-custom-adding.adoc[leveloffset=+1]
 
 include::modules/nodes-pods-autoscaling-custom-creating-workload.adoc[leveloffset=+2]
@@ -93,6 +94,7 @@ include::modules/nodes-pods-autoscaling-custom-creating-workload.adoc[leveloffse
 * xref:../../nodes/pods/nodes-pods-autoscaling.adoc#nodes-pods-autoscaling-policies_nodes-pods-autoscaling[Scaling policies]
 * xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-trigger_nodes-pods-autoscaling-custom[Understanding the custom metrics autoscaler triggers]
 * xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-trigger-auth_nodes-pods-autoscaling-custom[Understanding custom metrics autoscaler trigger authentications]
+* xref:../../nodes/pods/nodes-pods-autoscaling-custom.adoc#nodes-pods-autoscaling-custom-audit_nodes-pods-autoscaling-custom[Configuring audit logging]
 
 include::modules/nodes-pods-autoscaling-custom-creating-job.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Release note for Custom Metrics Autoscaler Operator 2.10. 

Separated 2.10 RN into their own module to allow for links to new features. Link to the errata will not work until it is published.

4.10+

Previews:
[Supported versions](https://59343--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-rn-versions_nodes-pods-autoscaling-custom). Updated table to 2.10
[Custom Metrics Autoscaler Operator 2.10 release notes](https://59343--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling-custom.html#nodes-pods-autoscaling-custom-rn-210_nodes-pods-autoscaling-custom)