### PR TITLE
OSDOCS-5989 Remove notice about transparent proxies being unsupported - they are supported

### DIFF
--- a/modules/cluster-wide-proxy-preqs.adoc
+++ b/modules/cluster-wide-proxy-preqs.adoc
@@ -86,10 +86,3 @@ When using a cluster-wide proxy, you must configure the `s3.<aws_region>.amazona
 |Used by the splunk-forwarder-operator as a log forwarding endpoint to be used by Red Hat SRE for log-based alerting.
 |===
 --
-+
-[IMPORTANT]
-====
-The use of a proxy server to perform TLS re-encryption is currently not supported if the server is acting as a transparent forward proxy where it is not configured on-cluster via the `--http-proxy` or `--https-proxy` arguments.
-
-A transparent forward proxy intercepts the cluster traffic, but it is not actually configured on the cluster itself.
-====


### PR DESCRIPTION
Version(s):
Transparent proxies are supported in all versions of OCP supported by ROSA

Issue:
[OSDOCS-5989](https://issues.redhat.com//browse/OSDOCS-5989)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.