### PR TITLE
[RHACS] 3.74 Fix the version number in common attributes

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -52,7 +52,7 @@ endif::[]
 :osp: Red Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.74.0
+:rhacs-version: 3.74.3
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 3.74


### PR DESCRIPTION
Fixes the currently released version number in RHACS 3.74 branch.

No cherrypicks.