### PR TITLE
OSSM-3149 Update the 2.x docs note to say "recent version" instead of "all versions"

### DIFF
--- a/service_mesh/v2x/ossm-about.adoc
+++ b/service_mesh/v2x/ossm-about.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 [NOTE]
 ====
-Because {SMProductName} releases on a different cadence from {product-title} and because the {SMProductName} Operator supports deploying multiple versions of the `ServiceMeshControlPlane`, the {SMProductShortName} documentation does not maintain separate documentation sets for minor versions of the product.  The current documentation set applies to all currently supported versions of {SMProductShortName} unless version-specific limitations are called out in a particular topic or for a particular feature.
+Because {SMProductName} releases on a different cadence from {product-title} and because the {SMProductName} Operator supports deploying multiple versions of the `ServiceMeshControlPlane`, the {SMProductShortName} documentation does not maintain separate documentation sets for minor versions of the product.  The current documentation set applies to the most recent version of {SMProductShortName} unless version-specific limitations are called out in a particular topic or for a particular feature.
 
 For additional information about the {SMProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossm[Platform Life Cycle Policy].
 ====


### PR DESCRIPTION
[OSSM-3149](https://issues.redhat.com/browse/OSSM-3149): Update the 2.x docs note to say "recent version" instead of "all versions"

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSSM-3149

Link to docs preview:
https://59367--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-about.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
