### PR TITLE
[OSDOCS-5974]: Add release note for bootstrap node removal causes etcd quorum loss

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1310,6 +1310,12 @@ Now that setting `crun` as the container runtime is generally available when a p
 
 * Previously, the `openshift-manila-csi-driver` namespace did not include labels that are required for the management of workload partitioning. These missing labels impacted the operation of restricting Manila CSI pods to run on a selected set of CPUs. With this update, the `openshift-manila-csi-driver` namespace now includes the `workload.openshift.io/allowed` label. (link:https://issues.redhat.com/browse/OCPBUGS-11341[*OCPBUGS-11341*])
 
+[discrete]
+[id="ocp-4-13-etcd-bug-fixes"]
+==== etcd
+
+* Previously, the `ControlPlaneMachineSet` Operator attempted to recreate a control machine before the cluster bootstrapping completed. This issue could result in the removal of the bootstrap node from the `etcd` cluster membership, which caused `etcd` quorum loss and the cluster going offline. With this update, `ControlPlaneMachineSet` Operator only recreates a controller machine after the `etcd` Cluster Operator removes the bootstrap node. (link:https://issues.redhat.com/browse/OCPBUGS-10960[*OCPBUGS-10960*])
+
 [id="ocp-4-13-technology-preview"]
 == Technology Preview features
 


### PR DESCRIPTION
Engineering Jira: [OCPBUGS-10960](https://issues.redhat.com/browse/OCPBUGS-10960)
Docs Jira: [OSDOCS-5974](https://issues.redhat.com/browse/OSDOCS-5974)

Version(s): 4.13

Link to docs preview: (last item in the list) http://file.rdu.redhat.com/tlove/etcd-osdocs-5974-tlove-new/release_notes/ocp-4-13-release-notes.html#ocp-4-13-bug-fixes


QE review:
- [ x] QE has approved this change.


