### PR TITLE
Update Tech Preview snippet guidance

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -830,12 +830,16 @@ You must get approval from the Engineering, QE, and Docs teams before embedding 
 
 == Indicating Technology Preview features
 
-To indicate that a feature is in Technology Preview, include the `snippets/technology-preview.adoc` file in the feature's assembly or module to keep the supportability wording consistent across Technology Preview features. Provide a value for the `:FeatureName:` variable before you include this module.
+To indicate that a feature is in Technology Preview, include the `snippets/technology-preview.adoc` file in the feature's assembly or module to keep the supportability wording consistent across Technology Preview features.
+Provide a value for the `:FeatureName:` variable before you include the snippet and unset the variable after the snippet include reference.
+This ensures that other parts of the docs that include the Technology Preview snippet do not accidentally pick up the wrong value for the `:FeatureName:` variable.
+You unset an AsciiDoc variable by prepending the variable name with an exclamation mark. For example:
 
 [source,text]
 ----
 :FeatureName: The XYZ plug-in
 \include::snippets/technology-preview.adoc[]
+:!FeatureName:
 ----
 
 == Indicating deprecated features


### PR DESCRIPTION
Best practice should be to unset the `FeatureName` variable immediately after setting it so that it doesn't get picked up incorrectly in other parts of the build.

Version(s):
main