### PR TITLE
[GH#60048] Fix syntax in failure domains param section

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1093,10 +1093,12 @@ For more information about the support scope of Red Hat Technology Preview featu
 Beginning with {product-title} 4.13, there is a unified definition of failure domains for {rh-openstack} deployments that covers all supported availability zone types. You can use failure domains to control related aspects of Nova, Neutron, and Cinder configurations from a single place. 
 
 In {rh-openstack}, a port describes a network connection and maps to an interface inside a compute machine. A port also:
+
 * Is defined by a network or by one more or subnets
 * Connects a machine to one or more subnets
 
 Failure domains group the services of your deployment by using ports. If you use failure domains, each machine connects to:
+
 * The `portTarget` object with the ID `control-plane` while that object exists.
 * All non-control-plane `portTarget` objects within its own failure domain.
 * All networks in the machine pool's `additionalNetworkIDs` list.
@@ -1126,16 +1128,16 @@ To configure failure domains for a machine pool, edit availability zone and port
 
 |`platform.openstack.failuredomains.portTargets.portTarget.network`
 |Required. The name or ID of the network to attach to machines in the failure domain.
-|A `network` object that contains either a name or UUID. For example:
-+
+a|A `network` object that contains either a name or UUID. For example:
+
 [source,yaml]
 ----
 network:
   id: 8db6a48e-375b-4caa-b20b-5b9a7218bfe6
 ----
-+
+
 or:
-+
+
 [source,yaml]
 ----
 network:

--- a/modules/installation-osp-failure-domains-config.adoc
+++ b/modules/installation-osp-failure-domains-config.adoc
@@ -13,7 +13,7 @@ The following section of an `install-config.yaml` file demonstrates the use of f
 
 [source,yaml]
 ----
-...
+# ...
 controlPlane:
   name: master
   platform:
@@ -39,5 +39,5 @@ controlPlane:
           network:
             id: 8e4b4e0d-3865-4a9b-a769-559270271242
 featureSet: TechPreviewNoUpgrade
-...
+# ...
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: #60048 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://magical-kringle-bdbd06.netlify.app/installing/installing_openstack/installing-openstack-installer-custom.html#installation-configuration-parameters-failure-domains-osp_installing-openstack-installer-custom
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] ~~QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
