### PR TITLE
[enterprise-4.12] OCPBUGS#13406: Update the ansible and helm base image version tags

### DIFF
--- a/modules/osdk-updating-v1220-to-v1250.adoc
+++ b/modules/osdk-updating-v1220-to-v1250.adoc
@@ -13,10 +13,12 @@ endif::[]
 ifeval::["{context}" == "osdk-ansible-updating-projects"]
 :ansible:
 :type: Ansible
+:img_prefix: ansible
 endif::[]
 ifeval::["{context}" == "osdk-helm-updating-projects"]
 :helm:
 :type: Helm
+:img_prefix: helm
 endif::[]
 ifeval::["{context}" == "osdk-hybrid-helm-updating-projects"]
 :hybrid:
@@ -233,6 +235,17 @@ $ make
 ----
 
 ifdef::ansible,helm[]
+. Update the image tag in your Operator's Dockerfile as shown in the following example:
++
+.Example Dockerfile
+[source,docker,subs="attributes+"]
+----
+FROM registry.redhat.io/openshift4/ose-{img_prefix}-operator:v{product-version} <1>
+----
+<1> Update the version tag to `v{product-version}`.
+endif::[]
+
+ifdef::ansible,helm[]
 . Update your `config/default/kustomizations.yaml` file as shown in the following examples:
 +
 .Example `kustomizations.yaml` file
@@ -320,10 +333,12 @@ endif::[]
 ifeval::["{context}" == "osdk-ansible-updating-projects"]
 :!ansible:
 :!type:
+:!img_prefix: ansible
 endif::[]
 ifeval::["{context}" == "osdk-helm-updating-projects"]
 :!helm:
 :!type:
+:!img_prefix: helm
 endif::[]
 ifeval::["{context}" == "osdk-hybrid-helm-updating-projects"]
 :!hybrid:


### PR DESCRIPTION
Version(s): 4.12 only

Issue: https://issues.redhat.com/browse/OCPBUGS-13406

Link to docs preview: https://60071--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/helm/osdk-helm-updating-projects.html#osdk-upgrading-projects_osdk-helm-updating-projects

https://60071--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/ansible/osdk-ansible-updating-projects.html#osdk-upgrading-projects_osdk-ansible-updating-projects

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
