### PR TITLE
OSDOCS-5726: Added link to in install docs to vSphere automatic mig s…

### DIFF
--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -64,7 +64,9 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc#deprecated-parameters-vsphere_installing-restricted-networks-installer-provisioned-vsphere[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration_persistent-storage-csi-migration[CSI automatic migration]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -98,7 +98,9 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#deprecated-parameters-vsphere_installing-restricted-networks-vsphere[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration_persistent-storage-csi-migration[CSI automatic migration]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -57,7 +57,9 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc#deprecated-parameters-vsphere_installing-vsphere-installer-provisioned-customizations[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration_persistent-storage-csi-migration[CSI automatic migration]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -59,7 +59,9 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc#deprecated-parameters-vsphere_installing-vsphere-installer-provisioned-network-customizations[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration_persistent-storage-csi-migration[CSI automatic migration]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -86,7 +86,9 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_vsphere/installing-vsphere-network-customizations.adoc#deprecated-parameters-vsphere_installing-vsphere-network-customizations[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration_persistent-storage-csi-migration[CSI automatic migration]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -86,7 +86,9 @@ include::modules/installation-vsphere-regions-zones.adoc[leveloffset=+1]
 
 * xref:../../installing/installing_vsphere/installing-vsphere.adoc#deprecated-parameters-vsphere_installing-vsphere[Deprecated VMware vSphere configuration parameters]
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration_persistent-storage-csi-migration[CSI automatic migration]
+* xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration-sc-vsphere_persistent-storage-csi-migration[vSphere automatic migration]
+
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-top-aware_persistent-storage-csi-vsphere[VMware vSphere CSI Driver Operator]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 

--- a/modules/installation-vsphere-regions-zones.adoc
+++ b/modules/installation-vsphere-regions-zones.adoc
@@ -17,7 +17,7 @@ You can deploy an {product-title} cluster to multiple vSphere datacenters that r
 ====
 The VMware vSphere region and zone enablement feature requires the vSphere Container Storage Interface (CSI) driver as the default storage driver in the cluster. As a result, the feature only available on a newly installed cluster.
 
-A cluster that was upgraded from a previous release defaults to using the in-tree vSphere driver, so you must enable CSI automatic migration for the cluster. You can then configure multiple regions and zones for the upgraded cluster. 
+A cluster that was upgraded from a previous release defaults to using the in-tree vSphere driver, so you must enable CSI automatic migration for the cluster. You can then configure multiple regions and zones for the upgraded cluster.
 ====
 
 The default installation configuration deploys a cluster to a single vSphere datacenter. If you want to deploy a cluster to multiple vSphere datacenters, you must create an installation configuration file that enables the region and zone feature.
@@ -27,15 +27,15 @@ The default `install-config.yaml` file includes `vcenters` and `failureDomains` 
 The following list describes terms associated with defining zones and regions for your cluster:
 
 * Failure domain: Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-* Region: Specifies a vCenter datacenter. You define a region by using a tag from the  `openshift-region` tag category. 
-* Zone: Specifies a vCenter cluster. You define a zone by using a tag from the `openshift-zone` tag category. 
+* Region: Specifies a vCenter datacenter. You define a region by using a tag from the  `openshift-region` tag category.
+* Zone: Specifies a vCenter cluster. You define a zone by using a tag from the `openshift-zone` tag category.
 
 [NOTE]
 ====
 If you plan on specifying more than one failure domain in your `install-config.yaml` file, you must create tag categories, zone tags, and region tags in advance of creating the configuration file.
 ====
 
-You must create a vCenter tag for each vCenter datacenter, which represents a region. Additionally, you must create a vCenter tag for each cluster than runs in a datacenter, which represents a zone. After you create the tags, you must attach each tag to their respective datacenters and clusters. 
+You must create a vCenter tag for each vCenter datacenter, which represents a region. Additionally, you must create a vCenter tag for each cluster than runs in a datacenter, which represents a zone. After you create the tags, you must attach each tag to their respective datacenters and clusters.
 
 The following table outlines an example of the relationship among regions, zones, and tags for a configuration with multiple vSphere datacenters running in a single VMware vCenter.
 
@@ -45,18 +45,18 @@ The following table outlines an example of the relationship among regions, zones
 
 .4+|us-east
 
-.2+|us-east-1 
+.2+|us-east-1
 |us-east-1a
 |us-east-1b
-.2+|us-east-2 
-|us-east-2a 
+.2+|us-east-2
+|us-east-2a
 |us-east-2b
 
 .4+|us-west
-.2+|us-west-1 
+.2+|us-west-1
 |us-west-1a
 |us-west-1b
 .2+|us-west-2
-|us-west-2a 
-|us-west-2b 
+|us-west-2a
+|us-west-2b
 |===


### PR DESCRIPTION
[OSDOCS-5726](https://issues.redhat.com/browse/OSDOCS-5726)

Version(s):
4.13

Link to docs preview:

[VMware vSphere region and zone enablement](http://file.emea.redhat.com/dfitzmau/OSDOCS-5726/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-vsphere-regions-zones_installing-vsphere-installer-provisioned-customizations)

Also visit the exact same module in the following Installing on vSphere subsections: 
* Installing a cluster on vSphere with network customization
* Installing a cluster on vSphere with user-provisioned infrastructure
* Installing a cluster on vSphere with user-provisioned infrastructure and network customizations
* Installing a cluster on vSphere with network customizations
* Installing a cluster on vSphere in a restricted network

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
