### PR TITLE
RHDEVDOCS-5308-fix-typo-and-phrasing-in-configuring-remote-write-storage

### DIFF
--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -7,7 +7,7 @@
 = Configuring remote write storage
 
 [role="_abstract"]
-You can configure remote write storage to enable Prometheus to send ingested metrics to remote systems for long-term storage. 
+You can configure remote write storage to enable Prometheus to send ingested metrics to remote systems for long-term storage.
 Doing so has no impact on how or for how long Prometheus stores metrics.
 
 .Prerequisites
@@ -23,7 +23,7 @@ Doing so has no impact on how or for how long Prometheus stores metrics.
 See the link:https://prometheus.io/docs/operating/integrations/#remote-endpoints-and-storage[Prometheus remote endpoints and storage documentation] for information about endpoints that are compatible with the remote write feature.
 * You have set up authentication credentials in a `Secret` object for the remote write endpoint.
 You must create the secret in the same namespace as the Prometheus object for which you configure remote write:  the `openshift-monitoring` namespace for default platform monitoring or the `openshift-user-workload-monitoring` namespace for user workload monitoring.
- 
+
 +
 [CAUTION]
 ====
@@ -36,8 +36,8 @@ Follow these steps to configure remote write for default platform monitoring in 
 
 [NOTE]
 ====
-If you configure remote write for the Prometheus instance that monitors user-defined projects, make similar edits to the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace. 
-Note that the Prometheus config map component is called `prometheus` in the `user-workload-monitoring-config` `ConfigMap` object and not `prometheusK8s`, as it is in the `cluster-monitoring-config` `ConfigMap` object. 
+If you configure remote write for the Prometheus instance that monitors user-defined projects, make similar edits to the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
+Note that the Prometheus config map component is called `prometheus` in the `user-workload-monitoring-config` `ConfigMap` object and not `prometheusK8s`, as it is in the `cluster-monitoring-config` `ConfigMap` object.
 ====
 
 . Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` project:
@@ -68,8 +68,8 @@ data:
 +
 <1> The URL of the remote write endpoint.
 <2> The authentication method and credentials for the endpoint.
-Currently supported authentication methods are AWS Signature Version 4, authentication using HTTP an `Authorization` request header, basic authentication, OAuth 2.0, and TLS client. 
-See _Supported remote write authentication settings_ below for sample configurations of supported authentication methods.
+Currently supported authentication methods are AWS Signature Version 4, authentication using HTTP in an `Authorization` request header, Basic authentication, OAuth 2.0, and TLS client.
+See _Supported remote write authentication settings_ for sample configurations of supported authentication methods.
 
 . Add write relabel configuration values after the authentication credentials:
 +

--- a/modules/monitoring-supported-remote-write-authentication-settings.adoc
+++ b/modules/monitoring-supported-remote-write-authentication-settings.adoc
@@ -7,7 +7,7 @@
 = Supported remote write authentication settings
 
 You can use different methods to authenticate with a remote write endpoint.
-Currently supported authentication methods are AWS Signature Version 4, basic authentication, authorization, OAuth 2.0, and TLS client.
+Currently supported authentication methods are AWS Signature Version 4, Basic authentication, authentication using HTTP in an `Authorization` request header, OAuth 2.0, and TLS client.
 The following table provides details about supported authentication methods for use with remote write.
 
 [options="header"]
@@ -16,15 +16,15 @@ The following table provides details about supported authentication methods for 
 |Authentication method|Config map field|Description
 
 |AWS Signature Version 4|`sigv4`|This method uses AWS Signature Version 4 authentication to sign requests.
-You cannot use this method simultaneously with authorization, OAuth 2.0, or basic authentication.
+You cannot use this method simultaneously with authorization, OAuth 2.0, or Basic authentication.
 
-|basic authentication|`basicAuth`|Basic authentication sets the authorization header on every remote write request with the configured username and password.
+|Basic authentication|`basicAuth`|Basic authentication sets the authorization header on every remote write request with the configured username and password.
 
 |authorization|`authorization`|Authorization sets the `Authorization` header on every remote write request using the configured token.
 
 |OAuth 2.0|`oauth2`|An OAuth 2.0 configuration uses the client credentials grant type.
 Prometheus fetches an access token from `tokenUrl` with the specified client ID and client secret to access the remote write endpoint.
-You cannot use this method simultaneously with authorization, AWS Signature Version 4, or basic authentication.
+You cannot use this method simultaneously with authorization, AWS Signature Version 4, or Basic authentication.
 
 |TLS client|`tlsConfig`|A TLS client configuration specifies the CA certificate, the client certificate, and the client key file information used to authenticate with the remote write endpoint server using TLS.
 The sample configuration assumes that you have already created a CA certificate file, a client certificate file, and a client key file.
@@ -50,7 +50,7 @@ data:
 ----
 <1> The URL of the remote write endpoint.
 <2> The required configuration details for the authentication method for the endpoint.
-Currently supported authentication methods are Amazon Web Services (AWS) Signature Version 4, authorization, basic authentication, OAuth 2.0, and TLS client.
+Currently supported authentication methods are Amazon Web Services (AWS) Signature Version 4, authentication using HTTP in an `Authorization` request header, Basic authentication, OAuth 2.0, and TLS client.
 
 [NOTE]
 ====
@@ -115,9 +115,9 @@ data:
 <5> The name of the AWS profile that is being used to authenticate.
 <6> The unique identifier for the Amazon Resource Name (ARN) assigned to your role.
 
-.Sample YAML for basic authentication
+.Sample YAML for Basic authentication
 
-The following shows sample basic authentication settings for a `Secret` object named `rw-basic-auth` in the `openshift-monitoring` namespace:
+The following shows sample Basic authentication settings for a `Secret` object named `rw-basic-auth` in the `openshift-monitoring` namespace:
 
 [source,yaml]
 ----


### PR DESCRIPTION
Summary: Changes "authentication using HTTP an Authorization request header" to say "authentication using HTTP in an Authorization request header"; makes phrasing consistent, changes "basic authentication" to "Basic authentication" per new guidance from the RH Supplementary Style Guide.

Also removes some trailing white spaces from certain lines.

NO TECHNICAL CONTENT CHANGES. Therefore, no QE approval required.

- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/RHDEVDOCS-5308
- Direct link to doc preview (RH VPN access required): http://file.rdu.redhat.com/~bburt/RHDEVDOCS-5308-fix-typo-in-configuring-remote-write-storage/monitoring/configuring-the-monitoring-stack.html#configuring_remote_write_storage_configuring-the-monitoring-stack
- SME review: N/A
- QE review: N/A (language updates and fixes only)
- Peer review: @gwynnemonahan 