### PR TITLE
Add more 4.13 relnotes for OLM / OSDK

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -511,6 +511,35 @@ $ oc get packagemanifests <operator_name> -n <catalog_namespace> -o <output_form
 
 For more information, see xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-specific-version-cli_olm-adding-operators-to-a-cluster[Installing a specific version of an Operator].
 
+[id=ocp-4-13-olm-multitenant]
+==== Operators in multitenant clusters
+
+The default behavior for Operator Lifecycle Manager (OLM) aims to provide simplicity during Operator installation. However, this behavior can lack flexibility, especially in multitenant clusters.
+
+Guidance and a recommended solution for Operator management in multitenant clusters has been added with the following topics:
+
+* xref:../operators/understanding/olm-multitenancy.adoc#olm-multitenancy[Operators in multitenant clusters]
+* xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-preparing-operators-multitenant_olm-adding-operators-to-a-cluster[Preparing for multiple instances of an Operator for multitenant clusters]
+
+[id=ocp-4-13-olm-colocation-namespace]
+==== Colocation of Operators in a namespace
+
+Operator Lifecycle Manager (OLM) handles OLM-managed Operators that are installed in the same namespace, meaning their Subscription resources are colocated in the same namespace, as related Operators. Even if they are not actually related, OLM considers their states, such as their version and update policy, when any one of them is updated.
+
+Guidance on Operator colocation and an alternative procedure that uses custom namespaces has been added with the following topics:
+
+* xref:../operators/understanding/olm/olm-understanding-dependency-resolution.adoc#olm-colocation-namespaces_olm-understanding-dependency-resolution[Colocation of Operators in a namespace]
+* xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-global-namespaces_olm-adding-operators-to-a-cluster[Installing global Operators in custom namespaces]
+
+[id=ocp-4-13-olm-disabled-csvs]
+==== Updated web console behavior when disabling copied CSVs
+
+The {product-title} web console has been updated to provide better Operator discovery when copied cluster service versions (CSVs) are disabled on a cluster.
+
+When copied CSVs are disabled by a cluster administrator, the web console is modified to show copied CSVs from the `openshift` namespace in every namespace for regular users, even though the CSVs are not actually copied to every namespace. This allows regular users to still be able to view the details of these Operators in their namespaces and create custom resources (CRs) brought in by globally installed Operators.
+
+For more information, see xref:../operators/admin/olm-config.adoc#olm-disabling-copied-csvs_olm-config[Disabling copied CSVs].
+
 [id="ocp-4-13-osdk"]
 === Operator development
 
@@ -817,6 +846,30 @@ For more information, see xref:../updating/updating-restricted-network-cluster/r
 === The `nodeip-configuration` service is now enabled on a vSphere user-provisioned infrastructure cluster
 
 In {product-title} {product-version}, the `nodeip-configuration` service is now enabled on a vSphere user-provisioned infrastructure cluster. This service determines the network interface controller (NIC) that {product-title} uses for communication with the Kubernetes API server when the node boots. In rare circumstances, the service might select an incorrect node IP after an upgrade. If this happens, you can use the `NODEIP_HINT` feature to restore the original node IP, as described in the "Troubleshooting network issues" section of the documentation.
+
+[discrete]
+[id="ocp-4-13-operator-sdk-1-28-z"]
+=== Operator SDK 1.28
+
+{product-title} {product-version} supports Operator SDK 1.28. See xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Installing the Operator SDK CLI] to install or update to this latest version.
+
+[NOTE]
+====
+Operator SDK 1.28 supports Kubernetes 1.26.
+
+====
+
+If you have Operator projects that were previously created or maintained with Operator SDK 1.25, update your projects to keep compatibility with Operator SDK 1.28.
+
+* xref:../operators/operator_sdk/golang/osdk-golang-updating-projects.adoc#osdk-upgrading-projects_osdk-golang-updating-projects[Updating Go-based Operator projects]
+
+* xref:../operators/operator_sdk/ansible/osdk-ansible-updating-projects.adoc#osdk-upgrading-projects_osdk-ansible-updating-projects[Updating Ansible-based Operator projects]
+
+* xref:../operators/operator_sdk/helm/osdk-helm-updating-projects.adoc#osdk-upgrading-projects_osdk-helm-updating-projects[Updating Helm-based Operator projects]
+
+* xref:../operators/operator_sdk/helm/osdk-hybrid-helm-updating-projects.adoc#osdk-upgrading-projects_osdk-hybrid-helm-updating-projects[Updating Hybrid Helm-based Operator projects]
+
+* xref:../operators/operator_sdk/java/osdk-java-updating-projects.adoc#osdk-upgrading-projects_osdk-java-updating-projects[Updating Java-based Operator projects]
 
 [id="ocp-4-13-deprecated-removed-features"]
 == Deprecated and removed features


### PR DESCRIPTION
Previews:

_New features and enhancements -> Operator lifecycle_
* [Operators in multitenant clusters](http://file.rdu.redhat.com/adellape/413_rn_of/release_notes/ocp-4-13-release-notes.html#ocp-4-13-olm-multitenant)
  * related to [OSDOCS-5303](https://issues.redhat.com/browse/OSDOCS-5303)
* [Colocation of Operators in a namespace](http://file.rdu.redhat.com/adellape/413_rn_of/release_notes/ocp-4-13-release-notes.html#ocp-4-13-olm-colocation-namespace)
  * related to [OSDOCS-5302](https://issues.redhat.com/browse/OSDOCS-5302)
* [Updated web console behavior when disabling copied CSVs](http://file.rdu.redhat.com/adellape/413_rn_of/release_notes/ocp-4-13-release-notes.html#ocp-4-13-olm-disabled-csvs)
  * related to [OSDOCS-5750](https://issues.redhat.com/browse/OSDOCS-5750)

_Notable technical changes_
* [Operator SDK 1.28](http://file.rdu.redhat.com/adellape/413_rn_of/release_notes/ocp-4-13-release-notes.html#ocp-4-13-operator-sdk-1-28-z)
  * related to [OSDOCS-5463](https://issues.redhat.com/browse/OSDOCS-5463)