### PR TITLE
Updated preview receiver for PR Previews

### DIFF
--- a/autopreview.sh
+++ b/autopreview.sh
@@ -14,7 +14,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then #to make sure it only runs on PR
             if [ "$USERNAME" != "openshift-cherrypick-robot" ] ; then # to make sure it doesn't run for USERNAME openshift-cherrypick-robot
                 echo "{\"PR_BRANCH\":\"${TRAVIS_PULL_REQUEST_BRANCH}\",\"BASE_REPO\":\"${TRAVIS_REPO_SLUG}\",\"PR_NUMBER\":\"${TRAVIS_PULL_REQUEST}\",\"USER_NAME\":\"${USERNAME}\",\"BASE_REF\":\"${TRAVIS_BRANCH}\",\"REPO_NAME\":\"${TRAVIS_PULL_REQUEST_SLUG}\",\"SHA\":\"${TRAVIS_PULL_REQUEST_SHA}\"}" > buildset.json
 
-                curl -H 'Content-Type: application/json' --request POST --data @buildset.json "https://eoa6vg2jiwjbnh6.m.pipedream.net"
+                curl -H 'Content-Type: application/json' --request POST --data @buildset.json "https://ocpdocs-preview-receiver.vercel.app/api/buildPreview"
 
                 echo -e "\\n\\033[0;32m[✓] Sent request for building a preview.\\033[0m"
             else


### PR DESCRIPTION
Pipedream reduced daily invocations from 300 per day to 100 per day. OpenShift docs typically uses around 133 invocations everyday. 

This is a custom receiver that replaces the Pipedream setup. 