### PR TITLE
[enterprise-4.13] Remove context tags from assembly anchor IDs

### DIFF
--- a/virt/live_migration/virt-configuring-live-migration-policies.adoc
+++ b/virt/live_migration/virt-configuring-live-migration-policies.adoc
@@ -11,6 +11,6 @@ You can define different migration configurations for specified groups of virtua
 :FeatureName: Live migration policy
 include::snippets/technology-preview.adoc[]
 
-To configure a live migration policy by using the web console, see the xref:../../virt/virt-web-console-overview.adoc#ui-migrationpolicies-page_virt-web-console-overview[MigrationPolicies page documentation].
+To configure a live migration policy by using the web console, see the xref:../../virt/virt-web-console-overview.adoc#ui-migrationpolicies-page[MigrationPolicies page documentation].
 
 include::modules/virt-configuring-a-live-migration-policy.adoc[leveloffset=+1]

--- a/virt/live_migration/virt-migrate-vmi.adoc
+++ b/virt/live_migration/virt-migrate-vmi.adoc
@@ -18,9 +18,9 @@ include::modules/virt-initiating-vm-migration-web.adoc[leveloffset=+1]
 [id="monitoring-live-migration-by-using-the-web-console_{context}"]
 === Monitoring live migration by using the web console
 
-You can monitor the progress of all live migrations on the xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-migrations_virt-web-console-overview[*Overview* -> *Migrations* tab] in the web console.
+You can monitor the progress of all live migrations on the xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-migrations[*Overview* -> *Migrations* tab] in the web console.
 
-You can view the migration metrics of a virtual machine on the xref:../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-metrics_virt-web-console-overview[*VirtualMachine details* -> *Metrics* tab] in the web console.
+You can view the migration metrics of a virtual machine on the xref:../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-metrics[*VirtualMachine details* -> *Metrics* tab] in the web console.
 
 include::modules/virt-initiating-vm-migration-cli.adoc[leveloffset=+1]
 

--- a/virt/support/virt-runbooks.adoc
+++ b/virt/support/virt-runbooks.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 You can use the procedures in these runbooks to diagnose and resolve issues that trigger {VirtProductName} xref:../../monitoring/managing-alerts.adoc#managing-alerts[alerts].
 
-{VirtProductName} alerts are displayed on the *Virtualization* -> *Overview* -> xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-overview_virt-web-console-overview[*Overview* tab] in the web console.
+{VirtProductName} alerts are displayed on the *Virtualization* -> *Overview* -> xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-overview[*Overview* tab] in the web console.
 
 
 include::modules/virt-runbook-cdidataimportcronoutdated.adoc[leveloffset=+1]

--- a/virt/support/virt-support-overview.adoc
+++ b/virt/support/virt-support-overview.adoc
@@ -21,19 +21,19 @@ The {product-title} web console displays resource usage, alerts, events, and tre
 |*Overview* page
 |Cluster details, status, alerts, inventory, and resource usage
 
-|*Virtualization* -> xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-overview_virt-web-console-overview[*Overview* tab]
+|*Virtualization* -> xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-overview[*Overview* tab]
 |{VirtProductName} resources, usage, alerts, and status
 
-|*Virtualization* -> xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-top-consumers_virt-web-console-overview[*Top consumers* tab]
+|*Virtualization* -> xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-top-consumers[*Top consumers* tab]
 |Top consumers of CPU, memory, and storage
 
-|*Virtualization* -> xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-migrations_virt-web-console-overview[*Migrations* tab]
+|*Virtualization* -> xref:../../virt/virt-web-console-overview.adoc#virtualization-overview-migrations[*Migrations* tab]
 |Progress of live migrations
 
-|*VirtualMachines* -> *VirtualMachine* -> *VirtualMachine details* -> xref:../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-metrics_virt-web-console-overview[*Metrics* tab]
+|*VirtualMachines* -> *VirtualMachine* -> *VirtualMachine details* -> xref:../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-metrics[*Metrics* tab]
 |VM resource usage, storage, network, and migration
 
