### PR TITLE
RHDEVDOCS-5177-update-prereqs-for-viewing-metrics-list

### DIFF
--- a/modules/monitoring-viewing-a-list-of-available-metrics.adoc
+++ b/modules/monitoring-viewing-a-list-of-available-metrics.adoc
@@ -9,11 +9,12 @@
 As a cluster administrator or as a user with view permissions for all projects, you can view a list of metrics available in a cluster and output the list in JSON format.
 
 .Prerequisites
+* You are a cluster administrator, or you have access to the cluster as a user with the `cluster-monitoring-view` role.
 * You have installed the {product-title} CLI (`oc`).
 * You have obtained the {product-title} API route for Thanos Querier.
-* You are a cluster administrator, or you have access to the cluster as a user with the `cluster-monitoring-view` role.
+* You are able to get a bearer token by using the `oc whoami -t` command.
 +
-[NOTE]
+[IMPORTANT]
 ====
 You can only use bearer token authentication to access the Thanos Querier API route.
 ====


### PR DESCRIPTION
Summary: This PR adds an explicit prerequisite that a user must log into `oc` using token authntication in order to view a list of metrics for a cluster.

- Aligned team: DevTools
- For branches: 4.12+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-5177
- Direct link to doc preview: https://59578--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-metrics.html#viewing-a-list-of-available-metrics_managing-metrics
- SME review: @jan--f (approved)
- QE review: @juzhao (approved)
- Peer review: @gwynnemonahan (approved)