### PR TITLE
OSDOCS-5822: Updated ubi8 references to ubi9 for 4.13+

### DIFF
--- a/_unused_topics/images-using-images-s2i-php-pulling-images.adoc
+++ b/_unused_topics/images-using-images-s2i-php-pulling-images.adoc
@@ -17,10 +17,10 @@ The RHEL 8 images are available through the Red Hat Registry.
 
 * To pull the RHEL 8 image, enter the following command for the version of PHP you want:
 
-.PHP `7.2`
+.PHP `8.1`
 [source,terminal]
 ----
-$ podman pull registry.redhat.io/ubi8/php-72:latest
+$ podman pull registry.redhat.io/ubi9/php-81:latest
 ----
 +
 .PHP `7.3`

--- a/_unused_topics/images-using-images-s2i-python-pulling-images.adoc
+++ b/_unused_topics/images-using-images-s2i-python-pulling-images.adoc
@@ -28,7 +28,7 @@ $ podman pull egistry.redhat.io/rhscl/python-27-rhel7:latest
 .Python `3.6`
 [source,terminal]
 ----
-$ podman pull  registry.redhat.io/ubi8/python-36:latest
+$ podman pull  registry.redhat.io/ubi9/python-39:latest
 ----
 +
 .Python `3.8`

--- a/modules/builds-create-custom-build-artifacts.adoc
+++ b/modules/builds-create-custom-build-artifacts.adoc
@@ -31,7 +31,7 @@ ENTRYPOINT ["/usr/bin/build.sh"]
 +
 [source,terminal]
 ----
-FROM registry.access.redhat.com/ubi8/ubi
+FROM registry.access.redhat.com/ubi9/ubi
 RUN touch /tmp/build
 ----
 

--- a/modules/builds-create-imagestreamtag.adoc
+++ b/modules/builds-create-imagestreamtag.adoc
@@ -18,7 +18,7 @@ The benefit of using image stream tags this way is that doing so grants access t
 +
 [source,terminal]
 ----
-$ oc tag --source=docker registry.redhat.io/ubi8/ubi:latest ubi:latest -n openshift
+$ oc tag --source=docker registry.redhat.io/ubi9/ubi:latest ubi:latest -n openshift
 ----
 +
 [TIP]
@@ -35,7 +35,7 @@ spec:
   tags:
   - from:
       kind: DockerImage
-      name: registry.redhat.io/ubi8/ubi:latest
+      name: registry.redhat.io/ubi9/ubi:latest
     name: latest
     referencePolicy:
       type: Source
@@ -46,7 +46,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc tag --source=docker registry.redhat.io/ubi8/ubi:latest ubi:latest
+$ oc tag --source=docker registry.redhat.io/ubi9/ubi:latest ubi:latest
 ----
 +
 [TIP]
@@ -62,7 +62,7 @@ spec:
   tags:
   - from:
       kind: DockerImage
-      name: registry.redhat.io/ubi8/ubi:latest
+      name: registry.redhat.io/ubi9/ubi:latest
     name: latest
     referencePolicy:
       type: Source

--- a/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
+++ b/modules/builds-running-entitled-builds-with-sharedsecret-objects.adoc
@@ -84,7 +84,7 @@ spec:
   runPolicy: Serial
   source:
     dockerfile: |
-      FROM registry.redhat.io/ubi8/ubi:latest
+      FROM registry.redhat.io/ubi9/ubi:latest
       RUN ls -la /etc/pki/entitlement
       RUN rm /etc/rhsm-host
       RUN yum repolist --disablerepo=*
@@ -127,8 +127,8 @@ Some sections of the following output have been replaced with `...`
 build.build.openshift.io/my-csi-bc-1 started
 Caching blobs under "/var/cache/blobs".
 
-Pulling image registry.redhat.io/ubi8/ubi:latest ...
-Trying to pull registry.redhat.io/ubi8/ubi:latest...
+Pulling image registry.redhat.io/ubi9/ubi:latest ...
+Trying to pull registry.redhat.io/ubi9/ubi:latest...
 Getting image source signatures
 Copying blob sha256:5dcbdc60ea6b60326f98e2b49d6ebcb7771df4b70c6297ddf2d7dede6692df6e
 Copying blob sha256:8671113e1c57d3106acaef2383f9bbfe1c45a26eacb03ec82786a494e15956c3
