### PR TITLE
OSDOCS-5992: Netobserv dashboard added to Observe>Dashboards

### DIFF
--- a/networking/network_observability/network-observability-overview.adoc
+++ b/networking/network_observability/network-observability-overview.adoc
@@ -36,6 +36,19 @@ The Network Observability Operator provides the Flow Collector API custom resour
 
 The {product-title} console offers the *Overview* tab which displays the overall aggregated metrics of the network traffic flow on the cluster. The information can be displayed by node, namespace, owner, pod, and service. Filters and display options can further refine the metrics.
 
+In *Observe* -> *Dashboards*, the *Netobserv* dashboard provides a quick overview of the network flows in your {product-title} cluster. You can view distillations of the network traffic metrics in the following categories:
+
+ * *Top flow rates per source and destination namespaces (1-min rates)*
+ * *Top byte rates emitted per source and destination nodes (1-min rates)*
+ * *Top byte rates received per source and destination nodes (1-min rates)*
+ * *Top byte rates emitted per source and destination workloads (1-min rates)*
+ * *Top byte rates received per source and destination workloads (1-min rates)*
+ * *Top packet rates emitted per source and destination workloads (1-min rates)*
+ * *Top packet rates received per source and destination workloads (1-min rates)*
+
+You can configure the `FlowCollector` `spec.processor.metrics` to add or remove metrics by changing the `ignoreTags` list. For more information about available tags, see the xref:../network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference]
+
+Also in *Observe* -> *Dashboards*, the *Netobserv/Health* dashboard provides metrics about the health of the Operator.
 
 [id="network-observability-topology-views"]
 === Network Observability topology views


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.10+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5992
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[Metrics Overview](https://60060--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/network-observability-overview.html#network-observability-dashboards)
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
