### PR TITLE
OSDOCS-5275-link-redo:Updated vSphere release notes by adding links t…

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -96,9 +96,13 @@ The VMware vSphere region and zone enablement feature is only available with a n
 A cluster that was upgraded from a previous release defaults to using the in-tree vSphere driver. As a result, you must enable CSI automatic migration for the cluster to use this feature. You can then configure multiple regions and zones for the upgraded cluster.
 ====
 
+For more information, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#installation-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations[VMware vSphere region and zone enablement].
+
 [id="ocp-4-13-installation-vsphere-default-config-yaml"]
 ==== Changes to the default vSphere `install-config.yaml` file
 After you run the installation program for {product-title} on vSphere, the default `install-config.yaml` file now includes `vcenters` and `failureDomains` fields, so that you can choose to specify multiple datacenters, region, and zone information for your cluster. You can leave these fields blank if you want to install an {product-title} cluster in a vSphere environment that consists of single datacenter running in a VMware vCenter.
+
+For more information, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations[Configuring regions and zones for a VMware vCenter].
 
 [id="ocp-4-13-installation-and-upgrade-three-node"]
 ==== Three-node cluster support
@@ -194,7 +198,7 @@ For more information about scaling a user-provisioned cluster by using the BMO, 
 === Post-installation configuration
 
 [id="ocp-4-13-multi-arch-compute-machines-ga"]
-==== {product-title} clusters with multi-architecture compute machines 
+==== {product-title} clusters with multi-architecture compute machines
 
 {product-title} {product-version} clusters with multi-architecture compute machines is now generally available. As a Day 2 operation, you can now create a cluster with compute nodes of different architectures on AWS and Azure installer provisioned infrastructures. User-provisioned installation on bare metal are in Technology Preview. For more information on creating a cluster with multi-architecture compute machines, see xref:../post_installation_configuration/multi-architecture-configuration.adoc#multi-architecture-configuration[Configuring multi-architecture compute machines on an {product-title} cluster].
 
@@ -202,6 +206,8 @@ For more information about scaling a user-provisioned cluster by using the BMO, 
 [id="ocp-4-13-post-installation-vsphere-failure-domains"]
 ==== Specifying multiple failure domains for your cluster on VSphere
 As an administrator, you can specify multiple failure domains for your {product-title} cluster that runs on a VMware VSphere instance. This means that you can distribute key control planes and workload elements among varied hardware resources for a datacenter. Additionally, you can configure your cluster to use a multiple layer 2 network configuration, so that data transfer among nodes can span across multiple networks.
+
+For more information, see xref:../post_installation_configuration/post-install-vsphere-zones-regions-configuration.adoc#specifying-regions-zones-infrastructure-vsphere_post-install-vsphere-zones-regions-configuration[Specifying multiple failure domains for your cluster on VSphere].
 
 [id="ocp-4-13-web-console"]
 === Web console
@@ -1069,6 +1075,8 @@ The toolbox script is deprecated and support will be removed from a future {prod
 * `platform.vsphere.apiVIP`
 * `platform.vsphere.ingressVIP`
 * `platform.vsphere.network`
+
+For more information, see xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#deprecated-parameters-vsphere_installing-vsphere-installer-provisioned-customizations[Deprecated VMware vSphere configuration parameters].
 
 [id="ocp-4-13-node-dep-topology-labels"]
 ==== Kubernetes topology labels


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-5725](https://issues.redhat.com/browse/OSDOCS-5725)

Link to docs preview:
* [Installation and update](https://59464--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-installation-and-update)
* [Multiple regions and zones configuration for a cluster on vSphere](https://59464--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-post-installation)

QE review:
- [X] QE has approved this change. Not needed for adding internal doc links to release notes. 

