### PR TITLE
Swaps order of assembly content to render product-registry

### DIFF
--- a/registry/index.adoc
+++ b/registry/index.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 [id="registry-overview"]
-= {product-registry} overview
 include::_attributes/common-attributes.adoc[]
+= {product-registry} overview
 :context: registry-overview
 
 toc::[]


### PR DESCRIPTION
Version(s):
4.10+ 

Issue:
https://issues.redhat.com/browse/OCPBUGS-13047

Link to docs preview:
https://59568--docspreview.netlify.app/openshift-enterprise/latest/registry/index.html

QE review:
Not needed. Portal rendering issue. 

Additional information:
Should hopefully fix rendering issues here: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/registry/registry-overview#annotations:127c6d00-aee7-4f7d-b5d6-d255bfdede47
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
