### PR TITLE
Update RAN software versions for OpenShift 4.13

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -15,17 +15,17 @@ The Red Hat Telco Radio Access Network (RAN) version {product-version} solution 
 |Software version
 
 |Hub cluster {product-title} version
-|4.12
+|4.13
 
 |{ztp} plugin
-|4.10, 4.11, or 4.12
+|4.11, 4.12, or 4.13
 
 |{rh-rhacm-first}
-|2.6, 2.7
+|2.7
 
 |{gitops-title}
 |1.6
 
 |{cgu-operator-first}
-|4.10, 4.11, or 4.12
+|4.11, 4.12, or 4.13
 |====


### PR DESCRIPTION
Update software versions for OpenShift 4.13 for Telco RAN

Version(s):
main, CP to enterprise-4.13

Issue:
https://issues.redhat.com/browse/TELCODOCS-1160

Link to docs preview:
http://file.emea.redhat.com/aireilly/acm-version/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
