### PR TITLE
Security Profiles Operator 0.7.1 release notes

### DIFF
--- a/modules/spo-custom-priority-class.adoc
+++ b/modules/spo-custom-priority-class.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * security/security_profiles_operator/spo-advanced.adoc
+
+:_content-type: PROCEDURE
+[id="spo-custom-priority-class_{context}"]
+= Setting a custom priority class name for the spod daemon pod
+
+The default priority class name of the `spod` daemon pod is set to `system-node-critical`. A custom priority class name can be configured in the `spod` configuration by setting a value in the `priorityClassName` field.
+
+.Procedure
+
+* Configure the priority class name by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"priorityClassName":"my-priority-class"}}'
+----
++
+.Example output
+[source,terminal]
+----
+securityprofilesoperatordaemon.openshift-security-profiles.x-k8s.io/spod patched
+----

--- a/modules/spo-daemon-requirements.adoc
+++ b/modules/spo-daemon-requirements.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * security/security_profiles_operator/spo-advanced.adoc
+
+:_content-type: PROCEDURE
+[id="spo-daemon-requirements_{context}"]
+= Customizing daemon resource requirements
+
+The default resource requirements of the daemon container can be adjusted by using the field `daemonResourceRequirements`
+from the `spod` configuration.
+
+.Procedure
+
+* To specify the memory and cpu requests and limits of the daemon container, run the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-security-profiles patch spod spod --type merge -p \
+    '{"spec":{"daemonResourceRequirements": { \
+    "requests": {"memory": "256Mi", "cpu": "250m"}, \
+    "limits": {"memory": "512Mi", "cpu": "500m"}}}}'
+----

--- a/modules/spo-memory-optimzation.adoc
+++ b/modules/spo-memory-optimzation.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * security/security_profiles_operator/spo-advanced.adoc
+
+:_content-type: PROCEDURE
+[id="spo-memory-optimization_{context}"]
+= Enabling memory optimization in the spod daemon
+
+The controller running inside of `spod` daemon process watches all pods available in the cluster when profile recording is enabled. This can lead to very high memory usage in large clusters, resulting in the `spod` daemon running out of memory or crashing.
+
+To prevent crashes, the `spod` daemon can be configured to only load the pods labeled for profile recording into the cache memory.
++
+[NOTE]
+====
+SPO memory optimization is not enabled by default.
+====
+
+.Procedure
+
+. Enable memory optimization by running the following command:
++
+[source,terminal]
+----
+$ oc -n openshift-security-profiles patch spod spod --type=merge -p '{"spec":{"enableMemoryOptimization":true}}'
+----
+
+. To record a security profile for a pod, the pod must be labeled with `spo.x-k8s.io/enable-recording: "true"`:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-recording-pod
+  labels:
+    spo.x-k8s.io/enable-recording: "true"
+----

--- a/security/security_profiles_operator/spo-advanced.adoc
+++ b/security/security_profiles_operator/spo-advanced.adoc
@@ -12,6 +12,12 @@ include::modules/spo-restrict-syscalls.adoc[leveloffset=+1]
 
 include::modules/spo-base-syscalls.adoc[leveloffset=+1]
 
+include::modules/spo-memory-optimzation.adoc[leveloffset=+1]
+
+include::modules/spo-daemon-requirements.adoc[leveloffset=+1]
+
+include::modules/spo-custom-priority-class.adoc[leveloffset=+1]
+
 include::modules/spo-using-metrics.adoc[leveloffset=+1]
 
 include::modules/spo-runtime-metrics.adoc[leveloffset=+2]

