### PR TITLE
RHDEVDOCS-3241: document-no-NFS-support-for-PV-for-Prometheus

### DIFF
--- a/modules/monitoring-configuring-persistent-storage.adoc
+++ b/modules/monitoring-configuring-persistent-storage.adoc
@@ -21,3 +21,10 @@ Running cluster monitoring with persistent storage means that your metrics are s
 ====
 If you use a local volume for persistent storage, do not use a raw block volume, which is described with `volumeMode: Block` in the `LocalVolume` object. Prometheus cannot use raw block volumes.
 ====
++
+[IMPORTANT]
+====
+Prometheus does not support file systems that are not POSIX compliant.
+For example, some NFS file system implementations are not POSIX compliant.
+If you want to use an NFS file system for storage, verify with the vendor that their NFS implementation is fully POSIX compliant.
+====


### PR DESCRIPTION
Summary: This PR adds an admonition stating that non-POSIX-compliant file systems are not supported for use as persistent storage with Prometheus.

- Aligned team: DevTools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-3241
- Direct link to doc preview: https://59924--docspreview.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#persistent-storage-prerequisites
- SME review: @simonpasquier (approved)
- QE review: @juzhao (approved)
- Peer review: @abrennan89 (approved)