### PR TITLE
OSDOCS#5936: Adds notes for Microshift 4.12.15 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -194,3 +194,12 @@ Issued: 2023-04-24
 {product-title} release 4.12.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1861[RHBA-2023:1861] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1858[RHBA-2023:1858] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-15-dp"]
+=== RHBA-2023:2040 - {product-title} 4.12.15 bug fix update
+
+Issued: 2023-05-03
+
+{product-title} release 4.12.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2040[RHBA-2023:2040] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2037[RHBA-2023:2037] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#5936: Adds notes for Microshift 4.12.15 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5936

Link to docs preview:
https://59438--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-15-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
links will not work yet
