### PR TITLE
RHDEVDOCS-5105: Add test / invoke docs for functions in ODC

### DIFF
--- a/modules/odc-invoke-serverless-function.adoc
+++ b/modules/odc-invoke-serverless-function.adoc
@@ -12,7 +12,6 @@ You can test a deployed serverless function by invoking it in the *Developer* pe
 
 * The {ServerlessOperatorName} and Knative Serving are installed on your {product-title} cluster.
 * You have logged in to the web console and are in the *Developer* perspective.
-* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
 * You have created and deployed a function.
 
 .Procedure
@@ -23,9 +22,9 @@ You can test a deployed serverless function by invoking it in the *Developer* pe
 . In the *Test Serverless Function* dialog box, modify the settings for your test as required:
 
 .. Choose the *Format* for your test. This can be either *CloudEvent* or *HTTP*.
-.. The *Content-Type* defaults to your function type.
-.. You can use the *Advanced Settings* to modify the *Type*, *Source*, and to add optional headers.
-.. You can modify the output message for the test.
+.. The *Content-Type* defaults to the `Content-Type` HTTP header value.
+.. You can use the *Advanced Settings* to modify the *Type* or *Source* for CloudEvent tests, or to add optional headers.
+.. You can modify the input data for the test.
 
 . Click *Test* to run your test.
 . After the test is complete, the *Test Serverless Function* dialog box displays a status code and a message that informs you whether your test was succesful.

--- a/modules/odc-invoke-serverless-function.adoc
+++ b/modules/odc-invoke-serverless-function.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
+:_content-type: PROCEDURE
+[id="odc-invoke-serverless-function_{context}"]
+= Testing a function in the web console
+
+You can test a deployed serverless function by invoking it in the *Developer* perspective of the {product-title} web console.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on your {product-title} cluster.
+* You have logged in to the web console and are in the *Developer* perspective.
+* You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You have created and deployed a function.
+
+.Procedure
+
+. In the *Developer* perspective, navigate to *Topology*.
+. Click on a function, then click *Test Serverless Function* from the *Actions* drop-down list in the *Details* panel. This opens the *Test Serverless Function* dialog box.
+
+. In the *Test Serverless Function* dialog box, modify the settings for your test as required:
+
+.. Choose the *Format* for your test. This can be either *CloudEvent* or *HTTP*.
+.. The *Content-Type* defaults to your function type.
+.. You can use the *Advanced Settings* to modify the *Type*, *Source*, and to add optional headers.
+.. You can modify the output message for the test.
+
+. Click *Test* to run your test.
+. After the test is complete, the *Test Serverless Function* dialog box displays a status code and a message that informs you whether your test was succesful.
+. Click *Back* to perform another test, or *Close* to close the testing dialog box.

--- a/serverless/functions/serverless-functions-getting-started.adoc
+++ b/serverless/functions/serverless-functions-getting-started.adoc
@@ -18,6 +18,7 @@ include::modules/serverless-kn-func-run.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-invoke.adoc[leveloffset=+1]
+include::modules/odc-invoke-serverless-function.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-delete.adoc[leveloffset=+1]
 
 ifdef::openshift-enterprise[]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-5105

Link to docs preview:
https://59750--docspreview.netlify.app/openshift-enterprise/latest/serverless/functions/serverless-functions-getting-started.html#odc-invoke-serverless-function_serverless-functions-getting-started

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- https://github.com/openshift/console/pull/12755