### PR TITLE
OCPBUGS 13378: Updating non-preempting priority classes to GA

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2116,7 +2116,7 @@ In the table below, features are marked with the following statuses:
 |Non-preempting priority classes
 |TP
 |TP
-|TP
+|GA
 
 |Kubernetes NMState Operator
 |TP


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-13378

Link to docs preview:
http://file.rdu.redhat.com/~ahoffer/2023/OCPBUGS-13378-411/release_notes/ocp-4-11-release-notes.html#ocp-4-11-technology-preview

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
