### PR TITLE
Add note about the release image signature's role

### DIFF
--- a/modules/update-restricted.adoc
+++ b/modules/update-restricted.adoc
@@ -23,6 +23,11 @@ If you have a local OpenShift Update Service, you can update by using the connec
 * Install the OpenShift CLI (`oc`).
 * Pause all `MachineHealthCheck` resources.
 
+[NOTE]
+====
+The release image signature config map allows the Cluster Version Operator (CVO) to verify that the release images have not been modified by comparing the expected and actual image signatures.
+====
+
 .Procedure
 
 * Update the cluster:

--- a/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
@@ -103,6 +103,11 @@ Before updating your cluster, confirm that the following conditions are met:
 * The current release and update target release images are mirrored to a locally accessible registry.
 * A recent graph data container image has been mirrored to your local registry.
 
+[NOTE]
+====
+The release image signature config map allows the Cluster Version Operator (CVO) to verify that the release images have not been modified by comparing the expected and actual image signatures.
+====
+
 After you configure your cluster to use the locally-installed OpenShift Update Service and local mirror registry, you can use any of the following update methods:
 
 ** xref:../../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster using the web console]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.8+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Until v4.7 of the documentation there was a paragraph about the release image signature, which is a prerequisite to update a cluster, especially in a restricted network, where you have to create it manually. (cf. [updating-restricted-network-cluster.html#updating-restricted-network-image-signature-configmap](https://docs.openshift.com/container-platform/4.7/updating/updating-restricted-network-cluster.html#updating-restricted-network-image-signature-configmap)
I added a note about its role. But we may add back the full section about how to create it?
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
