### PR TITLE
TELCODOCS-432: Adding iPXE content again for RHACM 2.8 release

### DIFF
--- a/modules/ztp-deploying-a-site.adoc
+++ b/modules/ztp-deploying-a-site.adoc
@@ -67,11 +67,6 @@ The folder includes example files for single node, three-node, and standard clus
 .. Change the cluster and host details in the example file to match the type of cluster you want. For example:
 +
 include::snippets/ztp-example-siteconfig.adoc[]
-+
-[NOTE]
-====
-For more information about BMC addressing, see the "Additional resources" section.
-====
 
 .. You can inspect the default set of extra-manifest `MachineConfig` CRs in `out/argocd/extra-manifest`. It is automatically applied to the cluster when it is installed.
 

--- a/modules/ztp-installation-crs.adoc
+++ b/modules/ztp-installation-crs.adoc
@@ -22,7 +22,7 @@ The following table lists the installation CRs that are automatically applied by
 
 |`BareMetalHost`
 |Contains the connection information for the Baseboard Management Controller (BMC) of the target bare-metal host.
-|Provides access to the BMC to load and start the discovery image on the target server by using the Redfish protocol.
+|Provides access to the BMC to load and start the discovery image on the target server. {ztp-first} supports iPXE and virtual media booting by using Redfish or IPMI protocols. To use iPXE booting, you must use {rh-rhacm} 2.8 or later.
 
 |`InfraEnv`
 |Contains information for installing {product-title} on the target bare-metal host.

--- a/snippets/ztp-example-siteconfig.adoc
+++ b/snippets/ztp-example-siteconfig.adoc
@@ -77,7 +77,7 @@ spec:
 <4> Cluster labels must correspond to the `bindingRules` field in the `PolicyGenTemplate` CRs that you define. For example, `policygentemplates/common-ranGen.yaml` applies to all clusters with `common: true` set, `policygentemplates/group-du-sno-ranGen.yaml` applies to all clusters with `group-du-sno: ""` set.
 <5> Optional. The CR specifed under `KlusterletAddonConfig` is used to override the default `KlusterletAddonConfig` that is created for the cluster.
 <6> For single-node deployments, define a single host. For three-node deployments, define three hosts. For standard deployments, define three hosts with `role: master` and two or more hosts defined with `role: worker`.
-<7> BMC address that you use to access the host. Applies to all cluster types.
+<7> BMC address that you use to access the host. Applies to all cluster types. {ztp} supports iPXE and virtual media booting by using Redfish or IPMI protocols. To use iPXE booting, you must use {rh-rhacm} 2.8 or later. For more information about BMC addressing, see the _Additional resources_ section. 
 <8> Name of the `bmh-secret` CR that you separately create with the host BMC credentials. When creating the `bmh-secret` CR, use the same namespace as the `SiteConfig` CR that provisions the host.
 <9> Configures the boot mode for the host. The default value is `UEFI`. Use `UEFISecureBoot` to enable secure boot on the host.
 <10> `cpuset` must match the value set in the cluster `PerformanceProfile` CR `spec.cpu.reserved` field for workload partitioning.


### PR DESCRIPTION
[TELCODOCS-432](https://issues.redhat.com//browse/TELCODOCS-432): The story was originally targeted for RHACM 2.7, which aligned with OCP 4.12. However, these changes were reversed. Instead the story applies to RHACM 2.8, which aligns with 4.13.3.

You can now use iPXE networking booting with the ZTP workflow to load and start RHCOS discovery images on a target host. You must use RHACM 2.8 or later.

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/TELCODOCS-432

Link to docs preview:
- https://59514--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.html#ztp-deploying-a-site_ztp-deploying-far-edge-sites
- https://59514--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-manual-install.html#ztp-generating-install-and-config-crs-manually_ztp-manual-install
-  https://59514--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-manual-install.html#ztp-installation-crs_ztp-manual-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

