### PR TITLE
ROSA with HCP Updates

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -29,5 +29,5 @@
 :openshift-local-productname: Red Hat OpenShift Local
 :openshift-dev-spaces-productname: Red Hat OpenShift Dev Spaces
 :hcp: hosted control planes
-:hcp-title: ROSA with {hcp}
-:hcp-title-first: {product-title} (ROSA) with {hcp}
+:hcp-title: ROSA with HCP
+:hcp-title-first: {product-title} (ROSA) with {hcp} (HCP)

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -102,12 +102,14 @@ Topics:
 - Name: Setting up your environment
   File: rosa-sts-setting-up-environment
 ---
-Name: Install hosted control plane for ROSA clusters
+Name: Install ROSA with HCP clusters
 Dir: rosa_hcp
 Distros: openshift-rosa
 Topics:
-- Name: Creating hosted control planes for ROSA clusters using the default options
+- Name: Creating ROSA with HCP clusters using the default options
   File: rosa-hcp-sts-creating-a-cluster-quickly
+- Name: Using the Node Tuning Operator on ROSA with HCP
+  File: rosa-tuning-config
 ---
 Name: Install ROSA classic clusters
 Dir: rosa_install_access_delete_clusters
@@ -253,6 +255,8 @@ Topics:
   File: rosa-upgrading-sts
 - Name: Upgrading ROSA
   File: rosa-upgrading
+- Name: Upgrading ROSA with HCP
+  File: rosa-hcp-upgrading
 ---
 Name: CI/CD
 Dir: cicd

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -2,6 +2,11 @@
 //
 // * scalability_and_performance/using-node-tuning-operator.adoc
 // * post_installation_configuration/node-tasks.adoc
+// * rosa_hcp/rosa-tuning-config.adoc
+
+ifeval::["{context}" == "rosa-tuning-config"]
+:rosa-hcp-tuning:
+endif::[]
 
 [id="custom-tuning-specification_{context}"]
 = Custom tuning specification
@@ -22,6 +27,7 @@ The Operator Management state is set by adjusting the default Tuned CR. By defau
 
 The `profile:` section lists TuneD profiles and their names.
 
+ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 profile:
@@ -45,11 +51,30 @@ profile:
 
     # tuned_profile_n profile settings
 ----
+endif::rosa-hcp-tuning[]
+ifdef::rosa-hcp-tuning[]
+[source,json]
+----
+{
+  "profile": [
+    {
+      "name": "tuned_profile_1",
+      "data": "# TuneD profile specification\n[main]\nsummary=Description of tuned_profile_1 profile\n\n[sysctl]\nnet.ipv4.ip_forward=1\n# ... other sysctl's or other TuneD daemon plugins supported by the containerized TuneD\n"
+    },
+    {
+      "name": "tuned_profile_n",
+      "data": "# TuneD profile specification\n[main]\nsummary=Description of tuned_profile_n profile\n\n# tuned_profile_n profile settings\n"
+    }
+  ]
+}
+----
+endif::[]
 
 *Recommended profiles*
 
 The `profile:` selection logic is defined by the `recommend:` section of the CR. The `recommend:` section is a list of items to recommend the profiles based on a selection criteria.
 
+ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 recommend:
@@ -57,9 +82,23 @@ recommend:
 # ...
 <recommend-item-n>
 ----
+endif::rosa-hcp-tuning[]
+ifdef::rosa-hcp-tuning[]
+[source,json]
+----
+"recommend": [
+    {
+      "recommend-item-1": details_of_recommendation,
+      # ... 
+      "recommend-item-n": details_of_recommendation,
+    }
+  ]
+----
+endif::[]
 
 The individual items of the list:
 
+ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 - machineConfigLabels: <1>
@@ -82,9 +121,41 @@ The individual items of the list:
 <7> Optional operand configuration.
 <8> Turn debugging on or off for the TuneD daemon. Options are `true` for on or `false` for off. The default is `false`.
 <9> Turn `reapply_sysctl` functionality on or off for the TuneD daemon. Options are `true` for on and `false` for off.
