### PR TITLE
OSDOCS-5232-4-12: Updated the 4.12 RNs to state vSphere 8.0 support

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -277,9 +277,9 @@ To install a CSI driver on a cluster running on vSphere, the following requireme
 
 * Virtual machines of hardware version 15 or later
 
-* VMware vSphere version 7.0 Update 2 or later, up to but not including version 8. vSphere 8 is not supported.
+* VMware vSphere version 7.0 Update 2 or later, which includes version 8.0.
 
-* vCenter 7.0 Update 2 or later, up to but not including version 8. vCenter 8 is not supported.
+* vCenter 7.0 Update 2 or later, which includes version 8.0.
 
 * No third-party CSI driver already installed in the cluster
 +
@@ -972,8 +972,8 @@ For more information, see xref:../storage/container_storage_interface/persistent
 ==== VMware vSphere CSI Driver Operator requirements
 For {product-title} 4.12, VMWare vSphere Container Storage Interface (CSI) Driver Operator requires the following minimum components installed:
 
-* VMware vSphere version 7.0 Update 2 or later, up to but not including version 8. vSphere 8 is not supported.
-* vCenter 7.0 Update 2 or later, up to but not including version 8. vCenter 8 is not supported.
+* VMware vSphere version 7.0 Update 2 or later, which includes version 8.0.
+* vCenter 7.0 Update 2 or later, which includes version 8.0.
 * Virtual machines of hardware version 15 or later
 * No third-party CSI driver already installed in the cluster
 


### PR DESCRIPTION
[OSDOCS-5232](https://issues.redhat.com/browse/OSDOCS-5232)

Version(s):
4.12

Link to docs preview:
[Preview link](http://file.emea.redhat.com/dfitzmau/OSDOCS-5232-4-12/release_notes/ocp-4-12-release-notes.html#ocp-4-12-post-installation)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
