### PR TITLE
TELCODOCS-1335: Backporting log-level enhancement to 4.10

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -4001,3 +4001,20 @@ $ oc adm release info 4.10.59 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+
+//To be included as a RN in next z-stream
+Features
+
+Control over logging verbosity for MetalLB 
+With this release, you can control the verbosity of MetalLB logs. You can control logging levels by using the following values for the `logLevel` specification in the MetalLB custom resource (CR):
+
+* all
+* debug
+* info
+* warn
+* error
+* none
+
+For example, you can specify the `debug` value to include diagnostic logging information that is helpful for troubleshooting. 
+
+For more information about logging levels for MetalLB, see xref:../networking/metallb/metallb-troubleshoot-support.adoc#nw-metallb-setting-metalb-logging-levels_metallb-troubleshoot-support[Setting the MetalLB logging levels]


### PR DESCRIPTION
[TELCODOCS-1335](https://issues.redhat.com//browse/TELCODOCS-1335): You can now use the `debug` value for `logLevel` in MetalLB CRs for more extensive logging information. This was introduced in 4.11 and is being backported to 4.10.z as a RN.

Version(s):
4.10.z

Issue:
https://issues.redhat.com/browse/OCPBUGS-11861

Link to docs preview:

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
