### PR TITLE
SRVCOM-2443 Remove streams for Kafka - sync to standalone docs

### DIFF
--- a/modules/serverless-kafka-sasl-source.adoc
+++ b/modules/serverless-kafka-sasl-source.adoc
@@ -65,4 +65,4 @@ spec:
           key: ca.crt
 ...
 ----
-<1> The `caCert` spec is not required if you are using a public cloud Kafka service, such as Red Hat OpenShift Streams for Apache Kafka.
+<1> The `caCert` spec is not required if you are using a public cloud Kafka service.

--- a/modules/serverless-kafka-sink-security-config.adoc
+++ b/modules/serverless-kafka-sink-security-config.adoc
@@ -51,7 +51,7 @@ $ oc create secret -n <namespace> generic <secret_name> \
   --from-literal=user=<username> \
   --from-literal=password=<password>
 ----
-<1> The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service, such as Red Hat OpenShift Streams for Apache Kafka.
+<1> The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service.
 
 ** For authentication and encryption using TLS:
 +
@@ -63,7 +63,7 @@ $ oc create secret -n <namespace> generic <secret_name> \
   --from-file=user.crt=<my_cert.pem_file_path> \
   --from-file=user.key=<my_key.pem_file_path>
 ----
-<1> The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service, such as Red Hat OpenShift Streams for Apache Kafka.
+<1> The `ca.crt` can be omitted to use the system's root CA set if you are using a public cloud managed Kafka service.
 
 . Create or modify a `KafkaSink` object and add a reference to your secret in the `auth` spec:
 +


### PR DESCRIPTION
Version(s):
Serverless docs 1.28+

Issue:
[SRVCOM-2443](https://issues.redhat.com//browse/SRVCOM-2443)

Link to docs preview:
https://59819--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sinks/serverless-kafka-developer-sink.html#serverless-kafka-sink-security-config_serverless-kafka-developer-sink

https://59819--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-kafka-developer-source.html#serverless-kafka-sasl-source_serverless-kafka-developer-source