+endif::rosa-hcp-tuning[]
+ifdef::rosa-hcp-tuning[]
+[source,json]
+----
+{
+  "profile": [
+    {
+    # ...
+    }
+  ],
+  "recommend": [
+    {
+      "profile": <tuned_profile_name>, <1>
+      "priority": <priority>, <2>
+      "machineConfigLabels": { <Key_Pair_for_MachineConfig> <3>
+      },
+      "match": [ <4>
+        {
+          "label": <label_information> <5>
+        },
+      ]
+    },
+  ]
+}
+----
+<1> Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
+<1> A TuneD profile to apply on a match. For example `tuned_profile_1`.
+<1> Optional: A dictionary of key-value pairs `MachineConfig` labels. The keys must be unique.
+<1> If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
+<1> The label for the profile matched items.
+endif::[]
 
 `<match>` is an optional list recursively defined as follows:
 
+ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 - label: <label_name> <1>
@@ -96,6 +167,18 @@ The individual items of the list:
 <2> Optional node or pod label value. If omitted, the presence of `<label_name>` is enough to match.
 <3> Optional object type (`node` or `pod`). If omitted, `node` is assumed.
 <4> An optional `<match>` list.
+endif::rosa-hcp-tuning[]
+ifdef::rosa-hcp-tuning[]
+[source,yaml]
+----
+"match": [
+        {
+          "label": <1>
+        },
+]
+----
+<1> Node or pod label name.
+endif::[]
 
 If `<match>` is not omitted, all nested `<match>` sections must also evaluate to `true`. Otherwise, `false` is assumed and the profile with the respective `<match>` section will not be applied or recommended. Therefore, the nesting (child `<match>` sections) works as logical AND operator. Conversely, if any item of the `<match>` list matches, the entire `<match>` list evaluates to `true`. Therefore, the list acts as logical OR operator.
 
@@ -109,6 +192,8 @@ When using machine config pool based matching, it is advised to group nodes with
 ====
 
 .Example: node or pod label based matching
+
+ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 - match:
@@ -127,9 +212,50 @@ When using machine config pool based matching, it is advised to group nodes with
 - priority: 30
   profile: openshift-node
 ----
+endif::rosa-hcp-tuning[]
+ifdef::rosa-hcp-tuning[]
+[source,JSON]
+----
+[
+  {
+    "match": [
+      {
+        "label": "tuned.openshift.io/elasticsearch",
+        "match": [
+          {
+            "label": "node-role.kubernetes.io/master"
+          },
+          {
+            "label": "node-role.kubernetes.io/infra"
+          }
+        ],
+        "type": "pod"
+      }
+    ],
+    "priority": 10,
+    "profile": "openshift-control-plane-es"
+  },
+  {
+    "match": [
+      {
+        "label": "node-role.kubernetes.io/master"
+      },
+      {
+        "label": "node-role.kubernetes.io/infra"
+      }
+    ],
+    "priority": 20,
+    "profile": "openshift-control-plane"
+  },
+  {
+    "priority": 30,
+    "profile": "openshift-node"
+  }
+]
+----
+endif::[]
 
-The CR above is translated for the containerized TuneD daemon into its `recommend.conf` file based on the profile priorities. The profile with the
-highest priority (`10`) is `openshift-control-plane-es` and, therefore, it is considered first. The containerized TuneD daemon running on a given node looks to see if there is a pod running on the same node with the `tuned.openshift.io/elasticsearch` label set. If not, the entire `<match>` section evaluates as `false`. If there is such a pod with the label, in order for the `<match>` section to evaluate to `true`, the node label also needs to be `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
+The CR above is translated for the containerized TuneD daemon into its `recommend.conf` file based on the profile priorities. The profile with the highest priority (`10`) is `openshift-control-plane-es` and, therefore, it is considered first. The containerized TuneD daemon running on a given node looks to see if there is a pod running on the same node with the `tuned.openshift.io/elasticsearch` label set. If not, the entire `<match>` section evaluates as `false`. If there is such a pod with the label, in order for the `<match>` section to evaluate to `true`, the node label also needs to be `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
 If the labels for the profile with priority `10` matched, `openshift-control-plane-es` profile is applied and no other profile is considered. If the node/pod label combination did not match, the second highest priority profile (`openshift-control-plane`) is considered. This profile is applied if the containerized TuneD pod runs on a node with labels `node-role.kubernetes.io/master` or `node-role.kubernetes.io/infra`.
 
