### PR TITLE
OADP-658: VSB cleanup for OADP 1.1

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -26,6 +26,29 @@ include::modules/oadp-backing-up-pvs-csi.adoc[leveloffset=+1]
 include::modules/oadp-backing-up-applications-restic.adoc[leveloffset=+1]
 include::modules/oadp-using-data-mover-for-csi-snapshots.adoc[leveloffset=+1]
 
+[id="oadp-cleaning-up-after-data-mover-1-1-backup"]
+== Cleaning up after a backup using Data Mover with OADP 1.1.
+
+For OADP 1.1., you must perform a data cleanup after you perform a backup using any version of Data Mover.
+
+The cleanup consists of deleting the following resources:
+
+* Snapshots in a bucket
+* Cluster resources
+* Volume snapshot backups (VSBs) after a backup procedure that is either run by a schedule or is run repetitively
+
+include::modules/oadp-cleaning-up-after-data-mover-snapshots.adoc[leveloffset=+2]
+
+[id="deleting-cluster-resources"]
+== Deleting cluster resources
+
+Data Mover might leave cluster resources whether or not it successfully backs up your container storage interface (CSI) volume snapshots to a remote object store.
+
+include::modules/oadp-deleting-cluster-resources-following-success.adoc[leveloffset=+2]
+include::modules/oadp-deleting-cluster-resources-following-failure.adoc[leveloffset=+2]
+
+include::modules/oadp-vsb-cleanup-after-scheduler.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[Installing Operators on clusters for administrators]

--- a/modules/oadp-cleaning-up-after-data-mover-snapshots.adoc
+++ b/modules/oadp-cleaning-up-after-data-mover-snapshots.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+:_content-type: PROCEDURE
+[id="oadp-cleaning-up-after-data-mover-snapshots_{context}"]
+= Deleting snapshots in a bucket
+
+Data Mover might leave one or more snapshots in a bucket after a backup. You can either delete all the snapshots or delete individual snapshots.
+
+.Procedure
+
+* To delete all snapshots in your bucket, delete the `/<protected-ns>` folder that is specified in the Data Protection Application (DPA) `.spec.backupLocation.objectStorage.bucket` resource.
+*  To delete an individual snapshot:
+. Browse to the `/<protected-ns>` folder that is specified in the DPA `.spec.backupLocation.objectStorage.bucket` resource.
+. Delete the appropriate folders that are prefixed with `/<volumeSnapshotContent name>-pvc` where `<VolumeSnapshotContent_name>` is the `VolumeSnapshotContent` created by Data Mover per PVC.

--- a/modules/oadp-deleting-cluster-resources-following-failure.adoc
+++ b/modules/oadp-deleting-cluster-resources-following-failure.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+:_content-type: PROCEDURE
+[id="oadp-deleting-cluster-resources-following-failure_{context}"]
+= Deleting cluster resources following a partially successful or a failed backup and restore that used Data Mover
+
+If your backup and restore operation that uses Data Mover either fails or only partially succeeds, you must clean up any `VolumeSnapshotBackup` (VSB) or `VolumeSnapshotrestore` custom resource definitions (CRDs) that exist in the application namespace, and clean up any extra resources created by these controllers.
+
+.Procedure
+
+. Clean up cluster resources that remain after a backup operation where you used Data Mover by entering the following commands:
+
+.. Delete VSB CRDs on the application namespace, the namespace with the application PVCs to backup and restore:
++
+[source,terminal]
+----
+$ oc delete vsb -n <app_namespace> --all
+----
+
+.. Delete `VolumeSnapshot` CRs:
++
+[source,terminal]
+----
+$ oc delete volumesnapshot -A --all
+----
+
+.. Delete `VolumeSnapshotContent` CRs:
++
+[source,terminal]
+----
+$ oc delete volumesnapshotcontent --all
+----
+
+.. Delete any PVCs on the protected namespace, the namespace the Operator is installed on.
++
+[source,terminal]
+----
+$ oc delete pvc -n <protected_namespace> --all
+----
+
+.. Delete any `ReplicationSource` resources on the namespace.
++
+[source,terminal]
+----
+$ oc delete replicationsource -n <protected_namespace> --all
+----
+
+. Clean up cluster resources that remain after a restore operation using Data Mover by entering the following commands:
+
+.. Delete VSR CRDs:
++
+[source,terminal]
+----
+$ oc delete vsr -n <app-ns> --all
+----
+
+.. Delete `VolumeSnapshot` CRs:
++
+[source,terminal]
+----
+$ oc delete volumesnapshot -A --all
+----
+
+.. Delete `VolumeSnapshotContent` CRs:
++
+[source,terminal]
+----
+$ oc delete volumesnapshotcontent --all
+----
+
+.. Delete any `ReplicationDestination` resources on the namespace.
++
+[source,terminal]
+----
+$ oc delete replicationdestination -n <protected_namespace> --all
+----

--- a/modules/oadp-deleting-cluster-resources-following-success.adoc
+++ b/modules/oadp-deleting-cluster-resources-following-success.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+:_content-type: PROCEDURE
+[id="oadp-deleting-cluster-resources-following-success_{context}"]
+= Deleting cluster resources following a successful backup and restore that used Data Mover
+
+You can delete any `VolumeSnapshotBackup` or `VolumeSnapshotRestore` CRs that remain in your application namespace after a successful backup and restore where you used Data Mover.
+
+.Procedure
+
+. Delete cluster resources that remain on the application namespace, the namespace with the application PVCs to backup and restore, after a backup where you use Data Mover:
++
+[source,terminal]
+----
+$ oc delete vsb -n <app_namespace> --all
+----
+
+. Delete cluster resources that remain after a restore where you use Data Mover:
++
+[source,terminal]
+----
+$ oc delete vsr -n <app_namespace> --all
+----
+
+. If needed, delete any `VolumeSnapshotContent` resources that remain after a backup and restore where you use Data Mover:
++
+[source,terminal]
+----
+$ oc delete volumesnapshotcontent --all
+----


### PR DESCRIPTION
OADP 1.1.x, OCP 4.10+

Resolves https://issues.redhat.com/browse/OADP-658 by adding a new section, "Cleaning up after a backup using Data Mover with OADP 1.1.x" to the OADP user guide.

Preview: https://59894--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-cleaning-up-after-data-mover-1-1-backup_backing-up-applications 

Approved by OADP QE. 
