### PR TITLE
[OSDOCS#5764]: Update the OPP installation instructions to use PolicySet

### DIFF
--- a/architecture/opp-architecture.adoc
+++ b/architecture/opp-architecture.adoc
@@ -5,16 +5,22 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} is a single hybrid-cloud platform for enterprises. Use it to build, deploy, run, and manage intelligent applications securely across infrastructures. It is based on {op-system-base-full}, Kubernetes, and Red Hat {ocp}. It includes the following products:
+{product-title} is a single hybrid-cloud platform for enterprises. Use it to build, deploy, run, and manage intelligent applications securely for multiple infrastructures. It is based on {op-system-base-full}, Kubernetes, and Red Hat {ocp} and includes the following products:
 
 * {rh-rhacm} for Kubernetes - Controls clusters and applications from a single console.
 * {acs} for Kubernetes - Provides information about cluster security, visibility management, and security compliance.
 * {quay} - Stores, builds, and deploys container images.
-* {rh-storage-essentials-first} - Provides a permanent place to store data while clusters spin up and down across environments.
+* {rh-storage-essentials-first} - Provides a permanent place for data storage when clusters start and stop for multiple environments.
 
 
 include::modules/opp-architecture-architecture.adoc[leveloffset=+1]
 include::modules/opp-architecture-installation.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/install/installing[Installing {rh-rhacm}]
+
+include::modules/opp-architecture-installing-policyset.adoc[leveloffset=+2]
 include::modules/opp-architecture-relnotes.adoc[leveloffset=+1]
 include::modules/opp-architecture-compatibility-matrix.adoc[leveloffset=+1]
 include::modules/opp-architecture-support.adoc[leveloffset=+1]

--- a/modules/opp-architecture-architecture.adoc
+++ b/modules/opp-architecture-architecture.adoc
@@ -2,7 +2,7 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_module-type: CONCEPT
+:_content-type: CONCEPT
 [id="opp-architecture-architecture_{context}"]
 = {product-title} description and architecture
 

--- a/modules/opp-architecture-installation.adoc
+++ b/modules/opp-architecture-installation.adoc
@@ -2,14 +2,10 @@
 //
 // * architecture/opp-architecture.adoc
 
-:_module-type: PROCEDURE
+:_content-type: CONCEPT
 [id="opp-architecture-installation_{context}"]
 = Install {product-title} products
 
-To install {product-title}, you must install two products in a specific order. Install {ocp} first. Then, install {rh-rhacm}. It does not matter what order you install the remaining products: {quay}, {rh-storage-essentials-first}, and {acs}. See the following detailed installation information for each product:
+To install {product-title}, you must install {ocp} followed by {rh-rhacm}. Install the additional products by applying the {rh-rhacm} policy sets: {quay}, {rh-storage-essentials-first}, and {acs}. 
 
-* {ocp} - link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/installing/installing-preparing#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms]
-* {rh-rhacm} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/install/installing[Installing {rh-rhacm}]
-* {acs} - link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.74/html/installing/installing-rhacs-on-red-hat-openshift#install-rhacs-ocp[Installing {acs-short} on Red Hat OpenShift]
-* {rh-storage-essentials-first} - link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12[Deploying {rh-storage-data-foundation}]
-* {quay} - link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.8/html/deploy_red_hat_quay_on_openshift_with_the_quay_operator/index[Deploy {quay} on OpenShift with the Quay Operator]
+See the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/governance/governance#opp-policy-set[Red Hat OpenShift Platform Plus policy set] for detailed information about installing the products.    

--- a/modules/opp-architecture-installing-policyset.adoc
+++ b/modules/opp-architecture-installing-policyset.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * architecture/opp-architecture.adoc
+
+:_content-type: PROCEDURE
+[id="opp-architecture-installing-policyset_{context}"]
+
+= Installing {product-title} by using policy sets
+
+The {ocp} installation uses two policy sets to install additional products.
+
+[NOTE]
+====
+Edit the `policyGenerator.yaml` file to remove any products that you do not want to install. You can delete the product entries or comment out the lines.
+====
+
+To install the policy sets using gitops, follow the steps in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/governance/governance#deploying-policies-using-gitops[Deploying policies using gitops]. Use the actual path to the policy set instead of the path in the example path `policygenerator/policy-sets/stable/openshift-plus`.
+
+Use the following procedure to install the policy sets by using CLI:
+
+.Procedure
+. Install the `PolicyGenerator` plugin by following the instructions in _Installing and using the PolicyGenerator Kustomize plug-in_.
+. Clone the `policy-collection` repository:
++
+[source,terminal]
+----
+$ git clone https://github.com/stolostron/policy-collection
+----
+. Navigate to the policy set directory:
++
+[source,terminal]
+----
+$ cd policy-collection/policygenerator/policy-sets/stable/openshift-plus
+----
+. Generate and apply the policies by using the following command:
++
+[source,terminal]
+----
+$ kustomize build --enable-alpha-plugins | oc apply -f -
+----
++
+The policy sets install the remaining products on the {ocp} cluster.


### PR DESCRIPTION
[OSDOCS-5764](https://issues.redhat.com/browse/OSDOCS-5764)

Peer reviewer: This PR was peer-reviewed, and after making several updates plus changing the content a bit, I need another review before merging. Also, a customer is waiting to receive this update, so we want to release this version and make additional updates soon after if needed.

Version(s):
This PR is based on the ‘opp-docs’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Link to docs preview: https://file.rdu.redhat.com/tlove/opp-osdocs-5764-tlove/architecture/opp-architecture.html#opp-architecture-installing-policyset_opp-architecture (Updated 6/23)

QE review:
- [x ] QE has approved this change.

Additional information:
This PR updates the initial OPP product installation (Installing OCP first, then ACM. Then install ACS, ODF, Quay in any order) to use PolicySet (Installing OCP first, the ACM. Then use  PolicySet to install the remaining products).

