### PR TITLE
CNV-25435: Update and assemble CNV 4.13 release notes

### DIFF
--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -32,7 +32,7 @@ include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
 [id="virt-guest-os"]
 === Supported guest operating systems
 //CNV-16390 Supported guest operating systems
-To view the supported guest operating systems for {VirtProductName}, refer to link:https://access.redhat.com/articles/973163#ocpvirt[Certified Guest Operating Systems in Red Hat OpenStack Platform, Red Hat Virtualization and OpenShift Virtualization].
+To view the supported guest operating systems for {VirtProductName}, see link:https://access.redhat.com/articles/973163#ocpvirt[Certified Guest Operating Systems in Red Hat OpenStack Platform, Red Hat Virtualization, OpenShift Virtualization and Red Hat Enterprise Linux with KVM].
 
 
 [id="virt-4-13-new"]
@@ -65,7 +65,10 @@ All VM templates that are included with {VirtProductName} now use this machine t
 //CNV-22972 Release note: Docs reorg
 * The "Logging, events, and monitoring" documentation is now called xref:../virt/support/virt-support-overview.adoc#virt-support-overview[Support]. The monitoring tools documentation has been moved to xref:../virt/support/monitoring/virt-monitoring-overview.adoc#virt-monitoring-overview[Monitoring].
 
-// CNV-24976 Release note: CHANGE Specify the supported guest operating systems
+//CNV-25423 Release note: NEW Loki
+
+//CNV-24976 Release note: CHANGE (CLOSED)
+
 
 // CNV-25423
 * You can view and filter aggregated {VirtProductName} logs in the web console by using the xref:../virt/support/virt-troubleshooting.adoc#virt-viewing-logs-loki_virt-troubleshooting[LokiStack].
@@ -77,8 +80,8 @@ All VM templates that are included with {VirtProductName} now use this machine t
 * Quick start tours are available for several {VirtProductName} features. To view the tours, click the *Help* icon *?* in the menu bar on the header of the {VirtProductName} console and then select *Quick Starts*. You can filter the available tours by entering the `virtualization` keyword in the *Filter* field.
 
 
-[id="virt-4-13-installation-new"]
-=== Installation
+//[id="virt-4-13-installation-new"]
+//=== Installation
 
 
 [id="virt-4-13-networking-new"]
@@ -102,8 +105,6 @@ All VM templates that are included with {VirtProductName} now use this machine t
 //CNV-23474 Release note: NEW Paste clipboard into VNC
 * You can now xref:../virt/virt-web-console-overview.adoc#ui-virtualmachine-details-console[paste a string] from your client’s clipboard into the guest when using the VNC console.
 
-//CNV-22555 Release note: CHANGE Hostname field moving from cloud-init options to VM details page
-
 //CNV-25427 Release note: NEW Allow VM admin to expose SSH service using LB in the UI
 * The *VirtualMachine details* -> *Details* tab now provides a new SSH service type *SSH over LoadBalancer* to expose the SSH service over a load balancer.
 
@@ -117,54 +118,32 @@ All VM templates that are included with {VirtProductName} now use this machine t
 * You can now enable headless mode for high performance VMs in the web console.
 
 //NOTE: Comment out deprecated and removed features (and their IDs) if not used in a release
-[id="virt-4-13-deprecated-removed"]
-== Deprecated and removed features
+//[id="virt-4-13-deprecated-removed"]
+//== Deprecated and removed features
 
 
-[id="virt-4-13-deprecated"]
-=== Deprecated features
+//[id="virt-4-13-deprecated"]
+//=== Deprecated features
 // NOTE: when uncommenting deprecated features list, change the header level below to ===
 
-Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
-
+//Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
 
 [id="virt-4-13-removed"]
-=== Removed features
+== Removed features
 
 Removed features are not supported in the current release.
-
 
 //CNV-19043 Release note: CHANGE Remove rhel6 support
 * Red Hat Enterprise Linux 6 is no longer supported on {VirtProductName}.
 
 //CNV-23499: Carry over/repeat removed feature from version 4.12
-* Support for the legacy HPP custom resource, and the associated storage class, has been removed for all new deployments. In {VirtProductName} 4.13, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. A legacy HPP custom resource is supported only if it had been installed on a previous version of {VirtProductName}.
-
+* Support for the legacy HPP custom resource, and the associated storage class, has been removed for all new deployments. In {VirtProductName} {VirtVersion}, the HPP Operator uses the Kubernetes Container Storage Interface (CSI) driver to configure local storage. A legacy HPP custom resource is supported only if it had been installed on a previous version of {VirtProductName}.
 
 //NOTE: Removed features for 4.13 are above this line.
 
