### PR TITLE
OCPBUGS-10482-Fix: Added vsphere zone and region enablement tech prev…

### DIFF
--- a/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
@@ -72,6 +72,8 @@ include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 //You extract the installation program from the mirrored content.
 
 //You can install the CLI on the mirror host.
@@ -81,6 +83,8 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 //include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-restricted-networks-vmc.adoc
+++ b/installing/installing_vmc/installing-restricted-networks-vmc.adoc
@@ -58,6 +58,8 @@ include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=
 
 include::modules/installation-creating-image-restricted.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
@@ -65,6 +67,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_vmc/installing-vmc-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-customizations.adoc
@@ -51,6 +51,8 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
@@ -58,6 +60,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
@@ -60,6 +60,8 @@ include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
@@ -67,6 +69,8 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
 

--- a/installing/installing_vmc/installing-vmc-network-customizations.adoc
+++ b/installing/installing_vmc/installing-vmc-network-customizations.adoc
@@ -51,6 +51,8 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
@@ -58,6 +60,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 // begin network customization
 include::modules/nw-network-config.adoc[leveloffset=+1]

--- a/installing/installing_vmc/installing-vmc-user-infra.adoc
+++ b/installing/installing_vmc/installing-vmc-user-infra.adoc
@@ -63,6 +63,8 @@ include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
@@ -70,6 +72,8 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 //include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
 

--- a/installing/installing_vmc/installing-vmc.adoc
+++ b/installing/installing_vmc/installing-vmc.adoc
@@ -8,8 +8,6 @@ toc::[]
 
 In {product-title} version {product-version}, you can install a cluster on VMware vSphere by deploying it to link:https://cloud.vmware.com/vmc-aws[VMware Cloud (VMC) on AWS].
 
-Once you have configured your VMC environment for {product-title} deployment, you use the {product-title} installation program from the bastion management host, co-located in the VMC environment. The installation program and control plane automates the process of deploying and managing the resources needed for the {product-title} cluster.
-
 include::snippets/vcenter-support.adoc[]
 
 include::modules/setting-up-vmc-for-vsphere.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -55,6 +55,8 @@ include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=
 
 include::modules/installation-creating-image-restricted.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
@@ -62,6 +64,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -84,6 +84,8 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 //You can install the CLI on the mirror host.
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
@@ -91,6 +93,8 @@ include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 //include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -47,6 +47,8 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
@@ -54,6 +56,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -50,6 +50,8 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
@@ -57,6 +59,8 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 include::modules/installation-installer-provisioned-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 // begin network customization
 include::modules/nw-network-config.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -72,6 +72,8 @@ include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
@@ -79,6 +81,8 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 // Network Operator specific configuration
 include::modules/nw-network-config.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -71,6 +71,8 @@ include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
+
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
@@ -80,6 +82,8 @@ include::modules/installation-vsphere-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 //include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
+
+include::modules/configuring-vsphere-regions-zones.adoc[leveloffset=+2]
 
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+1]
 

