### PR TITLE
For RHACS docs: Added a rewrite rule for Managing vulnerabilities section

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -145,6 +145,8 @@ AddType text/vtt                            vtt
     RewriteRule ^acs/installing/install-ocp-operator.html /acs/4.0/installing/installing_ocp/init-bundle-ocp.html [NE,R=301]
     RewriteRule ^acs/(\D.*)$ /acs/4.0/$1 [NE,R=301]
     RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73|3\.74|4\.0)/?$ /acs/$1/welcome/index.html [L,R=301]
+    #redirect for 4.0 Manage vulneribility page
+    RewriteRule ^(acs/(?:\d\.\d+/)?)?operating/manage-vulnerabilities\.html$ /acs/4.0/operating/manage-vulnerabilities/vulnerability-management.html [NE,R=301]
 
     # this pipeline redirect has to come before the latest kicks in generically
     RewriteRule ^container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html /container-platform/4.7/cicd/pipelines/creating-applications-with-cicd-pipelines.html [NE,R=301]


### PR DESCRIPTION
The **Managing vulnerabilities** section from 3.74 docs is moved to the new page in 4.0 docs. This rewrite rule makes the link to the updated page.

Old:/operating/manage-vulnerabilities.html
New:/operating/manage-vulnerabilities/vulnerability-management.html