### PR TITLE
OCPBUGS#12217: Add bond+vlan to the master description

### DIFF
--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -31,7 +31,7 @@ plugin:
 
 |`master`
 |`string`
-|The host network interface to associate with the newly created macvlan interface. If a value is not specified, then the default route interface is used.
+|The host network interface, such as a network interface, bond, or bond with VLAN, to associate with the newly created macvlan interface. If a value is not specified, then the default route interface is used.
 
 |`mtu`
 |`string`


### PR DESCRIPTION
Version(s): 4.12+

Issue: https://issues.redhat.com/browse/OCPBUGS-12217

Link to docs preview: https://59513--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-macvlan-object_configuring-additional-network

QE review:
- [x] QE has approved this change. @rbbratta
- [x] SME has approved this change. @dougbtv 