--- a/modules/configuring-vsphere-regions-zones.adoc
+++ b/modules/configuring-vsphere-regions-zones.adoc
@@ -1,0 +1,157 @@
+// Module included in the following assemblies:
+//
+//* installing/Installing-vsphere-installer-provisioned-customizations.adoc [IPI]
+//* installing/installing-vsphere-installer-provisioned-network-customizations.adoc [IPI]
+//* installing/installing-vsphere.adoc [UPI]
+//* installing/installing-vsphere-network-customizations.adoc [UPI]
+//* installing/installing-restricted-networks-installer-provisioned-vsphere.adoc [IPI]
+//* installing/installing-restricted-networks-vsphere.adoc [IPI]
+
+:_content-type: PROCEDURE
+[id="configuring-vsphere-regions-zones_{context}"]
+= Configuring regions and zones for a VMware vCenter
+You can modify the default installation configuration file to deploy an {product-title} cluster to multiple vSphere datacenters that run in a single VMware vCenter.
+
+:FeatureName: VMware vSphere region and zone enablement
+include::snippets/technology-preview.adoc[]
+
+[IMPORTANT]
+====
+The example uses the `govc` command. The `govc` command is an open source command available from VMware. The `govc` command is not available from Red Hat. Red Hat Support does not maintain the `govc` command. Instructions for downloading and installing `govc` are found on the VMware documentation website.
+====
+
+.Prerequisites
+* You have an existing `install-config.yaml` installation configuration file.
++
+[IMPORTANT]
+====
+You must specify at least one failure domain for your {product-title} cluster, so that you can provision datacenter objects for your VMware vCenter server. Consider specifying multiple failure domains if you need to provision virtual machine nodes in different datacenters, clusters, datastores, and other components.
+====
++
+[NOTE]
+====
+You cannot change a failure domain after you installed an {product-title} cluster on the VMware vSphere platform. You can add additional failure domains after cluster installation.
+====
+
+.Procedure
+
+. Enter the following `govc` command-line tool commands to create the `openshift-region` and `openshift-zone` vCenter tag categories:
++
+[IMPORTANT]
+====
+If you specify different names for the `openshift-region` and `openshift-zone` vCenter tag categories, the installation of the {product-title} cluster fails.
+====
++
+[source,terminal]
+----
+$ govc tags.category.create -d "OpenShift region" openshift-region
+----
++
+[source,terminal]
+----
+$ govc tags.category.create -d "OpenShift zone" openshift-zone
+----
+
+. To create a region tag for each region vSphere datacenter where you want to deploy your cluster, enter the following command in your terminal:
++
+[source,terminal]
+----
+$ govc tags.create -c <region_tag_category> <region_tag>
+----
+
+. To create a zone tag for each vSphere cluster where you want to deploy your cluster, enter the following command:
++
+[source,terminal]
+----
+$ govc tags.create -c <zone_tag_category> <zone_tag>
+----
+
+. Attach region tags to each vCenter datacenter object by entering the following command:
++
+[source,terminal]
+----
+$ govc tags.attach -c <region_tag_category> <region_tag_1> /<datacenter_1>
+----
+
+. Attach the zone tags to each vCenter datacenter object by entering the following command:
++
+[source,terminal]
+----
+$ govc tags.attach -c <zone_tag_category> <zone_tag_1> /<datacenter_1>/host/vcs-mdcnc-workload-1
+----
+
+. Change to the directory that contains the installation program and initialize the cluster deployment according to your chosen installation requirements.
+
+.Sample `install-config.yaml` file with multiple datacenters defined in a vSphere center
+
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: example.com
+featureSet: TechPreviewNoUpgrade <1>
+compute:
+- hyperthreading: Enabled
+  name: worker
+  replicas: 3
+  vsphere:
+    zones: <2>
+      - "<machine_pool_zone_1>"
+      - "<machine_pool_zone_2>"
+controlPlane:
+  hyperthreading: Enabled
+  name: master
+  replicas: 3
+  vsphere:
+    zones: <2>
+      - "<machine_pool_zone_1>"
+      - "<machine_pool_zone_2>"
+metadata:
+  name: cluster
+platform:
+  vsphere:
+    vcenter: <vcenter_server> <3>
+    username: <username> <3>
+    password: <password> <3>
+    datacenter: datacenter <3>
+    defaultDatastore: datastore <3>
+    folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <3>
+    cluster: cluster <3>
+    resourcePool: "/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>" <3>
+    diskType: thin
+    failureDomains: <4>
+    - name: <machine_pool_zone_1> <5>
+      region: <region_tag_1> <6>
+      zone: <zone_tag_1> <7>
+      topology: <8>
+        datacenter: <datacenter1> <9>
+        computeCluster: "/<datacenter1>/host/<cluster1>" <10>
+        resourcePool: "/<datacenter1>/host/<cluster1>/Resources/<resourcePool1>" <11>
+        networks: <12>
+        - <VM_Network1_name>
+        datastore: "/<datacenter1>/datastore/<datastore1>" <13>
+    - name: <machine_pool_zone_2>
+      region: <region_tag_2>
+      zone: <zone_tag_2>
+      topology:
+        datacenter: <datacenter2>
+        computeCluster: "/<datacenter2>/host/<cluster2>"
+        networks:
+        - <VM_Network2_name>
+        datastore: "/<datacenter2>/datastore/<datastore2>"
+        resourcePool: "/<datacenter2>/host/<cluster2>/Resources/<resourcePool2>"
+        folder: "/<datacenter2>/vm/<folder2>"
+# ...
+----
+<1> You must define set the `TechPreviewNoUpgrade` as the value for this parameter, so that you can use the VMware vSphere region and zone enablement feature.
+<2> An optional parameter for specifying a vCenter cluster. You define a zone by using a tag from the `openshift-zone` tag category. If you do not define this parameter, nodes will be distributed among all defined failure-domains.
+<3> The default vCenter topology. The installation program uses this topology information to deploy the bootstrap node. Additionally, the topology defines the default datastore for vSphere persistent volumes.
+<4> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a datastore object. A failure domain defines the vCenter location for {product-title} cluster nodes. If you do not define this parameter, the installation program uses the default vCenter topology.
+<5> Defines the name of the failure domain. Each failure domain is referenced in the `zones` parameter to scope a machine pool to the failure domain.
+<6> You define a region by using a tag from the `openshift-region` tag category. The tag must be attached to the vCenter datacenter.
+<7> You define a zone by using a tag from the `openshift-zone tag` category. The tag must be attached to the vCenter datacenter.
+<8> Specifies the vCenter resources associated with the failure domain.
+<9> An optional parameter for defining the vSphere datacenter that is associated with a failure domain. If you do not define this parameter, the installation program uses the default vCenter topology.
+<10> An optional parameter for stating the absolute file path for the compute cluster that is associated with the failure domain. If you do not define this parameter, the installation program uses the default vCenter topology.
+<11> An optional parameter for the installer-provisioned infrastructure. The parameter sets the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
+<12> An optional parameter that lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured. If you do not define this parameter, the installation program uses the default vCenter topology.
+<13> An optional parameter for specifying a datastore to use for provisioning volumes. If you do not define this parameter, the installation program uses the default vCenter topology.

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1699,6 +1699,60 @@ Optional VMware vSphere machine pool configuration parameters are described in t
 |Integer
 |====
 