@@ -138,6 +264,7 @@ Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks 
 image::node-tuning-operator-workflow-revised.png[Decision workflow]
 
 .Example: machine config pool based matching
+ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 apiVersion: tuned.openshift.io/v1
@@ -161,6 +288,37 @@ spec:
     priority: 20
     profile: openshift-node-custom
 ----
+endif::rosa-hcp-tuning[]
+ifdef::rosa-hcp-tuning[]
+[source,JSON]
+----
+{
+  "apiVersion": "tuned.openshift.io/v1",
+  "kind": "Tuned",
+  "metadata": {
+    "name": "openshift-node-custom",
+    "namespace": "openshift-cluster-node-tuning-operator"
+  },
+  "spec": {
+    "profile": [
+      {
+        "data": "[main]\nsummary=Custom OpenShift node profile with an additional kernel parameter\ninclude=openshift-node\n[bootloader]\ncmdline_openshift_node_custom=+skew_tick=1\n",
+        "name": "openshift-node-custom"
+      }
+    ],
+    "recommend": [
+      {
+        "machineConfigLabels": {
+          "machineconfiguration.openshift.io/role": "worker-custom"
+        },
+        "priority": 20,
+        "profile": "openshift-node-custom"
+      }
+    ]
+  }
+}
+----
+endif::[]
 
 To minimize node reboots, label the target nodes with a label the machine config pool's node selector will match, then create the Tuned CR above and finally create the custom machine config pool itself.
 
@@ -184,25 +342,14 @@ To minimize node reboots, label the target nodes with a label the machine config
 
 *Cloud provider-specific TuneD profiles*
 
-With this functionality, all Cloud provider-specific nodes can conveniently
-be assigned a TuneD profile specifically tailored to a given Cloud provider
-on a {product-title} cluster. This can be accomplished without adding
-additional node labels or grouping nodes into machine config pools.
+With this functionality, all Cloud provider-specific nodes can conveniently be assigned a TuneD profile specifically tailored to a given Cloud provider on a {product-title} cluster. This can be accomplished without adding additional node labels or grouping nodes into machine config pools.
 
-This functionality takes advantage of `spec.providerID` node object values
-in the form of `<cloud-provider>://<cloud-provider-specific-id>` and writes
-the file `/var/lib/tuned/provider` with the value `<cloud-provider>` in NTO
-operand containers.  The content of this file is then used by TuneD to load
-`provider-<cloud-provider>` profile if such profile exists.
+This functionality takes advantage of `spec.providerID` node object values in the form of `<cloud-provider>://<cloud-provider-specific-id>` and writes the file `/var/lib/tuned/provider` with the value `<cloud-provider>` in NTO operand containers.  The content of this file is then used by TuneD to load `provider-<cloud-provider>` profile if such profile exists.
 
-The `openshift` profile that both `openshift-control-plane` and
-`openshift-node` profiles inherit settings from is now updated to use
-this functionality through the use of conditional profile loading.
-Neither NTO nor TuneD currently ship any Cloud provider-specific profiles.
-However, it is possible to create a custom profile `provider-<cloud-provider>`
-that will be applied to all Cloud provider-specific cluster nodes.
+The `openshift` profile that both `openshift-control-plane` and `openshift-node` profiles inherit settings from is now updated to use this functionality through the use of conditional profile loading. Neither NTO nor TuneD currently include any Cloud provider-specific profiles. However, it is possible to create a custom profile `provider-<cloud-provider>` that will be applied to all Cloud provider-specific cluster nodes.
 
 .Example GCE Cloud provider profile
+ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 apiVersion: tuned.openshift.io/v1
@@ -218,10 +365,30 @@ spec:
       # Your tuning for GCE Cloud provider goes here.
     name: provider-gce
 ----
+endif::rosa-hcp-tuning[]
+ifdef::rosa-hcp-tuning[]
+[source,JSON]
+----
+{
+  "apiVersion": "tuned.openshift.io/v1",
+  "kind": "Tuned",
+  "metadata": {
+    "name": "provider-gce",
+    "namespace": "openshift-cluster-node-tuning-operator"
+  },
+  "spec": {
+    "profile": [
+      {
+        "data": "[main]\nsummary=GCE Cloud provider-specific profile\n# Your tuning for GCE Cloud provider goes here.\n",
+        "name": "provider-gce"
+      }
+    ]
+  }
+}
+----
+endif::[]
 
 [NOTE]
 ====
-Due to profile inheritance, any setting specified in the
-`provider-<cloud-provider>` profile will be overwritten by the `openshift`
-profile and its child profiles.
+Due to profile inheritance, any setting specified in the `provider-<cloud-provider>` profile will be overwritten by the `openshift` profile and its child profiles.
 ====

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -14,7 +14,6 @@ ifeval::["{context}" == "cluster-capabilities"]
 :cluster-caps:
 endif::[]
 
-
 :_content-type: CONCEPT
 [id="about-node-tuning-operator_{context}"]
 ifdef::operators[]

--- a/modules/rosa-adding-tuning.adoc
+++ b/modules/rosa-adding-tuning.adoc
@@ -1,0 +1,90 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+
+:_content-type: PROCEDURE
+[id="rosa-adding-tuning_{context}"]
+= Adding node tuning to a machine pool
+
+You can add tunings for compute (also known as worker) nodes in a machine pool to control their configuration.
+
+.Prerequisites
+
+ifdef::openshift-rosa[]
+* You installed and configured the latest AWS (`aws`), ROSA (`rosa`), and OpenShift (`oc`) CLIs on your workstation.
+* You logged in to your Red Hat account by using the `rosa` CLI.
+* You created a {product-title} (ROSA) cluster.
+endif::openshift-rosa[]
+ifndef::openshift-rosa[]
+* You created an {product-title} cluster.
+endif::[]
+* You have an existing machine pool.
+* You have an existing tuning configuration.
+
+.Procedure
+
+ifdef::openshift-rosa[]
+. List the machine pools in the cluster:
++
+[source,terminal]
+----
+$ rosa list machinepools --cluster=<cluster_name>
+----
++
+.Example output
++
+[source,terminal]
+----
+ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONES    SUBNET  VERSION  AUTOREPAIR  TUNING CONFIGS  MESSAGE
+Default      No           2         m5.xlarge                          us-east-1a            N/A     4.12.14  Yes
+db-nodes-mp  No           2         m5.xlarge                          us-east-1a            No      4.12.14  Yes         
+----
+
+. You can add tuning configurations to an existing or new machine pool.
+
+.. Add tunings when creating a machine pool:
++
+[source,terminal]
+----
+$ rosa create machinepool -c <cluster-name> <machinepoolname> --tuning-configs <tuning_config_name>
+----
++
+.Example output
+[source,terminal]
+----
+? Tuning configs: sample-tuning
+I: Machine pool 'db-nodes-mp' created successfully on hosted cluster 'sample-cluster'
+I: To view all machine pools, run 'rosa list machinepools -c sample-cluster'
+----
+
+.. Add or update the tunings for a machine pool:
++
+[source,terminal]
+----
+$ rosa edit machinepool -c <cluster-name> <machinepoolname> --tuning-configs <tuningconfigname>
+----
++
+.Example output
+[source,terminal]
+----
+I: Updated machine pool 'db-nodes-mp' on cluster 'mycluster'
+----
+
+.Verification
+
+. List the available machine pools in your cluster:
++
+[source,terminal]
+----
+$ rosa list machinepools --cluster=<cluster_name>
+----
++
+.Example output
+[source,terminal]
+----
+ID          AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS  TAINTS  AVAILABILITY ZONES  SUBNET  VERSION  AUTOREPAIR  TUNING CONFIGS MESSAGE                                                       
+Default      No           2         m5.xlarge                     us-east-1a          N/A     4.12.14  Yes        
+db-nodes-mp  No           2         m5.xlarge                     us-east-1a          No      4.12.14  Yes          sample-tuning 
+----
+
+. Verify that the tuning config is included for your machine pool in the output.

