### PR TITLE
RHDEVDOCS-5236: Add docs for creating a function via ODC

### DIFF
--- a/modules/odc-creating-functions.adoc
+++ b/modules/odc-creating-functions.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
+:_content-type: PROCEDURE
+[id="odc-creating-functions_{context}"]
+= Creating a function in the web console
+
+You can create a function from a Git repository by using the *Developer* perspective of the {product-title} web console.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on the cluster.
+* The {pipelines-shortname} Operator is installed on the cluster.
+* You have logged in to the {product-title} web console.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You have created or have access to a Git repository that contains the code for your function. The repostory must contain a `func.yaml` file and use the `s2i` build strategy.
+
+[IMPORTANT]
+====
+Before you can create a function by using the web console, a cluster administrator must create the following tasks and pipeline, so that they are available for all namespaces on your cluster.
+
+* Create the `func-s2i` task:
++
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/release-next/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+----
+
+* Create the `func-deploy` task:
++
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/release-next/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+----
+
+* Create the Node.js function pipeline:
++
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/release-next/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+----
+====
+
+.Procedure
+
+. In the *Developer* perspective, navigate to *+Add* → *Create Serverless function*. The *Create Serverless function* page is displayed.
+. Enter a *Git Repo URL* that points to the Git repository that contains the code for your function.
+. In the *Pipelines* section:
+.. Select the *Build, deploy and configure a Pipeline Repository* radio button to create a new pipeline for your function.
+.. Select the *Use Pipeline from this cluster* radio button to connect your function to an existing pipeline in the cluster.
+. Click *Create*.
+
+.Verification
+
+* After you have created a function, you can view it in the *Topology* view of the *Developer* perspective.

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -14,6 +14,7 @@ Function lifecycle management includes creating, building, and deploying a funct
 Before you can complete the following procedures, you must ensure that you have completed all of the prerequisite tasks in xref:../../serverless/functions/serverless-functions-setup.adoc#serverless-functions-setup[Setting up {FunctionsProductName}].
 
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
+include::modules/odc-creating-functions.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-run.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.13+

**Requires manual cherrypicks to various serverless docs versions due to different URLs**

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-5236

Link to docs preview:
https://59549--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html#odc-creating-functions_serverless-functions-getting-started

QE review:
- [ ] QE has approved this change.