### PR TITLE
JIRA OSDOCS-5108: Upgrade to Kubernetes 1.26

### DIFF
--- a/metering/configuring_metering/metering-common-config-options.adoc
+++ b/metering/configuring_metering/metering-common-config-options.adoc
@@ -156,12 +156,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS   ROLES    AGE   VERSION
-ip-10-0-147-106.us-east-2.compute.internal   Ready    master   14h   v1.25.0
-ip-10-0-150-175.us-east-2.compute.internal   Ready    worker   14h   v1.25.0
-ip-10-0-175-23.us-east-2.compute.internal    Ready    master   14h   v1.25.0
-ip-10-0-189-6.us-east-2.compute.internal     Ready    worker   14h   v1.25.0
-ip-10-0-205-158.us-east-2.compute.internal   Ready    master   14h   v1.25.0
-ip-10-0-210-167.us-east-2.compute.internal   Ready    worker   14h   v1.25.0
+ip-10-0-147-106.us-east-2.compute.internal   Ready    master   14h   v1.26.0
+ip-10-0-150-175.us-east-2.compute.internal   Ready    worker   14h   v1.26.0
+ip-10-0-175-23.us-east-2.compute.internal    Ready    master   14h   v1.26.0
+ip-10-0-189-6.us-east-2.compute.internal     Ready    worker   14h   v1.26.0
+ip-10-0-205-158.us-east-2.compute.internal   Ready    master   14h   v1.26.0
+ip-10-0-210-167.us-east-2.compute.internal   Ready    worker   14h   v1.26.0
 ----
 --
 

--- a/modules/ai-adding-worker-nodes-to-cluster.adoc
+++ b/modules/ai-adding-worker-nodes-to-cluster.adoc
@@ -315,6 +315,6 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES           AGE   VERSION
-control-plane-1.example.com    Ready    master,worker   56m   v1.25.0
-compute-1.example.com          Ready    worker          11m   v1.25.0
+control-plane-1.example.com    Ready    master,worker   56m   v1.26.0
+compute-1.example.com          Ready    worker          11m   v1.26.0
 ----

--- a/modules/capi-machine-set-creating.adoc
+++ b/modules/capi-machine-set-creating.adoc
@@ -200,7 +200,7 @@ $ oc get node
 [source,terminal]
 ----
 NAME                                     STATUS ROLES  AGE   VERSION
-<ip_address_1>.<region>.compute.internal Ready  worker 5h14m v1.25.0
-<ip_address_2>.<region>.compute.internal Ready  master 5h19m v1.25.0
-<ip_address_3>.<region>.compute.internal Ready  worker 7m    v1.25.0
+<ip_address_1>.<region>.compute.internal Ready  worker 5h14m v1.26.0
+<ip_address_2>.<region>.compute.internal Ready  master 5h19m v1.26.0
+<ip_address_3>.<region>.compute.internal Ready  worker 7m    v1.26.0
 ----

--- a/modules/cleaning-crio-storage.adoc
+++ b/modules/cleaning-crio-storage.adoc
@@ -118,7 +118,7 @@ $ oc get nodes
 +
 ----
 NAME				    STATUS	                ROLES    AGE    VERSION
-ci-ln-tkbxyft-f76d1-nvwhr-master-1  Ready, SchedulingDisabled   master	 133m   v1.25.0
+ci-ln-tkbxyft-f76d1-nvwhr-master-1  Ready, SchedulingDisabled   master	 133m   v1.26.0
 ----
 +
 . Mark the node schedulable. You will know that the scheduling is enabled when `SchedulingDisabled` is no longer in status:
@@ -133,5 +133,5 @@ $ oc adm uncordon <nodename>
 +
 ----
 NAME				     STATUS	      ROLES    AGE    VERSION
-ci-ln-tkbxyft-f76d1-nvwhr-master-1   Ready            master   133m   v1.25.0
+ci-ln-tkbxyft-f76d1-nvwhr-master-1   Ready            master   133m   v1.26.0
 ----

--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -128,16 +128,16 @@ Use this command to verify that the real-time kernel is installed:
 $ oc get node -o wide
 ----
 
-Note the worker with the role `worker-rt` that contains the string `4.18.0-305.30.1.rt7.102.el8_4.x86_64   cri-o://1.25.0-99.rhaos4.10.gitc3131de.el8`:
+Note the worker with the role `worker-rt` that contains the string `4.18.0-305.30.1.rt7.102.el8_4.x86_64   cri-o://1.26.0-99.rhaos4.10.gitc3131de.el8`:
 
 [source,terminal]
 ----
 NAME                               	STATUS   ROLES           	AGE 	VERSION                  	INTERNAL-IP
 EXTERNAL-IP   OS-IMAGE                                       	KERNEL-VERSION
 CONTAINER-RUNTIME
-rt-worker-0.example.com	          Ready	 worker,worker-rt   5d17h   v1.25.0
+rt-worker-0.example.com	          Ready	 worker,worker-rt   5d17h   v1.26.0
 128.66.135.107   <none>    	        Red Hat Enterprise Linux CoreOS 46.82.202008252340-0 (Ootpa)
-4.18.0-305.30.1.rt7.102.el8_4.x86_64   cri-o://1.25.0-99.rhaos4.10.gitc3131de.el8
+4.18.0-305.30.1.rt7.102.el8_4.x86_64   cri-o://1.26.0-99.rhaos4.10.gitc3131de.el8
 [...]
 ----
 

--- a/modules/compliance-apply-remediation-for-customized-mcp.adoc
+++ b/modules/compliance-apply-remediation-for-customized-mcp.adoc
@@ -23,11 +23,11 @@ $ oc get nodes -n openshift-compliance
 [source,terminal]
 ----
 NAME                                       STATUS  ROLES  AGE    VERSION
-ip-10-0-128-92.us-east-2.compute.internal  Ready   master 5h21m  v1.25.0
-ip-10-0-158-32.us-east-2.compute.internal  Ready   worker 5h17m  v1.25.0
-ip-10-0-166-81.us-east-2.compute.internal  Ready   worker 5h17m  v1.25.0
-ip-10-0-171-170.us-east-2.compute.internal Ready   master 5h21m  v1.25.0
-ip-10-0-197-35.us-east-2.compute.internal  Ready   master 5h22m  v1.25.0
+ip-10-0-128-92.us-east-2.compute.internal  Ready   master 5h21m  v1.26.0
+ip-10-0-158-32.us-east-2.compute.internal  Ready   worker 5h17m  v1.26.0
+ip-10-0-166-81.us-east-2.compute.internal  Ready   worker 5h17m  v1.26.0
+ip-10-0-171-170.us-east-2.compute.internal Ready   master 5h21m  v1.26.0
+ip-10-0-197-35.us-east-2.compute.internal  Ready   master 5h22m  v1.26.0
 ----
 
 . Add a label to nodes.