--- a/modules/rosa-creating-node-tuning.adoc
+++ b/modules/rosa-creating-node-tuning.adoc
@@ -1,0 +1,87 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-tuning-config.adoc
+
+:_content-type: PROCEDURE
+[id="rosa-creating-node-tuning_{context}"]
+= Creating node tuning configurations on {hcp-title}
+
+You can create tuning configurations using the `rosa` CLI.
+
+.Prerequisites
+
+* You have downloaded the latest version of the ROSA CLI.
+* You have a cluster on the latest version.
+* You have a specification file configured for node tuning.
+
+.Procedure
+
+. Run the following command to create your tuning configuration:
++
+[source,terminal]
+----
+$ rosa create tuning-config -c <cluster_id> --name <name_of_tuning> --spec-path <path_to_spec_file>
+----
++
+You must supply the path to the `spec.json` file or the command returns an error.
++
+.Sample output
+[source,terminal]
+----
+$ I: Tuning config 'sample-tuning' has been created on cluster 'cluster-example'.
+$ I: To view all tuning configs, run 'rosa list tuning-configs -c cluster-example'
+----
+
+.Validation
+
+* You can verify the existing tuning configurations that are applied by your account with the following command:
++
+[source,terminal]
+----
+$ rosa list tuning-configs -c <cluster_name> [-o json]
+----
++
+You can specify the type of output you want for the configuration list.
+
+** Without specifying the output type, you see the ID and name of the tuning configuration:
++
+.Sample output without specifying output type
+[source,terminal]
+----
+ID                                    NAME
+20468b8e-edc7-11ed-b0e4-0a580a800298  sample-tuning
+----
+
+** If you specify an output type, such as `json`, you receive the tuning configuration as JSON text:
++
+[NOTE]
+====
+The following JSON output has hard line-returns for the sake of reading clarity. This JSON output is invalid unless you remove the newlines in the JSON strings.
+====
++
+.Sample output specifying JSON output
+[source,terminal]
+----
+[
+  {
+    "kind": "TuningConfig",
+    "id": "20468b8e-edc7-11ed-b0e4-0a580a800298",
+    "href": "/api/clusters_mgmt/v1/clusters/23jbsevqb22l0m58ps39ua4trff9179e/tuning_configs/20468b8e-edc7-11ed-b0e4-0a580a800298",
+    "name": "sample-tuning",
+    "spec": {
+      "profile": [
+        {
+          "data": "[main]\nsummary=Custom OpenShift profile\ninclude=openshift-node\n\n[sysctl]\nvm.dirty_ratio=\"55\"\n",
+          "name": "tuned-1-profile"
+        }
+      ],
+      "recommend": [
+        {
+          "priority": 20,
+          "profile": "tuned-1-profile"
+        }
+      ]
+    }
+  }
+]
+----

