### PR TITLE
OSDOCS#6066: Updated RN for a Nutanix restricted installation

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -268,6 +268,13 @@ For more information, see xref:../installing/installing_with_agent_based_install
 With the Agent-based {product-title} Installer, you can deploy to environments where you rely on DHCP to configure networking for all the nodes, as long as you know the IP that at least one of the systems will receive. This IP is required so that all nodes use it as a meeting point.
 For more information, see xref:../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#dhcp[DHCP].
 
+[id="ocp-4-12-nutanix-restricted-install"]
+==== Installing a cluster on Nutanix with limited internet access
+You can now install a cluster on Nutanix when the environment has limited access to to the internet, as in the case of a disconnected or restricted network cluster. With this type of installation, you create a registry that mirrors the contents of the {product-title} image registry and contains the installation media. You can create this registry on a mirror host, which can access both the internet and your closed network.
+
+For more information, see xref:../installing/disconnected_install/index.adoc#installing-mirroring-disconnected-about[About disconnected installation mirroring] and xref:../installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc#installing-restricted-networks-nutanix-installer-provisioned[Installing a cluster on Nutanix in a restricted network].
+
+
 [id="ocp-4-12-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
Version(s):
4.12

Issue:
This PR addresses [osdocs-6066](https://issues.redhat.com/browse/OSDOCS-6066).

Link to docs preview:
[Installing a cluster on Nutanix with limited internet access](http://file.rdu.redhat.com/mpytlak/osdocs-6066/release_notes/ocp-4-12-release-notes.html#ocp-4-12-nutanix-restricted-install)

Public preview are presently not working. This preview link requires that you be on the VPN.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The request to cover the restricted Nutanix installation use case came into the 4.12 program late, and was added to the the 4.12 docs post 4.12 GA [1]. However, I failed to update the 4.12 RN to announce support. This PR updates the RN to announce support of a restricted installation.

[1] https://github.com/openshift/openshift-docs/pull/54259
