### PR TITLE
[OSDOCS-4789]: Editorial feedback from manual cherrypick review

### DIFF
--- a/machine_management/deleting-machine.adoc
+++ b/machine_management/deleting-machine.adoc
@@ -28,5 +28,5 @@ include::modules/machine-lifecycle-hook-deletion-etcd.adoc[leveloffset=+2]
 [id="additional-resources_unhealthy-etcd-member"]
 == Additional resources
 
-* xref:../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc[Replacing an unhealthy etcd member]
+* xref:../backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.adoc#replacing-unhealthy-etcd-member[Replacing an unhealthy etcd member]
 * xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-using[Managing control plane machines with control plane machine sets]

--- a/modules/machine-lifecycle-hook-deletion-format.adoc
+++ b/modules/machine-lifecycle-hook-deletion-format.adoc
@@ -18,8 +18,8 @@ metadata:
 spec:
   lifecycleHooks:
     preDrain:
-    - name: <hook-name> <1>
-      owner: <hook-owner> <2>
+    - name: <hook_name> <1>
+      owner: <hook_owner> <2>
   ...
 ----
 <1> The name of the `preDrain` lifecycle hook.
@@ -35,8 +35,8 @@ metadata:
 spec:
   lifecycleHooks:
     preTerminate:
-    - name: <hook-name> <1>
-      owner: <hook-owner> <2>
+    - name: <hook_name> <1>
+      owner: <hook_owner> <2>
   ...
 ----
 <1> The name of the `preTerminate` lifecycle hook.

--- a/modules/machine-lifecycle-hook-deletion-uses.adoc
+++ b/modules/machine-lifecycle-hook-deletion-uses.adoc
@@ -6,7 +6,7 @@
 [id="machine-lifecycle-hook-deletion-uses_{context}"]
 = Machine deletion lifecycle hook examples for Operator developers
 
-Operators can use lifecycle hooks for the machine deletion phase to modify the machine deletion process. The following examples demonstrate possible ways that an Operator can use this functionality:
+Operators can use lifecycle hooks for the machine deletion phase to modify the machine deletion process. The following examples demonstrate possible ways that an Operator can use this functionality.
 
 [discrete]
 [id="machine-lifecycle-hook-deletion-uses-predrain_{context}"]

--- a/modules/machine-lifecycle-hook-deletion.adoc
+++ b/modules/machine-lifecycle-hook-deletion.adoc
@@ -27,7 +27,7 @@ In the context of machine deletion, the machine controller performs the followin
 * Delete the `Node` object.
 --
 
-Lifecycle hook:: A defined point in the reconciliation lifecycle of an object where the normal lifecycle process can be interrupted. Components can use a lifecycle hook to inject changes into the process to accomplish a desired outcome.
+Lifecycle hook:: A lifecycle hook is a defined point in the reconciliation lifecycle of an object where the normal lifecycle process can be interrupted. Components can use a lifecycle hook to inject changes into the process to accomplish a desired outcome.
 +
 There are two lifecycle hooks in the machine `Deleting` phase:
 --
@@ -35,7 +35,7 @@ There are two lifecycle hooks in the machine `Deleting` phase:
 * `preTerminate` lifecycle hooks must be resolved before the instance can be removed from the infrastructure provider.
 --
 
-Hook-implementing controller:: A controller, other than the machine controller, that can interact with a lifecycle hook. A hook-implementing controller can do one or more of the following actions:
+Hook-implementing controller:: A hook-implementing controller is a controller, other than the machine controller, that can interact with a lifecycle hook. A hook-implementing controller can do one or more of the following actions:
 +
 --
 * Add a lifecycle hook.


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OSDOCS-4789](https://issues.redhat.com//browse/OSDOCS-4789)

Link to docs preview (VPN required):
* [Terminology and definitions](http://file.rdu.redhat.com/~jrouth/OSDOCS-4789/machine_management/deleting-machine.html#machine-lifecycle-hook-deletion-terms_deleting-machine)
* [Deletion lifecycle hook configuration](http://file.rdu.redhat.com/~jrouth/OSDOCS-4789/machine_management/deleting-machine.html#machine-lifecycle-hook-deletion-format_deleting-machine)
* [Machine deletion lifecycle hook examples for Operator developers](http://file.rdu.redhat.com/~jrouth/OSDOCS-4789/machine_management/deleting-machine.html#machine-lifecycle-hook-deletion-uses_deleting-machine)

QE review:
- [ ] QE has approved this change.

Additional information:
* Holding for 4.13 GA
* IMO, no dev or QE review required for these changes
* Incorporates [Alex's feedback](https://github.com/openshift/openshift-docs/pull/59032#pullrequestreview-1400800436) from #59032, which was a manual cherrypick of #55175