--- a/modules/rosa-deleting-node-tuning.adoc
+++ b/modules/rosa-deleting-node-tuning.adoc
@@ -1,0 +1,38 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-tuning-config.adoc
+
+:_content-type: PROCEDURE
+[id="rosa-deleting-node-tuning_{context}"]
+= Deleting node tuning configurations on {hcp-title}
+
+You can delete tuning configurations by using the `rosa` CLI.
+
+[NOTE]
+====
+You cannot delete a tuning configuration referenced in a machine pool. You must first remove the tuning configuration from all machine pools before you can delete  it.
+====
+
+.Prerequisites
+
+* You have downloaded the latest version of the ROSA CLI.
+* You have a cluster on the latest version .
+* Your cluster has a node tuning configuration that you want delete.
+
+.Procedure
+
+* To delete the tuning configurations, run the following command:
++
+[source,terminal]
+----
+$ rosa delete tuning-config -c <cluster_id> <name_of_tuning>
+----
++
+The tuning configuration on the cluster is deleted
++
+.Sample output
+[source,terminal]
+----
+? Are you sure you want to delete tuning config sample-tuning on cluster sample-cluster? Yes
+I: Successfully deleted tuning config 'sample-tuning' from cluster 'sample-cluster'
+----

--- a/modules/rosa-hcp-classic-comparison.adoc
+++ b/modules/rosa-hcp-classic-comparison.adoc
@@ -52,13 +52,11 @@
 
 | *Regional Availability* 
 | 
-//This list is for GA; conceal until ready.
-//    * us-east-1
-    * us-east-2
-//    * us-west2
-    * eu-west-1
-//    * eu-central-1
-//    * ap-southeast-2
+* eu-central-1
+* eu-west-1
+* us-east-1
+* us-east-2
+* us-west-2
 | Available for purchase in all countries where AWS is commercially available 
 
 | *Compliance* 

--- a/modules/rosa-modifying-node-tuning.adoc
+++ b/modules/rosa-modifying-node-tuning.adoc
@@ -1,0 +1,117 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-tuning-config.adoc
+
+:_content-type: PROCEDURE
+[id="rosa-modifying-node-tuning_{context}"]
+= Modifying your node tuning configurations for {hcp-title}
+
+You can can view and update the node tuning configurations using the `rosa` CLI.
+
+.Prerequisites
+
+* You have downloaded the latest version of the ROSA CLI.
+* You have a cluster on the latest version 
+* Your cluster has a node tuning configuration added to it
+
+.Procedure
+
+. You view the tuning configurations with the `rosa describe` command:
++
+[source,terminal]
+----
+$ rosa describe tuning-config -c <cluster_id> <1> 
+       --name <name_of_tuning> <2> 
+       [-o json] <3>
+----
++
+The following items in this spec file are:
++
+<1> Provide the cluster ID for the cluster that you own that you want to apply a node tuning configurations. 
+<2> Provide the name of your tuning configuration.
+<3> Optionally, you can provide the output type. If you do not specify any outputs, you only see the ID and name of the tuning configuration.
++
+.Sample output without specifying output type
+[source,terminal]
+----
+Name:    sample-tuning
+ID:      20468b8e-edc7-11ed-b0e4-0a580a800298
+Spec:    {
+            "profile": [
+              {
+                "data": "[main]\nsummary=Custom OpenShift profile\ninclude=openshift-node\n\n[sysctl]\nvm.dirty_ratio=\"55\"\n",
+                "name": "tuned-1-profile"
+              }
+            ],
+            "recommend": [
+              {
+                 "priority": 20,
+                 "profile": "tuned-1-profile"
+              }
+            ]
+         }
+
+----
++
+.Sample output specifying JSON output
+[source,terminal]
+----
+{
+  "kind": "TuningConfig",
+  "id": "20468b8e-edc7-11ed-b0e4-0a580a800298",
+  "href": "/api/clusters_mgmt/v1/clusters/23jbsevqb22l0m58ps39ua4trff9179e/tuning_configs/20468b8e-edc7-11ed-b0e4-0a580a800298",
+  "name": "sample-tuning",
+  "spec": {
+    "profile": [
+      {
+        "data": "[main]\nsummary=Custom OpenShift profile\ninclude=openshift-node\n\n[sysctl]\nvm.dirty_ratio=\"55\"\n",
+        "name": "tuned-1-profile"
+      }
+    ],
+    "recommend": [
+      {
+        "priority": 20,
+        "profile": "tuned-1-profile"
+      }
+    ]
+  }
+}
+----
+
+. After verifying the tuning configuration, you edit the existing configurations with the `rosa edit` command:
++
+----
+$ rosa edit tuning-config -c <cluster_id> --name <name_of_tuning> --spec-path <path_to_spec_file>
+----
++
+In this command, you use the `spec.json` file to edit your configurations.
+
+.Verification
+
+* Run the `rosa describe` command again, to see that the changes you made to the `spec.json` file are updated in the tuning configurations:
++
+[source,terminal]
+----
+$ rosa describe tuning-config -c <cluster_id> --name <name_of_tuning>
+----
++
+.Sample output
+[source,terminal]
+----
+Name:  sample-tuning
+ID:    20468b8e-edc7-11ed-b0e4-0a580a800298
+Spec:  {
+           "profile": [
+             {
+              "data": "[main]\nsummary=Custom OpenShift profile\ninclude=openshift-node\n\n[sysctl]\nvm.dirty_ratio=\"55\"\n",
+              "name": "tuned-2-profile"
+             }
+           ],
+           "recommend": [
+             {
+              "priority": 10,
+              "profile": "tuned-2-profile"
+             }
+           ]
+       }
+----

