### PR TITLE
OSSM-3897: [DOC] Wrong must-gather image in example

### DIFF
--- a/modules/about-must-gather.adoc
+++ b/modules/about-must-gather.adoc
@@ -3,7 +3,6 @@
 // * sandboxed_containers/troubleshooting-sandboxed-containers.adoc
 // * virt/support/virt-collecting-virt-data.adoc
 // * support/gathering-cluster-data.adoc
-// * service_mesh/v2x/ossm-troubleshooting-istio.adoc
 // * service_mesh/v2x/ossm-support.adoc
 // * service_mesh/v1x/servicemesh-release-notes.adoc
 // * serverless/serverless-support.adoc

--- a/modules/ossm-about-collecting-ossm-data.adoc
+++ b/modules/ossm-about-collecting-ossm-data.adoc
@@ -22,12 +22,12 @@ You can use the `oc adm must-gather` CLI command to collect information about yo
 +
 [source,terminal]
 ----
-$ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:2.3
+$ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:2.4
 ----
 +
-. To collect {SMProductName} data for a specific {SMProductShortName} control plane namespace with `must-gather`, you must specify the {SMProductName} image and namespace. In this example, replace  `<namespace>` with your {SMProductShortName} control plane namespace, such as `istio-system`.
+. To collect {SMProductName} data for a specific {SMProductShortName} control plane namespace with `must-gather`, you must specify the {SMProductName} image and namespace. In this example, after `gather,` replace `<namespace>` with your {SMProductShortName} control plane namespace, such as `istio-system`.
 +
 [source,terminal]
 ----
-$ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:2.3 gather <namespace>
+$ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:2.4 gather <namespace>
 ----

--- a/service_mesh/v2x/ossm-troubleshooting-istio.adoc
+++ b/service_mesh/v2x/ossm-troubleshooting-istio.adoc
@@ -64,8 +64,6 @@ include::modules/support-knowledgebase-about.adoc[leveloffset=+2]
 
 include::modules/support-knowledgebase-search.adoc[leveloffset=+2]
 
-include::modules/about-must-gather.adoc[leveloffset=+2]
-
 include::modules/ossm-about-collecting-ossm-data.adoc[leveloffset=+2]
 
 For prompt support, supply diagnostic information for both {product-title} and {SMProductName}.


### PR DESCRIPTION
[OSSM-3897](https://issues.redhat.com//browse/OSSM-3897): [DOC] Wrong must-gather image in example

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSSM-3897

Link to docs preview:
https://59858--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-troubleshooting-istio.html#about-must-gather_troubleshooting-ossm

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
