### PR TITLE
OSDOCS#5138: Adding grep -v guard to restoring cluster commands

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -256,7 +256,7 @@ $ oc adm certificate approve <csr_name>
 +
 [source,terminal]
 ----
-$ sudo crictl ps | grep etcd | grep -v operator
+$ sudo crictl ps | grep etcd | egrep -v "operator|etcd-guard"
 ----
 +
 .Example output


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-5138

Link to docs preview:
https://59826--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
