### PR TITLE
ROX-16716: Update Release Notes for 3.74.3 patch

### DIFF
--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -15,6 +15,7 @@ toc::[]
 |`3.74.0` |27 February 2023
 |`3.74.1` | 20 March 2023
 |`3.74.2` | 13 April 2023
+|`3.74.3` | 2 May 2023
 |====
 
 [id="about-this-release-374"]
@@ -22,17 +23,17 @@ toc::[]
 
 {product-title-short} 3.74 includes the following new features, improvements, and updates:
 
-* <<ibm-power-z-374>>
-* <<clair-v4-374>>
-* <<network-graph-2-374>>
-* <<global-search-updates-374>>
-* <<syslog-integration-374>>
-* <<troubleshooting-collector-374>>
-* <<scale-performance-improvements-374>>
-* <<postgresql-technology-preview-374>>
-** <<collections-374>>
-** <<policy-categories-374>>
-* <<bug-fixes-374>>
+* xref:../release_notes/374-release-notes.adoc#ibm-power-z-374[{ibm-power}, {ibm-zsystems}, and {ibm-linuxone} support for secured clusters]
+* xref:../release_notes/374-release-notes.adoc#clair-v4-374[Clair scanner version 4 support]
+* xref:../release_notes/374-release-notes.adoc#network-graph-2-374[Network graph 2.0 (Technology Preview)]
+* xref:../release_notes/374-release-notes.adoc#global-search-updates-374[Updated global search in the {product-title-short} portal]
+* xref:../release_notes/374-release-notes.adoc#syslog-integration-374[Extra fields for improved syslog integration]
+* xref:../release_notes/374-release-notes.adoc#troubleshooting-collector-374[Troubleshooting guide enhanced when the Collector kernel module is missing]
+* xref:../release_notes/374-release-notes.adoc#scale-performance-improvements-374[Scale and performance improvements]
+* xref:../release_notes/374-release-notes.adoc#postgresql-technology-preview-374[Features available if the PostgreSQL database option is installed]
+** xref:../release_notes/374-release-notes.adoc#collections-374[{product-title-short} collections]
+** xref:../release_notes/374-release-notes.adoc#policy-categories-374[Policy categories]
+* xref:../release_notes/374-release-notes.adoc#bug-fixes-374[Bug fixes]
 
 [id="new-features-374"]
 == New features
@@ -369,6 +370,14 @@ Release date: 13 April 2023
 
 * This release of {product-title-short} includes a fix for link:https://access.redhat.com/errata/RHSA-2023:1405[RHSA-2023:1405] OpenSSL security update for {op-system-base-full} 8.
 * This release fixes a crash that occurs during migration to the PostgreSQL database (Technology Preview) when there are clusters that have not checked in recently.
+
+[id="resolved-in-version-3743"]
+=== Resolved in version 3.74.3
+
+Release date: 2 May 2023
+
+* This release of {product-title-short} includes a fix for link:https://access.redhat.com/security/cve/CVE-2023-28617[CVE-2023-28617] for {op-system-base}.
+* This release includes a fix for an issue with migration to the PostgreSQL database (Technology Preview).
 
 [id="known-issues-374"]
 === Known issues


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.74`

[Issue](https://issues.redhat.com/browse/ROX-16716)

[Link to docs preview
](https://59411--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- Also changed the hyperlinks to doc sections to standard `xref` format.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