--- a/modules/connected-to-disconnected-verify.adoc
+++ b/modules/connected-to-disconnected-verify.adoc
@@ -44,10 +44,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-47ltxtb-f76d1-mrffg-master-0         Ready    master   42m   v1.25.0
-ci-ln-47ltxtb-f76d1-mrffg-master-1         Ready    master   42m   v1.25.0
-ci-ln-47ltxtb-f76d1-mrffg-master-2         Ready    master   42m   v1.25.0
-ci-ln-47ltxtb-f76d1-mrffg-worker-a-gsxbz   Ready    worker   35m   v1.25.0
-ci-ln-47ltxtb-f76d1-mrffg-worker-b-5qqdx   Ready    worker   35m   v1.25.0
-ci-ln-47ltxtb-f76d1-mrffg-worker-c-rjkpq   Ready    worker   34m   v1.25.0
+ci-ln-47ltxtb-f76d1-mrffg-master-0         Ready    master   42m   v1.26.0
+ci-ln-47ltxtb-f76d1-mrffg-master-1         Ready    master   42m   v1.26.0
+ci-ln-47ltxtb-f76d1-mrffg-master-2         Ready    master   42m   v1.26.0
+ci-ln-47ltxtb-f76d1-mrffg-worker-a-gsxbz   Ready    worker   35m   v1.26.0
+ci-ln-47ltxtb-f76d1-mrffg-worker-b-5qqdx   Ready    worker   35m   v1.26.0
+ci-ln-47ltxtb-f76d1-mrffg-worker-c-rjkpq   Ready    worker   34m   v1.26.0
 ----

--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -161,12 +161,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS                     ROLES                  AGE   VERSION
-ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.25.0+3ef6ef3
-ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.25.0+3ef6ef3
-ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
-ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
-ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
-ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.25.0+3ef6ef3
+ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.26.0
+ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.26.0
+ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.26.0
+ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.26.0
+ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.26.0
+ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.26.0
 ----
 
 . When the node is back in the `Ready` state, check that the node is using the custom layered image:

--- a/modules/coreos-layering-removing.adoc
+++ b/modules/coreos-layering-removing.adoc
@@ -52,12 +52,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS                     ROLES                  AGE   VERSION
-ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.25.0+3ef6ef3
-ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.25.0+3ef6ef3
-ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
-ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
-ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.25.0+3ef6ef3
-ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.25.0+3ef6ef3
+ip-10-0-148-79.us-west-1.compute.internal    Ready                      worker                 32m   v1.26.0
+ip-10-0-155-125.us-west-1.compute.internal   Ready,SchedulingDisabled   worker                 35m   v1.26.0
+ip-10-0-170-47.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.26.0
+ip-10-0-174-77.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.26.0
+ip-10-0-211-49.us-west-1.compute.internal    Ready                      control-plane,master   42m   v1.26.0
+ip-10-0-218-151.us-west-1.compute.internal   Ready                      worker                 31m   v1.26.0
 ----
 
 . When the node is back in the `Ready` state, check that the node is using the base image:

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -162,14 +162,14 @@ $ oc get nodes -w
 [source,terminal]
 ----
 NAME                STATUS  ROLES          AGE     VERSION
-host-172-25-75-28   Ready   master         3d20h   v1.25.0
-host-172-25-75-38   Ready   infra,worker   3d20h   v1.25.0
-host-172-25-75-40   Ready   master         3d20h   v1.25.0
-host-172-25-75-65   Ready   master         3d20h   v1.25.0
-host-172-25-75-74   Ready   infra,worker   3d20h   v1.25.0
-host-172-25-75-79   Ready   worker         3d20h   v1.25.0
-host-172-25-75-86   Ready   worker         3d20h   v1.25.0
-host-172-25-75-98   Ready   infra,worker   3d20h   v1.25.0
+host-172-25-75-28   Ready   master         3d20h   v1.26.0
+host-172-25-75-38   Ready   infra,worker   3d20h   v1.26.0
+host-172-25-75-40   Ready   master         3d20h   v1.26.0
+host-172-25-75-65   Ready   master         3d20h   v1.26.0
+host-172-25-75-74   Ready   infra,worker   3d20h   v1.26.0
+host-172-25-75-79   Ready   worker         3d20h   v1.26.0
+host-172-25-75-86   Ready   worker         3d20h   v1.26.0
+host-172-25-75-98   Ready   infra,worker   3d20h   v1.26.0
 ----
 +
 It can take several minutes for all nodes to report their state.

--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -35,9 +35,9 @@ The control plane nodes are ready if the status is `Ready`, as shown in the foll
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   75m   v1.25.0
-ip-10-0-170-223.ec2.internal   Ready    master   75m   v1.25.0
-ip-10-0-211-16.ec2.internal    Ready    master   75m   v1.25.0
+ip-10-0-168-251.ec2.internal   Ready    master   75m   v1.26.0
+ip-10-0-170-223.ec2.internal   Ready    master   75m   v1.26.0
+ip-10-0-211-16.ec2.internal    Ready    master   75m   v1.26.0
 ----
 
 . If the control plane nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -76,9 +76,9 @@ The worker nodes are ready if the status is `Ready`, as shown in the following o
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.25.0
-ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.25.0
-ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.25.0
+ip-10-0-179-95.ec2.internal    Ready    worker   64m   v1.26.0
+ip-10-0-182-134.ec2.internal   Ready    worker   64m   v1.26.0
+ip-10-0-250-100.ec2.internal   Ready    worker   64m   v1.26.0
 ----
 
 . If the worker nodes are _not_ ready, then check whether there are any pending certificate signing requests (CSRs) that must be approved.
@@ -142,12 +142,12 @@ Check that the status for all nodes is `Ready`.
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.25.0
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.25.0
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.25.0
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.25.0
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.25.0
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.25.0
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.26.0
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.26.0
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.26.0
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.26.0
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.26.0
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.26.0
 ----
 
 If the cluster did not start properly, you might need to restore your cluster using an etcd backup.

