### PR TITLE
OCPBUGS 13378: Removing TP label for non-preempting priority classes

### DIFF
--- a/modules/nodes-pods-priority-preempt-about.adoc
+++ b/modules/nodes-pods-priority-preempt-about.adoc
@@ -19,7 +19,7 @@ Preemption does not necessarily remove all lower-priority pods from a node. The 
 The scheduler considers a node for pod preemption only if the pending pod can be scheduled on the node.
 
 [id="non-preempting-priority-class_{context}"]
-== Non-preempting priority classes (Technology Preview)
+== Non-preempting priority classes
 
 Pods with the preemption policy set to `Never` are placed in the scheduling queue ahead of lower-priority pods, but they cannot preempt other pods. A non-preempting pod waiting to be scheduled stays in the scheduling queue until sufficient resources are free and it can be scheduled. Non-preempting pods, like other pods, are subject to scheduler back-off. This means that if the scheduler tries unsuccessfully to schedule these pods, they are retried with lower frequency, allowing other pods with lower priority to be scheduled before them.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-13378

Link to docs preview:
https://59810--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-priority.html#non-preempting-priority-class_nodes-pods-priority

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
