### PR TITLE
Adding AsciiDoc and OpenShiftAsciiDoc packages and applying in root and modules dirs

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,11 +2,11 @@ StylesPath = .vale/styles
 
 MinAlertLevel = suggestion
 
-Packages = RedHat
+Packages = RedHat, https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/AsciiDoc.zip, https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/OpenShiftAsciiDoc.zip
 
 #ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
-BasedOnStyles = RedHat
+BasedOnStyles = RedHat, AsciiDoc
 
 #optional: pass doc attributes to asciidoctor before linting
 #[asciidoctor]

--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -1,0 +1,6 @@
+StylesPath = ../.vale/styles
+
+MinAlertLevel = suggestion
+
+[[!.]*.adoc]
+BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat


### PR DESCRIPTION
This adds two new Vale rule packages: AsciiDoc and OpenShiftAsciiDoc. For anybody using Vale, you will pick up these new rules the next time you run `vale sync`.

The AsciiDoc style checks for common AsciiDoc syntax errors in modules and assemblies, for example: 

- Attribute blocks is not closed
- Quoted ID value is not closed
- Images missing accessibility alt tags
- Missing or incorrect callouts
- Unterminated admonition blocks
- Unterminated listing blocks
- Unbalanced if statements
- Unterminated table block found in file

The OpenShiftAsciiDoc style applies only to the modules folder.  The OpenShiftAsciiDoc style checks OpenShift-specific metadata, for example:

- "_additional-resources" role attribute declaration
- ID missing the "_{context}" variable at the end of the ID.
- Module missing the "_content-type" variable.
- Xrefs missing an anchor ID
- Use .adoc instead of .html in xrefs
- The xref is missing link text
-  Terminal code block missing a command prompt at the beginning of the line. For example output, prepend the code block with '.Example output'.

Version(s):
Main+ and backported to supported versions.

