### PR TITLE
Changed CSI plugin note to Kubernetes snapshot API

### DIFF
--- a/modules/oadp-plugins.adoc
+++ b/modules/oadp-plugins.adoc
@@ -34,5 +34,7 @@ OADP also provides plugins for {product-title} resource backups, OpenShift Virtu
 --
 1. Mandatory.
 2. Virtual machine disks are backed up with CSI snapshots or Restic.
-3. The `csi` plugin uses the link:https://velero.io/docs/main/csi/[Velero CSI beta snapshot API].
+3. The `csi` plugin uses Kubernetes CSI snapshot API.
+* OADP 1.1 or later uses `snapshot.storage.k8s.io/v1`
+* OADP 1.0 uses `snapshot.storage.k8s.io/v1beta1`
 --

--- a/modules/oadp-plugins.adoc
+++ b/modules/oadp-plugins.adoc
@@ -34,7 +34,7 @@ OADP also provides plugins for {product-title} resource backups, OpenShift Virtu
 --
 1. Mandatory.
 2. Virtual machine disks are backed up with CSI snapshots or Restic.
-3. The `csi` plugin uses Kubernetes CSI snapshot API.
+3. The `csi` plugin uses the Kubernetes CSI snapshot API.
 * OADP 1.1 or later uses `snapshot.storage.k8s.io/v1`
 * OADP 1.0 uses `snapshot.storage.k8s.io/v1beta1`
 --


### PR DESCRIPTION
@PrasadJoshi12 

GH# : 
OCPBUGS# : [OADP-1068](https://issues.redhat.com//browse/OADP-1068)
OSDOCS# : [OADP-1068](https://issues.redhat.com//browse/OADP-1068)

Replaced note for CSI plugin to:
"The CSI plugin uses Kubernetes CSI snapshot API.
* OADP 1.1 or later uses snapshot.storage.k8s.io/v1
* OADP 1.0 uses snapshot.storage.k8s.io/v1beta1
 
Version(s):
1.1.0 and later

Issue:
https://issues.redhat.com/browse/OADP-1068


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://59662--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-features-plugins.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
