### PR TITLE
Add details about image signature ConfigMap

### DIFF
--- a/modules/update-restricted.adoc
+++ b/modules/update-restricted.adoc
@@ -19,6 +19,11 @@ If you have a local OpenShift Update Service, you can update by using the connec
 
 * You mirrored the images for the new release to your registry.
 * You applied the release image signature ConfigMap for the new release to your cluster.
++
+[NOTE]
+====
+The release image signature config map allows the Cluster Version Operator (CVO) to ensure the integrity of release images by verifying that the actual image signatures match the expected signatures.
+====
 * You obtained the sha256 digest for your targeted release image.
 * You installed the OpenShift CLI (`oc`).
 * You paused all `MachineHealthCheck` resources.

--- a/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
@@ -114,6 +114,11 @@ Before updating your cluster, confirm that the following conditions are met:
 
 * The Cluster Version Operator (CVO) is configured to use your locally-installed OpenShift Update Service application.
 * The release image signature config map for the new release is applied to your cluster.
++
+[NOTE]
+====
+The release image signature config map allows the Cluster Version Operator (CVO) to ensure the integrity of release images by verifying that the actual image signatures match the expected signatures.
+====
 * The current release and update target release images are mirrored to a locally accessible registry.
 * A recent graph data container image has been mirrored to your local registry.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Until v4.7 of the documentation there was a paragraph about the release image signature, which is a prerequisite to update a cluster, especially in a restricted network, where you have to create it manually. (cf. [updating-restricted-network-cluster.html#updating-restricted-network-image-signature-configmap](https://docs.openshift.com/container-platform/4.7/updating/updating-restricted-network-cluster.html#updating-restricted-network-image-signature-configmap)
I added a note about its role. But we may add back the full section about how to create it?
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.10+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
None.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
