### PR TITLE
Removed Tech Preview note from AWS Load Balancer Operator docs

### DIFF
--- a/networking/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc
+++ b/networking/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc
@@ -8,7 +8,4 @@ toc::[]
 
 The AWS Load Balancer (ALB) Operator deploys and manages an instance of the `aws-load-balancer-controller` resource. You can install the AWS Load Balancer Operator from the OperatorHub by using {product-title} web console or CLI.
 
-:FeatureName: AWS Load Balancer Operator deployment
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 include::modules/installing-aws-load-balancer-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
The AWS Load Balancer Operator became GA on 25 April
https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.html

Link to docs preview:
https://59483--docspreview.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/install-aws-load-balancer-operator.html

A separate PR will make updates to https://docs.openshift.com/container-platform/4.12/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.html to clarify that it is GA. And we will also possibly update the core release notes for 4.11 and 4.12 to update the TP table.
