### PR TITLE
ocp-glines-conscious-lang-machines: Updated the concious lang. sectio…

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -434,10 +434,10 @@ To assist with the removal of the problematic word "master" from the documentati
 |===
 |Branch |Control plane node reference
 
-|`main` and `enterprise-4.9`
+|`main`, `enterprise-4.9`, and later enterprise versions
 |Control plane node
 
-|`enterprise-4.8` and earlier
+|`enterprise-4.8` and earlier enterprise versions
 |Control plane (also known as master) node
 
 |`enterprise-3.11`
@@ -446,6 +446,8 @@ To assist with the removal of the problematic word "master" from the documentati
 |===
 
 You can replace "node" in the preceding examples with "machine", "host", or another suitable description.
+
+In general text, use the term "control plane machine" in place of "master machine"; use the term "compute machine" in place of "worker machine". Be mindful of certain valid code entities, such as `master` role, `worker` role, and `infra` role.
 
 [NOTE]
 ====


### PR DESCRIPTION
Internal OCP docs team update. No Jira required. 

Version(s):
Main

Link to docs preview: [Using conscious language](http://file.emea.redhat.com/dfitzmau/ocp-glines-conscious-lang-machines/doc_guidelines.html#using-conscious-language:~:text=You%20can%20replace,and%20infra%20role.)

Additional resources:

[OCP Guidelines](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#using-conscious-language)
