### PR TITLE
Fixed a bad indentation in SriovNetworkNodePolicy example

### DIFF
--- a/modules/nw-sriov-networknodepolicy-object.adoc
+++ b/modules/nw-sriov-networknodepolicy-object.adoc
@@ -33,7 +33,7 @@ spec:
     netFilter: "<filter_string>" <14>
   deviceType: <device_type> <15>
   isRdma: false <16>
-    linkType: <link_type> <17>
+  linkType: <link_type> <17>
   eSwitchMode: "switchdev" <18>
 ----
 <1> The name for the custom resource object.


### PR DESCRIPTION
Fixed a bad indentation in SriovNetworkNodePolicy example

Version(s):
4.12

Issue: https://github.com/openshift/openshift-docs/issues/55357

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.


---
ref:

```
❯ oc explain SriovNetworkNodePolicy.spec
KIND:     SriovNetworkNodePolicy
VERSION:  sriovnetwork.openshift.io/v1

RESOURCE: spec <Object>

DESCRIPTION:
     SriovNetworkNodePolicySpec defines the desired state of
     SriovNetworkNodePolicy

FIELDS:
   deviceType   <string>
     The driver type for configured VFs. Allowed value "netdevice", "vfio-pci".
     Defaults to netdevice.

   eSwitchMode  <string>
     NIC Device Mode. Allowed value "legacy","switchdev".

   isRdma       <boolean>
     RDMA mode. Defaults to false.

   linkType     <string>
     NIC Link Type. Allowed value "eth", "ETH", "ib", and "IB".

   mtu  <integer>
     MTU of VF

   needVhostNet <boolean>
     mount vhost-net device. Defaults to false.

   nicSelector  <Object> -required-
     NicSelector selects the NICs to be configured

   nodeSelector <map[string]string> -required-
     NodeSelector selects the nodes to be configured

   numVfs       <integer> -required-
     Number of VFs for each PF

   priority     <integer>
     Priority of the policy, higher priority policies can override lower ones.

   resourceName <string> -required-
     SRIOV Network device plugin endpoint resource name
```
```
❯ oc explain SriovNetworkNodePolicy.spec.isRdma
KIND:     SriovNetworkNodePolicy
VERSION:  sriovnetwork.openshift.io/v1

FIELD:    isRdma <boolean>

DESCRIPTION:
     RDMA mode. Defaults to false.

```
