### PR TITLE
OSDOCS-6080: Documented the 4.11.40 z-stream release

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3539,3 +3539,26 @@ $ oc adm release info 4.11.39 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-11-40"]
+=== RHBA-2023:2694 - {product-title} 4.11.40 bug fix update
+
+Issued: 2023-05-18
+
+{product-title} release 4.11.40 is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:2694[RHBA-2023:2694] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2693[RHBA-2023:2693] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.40 --pullspecs
+----
+
+[id="ocp-4-11-40-bug-fixes"]
+==== Bug fixes
+* Previously, when you deleted a Knative (`kn`) service on the OpenShift web console, the associated `<kn-service-name>-github-webhook-secret` webhook was not deleted. If you attempted to recreate the Knative service, while retaining the same name as the original service, the operation would fail. With this update, when you delete a Knative (`kn`) service on the OpenShift web console, the associated webhook is deleted at the same time as the service. You can now recreate a Knative service with the same name as the deleted service without the operation failing. (link:https://issues.redhat.com/browse/OCPBUGS-7949[*OCPBUGS-7949*])
+
+[id="ocp-4-11-40-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-6080](https://issues.redhat.com/browse/OSDOCS-6080). See https://issues.redhat.com/browse/OSDOCS-6113 Jira (new Jira with correct labels)

Version(s):
4.11

Link to docs preview:
[OpenShift Container Platform 4.11.40 bug fix update](http://file.emea.redhat.com/dfitzmau/OSDOCS-6080/release_notes/ocp-4-11-release-notes.html#ocp-4-11-40)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[ART ticket](https://issues.redhat.com/browse/ART-6769)
