### PR TITLE
virt: Remove unsupported runtime class config

### DIFF
--- a/modules/virt-configuring-cluster-dpdk.adoc
+++ b/modules/virt-configuring-cluster-dpdk.adoc
@@ -74,6 +74,7 @@ spec:
     topologyPolicy: single-numa-node
   nodeSelector:
     node-role.kubernetes.io/worker-dpdk: "" 
+  globallyDisableIrqLoadBalancing: true
 ----
 +
 [NOTE]
@@ -107,17 +108,4 @@ spec:
   nodeSelector:
     feature.node.kubernetes.io/network-sriov.capable: "true"
 ----
-
-. Set the container runtime configuration for the `virt-launcher` pod by adding the following annotation to the `HyperConverged` custom resource (CR):
-+
-[source,terminal]
-----
-$ oc annotate --overwrite -n openshift-cnv hco kubevirt-hyperconverged \
-    kubevirt.kubevirt.io/jsonpatch='[{"op": "add", "path": "/spec/configuration/defaultRuntimeClass", "value": <runtimeclass-name>}]'
-----
-+
-[NOTE]
-====
-Adding the annotation to the `HyperConverged` CR changes a global setting that affects all VMs that are created after the annotation is applied.
-====
  


### PR DESCRIPTION
Using HCO jsonpatch breaches support of CNV.

With this patch, we use a support PerformanceProfile attribute instead, achieving the same result.

This is based on https://access.redhat.com/solutions/7007632 and https://bugzilla.redhat.com/show_bug.cgi?id=2185411.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
