### PR TITLE
OSDOCS-5637: adds monitoring and networking bug batch to RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1239,6 +1239,9 @@ With this release, replacement control plane nodes are assigned to the correct i
 
 * Previously, the Kubernetes scheduler could skip scheduling certain pods for a node that received multiple restart operations. {product-title} {product-version} counteracts this issue by including the `KubePodNotScheduled` alert for pods that cannot be scheduled within 30 minutes. (link:https://issues.redhat.com/browse/OCPBUGS-2260[*OCPBUGS-2260*])
 
+* Previously, if more than one label was defined for Thanos Ruler, then the statefulset could enter a recreation loop because the `prometheus-operator` did not add the labels in a specified order each time it reconciled the custom resource. After this fix, the `prometheus-operator` now sorts extra labels before adding them to the statefulset. (link:https://issues.redhat.com/browse/OCPBUGS-6055[*OCPBUGS-6055*])
+
+* With this release, the `NodeFilesystemAlmostOutOfSpace` no longer launches for certain read-only `tmpfs` instances. This change fixes an issue in which the alert launches for certain `tmpfs` mount points that were full by design. (link:https://issues.redhat.com/browse/OCPBUGS-6577[*OCPBUGS-6577*])
 
 [discrete]
 [id="ocp-4-13-networking-bug-fixes"]
@@ -1251,6 +1254,8 @@ With this release, replacement control plane nodes are assigned to the correct i
 * Previously, the Ingress Operator had the wrong service name in `ensureNodePortService` log message causing incorrect information to be logged. With this update, the Ingress Operator accurately logs the service in `ensureNodePortService`. (link:https://issues.redhat.com/browse/OCPBUGS-6698[*OCPBUGS-6698*])
 
 * Previously, in {product-title} 4.7.0 and 4.6.20, the Ingress Operator used an annotation for router pods that was specific for {product-title}. This was a temporary way to configure the liveness probe's grace period in order to fix a bug. As a result, {product-title} was required to carry a patch to implement the fix. With this update, the Ingress Operator uses `terminationGracePeriodSeconds` API field making the previous patch removable in future releases. (link:https://issues.redhat.com/browse/OCPBUGS-4703[*OCPBUGS-4703*])
+
+* Previously, CoreDNS was using the old toolchain for building of the main binary and the old base image. With this update, {product-title} is using {product-version} for the build toolchain and the base image. (link:https://issues.redhat.com/browse/OCPBUGS-6228[*OCPBUGS-6228*])
 
 [discrete]
 [id="ocp-4-13-node-bug-fixes"]
@@ -1266,6 +1271,8 @@ With this release, replacement control plane nodes are assigned to the correct i
 
 * Previously, the `oc-mirror` command built the catalog content in the console for OCI and FBC Operators from a mirrored disk image. Consequently, not all content of the catalog was mirrored so some content was missing from the catalog. With this update, the catalog image is built to reflect the mirrored content prior to pushing it to the destination registry resulting in a more complete catalog. (link:https://issues.redhat.com/browse/OCPBUGS-5805[*OCPBUGS-5805*])
 
+* Previously, the `oc-mirror` command added the operator catalog as an entry in the `ImageContentSourcePolicy`. With this update, the operator catalog is consumed directly from the destination registry.(link:https://issues.redhat.com/browse/OCPBUGS-10320[*OCPBUGS-10320*])
+
 [discrete]
 [id="ocp-4-13-olm-bug-fixes"]
 ==== Operator Lifecycle Manager (OLM)
@@ -1274,17 +1281,17 @@ With this release, replacement control plane nodes are assigned to the correct i
 
 * Operator Lifecycle Manager (OLM) manages a set of `CatalogSource` objects from which Operators can be searched for and installed from. These catalog sources are the default sources for this action and are managed by Red Hat. However, it was possible to change these default catalog sources in a way that the OLM system would not notice. Modifying a default catalog source in a way that rendered it inoperable could cause cascading issues through OLM that might prevent a user from installing new or upgrading existing Operators on their cluster. This bug fix updates the `catalog-operator` runtime, which manages the default catalog sources, to be made aware of other changes to the `CatalogSource` spec. As a result, when a change is made to a default catalog source, OLM detects the change and resets it back to default. (link:https://issues.redhat.com/browse/OCPBUGS-5466[*OCPBUGS-5466*])
 
-[discrete]
-[id="ocp-4-13-openshift-operator-sdk-bug-fixes"]
-==== Operator SDK
+//[discrete]
+//[id="ocp-4-13-openshift-operator-sdk-bug-fixes"]
+//==== Operator SDK
 
-[discrete]
-[id="ocp-4-13-file-integrity-operator-bug-fixes"]
-==== File Integrity Operator
+//[discrete]
+//[id="ocp-4-13-file-integrity-operator-bug-fixes"]
+//==== File Integrity Operator
 
-[discrete]
-[id="ocp-4-13-compliance-operator-bug-fixes"]
-==== Compliance Operator
+//[discrete]
+//[id="ocp-4-13-compliance-operator-bug-fixes"]
+//==== Compliance Operator
 
 [discrete]
 [id="ocp-4-13-openshift-api-server-bug-fixes"]


### PR DESCRIPTION
[OSDOCS-5637](https://issues.redhat.com//browse/OSDOCS-5637): adds monitoring and networking bug batch to RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5637
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://59536--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-bug-fixes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