@@ -136,7 +136,7 @@ Copying config sha256:b81e86a2cb9a001916dc4697d7ed4777a60f757f0b8dcc2c4d8df42f2f
 Writing manifest to image destination
 Storing signatures
 Adding transient rw bind mount for /run/secrets/rhsm
-STEP 1/9: FROM registry.redhat.io/ubi8/ubi:latest
+STEP 1/9: FROM registry.redhat.io/ubi9/ubi:latest
 STEP 2/9: RUN ls -la /etc/pki/entitlement
 total 360
 drwxrwxrwt. 2 root root 	80 Feb  3 20:28 .

--- a/modules/builds-strategy-docker-entitled-satellite.adoc
+++ b/modules/builds-strategy-docker-entitled-satellite.adoc
@@ -17,7 +17,7 @@ Use the following as an example Dockerfile to install content with Satellite:
 
 [source,terminal]
 ----
-FROM registry.redhat.io/ubi8/ubi:latest
+FROM registry.redhat.io/ubi9/ubi:latest
 RUN dnf search kernel-devel --showduplicates && \
         dnf install -y kernel-devel
 ----

--- a/modules/builds-strategy-docker-entitled-subman.adoc
+++ b/modules/builds-strategy-docker-entitled-subman.adoc
@@ -18,7 +18,7 @@ Use the following as an example Dockerfile to install content with the Subscript
 
 [source,terminal]
 ----
-FROM registry.redhat.io/ubi8/ubi:latest
+FROM registry.redhat.io/ubi9/ubi:latest
 RUN dnf search kernel-devel --showduplicates && \
         dnf install -y kernel-devel
 ----

--- a/modules/compliance-results.adoc
+++ b/modules/compliance-results.adoc
@@ -68,7 +68,7 @@ metadata:
 spec:
   containers:
     - name: pv-extract-pod
-      image: registry.access.redhat.com/ubi8/ubi
+      image: registry.access.redhat.com/ubi9/ubi
       command: ["sleep", "3000"]
       volumeMounts:
       - mountPath: "/workers-scan-results"

--- a/modules/getting-started-cli-deploying-python-app.adoc
+++ b/modules/getting-started-cli-deploying-python-app.adoc
@@ -29,7 +29,7 @@ $ oc new-app python~https://github.com/openshift-roadshow/nationalparks-py.git -
 +
 [source,text]
 ----
---> Found image 0406f6c (13 days old) in image stream "openshift/python" under tag "3.9-ubi8" for "python"
+--> Found image 0406f6c (13 days old) in image stream "openshift/python" under tag "3.9-ubi9" for "python"
 
     Python 3.9
     ----------

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -84,11 +84,11 @@ For example, after installing the skopeo RPM package on a Red Hat Enterprise Lin
 [source,terminal]
 ----
 $ skopeo copy \
-docker://registry.access.redhat.com/ubi8/ubi-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187adb32e89fd83fa455ebaa6 \
+docker://registry.access.redhat.com/ubi9/ubi-minimal:latest@sha256:5cf... \
 docker://example.io/example/ubi-minimal
 ----
 +
-In this example, you have a container image registry that is named `example.io` with an image repository named `example` to which you want to copy the `ubi8/ubi-minimal` image from `registry.access.redhat.com`. After you create the registry, you can configure your {product-title} cluster to redirect requests made of the source repository to the mirrored repository.
+In this example, you have a container image registry that is named `example.io` with an image repository named `example` to which you want to copy the `ubi9/ubi-minimal` image from `registry.access.redhat.com`. After you create the registry, you can configure your {product-title} cluster to redirect requests made of the source repository to the mirrored repository.
 
 . Log in to your {product-title} cluster.
 
@@ -99,13 +99,13 @@ In this example, you have a container image registry that is named `example.io` 
 apiVersion: config.openshift.io/v1 <1>
 kind: ImageDigestMirrorSet <2>
 metadata:
-  name: ubi8repo
+  name: ubi9repo
 spec:
   imageDigestMirrors: <3>
   - mirrors:
     - example.io/example/ubi-minimal <4>
     - example.com/example/ubi-minimal <5>
-    source: registry.access.redhat.com/ubi8/ubi-minimal <6>
+    source: registry.access.redhat.com/ubi9/ubi-minimal <6>
     mirrorSourcePolicy: AllowContactingSource <7>
   - mirrors:
     - mirror.example.com/redhat
@@ -267,7 +267,7 @@ short-name-mode = ""
     pull-from-mirror = "digest-only"
 [[registry]]
   prefix = ""