-//CNV-16317 NMState is no longer part of CNV
-* {VirtProductName} 4.11 removed support for link:https://nmstate.io/[nmstate], including the following objects:
-+
---
-** `NodeNetworkState`
-** `NodeNetworkConfigurationPolicy`
-** `NodeNetworkConfigurationEnactment`
---
-+
-To preserve and support your existing nmstate configuration, install the xref:../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState Operator] before updating to {VirtProductName} 4.11. For {VirtVersion} for xref:../virt/upgrading-virt.adoc#virt-about-eus-updates_upgrading-virt[Extended Update Support (EUS)] versions, install the Kubernetes NMState Operator after updating to {VirtVersion}. You can install the Operator from the *OperatorHub* in the {product-title} web console, or by using the OpenShift CLI (`oc`).
-
-* The Node Maintenance Operator (NMO) is no longer shipped with {VirtProductName}. You can install the NMO from the *OperatorHub* in the {product-title} web console, or by using the OpenShift CLI (`oc`).
-+
-You must perform one of the following tasks before updating to {VirtProductName} 4.11 from {VirtProductName} 4.10.2 and later 4.10 releases. For xref:../virt/upgrading-virt.adoc#virt-about-eus-updates_upgrading-virt[Extended Update Support (EUS)] versions, you must perform the following tasks before updating to {VirtProductName} {VirtVersion} from 4.10.2 and later 4.10 releases:
-
-** Move all nodes out of maintenance mode.
-** Install the standalone NMO and replace the `nodemaintenances.nodemaintenance.kubevirt.io` custom resource (CR) with a `nodemaintenances.nodemaintenance.medik8s.io` CR.
-
-
-[id="virt-4-13-changes"]
-== Notable technical changes
+//[id="virt-4-13-changes"]
+//== Notable technical changes
 
 
 [id="virt-4-13-technology-preview"]
@@ -177,9 +156,8 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 
 //NOTE: RNs related to 4.13 TP features begin here
 
-//CNV-17910 Release note: PREVIEW CNV Observability
-
-//CNV-18090 Release note: PREVIEW OVN Secondary Network
+//CNV-27681/BZ2183594 Migration of VMs does not complete with descheduler operator enabled
+* The Descheduler is a Technical Preview and might cause failed migrations and unstable scheduling. 
 
 //CNV-18095 Release note: NEW [TechPreview] Add Virtual machines CPU metrics
 * You can now use xref:../virt/support/monitoring/virt-prometheus-queries.adoc#about-querying-metrics_virt-prometheus-queries[Prometheus] to monitor the following metrics:
@@ -197,44 +175,25 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //CNV-18413 Release note: PREVIEW Accessing VMs on secondary networks by using cluster domain name
 * You can now xref:../virt/virtual_machines/vm_networking/virt-accessing-vm-secondary-network-fqdn.adoc#virt-accessing-vm-secondary-network-fqdn[access a VM that is attached to a secondary network interface] from outside the cluster by using its fully qualified domain name (FQDN).
 
+//CNV-21991 Release notes: PREVIEW CNV hypershift
+//NOTE: Targeted for 4.13.1 per Avital and Pan
 
 //CNV-19436 Release note: NEW Retrieve a temporary token to access the VNC endpoint of a VM
-//NOTE: This is a TP item for virt-4.13
+//NOTE: This is a TP item for virt-4.14
 
 //CNV-20965 Release note: PREVIEW Default creation and deployment of common set of instancetypes and preferences that eventually replace common templates
-
-//CNV-21991 Release note: PREVIEW CNV Provider for Hypershift
+//NOTE: This is a TP item for virt-4.14
 
 
 //NOTE: Existing 4.12 TP notes begin here
 
-
-//CNV-21824
-* You can now run xref:../virt/support/monitoring/virt-running-cluster-checkups.adoc#virt-running-cluster-checkups[{product-title} cluster checkups] to measure network latency between VMs.
-
-//CNV-20526
-* The Tekton Tasks Operator (TTO) now xref:../virt/virtual_machines/virt-managing-vms-openshift-pipelines.adoc#virt-managing-vms-openshift-pipelines[integrates {VirtProductName} with {pipelines-title}]. TTO includes cluster tasks and example pipelines that allow you to:
-+
-** Create and manage virtual machines (VMs), persistent volume claims (PVCs), and data volumes.
-** Run commands in VMs.
-** Manipulate disk images with `libguestfs` tools.
-** Install Windows 10 into a new data volume from a Windows installation image (ISO file).
-** Customize a basic Windows 10 installation and then create a new image and template.
-
-//CNV-20149
-* You can now use the xref:../virt/support/monitoring/virt-monitoring-vm-health.adoc#virt-define-guest-agent-ping-probe_virt-monitoring-vm-health[guest agent ping probe] to determine if the QEMU guest agent is running on a virtual machine.
-
-//CNV-20963
+//CNV-20963 leave in 
 * You can now use Microsoft Windows 11 as a guest operating system. However, {VirtProductName} {VirtVersion} does not support USB disks, which are required for a critical function of BitLocker recovery. To protect recovery keys, use other methods described in the link:https://learn.microsoft.com/en-us/windows/security/information-protection/bitlocker/bitlocker-recovery-guide-plan[BitLocker recovery guide].
 
