### PR TITLE
OSDOCS-5158 release notes and known issue

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -149,6 +149,15 @@ For more information, see xref:../installing/installing_gcp/installing-gcp-share
 ==== Installing a cluster on GCP using Shielded VMs
 In {product-title} {product-version}, you can use Shielded VMs when installing your cluster. Shielded VMs have extra security features including secure boot, firmware and integrity monitoring, and rootkit detection. For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-enabling-shielded-vms_installing-gcp-customizations[Enabling Shielded VMs] and Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
 
+[id="ocp-4-13-installation-gcp-confidential-vms"]
+==== Installing a cluster on GCP using Confidential VMs
+In {product-title} {product-version}, you can use Confidential VMs when installing your cluster. Confidential VMs encrypt data while it is being processed. For more information, see Google's documentation about link:https://cloud.google.com/confidential-computing[Confidential Computing]. You can enable Confidential VMs and Shielded VMs at the same time, although they are not dependent on each other.
+
+[IMPORTANT]
+====
+Due to a known issue, you cannot use persistent volume storage on a cluster with Confidential VMs. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-7582[OCPBUGS-7582].
+====
+
 [id="ocp-4-13-admin-ack-upgrading"]
 ==== Required administrator acknowledgment when upgrading from {product-title} 4.12 to 4.13
 
@@ -2028,6 +2037,11 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 
+|GCP Confidential VMs
+|Not Available
+|Not Available
+|Technology Preview
+
 |====
 
 [discrete]
@@ -2453,6 +2467,8 @@ Workaround: Manually or by using a daemon set, modify the file `/etc/cni/tuning/
 Workaround: By using SSH to connect to the node that is the current leader of the vsphere-syncer process and restarting the vsphere-syncer container (using crictl), this issue can be mitigated and the driver successfully comes up. (link:https://issues.redhat.com/browse/OCPBUGS-13385[*OCPBUGS-13385*])
 
 * For {product-title} {product-version}, installing version 4.13 on top of {rh-openstack-first} 16.2 with baremetal workers fails because baremetal workers are not able to boot from the {op-system-first} image that comes with OpenShift 4.13. The fundamental issue is the {op-system} image lacks a byte order marker. These fixes are planned for the next 16.2 build. (link:https://issues.redhat.com/browse/OCPBUGS-13395[*OCPBUGS-13395*])
+
+* Due to a known issue in RHEL 9.2, you cannot use persistent volumes on a GCP cluster with Confidential VMs. (link:https://issues.redhat.com/browse/OCPBUGS-7582[*OCPBUGS-7582*])
 
 [id="ocp-4-13-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-5158
https://issues.redhat.com/browse/OCPBUGS-7582

Link to docs preview:
Main release note: https://bscott-rh.github.io/openshift-docs/OSDOCS-5158-bug-RN/release_notes/ocp-4-13-release-notes.html#ocp-4-13-installation-gcp-confidential-vms
Known issue (last bullet point): https://bscott-rh.github.io/openshift-docs/OSDOCS-5158-bug-RN/release_notes/ocp-4-13-release-notes.html#ocp-4-13-known-issues
QE review:
- [x] QE has approved this change.

Corresponding PR is https://github.com/openshift/openshift-docs/pull/59818