--- a/modules/rosa-upgrading-cli-tutorial.adoc
+++ b/modules/rosa-upgrading-cli-tutorial.adoc
@@ -6,6 +6,10 @@
 ifeval::["{context}" == "rosa-upgrading-sts"]
 :sts:
 endif::[]
+ifeval::["{context}" == "rosa-hcp-upgrading"]
+:rosa-hcp:
+endif::[]
+
 
 :_content-type: PROCEDURE
 [id="rosa-upgrading-cli_{context}"]
@@ -47,15 +51,23 @@ The command returns a list of versions to which the cluster can be upgraded, inc
 
 . To upgrade a cluster to the latest available version, enter the following command:
 +
+ifndef::rosa-hcp[]
 [source,terminal]
 ----
 $ rosa upgrade cluster --cluster=<cluster_name|cluster_id>
 ----
+endif::rosa-hcp[]
+ifdef::rosa-hcp[]
+[source,terminal]
+[source,terminal]
+----
+$ rosa upgrade cluster --cluster=<cluster_name|cluster_id> --control-plane
+----
+endif::rosa-hcp[]
 +
 The cluster is scheduled for an immediate upgrade. This action can take an hour or longer, depending on your workload configuration, such as pod disruption budgets.
 +
 You will receive an email when the upgrade is complete. You can also check the status by running `rosa describe cluster` again from the `rosa` CLI or view the status in {cluster-manager} console.
-
 ifeval::["{context}" == "rosa-upgrading-sts"]
 :!sts:
 endif::[]

--- a/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
@@ -30,6 +30,7 @@ include::modules/rosa-osd-node-label-about.adoc[leveloffset=+1]
 
 include::modules/rosa-adding-node-labels.adoc[leveloffset=+2]
 include::modules/rosa-adding-taints.adoc[leveloffset=+1]
+include::modules/rosa-adding-tuning.adoc[leveloffset=+1]
 
 == Additional resources
 * xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc#rosa-nodes-machinepools-about[About machine pools]

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="rosa-hcp-sts-creating-a-cluster-quickly"]
-= Creating hosted control planes for ROSA cluster using the default options
+= Creating {hcp-title} cluster using the default options
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-sts-creating-a-cluster-quickly
 

