### PR TITLE
BZ2193267: 4.13 single-stack IPv6 not supported

### DIFF
--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -223,6 +223,8 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 [id="virt-4-13-known-issues"]
 == Known issues
 
+You cannot run {VirtProductName} on a single-stack IPv6 cluster. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2193267[*BZ#2193267*])
+
 * When you use two pods with different SELinux contexts, VMs with the `ocs-storagecluster-cephfs` storage class fail to migrate and the VM status changes to `Paused`. This is because both pods try to access the shared `ReadWriteMany` CephFS volume at the same time. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2092271[*BZ#2092271*])
 ** As a workaround, use the `ocs-storagecluster-ceph-rbd` storage class to live migrate VMs on a cluster that uses Red Hat Ceph Storage.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [BZ2193267](https://bugzilla.redhat.com/show_bug.cgi?id=2193267), [CNV-28585](https://issues.redhat.com//browse/CNV-28585)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
