### PR TITLE
fix-conflict-4-12-16-bug: Fixed merge conflict delimiters present on …

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3608,8 +3608,6 @@ $ oc adm release info 4.12.15 --pullspecs
 [id="ocp-4-12-15-updating"]
 ==== Updating
 
-<<<<<<< HEAD
-=======
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-12-16"]
@@ -3634,5 +3632,4 @@ $ oc adm release info 4.12.16 --pullspecs
 [id="ocp-4-12-16-updating"]
 ==== Updating
 
->>>>>>> 7b9e41e989 (OSDOCS-6001:adds 4.12.16 to RNs)
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Internal docs fix, so not linking Jira or CCS-external approvals needed

[Preview linl](http://file.emea.redhat.com/dfitzmau/fix-conflict-4-12-16-bug/release_notes/ocp-4-12-release-notes.html#ocp-4-12-16)