+[id="installation-parameters-region-zone-technology-preview-vsphere_{context}"]
+== Region and zone enablement configuration parameters
+
+To use the region and zone enablement feature, you must specify region and zone enablement parameters in your installation file.
+
+[IMPORTANT]
+====
+Before you modify the `install-config.yaml` file to configure a region and zone enablement environment, read the "VMware vSphere region and zone enablement" and the "Configuring regions and zones for a VMware vCenter" sections.
+====
+
+.Region and zone enablement parameters
+[cols=".^2,.^3a,.^3a",options="header"]
+|====
+|Parameter|Description|Values
+
+|`platform.vsphere.failureDomains`
+|Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+|String
+
+|`platform.vsphere.failureDomains.name`
+|The name of the failure domain. The machine pools use this name to reference the failure domain.
+|String
+
+|`platform.vsphere.failureDomains.region`
+|You define a region by using a tag from the `openshift-region` tag category. The tag must be attached to the vCenter datacenter.
+|String
+
+|`platform.vsphere.failureDomains.zone`
+|You define a zone by using a tag from the `openshift-zone` tag category. The tag must be attached to the vCenter datacenter.
+|String
+
+|`platform.vsphere.failureDomains.topology.computeCluster`
+|This parameter defines the compute cluster associated with the failure domain. If you do not define this parameter in your configuration, the compute cluster takes the value of `platform.vsphere.cluster` and `platform.vsphere.datacenter`.
+|String
+
+|`platform.vsphere.failureDomains.topology.folder`
+|The absolute path of an existing folder where the installation program creates the virtual machines. If you do not define this parameter in your configuration, the folder takes the value of `platform.vsphere.folder`.
+|String
+
+|`platform.vsphere.failureDomains.topology.datacenter`
+|Defines the datacenter where {product-title} virtual machines (VMs) operate. If you do not define this parameter in your configuration, the datacenter defaults to `platform.vsphere.datacenter`.
+|String
+
+|`platform.vsphere.failureDomains.topology.datastore`
+| The name of the datastore to use for provisioning volumes. If you do not define this parameter in your configuration, the datastore takes the value of `platform.vsphere.defaultDatastore`.
+|String
+
+|`platform.vsphere.failureDomains.topology.networks`
+| Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured. If you do not define this parameter in your configuration, the network takes the value of `platform.vsphere.network`.
+|String
+
+|`platform.vsphere.failureDomains.topology.resourcePool`
+|The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not define this parameter in your configuration, the resource pool takes the value of `platform.vsphere.failureDomains.topology.computeCluster`.
+|====
 endif::vsphere,vmc[]
 
 ifdef::ash[]

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -23,7 +23,7 @@ endif::[]
 [id="installation-installer-provisioned-vsphere-config-yaml_{context}"]
 = Sample install-config.yaml file for an installer-provisioned VMware vSphere cluster
 
