### PR TITLE
OCPBUGS#13060: Update IPI bootstrap size to D8s_v3

### DIFF
--- a/modules/installation-azure-limits.adoc
+++ b/modules/installation-azure-limits.adoc
@@ -58,9 +58,19 @@ endif::ash[]
 
 |vCPU
 ifndef::ash[]
+ifndef::upi[]
+|44
+endif::upi[]
+ifdef::upi[]
 |40
+endif::upi[]
 |20 per region
+ifndef::upi[]
+|A default cluster requires 44 vCPUs, so you must increase the account limit.
+endif::upi[]
+ifdef::upi[]
 |A default cluster requires 40 vCPUs, so you must increase the account limit.
+endif::upi[]
 
 By default, each cluster creates the following instances:
 
@@ -68,11 +78,19 @@ By default, each cluster creates the following instances:
 * Three control plane machines
 * Three compute machines
 
+ifndef::upi[]
+Because the bootstrap and control plane machines use `Standard_D8s_v3` virtual
+machines, which use 8 vCPUs, and the compute machines use `Standard_D4s_v3`
+virtual machines, which use 4 vCPUs, a default cluster requires 44 vCPUs.
+The bootstrap node VM, which uses 8 vCPUs, is used only during installation.
+endif::upi[]
+ifdef::upi[]
 Because the bootstrap machine uses `Standard_D4s_v3` machines, which use 4 vCPUs,
 the control plane machines use `Standard_D8s_v3` virtual
 machines, which use 8 vCPUs, and the worker machines use `Standard_D4s_v3`
 virtual machines, which use 4 vCPUs, a default cluster requires 40 vCPUs.
 The bootstrap node VM, which uses 4 vCPUs, is used only during installation.
+endif::upi[]
 endif::ash[]
 ifdef::ash[]
 |56


### PR DESCRIPTION
Version(s): `4.12`

Issue: [OCPBUGS-13060](https://issues.redhat.com/browse/OCPBUGS-13060)

Link to docs preview:
- [Configuring an Azure account: Azure account limits](https://59548--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#installation-azure-limits_installing-azure-account)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: IPI installation in Azure now uses D8s_v3 for bootstrap node, as it defaults to the control plane sizing. The current documentation lists 4 vCPUs are used, so all the calculated quota requirements for IPI are off by 4.