### PR TITLE
[RHACS] Fix 4.0 roxctl upgrade

### DIFF
--- a/modules/generate-central-database-provisioning-bundle.adoc
+++ b/modules/generate-central-database-provisioning-bundle.adoc
@@ -29,7 +29,7 @@ $ export ROX_CENTRAL_ADDRESS=<address>:<port_number>
 +
 [source,terminal,subs=attributes+]
 ----
-$ roxctl -n stackrox central db generate \
+$ roxctl -e $ROX_CENTRAL_ADDRESS central db generate \
   <cluster_type> \ <1>
   <storage> \ <2>
   --output-dir <bundle_dir> \ <3>


### PR DESCRIPTION
For [ROX-16956](https://issues.redhat.com/browse/ROX-16956)

Fixes the incorrect command.


Cherrypick into `rhacs-docs-4.0`