-  location = "registry.access.redhat.com/ubi8/ubi-minimal"
+  location = "registry.access.redhat.com/ubi9/ubi-minimal"
   blocked = true <4>
 
   [[registry.mirror]]
@@ -284,7 +284,7 @@ short-name-mode = ""
 +
 [source,terminal]
 ----
-sh-4.2# podman pull --log-level=debug registry.access.redhat.com/ubi8/ubi-minimal@sha256:5cfbaf45ca96806917830c183e9f37df2e913b187adb32e89fd83fa455ebaa6
+sh-4.2# podman pull --log-level=debug registry.access.redhat.com/ubi9/ubi-minimal@sha256:5cf...
 ----
 
 .Troubleshooting repository mirroring

--- a/modules/kmm-building-a-moduleloader-image.adoc
+++ b/modules/kmm-building-a-moduleloader-image.adoc
@@ -12,14 +12,14 @@
 +
 [source,dockerfile]
 ----
-FROM registry.redhat.io/ubi8/ubi-minimal as builder
+FROM registry.redhat.io/ubi9/ubi-minimal as builder
 
 # Build the kmod
 
 RUN ["mkdir", "/firmware"]
 RUN ["curl", "-o", "/firmware/firmware.bin", "https://artifacts.example.com/firmware.bin"]
 
-FROM registry.redhat.io/ubi8/ubi-minimal
+FROM registry.redhat.io/ubi9/ubi-minimal
 
 # Copy the kmod, install modprobe, run depmod
 

--- a/modules/kmm-building-and-signing-a-moduleloader-container-image.adoc
+++ b/modules/kmm-building-and-signing-a-moduleloader-container-image.adoc
@@ -41,7 +41,7 @@ data:
     RUN git clone -b main --single-branch https://github.com/rh-ecosystem-edge/kernel-module-management.git
     WORKDIR kernel-module-management/ci/kmm-kmod/
     RUN make
-    FROM registry.access.redhat.com/ubi8/ubi:latest
+    FROM registry.access.redhat.com/ubi9/ubi:latest
     ARG KERNEL_VERSION
     RUN yum -y install kmod && yum clean all
     RUN mkdir -p /opt/lib/modules/${KERNEL_VERSION}

--- a/modules/kmm-running-depmod.adoc
+++ b/modules/kmm-running-depmod.adoc
@@ -40,7 +40,7 @@ data:
     RUN ["git", "clone", "https://github.com/rh-ecosystem-edge/kernel-module-management.git"]
     WORKDIR /usr/src/kernel-module-management/ci/kmm-kmod
     RUN KERNEL_SRC_DIR=/lib/modules/${KERNEL_VERSION}/build make all
-    FROM registry.redhat.io/ubi8/ubi-minimal
+    FROM registry.redhat.io/ubi9/ubi-minimal
     ARG KERNEL_VERSION
     RUN microdnf install kmod
     COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_a.ko /opt/lib/modules/${KERNEL_VERSION}/

--- a/modules/kmm-using-driver-toolkit.adoc
+++ b/modules/kmm-using-driver-toolkit.adoc
@@ -16,7 +16,7 @@ Use DTK as the first stage of a multi-stage `Dockerfile`.
 
 . Build the kernel modules.
 
-. Copy the `.ko` files into a smaller end-user image such as https://catalog.redhat.com/software/containers/ubi8/ubi-minimal[`ubi-minimal`].
+. Copy the `.ko` files into a smaller end-user image such as https://catalog.redhat.com/software/containers/ubi9/ubi-minimal[`ubi-minimal`].
 
 . To leverage DTK in your in-cluster build, use the `DTK_AUTO` build argument.
 The value is automatically set by KMM when creating the `Build` resource. See the following example.
@@ -30,7 +30,7 @@ WORKDIR /usr/src
 RUN ["git", "clone", "https://github.com/rh-ecosystem-edge/kernel-module-management.git"]
 WORKDIR /usr/src/kernel-module-management/ci/kmm-kmod
 RUN KERNEL_SRC_DIR=/lib/modules/${KERNEL_VERSION}/build make all
-FROM registry.redhat.io/ubi8/ubi-minimal
+FROM registry.redhat.io/ubi9/ubi-minimal
 ARG KERNEL_VERSION
 RUN microdnf install kmod
 COPY --from=builder /usr/src/kernel-module-management/ci/kmm-kmod/kmm_ci_a.ko /opt/lib/modules/${KERNEL_VERSION}/

