### PR TITLE
Added RHEL 9.2-based RHCOS description to planning migration architec…

### DIFF
--- a/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
+++ b/migrating_from_ocp_3_to_4/planning-migration-3-4.adoc
@@ -21,6 +21,8 @@ With {product-title} 3, administrators individually deployed {op-system-base-ful
 
 {product-title} 4 represents a significant change in the way that {product-title} clusters are deployed and managed. {product-title} 4 includes new technologies and functionality, such as Operators, machine sets, and {op-system-first}, which are core to the operation of the cluster. This technology shift enables clusters to self-manage some functions previously performed by administrators. This also ensures platform stability and consistency, and simplifies installation and scaling.
 
+Beginning with {product-title} 4.13, {op-system} now uses {op-system-base-full} 9.2 packages. This enhancement enables the latest fixes and features as well as the latest hardware support and driver updates. For more information about how this upgrade to RHEL 9.2 might affect your options configuration and services as well as driver and container support, see the xref:../release_notes/ocp-4-13-release-notes.adoc#ocp-4-13-rhcos-rhel-9-2-packages[RHCOS now uses RHEL 9.2] in the _OpenShift Container Platform 4.13 release notes_.
+
 For more information, see xref:../architecture/architecture.adoc#architecture[OpenShift Container Platform architecture].
 
 [discrete]
@@ -129,8 +131,15 @@ For more information, see xref:../storage/understanding-persistent-storage.adoc#
 
 * Amazon Web Services (AWS) Elastic Block Storage (EBS)
 * Azure Disk
+* Azure File
 * Google Cloud Platform Persistent Disk (GCP PD)
 * OpenStack Cinder
+* VMware vSphere
++
+[NOTE]
+====
+As of {product-title} 4.13, VMware vSphere is not available by default. However, you can opt into VMware vSphere.
+====
 
 All aspects of volume lifecycle, such as creation, deletion, mounting, and unmounting, is handled by the CSI driver.
 


### PR DESCRIPTION
[OSDOCS-4861](https://issues.redhat.com//browse/OSDOCS-4861): Updated Architecture and Storage sections of the _Differences between OpenShift Container Platform 3 and 4_ document

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-4861](https://issues.redhat.com//browse/OSDOCS-4861): Update migration planning content for 4.13
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://59622--docspreview.netlify.app/

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: At the beginning of the Architecture section, I added a paragraph that briefly introduces the change to RHEL 9.2. I also added Azure File and VMWare vSphere to the list of supported CSI drivers in the Storage section.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
