### PR TITLE
OSDOCS#4858: Updated AWS AMI image IDs

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,76 +23,91 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-073850a7021953a5c`
+|`ami-052b3e6b060b5595d`
 
 |`ap-east-1`
-|`ami-0f8800a05c09be42d`
+|`ami-09c502968481ee218`
 
 |`ap-northeast-1`
-|`ami-0a226dbcc9a561c40`
+|`ami-06b1dbe049e3c1d23`
 
 |`ap-northeast-2`
-|`ami-041ae0537e2eddec1`
+|`ami-08add6eb5aa1c8639`
 
 |`ap-northeast-3`
-|`ami-0bb8d9b69dc5b7670`
+|`ami-0af4dfc64506fe20e`
 
 |`ap-south-1`
-|`ami-0e9c18058fc5f94fd`
+|`ami-09b1532dd3d63fdc0`
+
+|`ap-south-2`
+|`ami-0a915cedf8558e600`
 
 |`ap-southeast-1`
-|`ami-03022d358ba2168be`
+|`ami-0c914fd7a50130c9e`
 
 |`ap-southeast-2`
-|`ami-09ffdc5be9b973be0`
+|`ami-04b54199f4be0ec9d`
 
 |`ap-southeast-3`
-|`ami-0facf1a0edeb20314`
+|`ami-0be3ee78b9a3fdf07`
+
+|`ap-southeast-4`
+|`ami-00a44d7d5054bb5f8`
 
 |`ca-central-1`
-|`ami-028cea206c2d03317`
+|`ami-0bb1fd49820ea09ae`
 
 |`eu-central-1`
-|`ami-002eb441f329ccb0f`
+|`ami-03d9cb166a11c9b8a`
+
+|`eu-central-2`
+|`ami-089865c640f876630`
 
 |`eu-north-1`
-|`ami-0b1a1fb68b3b9fee7`
+|`ami-0e94d896e72eeae0d`
 
 |`eu-south-1`
-|`ami-0bd0fd41a1d3f799a`
+|`ami-04df4e2850dce0721`
+
+|`eu-south-2`
+|`ami-0d80de3a5ba722545`
 
 |`eu-west-1`
-|`ami-04504e8799057980c`
+|`ami-066f2d86026ef97a8`
 
 |`eu-west-2`
-|`ami-0cc9297ddb3bce971`
+|`ami-0f1c0b26b1c99499d`
 
 |`eu-west-3`
-|`ami-06f98f607a50937c6`
+|`ami-0f639505a9c74d9a2`
+
+|`me-central-1`
+|`ami-0fbb2ece8478f1402`
 
 |`me-south-1`
-|`ami-0fe39da7871a5b2a5`
+|`ami-01507551558853852`
 
 |`sa-east-1`
-|`ami-08265cc3226697767`
+|`ami-097132aa0da53c981`
 
 |`us-east-1`
-|`ami-0fe05b1aa8dacfa90`
+|`ami-0624891c612b5eaa0`
 
 |`us-east-2`
-|`ami-0ff64f495c7e977cf`
+|`ami-0dc6c4d1bd5161f13`
 
 |`us-gov-east-1`
-|`ami-0c99658076c41872a`
+|`ami-0bab20368b3b9b861`
 
 |`us-gov-west-1`
-|`ami-0ca4acd5b8ba1cb1d`
+|`ami-0fe8299f8e808e720`
 
 |`us-west-1`
-|`ami-01dc5d8e6bb6f23f4`
+|`ami-0c03b7e5954f10f9b`
 
 |`us-west-2`
-|`ami-0404a109adfd00019`
+|`ami-0f4cdfd74e4a3fc29`
 
 |===
 
@@ -105,76 +120,91 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-0574bcc5f80b0ad9a`
+|`ami-0d684ca7c09e6f5fc`
 
 |`ap-east-1`
-|`ami-0a65e79822ae2d235`
+|`ami-01b0e1c24d180fe5d`
 
 |`ap-northeast-1`
-|`ami-0f7ef19d48e22353b`
+|`ami-06439c626e2663888`
 
 |`ap-northeast-2`
-|`ami-051dc6de359975e3c`
+|`ami-0a19d3bed3a2854e3`
 
 |`ap-northeast-3`
-|`ami-0fd0b4222595650ac`
+|`ami-08b8fa76fd46b5c58`
 
 |`ap-south-1`
-|`ami-05f9d14fe4a90ed6f`
+|`ami-0ec6463b788929a6a`
+
+|`ap-south-2`
+|`ami-0f5077b6d7e1b10a5`
 
 |`ap-southeast-1`
-|`ami-0afdb9133d22fba5f`
+|`ami-081a6c6a24e2ee453`
 
 |`ap-southeast-2`
-|`ami-0ef979abe82d07d44`
+|`ami-0a70049ac02157a02`
 
 |`ap-southeast-3`
-|`ami-025f9103ac4310e7f`
+|`ami-065fd6311a9d7e6a6`
+
+|`ap-southeast-4`
+|`ami-0105993dc2508c4f4`
 
 |`ca-central-1`
-|`ami-0588cdf59e5c14847`
+|`ami-04582d73d5aad9a85`
 
 |`eu-central-1`
-|`ami-0ef24c0e18f93fa42`
+|`ami-0f72c8b59213f628e`
+
+|`eu-central-2`
+|`ami-0647f43516c31119c`
 
 |`eu-north-1`
-|`ami-0439e2a3bf315df1a`
+|`ami-0d155ca6a531f5f72`
 
 |`eu-south-1`
-|`ami-0714e7c2e0106cdd3`
+|`ami-02f8d2794a663dbd0`
+
+|`eu-south-2`
+|`ami-0427659985f520cae`
 
 |`eu-west-1`
-|`ami-0b960e76764ccd0c3`
+|`ami-04e9944a8f9761c3e`
 
 |`eu-west-2`
-|`ami-02621f50de62b3b89`
+|`ami-09c701f11d9a7b167`
 
 |`eu-west-3`
-|`ami-0933ce7f5e2bfb50e`
+|`ami-02cd8181243610e0d`
+
+|`me-central-1`
+|`ami-03008d03f133e6ec0`
 
 |`me-south-1`
-|`ami-074bde61a2ab740ee`
+|`ami-096bc3b4ec0faad76`
 
 |`sa-east-1`
-|`ami-03b4f97cfc8033ae0`
+|`ami-01f9b5a4f7b8c50a1`
 
 |`us-east-1`
-|`ami-02a574449d4f4d280`
+|`ami-09ea6f8f7845792e1`
 
 |`us-east-2`
-|`ami-020e5600ef28c60ae`
+|`ami-039cdb2bf3b5178da`
 
 |`us-gov-east-1`
-|`ami-069f60e1dcf766d24`
+|`ami-0fed54a5ab75baed0`
 
 |`us-gov-west-1`
-|`ami-0db3cda4dbaccda02`
+|`ami-0fc5be5af4bb1d79f`
 
 |`us-west-1`
-|`ami-0c90cabeb5dee3178`
+|`ami-018e5407337da1062`
 
 |`us-west-2`
-|`ami-0f96437a23aeae53f`
+|`ami-0c0c67ef81b80e8eb`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.13

Issue:
This PR addresses [osdocs-4858](https://issues.redhat.com/browse/OSDOCS-4858).

Link to docs preview:
[RHCOS AMIs for the AWS infrastructure](https://59675--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-user-infra-rhcos-ami_installing-restricted-networks-aws)

QE review:
- [ ] QE has approved this change.
