### PR TITLE
OSDOCS#5988: Adds notes for MS 4.12.16 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -203,3 +203,12 @@ Issued: 2023-05-03
 {product-title} release 4.12.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2040[RHBA-2023:2040] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2037[RHBA-2023:2037] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-16-dp"]
+=== RHBA-2023:2113 - {product-title} 4.12.16 bug fix and security update
+
+Issued: 2023-05-10
+
+{product-title} release 4.12.16, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2113[RHBA-2023:2113] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:2110[RHSA-2023:2110] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#5988: Adds notes for MS 4.12.16 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-5988

Link to docs preview:
(VPN req.)
http://file.rdu.redhat.com/opayne/OSDOCS-5988/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-16-dp

QE review:
- [ ] QE has approved this change.
QE not needed for this change

Additional information:
Links will not work yet
