### PR TITLE
Re-enable non tech preview upgrade instructions

### DIFF
--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -26,7 +26,7 @@ include::modules/prepare-operator-upgrades.adoc[leveloffset=+1]
 * link:https://docs.openshift.com/container-platform/latest/operators/admin/olm-upgrading-operators.html[Updating installed Operators]
 * xref:../backup_and_restore/backing-up-acs.adoc[Backing up {product-title}]
 
-//include::modules/operator-upgrade-modify-central-custom-resource.adoc[leveloffset=+1]
+include::modules/operator-upgrade-modify-central-custom-resource.adoc[leveloffset=+1]
 
 include::modules/operator-upgrade-modify-central-custom-resource-tech-preview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

This restores the original docs when not using tech preview

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

rhacs-4.0, cherrypick to rhacs-docs-4-0

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->


cc: @gaurav-nelson @kcarmichael08 