### PR TITLE
OSDOCS-5889: Documented the 4.12.15 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3470,6 +3470,7 @@ You can view the container images in this release by running the following comma
 ----
 $ oc adm release info 4.12.11 --pullspecs
 ----
+
 [id="ocp-4-12-11-features"]
 ==== Features
 
@@ -3571,6 +3572,30 @@ $ oc adm release info 4.12.14 --pullspecs
 With this release, Cloud Provider {rh-openstack-first} is updated to 1.25.5. The update includes the addition of an annotation for real load balancer IP addresses and the global source for `math/rand` packages are seeded in `main.go`.
 
 [id="ocp-4-12-14-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-12-15"]
+=== RHBA-2023:2037 - {product-title} 4.12.15 bug fix update
+
+Issued: 2023-05-03
+
+{product-title} release 4.12.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2037[RHBA-2023:2037] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2036[RHBA-2023:2036] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.15 --pullspecs
+----
+
+[id="ocp-4-12-15-bug-fixes"]
+==== Bug fixes
+
+* Previously, the Cluster Network Operator (CNO) configuration ignored Kuryr's maximum transmission unit (MTU) settings when using the {rh-openstack-first} Networking service (neutron) component to create a network for OpenShift services. CNO would create a network in Neutron with the wrong MTU property, and this action could cause incompatibility issues among network components. With this update, the CNO does not ignore the Kuryr MTU setting when creating the network for services. You can then use the network to host OpenShift services.(link:https://issues.redhat.com/browse/OCPBUGS-4896[*OCPBUGS-4896*])
+
+[id="ocp-4-12-15-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5889](https://issues.redhat.com/browse/OSDOCS-5889)

Version(s):
4.12

Link to docs preview:

[Preview link](https://59394--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-15)

QE review:
- [ ] QE has approved this change.

