### PR TITLE
Added `Note` in API Server Named Certificate

### DIFF
--- a/modules/customize-certificates-api-add-named.adoc
+++ b/modules/customize-certificates-api-add-named.adoc
@@ -113,3 +113,8 @@ kube-apiserver   {product-version}.0     True        False         False      14
 ----
 +
 If `PROGRESSING` is showing `True`, wait a few minutes and try again.
++
+[NOTE]
+====
+A new revision of the Kubernetes API server only rolls out if the API server named certificate is added for the first time. When the API server named certificate is renewed, a new revision of the Kubernetes API server does not roll out because the `kube-apiserver` pods dynamically reload the updated certificate.
+====


### PR DESCRIPTION
Replaces #57075.

4.10+

Implementing the peer review feedback from the above PR. 

Preview: https://59429--docspreview.netlify.app/openshift-enterprise/latest/security/certificates/api-server.html#customize-certificates-api-add-named_api-server-certificates

QE review:
- [x] QE has approved this change.