### PR TITLE
OADP -1639 Roles

### DIFF
--- a/modules/migration-configuring-gcp.adoc
+++ b/modules/migration-configuring-gcp.adoc
@@ -95,6 +95,11 @@ $ ROLE_PERMISSIONS=(
     compute.snapshots.useReadOnly
     compute.snapshots.delete
     compute.zones.get
+    storage.objects.create
+    storage.objects.delete
+    storage.objects.get
+    storage.objects.list
+    iam.serviceAccounts.signBlob
 )
 ----
 


### PR DESCRIPTION
OADP 1.2.0

OCP - 4.10+

Resolves - https://issues.redhat.com/browse/OADP-1639

Deploy preview - https://59515--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.html   Step 8.
