### PR TITLE
OCPBUGS-13691: Fixed broken xrefs on customer portal

### DIFF
--- a/security/security_profiles_operator/spo-overview.adoc
+++ b/security/security_profiles_operator/spo-overview.adoc
@@ -4,16 +4,16 @@
 include::_attributes/common-attributes.adoc[]
 :context: spo-overview
 
-{product-title} Security Profiles Operator (SPO) provides a way to define secure computing (https://kubernetes.io/docs/tutorials/security/seccomp/[seccomp]) profiles and SELinux profiles as custom resources, synchronizing profiles to every node in a given namespace. For the latest updates, see the xref:../security_profiles_operator/spo-release-notes.adoc#spo-release-notes[release notes].
+{product-title} Security Profiles Operator (SPO) provides a way to define secure computing (https://kubernetes.io/docs/tutorials/security/seccomp/[seccomp]) profiles and SELinux profiles as custom resources, synchronizing profiles to every node in a given namespace. For the latest updates, see the xref:../../security/security_profiles_operator/spo-release-notes.adoc#spo-release-notes[release notes].
 
-The SPO can distribute custom resources to each node while a reconciliation loop ensures that the profiles stay up-to-date. See xref:../security_profiles_operator/spo-understanding.adoc#spo-understanding[Understanding the Security Profiles Operator].
+The SPO can distribute custom resources to each node while a reconciliation loop ensures that the profiles stay up-to-date. See xref:../../security/security_profiles_operator/spo-understanding.adoc#spo-understanding[Understanding the Security Profiles Operator].
 
-The SPO manages SELinux policies and seccomp profiles for namespaced workloads. For more information, see xref:../security_profiles_operator/spo-enabling.adoc#spo-enabling[Enabling the Security Profiles Operator].
+The SPO manages SELinux policies and seccomp profiles for namespaced workloads. For more information, see xref:../../security/security_profiles_operator/spo-enabling.adoc#spo-enabling[Enabling the Security Profiles Operator].
 
-You can create xref:../security_profiles_operator/spo-seccomp.adoc#spo-seccomp[seccomp] and xref:../security_profiles_operator/spo-selinux.adoc#spo-selinux[SELinux] profiles, bind policies to pods, record workloads, and synchronize all worker nodes in a namespace.
+You can create xref:../../security/security_profiles_operator/spo-seccomp.adoc#spo-seccomp[seccomp] and xref:../../security/security_profiles_operator/spo-selinux.adoc#spo-selinux[SELinux] profiles, bind policies to pods, record workloads, and synchronize all worker nodes in a namespace.
 
-Use xref:../security_profiles_operator/spo-advanced.adoc#spo-advanced[Advanced Security Profile Operator tasks] to enable the log enricher, configure webhooks and metrics, or restrict profiles to a single namespace.
+Use xref:../../security/security_profiles_operator/spo-advanced.adoc#spo-advanced[Advanced Security Profile Operator tasks] to enable the log enricher, configure webhooks and metrics, or restrict profiles to a single namespace.
 
-xref:../security_profiles_operator/spo-troubleshooting.adoc#[Troubleshoot the Security Profiles Operator] as needed, or engage link:https://access.redhat.com/support/[Red Hat support].
+xref:../../security/security_profiles_operator/spo-troubleshooting.adoc#[Troubleshoot the Security Profiles Operator] as needed, or engage link:https://access.redhat.com/support/[Red Hat support].
 
-You can xref:../security_profiles_operator/spo-uninstalling.adoc#spo-uninstalling[Uninstall the Security Profiles Operator] by removing the profiles before removing the Operator.
+You can xref:../../security/security_profiles_operator/spo-uninstalling.adoc#spo-uninstalling[Uninstall the Security Profiles Operator] by removing the profiles before removing the Operator.

--- a/security/security_profiles_operator/spo-release-notes.adoc
+++ b/security/security_profiles_operator/spo-release-notes.adoc
@@ -10,7 +10,7 @@ The Security Profiles Operator provides a way to define secure computing (https:
 
 These release notes track the development of the Security Profiles Operator in {product-title}.
 
-For an overview of the Security Profiles Operator, see xref:../security_profiles_operator/spo-overview.adoc#[Security Profiles Operator Overview].
+For an overview of the Security Profiles Operator, see xref:../../security/security_profiles_operator/spo-overview.adoc#[Security Profiles Operator Overview].
 
 [id="spo-release-notes-0-7-1"]
 == Security Profiles Operator 0.7.1


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-13691

Link to docs preview (VPN required):
[Security Profiles Operator overview](http://file.rdu.redhat.com/antaylor/OCPBUGS-13691/security/security_profiles_operator/spo-overview.html)
[Security Profiles Operator release notes](http://file.rdu.redhat.com/antaylor/OCPBUGS-13691/security/security_profiles_operator/spo-release-notes.html#spo-release-notes)

Additional information:
This PR fixes xref issues in the customer portal only - not an issue in docs.openshift.com. The syntax in the xrefs has been changed to meet our [guidelines](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#internal-cross-references).

These changes are NOT affected by the 4.13 release process and can wait to be merged after docs freeze. 
