### PR TITLE
OCPBUGS#9904: Infra Node creation requires DNS follow-up actions

### DIFF
--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -151,6 +151,12 @@ Custom tags can also be specified during installation in the `install-config.yml
 
 ifdef::infra[]
 <9> Specify a taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+====
+
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/machineset-yaml-azure-stack-hub.adoc
+++ b/modules/machineset-yaml-azure-stack-hub.adoc
@@ -159,9 +159,16 @@ ifdef::infra[]
 <2> Specify the `<infra>` node label.
 <3> Specify the infrastructure ID, `<infra>` node label, and region.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+====
+
 <5> Specify the region to place machines on.
 <6> Specify the availability set for the cluster.
 <7> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
+
 endif::infra[]
 
 

--- a/modules/machineset-yaml-azure.adoc
+++ b/modules/machineset-yaml-azure.adoc
@@ -159,6 +159,11 @@ endif::infra[]
 <9> Optional: Specify custom tags in your machine set. Provide the tag name in `<custom_tag_name>` field and the corresponding tag value in `<custom_tag_value>` field.
 ifdef::infra[]
 <10> Specify a taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+====
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/machineset-yaml-gcp.adoc
+++ b/modules/machineset-yaml-gcp.adoc
@@ -141,6 +141,11 @@ To use a GCP Marketplace image, specify the offer to use:
 <5> For `<project_name>`, specify the name of the GCP project that you use for your cluster.
 ifdef::infra[]
 <6> Specify a taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+====
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/machineset-yaml-ibm-cloud.adoc
+++ b/modules/machineset-yaml-ibm-cloud.adoc
@@ -120,6 +120,11 @@ endif::infra[]
 <10> Specify the zone within your region to place machines on. Be sure that your region supports the zone that you specify.
 ifdef::infra[]
 <11> The taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+====
 endif::infra[]
 
 

--- a/modules/machineset-yaml-nutanix.adoc
+++ b/modules/machineset-yaml-nutanix.adoc
@@ -125,6 +125,11 @@ endif::infra[]
 <10> Specify the number of vCPUs per socket.
 ifdef::infra[]
 <11> Specify a taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+====
 endif::infra[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]

--- a/modules/machineset-yaml-osp.adoc
+++ b/modules/machineset-yaml-osp.adoc
@@ -136,6 +136,12 @@ ifdef::infra[]
 <2> Specify the `<infra>` node label.
 <3> Specify the infrastructure ID and `<infra>` node label.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+====
+
 <5> To set a server group policy for the MachineSet, enter the value that is returned from
 link:https://access.redhat.com/documentation/en-us/red_hat_openstack_platform/16.0/html/command_line_interface_reference/server#server_group_create[creating a server group]. For most deployments, `anti-affinity` or `soft-anti-affinity` policies are recommended.
 <6> Required for deployments to multiple networks. If deploying to multiple networks, this list must include the network that is used as the `primarySubnet` value.

--- a/modules/machineset-yaml-vsphere.adoc
+++ b/modules/machineset-yaml-vsphere.adoc
@@ -139,6 +139,12 @@ ifdef::infra[]
 <2> Specify the infrastructure ID and `<infra>` node label.
 <3> Specify the `<infra>` node label.
 <4> Specify a taint to prevent user workloads from being scheduled on infra nodes.
++
+[NOTE]
+====
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+====
+
 <5> Specify the vSphere VM network to deploy the compute machine set to. This VM network must be where other compute machines reside in the cluster.
 <6> Specify the vSphere VM template to use, such as `user-5ddjd-rhcos`.
 <7> Specify the vCenter Datacenter to deploy the compute machine set on.

--- a/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
+++ b/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc
@@ -13,11 +13,16 @@ You can use infrastructure machine sets to create machines that host only infras
 
 In a production deployment, it is recommended that you deploy at least three machine sets to hold infrastructure components. Both OpenShift Logging and {SMProductName} deploy Elasticsearch, which requires three instances to be installed on different nodes. Each of these nodes can be deployed to different availability zones for high availability. This configuration requires three different machine sets, one for each availability zone. In global Azure regions that do not have multiple availability zones, you can use availability sets to ensure high availability.
 
+[NOTE]
+====
+After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
+====
+
 include::modules/infrastructure-components.adoc[leveloffset=+1]
 
 For information about infrastructure nodes and which components can run on infrastructure nodes, see the "Red Hat OpenShift control plane and infrastructure nodes" section in the link:https://www.redhat.com/en/resources/openshift-subscription-sizing-guide[OpenShift sizing and subscription guide for enterprise Kubernetes] document.
 
-To create an infrastructure node, you can xref:../../machine_management/creating-infrastructure-machinesets.adoc#machineset-creating_creating-infrastructure-machinesets[use a machine set], xref:../../nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc#creating-an-infra-node_creating-infrastructure-nodes[label the node], or xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infra-machines_creating-infrastructure-machinesets[use a machine config pool].  
+To create an infrastructure node, you can xref:../../machine_management/creating-infrastructure-machinesets.adoc#machineset-creating_creating-infrastructure-machinesets[use a machine set], xref:../../nodes/nodes/nodes-nodes-creating-infrastructure-nodes.adoc#creating-an-infra-node_creating-infrastructure-nodes[label the node], or xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infra-machines_creating-infrastructure-machinesets[use a machine config pool].
 
 include::modules/creating-an-infra-node.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s): 4.10+

Issue: https://issues.redhat.com/browse/OCPBUGS-9904

Link to docs preview: https://59893--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets.html#creating-infrastructure-machinesets-clouds
 
https://59893--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-creating-infrastructure-nodes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
