### PR TITLE
Telcodocs 994 Documenting TAP device plugin

### DIFF
--- a/modules/nw-multus-tap-object.adoc
+++ b/modules/nw-multus-tap-object.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_content-type: REFERENCE
+[id="nw-multus-tap-object_{context}"]
+= Configuration for a TAP additional network
+
+The following object describes the configuration parameters for the TAP CNI
+plugin:
+
+.TAP CNI plugin JSON configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`cniVersion`
+|`string`
+|The CNI specification version. The `0.3.1` value is required.
+
+|`name`
+|`string`
+|The value for the `name` parameter you provided previously for the CNO configuration.
+
+|`type`
+|`string`
+|The name of the CNI plugin to configure: `tap`.
+
+|`mac`
+|`string`
+|Optional: Request the specified MAC address for the interface.
+
+|`mtu`
+|`integer`
+|Optional: Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
+
+|`selinuxcontext`
+|`string`
+a|Optional: The SELinux context to associate with the tap device.
+
+[NOTE]
+====
+The value `system_u:system_r:container_t:s0` is required for {product-title}.
+====
+
+|`multiQueue`
+|`boolean`
+|Optional: Set to `true` to enable multi-queue.
+
+|`owner`
+|`integer`
+|Optional: The user owning the tap device.
+
+|`group`
+|`integer`
+|Optional: The group owning the tap device.
+
+|`bridge`
+|`string`
+|Optional: Set the tap device as a port of an already existing bridge.
+|====
+
+[id="nw-multus-tap-config-example_{context}"]
+== Tap configuration example
+
+The following example configures an additional network named `mynet`:
+
+[source,json]
+----
+{
+ "name": "mynet",
+ "cniVersion": "0.3.1",
+ "type": "tap",
+ "mac": "00:11:22:33:44:55",
+ "mtu": 1500,
+ "selinuxcontext": "system_u:system_r:container_t:s0",
+ "multiQueue": true,
+ "owner": 0,
+ "group": 0
+ "bridge": "br1"
+}
+----
+
+[NOTE]
+====
+To create the tap device with the `container_t` SELinux context, enable the `container_use_devices` boolean on the host by using the Machine Config Operator (MCO).
+====

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -13,6 +13,7 @@ As a cluster administrator, you can configure an additional network for your clu
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-vlan-object_configuring-additional-network[VLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[IPVLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[MACVLAN]
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-tap-object_configuring-additional-network[TAP]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuration-ovnk-additional-networks_configuring-additional-network[OVN-Kubernetes]
 
 [id="{context}_approaches-managing-additional-network"]
@@ -131,6 +132,13 @@ include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
 include::modules/nw-multus-vlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
+include::modules/nw-multus-tap-object.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about enabling an SELinux boolean on a node, see xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-working-setting-booleans_nodes-nodes-managing[Setting SELinux booleans]
+
 include::modules/configuring-ovnk-additional-networks.adoc[leveloffset=+2]
 include::modules/configuration-ovnk-network-plugin-json-object.adoc[leveloffset=+3]
 //include::modules/configuring-layer-three-routed-topology.adoc[leveloffset=+3]

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -57,4 +57,6 @@ networks in your cluster:
 
  * *macvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[Configure a macvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts by using a physical network interface. Each pod that is attached to a macvlan-based additional network is provided a unique MAC address.
 
+  * *tap*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-tap-object_configuring-additional-network[Configure a tap-based additional network] to create a tap device inside the container namespace. A tap device enables user space programs to send and receive network packets.
+
  * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configure an SR-IOV based additional network] to allow pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.


### PR DESCRIPTION
Telcodocs 994: D/S Docs 6184 CNF-TAP CNI plugin (GA)

Version(s): 4.14 and main

Issue:
https://issues.redhat.com/browse/TELCODOCS-994

Link to docs preview: https://59526--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-about-a-tap-device_configuring-additional-network

https://59526--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
