### PR TITLE
WINC fix index.adoc

### DIFF
--- a/windows_containers/index.adoc
+++ b/windows_containers/index.adoc
@@ -33,4 +33,3 @@ You can xref:../windows_containers/disabling-windows-container-workloads.adoc#di
 
 * Uninstalling the Windows Machine Config Operator
 * Deleting the Windows Machine Config Operator namespace
-


### PR DESCRIPTION
Somehow, the [redirect wording temporarily added for 4.12](https://github.com/openshift/openshift-docs/pull/50315/files#diff-1ee473bd36ff86f876fd9528c49edcd09a8a59ca2d1b560246230475c7314ea3) got into 4.13. This removes that wording.