-|*VirtualMachines* -> *VirtualMachine* -> *VirtualMachine details* -> xref:../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-events_virt-web-console-overview[*Events* tab]
+|*VirtualMachines* -> *VirtualMachine* -> *VirtualMachine details* -> xref:../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-events[*Events* tab]
 |List of VM events
 |====
 

--- a/virt/support/virt-troubleshooting.adoc
+++ b/virt/support/virt-troubleshooting.adoc
@@ -11,7 +11,7 @@ toc::[]
 
 xref:../../nodes/clusters/nodes-containers-events.adoc#nodes-containers-events[{product-title} events] are records of important life-cycle information and are useful for monitoring and troubleshooting resource issues. You can gather information about the following events:
 
-* VM events: Navigate to the xref:../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-events_virt-web-console-overview[*Events* tab] of the *VirtualMachine details* page in the web console.
+* VM events: Navigate to the xref:../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-events[*Events* tab] of the *VirtualMachine details* page in the web console.
 
 * Namespace events: Use the `oc get` command with the namespace:
 +

--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -86,10 +86,10 @@ The SVVP Certification applies to:
 === Web console
 
 //CNV-27552 Release note: VM configuration tab
-* On the *VirtualMachine details* page, the *Scheduling*, *Environment*, *Network interfaces*, *Disks*, and *Scripts* tabs are displayed on the new xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-configuration_virt-web-console-overview[*Configuration* tab].
+* On the *VirtualMachine details* page, the *Scheduling*, *Environment*, *Network interfaces*, *Disks*, and *Scripts* tabs are displayed on the new xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-configuration[*Configuration* tab].
 
 //CNV-23474 Release note: NEW Paste clipboard into VNC
-* You can now xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-console_virt-web-console-overview[paste a string] from your client’s clipboard into the guest when using the VNC console.
+* You can now xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-console[paste a string] from your client’s clipboard into the guest when using the VNC console.
 
 //CNV-22555 Release note: CHANGE Hostname field moving from cloud-init options to VM details page
 
@@ -97,7 +97,7 @@ The SVVP Certification applies to:
 * The *VirtualMachine details* -> *Details* tab now provides a new SSH service type *SSH over LoadBalancer* to expose the SSH service over a load balancer.
 
 //CNV-25574 Release note: NEW UI - Ability to make a hot-plug disk part of the VM
-* The option to make a hot-plug volume a persistent volume is added to the xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-disks_virt-web-console-overview[*Disks* tab].
+* The option to make a hot-plug volume a persistent volume is added to the xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-disks[*Disks* tab].
 
 //NOTE: Comment out deprecated and removed features (and their IDs) if not used in a release
 [id="virt-4-13-deprecated-removed"]
@@ -121,7 +121,7 @@ Removed features are not supported in the current release.
 //CNV-19043 Release note: CHANGE Remove rhel6 support
 * Red Hat Enterprise Linux 6 is no longer supported on {VirtProductName}.
 
-//CNV-23499: Carry over/repeat removed feature from version 4.12 
+//CNV-23499: Carry over/repeat removed feature from version 4.12
 * Support for the legacy HPP custom resource, and the associated storage class, has been removed for all new deployments. In {VirtProductName} 4.13, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. A legacy HPP custom resource is supported only if it had been installed on a previous version of {VirtProductName}.
 
 

--- a/virt/virt-web-console-overview.adoc
+++ b/virt/virt-web-console-overview.adoc
@@ -15,22 +15,22 @@ The *Virtualization* section of the {product-title} web console contains the fol
 |Page
 |Description
 
-|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-page_virt-web-console-overview[Overview page]
+|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-page[Overview page]
 |Manage and monitor the {VirtProductName} environment.
 
