### PR TITLE
Backing up from one cluster and restoring to another

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-This document provides information on advanced features and functionalities of OpenShift API for Data Protection (OADP).
+This document provides information about advanced features and functionalities of OpenShift API for Data Protection (OADP).
 
 [id="oadp-different-kubernetes-api-versions"]
 == Working with different Kubernetes API versions on the same cluster
@@ -14,5 +14,21 @@ This document provides information on advanced features and functionalities of O
 include::modules/oadp-checking-api-group-versions.adoc[leveloffset=+2]
 include::modules/oadp-about-enable-api-group-versions.adoc[leveloffset=+2]
 include::modules/oadp-using-enable-api-group-versions.adoc[leveloffset=+2]
+
+[id="backing-up-data-one-cluster-restoring-another-cluster"]
+== Backing up data from one cluster and restoring it to another cluster
+
+include::modules/oadp-about-backing-and-restoring-from-cluster-to-cluster.adoc[leveloffset=+2]
+include::modules/oadp-backing-and-restoring-from-cluster-to-cluster.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_oadp-advanced-topics"]
+== Additional resources
+
+For more information about API group versions, see xref:../../backup_and_restore/application_backup_and_restore/oadp-advanced-topics.adoc#oadp-different-kubernetes-api-versions[Working with different Kubernetes API versions on the same cluster].
+
+For more information about OADP Data Mover, see xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-using-data-mover-for-csi-snapshots_backing-up-applications[Using Data Mover for CSI snapshots].
+
+For more information about using Restic with OADP, see xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#oadp-backing-up-applications-restic_backing-up-applications[Backing up applications with Restic].
 
 :!oadp-advanced-topics:

--- a/modules/oadp-about-backing-and-restoring-from-cluster-to-cluster.adoc
+++ b/modules/oadp-about-backing-and-restoring-from-cluster-to-cluster.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/advanced-topics.adoc
+
+
+:_content-type: CONCEPT
+[id="oadp-about-backing-and-restoring-from-cluster-to-cluster_{context}"]
+= About backing up data from one cluster and restoring it on another cluster
+
+{oadp-first} is designed to back up and restore application data in the same {product-title} cluster. {mtc-full} ({mtc-short}) is designed to migrate containers, including application data, from one {product-title} cluster to another cluster.
+
+You can use OADP to back up application data from one {product-title} cluster and restore it on another cluster. However, doing so is more complicated than using {mtc-short} or using OADP to back up and restore on the same cluster.
+
+To successfully use OADP to back up data from one cluster and restore it to another cluster, you must take into account the following factors, in addition to the prerequisites and procedures that apply to using OADP to back up and restore data on the same cluster:
+
+* Operators
+* Use of Velero
+* UID and GID ranges
+
+[id="oadp-cluster-to-cluster-operators_{context}"]
+== Operators
+You must exclude Operators from the backup of an application for backup and restore to succeed.
+
+[id="oadp-cluster-to-cluster-velero_{context}"]
+== Use of Velero
+
+Velero, which OADP is built upon, does not natively support migrating persistent volume snapshots across cloud providers. To migrate volume snapshot data between cloud platforms, you must _either_ enable the Velero Restic file system backup option, which backs up volume contents at the filesystem level, _or_ use the OADP Data Mover for CSI snapshots.
+
+[NOTE]
+====
+In OADP 1.1 and earlier, the Velero Restic file system backup option is called `restic`.
+In OADP 1.2 and later, the Velero Restic file system backup option is called `file-system-backup`.
+====
+
+[NOTE]
+====
+Velero's file system backup feature supports both Kopia and Restic, but currently OADP supports only Restic.
+====
+
+* You must also use Velero's link:https://velero.io/docs/main/file-system-backup/[File System Backup] to migrate data between AWS regions or between Microsoft Azure regions.
+* Velero does not support restoring data to a cluster with an _earlier_ Kubernetes version than the source cluster.
+* It is theoretically possible to migrate workloads to a destination with a _later_ Kubernetes version than the source, but you must consider the compatibility of API groups between clusters for each custom resource. If a Kubernetes version upgrade breaks the compatibility of core or native API groups, you must first update the impacted custom resources.
+
+[id="oadp-cluster-to-cluster-uid-and-gid-ranges_{context}"]
+== UID and GID ranges
+
+When you back up data from one cluster and restore it to another cluster,  there are potential issues that might arise with UID (User ID) and GID (Group ID) ranges. The following section explains these potential issues and mitigations:
+
+Summary of issues::
+The UID and GID ranges of the namespace might change on the destination cluster. OADP does not back up and restore OpenShift UID range metadata. If the backed application requires a specific UID, ensure the range is available when restored. For more information about OpenShift's UID and GID ranges, see link:https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids[A Guide to OpenShift and UIDs].
+
+Detailed description of issues::
+When you create a namespace in {product-title} by using the shell command `oc create namespace`, {product-title} assigns the namespace a unique User ID (UID) range from its available pool of UIDs, a Supplemental Group (GID) range, and unique SELinux MCS labels. This information is stored in the `metadata.annotations` field of the cluster. This information is part of the Security Context Constraints (SCC) annotations, which comprise the following components:
+
+* `openshift.io/sa.scc.mcs`
+* `openshift.io/sa.scc.supplemental-groups`
+* `openshift.io/sa.scc.uid-range`
+
++
+When you use OADP to restore the namespace, it automatically uses the information in `metadata.annotations` without resetting it for the destination cluster. As a result, the workload might not have access to the backed up data if one of the following is true:
+
+* There is a pre-existing namespace with different SCC annotations, for example, on a different cluster. In this case, at backup time, OADP reuses the pre-existing namespace instead of the namespace you are trying to restore.
+* The backup used a label selector, but the namespace where workloads run on does not have the label on it. In this case, OADP does not back up the namespace, but instead creates a new namespace during restore that does not include the annotations of the namespace you backed up. This causes a new UID range to be assigned to the namespace.
++
+This might be an issue for customer workloads if {product-title} assigns a pod a `securityContext` UID based on namespace annotations that have changed from the time the persistent volume data was backed up.
+* The container UID no longer matches the UID of the file owner.
+* An error occurs because {product-title} did not modify the UID range of the destination cluster to match the data of the backup cluster. As a result, the backup cluster has a different UID than the destination cluster, which means the application cannot read or write data to the destination cluster.
+
+Mitigations::
+
+You can use one or more of the following mitigations to resolve the UID and GID range issues:
+
+* Simple mitigations:
+
+** If you use a label selector in the `Backup` CR to filter the objects to include in the backup, be sure to add this label selector to the namespace that contains the workspace.
+** Remove any pre-existing version of a namespace on the destination cluster before attempting to restore a namespace with the same name.
+
+* Advanced mitigations:
+** Fix UID ranges after migration by performing steps 1-4 of link:https://access.redhat.com/articles/6844071[Fixing UID ranges after migration]. Step 1 is optional.
+
+For an in-depth discussion of UID and GID ranges in {product-title} with an emphasis on overcoming issues in backing up data on one cluster and restoring it on another, see link:https://cloud.redhat.com/blog/a-guide-to-openshift-and-uids[A Guide to OpenShift and UIDs].