--- a/security/security_profiles_operator/spo-release-notes.adoc
+++ b/security/security_profiles_operator/spo-release-notes.adoc
@@ -12,6 +12,50 @@ These release notes track the development of the Security Profiles Operator in {
 
 For an overview of the Security Profiles Operator, see xref:../security_profiles_operator/spo-overview.adoc#[Security Profiles Operator Overview].
 
+[id="spo-release-notes-0-7-1"]
+== Security Profiles Operator 0.7.1
+
+The following advisory is available for the Security Profiles Operator 0.7.1:
+
+* link:https://access.redhat.com/errata/RHSA-2023:2029[RHSA-2023:2029 - OpenShift Security Profiles Operator bug fix update]
+
+[id="spo-0-7-1-new-features-and-enhancements"]
+=== New features and enhancements
+
+* Security Profiles Operator (SPO) now automatically selects the appropriate `selinuxd` image for RHEL 8- and 9-based RHCOS systems.
++
+[IMPORTANT]
+====
+Users that mirror images for disconnected environments must mirror both `selinuxd` images provided by the Security Profiles Operator.
+====
+
+* You can now enable memory optimization inside of an `spod` daemon. For more information, see xref:../../security/security_profiles_operator/spo-advanced.adoc#spo-memory-optimization_spo-advanced[Enabling memory optimization in the spod daemon].
++
+[NOTE]
+====
+SPO memory optimization is not enabled by default.
+====
+
+* The daemon resource requirements are now configurable. For more information, see xref:../../security/security_profiles_operator/spo-advanced.adoc#spo-daemon-requirements_spo-advanced[Customizing daemon resource requirements].
+
+* The priority class name is now configurable in the `spod` configuration. For more information, see xref:../../security/security_profiles_operator/spo-advanced.adoc#spo-custom-priority-class_spo-advanced[Setting a custom priority class name for the spod daemon pod].
+
+[id="spo-0-7-1-deprecations"]
+=== Deprecated and removed features
+
+* The default `nginx-1.19.1` seccomp profile is now removed from the Security Profiles Operator deployment.
+
+[id="spo-0-7-1-bug-fixes"]
+=== Bug fixes
+
+* Previously, a Security Profiles Operator (SPO) SELinux policy did not inherit low-level policy definitions from the container template. If you selected another template, such as net_container, the policy would not work because it required low-level policy definitions that only existed in the container template. This issue occurred when the SPO SELinux policy attempted to translate SELinux policies from the SPO custom format to the Common Intermediate Language (CIL) format. With this update, the container template appends to any SELinux policies that require translation from SPO to CIL. Additionally, the SPO SELinux policy can inherit low-level policy definitions from any supported policy template. (link:https://issues.redhat.com/browse/OCPBUGS-12879[*OCPBUGS-12879*])
+
+[discrete]
+[id="spo-0-7-1-known-issue"]
+=== Known issue
+
+* When uninstalling the Security Profiles Operator, the `MutatingWebhookConfiguration` object is not deleted and must be manually removed. As a workaround, delete the `MutatingWebhookConfiguration` object after uninstalling the Security Profiles Operator. These steps are defined in xref:../security_profiles_operator/spo-uninstalling.adoc#[Uninstalling the Security Profiles Operator]. (link:https://issues.redhat.com/browse/OCPBUGS-4687[*OCPBUGS-4687*])
+
 [id="spo-release-notes-0-5-2"]
 == Security Profiles Operator 0.5.2
 


### PR DESCRIPTION
Version(s):
4.12+

Link to docs preview (VPN required):
[Security Profiles Operator 0.7.1](http://file.rdu.redhat.com/antaylor/SPO-0.7.0/security/security_profiles_operator/spo-release-notes.html#spo-release-notes-0-7-1)
[Enabling memory optimization in the spod daemon](http://file.rdu.redhat.com/antaylor/SPO-0.7.0/security/security_profiles_operator/spo-advanced.html#spo-memory-optimization_spo-advanced)
[Customizing daemon resource requirements](http://file.rdu.redhat.com/antaylor/SPO-0.7.0/security/security_profiles_operator/spo-advanced.html#spo-daemon-requirements_spo-advanced)
[Setting a custom priority class name for the spod daemon pod](http://file.rdu.redhat.com/antaylor/SPO-0.7.0/security/security_profiles_operator/spo-advanced.html#spo-custom-priority-class_spo-advanced)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None at this time.