### PR TITLE
OSDOCS-5392 Fixing vsphere 6.7 references

### DIFF
--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -59,8 +59,8 @@ You can host the VMware vSphere infrastructure on-premise or on a link:https://c
 |===
 |Virtual environment product |Required version
 |VM hardware version | 15 or later
-|vSphere ESXi hosts | 7.0 Update 2 or later
-|vCenter host   | 7.0 Update 2 or later
+|vSphere ESXi hosts | 7
+|vCenter host   | 7
 |===
 
 [IMPORTANT]
@@ -75,17 +75,17 @@ If your vSphere nodes are below hardware version 15 or your VMware vSphere versi
 |Component | Minimum supported versions |Description
 
 |Hypervisor
-|vSphere 6.7u3 and later with HW version 15
+|vSphere 7 with HW version 15
 |This version is the minimum version that {op-system-first} supports. See the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux?sort=sortTitle%20asc&vendors=VMware&category=Server[Red Hat Enterprise Linux 8 supported hypervisors list].
 
 |Storage with in-tree drivers
-|vSphere 6.7u3 and later
+|vSphere 7
 |This plugin creates vSphere storage by using the in-tree storage drivers for vSphere included in {product-title}.
 
 ifndef::vmc[]
 |Optional: Networking (NSX-T)
-|vSphere 7.0 Update 1 and later
-|vSphere 7.0 Update 1 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
+|vSphere 7
+|vSphere 7 is required for {product-title}. For more information about the compatibility of NSX and {product-title}, see the Release Notes section of VMware's link:https://docs.vmware.com/en/VMware-NSX-Container-Plugin/index.html[NSX container plugin documentation].
 endif::vmc[]
 |===
 


### PR DESCRIPTION
4.10 and 4.11
Fixing a few more references to vSphere 6.7 in the 4.10 and 4.11 vsphere installation docs. I removed "and later" and changed the version to "7" so that it is clear that multiple versions of 7 are supported, but 8 is not supported. 

Jira: https://issues.redhat.com/browse/OSDOCS-5392

Preview: https://59606--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-vsphere-infrastructure_installing-vsphere-installer-provisioned-network-customizations

QE: 