### PR TITLE
Document GitOps RN-1.8.3

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,6 +23,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-8-3.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-8-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-8-1.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-8-3.adoc
+++ b/modules/gitops-release-notes-1-8-3.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+:_content-type: REFERENCE
+[id="gitops-release-notes-1-8-3_{context}"]
+= Release notes for {gitops-title} 1.8.3
+
+{gitops-title} 1.8.3 is now available on {product-title} 4.10, 4.11, 4.12, and 4.13.
+
+[id="errata-updates-1-8-3_{context}"]
+== Errata updates
+
+=== RHBA-2023:3206 and RHSA-2023:3229 - {gitops-title} 1.8.3 security update advisory 
+
+Issued: 2023-05-18
+
+The list of security fixes that are included in this release is documented in the following advisories:
+
+* link:https://access.redhat.com/errata/RHBA-2023:3206[RHBA-2023:3206]
+* link:https://access.redhat.com/errata/RHSA-2023:3229[RHSA-2023:3229]
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----
+
+[id="fixed-issues-1-8-3_{context}"]
+== Fixed issues
+
+* Before this update, when `Autoscale` was enabled and the horizontal pod autoscaler (HPA) controller tried to edit the replica settings in server deployment, the Operator overwrote it. In addition, any changes specified to the autoscaler parameters were not propagated correctly to the HPA on the cluster. This update fixes the issue. Now the Operator reconciles on replica drift only if `Autoscale` is disabled and the HPA parameters are updated correctly. link:https://issues.redhat.com/browse/GITOPS-2629[GITOPS-2629]

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -14,6 +14,11 @@ In the table, features are marked with the following statuses:
 * *GA*: _General Availability_
 * *NA*: _Not Applicable_
 
+[IMPORTANT]
+====
+In {product-title} 4.13, the `stable` channel has been removed. Before upgrading to {product-title} 4.13, if you are already on the `stable` channel, choose the appropriate channel and switch to it.
+====
+
 |===
 |*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
 


### PR DESCRIPTION
**NOTE**: From GitOps 1.7.0 onwards, we are documenting security issues in a new advisory format as part of errata updates.

**Aligned team**: Dev Tools

**Purpose**: To resolve the following issues:
(https://issues.redhat.com/browse/RHDEVDOCS-5216)

**OCP version this PR applies to**: enterprise-`4.10` and later

**Link to docs preview**: [Download to see the preview in your browser - Release notes for Red Hat OpenShift GitOps 1.8.3](https://drive.google.com/file/d/1kxNWkbKGIBsH7Nzn1iH-J8ovQyJFZQZk/view?usp=share_link)

**SME review**: Completed by @iam-veeramalla, @jaideepr97 
**QE review**: Completed by @varshab1210
**Peer-review**:  Completed by @rolfedh 