### PR TITLE
OCPBUGS 13378: Updating non-preempting priority classes to GA

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1692,9 +1692,9 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.11 |4.12 |4.13
 
 |Non-preempting priority classes
-|Technology Preview
-|Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
+|General Availability
 
 |Linux Control Group version 2 (cgroup v2)
 |Developer Preview


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-13378

Link to docs preview:
(single page / VPN required): http://file.rdu.redhat.com/~ahoffer/2023/OCPBUGS-13378-413/release_notes/ocp-4-13-release-notes.html#node-technology-preview-features

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
