### PR TITLE
OCPBUGS#8980: You must follow manual steps to add RHEL nodes on IPI

### DIFF
--- a/modules/rhel-compute-overview.adoc
+++ b/modules/rhel-compute-overview.adoc
@@ -8,9 +8,11 @@
 [id="rhel-compute-overview_{context}"]
 = About adding RHEL compute nodes to a cluster
 
-In {product-title} {product-version}, you have the option of using {op-system-base-full} machines as compute machines in your cluster if you use a user-provisioned infrastructure installation on the `x86_64` architecture. You must use {op-system-first} machines for the control plane machines in your cluster.
+In {product-title} {product-version}, you have the option of using {op-system-base-full} machines as compute machines in your cluster if you use a user-provisioned or installer-provisioned infrastructure installation on the `x86_64` architecture. You must use {op-system-first} machines for the control plane machines in your cluster.
 
-If you choose to use {op-system-base} compute machines in your cluster, you are responsible for all operating system life cycle management and maintenance. You must perform system updates, apply patches, and complete all other required tasks.
+If you choose to use {op-system-base} compute machines in your cluster, you are responsible for all operating system life cycle management and maintenance. You must perform system updates, apply patches, and complete all other required tasks. 
+
+For installer-provisioned infrastructure clusters, you must manually add {op-system-base} compute machines because automatic scaling in installer-provisioned infrastructure clusters adds Red Hat Enterprise Linux CoreOS (RHCOS) compute machines by default.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
OCPBUGS-8980: Make it clearer that the manual steps to add RHEL compute nodes are valid for UPI and IPI clusters.

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-8980

Link to docs preview:
https://59719--docspreview.netlify.app/openshift-enterprise/latest/machine_management/adding-rhel-compute.html#rhel-compute-overview_adding-rhel-compute

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
