### PR TITLE
OADP-1360 replaced step 13 in procedure with deleting secrets

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -238,7 +238,7 @@ $ oc describe csr <csr_name> <1>
 $ oc adm certificate approve <csr_name>
 ----
 
-.. For user-provisioned installations, approve each valid kubelet service CSR:
+. (Optional) For user-provisioned installations, approve each valid kubelet CSR, as described above steps a, b, and c in the step above:
 +
 [source,terminal]
 ----

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -112,7 +112,7 @@ You can check whether the proxy is enabled by reviewing the output of `oc get pr
 +
 [source,terminal]
 ----
-$ sudo -E /usr/local/bin/cluster-restore.sh /home/core/backup
+$ sudo -E /usr/local/bin/cluster-restore.sh /home/core/assets/backup
 ----
 +
 .Example script output

--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -257,7 +257,9 @@ $ sudo crictl ps | grep etcd | grep -v operator
 .Example output
 [source,terminal]
 ----
-3ad41b7908e32       36f86e2eeaaffe662df0d21041eb22b8198e0e58abeeae8c743c3e6e977e8009                                                         About a minute ago   Running             etcd                                          0                   7c05f8af362f0
+3ad41b7908e32       36f86e2eeaaffe662df0d21041eb22b8198e0e58abeeae8c743c3e6e977e8009
+About a minute ago   Running             etcd
+0               7c05f8af362f0
 ----
 
 .. From the recovery host, verify that the etcd pod is running.
@@ -292,12 +294,49 @@ If the status is `Pending`, or the output lists more than one running etcd pod, 
 Perform the following step only if you are using `OVNKubernetes` network plugin.
 ====
 
-. Delete the node objects that are associated with control plane hosts that are not the recovery control plane host.
+. Remove the old secrets for the unhealthy etcd member that was removed.
+
+.. List the secrets for the unhealthy etcd member that was removed.
 +
 [source,terminal]
 ----
-$ oc delete node <non-recovery-controlplane-host-1> <non-recovery-controlplane-host-2>
+$ oc get secrets -n openshift-etcd | grep ip-10-0-131-183.ec2.internal <1>
 ----
+<1> Pass in the name of the unhealthy etcd member that you took note of earlier in this procedure.
++
+There is a peer, serving, and metrics secret as shown in the following output:
++
+.Example output
+[source,terminal]
+----
+etcd-peer-ip-10-0-131-183.ec2.internal              kubernetes.io/tls                     2      47m
+etcd-serving-ip-10-0-131-183.ec2.internal           kubernetes.io/tls                     2      47m
+etcd-serving-metrics-ip-10-0-131-183.ec2.internal   kubernetes.io/tls                     2      47m
+----
+
+.. Delete the secrets for the unhealthy etcd member that was removed.
+
+... Delete the peer secret:
++
+[source,terminal]
+----
+$ oc delete secret -n openshift-etcd etcd-peer-ip-10-0-131-183.ec2.internal
+----
+
+... Delete the serving secret:
++
+[source,terminal]
+----
+$ oc delete secret -n openshift-etcd etcd-serving-ip-10-0-131-183.ec2.internal
+----
+
+... Delete the metrics secret:
++
+[source,terminal]
+----
+$ oc delete secret -n openshift-etcd etcd-serving-metrics-ip-10-0-131-183.ec2.internal
+----
+
 
 . Turn off the quorum guard by entering the following command:
 +


### PR DESCRIPTION
@anarnold97

GH# : 
OCPBUGS#: [OADP-1360](https://issues.redhat.com//browse/OADP-1360), OADP-1361, OADP-1362, [OADP-1363](https://issues.redhat.com//browse/OADP-1363)
OSCDOCS# : [OADP-1360](https://issues.redhat.com//browse/OADP-1360), OADP-1361, OADP-1362, [OADP-1363](https://issues.redhat.com//browse/OADP-1363)

Implement changes in modules/dr-restoring-cluster-state.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): OADP 1.2.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
