### PR TITLE
TELCODOCS-1175-RN: Release Notes - Metal3 Support Added / Removal of remediation content from docs.openshift.com

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -615,6 +615,13 @@ To configure graceful node shutdowns, you can specify a termination grace period
 
 For further information see xref:../nodes/nodes/nodes-nodes-graceful-shutdown.adoc#nodes-nodes-graceful-shutdown[Managing graceful node shutdown].
 
+[id="ocp-4-13-metal3-remediation-support"]
+==== Metal3 remediation support
+
+Previously, Machine Health Checks could self-remediate or use the Self Node Remediation provider. With this release, the new Metal3 remediation provider is also supported on bare metal clusters.
+
+For more information, see xref:../machine_management/deploying-machine-health-checks.html#mgmt-power-remediation-baremetal-about_deploying-machine-health-checks[About power-based remediation of bare metal].
+
 [id="ocp-4-13-monitoring"]
 === Monitoring
 The monitoring stack for this release includes the following new and modified features.


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1175 Release Notes - Metal3 Support Added / Removal of remediation content from docs.openshift.com

Applies to OpenShift version : 4.13 

Preview: [Metal3 remediation support](http://file.emea.redhat.com/pogrady/TELCODOCS-1175-RN/release_notes/ocp-4-13-release-notes.html#ocp-4-13-metal3-remediation-support)

Dev review completed by @slintes 

Thank you.