--- a/rosa_hcp/rosa-tuning-config.adoc
+++ b/rosa_hcp/rosa-tuning-config.adoc
@@ -1,0 +1,19 @@
+:_content-type: ASSEMBLY
+[id="rosa-tuning-config"]
+= Using the Node Tuning Operator on {hcp-title} clusters
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-tuning-config
+
+toc::[]
+
+{hcp-title-first} supports the Node Tuning Operator to improve performance of your nodes on your {hcp-title} clusters. Prior to creating a node tuning configuration, you must create a custom tuning specification.
+
+include::modules/node-tuning-operator.adoc[leveloffset=+1]
+
+include::modules/custom-tuning-specification.adoc[leveloffset=+1]
+
+include::modules/rosa-creating-node-tuning.adoc[leveloffset=+1]
+
+include::modules/rosa-modifying-node-tuning.adoc[leveloffset=+1]
+
+include::modules/rosa-deleting-node-tuning.adoc[leveloffset=+1]

--- a/upgrading/rosa-hcp-upgrading.adoc
+++ b/upgrading/rosa-hcp-upgrading.adoc
@@ -1,0 +1,25 @@
+:_content-type: ASSEMBLY
+[id="rosa-hcp-upgrading"]
+= Upgrading {hcp-title}
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-hcp-upgrading
+
+toc::[]
+
+[id="rosa-hcp-lifecycle-policy_{context}"]
+== Life cycle policies and planning
+
+To plan an upgrade, review the xref:../rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc#rosa-life-cycle[{product-title} update life cycle]. The life cycle page includes release definitions, support and upgrade requirements, installation policy information and life cycle dates.
+
+You can manually upgrade your cluster. Red Hat Site Reliability Engineers (SREs) monitor upgrade progress and remedy any issues encountered.
+
+[id="rosa-hcp-upgrading-a-cluster"]
+== Upgrading a ROSA cluster
+You can upgrade {hcp-title-first} clusters by using individual upgrades through the `rosa` CLI.
+
+[NOTE]
+====
+When following a scheduled upgrade policy, there might be a delay of no more than thirty minutes before the upgrade process begins, even if it is an immediate upgrade. Additionally, the duration of the upgrade might vary based on your workload configuration and with machine pool upgrades, the number of worker nodes.
+====
+
+include::modules/rosa-upgrading-cli-tutorial.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:

- [OSDOCS-5816](https://issues.redhat.com/browse/OSDOCS-5816) 
- [OSDOCS-6008](https://issues.redhat.com/browse/OSDOCS-6008)
- [OSDOCS-6042](https://issues.redhat.com/browse/OSDOCS-6042)
- [OSDOCS-6068](https://issues.redhat.com/browse/OSDOCS-6068)

Link to docs preview:

- **[OSDOCS-5816](https://issues.redhat.com//browse/OSDOCS-5816)** - [ROSA with hosted control planes](http://file.rdu.redhat.com/~eponvell/05112023/openshift-rosa/OSDOCS-5816_HCP-Tunings/rosa_hcp/rosa-tuning-config.html)
    - [Adding node tuning to machine pools](http://file.rdu.redhat.com/~eponvell/05112023/openshift-rosa/OSDOCS-5816_HCP-Tunings/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-adding-tuning_rosa-managing-worker-nodes)
- **[OSDOCS-6008](https://issues.redhat.com/browse/OSDOCS-6008)** - [Upgrading ROSA with hosted control planes clusters](http://file.rdu.redhat.com/~eponvell/05112023/openshift-rosa/OSDOCS-5816_HCP-Tunings/upgrading/rosa-hcp-upgrading.html)
- **[OSDOCS-6042](https://issues.redhat.com/browse/OSDOCS-6042)** - Revised the variables to represent the new product title: [ROSA with HCP](http://file.rdu.redhat.com/~eponvell/05112023/openshift-rosa/OSDOCS-5816_HCP-Tunings/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html)
- **[OSDOCS-6068](https://issues.redhat.com/browse/OSDOCS-6068)**: List of supported [AWS regions for ROSA with HCP](http://file.rdu.redhat.com/~eponvell/05112023/openshift-rosa/OSDOCS-5816_HCP-Tunings/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-classic-comparison_rosa-hcp-sts-creating-a-cluster-quickly).

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Created new content for adding, viewing, editing, and deleting tuning configurations.