-You can customize the install-config.yaml file to specify more details about
+You can customize the `install-config.yaml` file to specify more details about
 your {product-title} cluster's platform or modify the values of the required
 parameters.
 
@@ -78,9 +78,9 @@ platform:
     diskType: thin <7>
     network: VM_Network
     cluster: vsphere_cluster_name <8>
-    apiVIPs: 
+    apiVIPs:
       - api_vip
-    ingressVIPs: 
+    ingressVIPs:
       - ingress_vip
 ifdef::restricted[]
     clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <9>

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -274,6 +274,10 @@ endif::[]
 
 You can install {product-title} on a compatible cloud platform.
 
+ifdef::vmc[]
+When you have configured your VMC environment for {product-title} deployment, you use the {product-title} installation program from the bastion management host that is co-located in the VMC environment. The installation program and control plane automates the process of deploying and managing the resources needed for the {product-title} cluster.
+endif::vmc[]
+
 [IMPORTANT]
 ====
 You can run the `create cluster` command of the installation program only once, during initial installation.
@@ -287,6 +291,8 @@ ifdef::rhv[* Open the `ovirt-imageio` port to the {rh-virtualization-engine-name
 
 * Obtain the {product-title} installation program and the pull secret for your
 cluster.
+
+* Verify the cloud provider account on your host has the correct permissions to deploy the cluster. An account with incorrect permissions causes the installation process to fail with an error message that displays the missing permissions.
 
 .Procedure
 

--- a/modules/installation-vsphere-regions-zones.adoc
+++ b/modules/installation-vsphere-regions-zones.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+//* installing/installing-vsphere-installer-provisioned-customizations.adoc [IPI]
+//* installing/installing-vsphere-installer-provisioned-network-customizations.adoc [IPI]
+//* installing/installing-vsphere.adoc [UPI]
+//* installing/installing-vsphere-network-customizations.adoc [UPI]
+//* installing/installing-restricted-networks-installer-provisioned-vsphere.adoc [IPI]
+//* installing/installing-restricted-networks-vsphere.adoc [IPI]
+
+:_content-type: CONCEPT
+[id="installation-vsphere-regions-zones_{context}"]
+= VMware vSphere region and zone enablement
+
+You can deploy an {product-title} cluster to multiple vSphere datacenters that run in a single VMware vCenter. Each datacenter can run multiple clusters. This configuration reduces the risk of a hardware failure or network outage that can cause your cluster to fail.
+
+:FeatureName: VMware vSphere region and zone enablement
+include::snippets/technology-preview.adoc[]
+
+The default installation configuration deploys a cluster to a single vSphere datacenter. If you want to deploy a cluster to multiple vSphere datacenters, you must create an installation configuration file that enables the region and zone feature.
+
+The default `install-config.yaml` file includes `vcenters` and `failureDomains` fields, where you can specify multiple vSphere datacenters and clusters for your {product-title} cluster. You can leave these fields blank if you want to install an {product-title} cluster in a vSphere environment that consists of single datacenter.
+
+The following list describes terms associated with defining zones and regions for your cluster:
+
+* Failure domain: Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+* Region: Specifies a vCenter datacenter. You define a region by using a tag from the  `openshift-region` tag category.
+* Zone: Specifies a vCenter cluster. You define a zone by using a tag from the `openshift-zone` tag category.
+
+[NOTE]
+====
+If you plan on specifying more than one failure domain in your `install-config.yaml` file, you must create tag categories, zone tags, and region tags in advance of creating the configuration file.
+====
+
+You must create a vCenter tag for each vCenter datacenter, which represents a region. Additionally, you must create a vCenter tag for each cluster than runs in a datacenter, which represents a zone. After you create the tags, you must attach each tag to their respective datacenters and clusters.
+
+The following table outlines an example of the relationship among regions, zones, and tags for a configuration with multiple vSphere datacenters running in a single VMware vCenter.
+
+.Example of a configuration with multiple vSphere datacenters that run in a single VMware vCenter
+[cols="2,2a,4a",options="header"]
+|===
+|Datacenter (region)| Cluster (zone)| Tags
+
+.4+|us-east
+
+.2+|us-east-1
+|us-east-1a
+|us-east-1b
+.2+|us-east-2
+|us-east-2a
+|us-east-2b
+
+.4+|us-west
+.2+|us-west-1
+|us-west-1a
+|us-west-1b
+.2+|us-west-2
+|us-west-2a
+|us-west-2b
+|===


### PR DESCRIPTION
**Note to reviewer: A lot of changes on this PR is based on pre-approved content in the 4.13 doc set**

[OCPBUGS-10482](https://issues.redhat.com/browse/OCPBUGS-10482)

Version(s):
4.12

Link to docs preview:

* [Preview for VMware vSphere region and zone enablement](https://59707--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-vsphere-regions-zones_installing-vsphere-installer-provisioned-network-customizations)
* [Preview for region and zone enablement configuration parameters](https://59707--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-parameters-region-zone-technology-preview-vsphere_installing-vsphere-installer-provisioned-network-customizations)
* [Preview for Configuring regions and zones for a VMware vCenter](https://59707--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-network-customizations)


*Impacted doc sets:*

vSphere doc set

* Installing a cluster on vSphere with 
* Installing a cluster on vSphere with network customizations
* Installing a cluster on vSphere with user-provisioned infrastructure
* Installing a cluster on vSphere with network customizations
* Installing a cluster on vSphere in a restricted network
* Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure


VM doc set

* Installing a cluster on VMC with customizations
* Installing a cluster on VMC with network customizations
* Installing a cluster on VMC in a restricted network
* Installing a cluster on VMC with user-provisioned infrastructure
* Installing a cluster on VMC with user-provisioned infrastructure and network customizations
* Installing a cluster on VMC in a restricted network with user-provisioned infrastructure

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* Request the closure of https://github.com/openshift/openshift-docs/pull/54549 when closing PR #59597.
* Backport [PR closed](https://github.com/openshift/openshift-docs/pull/59597) as all changes not possible for 4.12.
* [4.13: VMware vSphere region and zone enablement](https://docs.openshift.com/container-platform/4.13/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations)