### PR TITLE
[OSDOCS-5514]: Release note about moved hosted control planes content

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1267,6 +1267,11 @@ With this change, you might need to adjust existing automation workflows in the 
 
 For more information, see the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_file_systems/assembly_overview-of-persistent-naming-attributes_managing-file-systems[{op-system-base} documentation].
 
+[discrete]
+[id="ocp-4-13-hosted-control-planes-moved-content"]
+=== Documentation about backup, restore, and disaster recovery for hosted control planes moved
+In the documentation for {product-title} {product-version}, the procedures to back up and restore etcd on a hosted cluster and to restore a hosted cluster within an AWS region were moved from the "Backup and restore" section to the "Hosted control planes" section. The content itself was not changed.
+
 [id="ocp-4-13-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5514
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://lahinson.github.io/previews/4.13-relnote-moved-hcp-content/release_notes/ocp-4-13-release-notes.html#ocp-4-13-notable-technical-changes (Scroll to the end of the "Notable technical changes" section)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- Per the DPM, QE review is not required for this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds a release note explaining that the backup, restore, and DR content for hosted control planes has changed locations in the documentation.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
