### PR TITLE
OSDOCS#5765: Replacing 3.3 podman recommendation to 3.4.2.0+

### DIFF
--- a/installing/disconnected_install/installing-mirroring-creating-registry.adoc
+++ b/installing/disconnected_install/installing-mirroring-creating-registry.adoc
@@ -14,7 +14,7 @@ If you already have a container image registry, such as Red Hat Quay, you can sk
 == Prerequisites
 
 * An {product-title} subscription.
-* {op-system-base-full} 8 and 9 with Podman 3.3 and OpenSSL installed.
+* {op-system-base-full} 8 and 9 with Podman 3.4.2 or later and OpenSSL installed.
 * Fully qualified domain name for the Red Hat Quay service, which must resolve through a DNS server.
 * Key-based SSH connectivity on the target host. SSH keys are automatically generated for local installs. For remote hosts, you must generate your own SSH keys.
 * 2 or more vCPUs.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-5765

Link to docs preview:
https://59441--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
