### PR TITLE
OSDOCS-5755

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -61,6 +61,10 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides access to the `odo` CLI tool that helps developers build on OpenShift and Kubernetes.
 
+|`registry.connect.redhat.com`
+|443, 80
+|Required for all third-party images and certified Operators.
+
 |`console.redhat.com`
 |443, 80
 |Required. Allows interactions between the cluster and OpenShift Console Manager to enable functionality, such as scheduling upgrades.
@@ -127,6 +131,10 @@ CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard ent
 |`cloud.redhat.com/api/ingress`
 |443
 |Required for telemetry and Red Hat Insights.
+
+|`observatorium-mst.api.openshift.com`
+|443
+|Required for managed OpenShift-specific telemetry.
 
 |`observatorium.api.openshift.com`
 |443


### PR DESCRIPTION
[OSDOCS-5755](https://issues.redhat.com//browse/OSDOCS-5755): Add URLs to firewall prerequisites

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5755

Link to docs preview:
https://59690--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
