### PR TITLE
turn-off-rn-vale-rule: Updated the vale.ini vile to turn off a rule

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -11,3 +11,6 @@ BasedOnStyles = RedHat
 #optional: pass doc attributes to asciidoctor before linting
 #[asciidoctor]
 #openshift-enterprise = YES
+
+# Disabling rules (NO)
+RedHat.ReleaseNotes = NO


### PR DESCRIPTION
PR stemmed from https://github.com/redhat-documentation/vale-at-red-hat/pull/522 . A [Slack channel](https://redhat-internal.slack.com/archives/C0218RXJK5E/p1683284410441429) indicated that an internal OCP change would be the best solution.

Version(s):
4.13, 4.12, 4.11, and 4.10


