### PR TITLE
OCPBUGS#6828: Correct the supported RHEL versions

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -10,7 +10,7 @@ After you update your cluster, you must update the {op-system-base-full} compute
 
 [IMPORTANT]
 ====
-{op-system-base-full} versions 8.4 and 8.5 are supported for {op-system-base} compute machines.
+{op-system-base-full} version 8.6 is supported for {op-system-base} compute machines.
 ====
 
 You can also update your compute machines to another minor version of {product-title} if you are using {op-system-base} as the operating system. You do not need to exclude any RPM packages from {op-system-base} when performing a minor version update.


### PR DESCRIPTION
Correct the supported RHEL versions

Version(s): 4.12 only

Issue: https://issues.redhat.com/browse/OCPBUGS-6828

Link to docs preview: http://file.rdu.redhat.com/sdudhgao/rhel-ver-412/updating/updating-cluster-rhel-compute.html#rhel-compute-updating-minor_updating-cluster-rhel-compute

QE review: QE ack is in other PR https://github.com/openshift/openshift-docs/pull/56115#issuecomment-1436543170
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: peer-review was done in the closed PR https://github.com/openshift/openshift-docs/pull/56115
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
