### PR TITLE
virt, DPDK checkup: Update tags of upstream images

### DIFF
--- a/modules/virt-checking-cluster-dpdk-readiness.adoc
+++ b/modules/virt-checking-cluster-dpdk-readiness.adoc
@@ -166,8 +166,8 @@ data:
   spec.timeout: 10m
   spec.param.networkAttachmentDefinitionName: <network_name> <1>
   spec.param.trafficGeneratorRuntimeClassName: <runtimeclass_name> <2>
-  spec.param.trafficGeneratorImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.0" <3>
-  spec.param.vmContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.0" <4>
+  spec.param.trafficGeneratorImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.1" <3>
+  spec.param.vmContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.1" <4>
 ----
 <1> The name of the `NetworkAttachmentDefinition` object.
 <2> The `RuntimeClass` resource that the traffic generator pod uses.
@@ -250,8 +250,8 @@ data:
   spec.timeout: 1h2m
   spec.param.NetworkAttachmentDefinitionName: "mlx-dpdk-network-1"
   spec.param.trafficGeneratorRuntimeClassName: performance-performance-zeus10
-  spec.param.trafficGeneratorImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.0"
-  spec.param.vmContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.0"
+  spec.param.trafficGeneratorImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.1"
+  spec.param.vmContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.1"
   status.succeeded: true
   status.failureReason: " "
   status.startTimestamp: 2022-12-21T09:33:06+00:00


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
The DPDK checkup currently uses two images from upstream. Update their tags to the latest release.


<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
