### PR TITLE
OSDOCS-5629

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -124,6 +124,10 @@ CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard ent
 |443
 |Required for telemetry and Red Hat Insights.
 
+|`cloud.redhat.com/api/ingress`
+|443
+|Required for telemetry and Red Hat Insights.
+
 |`observatorium.api.openshift.com`
 |443
 |Required for managed OpenShift-specific telemetry.


### PR DESCRIPTION
[OSDOCS-5629](https://issues.redhat.com//browse/OSDOCS-5629): Add "cloud.redhat.com/api/ingress" to the telemetry allowlist for ROSA docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-5629

Link to docs preview:
https://59585--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
