### PR TITLE
OCPBUGS-13163 Adding late breaking know issue OCPBUGS-13163

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -274,9 +274,9 @@ You can now deploy clusters on {rh-openstack} with user-managed load balancers r
 // TODO: For more information, see xref :../installing/installing_openstack/installing-openstack-installer-custom.adoc#install-osp-external-lb-config_installing-openstack-installer-custom[Installation configuration for a cluster on OpenStack with a user-managed load balancer].
 
 [id="ocp-4-13-installation-nutanix-projects-categories"]
-==== Using projects and categories when installing a cluster on Nutanix 
+==== Using projects and categories when installing a cluster on Nutanix
 
-In {product-title} {product-version}, you can use projects and categories to organize compute plane virtual machines in a cluster installed on Nutanix. Projects define logical groups of user roles for managing permissions, networks, and other parameters. You can use categories to apply policies to groups of virtual machines based on shared characteristics. 
+In {product-title} {product-version}, you can use projects and categories to organize compute plane virtual machines in a cluster installed on Nutanix. Projects define logical groups of user roles for managing permissions, networks, and other parameters. You can use categories to apply policies to groups of virtual machines based on shared characteristics.
 
 For more information, see xref:../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installation-configuration-parameters-additional-vsphere_installing-nutanix-installer-provisioned[Installing a cluster on Nutanix].
 
@@ -2625,6 +2625,10 @@ To workaround the issue, delete the `cloud-event-proxy-store-storage-class-http-
 
 * Performance tests run on a {sno} cluster with {product-title} 4.13 installed show a `cyclictest` maximum latency result greater than 20 microseconds.
 (link:https://issues.redhat.com/browse/RHELPLAN-155460[*RHELPLAN-155460*])
+
+* The `cpu-load-balancing.crio.io: "disable"` annotation associated with the low latency tuning described in xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#node-tuning-operator-disabling-cpu-load-balancing-for-dpdk_cnf-master[Disabling CPU load balancing for DPDK] does not work on systems that do not have workload partitioning configured. More specifically, this affects clusters where the infrastructure does not set the `cpuPartitioningMode` to the `AllNodes` value as described in xref:../scalability_and_performance/enabling-workload-partitioning.adoc[Workload partitioning].
++
+This affects the achievable latency of such clusters and might prevent proper operation of low latency workloads. (link:https://issues.redhat.com/browse/OCPBUGS-13163[*OCPBUGS-13163*])
 
 [id="ocp-4-13-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
OCPBUGS-13163]: cgroupv1 support for cpu balancing is broken for non-SNO nodes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13 RN

Issue:
https://issues.redhat.com/browse/OCPBUGS-13163

Link to docs preview:
http://file.emea.redhat.com/kquinn/OCPBUGS-13163/release_notes/ocp-4-13-release-notes.html#ocp-4-13-known-issues

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