--- a/modules/migration-installing-legacy-operator.adoc
+++ b/modules/migration-installing-legacy-operator.adoc
@@ -99,7 +99,7 @@ ifdef::installing-3-4,installing-mtc[]
 +
 [source,terminal]
 ----
-$ oc run test --image registry.redhat.io/ubi8 --command sleep infinity
+$ oc run test --image registry.redhat.io/ubi9 --command sleep infinity
 ----
 endif::[]
 

--- a/modules/nbde-rekeying-all-nbde-nodes.adoc
+++ b/modules/nbde-rekeying-all-nbde-nodes.adoc
@@ -42,7 +42,7 @@ spec:
     spec:
       containers:
       - name: tang-rekey
-        image: registry.access.redhat.com/ubi8/ubi-minimal:8.4
+        image: registry.access.redhat.com/ubi9/ubi-minimal:latest
         imagePullPolicy: IfNotPresent
         command:
         - "/sbin/chroot"

--- a/modules/nodes-containers-init-creating.adoc
+++ b/modules/nodes-containers-init-creating.adoc
@@ -23,14 +23,14 @@ metadata:
 spec:
   containers:
   - name: myapp-container
-    image: registry.access.redhat.com/ubi8/ubi:latest
+    image: registry.access.redhat.com/ubi9/ubi:latest
     command: ['sh', '-c', 'echo The app is running! && sleep 3600']
   initContainers:
   - name: init-myservice
-    image: registry.access.redhat.com/ubi8/ubi:latest
+    image: registry.access.redhat.com/ubi9/ubi:latest
     command: ['sh', '-c', 'until getent hosts myservice; do echo waiting for myservice; sleep 2; done;']
   - name: init-mydb
-    image: registry.access.redhat.com/ubi8/ubi:latest
+    image: registry.access.redhat.com/ubi9/ubi:latest
     command: ['sh', '-c', 'until getent hosts mydb; do echo waiting for mydb; sleep 2; done;']
 ----
 

--- a/modules/nw-enabling-multicast.adoc
+++ b/modules/nw-enabling-multicast.adoc
@@ -78,7 +78,7 @@ metadata:
 spec:
   containers:
     - name: mlistener
-      image: registry.access.redhat.com/ubi8
+      image: registry.access.redhat.com/ubi9
       command: ["/bin/sh", "-c"]
       args:
         ["dnf -y install socat hostname && sleep inf"]
@@ -103,7 +103,7 @@ metadata:
 spec:
   containers:
     - name: msender
-      image: registry.access.redhat.com/ubi8
+      image: registry.access.redhat.com/ubi9
       command: ["/bin/sh", "-c"]
       args:
         ["dnf -y install socat && sleep inf"]

--- a/modules/nw-sctp-verifying.adoc
+++ b/modules/nw-sctp-verifying.adoc
@@ -2,7 +2,7 @@
 //
 // * networking/using-sctp.adoc
 
-:image: registry.access.redhat.com/ubi8/ubi
+:image: registry.access.redhat.com/ubi9/ubi
 
 ifdef::openshift-origin[]
 :image: fedora:31

--- a/modules/oc-mirror-creating-image-set-config.adoc
+++ b/modules/oc-mirror-creating-image-set-config.adoc
@@ -54,7 +54,7 @@ mirror:
       channels:
       - name: stable                                                <8>
   additionalImages:
-  - name: registry.redhat.io/ubi8/ubi:latest                        <9>
+  - name: registry.redhat.io/ubi9/ubi:latest                        <9>
   helm: {}
 ----
 <1> Add `archiveSize` to set the maximum size, in GiB, of each file within the image set.

--- a/modules/oc-mirror-image-set-config-examples.adoc
+++ b/modules/oc-mirror-image-set-config-examples.adoc
@@ -41,7 +41,7 @@ mirror:
          - name: ibm-mongodb-enterprise-helm
            version: 0.2.0
  additionalImages:
-   - name: registry.redhat.io/ubi8/ubi:latest
+   - name: registry.redhat.io/ubi9/ubi:latest
 ----
 
 [discrete]
@@ -169,5 +169,5 @@ The following `ImageSetConfiguration` file uses a local storage backend and incl
         channels:
         - name: stable
     additionalImages:
-    - name: registry.redhat.io/ubi8/ubi:latest
+    - name: registry.redhat.io/ubi9/ubi:latest
 ----

