### PR TITLE
OCPBUGS13238: CoreOS Layering docs should have info about using the cluster pull-secret

### DIFF
--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -44,6 +44,8 @@ RUN rpm-ostree override replace https://example.com/hotfixes/haproxy-1.0.16-5.el
 Instructions on how to create a Containerfile are beyond the scope of this documentation.
 ====
 
+* Because the process for building a custom layered image is performed outside of the cluster, you must use the `--authfile /path/to/pull-secret` option with Podman or Buildah. Alternatively, to have the pull secret read by these tools automatically, you can add it to one of the default file locations: `~/.docker/config.json`, `$XDG_RUNTIME_DIR/containers/auth.json`, `~/.docker/config.json`, or `~/.dockercfg`. Refer to the `containers-auth.json` man page for more information. 
+
 * You must push the custom layered image to a repository that your cluster can access.
 
 .Procedure


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-13238

Preview: [Applying a RHCOS custom layered image](https://59693--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering.html#coreos-layering-configuring_coreos-layering
): Second Prereq bullet

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
