### PR TITLE
OSDOCS#6018: Authenticating cert-manager Operator on the AWS STS cluster

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1004,6 +1004,8 @@ Topics:
     File: cert-manager-operator-proxy
   - Name: Customizing cert-manager by using the cert-manager Operator API fields
     File: cert-manager-customizing-api-fields
+  - Name: Authenticating the cert-manager Operator with AWS Security Token Service
+    File: cert-manager-authenticate-aws
   - Name: Uninstalling the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-operator-uninstall
 - Name: Viewing audit logs

--- a/modules/cert-manager-configure-cloud-credentials-aws-sts.adoc
+++ b/modules/cert-manager-configure-cloud-credentials-aws-sts.adoc
@@ -1,0 +1,125 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-authenticate-aws.adoc
+
+:_content-type: PROCEDURE
+[id="cert-manager-configure-cloud-credentials-aws-sts_{context}"]
+= Configuring cloud credentials for the {cert-manager-operator} for the AWS Security Token Service cluster
+
+To configure the cloud credentials for the {cert-manager-operator} on the AWS Security Token Service (STS) cluster with the cloud credentials. You must generate the cloud credentials manually, and apply it on the cluster by using the `ccoctl` binary.
+
+.Prerequisites
+
+* You have extracted and prepared the `ccoctl` binary.
+* You have configured an {product-title} cluster with AWS STS by using the Cloud Credential Operator in manual mode.
+
+.Procedure
+
+. Create a directory to store a `CredentialsRequest` resource YAML file by running the following command:
++
+[source,terminal]
+----
+$ mkdir credentials-request
+----
+
+. Create a `CredentialsRequest` resource YAML file under the `credentials-request` directory, such as, `sample-credential-request.yaml`, by applying the following yaml:
++
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: cert-manager
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - action:
+      - "route53:GetChange"
+      effect: Allow
+      resource: "arn:aws:route53:::change/*"
+    - action:
+      - "route53:ChangeResourceRecordSets"
+      - "route53:ListResourceRecordSets"
+      effect: Allow
+      resource: "arn:aws:route53:::hostedzone/*"
+    - action:
+      - "route53:ListHostedZonesByName"
+      effect: Allow
+      resource: "*"
+  secretRef:
+    name: aws-creds
+    namespace: cert-manager
+  serviceAccountNames:
+  - cert-manager
+----
+
+. Use the `ccoctl` tool to process `CredentialsRequest` objects by running the following command:
++
+[source,terminal]
+----
+$ ccoctl aws create-iam-roles \
+    --name <user_defined_name> --region=<aws_region> \
+    --credentials-requests-dir=<path_to_credrequests_dir> \
+    --identity-provider-arn <oidc_provider_arn> --output-dir=<path_to_output_dir>
+----
++
+.Example output
+[source,terminal]
+----
+2023/05/15 18:10:34 Role arn:aws:iam::XXXXXXXXXXXX:role/<user_defined_name>-cert-manager-aws-creds created
+2023/05/15 18:10:34 Saved credentials configuration to: <path_to_output_dir>/manifests/cert-manager-aws-creds-credentials.yaml
+2023/05/15 18:10:35 Updated Role policy for Role <user_defined_name>-cert-manager-aws-creds
+----
++
+Copy the `<aws_role_arn>` from the output to use in the next step. For example, `"arn:aws:iam::XXXXXXXXXXXX:role/<user_defined_name>-cert-manager-aws-creds"`
+
+. Add the `eks.amazonaws.com/role-arn="<aws_role_arn>"` annotation to the service account by running the following command:
++
+[source,terminal]
+----
+$ oc -n cert-manager annotate serviceaccount cert-manager eks.amazonaws.com/role-arn="<aws_role_arn>"
+----
+
+. To create a new pod, delete the existing cert-manager controller pod by running the following command:
++
+[source,terminal]
+----
+$ oc delete pods -l app.kubernetes.io/name=cert-manager -n cert-manager
+----
++
+The AWS credentials are applied to a new cert-manager controller pod within a minute.
+
+.Verification
+
+. Get the name of the updated cert-manager controller pod by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -l app.kubernetes.io/name=cert-manager -n cert-manager
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          READY   STATUS    RESTARTS   AGE
+cert-manager-bd7fbb9fc-wvbbt  1/1     Running   0          39s
+----
+
+. Verify that AWS credentials are updated by running the following command:
++
+[source,terminal]
+----
+$ oc set env -n cert-manager po/<cert_manager_controller_pod_name> --list
+----
++
+.Example output
+[source,terminal]
+----
+# pods/cert-manager-57f9555c54-vbcpg, container cert-manager-controller
+# POD_NAMESPACE from field path metadata.namespace
+AWS_ROLE_ARN=XXXXXXXXXXXX
+AWS_WEB_IDENTITY_TOKEN_FILE=/var/run/secrets/eks.amazonaws.com/serviceaccount/token
+----

--- a/security/cert_manager_operator/cert-manager-authenticate-aws.adoc
+++ b/security/cert_manager_operator/cert-manager-authenticate-aws.adoc
@@ -1,0 +1,16 @@
+:_content-type: ASSEMBLY
+[id="cert-manager-authenticate-aws"]
+= Authenticating the {cert-manager-operator} with AWS Security Token Service
+include::_attributes/common-attributes.adoc[]
+:context: cert-manager-authenticate-aws
+
+toc::[]
+
+You can authenticate the {cert-manager-operator} on the AWS Security Token Service (STS) cluster. You can configure cloud credentials for the {cert-manager-operator} by using the `ccoctl` binary.
+
+include::modules/cert-manager-configure-cloud-credentials-aws-sts.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_cert-manager-authenticate-gcp"]
+== Additional resources
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6018
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://59717--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-authenticate-aws.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
