### PR TITLE
Clean up web terminal docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -175,3 +175,4 @@ endif::[]
 :ztp: GitOps ZTP
 :3no: three-node OpenShift
 :3no-caps: Three-node OpenShift
+:web-terminal-op: Web Terminal Operator

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -744,8 +744,8 @@ Topics:
     File: dynamic-plug-in-example
   - Name: Dynamic plugin reference
     File: dynamic-plug-ins-reference
-- Name: Web terminal
-  File: odc-about-web-terminal
+- Name: Using the web terminal
+  File: odc-using-web-terminal
   Distros: openshift-enterprise,openshift-online
 - Name: Disabling the web console
   File: disabling-web-console

--- a/applications/working_with_helm_charts/configuring-custom-helm-chart-repositories.adoc
+++ b/applications/working_with_helm_charts/configuring-custom-helm-chart-repositories.adoc
@@ -32,7 +32,7 @@ include::modules/odc-creating-helm-releases-using-developer-perspective.adoc[lev
 
 == Using Helm in the web terminal
 
-You can use Helm by initializing the web terminal in the *Developer* perspective of the web console. For more information, see xref:../../web_console/odc-about-web-terminal.html#odc-using-web-terminal_odc-about-web-terminal[Using the web terminal].
+You can use Helm by xref:../../web_console/odc-using-web-terminal.adoc#odc-access-web-terminal_odc-using-web-terminal[Accessing the web terminal] in the *Developer* perspective of the web console.
 
 include::modules/helm-creating-a-custom-helm-chart-on-openshift.adoc[leveloffset=+1]
 

--- a/modules/odc-access-web-terminal.adoc
+++ b/modules/odc-access-web-terminal.adoc
@@ -1,13 +1,17 @@
 // Module included in the following assemblies:
 //
-// web_console/odc-about-web-terminal.adoc
-:_content-type: PROCEDURE
-[id="odc-using-web-terminal_{context}"]
-= Using the web terminal
+// web_console/odc-using-web-terminal.adoc
 
-After the Web Terminal Operator is installed, you can use the web terminal as follows:
+:_content-type: PROCEDURE
+[id="odc-access-web-terminal_{context}"]
+= Accessing the web terminal
+
+After the {web-terminal-op} is installed, you can access the web terminal.
+
+.Procedure
 
 . To launch the web terminal, click the command line terminal icon (image:odc-wto-icon.png[title="wto icon"]) on the upper right of the console. A web terminal instance is displayed in the *Command line terminal* pane. This instance is automatically logged in with your credentials.
+
 . Select the project where the `DevWorkspace` CR must be created from the *Project* drop-down list. By default, the current project is selected.
 +
 [NOTE]
@@ -32,6 +36,6 @@ After the web terminal is initialized, you can use the preinstalled CLI tools li
 [id="web-terminal-and-network-policies_{context}"]
 == Web terminal and network policies
 
-Web terminals might fail to launch if the cluster has network policies configured. To initialize a web terminal instance, the Web Terminal Operator must communicate with the web terminal's pod to verify it is running, and the {product-title} web console needs to send information to automatically log in to the cluster within the terminal. If either step fails, the web terminal fails to initialize and the terminal panel appears to be in a loading state.
+The web terminal might fail to launch if the cluster has network policies configured. To initialize a web terminal instance, the {web-terminal-op} must communicate with the web terminal's pod to verify it is running, and the {product-title} web console needs to send information to automatically log in to the cluster within the terminal. If either step fails, the web terminal fails to initialize and the terminal panel appears to be in a loading state.
 
 To avoid this issue, ensure that the network policies for namespaces that are used for terminals allow ingress from the `openshift-console` and `openshift-operators` namespaces.

--- a/modules/odc-installing-web-terminal.adoc
+++ b/modules/odc-installing-web-terminal.adoc
@@ -1,23 +1,23 @@
 // Module included in the following assemblies:
 //
-// web_console/odc-about-web-terminal.adoc
+// web_console/odc-using-web-terminal.adoc
 
 :_content-type: PROCEDURE
 [id="odc-installing-web-terminal_{context}"]
 = Installing the web terminal
 
-You can install the web terminal using the Web Terminal Operator listed in the {product-title} OperatorHub. When you install the Web Terminal Operator, the custom resource definitions (CRDs) that are required for the command line configuration, such as the `DevWorkspace` CRD, are automatically installed. The web console creates the required resources when you open the web terminal.
+You can install the web terminal by using the {web-terminal-op} listed in the {product-title} OperatorHub. When you install the {web-terminal-op}, the custom resource definitions (CRDs) that are required for the command line configuration, such as the `DevWorkspace` CRD, are automatically installed. The web console creates the required resources when you open the web terminal.
 
 .Prerequisites
 * Access to an {product-title} cluster using an account with `cluster-admin` permissions.
 
 .Procedure
 . In the *Administrator* perspective of the web console, navigate to *Operators -> OperatorHub*.
-. Use the *Filter by keyword* box to search for the `Web Terminal` Operator in the catalog, and then click the *Web Terminal* tile.
+. Use the *Filter by keyword* box to search for the {web-terminal-op} in the catalog, and then click the *Web Terminal* tile.
 . Read the brief description about the Operator on the *Web Terminal*  page, and then click *Install*.
 . On the *Install Operator* page, retain the default values for all fields.
 
-** The *fast* option in the *Update Channel* menu enables installation of the latest release of the Web Terminal Operator.
+** The *fast* option in the *Update Channel* menu enables installation of the latest release of the {web-terminal-op}.
 ** The *All namespaces on the cluster* option in the *Installation Mode* menu  enables the Operator to watch and be available to all namespaces in the cluster.
 ** The *openshift-operators* option in the *Installed Namespace* menu installs the Operator in the default `openshift-operators` namespace.
 ** The *Automatic* option in the *Approval Strategy* menu ensures that the future upgrades to the Operator are handled automatically by the Operator Lifecycle Manager.
@@ -27,7 +27,7 @@ You can install the web terminal using the Web Terminal Operator listed in the {
 +
 [NOTE]
 ====
-Prior to {product-title} 4.8, the Web Terminal Operator bundled all its functionality in a single Operator. As of {product-title} 4.8, the Web Terminal Operator installs the DevWorkspace Operator as a dependency to provide the same features.
+The {web-terminal-op} installs the DevWorkspace Operator as a dependency.
 ====
 
 . After the Operator is installed, refresh your page to see the command line terminal icon on the upper right of the console.

--- a/modules/odc-uninstalling-web-terminal.adoc
+++ b/modules/odc-uninstalling-web-terminal.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// web_console/odc-about-web-terminal.adoc
+// web_console/odc-using-web-terminal.adoc
 
 :_content-type: PROCEDURE
 [id="odc-uninstalling-web-terminal_{context}"]
@@ -8,28 +8,24 @@
 
 Uninstalling the web terminal is a two-step process:
 
-. Uninstall the Web Terminal Operator and related custom resources (CRs) that were added when you installed the Operator.
-. Uninstall the DevWorkspace Operator and its related custom resources that were added as a dependency of the Web Terminal Operator.
+. Uninstall the {web-terminal-op} and related custom resources (CRs) that were added when you installed the Operator.
+. Uninstall the DevWorkspace Operator and its related custom resources that were added as a dependency of the {web-terminal-op}.
 
-Uninstalling the Web Terminal Operator does not remove any of its custom resource definitions (CRDs) or managed resources that are created when the Operator is installed. These components must be manually uninstalled for security purposes. Removing these components also allows you to save cluster resources by ensuring that terminals do not idle when the Operator is uninstalled.
+Uninstalling the {web-terminal-op} does not remove any of its custom resource definitions (CRDs) or managed resources that are created when the Operator is installed. These components must be manually uninstalled for security purposes. Removing these components also allows you to save cluster resources by ensuring that terminals do not idle when the Operator is uninstalled.
 
 .Prerequisites
 * Access to an {product-title} cluster using an account with `cluster-admin` permissions.
 
 == Removing the Web Terminal Operator and the custom resources that support it
 
-Use the console and the CLI to delete any existing web terminals and CRs that were created during the installation of the Web Terminal Operator.
-
-[NOTE]
-====
-Prior to {product-title} 4.8, the Web Terminal Operator used different CRDs to provide Web Terminal capabilities. To uninstall versions 1.2.1 and below of the Web Terminal Operator, refer to the documentation for {product-title} 4.7.
-====
+Use the console and the CLI to delete any existing web terminals and CRs that were created during the installation of the {web-terminal-op}.
 
 .Procedure
-. Uninstall the Web Terminal Operator using the web console:
+
+. Uninstall the {web-terminal-op} using the web console:
 .. In the *Administrator* perspective of the web console, navigate to *Operators -> Installed Operators*.
-.. Scroll the filter list or type a keyword into the *Filter by name* box to find the *Web Terminal* Operator.
-.. Click the Options menu {kebab} for the Web Terminal Operator, and then select *Uninstall Operator*.
+.. Scroll the filter list or type a keyword into the *Filter by name* box to find the {web-terminal-op}.
+.. Click the Options menu {kebab} for the {web-terminal-op}, and then select *Uninstall Operator*.
 .. In the *Uninstall Operator* confirmation dialog box, click *Uninstall* to remove the Operator, Operator deployments, and pods from the cluster. The Operator stops running and no longer receives updates.
 +
 . Remove the CRs used by the Operator.
@@ -48,7 +44,7 @@ $ oc delete devworkspacetemplates.workspace.devfile.io --all-namespaces \
 
 == Deleting the DevWorkspace Operator dependency
 
-Use the CLI to delete the custom resource definitions (CRDs) and additional resources that are created during installation of the Web Terminal Operator.
+Use the CLI to delete the custom resource definitions (CRDs) and additional resources that are created during installation of the {web-terminal-op}.
 
 [IMPORTANT]
 ====

--- a/web_console/odc-using-web-terminal.adoc
+++ b/web_console/odc-using-web-terminal.adoc
@@ -1,23 +1,18 @@
 :_content-type: ASSEMBLY
-[id="odc-about-web-terminal"]
-= About the web terminal in the web console
+[id="odc-using-web-terminal"]
+= Using the web terminal
 include::_attributes/common-attributes.adoc[]
-:context: odc-about-web-terminal
+:context: odc-using-web-terminal
 
 toc::[]
 
-You can launch an embedded command line terminal instance in the web console. You must first install the Web Terminal Operator to use the web terminal.
-
-[NOTE]
-====
-Cluster administrators can access the web terminal in {product-title} 4.7 and later.
-====
+You can launch an embedded command line terminal instance in the web console. You must first install the {web-terminal-op} to use the web terminal.
 
 This terminal instance is preinstalled with common CLI tools for interacting with the cluster, such as `oc`, `kubectl`,`odo`, `kn`, `tkn`, `helm`, `kubens`, `subctl`, and `kubectx`. It also has the context of the project you are working on and automatically logs you in using your credentials.
 
 :FeatureName: Web terminal
 include::modules/odc-installing-web-terminal.adoc[leveloffset=+1]
 
-include::modules/odc-using-web-terminal.adoc[leveloffset=+1]
+include::modules/odc-access-web-terminal.adoc[leveloffset=+1]
 
 include::modules/odc-uninstalling-web-terminal.adoc[leveloffset=+1]

--- a/web_console/web-console-overview.adoc
+++ b/web_console/web-console-overview.adoc
@@ -11,13 +11,6 @@ The Red Hat {product-title} web console provides a graphical user interface to v
 Both *Administrator* and *Developer* perspectives enable you to create quick start tutorials for {product-title}. A quick start is a guided tutorial with user tasks and is useful for getting oriented with an application, Operator, or other product offering.
 
 include::modules/about-administrator-perspective.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-See xref:../web_console/odc-about-web-terminal.adoc#odc-about-web-terminal[About the web terminal in the web console] for more information on the web terminal Operator.
-
-
 include::modules/about-developer-perspective.adoc[leveloffset=+1]
 include::modules/odc-accessing-perspectives.adoc[leveloffset=+1]
 
@@ -31,6 +24,6 @@ include::modules/odc-accessing-perspectives.adoc[leveloffset=+1]
 * xref:../web_console/using-dashboard-to-get-cluster-information.adoc#using-dashboard-to-get-cluster-info[Viewing cluster information]
 * xref:../web_console/configuring-web-console.adoc#configuring-web-console[Configuring the web console]
 * xref:../web_console/customizing-the-web-console.adoc#customizing-web-console[Customizing the web console]
-* xref:../web_console/odc-about-web-terminal.adoc#odc-about-web-terminal[Launching an embedded command line terminal instance in the web console]
+* xref:../web_console/odc-using-web-terminal.adoc#odc-using-web-terminal[Using the web terminal]
 * xref:../web_console/creating-quick-start-tutorials.adoc#creating-quick-start-tutorials[Creating quick start tutorials]
 * xref:../web_console/disabling-web-console.adoc#disabling-web-console[Disabling the web console]


### PR DESCRIPTION
No related Jira for this one, but I wanted to clean up the web terminal docs as a precursor to adding the docs for https://issues.redhat.com/browse/RHDEVDOCS-5264

Changes:
- Added attribute for Web Terminal Operator
- Removed some outdated notes (pre-4.8)
- Updated title to make consistent in left nav
- Renamed assembly file
- Removed unnecessary link (additional resources duplicated)

Version(s):
4.10+

Issue:
N/A

Link to docs preview:
https://59678--docspreview.netlify.app/openshift-enterprise/latest/web_console/odc-using-web-terminal.html

QE review not required
