### PR TITLE
OSDOCS-5694-4-13:Updated Golang release note for consistency

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1870,7 +1870,7 @@ This script removes unauthenticated subjects from the following cluster role bin
 +
 Workaround: Add the mandatory `spec.git_provider.user` field for Bitbucket. In addition, select either *Git access token* or *Git access token secret* to continue adding a Git Repository. (link:https://issues.redhat.com/browse/OCPBUGS-7036[*OCPBUGS-7036*])
 
-* Currently, a certificate compliance issue, specifically outputted as `x509: certificate is not standards compliant`, exists when you run the `openshift-installer` on macOS for the purposes of installing an {product-title} cluster on VMware vSphere. This issue relates to a known issue with the `golang` compiler in that the compiler does not recognize newly supported macOS certificate standards. No workaround exists for this issue. (link:https://issues.redhat.com/browse/OSDOCS-5694[*OSDOCS-5694*])
+* Currently, a certificate compliance issue, specifically outputted as `x509: certificate is not standards compliant`, exists when you run the installation program on macOS for the purposes of installing an {product-title} cluster on VMware vSphere. This issue relates to a known issue with the `golang` compiler in that the compiler does not recognize newly supported macOS certificate standards. No workaround exists for this issue. (link:https://issues.redhat.com/browse/OSDOCS-5694[*OSDOCS-5694*])
 
 
 [id="ocp-4-13-asynchronous-errata-updates"]


### PR DESCRIPTION
Updated existing 4.13 release note to align with 4.12 and 4.11 equivalent updates:

* [4.11 RN](https://github.com/openshift/openshift-docs/pull/59123)
* [4.12 RN](https://github.com/openshift/openshift-docs/pull/59122)


[OSDOCS-5694](https://issues.redhat.com/browse/OSDOCS-5694)

Version(s):
4.13

Link to docs preview:
[Preview-see last note in Known Issues section](https://59346--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-known-issues)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->