### PR TITLE
OSDOCS-5891: adds 4.10.59 to RN

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3967,3 +3967,28 @@ $ oc adm release info 4.10.58 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-59"]
+=== RHBA-2023:2018 - {product-title} 4.10.59 bug fix update
+
+Issued: 2023-05-03
+
+{product-title} release 4.10.59 is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:2018[RHBA-2023:2018] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:2017[RHSA-2023:2017] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.59 --pullspecs
+----
+
+[id="ocp-4-10-59-bug-fixes"]
+==== Bug fixes
+* Previously, the topology sidebar did not display updated information. When you updated the resources directly from the topology sidebar, you had to reopen the sidebar to see the changes. With this fix, the updated resources are displayed correctly. As a result, you can see the latest changes directly in the topology sidebar. (link:https://issues.redhat.com/browse/OCPBUGS-12438[*OCPBUGS-12438*])
+
+* Previously, when creating a `Secret`, the *Start Pipeline* model created an invalid JSON value. As a result, the `Secret` was unusable and the `PipelineRun` could fail. With this fix, the *Start Pipeline* model creates a valid JSON value for the secret. Now, you can create valid secrets while starting a pipeline. (link:https://issues.redhat.com/browse/OCPBUGS-7961[*OCPBUGS-7961*])
+
+[id="ocp-4-10-59-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-5891](https://issues.redhat.com//browse/OSDOCS-5891): adds 4.10.59
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5891
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[[Preview](http://file.rdu.redhat.com/jaldinge/OSDOCS-5891/release_notes/ocp-4-10-release-notes.html#ocp-4-10-59)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
