### PR TITLE
[enterprise-4.12] OCPBUGS#12214: Add example for bond+vlan

### DIFF
--- a/modules/virt-example-nmstate-multiple-interfaces.adoc
+++ b/modules/virt-example-nmstate-multiple-interfaces.adoc
@@ -7,26 +7,52 @@
 
 You can create multiple interfaces in the same node network configuration policy. These interfaces can reference each other, allowing you to build and deploy a network configuration by using a single policy manifest.
 
-The following example snippet creates a bond that is named `bond10` across two NICs and a Linux bridge that is named `br1` that connects to the bond.
+The following example YAML file creates a bond that is named `bond10` across two NICs and VLAN that is named `bond10.103` that connects to the bond.
 
 [source,yaml]
 ----
-#...
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: bond-vlan <1>
+spec:
+  nodeSelector: <2>
+    kubernetes.io/hostname: <node01> <3>
+  desiredState:
     interfaces:
-    - name: bond10
-      description: Bonding eth2 and eth3 for Linux bridge
-      type: bond
-      state: up
+    - name: bond10 <4>
+      description: Bonding eth2 and eth3 <5>
+      type: bond <6>
+      state: up <7>
       link-aggregation:
-        port:
+        mode: balance-rr <8>
+        options:
+          miimon: '140' <9>
+        port: <10>
         - eth2
         - eth3
-    - name: br1
-      description: Linux bridge on bond
-      type: linux-bridge
-      state: up
-      bridge:
-        port:
-        - name: bond10
-#...
+    - name: bond10.103 <4>
+      description: vlan using bond10 <5>
+      type: vlan <6>
+      state: up <7>
+      vlan:
+         base-iface: bond10 <11>
+         id: 103 <12>
+      ipv4:
+        dhcp: true <13>
+        enabled: true <14>
 ----
+<1> Name of the policy.
+<2> Optional: If you do not include the `nodeSelector` parameter, the policy applies to all nodes in the cluster.
+<3> This example uses `hostname` node selector.
+<4> Name of the interface.
+<5> Optional: Human-readable description of the interface.
+<6> The type of interface.
+<7> The requested state for the interface after creation.
+<8> The driver mode for the bond.
+<9> Optional: This example uses miimon to inspect the bond link every 140ms.
+<10> The subordinate node NICs in the bond.
+<11> The node NIC to which the VLAN is attached.
+<12> The VLAN tag.
+<13> Optional: If you do not use dhcp, you can either set a static IP or leave the interface without an IP address.
+<14> Enables ipv4 in this example.


### PR DESCRIPTION
Main PR: #59345 
Version(s): 4.12

Issue: https://issues.redhat.com/browse/OCPBUGS-12214

Preview: http://file.rdu.redhat.com/snarayan/OCPBUGS-12214_nmstatevlan_4_12/networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.html#virt-example-nmstate-multiple-interfaces_k8s_nmstate-updating-node-network-config