### PR TITLE
[OADP-1631] Velero CSI plugin now determines whether to restore Volume’s data from snapshots on the restore’s restorePVs setting.

### DIFF
--- a/modules/oadp-creating-restore-cr.adoc
+++ b/modules/oadp-creating-restore-cr.adoc
@@ -36,10 +36,11 @@ spec:
   - backups.velero.io
   - restores.velero.io
   - resticrepositories.velero.io
-  restorePVs: true
+  restorePVs: true <3>
 ----
 <1> Name of the `Backup` CR.
-<2> Optional. Specify an array of resources to include in the restore process. Resources might be shortcuts (for example, 'po' for 'pods') or fully-qualified. If unspecified, all resources are included.
+<2> Optional: Specify an array of resources to include in the restore process. Resources might be shortcuts (for example, `po` for `pods`) or fully-qualified. If unspecified, all resources are included.
+<3> Optional: The `restorePVs` parameter can be set to `false` in order to turn off restore of `PersistentVolumes` from `VolumeSnapshot` of Container Storage Interface (CSI) snapshots, or from native snapshots when `VolumeSnaphshotLocation` is configured.
 
 . Verify that the status of the `Restore` CR is `Completed` by entering the following command:
 +


### PR DESCRIPTION
OADP 1.2.0

OCP - 4.10 +

Resolves - https://issues.redhat.com/browse/OADP-1631

Deploy preview - https://59780--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.html
