### PR TITLE
OCPBUGS12917: Garbage Collection add descriptions of each type

### DIFF
--- a/modules/nodes-nodes-garbage-collection-configuring.adoc
+++ b/modules/nodes-nodes-garbage-collection-configuring.adoc
@@ -21,6 +21,8 @@ You can configure any combination of the following:
 * Hard eviction for containers
 * Eviction for images
 
+Container garbage collection removes terminated containers. Image garbage collection removes images that are not referenced by any running pods. 
+
 .Prerequisites
 
 . Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command:
@@ -106,15 +108,15 @@ spec:
 ----
 <1> Name for the object.
 <2> Specify the label from the machine config pool.
-<3> Type of eviction: `evictionSoft` or `evictionHard`.
-<4> Eviction thresholds based on a specific eviction trigger signal.
-<5> Grace periods for the soft eviction. This parameter does not apply to `eviction-hard`.
-<6> Eviction thresholds based on a specific eviction trigger signal.
+<3> For container garbage collection: Type of eviction: `evictionSoft` or `evictionHard`.
+<4> For container garbage collection: Eviction thresholds based on a specific eviction trigger signal.
+<5> For container garbage collection: Grace periods for the soft eviction. This parameter does not apply to `eviction-hard`.
+<6> For container garbage collection: Eviction thresholds based on a specific eviction trigger signal.
 For `evictionHard` you must specify all of these parameters.  If you do not specify all parameters, only the specified parameters are applied and the garbage collection will not function properly.
-<7> The duration to wait before transitioning out of an eviction pressure condition.
-<8> The minimum age for an unused image before the image is removed by garbage collection.
-<9> The percent of disk usage (expressed as an integer) that triggers image garbage collection.
-<10> The percent of disk usage (expressed as an integer) that image garbage collection attempts to free.
+<7> For container garbage collection: The duration to wait before transitioning out of an eviction pressure condition.
+<8> For image garbage collection: The minimum age for an unused image before the image is removed by garbage collection.
+<9> For image garbage collection: The percent of disk usage (expressed as an integer) that triggers image garbage collection.
+<10> For image garbage collection: The percent of disk usage (expressed as an integer) that image garbage collection attempts to free.
 
 . Run the following command to create the CR:
 +

--- a/modules/nodes-nodes-garbage-collection-containers.adoc
+++ b/modules/nodes-nodes-garbage-collection-containers.adoc
@@ -8,7 +8,7 @@
 [id="nodes-nodes-garbage-collection-containers_{context}"]
 = Understanding how terminated containers are removed through garbage collection
 
-Container garbage collection can be performed using eviction thresholds.
+Container garbage collection removes terminated containers by using eviction thresholds.
 
 When eviction thresholds are set for garbage collection, the node tries to keep any container for any pod accessible from the API. If the pod has been deleted, the containers will be as well. Containers are preserved as long the pod is not deleted and the eviction threshold is not reached. If the node is under disk pressure, it will remove containers and their logs will no longer be accessible using `oc logs`.
 

--- a/modules/nodes-nodes-garbage-collection-images.adoc
+++ b/modules/nodes-nodes-garbage-collection-images.adoc
@@ -7,8 +7,9 @@
 [id="nodes-nodes-garbage-collection-images_{context}"]
 = Understanding how images are removed through garbage collection
 
-Image garbage collection relies on disk usage as reported by *cAdvisor* on the
-node to decide which images to remove from the node.
+Image garbage collection removes images that are not referenced by any running pods.
+
+{produt-title} determines which images to remove from a node based on the disk usage that is reported by *cAdvisor*.
 
 The policy for image garbage collection is based on two conditions:
 


### PR DESCRIPTION
Explain the difference between Container Image GC and Container Garbage collection. Copy down the description of each GC type at the [top of the assembly](https://docs.openshift.com/container-platform/4.12/nodes/nodes/nodes-nodes-garbage-collection.html). 

https://issues.redhat.com/browse/OCPBUGS-12917

Previews
[Understanding how terminated containers are removed through garbage collection](https://59409--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-garbage-collection.html)
[Understanding how images are removed through garbage collection](https://59409--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-garbage-collection.html#nodes-nodes-garbage-collection-images_nodes-nodes-configuring)


No QE review required. Small changes to wording only.