-|xref:../virt/virt-web-console-overview.adoc#ui-catalog-page_virt-web-console-overview[Catalog page]
+|xref:../virt/virt-web-console-overview.adoc#ui-catalog-page[Catalog page]
 |Create VirtualMachines from a catalog of templates.
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachines-page_virt-web-console-overview[VirtualMachines page]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachines-page[VirtualMachines page]
 |Configure and monitor VirtualMachines.
 
-|xref:../virt/virt-web-console-overview.adoc#ui-templates-page_virt-web-console-overview[Templates page]
+|xref:../virt/virt-web-console-overview.adoc#ui-templates-page[Templates page]
 |Create and manage templates.
 
-|xref:../virt/virt-web-console-overview.adoc#ui-datasources-page_virt-web-console-overview[DataSources page]
+|xref:../virt/virt-web-console-overview.adoc#ui-datasources-page[DataSources page]
 |Create and manage DataSources for VirtualMachine boot sources.
 
-|xref:../virt/virt-web-console-overview.adoc#ui-migrationpolicies-page_virt-web-console-overview[MigrationPolicies page]
+|xref:../virt/virt-web-console-overview.adoc#ui-migrationpolicies-page[MigrationPolicies page]
 |Create and manage MigrationPolicies for workloads.
 |====
 
@@ -47,7 +47,7 @@ The *Virtualization* section of the {product-title} web console contains the fol
 |Link icon
 |====
 
-[id="virtualization-overview-page_{context}"]
+[id="virtualization-overview-page"]
 == Overview page
 
 The Overview page displays resources, metrics, migration progress, and cluster-level settings.
@@ -63,21 +63,21 @@ The Overview page displays resources, metrics, migration progress, and cluster-l
 |*Download virtctl* image:icon-link.png[title="link icon",20]
 |Download the `virtctl` command line tool to manage resources.
 
-|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-overview_virt-web-console-overview[*Overview* tab]
+|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-overview[*Overview* tab]
 |Resources, usage, alerts, and status
 
-|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-top-consumers_virt-web-console-overview[*Top consumers* tab]
+|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-top-consumers[*Top consumers* tab]
 |Top consumers of CPU, memory, and storage resources
 
-|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-migrations_virt-web-console-overview[*Migrations* tab]
+|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-migrations[*Migrations* tab]
 |Status of live migrations
 
-|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-settings_virt-web-console-overview[*Settings* tab]
+|xref:../virt/virt-web-console-overview.adoc#virtualization-overview-settings[*Settings* tab]
 |Cluster-wide settings, including live migration limits and user permissions
 |====
 =====
 
-[id="virtualization-overview-overview_{context}"]
+[id="virtualization-overview-overview"]
 === Overview tab
 
 The *Overview* tab displays resources, usage, alerts, and status.
@@ -117,7 +117,7 @@ The *Overview* tab displays resources, usage, alerts, and status.
 |====
 =====
 
-[id="virtualization-overview-top-consumers_{context}"]
+[id="virtualization-overview-top-consumers"]
 === Top consumers tab
 
 The *Top consumers* tab displays the top consumers of CPU, memory, and storage.
@@ -158,7 +158,7 @@ The *Top consumers* tab displays the top consumers of CPU, memory, and storage.
 |====
 =====
 
-[id="virtualization-overview-migrations_{context}"]
+[id="virtualization-overview-migrations"]
 === Migrations tab
 
 The *Migrations* tab displays the status of VirtualMachineInstance migrations.
@@ -179,7 +179,7 @@ The *Migrations* tab displays the status of VirtualMachineInstance migrations.
 |====
 =====
 
-[id="virtualization-overview-settings_{context}"]
+[id="virtualization-overview-settings"]
 === Settings tab
 
 The *Settings* tab displays cluster-wide settings on the following tabs:
