### PR TITLE
[OSDOCS-5697] added decprecation to ROSA what's new

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -30,6 +30,6 @@ include::modules/rosa-update-cli-tool.adoc[]
 == Deprecated and removed features
 Some features available in previous releases have been deprecated or removed. Deprecated functionality is still included in ROSA and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
 
-[id="rosa-deprecated-feature-nonSTS-deployment_{context}"]
-=== ROSA non-STS deployment mode
-ROSA non-STS deployment mode is no longer the preferred method for new clusters. Instead, users must deploy ROSA with the STS mode. This deprecation is in line with our new ROSA provisioning wizard UI experience at https://console.redhat.com/openshift/create/rosa/wizard.
+* **ROSA non-STS deployment mode.** ROSA non-STS deployment mode is no longer the preferred method for new clusters. Instead, users must deploy ROSA with the STS mode. This deprecation is in line with our new ROSA provisioning wizard UI experience at https://console.redhat.com/openshift/create/rosa/wizard.
+
+* **Label removal on core namespaces.** ROSA is no longer labeling OpenShift core using the `name` label. Customers should migrate to referencing the `kubernetes.io/metadata.name` label if needed for Network Policies or other use cases.


### PR DESCRIPTION
[OSDOCS-5697] added decprecation to ROSA what's new

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-5697

Link to docs preview:
https://59485--docspreview.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html#rosa-deprecated-removed-features_rosa-whats-new

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
