### PR TITLE
TELCODOCS-1312 Document VLAN plugin

### DIFF
--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -71,4 +71,3 @@ The following example configures an additional network named `ipvlan-net`:
   }
 }
 ----
-

--- a/modules/nw-multus-vlan-object.adoc
+++ b/modules/nw-multus-vlan-object.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+//37.1. VLAN overview
+//
+:_content-type: REFERENCE
+[id="nw-multus-vlan-object_{context}"]
+= Configuration for an VLAN additional network
+
+The following object describes the configuration parameters for the VLAN CNI plugin:
+
+.VLAN CNI plugin JSON configuration object
+[cols=".^2,.^2,.^6",options="header"]
+|====
+|Field|Type|Description
+
+|`cniVersion`
+|`string`
+|The CNI specification version. The `0.3.1` value is required.
+
+|`name`
+|`string`
+|The value for the `name` parameter you provided previously for the CNO configuration.
+
+|`type`
+|`string`
+|The name of the CNI plugin to configure: `vlan`.
+
+|`master`
+|`string`
+|The Ethernet interface to associate with the network attachment. If a `master` is not specified, the interface for the default network route is used.
+
+|`vlanId`
+|`integer`
+|Set the id of the vlan.
+
+|`ipam`
+|`object`
+|The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition.
+
+|`mtu`
+|`integer`
+|Optional: Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
+
+|`dns`
+|`integer`
+|Optional: DNS information to return, for example, a priority-ordered list of DNS nameservers.
+
+|`linkInContainer`
+|`boolean`
+|Optional: Specifies if the master interface is in the container network namespace or the main network namespace.
+
+|====
+
+[id="nw-multus-vlan-config-example_{context}"]
+== vlan configuration example
+
+The following example configures an additional network named `vlan-net`:
+
+[source,json]
+----
+{
+  "name": "vlan-net",
+  "cniVersion": "0.3.1",
+  "type": "vlan",
+  "master": "eth0",
+  "mtu": 1500,
+  "vlanId": 5,
+  "linkInContainer": false,
+  "ipam": {
+      "type": "host-local",
+      "subnet": "10.1.1.0/24"
+  },
+  "dns": {
+      "nameservers": [ "10.1.1.1", "8.8.8.8" ]
+  }
+}
+----

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -10,6 +10,7 @@ As a cluster administrator, you can configure an additional network for your clu
 
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-bridge-object_configuring-additional-network[Bridge]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-host-device-object_configuring-additional-network[Host device]
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-vlan-object_configuring-additional-network[VLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[IPVLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[MACVLAN]
 * xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuration-ovnk-additional-networks_configuring-additional-network[OVN-Kubernetes]
@@ -127,6 +128,7 @@ The specific configuration fields for additional networks is described in the fo
 
 include::modules/nw-multus-bridge-object.adoc[leveloffset=+2]
 include::modules/nw-multus-host-device-object.adoc[leveloffset=+2]
+include::modules/nw-multus-vlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-ipvlan-object.adoc[leveloffset=+2]
 include::modules/nw-multus-macvlan-object.adoc[leveloffset=+2]
 include::modules/configuring-ovnk-additional-networks.adoc[leveloffset=+2]

--- a/networking/multiple_networks/understanding-multiple-networks.adoc
+++ b/networking/multiple_networks/understanding-multiple-networks.adoc
@@ -53,6 +53,8 @@ networks in your cluster:
 
  * *ipvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-ipvlan-object_configuring-additional-network[Configure an ipvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts, similar to a macvlan-based additional network. Unlike a macvlan-based additional network, each pod shares the same MAC address as the parent physical network interface.
 
+* *vlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-vlan-object_configuring-additional-network[Configure a vlan-based additional network] to allow VLAN-based network isolation and connectivity for pods.
+
  * *macvlan*: xref:../../networking/multiple_networks/configuring-additional-network.adoc#nw-multus-macvlan-object_configuring-additional-network[Configure a macvlan-based additional network] to allow pods on a host to communicate with other hosts and pods on those hosts by using a physical network interface. Each pod that is attached to a macvlan-based additional network is provided a unique MAC address.
- 
+
  * *SR-IOV*: xref:../../networking/hardware_networks/about-sriov.adoc#about-sriov[Configure an SR-IOV based additional network] to allow pods to attach to a virtual function (VF) interface on SR-IOV capable hardware on the host system.


### PR DESCRIPTION
[TELCODOCS-1312]: Document VLAN plugin
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/TELCODOCS-1312

Link to docs preview:
https://59607--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-vlan-object_configuring-additional-network

https://59607--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-vlan-object_configuring-additional-network

https://59607--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/understanding-multiple-networks.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
