### PR TITLE
OSDOCS#6006: Fixes typo in MS etcd module

### DIFF
--- a/microshift_storage/microshift-storage-plugin-overview.adoc
+++ b/microshift_storage/microshift-storage-plugin-overview.adoc
@@ -13,5 +13,5 @@ LVMS provisions new logical volume management (LVM) logical volumes (LVs) for co
 include::modules/microshift-lvms-system-requirements.adoc[leveloffset=+1]
 include::modules/microshift-lvms-deployment.adoc[leveloffset=+1]
 include::modules/microshift-lvmd-yaml-creating.adoc[leveloffset=+1]
-include::modules/microshift-lvms-config-example-basic.adoc[][leveloffset=+1]
+include::modules/microshift-lvms-config-example-basic.adoc[leveloffset=+1]
 include::modules/microshift-lvms-using.adoc[leveloffset=+1]

--- a/modules/microshift-observe-debug-etcd-server.adoc
+++ b/modules/microshift-observe-debug-etcd-server.adoc
@@ -23,5 +23,5 @@ $ sudo journalctl -u microshift-etcd.scope
 +
 [NOTE]
 ====
-{product-title} logs can be accessed seperately from etcd logs using the `journalctl -u microshift` command.
+{product-title} logs can be accessed separately from etcd logs using the `journalctl -u microshift` command.
 ====


### PR DESCRIPTION
OSDOCS#6006: Fixes typo in MS etcd module

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-6063

Link to docs preview:
Typo https://59730--docspreview.netlify.app/microshift/latest/microshift_support/microshift-etcd.html

Build error fix:https://59730--docspreview.netlify.app/microshift/latest/microshift_storage/microshift-storage-plugin-overview.html#microshift-lvmd-config-example-basic_microshift-storage-plugin-overview

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
