### PR TITLE
OSDOCS#5988: Adds notes for MS 4.12.16 release

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -11,3 +11,6 @@ BasedOnStyles = RedHat
 #optional: pass doc attributes to asciidoctor before linting
 #[asciidoctor]
 #openshift-enterprise = YES
+
+# Disabling rules (NO)
+RedHat.ReleaseNotes = NO

--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -203,3 +203,12 @@ Issued: 2023-05-03
 {product-title} release 4.12.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2040[RHBA-2023:2040] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2037[RHBA-2023:2037] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-16-dp"]
+=== RHBA-2023:2113 - {product-title} 4.12.16 bug fix and security update
+
+Issued: 2023-05-09
+
+{product-title} release 4.12.16, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2113[RHBA-2023:2113] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:2110[RHSA-2023:2110] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].

--- a/modules/nodes-pods-pod-disruption-about.adoc
+++ b/modules/nodes-pods-pod-disruption-about.adoc
@@ -30,6 +30,9 @@ parts:
 
 [NOTE]
 ====
+`Available` refers to the number of pods that has condition `Ready=True`.
+`Ready=True` refers to the pod that is able to serve requests and should be added to the load balancing pools of all matching services.
+
 A `maxUnavailable` of `0%` or `0` or a `minAvailable` of `100%` or equal to the number of replicas
 is permitted but can block nodes from being drained.
 ====


### PR DESCRIPTION
OSDOCS#5988: Adds notes for MS 4.12.16 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5988

Link to docs preview: (VPN req.)
http://file.rdu.redhat.com/opayne/OSDOCS-5988/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-16-dp

QE review:
- [ ] QE has approved this change.
QE not needed for this change

Additional information:
links will not work yet