--- a/modules/images-configuration-file.adoc
+++ b/modules/images-configuration-file.adoc
@@ -86,10 +86,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS                     ROLES                  AGE   VERSION
-ip-10-0-137-182.us-east-2.compute.internal   Ready,SchedulingDisabled   worker                 65m   v1.25.4+77bec7a
-ip-10-0-139-120.us-east-2.compute.internal   Ready,SchedulingDisabled   control-plane          74m   v1.25.4+77bec7a
-ip-10-0-176-102.us-east-2.compute.internal   Ready                      control-plane          75m   v1.25.4+77bec7a
-ip-10-0-188-96.us-east-2.compute.internal    Ready                      worker                 65m   v1.25.4+77bec7a
-ip-10-0-200-59.us-east-2.compute.internal    Ready                      worker                 63m   v1.25.4+77bec7a
-ip-10-0-223-123.us-east-2.compute.internal   Ready                      control-plane          73m   v1.25.4+77bec7a
+ip-10-0-137-182.us-east-2.compute.internal   Ready,SchedulingDisabled   worker                 65m   v1.26.0
+ip-10-0-139-120.us-east-2.compute.internal   Ready,SchedulingDisabled   control-plane          74m   v1.26.0
+ip-10-0-176-102.us-east-2.compute.internal   Ready                      control-plane          75m   v1.26.0
+ip-10-0-188-96.us-east-2.compute.internal    Ready                      worker                 65m   v1.26.0
+ip-10-0-200-59.us-east-2.compute.internal    Ready                      worker                 63m   v1.26.0
+ip-10-0-223-123.us-east-2.compute.internal   Ready                      control-plane          73m   v1.26.0
 ----

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -169,12 +169,12 @@ $ oc get node
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE  VERSION
-ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.25.0
-ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.25.0
-ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.25.0
-ip-10-0-147-35.ec2.internal    Ready                      worker   7m   v1.25.0
-ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.25.0
-ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.25.0
+ip-10-0-137-44.ec2.internal    Ready                      worker   7m   v1.26.0
+ip-10-0-138-148.ec2.internal   Ready                      master   11m  v1.26.0
+ip-10-0-139-122.ec2.internal   Ready                      master   11m  v1.26.0
+ip-10-0-147-35.ec2.internal    Ready                      worker   7m   v1.26.0
+ip-10-0-153-12.ec2.internal    Ready                      worker   7m   v1.26.0
+ip-10-0-154-10.ec2.internal    Ready                      master   11m  v1.26.0
 ----
 
 .. Start the debugging process to access the node:

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -112,13 +112,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                         STATUS   ROLES          AGE   VERSION
-ip-10-0-133-216.us-east-2.compute.internal   Ready    master         60m   v1.25.0
-ip-10-0-139-146.us-east-2.compute.internal   Ready    master         60m   v1.25.0
-ip-10-0-139-192.us-east-2.compute.internal   Ready    worker         51m   v1.25.0
-ip-10-0-139-241.us-east-2.compute.internal   Ready    worker         51m   v1.25.0
-ip-10-0-147-79.us-east-2.compute.internal    Ready    worker         51m   v1.25.0
-ip-10-0-152-241.us-east-2.compute.internal   Ready    master         60m   v1.25.0
-ip-10-0-139-48.us-east-2.compute.internal    Ready    infra          51m   v1.25.0
+ip-10-0-133-216.us-east-2.compute.internal   Ready    master         60m   v1.26.0
+ip-10-0-139-146.us-east-2.compute.internal   Ready    master         60m   v1.26.0
+ip-10-0-139-192.us-east-2.compute.internal   Ready    worker         51m   v1.26.0
+ip-10-0-139-241.us-east-2.compute.internal   Ready    worker         51m   v1.26.0
+ip-10-0-147-79.us-east-2.compute.internal    Ready    worker         51m   v1.26.0
+ip-10-0-152-241.us-east-2.compute.internal   Ready    master         60m   v1.26.0
+ip-10-0-139-48.us-east-2.compute.internal    Ready    infra          51m   v1.26.0
 ----
 +
 Note that the node has a `node-role.kubernetes.io/infra: ''` label:

--- a/modules/infrastructure-moving-router.adoc
+++ b/modules/infrastructure-moving-router.adoc
@@ -104,7 +104,7 @@ $ oc get node <node_name> <1>
 [source,terminal]
 ----
 NAME                          STATUS  ROLES         AGE   VERSION
-ip-10-0-217-226.ec2.internal  Ready   infra,worker  17h   v1.25.0
+ip-10-0-217-226.ec2.internal  Ready   infra,worker  17h   v1.26.0
 ----
 +
 Because the role list includes `infra`, the pod is running on the correct node.

--- a/modules/install-sno-monitoring-the-installation-manually.adoc
+++ b/modules/install-sno-monitoring-the-installation-manually.adoc
@@ -41,5 +41,5 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                         STATUS   ROLES           AGE     VERSION
-control-plane.example.com    Ready    master,worker   10m     v1.25.0
+control-plane.example.com    Ready    master,worker   10m     v1.26.0
 ----

--- a/modules/installation-approve-csrs.adoc
+++ b/modules/installation-approve-csrs.adoc
@@ -57,9 +57,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  63m  v1.25.0
-master-1  Ready     master  63m  v1.25.0
-master-2  Ready     master  64m  v1.25.0
+master-0  Ready     master  63m  v1.26.0
+master-1  Ready     master  63m  v1.26.0
+master-2  Ready     master  64m  v1.26.0
 ----
 +
 The output lists all of the machines that you created.
@@ -179,11 +179,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME      STATUS    ROLES   AGE  VERSION
-master-0  Ready     master  73m  v1.25.0
-master-1  Ready     master  73m  v1.25.0
-master-2  Ready     master  74m  v1.25.0
-worker-0  Ready     worker  11m  v1.25.0
-worker-1  Ready     worker  11m  v1.25.0
+master-0  Ready     master  73m  v1.26.0
+master-1  Ready     master  73m  v1.26.0
+master-2  Ready     master  74m  v1.26.0
+worker-0  Ready     worker  11m  v1.26.0
+worker-1  Ready     worker  11m  v1.26.0
 ----
 +
 [NOTE]

--- a/modules/installation-aws-user-infra-bootstrap.adoc
+++ b/modules/installation-aws-user-infra-bootstrap.adoc
@@ -40,7 +40,7 @@ stored the installation files in.
 [source,terminal]
 ----
 INFO Waiting up to 20m0s for the Kubernetes API at https://api.mycluster.example.com:6443...
-INFO API v1.25.0 up
+INFO API v1.26.0 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 INFO It is now safe to remove the bootstrap resources
 INFO Time elapsed: 1s

--- a/modules/installation-installing-bare-metal.adoc
+++ b/modules/installation-installing-bare-metal.adoc
@@ -65,7 +65,7 @@ $ ./openshift-install --dir <installation_directory> wait-for bootstrap-complete
 [source,terminal]
 ----
 INFO Waiting up to 30m0s for the Kubernetes API at https://api.test.example.com:6443...
-INFO API v1.25.0 up
+INFO API v1.26.0 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 INFO It is now safe to remove the bootstrap resources
 ----

