### PR TITLE
Mhess fix rhacs docs

### DIFF
--- a/modules/create-policy-from-risk-view.adoc
+++ b/modules/create-policy-from-risk-view.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/evaluate-security-risks.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="create-policy-from-risk-view_{context}"]
 = Creating a security policy from the risk view
 
@@ -10,5 +10,5 @@ While evaluating risks in your deployments in the *Risk* view, when you apply lo
 
 .Procedure
 . Navigate to the RHACS portal and select *Risk* from the navigation menu.
-. Apply local page filtering criteria that you want to create a policy.
+. Apply local page filtering criteria that you want to create a policy for.
 . Select *New Policy* and fill in the required fields to create a new policy.

--- a/modules/use-process-baselines.adoc
+++ b/modules/use-process-baselines.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * operating/evaluate-security-risks.adoc
-:_module-type: CONCEPT
+:_content-type: CONCEPT
 [id="use-process-baselines_{context}"]
 = Using process baselines
 
@@ -9,14 +9,14 @@
 You can minimize risk by using process baselining for infrastructure security. With this approach, {product-title} first discovers existing processes and creates a baseline.
 Then it operates in the default deny-all mode and only allows processes listed in the baseline to run.
 
-[discreet]
+[discrete]
 == Process baselines
 
 When you install {product-title}, there is no default process baseline.
 As {product-title} discovers deployments, it creates a process baseline for every container type in a deployment.
 Then it adds all discovered processes to their own process baselines.
 
-[discreet]
+[discrete]
 == Process baseline states
 
 During the process discovery phase, all baselines are in an unlocked state.


### PR DESCRIPTION
Fixed an ascii doc formatting issue due to a misspelled keyword.
Fixed a sentence by adding a missing word.

Version(s):

- Merge to rhacs-docs
- Cherry pick to rhacs-docs-3.73
- Cherry pick to rhacs-docs-3.74
- Cherry pick to rhacs-docs-4.0

Issue:
N/A

Link to docs preview:
N/A - see changes in PR...?
