### PR TITLE
OSDOCS#5808: Added NMState operator prerequisite

### DIFF
--- a/modules/virt-creating-linux-bridge-nncp.adoc
+++ b/modules/virt-creating-linux-bridge-nncp.adoc
@@ -9,6 +9,9 @@
 
 Use a `NodeNetworkConfigurationPolicy` manifest YAML file to create the Linux bridge.
 
+.Prerequisites
+* You have installed the Kubernetes NMState Operator.
+
 .Procedure
 
 * Create the `NodeNetworkConfigurationPolicy` manifest. This example includes sample values that you must replace with your own information.


### PR DESCRIPTION
Version(s): 4.11+

Issue: https://issues.redhat.com/browse/OSDOCS-5808

Link to docs preview: https://59393--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.html#virt-creating-linux-bridge-nncp_virt-attaching-vm-multiple-networks

QE review:
- [x] QE has approved this change. @yossisegev 