### PR TITLE
OSDOCS-4058

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -91,7 +91,7 @@ Distros: openshift-rosa
 Topics:
 - Name: AWS prerequisites for ROSA with STS
   File: rosa-sts-aws-prereqs
-- Name: OpenShift Cluster Manager IAM role resources
+- Name: ROSA IAM role resources
   File: rosa-sts-ocm-role
 - Name: Limits and scalability
   File: rosa-limits-scalability

--- a/modules/rosa-sts-aws-requirements-association-concept.adoc
+++ b/modules/rosa-sts-aws-requirements-association-concept.adoc
@@ -6,6 +6,6 @@
 [id="rosa-associating-concept_{context}"]
 = AWS account association
 
-{product-title} (ROSA) cluster-provisioning tasks require linking `ocm-role` and `user-role` {cluster-manager} IAM roles to your AWS account using your Amazon Resource Name (ARN).
+{product-title} (ROSA) cluster-provisioning tasks require linking `ocm-role` and `user-role` IAM roles to your AWS account using your Amazon Resource Name (ARN).
 
 The `ocm-role` ARN is stored as a label in your Red Hat organization while the `user-role` ARN is stored as a label inside your Red Hat user account. Red Hat uses these ARN labels to confirm that the user is a valid account holder and that the correct permissions are available to perform the necessary tasks in the AWS account.

--- a/modules/rosa-sts-ocm-role-creation.adoc
+++ b/modules/rosa-sts-ocm-role-creation.adoc
@@ -4,9 +4,9 @@
 // * rosa_planning/rosa-sts-ocm-role.adoc
 :_content-type: PROCEDURE
 [id="rosa-sts-ocm-roles-and-permissions-iam-basic-role_{context}"]
-= Creating an {cluster-manager} IAM role
+= Creating an ocm-role IAM role
 
-You create your {cluster-manager} IAM roles by using the command-line interface (CLI).
+You create your `ocm-role` IAM roles by using the command-line interface (CLI).
 
 .Prerequisites
 

--- a/modules/rosa-sts-user-role-creation.adoc
+++ b/modules/rosa-sts-user-role-creation.adoc
@@ -4,9 +4,9 @@
 // * rosa_planning/rosa-sts-ocm-role.adoc
 :_content-type: PROCEDURE
 [id="rosa-sts-user-role-iam-basic-role_{context}"]
-= Creating an user-role IAM role
+= Creating a user-role IAM role
 
-You can create your {cluster-manager} IAM roles by using the command-line interface (CLI).
+You can create your `user-role` IAM roles by using the command-line interface (CLI).
 
 .Prerequisites
 
@@ -14,7 +14,7 @@ You can create your {cluster-manager} IAM roles by using the command-line interf
 * You have installed and configured the latest AWS (`aws`) and ROSA (`rosa`) CLIs on your installation host.
 
 .Procedure
-* To create an ocm-role IAM role with basic privileges, run the following command:
+* To create a `user-role` IAM role with basic privileges, run the following command:
 +
 [source,terminal]
 ----

--- a/rosa_planning/rosa-sts-ocm-role.adoc
+++ b/rosa_planning/rosa-sts-ocm-role.adoc
@@ -2,7 +2,7 @@
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-sts-ocm-role
 [id="rosa-sts-ocm-role"]
-= {cluster-manager} IAM role resources
+= ROSA IAM role resources
 
 toc::[]
 


### PR DESCRIPTION
[OSDOCS-4058](https://issues.redhat.com//browse/OSDOCS-4058): Quick fixes to ocm-role wording

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-4058

Link to docs preview:
https://59434--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-ocm-role.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
