### PR TITLE
OSDOCS-5637-bugbatch4: Documented another batch of 4.13 z-stream notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -559,6 +559,13 @@ You can now create a password for the {op-system} `core` user. If you cannot use
 
 For more information, see xref:../post_installation_configuration/machine-configuration-tasks.adoc#core-user-password_post-install-machine-configuration-tasks[Changing the core user password for node access].
 
+[id="ocp-4-13-management-console"]
+=== Management console
+
+* Previously, a terminated container would render `{{label}}` and {{exitCode}}' codes for each terminated container. With this update, the internationalization code is fixed to render a readable output message. (link:https://issues.redhat.com/browse/OCPBUGS-4206[*OCPBUGS-4206])
+
+* Previously, a regression was introduced causing the *Cluster Settings* page to return an error when a ClusterVersion’s `status.availableUpdates` had a value of `null` and `Upgradeable=False`. With this update,  `status.availableUpdates` are allowed to have a `null` value. (link:https://issues.redhat.com/browse/OCPBUGS-6053[*OCPBUGS-6053*])
+
 [id="ocp-4-13-nodes"]
 === Nodes
 


### PR DESCRIPTION
[OSDOCS-5637](https://issues.redhat.com/browse/OSDOCS-5637)

Version(s):
4.13

Link to docs preview:
[OCP 4.13 RN Bug Fixes]

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Filter](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12347491)
