### PR TITLE
Add DNS forwarding content to ROSA and OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -232,6 +232,8 @@ Name: Networking
 Dir: networking
 Distros: openshift-dedicated
 Topics:
+- Name: Understanding the DNS Operator
+  File: dns-operator
 - Name: Understanding the Ingress Operator
   File: ingress-operator
 - Name: OpenShift SDN default CNI network provider

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -329,6 +329,8 @@ Name: Networking
 Dir: networking
 Distros: openshift-rosa
 Topics:
+- Name: Understanding the DNS Operator
+  File: dns-operator
 - Name: Understanding the Ingress Operator
   File: ingress-operator
 - Name: OpenShift SDN default CNI network provider

--- a/modules/nw-dns-forward.adoc
+++ b/modules/nw-dns-forward.adoc
@@ -9,13 +9,21 @@
 You can use DNS forwarding to override the default forwarding configuration in the `/etc/resolv.conf` file in the following ways:
 
 * Specify name servers for every zone. If the forwarded zone is the Ingress domain managed by {product-title}, then the upstream name server must be authorized for the domain.
++
+ifdef::openshift-rosa,openshift-dedicated[]
+[IMPORTANT]
+====
+You must specify at least one zone. Otherwise, your cluster can lose functionality.
+====
+endif::[]
++
 * Provide a list of upstream DNS servers.
 * Change the default forwarding policy.
 
 [NOTE]
-=====
+====
 A DNS forwarding configuration for the default domain can have both the default servers specified in the `/etc/resolv.conf` file and the upstream DNS servers.
-=====
+====
 
 .Procedure
 
@@ -55,6 +63,14 @@ spec:
 ----
 <1> Must comply with the `rfc6335` service name syntax.
 <2> Must conform to the definition of a subdomain in the `rfc1123` service name syntax. The cluster domain, `cluster.local`, is an invalid subdomain for the `zones` field.
+ifdef::openshift-rosa,openshift-dedicated[]
++
+[IMPORTANT]
+====
+Only forward to specific zones, such as your intranet. You must specify at least one zone. Otherwise, your cluster can lose functionality.
+====
++
+endif::[]
 <3> Defines the policy to select upstream resolvers. Default value is `Random`. You can also use the values `RoundRobin`, and `Sequential`.
 <4> A maximum of 15 `upstreams` is allowed per `forwardPlugin`.
 <5> Optional. You can use it to override the default policy and forward DNS resolution to the specified DNS resolvers (upstream resolvers) for the default domain. If you do not provide any upstream resolvers, the DNS name queries go to the servers in `/etc/resolv.conf`.
@@ -103,6 +119,14 @@ spec:
 ----
 <1> Must comply with the `rfc6335` service name syntax.
 <2> Must conform to the definition of a subdomain in the `rfc1123` service name syntax. The cluster domain, `cluster.local`, is an invalid subdomain for the `zones` field. The cluster domain, `cluster.local`, is an invalid `subdomain` for `zones`.
+ifdef::openshift-rosa,openshift-dedicated[]
++
+[IMPORTANT]
+====
+Only forward to specific zones, such as your intranet. You must specify at least one zone. Otherwise, your cluster can lose functionality.
+====
++
+endif::[]
 <3> When configuring TLS for forwarded DNS queries, set the `transport` field to have the value `TLS`.
 By default, CoreDNS caches forwarded connections for 10 seconds. CoreDNS will hold a TCP connection open for those 10 seconds if no request is issued. With large clusters, ensure that your DNS server is aware that it might get many new connections to hold open because you can initiate a connection per node. Set up your DNS hierarchy accordingly to avoid performance issues.
 <4> When configuring TLS for forwarded DNS queries, this is a mandatory server name used as part of the server name indication (SNI) to validate the upstream TLS server certificate.

--- a/networking/dns-operator.adoc
+++ b/networking/dns-operator.adoc
@@ -10,6 +10,7 @@ The DNS Operator deploys and manages CoreDNS to provide a name resolution
 service to pods, enabling DNS-based Kubernetes Service discovery in
 {product-title}.
 
+ifndef::openshift-rosa,openshift-osd[]
 include::modules/nw-dns-operator.adoc[leveloffset=+1]
 
 include::modules/nw-dns-operator-managementState.adoc[leveloffset=+1]
@@ -17,9 +18,11 @@ include::modules/nw-dns-operator-managementState.adoc[leveloffset=+1]
 include::modules/nw-controlling-dns-pod-placement.adoc[leveloffset=+1]
 
 include::modules/nw-dns-view.adoc[leveloffset=+1]
+endif::[]
 
 include::modules/nw-dns-forward.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-osd[]
 include::modules/nw-dns-operator-status.adoc[leveloffset=+1]
 
 include::modules/nw-dns-operator-logs.adoc[leveloffset=+1]
@@ -29,3 +32,4 @@ include::modules/nw-dns-loglevel.adoc[leveloffset=+1]
 include::modules/nw-dns-operatorloglevel.adoc[leveloffset=+1]
 
 include::modules/nw-dns-cache-tuning.adoc[leveloffset=+1]
+endif::[]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5568

Link to docs preview:
ROSA: https://59695--docspreview.netlify.app/openshift-rosa/latest/networking/dns-operator.html
Dedicated: https://59695--docspreview.netlify.app/openshift-dedicated/latest/networking/dns-operator.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
