### PR TITLE
OSDOCS-5289/5287-Network Observability multi-arch and multi-tenancy prereqs

### DIFF
--- a/modules/network-observability-loki-install.adoc
+++ b/modules/network-observability-loki-install.adoc
@@ -5,7 +5,7 @@
 :_content-type: PROCEDURE
 [id="network-observability-loki-installation_{context}"]
 = Installing the Loki Operator
-It is recommended to install Loki using the link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel8-operator/622b46bcae289285d6fcda39[Loki Operator version 5.6], This version provides the ability to create a LokiStack instance using the `openshift-network` tennant configuration mode. It also provides fully automatic, in-cluster authentication and authorization support for Network Observability.
+It is recommended to install link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel8-operator/622b46bcae289285d6fcda39[Loki Operator version 5.7], This version provides the ability to create a LokiStack instance using the `openshift-network` tenant configuration mode. It also provides fully automatic, in-cluster authentication and authorization support for Network Observability.
 
 .Prerequisites
 

--- a/modules/network-observability-operator-install.adoc
+++ b/modules/network-observability-operator-install.adoc
@@ -9,7 +9,9 @@ You can install the Network Observability Operator using the {product-title} web
 
 .Prerequisites
 
-* Installed Loki. It is recommended to install Loki using the link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel8-operator/622b46bcae289285d6fcda39[Loki Operator version 5.6].
+* Installed Loki. It is recommended to install Loki using the link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel8-operator/622b46bcae289285d6fcda39[Loki Operator version 5.7].
+* One of the following supported architectures is required: `amd64`, `ppc64le`, `arm64`, or `s390x`.
+* Any CPU supported by Red Hat Enterprise Linux (RHEL) 9
 
 [NOTE]
 ====
@@ -19,7 +21,6 @@ This documentation assumes that your `LokiStack` instance name is `loki`. Using 
 .Procedure
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
-//In the Operator Hub on the test console Julian provided perms for, its NetObserv Operator, with a capital O.
 . Choose  *Network Observability Operator* from the list of available Operators in the *OperatorHub*, and click *Install*.
 . Select the checkbox `Enable Operator recommended cluster monitoring on this Namespace`.
 . Navigate to *Operators* -> *Installed Operators*. Under Provided APIs for Network Observability, select the *Flow Collector* link.

--- a/networking/network_observability/installing-operators.adoc
+++ b/networking/network_observability/installing-operators.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 Installing Loki is a prerequisite for using the Network Observability Operator. It is recommended to install Loki using the Loki Operator; therefore, these steps are documented below prior to the Network Observability Operator installation.
 
-The Loki Operator integrates a gateway that implements multi-tenancy & authentication with Loki for data flow storage. The *LokiStack* resource manages *Loki*, which is a scalable, highly-available, multitenant log aggregation system, and a web proxy with {product-title} authentication. The *LokiStack* proxy uses {product-title} authentication to enforce multi-tenancy and facilitate the saving and indexing of data in *Loki* log stores. 
+The Loki Operator integrates a gateway that implements multi-tenancy and authentication with Loki for data flow storage. The *LokiStack* resource manages *Loki*, which is a scalable, highly-available, multitenant log aggregation system, and a web proxy with {product-title} authentication. The *LokiStack* proxy uses {product-title} authentication to enforce multi-tenancy and facilitate the saving and indexing of data in *Loki* log stores. 
 
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.10+ planned for Network Observability 1.3 release June 19th.
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5289 (multiple architectures)
https://issues.redhat.com/browse/NETOBSERV-1067 (RHEL 9)
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://59694--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/installing-operators.html#network-observability-operator-installation_network_observability
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This PR comprises a couple of different Jira tickets for prerequisites related to multi-arch and a prerequisite related to multi-tenancy (Loki 5.7)
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
