### PR TITLE
OCP 4.11 Netobserv updates RN

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -666,6 +666,9 @@ The Network Observability Operator is General Availability (GA) status in the 4.
 
 For more information, see xref:../networking/network_observability/network-observability-overview.adoc#network-observability-overview[Network Observability].
 
+[id="ocp-411-nw-network-observability-updates"]
+===== Network Observability Operator updates
+The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, rolling stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator can be found in the xref:../networking/network_observability/network-observability-operator-release-notes.adoc[Network Observability release notes].
 
 [id="ocp-4-11-storage"]
 === Storage


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
OCP 4.11 release notes
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://59415--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#new-network-observability

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This PR creates a small announcement of Network Observability in the big OpenShift Container Platform documentation release notes. It doesn't include specifics, but rather points to the Operator release notes.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
