### PR TITLE
Adding aesgcm info back in and mentioning migrating between types

### DIFF
--- a/modules/enabling-etcd-encryption.adoc
+++ b/modules/enabling-etcd-encryption.adoc
@@ -20,6 +20,13 @@ After you enable etcd encryption, several changes can occur:
 * A disk I/O can affect the node that receives the backup state.
 ====
 
+You can encrypt the etcd database in either AES-GCM or AES-CBC encryption.
+
+[NOTE]
+====
+To migrate your etcd database from one encryption type to the other, you can modify the API server's `spec.encryption.type` field. Migration of the etcd data to the new encryption type occurs automatically.
+====
+
 .Prerequisites
 
 * Access to the cluster as a user with the `cluster-admin` role.
@@ -33,19 +40,19 @@ After you enable etcd encryption, several changes can occur:
 $ oc edit apiserver
 ----
 
-. Set the `encryption` field type to `aescbc`:
+. Set the `spec.encryption.type` field to `aesgcm` or `aescbc`:
 +
 [source,yaml]
 ----
 spec:
   encryption:
-    type: aescbc <1>
+    type: aesgcm <1>
 ----
-<1> The `aescbc` type means that AES-CBC with PKCS#7 padding and a 32 byte key is used to perform the encryption.
+<1> Set to `aesgcm` for AES-GCM encryption or `aescbc` for AES-CBC encryption.
 
 . Save the file to apply the changes.
 +
-The encryption process starts. It can take 20 minutes or longer for this process to complete, depending on the size of your cluster.
+The encryption process starts. It can take 20 minutes or longer for this process to complete, depending on the size of the etcd database.
 
 . Verify that etcd encryption was successful.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5977

Link to docs preview:
https://59554--docspreview.netlify.app/openshift-enterprise/latest/security/encrypting-etcd.html#enabling-etcd-encryption_encrypting-etcd

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