--- a/modules/oc-mirror-oci-format.adoc
+++ b/modules/oc-mirror-oci-format.adoc
@@ -58,7 +58,7 @@ mirror:
     packages:
     - name: rhacs-operator
   additionalImages:
-  - name: registry.redhat.io/ubi8/ubi:latest                                 <5>
+  - name: registry.redhat.io/ubi9/ubi:latest                                 <5>
 ----
 <1> Set the back-end location to save the image set metadata to. This location can be a registry or local directory. It is required to specify `storageConfig` values.
 <2> Optionally, include an {product-title} release to mirror from `registry.redhat.io`.

--- a/modules/op-mirroring-images-to-run-pipelines-in-restricted-environment.adoc
+++ b/modules/op-mirroring-images-to-run-pipelines-in-restricted-environment.adoc
@@ -28,8 +28,8 @@ Name:			python
 Namespace:		openshift
 [...]
 
-3.8-ubi8 (latest)
-  tagged from registry.redhat.io/ubi8/python-38:latest
+3.8-ubi9 (latest)
+  tagged from registry.redhat.io/ubi9/python-38:latest
     prefer registry pullthrough when referencing this tag
 
   Build and run Python 3.8 applications on UBI 8. For more information about using this builder image, including OpenShift considerations, see https://github.com/sclorg/s2i-python-container/blob/master/3.8/README.md.
@@ -44,14 +44,14 @@ Namespace:		openshift
 +
 [source,terminal]
 ----
-$ oc image mirror registry.redhat.io/ubi8/python-38:latest <mirror-registry>:<port>/ubi8/python-38
+$ oc image mirror registry.redhat.io/ubi9/python-39:latest <mirror-registry>:<port>/ubi9/python-39
 ----
 
 .. Import the image:
 +
 [source,terminal]
 ----
-$ oc tag <mirror-registry>:<port>/ubi8/python-38 python:latest --scheduled -n openshift
+$ oc tag <mirror-registry>:<port>/ubi9/python-39 python:latest --scheduled -n openshift
 ----
 +
 You must periodically re-import the image. The `--scheduled` flag enables automatic re-import of the image.
@@ -71,9 +71,9 @@ Namespace:		openshift
 [...]
 
 latest
-  updates automatically from registry <mirror-registry>:<port>/ubi8/python-38
+  updates automatically from registry  <mirror-registry>:<port>/ubi9/python-39
 
-  * <mirror-registry>:<port>/ubi8/python-38@sha256:3ee3c2e70251e75bfeac25c0c33356add9cc4abcbc9c51d858f39e4dc29c5f58
+  *  <mirror-registry>:<port>/ubi9/python-39@sha256:3ee...
 
 [...]
 ----
@@ -109,14 +109,14 @@ Namespace:		openshift
 +
 [source,terminal]
 ----
-$ oc image mirror registry.redhat.io/ubi8/go-toolset:1.14.7 <mirror-registry>:<port>/ubi8/go-toolset
+$ oc image mirror registry.redhat.io/ubi9/go-toolset:latest <mirror-registry>:<port>/ubi9/go-toolset
 ----
 
 .. Import the image:
 +
 [source,terminal]
 ----
-$ oc tag <mirror-registry>:<port>/ubi8/go-toolset golang:latest --scheduled -n openshift
+$ oc tag <mirror-registry>:<port>/ubi9/go-toolset golang:latest --scheduled -n openshift
 ----
 +
 You must periodically re-import the image. The `--scheduled` flag enables automatic re-import of the image.
@@ -136,9 +136,9 @@ Namespace:		openshift
 [...]
 
 latest
-  updates automatically from registry <mirror-registry>:<port>/ubi8/go-toolset
+  updates automatically from registry <mirror-registry>:<port>/ubi9/go-toolset
 
-  * <mirror-registry>:<port>/ubi8/go-toolset@sha256:59a74d581df3a2bd63ab55f7ac106677694bf612a1fe9e7e3e1487f55c421b37
+  * <mirror-registry>:<port>/ubi9/go-toolset@sha256:59a74d581df3a2bd63ab55f7ac106677694bf612a1fe9e7e3e1487f55c421b37
 
 [...]
 ----

--- a/modules/op-starting-a-task-run-pipeline-run-build-user.adoc
+++ b/modules/op-starting-a-task-run-pipeline-run-build-user.adoc
@@ -18,7 +18,7 @@ After defining the custom Buildah cluster task, you can create a `TaskRun` objec
 apiVersion: v1
 data:
   Dockerfile: |