--- a/modules/oadp-backing-and-restoring-from-cluster-to-cluster.adoc
+++ b/modules/oadp-backing-and-restoring-from-cluster-to-cluster.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/advanced-topics.adoc
+
+
+:_content-type: CONCEPT
+[id="oadp-backing-and-restoring-from-cluster-to-cluster_{context}"]
+= Backing up data from one cluster and restoring it to another cluster
+
+In general, you back up data from one {product-title} cluster and restore it on another {product-title} cluster in the same way that you back up and restore data to the same cluster. However, there are some additional prerequisites and differences in the procedure when backing up data from one {product-title} cluster and restoring it on another.
+
+.Prerequisites
+
+* All relevant prerequisites for backing up and restoring on your platform (for example, AWS, Microsoft Azure, GCP, and so on), especially the prerequisites for for the Data Protection Application (DPA), are described in the relevant sections of this guide.
+
+.Procedure
+
+* Make the following additions to the procedures given for your platform:
+
+** Ensure that the backup store location (BSL) and volume snapshot location have the same names and paths to restore resources to another cluster.
+** Share the same object storage location credentials across the clusters.
+** For best results, use OADP to create the namespace on the destination cluster.
+** If you use the Velero `file-system-backup` option, enable the `--default-volumes-to-fs-backup` flag for use during backup by running the following command:
++
+[source,terminal]
+----
+$ velero backup create <backup_name> --default-volumes-to-fs-backup <any_other_options>
+----
+
+[NOTE]
+====
+In OADP 1.2 and later, the Velero Restic option is called `file-system-backup`.
+====


### PR DESCRIPTION
OADP 1.2; OCP 4.10+

Resolves https://issues.redhat.com/browse/OADP-807 by adding a new section, "Backing up data from one cluster and restoring it to another cluster" to "Advanced OADP features and functionalities".

Preview: https://59740--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-advanced-topics.html#backing-up-data-from-one-cluster-and-restoring-it-to-another-cluster

QE approved. 