-//CNV-19145 Support live migration policies
-* You can create live migration policies with specific parameters, such as bandwidth usage, maximum number of parallel migrations, and timeout, and apply the policies to groups of virtual machines by using virtual machine and namespace labels.
+[id="virt-4-13-bug-fix"]
+== Bug fix
 
-
-[id="virt-4-13-bug-fixes"]
-== Bug fixes
-
-
+* The virtual machine snapshot restore operation no longer hangs indefinitely due to some persistent volume claim (PVC) annotations created by the Containerized Data Importer (CDI). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2070366[*BZ#2070366*])
 
 
 
@@ -246,7 +205,18 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 * When you use two pods with different SELinux contexts, VMs with the `ocs-storagecluster-cephfs` storage class fail to migrate and the VM status changes to `Paused`. This is because both pods try to access the shared `ReadWriteMany` CephFS volume at the same time. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2092271[*BZ#2092271*])
 ** As a workaround, use the `ocs-storagecluster-ceph-rbd` storage class to live migrate VMs on a cluster that uses Red Hat Ceph Storage.
 
+//Leave in per Dominik
+* If you clone more than 100 VMs using the `csi-clone` cloning strategy, then the Ceph CSI might not purge the clones. Manually deleting the clones might also fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055595[*BZ#2055595*])
+** As a workaround, you can restart the `ceph-mgr` to purge the VM clones.
+
+//OCPBUGS-8398 for Dominik
+* If you stop a node on a cluster and then use the Node Health Check Operator to bring the node back up, connectivity to Multus might be lost. (link:https://issues.redhat.com/browse/OCPBUGS-8398[*OCPBUGS-8398*])
+
+//OCPBUGS-11277 for Dominik
+* The must-gather tool might not collect diagnostic information for a node that is in a `NotReady` state. (link:https://issues.redhat.com/browse/OCPBUGS-11277[*OCPBUGS-11277*])
+
 // Fix targeted for 4.12.1
+//Pending reply from Jenia and kmajcher
 * The `TopoLVM` provisioner name string has changed in {VirtProductName} 4.12. As a result, the automatic import of operating system images might fail with the following error message (link:https://bugzilla.redhat.com/show_bug.cgi?id=2158521[*BZ#2158521*]):
 +
 [source,terminal]
@@ -263,41 +233,36 @@ $ oc patch storageprofile <storage_profile> --type=merge -p '{"spec": {"claimPro
 ----
 . Delete the affected data volumes in the `openshift-virtualization-os-images` namespace. They are recreated with the access mode and volume mode from the updated storage profile.
 
-// Fix targeted for 4.13
+// Fix targeted for 4.13 Pending reply from Jenia and kmajcher
 * When restoring a VM snapshot for storage whose binding mode is `WaitForFirstConsumer`, the restored PVCs remain in the `Pending` state and the restore operation does not progress.
 ** As a workaround, start the restored VM, stop it, and then start it again. The VM will be scheduled, the PVCs will be in the `Bound` state, and the restore operation will complete. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2149654[*BZ#2149654*])
 
 //New known issues for 4.13 go above this comment
+//Leave in per Stu
 * VMs created from common templates on a Single Node OpenShift (SNO) cluster display a `VMCannotBeEvicted` alert because the template's default eviction strategy is `LiveMigrate`. You can ignore this alert or remove the alert by updating the VM's eviction strategy. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2092412[*BZ#2092412*])
 
+//Leave in per Simone
 * Uninstalling {VirtProductName} does not remove the `feature.node.kubevirt.io` node labels created by {VirtProductName}. You must remove the labels manually. (link:https://issues.redhat.com/browse/CNV-22036[*CNV-22036*])
 
-* Some persistent volume claim (PVC) annotations created by the Containerized Data Importer (CDI) can cause the virtual machine snapshot restore operation to hang indefinitely. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2070366[*BZ#2070366*])
-** As a workaround, you can remove the annotations manually:
-. Obtain the xref:../virt/virtual_machines/virtual_disks/virt-managing-vm-snapshots.adoc#vm-snapshot-controller-and-crds_virt-managing-vm-snapshots[VirtualMachineSnapshotContent] custom resource (CR) name from the `status.virtualMachineSnapshotContentName` value in the `VirtualMachineSnapshot` CR.
-. Edit the `VirtualMachineSnapshotContent` CR and remove all lines that contain `k8s.io/cloneRequest`.
-. If you did not specify a value for `spec.dataVolumeTemplates` in the `VirtualMachine` object, delete any `DataVolume` and `PersistentVolumeClaim` objects in this namespace where both of the following conditions are true:
-+
-.. The object's name begins with `restore-`.
-.. The object is not referenced by virtual machines.
-+
-This step is optional if you specified a value for `spec.dataVolumeTemplates`.
-. Repeat the xref:../virt/virtual_machines/virtual_disks/virt-managing-vm-snapshots.adoc#virt-restoring-vm-from-snapshot-cli_virt-managing-vm-snapshots[restore operation] with the updated `VirtualMachineSnapshot` CR.
-
+//Leave in per Kedar
 * Windows 11 virtual machines do not boot on clusters running in link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/security_hardening/index#con_federal-information-processing-standard-fips_assembly_installing-the-system-in-fips-mode[FIPS mode]. Windows 11 requires a TPM (trusted platform module) device by default. However, the `swtpm` (software TPM emulator) package is incompatible with FIPS. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2089301[*BZ#2089301*])
 
 //BZ-1885605
+//Leave in per Petr
 * If your {product-title} cluster uses OVN-Kubernetes as the default Container Network Interface (CNI) provider, you cannot attach a Linux bridge or bonding device to a host's default interface because of a change in the host network topology of OVN-Kubernetes. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1885605[*BZ#1885605*])
 ** As a workaround, you can use a secondary network interface connected to your host, or switch to the OpenShift SDN default CNI provider.
 
+//Pending for Kevin
 * In some instances, multiple virtual machines can mount the same PVC in read-write mode, which might result in data corruption. (link:https://bugzilla.redhat.com/show_bug.cgi?id=1992753[*BZ#1992753*])
 ** As a workaround, avoid using a single PVC in read-write mode with multiple VMs.
 
+//Leave in per Stu
 * The Pod Disruption Budget (PDB) prevents pod disruptions for migratable virtual machine images. If the PDB detects pod disruption, then `openshift-monitoring` sends a `PodDisruptionBudgetAtLimit` alert every 60 minutes for virtual machine images that use the `LiveMigrate` eviction strategy. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2026733[*BZ#2026733*])
 ** As a workaround, xref:../monitoring/managing-alerts.adoc#silencing-alerts_managing-alerts[silence alerts].
 
+//Leave in per Stu
 * {VirtProductName} links a service account token in use by a pod to that specific pod. {VirtProductName} implements a service account volume by creating a disk image that contains a token. If you migrate a VM, then the service account volume becomes invalid. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2037611[*BZ#2037611*])
 ** As a workaround, use user accounts rather than service accounts because user account tokens are not bound to a specific pod.
 
-* If you clone more than 100 VMs using the `csi-clone` cloning strategy, then the Ceph CSI might not purge the clones. Manually deleting the clones can also fail. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2055595[*BZ#2055595*])
-** As a workaround, you can restart the `ceph-mgr` to purge the VM clones.
+//CNV-26301/BZ2151169 Leave in per Kedar
+* In a heterogeneous cluster with different compute nodes, virtual machines that have HyperV Reenlightenment enabled cannot be scheduled on nodes that do not support timestamp-counter scaling (TSC) or have the appropriate TSC frequency.(link:https://bugzilla.redhat.com/show_bug.cgi?id=2151169[*BZ#2151169*]) 


### PR DESCRIPTION
Version(s): 4.13

Issue: [CNV-25435](https://issues.redhat.com/browse/CNV-25435)


Link to docs preview: Netlify preview not currently working. 

Remote file server version for merge review: http://file.rdu.redhat.com/pousley/audrey-rn-final-4-13/virt/virt-4-13-release-notes.html

(Git file view used for peer review:  https://github.com/openshift/openshift-docs/blob/978681811df8f40a66faa75d2aac119fc0ac90df/virt/virt-4-13-release-notes.adoc)

QE review: Ongoing with overall release notes document review

Additional information: All links verified in the local Asciibinder build of the release notes.