--- a/modules/installation-osp-creating-control-plane.adoc
+++ b/modules/installation-osp-creating-control-plane.adoc
@@ -40,7 +40,7 @@ You will see messages that confirm that the control plane machines are running a
 +
 [source,terminal]
 ----
-INFO API v1.25.0 up
+INFO API v1.26.0 up
 INFO Waiting up to 30m0s for bootstrapping to complete...
 ...
 INFO It is now safe to remove the bootstrap resources

--- a/modules/installation-rhv-creating-control-plane-nodes.adoc
+++ b/modules/installation-rhv-creating-control-plane-nodes.adoc
@@ -28,7 +28,7 @@ $ openshift-install wait-for bootstrap-complete --dir $ASSETS_DIR
 .Example output
 [source,terminal]
 ----
-INFO API v1.25.0 up
+INFO API v1.26.0 up
 INFO Waiting up to 40m0s for bootstrapping to complete...
 ----
 

--- a/modules/installation-special-config-rtkernel.adoc
+++ b/modules/installation-special-config-rtkernel.adoc
@@ -92,12 +92,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.25.0
-ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.25.0
-ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.25.0
-ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.25.0
-ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.25.0
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.25.0
+ip-10-0-139-200.us-east-2.compute.internal  Ready   master   111m  v1.26.0
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.26.0
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.26.0
+ip-10-0-156-255.us-east-2.compute.internal  Ready   master   111m  v1.26.0
+ip-10-0-164-74.us-east-2.compute.internal   Ready   master   111m  v1.26.0
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.26.0
 ----
 +
 [source,terminal]

--- a/modules/ipi-install-provisioning-the-bare-metal-node.adoc
+++ b/modules/ipi-install-provisioning-the-bare-metal-node.adoc
@@ -35,11 +35,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                                STATUS   ROLES           AGE     VERSION
-openshift-master-1.openshift.example.com            Ready    master          30h     v1.25.0
-openshift-master-2.openshift.example.com            Ready    master          30h     v1.25.0
-openshift-master-3.openshift.example.com            Ready    master          30h     v1.25.0
-openshift-worker-0.openshift.example.com            Ready    worker          30h     v1.25.0
-openshift-worker-1.openshift.example.com            Ready    worker          30h     v1.25.0
+openshift-master-1.openshift.example.com            Ready    master          30h     v1.26.0
+openshift-master-2.openshift.example.com            Ready    master          30h     v1.26.0
+openshift-master-3.openshift.example.com            Ready    master          30h     v1.26.0
+openshift-worker-0.openshift.example.com            Ready    worker          30h     v1.26.0
+openshift-worker-1.openshift.example.com            Ready    worker          30h     v1.26.0
 ----
 
 . Get the compute machine set.
@@ -99,12 +99,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                          STATUS   ROLES   AGE     VERSION
-openshift-master-1.openshift.example.com      Ready    master  30h     v1.25.0
-openshift-master-2.openshift.example.com      Ready    master  30h     v1.25.0
-openshift-master-3.openshift.example.com      Ready    master  30h     v1.25.0
-openshift-worker-0.openshift.example.com      Ready    worker  30h     v1.25.0
-openshift-worker-1.openshift.example.com      Ready    worker  30h     v1.25.0
-openshift-worker-<num>.openshift.example.com  Ready    worker  3m27s   v1.25.0
+openshift-master-1.openshift.example.com      Ready    master  30h     v1.26.0
+openshift-master-2.openshift.example.com      Ready    master  30h     v1.26.0
+openshift-master-3.openshift.example.com      Ready    master  30h     v1.26.0
+openshift-worker-0.openshift.example.com      Ready    worker  30h     v1.26.0
+openshift-worker-1.openshift.example.com      Ready    worker  30h     v1.26.0
+openshift-worker-<num>.openshift.example.com  Ready    worker  3m27s   v1.26.0
 ----
 +
 You can also check the kubelet.

--- a/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
+++ b/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
@@ -20,10 +20,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                         STATUS   ROLES    AGE   VERSION
-master-0.cloud.example.com   Ready    master   145m   v1.25.0
-master-1.cloud.example.com   Ready    master   135m   v1.25.0
-master-2.cloud.example.com   Ready    master   145m   v1.25.0
-worker-2.cloud.example.com   Ready    worker   100m   v1.25.0
+master-0.cloud.example.com   Ready    master   145m   v1.26.0
+master-1.cloud.example.com   Ready    master   135m   v1.26.0
+master-2.cloud.example.com   Ready    master   145m   v1.26.0
+worker-2.cloud.example.com   Ready    worker   100m   v1.26.0
 ----
 
 . Check for inconsistent timing delays due to clock drift. For example:

--- a/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
+++ b/modules/ipi-install-troubleshooting-reviewing-the-installation.adoc
@@ -20,9 +20,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS   ROLES           AGE  VERSION
-master-0.example.com   Ready    master,worker   4h   v1.25.0
-master-1.example.com   Ready    master,worker   4h   v1.25.0
-master-2.example.com   Ready    master,worker   4h   v1.25.0
+master-0.example.com   Ready    master,worker   4h   v1.26.0
+master-1.example.com   Ready    master,worker   4h   v1.26.0
+master-2.example.com   Ready    master,worker   4h   v1.26.0
 ----
 
 . Confirm the installer deployed all pods successfully. The following command

--- a/modules/machine-node-custom-partition.adoc
+++ b/modules/machine-node-custom-partition.adoc
@@ -236,13 +236,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE     VERSION
-ip-10-0-128-78.ec2.internal    Ready    worker   117m    v1.25.0
-ip-10-0-146-113.ec2.internal   Ready    master   127m    v1.25.0
-ip-10-0-153-35.ec2.internal    Ready    worker   118m    v1.25.0
-ip-10-0-176-58.ec2.internal    Ready    master   126m    v1.25.0
-ip-10-0-217-135.ec2.internal   Ready    worker   2m57s   v1.25.0 <1>
-ip-10-0-225-248.ec2.internal   Ready    master   127m    v1.25.0
-ip-10-0-245-59.ec2.internal    Ready    worker   116m    v1.25.0
+ip-10-0-128-78.ec2.internal    Ready    worker   117m    v1.26.0
+ip-10-0-146-113.ec2.internal   Ready    master   127m    v1.26.0
+ip-10-0-153-35.ec2.internal    Ready    worker   118m    v1.26.0
+ip-10-0-176-58.ec2.internal    Ready    master   126m    v1.26.0
+ip-10-0-217-135.ec2.internal   Ready    worker   2m57s   v1.26.0 <1>
+ip-10-0-225-248.ec2.internal   Ready    master   127m    v1.26.0
+ip-10-0-245-59.ec2.internal    Ready    worker   116m    v1.26.0
 ----
 <1> This is new new node.
 

--- a/modules/nodes-clusters-cgroups-2.adoc
+++ b/modules/nodes-clusters-cgroups-2.adoc
@@ -196,12 +196,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                       STATUS                     ROLES    AGE   VERSION
-ci-ln-fm1qnwt-72292-99kt6-master-0         Ready,SchedulingDisabled   master   58m   v1.25.0
-ci-ln-fm1qnwt-72292-99kt6-master-1         Ready                      master   58m   v1.25.0
-ci-ln-fm1qnwt-72292-99kt6-master-2         Ready                      master   58m   v1.25.0
-ci-ln-fm1qnwt-72292-99kt6-worker-a-h5gt4   Ready,SchedulingDisabled   worker   48m   v1.25.0
-ci-ln-fm1qnwt-72292-99kt6-worker-b-7vtmd   Ready                      worker   48m   v1.25.0
-ci-ln-fm1qnwt-72292-99kt6-worker-c-rhzkv   Ready                      worker   48m   v1.25.0
+ci-ln-fm1qnwt-72292-99kt6-master-0         Ready,SchedulingDisabled   master   58m   v1.26.0
+ci-ln-fm1qnwt-72292-99kt6-master-1         Ready                      master   58m   v1.26.0
+ci-ln-fm1qnwt-72292-99kt6-master-2         Ready                      master   58m   v1.26.0
+ci-ln-fm1qnwt-72292-99kt6-worker-a-h5gt4   Ready,SchedulingDisabled   worker   48m   v1.26.0
+ci-ln-fm1qnwt-72292-99kt6-worker-b-7vtmd   Ready                      worker   48m   v1.26.0
+ci-ln-fm1qnwt-72292-99kt6-worker-c-rhzkv   Ready                      worker   48m   v1.26.0
 ----
 
 . After a node returns to the `Ready` state, start a debug session for that node:

--- a/modules/nodes-clusters-cgroups-okd-configure.adoc
+++ b/modules/nodes-clusters-cgroups-okd-configure.adoc
@@ -101,12 +101,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.25.0
-ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.25.0
-ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.25.0
-ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.25.0
-ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.25.0
-ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.25.0
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.26.0
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.26.0
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.26.0
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.26.0
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.26.0
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.26.0
 ----
 +
 You can see that the command disables scheduling on each worker node.

--- a/modules/nodes-nodes-kernel-arguments.adoc
+++ b/modules/nodes-nodes-kernel-arguments.adoc
@@ -170,12 +170,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.25.0
-ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.25.0
-ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.25.0
-ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.25.0
-ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.25.0
-ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.25.0
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.26.0
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.26.0
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.26.0
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.26.0
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.26.0
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.26.0
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/nodes-nodes-rtkernel-arguments.adoc
+++ b/modules/nodes-nodes-rtkernel-arguments.adoc
@@ -58,9 +58,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.25.0
-ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.25.0
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.25.0
+ip-10-0-143-147.us-east-2.compute.internal  Ready   worker   103m  v1.26.0
+ip-10-0-146-92.us-east-2.compute.internal   Ready   worker   101m  v1.26.0
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.26.0
 ----
 +
 [source,terminal]

--- a/modules/nodes-nodes-viewing-listing.adoc
+++ b/modules/nodes-nodes-viewing-listing.adoc
@@ -26,9 +26,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS    ROLES     AGE       VERSION
-master.example.com     Ready     master    7h        v1.25.0
-node1.example.com      Ready     worker    7h        v1.25.0
-node2.example.com      Ready     worker    7h        v1.25.0
+master.example.com     Ready     master    7h        v1.26.0
+node1.example.com      Ready     worker    7h        v1.26.0
+node2.example.com      Ready     worker    7h        v1.26.0
 ----
 +
 The following example is a cluster with one unhealthy node:
@@ -42,9 +42,9 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                   STATUS                      ROLES     AGE       VERSION
-master.example.com     Ready                       master    7h        v1.25.0
-node1.example.com      NotReady,SchedulingDisabled worker    7h        v1.25.0
-node2.example.com      Ready                       worker    7h        v1.25.0
+master.example.com     Ready                       master    7h        v1.26.0
+node1.example.com      NotReady,SchedulingDisabled worker    7h        v1.26.0
+node2.example.com      Ready                       worker    7h        v1.26.0
 ----
 +
 The conditions that trigger a `NotReady` status are shown later in this section.
@@ -60,9 +60,9 @@ $ oc get nodes -o wide
 [source,terminal]
 ----
 NAME                STATUS   ROLES    AGE    VERSION   INTERNAL-IP    EXTERNAL-IP   OS-IMAGE                                                       KERNEL-VERSION                 CONTAINER-RUNTIME
-master.example.com  Ready    master   171m   v1.25.0   10.0.129.108   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.25.0-30.rhaos4.10.gitf2f339d.el8-dev
-node1.example.com   Ready    worker   72m    v1.25.0   10.0.129.222   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.25.0-30.rhaos4.10.gitf2f339d.el8-dev
-node2.example.com   Ready    worker   164m   v1.25.0   10.0.142.150   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.25.0-30.rhaos4.10.gitf2f339d.el8-dev
+master.example.com  Ready    master   171m   v1.26.0   10.0.129.108   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.26.0-30.rhaos4.10.gitf2f339d.el8-dev
+node1.example.com   Ready    worker   72m    v1.26.0   10.0.129.222   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.26.0-30.rhaos4.10.gitf2f339d.el8-dev
+node2.example.com   Ready    worker   164m   v1.26.0   10.0.142.150   <none>        Red Hat Enterprise Linux CoreOS 48.83.202103210901-0 (Ootpa)   4.18.0-240.15.1.el8_3.x86_64   cri-o://1.26.0-30.rhaos4.10.gitf2f339d.el8-dev
 ----
 
 * The following command lists information about a single node:
@@ -83,7 +83,7 @@ $ oc get node node1.example.com
 [source,terminal]
 ----
 NAME                   STATUS    ROLES     AGE       VERSION
-node1.example.com      Ready     worker    7h        v1.25.0
+node1.example.com      Ready     worker    7h        v1.26.0
 ----
 
 * The following command provides more detailed information about a specific node, including the reason for
@@ -155,9 +155,9 @@ System Info:    <9>
  OS Image:                                Red Hat Enterprise Linux CoreOS 410.8.20190520.0 (Ootpa)
  Operating System:                        linux
  Architecture:                            amd64
- Container Runtime Version:               cri-o://1.25.0-0.6.dev.rhaos4.3.git9ad059b.el8-rc2
- Kubelet Version:                         v1.25.0
- Kube-Proxy Version:                      v1.25.0
+ Container Runtime Version:               cri-o://1.26.0-0.6.dev.rhaos4.3.git9ad059b.el8-rc2
+ Kubelet Version:                         v1.26.0
+ Kube-Proxy Version:                      v1.26.0
 PodCIDR:                                  10.128.4.0/24
 ProviderID:                               aws:///us-east-2a/i-04e87b31dc6b3e171
 Non-terminated Pods:                      (12 in total)  <10>

--- a/modules/nodes-nodes-working-evacuating.adoc
+++ b/modules/nodes-nodes-working-evacuating.adoc
@@ -44,7 +44,7 @@ $ oc get node <node1>
 [source,terminal]
 ----
 NAME        STATUS                     ROLES     AGE       VERSION
-<node1>     Ready,SchedulingDisabled   worker    1d        v1.25.0
+<node1>     Ready,SchedulingDisabled   worker    1d        v1.26.0
 ----
 
 . Evacuate the pods using one of the following methods:

--- a/modules/nodes-scheduler-node-selectors-cluster.adoc
+++ b/modules/nodes-scheduler-node-selectors-cluster.adoc
@@ -145,7 +145,7 @@ $ oc get nodes -l type=user-node
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.25.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.26.0
 ----
 
 * Add labels directly to a node:
@@ -198,5 +198,5 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.25.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.26.0
 ----

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -168,7 +168,7 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                          STATUS   ROLES    AGE   VERSION
-ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.25.0
+ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.26.0
 ----
 
 . Add the matching node selector to a pod:

--- a/modules/nodes-scheduler-node-selectors-project.adoc
+++ b/modules/nodes-scheduler-node-selectors-project.adoc
@@ -161,7 +161,7 @@ $ oc get nodes -l type=user-node
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.25.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-c-vmqzp   Ready    worker   61s   v1.26.0
 ----
 
 * Add labels directly to a node:
@@ -214,5 +214,5 @@ $ oc get nodes -l type=user-node,region=east
 [source,terminal]
 ----
 NAME                                       STATUS   ROLES    AGE   VERSION
-ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.25.0
+ci-ln-l8nry52-f76d1-hl7m7-worker-b-tgq49   Ready    worker   17m   v1.26.0
 ----

--- a/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
@@ -39,12 +39,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                        STATUS   ROLES                  AGE     VERSION
-ip-10-0-52-50.us-east-2.compute.internal    Ready    worker                 3d17h   v1.25.4+86bd4ff
-ip-10-0-58-24.us-east-2.compute.internal    Ready    control-plane,master   3d17h   v1.25.4+86bd4ff
-ip-10-0-68-148.us-east-2.compute.internal   Ready    worker                 3d17h   v1.25.4+86bd4ff
-ip-10-0-68-68.us-east-2.compute.internal    Ready    control-plane,master   3d17h   v1.25.4+86bd4ff
-ip-10-0-72-170.us-east-2.compute.internal   Ready    control-plane,master   3d17h   v1.25.4+86bd4ff
-ip-10-0-74-50.us-east-2.compute.internal    Ready    worker                 3d17h   v1.25.4+86bd4ff
+ip-10-0-52-50.us-east-2.compute.internal    Ready    worker                 3d17h   v1.26.0
+ip-10-0-58-24.us-east-2.compute.internal    Ready    control-plane,master   3d17h   v1.26.0
+ip-10-0-68-148.us-east-2.compute.internal   Ready    worker                 3d17h   v1.26.0
+ip-10-0-68-68.us-east-2.compute.internal    Ready    control-plane,master   3d17h   v1.26.0
+ip-10-0-72-170.us-east-2.compute.internal   Ready    control-plane,master   3d17h   v1.26.0
+ip-10-0-74-50.us-east-2.compute.internal    Ready    worker                 3d17h   v1.26.0
 ----
 
 . View the machines and machine sets that exist in the `openshift-machine-api` namespace by running the following command. Each compute machine set is associated with a different availability zone within the AWS region. The installer automatically load balances compute machines across availability zones.

--- a/modules/nvidia-gpu-azure-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-azure-adding-a-gpu-node.adoc
@@ -346,13 +346,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                                STATUS   ROLES                  AGE     VERSION
-myclustername-master-0                              Ready    control-plane,master   6h39m   v1.25.4+a34b9e9
-myclustername-master-1                              Ready    control-plane,master   6h41m   v1.25.4+a34b9e9
-myclustername-master-2                              Ready    control-plane,master   6h39m   v1.25.4+a34b9e9
-myclustername-nc4ast4-gpu-worker-centralus1-w9bqn   Ready    worker                 14m     v1.25.4+a34b9e9
-myclustername-worker-centralus1-rbh6b               Ready    worker                 6h29m   v1.25.4+a34b9e9
-myclustername-worker-centralus2-dbz7w               Ready    worker                 6h29m   v1.25.4+a34b9e9
-myclustername-worker-centralus3-p9b8c               Ready    worker                 6h31m   v1.25.4+a34b9e9
+myclustername-master-0                              Ready    control-plane,master   6h39m   v1.26.0
+myclustername-master-1                              Ready    control-plane,master   6h41m   v1.26.0
+myclustername-master-2                              Ready    control-plane,master   6h39m   v1.26.0
+myclustername-nc4ast4-gpu-worker-centralus1-w9bqn   Ready    worker                 14m     v1.26.0
+myclustername-worker-centralus1-rbh6b               Ready    worker                 6h29m   v1.26.0
+myclustername-worker-centralus2-dbz7w               Ready    worker                 6h29m   v1.26.0
+myclustername-worker-centralus3-p9b8c               Ready    worker                 6h31m   v1.26.0
 ----
 
 . View the list of compute machine sets:

--- a/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
@@ -156,13 +156,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                                                             STATUS     ROLES                  AGE     VERSION
-myclustername-2pt9p-master-0.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.25.4+77bec7a
-myclustername-2pt9p-master-1.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.25.4+77bec7a
-myclustername-2pt9p-master-2.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.25.4+77bec7a
-myclustername-2pt9p-worker-a-mxtnz.c.openshift-qe.internal       Ready      worker                 8h      v1.25.4+77bec7a
-myclustername-2pt9p-worker-b-9pzzn.c.openshift-qe.internal       Ready      worker                 8h      v1.25.4+77bec7a
-myclustername-2pt9p-worker-c-6pbg6.c.openshift-qe.internal       Ready      worker                 8h      v1.25.4+77bec7a
-myclustername-2pt9p-worker-gpu-a-wxcr6.c.openshift-qe.internal   Ready      worker                 4h35m   v1.25.4+77bec7a
+myclustername-2pt9p-master-0.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.26.0
+myclustername-2pt9p-master-1.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.26.0
+myclustername-2pt9p-master-2.c.openshift-qe.internal             Ready      control-plane,master   8h      v1.26.0
+myclustername-2pt9p-worker-a-mxtnz.c.openshift-qe.internal       Ready      worker                 8h      v1.26.0
+myclustername-2pt9p-worker-b-9pzzn.c.openshift-qe.internal       Ready      worker                 8h      v1.26.0
+myclustername-2pt9p-worker-c-6pbg6.c.openshift-qe.internal       Ready      worker                 8h      v1.26.0
+myclustername-2pt9p-worker-gpu-a-wxcr6.c.openshift-qe.internal   Ready      worker                 4h35m   v1.26.0
 ----
 
 . View the machines and machine sets that exist in the `openshift-machine-api` namespace by running the following command. Each compute machine set is associated with a different availability zone within the GCP region. The installer automatically load balances compute machines across availability zones.

--- a/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
+++ b/modules/nw-sriov-hwol-configuring-machine-config-pool.adoc
@@ -62,13 +62,13 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME       STATUS   ROLES                   AGE   VERSION
-master-0   Ready    master                  2d    v1.25.0
-master-1   Ready    master                  2d    v1.25.0
-master-2   Ready    master                  2d    v1.25.0
-worker-0   Ready    worker                  2d    v1.25.0
-worker-1   Ready    worker                  2d    v1.25.0
-worker-2   Ready    mcp-offloading,worker   47h   v1.25.0
-worker-3   Ready    mcp-offloading,worker   47h   v1.25.0
+master-0   Ready    master                  2d    v1.26.0
+master-1   Ready    master                  2d    v1.26.0
+master-2   Ready    master                  2d    v1.26.0
+worker-0   Ready    worker                  2d    v1.26.0
+worker-1   Ready    worker                  2d    v1.26.0
+worker-2   Ready    mcp-offloading,worker   47h   v1.26.0
+worker-3   Ready    mcp-offloading,worker   47h   v1.26.0
 ----
 --
 

--- a/modules/olm-catalogsource-image-template.adoc
+++ b/modules/olm-catalogsource-image-template.adoc
@@ -64,7 +64,7 @@ metadata:
       "quay.io/example-org/example-catalog:v{kube_major_version}.{kube_minor_version}"
 spec:
   displayName: Example Catalog
-  image: quay.io/example-org/example-catalog:v1.25
+  image: quay.io/example-org/example-catalog:v1.26
   priority: -400
   publisher: Example Org
 ----
