### PR TITLE
BZ#2097632: Added note about traffic on pod network vNICs

### DIFF
--- a/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
+++ b/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 You can connect a virtual machine to the default internal pod network by configuring its network interface to use the `masquerade` binding mode.
 
+[NOTE]
+====
+Traffic on the virtual Network Interface Cards (vNICs) that are attached to the default pod network is interrupted during live migration.
+====
+
 include::modules/virt-configuring-masquerade-mode-cli.adoc[leveloffset=+1]
 
 include::modules/virt-configuring-masquerade-mode-dual-stack.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2097632
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/sjhala/BZ2097632/virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