-    ARG BASE_IMG=registry.access.redhat.com/ubi8/ubi
+    ARG BASE_IMG=registry.access.redhat.com/ubi9/ubi
     FROM $BASE_IMG AS buildah-runner
     RUN dnf -y update && \
         dnf -y install git && \

--- a/modules/persistent-storage-hostpath-about.adoc
+++ b/modules/persistent-storage-hostpath-about.adoc
@@ -24,7 +24,7 @@ metadata:
   name: test-host-mount
 spec:
   containers:
-  - image: registry.access.redhat.com/ubi8/ubi
+  - image: registry.access.redhat.com/ubi9/ubi
     name: test-container
     command: ['sh', '-c', 'sleep 3600']
     volumeMounts:

--- a/modules/preparing-an-inital-cluster-deployment-for-mce-disconnected.adoc
+++ b/modules/preparing-an-inital-cluster-deployment-for-mce-disconnected.adoc
@@ -39,7 +39,7 @@ To mirror your {product-title} image repository to your mirror registry, you can
         - name: stable-4.13 <4>
           type: ocp
     additionalImages:
-      - name: registry.redhat.io/ubi8/ubi:latest
+      - name: registry.redhat.io/ubi9/ubi:latest
     operators:
       - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13 <5>
         packages: <6>
@@ -81,9 +81,9 @@ $ oc mirror --dest-skip-tls --config ocp-mce-imageset.yaml docker://<your-local-
     - source: "quay.io/openshift-release-dev/ocp-v4.0-art-dev"
       mirrors:
         - "<your-local-registry-dns-name>:<your-local-registry-port>/openshift/release"
-    - source: "registry.redhat.io/ubi8"
+    - source: "registry.redhat.io/ubi9"
       mirrors:
-        - "<your-local-registry-dns-name>:<your-local-registry-port>/ubi8"
+        - "<your-local-registry-dns-name>:<your-local-registry-port>/ubi9"
     - source: "registry.redhat.io/multicluster-engine"
       mirrors:
         - "<your-local-registry-dns-name>:<your-local-registry-port>/multicluster-engine"

--- a/modules/security-container-content-universal.adoc
+++ b/modules/security-container-content-universal.adoc
@@ -22,9 +22,8 @@ to both find and check the health of different UBI images.
 As someone creating secure container images, you might
 be interested in these two general types of UBI images:
 
-* **UBI**: There are standard UBI images for RHEL 7 and 8 (`ubi7/ubi` and
-`ubi8/ubi`), as well as minimal images based on those systems (`ubi7/ubi-minimal`
-and `ubi8/ubi-mimimal`). All of these images are preconfigured to point to free
+* **UBI**: There are standard UBI images for RHEL 7, 8, and 9 (`ubi7/ubi`,
+`ubi8/ubi`, and `ubi9/ubi`), as well as minimal images based on those systems (`ubi7/ubi-minimal`, `ubi8/ubi-mimimal`, and ubi9/ubi-minimal). All of these images are preconfigured to point to free
 repositories of {op-system-base} software that you can add to the container images you build,
 using standard `yum` and `dnf` commands.
 Red Hat encourages people to use these images on other distributions,

--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -18,7 +18,7 @@ The oc-mirror OpenShift CLI (`oc`) plugin creates this graph data container imag
 +
 [source,terminal]
 ----
-FROM registry.access.redhat.com/ubi8/ubi:8.1
+FROM registry.access.redhat.com/ubi9/ubi:latest
 
 RUN curl -L -o cincinnati-graph-data.tar.gz https://api.openshift.com/api/upgrades_info/graph-data
 

--- a/snippets/lvms-disconnected-ImageSetConfig.adoc
+++ b/snippets/lvms-disconnected-ImageSetConfig.adoc
@@ -22,7 +22,7 @@ mirror:
       channels:
       - name: stable <8>
   additionalImages:
-  - name: registry.redhat.io/ubi8/ubi:latest <9>
+  - name: registry.redhat.io/ubi9/ubi:latest <9>
   helm: {}
 ----
 <1> Add `archiveSize` to set the maximum size, in GiB, of each file within the image set.


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5822

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I updated as many UBI references as possible where it made sense to do so, like `ubi9/latest`. Some ubi8 references were in release notes for asynchronous projects or in developer output defining a specific version of ubi8. 