@@ -81,7 +81,7 @@ For an {product-title} 4.13 cluster, which uses Kubernetes 1.26, the `olm.catalo
 
 [source,terminal]
 ----
-quay.io/example-org/example-catalog:v1.25
+quay.io/example-org/example-catalog:v1.26
 ----
 
 For future releases of {product-title}, you can create updated index images for your custom catalogs that target the later Kubernetes version that is used by the later {product-title} version. With the `olm.catalogImageTemplate` annotation set before the upgrade, upgrading the cluster to the later {product-title} version would then automatically update the catalog's index image as well.

--- a/modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc
+++ b/modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc
@@ -26,12 +26,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                          STATUS   ROLES    AGE   VERSION
-compute-1.example.com         Ready    worker   33m   v1.25.0
-control-plane-1.example.com   Ready    master   41m   v1.25.0
-control-plane-2.example.com   Ready    master   45m   v1.25.0
-compute-2.example.com         Ready    worker   38m   v1.25.0
-compute-3.example.com         Ready    worker   33m   v1.25.0
-control-plane-3.example.com   Ready    master   41m   v1.25.0
+compute-1.example.com         Ready    worker   33m   v1.26.0
+control-plane-1.example.com   Ready    master   41m   v1.26.0
+control-plane-2.example.com   Ready    master   45m   v1.26.0
+compute-2.example.com         Ready    worker   38m   v1.26.0
+compute-3.example.com         Ready    worker   33m   v1.26.0
+control-plane-3.example.com   Ready    master   41m   v1.26.0
 ----
 
 . Review CPU and memory resource availability for each cluster node:

--- a/modules/restore-determine-state-etcd-member.adoc
+++ b/modules/restore-determine-state-etcd-member.adoc
@@ -71,7 +71,7 @@ $ oc get nodes -l node-role.kubernetes.io/master | grep "NotReady"
 .Example output
 [source,terminal]
 ----
-ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.25.0 <1>
+ip-10-0-131-183.ec2.internal   NotReady   master   122m   v1.26.0 <1>
 ----
 <1> If the node is listed as `NotReady`, then the *node is not ready*.
 
@@ -95,9 +95,9 @@ $ oc get nodes -l node-role.kubernetes.io/master
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE     VERSION
-ip-10-0-131-183.ec2.internal   Ready    master   6h13m   v1.25.0
-ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.25.0
-ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.25.0
+ip-10-0-131-183.ec2.internal   Ready    master   6h13m   v1.26.0
+ip-10-0-164-97.ec2.internal    Ready    master   6h13m   v1.26.0
+ip-10-0-154-204.ec2.internal   Ready    master   6h13m   v1.26.0
 ----
 
 .. Check whether the status of an etcd pod is either `Error` or `CrashloopBackoff`:

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -390,10 +390,10 @@ examplecluster-compute-1          Running                          165m    opens
 $ oc get nodes
 
 NAME                     STATUS ROLES   AGE   VERSION
-openshift-control-plane-0 Ready master 3h24m v1.25.0
-openshift-control-plane-1 Ready master 3h24m v1.25.0
-openshift-compute-0       Ready worker 176m v1.25.0
-openshift-compute-1       Ready worker 176m v1.25.0
+openshift-control-plane-0 Ready master 3h24m v1.26.0
+openshift-control-plane-1 Ready master 3h24m v1.26.0
+openshift-compute-0       Ready worker 176m v1.26.0
+openshift-compute-1       Ready worker 176m v1.26.0
 ----
 
 . Create the new `BareMetalHost` object and the secret to store the BMC credentials:
@@ -525,11 +525,11 @@ $ oc get nodes
 ----
 $ oc get nodes
 NAME                     STATUS ROLES   AGE   VERSION
-openshift-control-plane-0 Ready master 4h26m v1.25.0
-openshift-control-plane-1 Ready master 4h26m v1.25.0
-openshift-control-plane-2 Ready master 12m   v1.25.0
-openshift-compute-0       Ready worker 3h58m v1.25.0
-openshift-compute-1       Ready worker 3h58m v1.25.0
+openshift-control-plane-0 Ready master 4h26m v1.26.0
+openshift-control-plane-1 Ready master 4h26m v1.26.0
+openshift-control-plane-2 Ready master 12m   v1.26.0
+openshift-compute-0       Ready worker 3h58m v1.26.0
+openshift-compute-1       Ready worker 3h58m v1.26.0
 ----
 
 . Turn the quorum guard back on by entering the following command:

--- a/modules/rhcos-add-extensions.adoc
+++ b/modules/rhcos-add-extensions.adoc
@@ -94,7 +94,7 @@ $ oc get node | grep worker
 [source,terminal]
 ----
 NAME                                        STATUS  ROLES    AGE   VERSION
-ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.25.0
+ip-10-0-169-2.us-east-2.compute.internal    Ready   worker   102m  v1.26.0
 ----
 +
 [source,terminal]

--- a/modules/rhcos-enabling-multipath-day-2.adoc
+++ b/modules/rhcos-enabling-multipath-day-2.adoc
@@ -105,12 +105,12 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE   VERSION
-ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.25.0
-ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.25.0
-ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.25.0
-ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.25.0
-ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.25.0
-ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.25.0
+ip-10-0-136-161.ec2.internal   Ready                      worker   28m   v1.26.0
+ip-10-0-136-243.ec2.internal   Ready                      master   34m   v1.26.0
+ip-10-0-141-105.ec2.internal   Ready,SchedulingDisabled   worker   28m   v1.26.0
+ip-10-0-142-249.ec2.internal   Ready                      master   34m   v1.26.0
+ip-10-0-153-11.ec2.internal    Ready                      worker   28m   v1.26.0
+ip-10-0-153-150.ec2.internal   Ready                      master   34m   v1.26.0
 ----
 +
 You can see that scheduling on each worker node is disabled as the change is being applied.

--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -125,13 +125,13 @@ The `upgrade` playbook only upgrades the {product-title} packages. It does not u
 [source,terminal]
 ----
 NAME                        STATUS                        ROLES    AGE    VERSION
-mycluster-control-plane-0   Ready                         master   145m   v1.25.0
-mycluster-control-plane-1   Ready                         master   145m   v1.25.0
-mycluster-control-plane-2   Ready                         master   145m   v1.25.0
-mycluster-rhel8-0           Ready                         worker   98m    v1.25.0
-mycluster-rhel8-1           Ready                         worker   98m    v1.25.0
-mycluster-rhel8-2           Ready                         worker   98m    v1.25.0
-mycluster-rhel8-3           Ready                         worker   98m    v1.25.0
+mycluster-control-plane-0   Ready                         master   145m   v1.26.0
+mycluster-control-plane-1   Ready                         master   145m   v1.26.0
+mycluster-control-plane-2   Ready                         master   145m   v1.26.0
+mycluster-rhel8-0           Ready                         worker   98m    v1.26.0
+mycluster-rhel8-1           Ready                         worker   98m    v1.26.0
+mycluster-rhel8-2           Ready                         worker   98m    v1.26.0
+mycluster-rhel8-3           Ready                         worker   98m    v1.26.0
 ----
 
 . Optional: Update the operating system packages that were not updated by the `upgrade` playbook. To update packages that are not on {product-version}, use the following command:

--- a/modules/sandboxed-containers-check-node-eligiblilty.adoc
+++ b/modules/sandboxed-containers-check-node-eligiblilty.adoc
@@ -110,6 +110,6 @@ $ oc get nodes --selector='feature.node.kubernetes.io/runtime.kata=true'
 [source,terminal]
 ----
 NAME                           STATUS                     ROLES    AGE     VERSION
-compute-3.example.com          Ready                      worker   4h38m   v1.25.0
-compute-2.example.com          Ready                      worker   4h35m   v1.25.0
+compute-3.example.com          Ready                      worker   4h38m   v1.26.0
+compute-2.example.com          Ready                      worker   4h35m   v1.26.0
 ----

--- a/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
+++ b/modules/sno-adding-worker-nodes-to-sno-clusters-manually.adoc
@@ -214,6 +214,6 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES           AGE   VERSION
-control-plane-1.example.com    Ready    master,worker   56m   v1.25.0
-compute-1.example.com          Ready    worker          11m   v1.25.0
+control-plane-1.example.com    Ready    master,worker   56m   v1.26.0
+compute-1.example.com          Ready    worker          11m   v1.26.0
 ----

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -152,10 +152,10 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS   ROLES    AGE   VERSION
-ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.25.0
-ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.25.0
-ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.25.0
-ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.25.0
-ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.25.0
-ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.25.0
+ip-10-0-168-251.ec2.internal   Ready    master   82m   v1.26.0
+ip-10-0-170-223.ec2.internal   Ready    master   82m   v1.26.0
+ip-10-0-179-95.ec2.internal    Ready    worker   70m   v1.26.0
+ip-10-0-182-134.ec2.internal   Ready    worker   70m   v1.26.0
+ip-10-0-211-16.ec2.internal    Ready    master   82m   v1.26.0
+ip-10-0-250-100.ec2.internal   Ready    worker   69m   v1.26.0
 ----

--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -31,9 +31,9 @@ $ oc get nodes -l node-role.kubernetes.io/worker
 [source,terminal]
 ----
 NAME              STATUS   ROLES    AGE   VERSION
-compute-node-0    Ready    worker   30m   v1.25.0
-compute-node-1    Ready    worker   30m   v1.25.0
-compute-node-2    Ready    worker   30m   v1.25.0
+compute-node-0    Ready    worker   30m   v1.26.0
+compute-node-1    Ready    worker   30m   v1.26.0
+compute-node-2    Ready    worker   30m   v1.26.0
 ----
 +
 Note the names of your compute nodes.

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -26,9 +26,9 @@ $ oc get nodes -l node-role.kubernetes.io/master
 [source,terminal]
 ----
 NAME                    STATUS   ROLES    AGE   VERSION
-control-plane-node-0    Ready    master   75m   v1.25.0
-control-plane-node-1    Ready    master   75m   v1.25.0
-control-plane-node-2    Ready    master   75m   v1.25.0
+control-plane-node-0    Ready    master   75m   v1.26.0
+control-plane-node-1    Ready    master   75m   v1.26.0
+control-plane-node-2    Ready    master   75m   v1.26.0
 ----
 +
 Note the names of your control plane nodes.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see: 
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-5108](https://issues.redhat.com//browse/OSDOCS-5108)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is my first time attempting to sweep the docs to update the Kubernetes version, so I wasn't always certain what I was looking at. Please help me make sure that nothing was bumped from 1.25 to 1.26 that shouldn't have been bumped.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
