### PR TITLE
OSDOCS-6026: Removing secondary scheduler docs from OKD, since it is …

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2265,6 +2265,7 @@ Topics:
     File: nodes-descheduler
   - Name: Secondary scheduler
     Dir: secondary_scheduler
+    Distros: openshift-enterprise
     Topics:
     - Name: Secondary scheduler overview
       File: index


### PR DESCRIPTION
…not available there

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-6026

Link to docs preview (VPN required):
* OCP (SSO section below descheduler exists): http://file.rdu.redhat.com/~ahoffer/2023/OSDOCS-6026/nodes/scheduling/secondary_scheduler/index.html
* OKD (SSO section below descheduler does NOT exist): http://file.rdu.redhat.com/~ahoffer/2023/OSDOCS-6026-OKD/nodes/scheduling/nodes-descheduler.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This change is really for OKD only (but still CPing to latest enterprise branch for sync purposes)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