@@ -190,20 +190,20 @@ The *Settings* tab displays cluster-wide settings on the following tabs:
 |Tab
 |Description
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-general_virt-web-console-overview[*General* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-general[*General* tab]
 |{VirtProductName} version and update status
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-live-migration_virt-web-console-overview[*Live migration* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-live-migration[*Live migration* tab]
 |Live migration limits and network settings
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-templates-project_virt-web-console-overview[*Templates project* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-templates-project[*Templates project* tab]
 |Project for Red Hat templates
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-user-permissions_virt-web-console-overview[*User permissions* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-user-permissions[*User permissions* tab]
 |Cluster-wide user permissions
 |====
 
-[id="ui-virtualization-settings-general_{context}"]
+[id="ui-virtualization-settings-general"]
 ==== General tab
 
 The *General* tab displays the {VirtProductName} version and update status.
@@ -233,7 +233,7 @@ The *General* tab displays the {VirtProductName} version and update status.
 |====
 =====
 
-[id="ui-virtualization-settings-live-migration_{context}"]
+[id="ui-virtualization-settings-live-migration"]
 ==== Live migration tab
 
 You can configure live migration on the *Live migration* tab.
@@ -257,7 +257,7 @@ You can configure live migration on the *Live migration* tab.
 |====
 =====
 
-[id="ui-virtualization-settings-templates-project_{context}"]
+[id="ui-virtualization-settings-templates-project"]
 ==== Templates project tab
 
 You can select a project for templates on the *Templates project* tab.
@@ -273,11 +273,11 @@ You can select a project for templates on the *Templates project* tab.
 |*Project* list
 |Select a project in which to store Red Hat templates. The default template project is `openshift`.
 
-If you want to define multiple template projects, you must clone the templates on the xref:../virt/virt-web-console-overview.adoc#ui-templates-page_virt-web-console-overview[Templates page] for each project.
+If you want to define multiple template projects, you must clone the templates on the xref:../virt/virt-web-console-overview.adoc#ui-templates-page[Templates page] for each project.
 |====
 =====
 
-[id="ui-virtualization-settings-user-permissions_{context}"]
+[id="ui-virtualization-settings-user-permissions"]
 ==== User permissions tab
 
 The *User permissions* tab displays cluster-wide user permissions for tasks.
@@ -295,7 +295,7 @@ The *User permissions* tab displays cluster-wide user permissions for tasks.
 |====
 =====
 
-[id="ui-catalog-page_{context}"]
+[id="ui-catalog-page"]
 == Catalog page
 
 You can create a VirtualMachine by selecting a template or boot source on the Catalog page.
@@ -311,7 +311,7 @@ You can create a VirtualMachine by selecting a template or boot source on the Ca
 |*Templates project* list
 |Select the project in which your templates are located.
 
-By default, Red Hat templates are stored in the `openshift` project. You can edit the template project on the xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-templates-project_virt-web-console-overview[*Overview -> Settings -> Template project* tab].
+By default, Red Hat templates are stored in the `openshift` project. You can edit the template project on the xref:../virt/virt-web-console-overview.adoc#ui-virtualization-settings-templates-project[*Overview -> Settings -> Template project* tab].
 
 |*All items*\|*Default templates*
 |Click *Default templates* to display only default templates.
@@ -371,7 +371,7 @@ By default, Red Hat templates are stored in the `openshift` project. You can edi
 // |====
 // =====
 
-[id="ui-virtualmachines-page_{context}"]
+[id="ui-virtualmachines-page"]
 == VirtualMachines page
 
 You can create and manage VirtualMachines on the VirtualMachines page.
@@ -405,7 +405,7 @@ Click a VirtualMachine to navigate to the VirtualMachine details page.
 |====
 =====
 
-[id="ui-virtualmachine-details-page_{context}"]
+[id="ui-virtualmachine-details-page"]
 === VirtualMachine details page
 
 You can configure a VirtualMachine on the VirtualMachine details page.
@@ -421,51 +421,51 @@ You can configure a VirtualMachine on the VirtualMachine details page.
 |*Actions* menu
 |Click the *Actions* menu to select *Stop*, *Restart*, *Pause*, *Clone*, *Migrate*, *Copy SSH command*, *Edit labels*, *Edit annotations*, or *Delete*.
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-overview_virt-web-console-overview[*Overview* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-overview[*Overview* tab]
 |Resource usage, alerts, disks, and devices
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-details_virt-web-console-overview[*Details* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-details[*Details* tab]
 |VirtualMachine details and configurations
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-metrics_virt-web-console-overview[*Metrics* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-metrics[*Metrics* tab]
 |Memory, CPU, storage, network, and migration metrics
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-yaml_virt-web-console-overview[*YAML* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-yaml[*YAML* tab]
 |VirtualMachine YAML configuration file
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-configuration_virt-web-console-overview[*Configuration* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-configuration[*Configuration* tab]
 |Contains the *Scheduling*, *Environment*, *Network interfaces*, *Disks*, and *Scripts* tabs
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-scheduling_virt-web-console-overview[*Configuration* -> *Scheduling* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-scheduling[*Configuration* -> *Scheduling* tab]
 |Scheduling a VirtualMachine to run on specific nodes
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-environment_virt-web-console-overview[*Configuration* -> *Environment* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-environment[*Configuration* -> *Environment* tab]
 |Config map, secret, and service account management
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-network-interfaces_virt-web-console-overview[*Configuration* -> *Network interfaces* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-network-interfaces[*Configuration* -> *Network interfaces* tab]
 |Network interfaces
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-disks_virt-web-console-overview[*Configuration* -> *Disks* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-disks[*Configuration* -> *Disks* tab]
 |Disks
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-scripts_virt-web-console-overview[*Configuration* -> *Scripts* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-scripts[*Configuration* -> *Scripts* tab]
 |Cloud-init settings, SSH key for Linux VirtualMachines, Sysprep answer file for Windows VirtualMachines
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-events_virt-web-console-overview[*Events* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-events[*Events* tab]
 |VirtualMachine event stream
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-console_virt-web-console-overview[*Console* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-console[*Console* tab]
 |Console session management
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-snapshots_virt-web-console-overview[*Snapshots* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-snapshots[*Snapshots* tab]
 |Snapshot management
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-diagnostics_virt-web-console-overview[*Diagnostics* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-diagnostics[*Diagnostics* tab]
 |Status conditions and volume snapshot status
 |====
 =====
 
-[id="ui-virtualmachine-details-overview_{context}"]
+[id="ui-virtualmachine-details-overview"]
 ==== Overview tab
 
 The *Overview* tab displays resource usage, alerts, and configuration information.
@@ -501,7 +501,7 @@ The *Overview* tab displays resource usage, alerts, and configuration informatio
 |====
 =====
 
-[id="ui-virtualmachine-details-details_{context}"]
+[id="ui-virtualmachine-details-details"]
 ==== Details tab
 
 You can view information about the VirtualMachine and edit labels, annotations, and other metadata and on the *Details* tab.
@@ -608,7 +608,7 @@ The number of CPUs is calculated by using the following formula: `sockets * thre
 |====
 =====
 
-[id="ui-virtualmachine-details-metrics_{context}"]
+[id="ui-virtualmachine-details-metrics"]
 ==== Metrics tab
 
 The *Metrics* tab displays memory, CPU, storage, network, and migration usage charts.
@@ -641,7 +641,7 @@ The *Metrics* tab displays memory, CPU, storage, network, and migration usage ch
 |====
 =====
 
-[id="ui-virtualmachine-details-yaml_{context}"]
+[id="ui-virtualmachine-details-yaml"]
 ==== YAML tab
 
 You can configure the VirtualMachine by editing the YAML file on the *YAML* tab.
@@ -671,7 +671,7 @@ You can configure the VirtualMachine by editing the YAML file on the *YAML* tab.
 |====
 =====
 
-[id="ui-virtualmachine-details-configuration_{context}"]
+[id="ui-virtualmachine-details-configuration"]
 ==== Configuration tab
 
 You can configure scheduling, network interfaces, disks, and other options on the *Configuration* tab.
@@ -684,24 +684,24 @@ You can configure scheduling, network interfaces, disks, and other options on th
 |Tab
 |Description
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-scheduling_virt-web-console-overview[*Scheduling* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-scheduling[*Scheduling* tab]
 |Scheduling a VirtualMachine to run on specific nodes
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-environment_virt-web-console-overview[*Environment* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-environment[*Environment* tab]
 |Config maps, secrets, and service accounts
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-network-interfaces_virt-web-console-overview[*Network interfaces* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-network-interfaces[*Network interfaces* tab]
 |Network interfaces
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-disks_virt-web-console-overview[*Disks* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-disks[*Disks* tab]
 |Disks
 
-|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-scripts_virt-web-console-overview[*Scripts* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-scripts[*Scripts* tab]
 |Cloud-init settings, SSH key for Linux VirtualMachines, Sysprep answer file for Windows VirtualMachines
 |====
 =====
 
-[id="ui-virtualmachine-details-scheduling_{context}"]
+[id="ui-virtualmachine-details-scheduling"]
 ===== Scheduling tab
 
 You can configure VirtualMachines to run on specific nodes on the *Scheduling* tab.
@@ -737,7 +737,7 @@ You can configure VirtualMachines to run on specific nodes on the *Scheduling* t
 |====
 =====
 
-[id="ui-virtualmachine-details-environment_{context}"]
+[id="ui-virtualmachine-details-environment"]
 ===== Environment tab
 
 You can manage config maps, secrets, and service accounts on the *Environment* tab.
@@ -758,7 +758,7 @@ You can manage config maps, secrets, and service accounts on the *Environment* t
 |====
 =====
 
-[id="ui-virtualmachine-details-network-interfaces_{context}"]
+[id="ui-virtualmachine-details-network-interfaces"]
 ===== Network interfaces tab
 
 You can manage network interfaces on the *Network interfaces* tab.
@@ -790,7 +790,7 @@ Click the Options menu {kebab} beside a network interface to select *Edit* or *D
 |====
 =====
 
-[id="ui-virtualmachine-details-disks_{context}"]
+[id="ui-virtualmachine-details-disks"]
 ===== Disks tab
 
 You can manage disks on the *Disks* tab.
@@ -828,7 +828,7 @@ Click the *Options* menu {kebab} beside a disk to select *Edit*, *Detach*, or *M
 |====
 =====
 
-[id="ui-virtualmachine-details-scripts_{context}"]
+[id="ui-virtualmachine-details-scripts"]
 ===== Scripts tab
 
 You can configure cloud-init, add an SSH key for a Linux VirtualMachine, and upload a Sysprep answer file for a Windows VirtualMachine on the *Scripts* tab.
@@ -855,12 +855,12 @@ You can configure cloud-init, add an SSH key for a Linux VirtualMachine, and upl
 |====
 =====
 
-[id="ui-virtualmachine-details-events_{context}"]
+[id="ui-virtualmachine-details-events"]
 ==== Events tab
 
 The *Events* tab displays a list of VirtualMachine events.
 
-[id="ui-virtualmachine-details-console_{context}"]
+[id="ui-virtualmachine-details-console"]
 ==== Console tab
 
 You can open a console session to the VirtualMachine on the *Console* tab.
@@ -894,7 +894,7 @@ You must manually disconnect the console connection if you open a new console se
 |====
 =====
 
-[id="ui-virtualmachine-details-snapshots_{context}"]
+[id="ui-virtualmachine-details-snapshots"]
 ==== Snapshots tab
 
 You can create snapshots and restore VirtualMachines from snapshots on the *Snapshots* tab.
@@ -923,7 +923,7 @@ Click the Options menu {kebab} beside a snapshot to select *Edit labels*, *Edit 
 |====
 =====
 
-[id="ui-virtualmachine-details-diagnostics_{context}"]
+[id="ui-virtualmachine-details-diagnostics"]
 ==== Diagnostics tab
 
 You can view the status conditions and volume snapshot status on the *Diagnostics* tab.
@@ -945,7 +945,7 @@ You can view the status conditions and volume snapshot status on the *Diagnostic
 |*Search* field
 |Search status conditions by reason.
 
-|*Manage columns* icon 
+|*Manage columns* icon
 |Select columns to display.
 
 |*Volume snapshot* table
@@ -953,7 +953,7 @@ You can view the status conditions and volume snapshot status on the *Diagnostic
 |====
 =====
 
-[id="ui-templates-page_{context}"]
+[id="ui-templates-page"]
 == Templates page
 
 You can create, edit, and clone VirtualMachine templates on the Templates page.
@@ -987,7 +987,7 @@ Click the Options menu {kebab} beside a template to select *Edit*, *Clone*, *Edi
 |====
 =====
 
-[id="ui-template-details-page_{context}"]
+[id="ui-template-details-page"]
 === Template details page
 
 You can view template settings and edit custom templates on the Template details page.
@@ -1003,30 +1003,30 @@ You can view template settings and edit custom templates on the Template details
 |*Actions* menu
 |Click the *Actions* menu to select *Edit*, *Clone*, *Edit boot source*, *Edit boot source reference*, *Edit labels*, *Edit annotations*, or *Delete*.
 
-|xref:../virt/virt-web-console-overview.adoc#ui-template-details-details_virt-web-console-overview[*Details* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-template-details-details[*Details* tab]
 |Template settings and configurations
 
-|xref:../virt/virt-web-console-overview.adoc#ui-template-details-yaml_virt-web-console-overview[*YAML* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-template-details-yaml[*YAML* tab]
 |YAML configuration file
 
-|xref:../virt/virt-web-console-overview.adoc#ui-template-details-scheduling_virt-web-console-overview[*Scheduling* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-template-details-scheduling[*Scheduling* tab]
 |Scheduling configurations
 
-|xref:../virt/virt-web-console-overview.adoc#ui-template-details-network-interfaces_virt-web-console-overview[*Network interfaces* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-template-details-network-interfaces[*Network interfaces* tab]
 |Network interface management
 
-|xref:../virt/virt-web-console-overview.adoc#ui-template-details-disks_virt-web-console-overview[*Disks* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-template-details-disks[*Disks* tab]
 |Disk management
 
-|xref:../virt/virt-web-console-overview.adoc#ui-template-details-scripts_virt-web-console-overview[*Scripts* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-template-details-scripts[*Scripts* tab]
 |Cloud-init, SSH key, and Sysprep management
 
-|xref:../virt/virt-web-console-overview.adoc#ui-template-details-parameters_virt-web-console-overview[*Parameters* tab]
+|xref:../virt/virt-web-console-overview.adoc#ui-template-details-parameters[*Parameters* tab]
 |Parameters
 |====
 =====
 
-[id="ui-template-details-details_{context}"]
+[id="ui-template-details-details"]
 ==== Details tab
 
 You can configure a custom template on the *Details* tab.
@@ -1103,7 +1103,7 @@ The number of CPUs is calculated by using the following formula: `sockets * thre
 |====
 =====
 
-[id="ui-template-details-yaml_{context}"]
+[id="ui-template-details-yaml"]
 ==== YAML tab
 
 You can configure a custom template by editing the YAML file on the *YAML* tab.
@@ -1133,7 +1133,7 @@ You can configure a custom template by editing the YAML file on the *YAML* tab.
 |====
 =====
 
-[id="ui-template-details-scheduling_{context}"]
+[id="ui-template-details-scheduling"]
 ==== Scheduling tab
 
 You can configure scheduling on the *Scheduling* tab.
@@ -1169,7 +1169,7 @@ You can configure scheduling on the *Scheduling* tab.
 |====
 =====
 
-[id="ui-template-details-network-interfaces_{context}"]
+[id="ui-template-details-network-interfaces"]
 ==== Network interfaces tab
 
 You can manage network interfaces on the *Network interfaces* tab.
@@ -1201,7 +1201,7 @@ Click the Options menu {kebab} beside a network interface to select *Edit* or *D
 |====
 =====
 
-[id="ui-template-details-disks_{context}"]
+[id="ui-template-details-disks"]
 ==== Disks tab
 
 You can manage disks on the *Disks* tab.
@@ -1233,7 +1233,7 @@ Click the Options menu {kebab} beside a disk to select *Edit* or *Detach*.
 |====
 =====
 
-[id="ui-template-details-scripts_{context}"]
+[id="ui-template-details-scripts"]
 ==== Scripts tab
 
 You can manage the cloud-init settings, SSH keys, and Sysprep answer files on the *Scripts* tab.
@@ -1260,7 +1260,7 @@ You can manage the cloud-init settings, SSH keys, and Sysprep answer files on th
 |====
 =====
 
-[id="ui-template-details-parameters_{context}"]
+[id="ui-template-details-parameters"]
 ==== Parameters tab
 
 You can edit selected template settings on the *Parameters* tab.
@@ -1284,7 +1284,7 @@ You can edit selected template settings on the *Parameters* tab.
 |====
 =====
 
-[id="ui-datasources-page_{context}"]
+[id="ui-datasources-page"]
 == DataSources page
 
 You can create and configure DataSources for VirtualMachine boot sources on the DataSources page.
@@ -1320,7 +1320,7 @@ Click the Options menu {kebab} beside a DataSource to select *Edit labels*, *Edi
 
 Click a DataSource to view the DataSource details page.
 
-[id="ui-datasource-details-page_{context}"]
+[id="ui-datasource-details-page"]
 === DataSource details page
 
 You can configure a DataSource on the DataSource details page.
@@ -1359,7 +1359,7 @@ You can configure a DataSource on the DataSource details page.
 |====
 =====
 
-[id="ui-migrationpolicies-page_{context}"]
+[id="ui-migrationpolicies-page"]
 == MigrationPolicies page
 
 You can manage MigrationPolicies for your workloads on the MigrationPolicies page.
@@ -1390,7 +1390,7 @@ Click the Options menu {kebab} beside a MigrationPolicy to select *Edit* or *Del
 
 Click a MigrationPolicy to view the MigrationPolicy details page.
 
-[id="ui-migrationpolicy-details-page_{context}"]
+[id="ui-migrationpolicy-details-page"]
 === MigrationPolicy details page
 
 You can configure a MigrationPolicy on the MigrationPolicy details page.

--- a/virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc
+++ b/virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc
@@ -24,4 +24,4 @@ include::modules/virt-creating-a-service-from-a-virtual-machine.adoc[leveloffset
 == Additional resources
 * xref:../../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-nodeport.adoc#configuring-ingress-cluster-traffic-nodeport[Configuring ingress cluster traffic using a NodePort]
 * xref:../../../networking/configuring_ingress_cluster_traffic/configuring-ingress-cluster-traffic-load-balancer.adoc#configuring-ingress-cluster-traffic-load-balancer[Configuring ingress cluster traffic using a load balancer]
-* xref:../../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-details_virt-web-console-overview[Web console overview]
+* xref:../../../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-details[Web console overview]


### PR DESCRIPTION
Cherry Picked from 38c34804d9878da7d420e630779fe3eb969b1b05 xref:https://github.com/openshift/openshift-docs/pull/59422