### PR TITLE
TELCODOCS1177: Adding machinesets content for bare metal deployments

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2132,6 +2132,8 @@ Topics:
     Distros: openshift-origin
   - Name: Creating a compute machine set on vSphere
     File: creating-machineset-vsphere
+  - Name: Creating a compute machine set on bare metal
+    File: creating-machineset-bare-metal
 - Name: Manually scaling a compute machine set
   File: manually-scaling-machineset
 - Name: Modifying a compute machine set

--- a/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
@@ -1,0 +1,18 @@
+:_content-type: ASSEMBLY
+[id="creating-machineset-bare-metal"]
+= Creating a compute machine set on bare metal
+include::_attributes/common-attributes.adoc[]
+:context: creating-machineset-bare-metal
+
+toc::[]
+
+You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on bare metal. For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
+
+include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+
+include::modules/machineset-yaml-baremetal.adoc[leveloffset=+1]
+
+include::modules/machineset-creating.adoc[leveloffset=+1]
+
+// Mothballed - re-add when available
+// include::modules/machineset-osp-adding-bare-metal.adoc[leveloffset=+1]

--- a/machine_management/index.adoc
+++ b/machine_management/index.adoc
@@ -43,6 +43,8 @@ As a cluster administrator, you can perform the following actions:
 
 ** xref:../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere[vSphere]
 
+* Create a machine set for a bare metal deployment: xref:../machine_management/creating_machinesets/creating-machineset-bare-metal.adoc#creating-machineset-bare-metal[Creating a compute machine set on bare metal]
+
 * xref:../machine_management/manually-scaling-machineset.adoc#manually-scaling-machineset[Manually scale a compute machine set] by adding or removing a machine from the compute machine set.
 
 * xref:../machine_management/modifying-machineset.adoc#modifying-machineset[Modify a compute machine set] through the `MachineSet` YAML configuration file.

--- a/modules/machineset-yaml-baremetal.adoc
+++ b/modules/machineset-yaml-baremetal.adoc
@@ -1,0 +1,108 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating-infrastructure-machinesets.adoc
+// * machine_management/creating_machinesets/creating-machineset-bare-metal.adoc
+
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+:infra:
+endif::[]
+
+:_content-type: REFERENCE
+[id="machineset-yaml-vsphere_{context}"]
+= Sample YAML for a compute machine set custom resource on bare metal
+
+This sample YAML defines a compute machine set that runs on bare metal and creates nodes that are labeled with
+ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
+ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
+
+In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
+ifndef::infra[`<role>`]
+ifdef::infra[`<infra>`]
+is the node label to add.
+
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  creationTimestamp: null
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+ifndef::infra[]
+  name: <infrastructure_id>-<role> <2>
+endif::infra[]
+ifdef::infra[]
+  name: <infrastructure_id>-infra <2>
+endif::infra[]
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+ifndef::infra[]
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+endif::infra[]
+ifdef::infra[]
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
+endif::infra[]
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+ifndef::infra[]
+        machine.openshift.io/cluster-api-machine-role: <role> <3>
+        machine.openshift.io/cluster-api-machine-type: <role> <3>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role> <2>
+endif::infra[]
+ifdef::infra[]
+        machine.openshift.io/cluster-api-machine-role: <infra> <3>
+        machine.openshift.io/cluster-api-machine-type: <infra> <3>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra <2>
+endif::infra[]
+    spec:
+      metadata:
+        creationTimestamp: null
+        labels:
+ifndef::infra[]
+          node-role.kubernetes.io/<role>: "" <3>
+endif::infra[]
+ifdef::infra[]
+          node-role.kubernetes.io/infra: "" <3>
+      taints: <4>
+      - key: node-role.kubernetes.io/infra
+        effect: NoSchedule
+endif::infra[]
+      providerSpec:
+        value:
+          apiVersion: baremetal.cluster.k8s.io/v1alpha1
+          hostSelector: {}
+          image:
+            checksum: http:/172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2.<md5sum> <4>
+            url: http://172.22.0.3:6181/images/rhcos-<version>.<architecture>.qcow2 <5>
+          kind: BareMetalMachineProviderSpec
+          metadata:
+            creationTimestamp: null
+          userData:
+            name: worker-user-data
+----
+<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+ifndef::infra[]
+<2> Specify the infrastructure ID and node label.
+<3> Specify the node label to add.
+<4> Edit the `checksum` URL to use the API VIP address.
+<5> Edit the `url` URL to use the API VIP address.
+endif::infra[]
+
+ifeval::["{context}" == "creating-infrastructure-machinesets"]
+:!infra:
+endif::[]
+ifeval::["{context}" == "cluster-tasks"]
+:!infra:
+endif::[]


### PR DESCRIPTION
[TELCODOCS-1177](https://issues.redhat.com//browse/TELCODOCS-1177): There is a docs gap regarding creating machinesets on bare-metal deployments. Currently only creating machine sets on cloud providers are documented. 

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1177

Link to docs preview:
- [Managing compute machines](https://59489--docspreview.netlify.app/openshift-enterprise/latest/machine_management/index.html#machine-mgmt-intro-managing-compute_overview-of-machine-management)
- [Creating a compute machine set on bare metal](https://59489--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-bare-metal.html#creating-machineset-bare-metal)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

