### PR TITLE
[enterprise-4.10] OCPBUGS#11688: Explained that adding new users is not supported

### DIFF
--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -48,7 +48,7 @@ The kinds of components that MCO can change include:
 
 [IMPORTANT]
 ====
-Changing SSH keys via machine configs is only supported for the `core` user.
+Changing SSH keys via machine configs is only supported for the `core` user. It is not supported to add any other user via machine configs.
 ====
 * **kernelArguments**: Add arguments to the kernel command line when {product-title} nodes boot.
 * **kernelType**: Optionally identify a non-standard kernel to use instead of the standard kernel. Use `realtime` to use the RT kernel (for RAN). This is only supported on select platforms.


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/58569