### PR TITLE
Oadp 1919 remove datamover snapshot hvider

### DIFF
--- a/modules/oadp-backup-restore-cr-issues.adoc
+++ b/modules/oadp-backup-restore-cr-issues.adoc
@@ -6,7 +6,7 @@
 [id="oadp-backup-restore-cr-issues_{context}"]
 = Backup and Restore CR issues
 
-You might encounter these common issues with `Backup` and `Restore` custom resources (CRs).
+The following issues may arise when performing `Backup` and `Restore` on custom resources (CRs).
 
 [id="backup-cannot-retrieve-volume_{context}"]
 == Backup CR cannot retrieve volume
@@ -29,7 +29,7 @@ The status of a `Backup` CR remains in the `InProgress` phase and does not compl
 
 .Cause
 
-If a backup is interrupted, it cannot be resumed.
+A backup that is interrupted cannot be resumed.
 
 .Solution
 
@@ -59,7 +59,7 @@ The status of a `Backup` CR without Restic in use remains in the `PartiallyFaile
 
 .Cause
 
-If the backup is created based on the CSI snapshot class, but the label is missing, CSI snapshot plugin fails to create a snapshot. As a result, the `Velero` pod logs an error similar to the following:
+If the backup is created based on the CSI snapshot class, but the label is missing, then the CSI snapshot plugin fails to create a snapshot. The `Velero` pod therefore logs an error similar to the following:
 +
 [source,text]
 ----
@@ -75,9 +75,9 @@ time="2023-02-17T16:33:13Z" level=error msg="Error backing up item" backup=opens
 $ oc delete backup <backup> -n openshift-adp
 ----
 
-. If required, clean up the stored data on the `BackupStorageLocation` to free up space.
+. If required, free up space by cleaning up the stored data on the `BackupStorageLocation`.
 
-. Apply label `velero.io/csi-volumesnapshot-class=true` to the `VolumeSnapshotClass` object:
+. Apply the label `velero.io/csi-volumesnapshot-class=true` to the `VolumeSnapshotClass` object:
 +
 [source,terminal]
 ----
@@ -94,12 +94,12 @@ $ oc label volumesnapshotclass/<snapclass_name> velero.io/csi-volumesnapshot-cla
 Applies to OADP 1.1.x and newer.
 ====
 
-Datamover may leave behind some older snapshots in the bucket, causing the system to recover an older backup. To prevent recovering an outdated backup, delete the folder with old snapshot, before creating a new snapshot.
+Datamover may leave behind some older snapshots in the bucket, causing the system to recover an older backup. To prevent recovering an outdated backup, delete the folder with old snapshot before creating a new snapshot.
 
 .Remove snapshots in bucket
 The snapshots are saved in your bucket specified in the `/<protected-ns> folder`, DPA'.spec.backupLocation.objectStorage.bucketw. Delete this folder to delete *all* snapshots in the bucket.
 
-Additional sub-folder(s) with the prefix z/<volumeSnapshotContent name>-pvc` may be inside the `/<protected-ns>` folder. These folders hold the _volumeSnapshotContent_ backups tht datamover created per PVC. Delete each of these sub-folder to delete *a single* snapshot in your bucket.
+Additional sub-folder(s) with the prefix z/<volumeSnapshotContent name>-pvc` may be inside the `/<protected-ns>` folder. These folders hold the _volumeSnapshotContent_ backups that datamover created per PVC. Delete each of these sub-folder to delete *a single* snapshot in your bucket.
 
 .Remove cluster resources
 The following scenarios can remove the cluster resources:
@@ -116,7 +116,7 @@ volumeSnapshotBackup/VolumeSnapshotRestore CRs are still in the application name
 oc delete vsb -n <app-ns> --all
 ----
 
-* Datamover retore:
+* Datamover restore:
 
 +
 [source, text]

--- a/modules/oadp-backup-restore-cr-issues.adoc
+++ b/modules/oadp-backup-restore-cr-issues.adoc
@@ -85,3 +85,68 @@ $ oc label volumesnapshotclass/<snapclass_name> velero.io/csi-volumesnapshot-cla
 ----
 
 . Create a new `Backup` CR.
+
+[id="backup-cr-remains-partiallyfailed_{context}"]
+== Datamover backup cleanup
+
+[NOTE]
+====
+Applies to OADP 1.1.x and newer.
+====
+
+Datamover may leave behind some older snapshots in the bucket, causing the system to recover an older backup. To prevent recovering an outdated backup, delete the folder with old snapshot, before creating a new snapshot.
+
+.Remove snapshots in bucket
+The snapshots are saved in your bucket specified in the `/<protected-ns> folder`, DPA'.spec.backupLocation.objectStorage.bucketw. Delete this folder to delete *all* snapshots in the bucket.
+
+Additional sub-folder(s) with the prefix z/<volumeSnapshotContent name>-pvc` may be inside the `/<protected-ns>` folder. These folders hold the _volumeSnapshotContent_ backups tht datamover created per PVC. Delete each of these sub-folder to delete *a single* snapshot in your bucket.
+
+.Remove cluster resources
+The following scenarios can remove the cluster resources:
+
+. Datamover completes
+
+volumeSnapshotBackup/VolumeSnapshotRestore CRs are still in the application namespace.
+
+* Datamover backup:
+
++
+[source, text]
+----
+oc delete vsb -n <app-ns> --all
+----
+
+* Datamover retore:
+
++
+[source, text]
+----
+oc delete vsr -n <app-ns> --all
+----
+
+. Datamover partiallyFails or Fails:
+
+VSB/VSR CRs exist in the application namespace, as well as extra resources created by these controllers.
+
+* Datamover backup:
+
++
+[source, text]
+----
+oc delete vsb -n <app-ns> --all
+oc delete volumesnapshot -A --all
+oc delete volumesnapshotcontent --all
+oc delete pvc -n <protected-ns> --all
+oc delete replicationsource -n <protected-ns> --all
+----
+
+* Datamover restore:
+
++
+[source, text]
+----
+oc delete vsr -n <app-ns> --all
+oc delete volumesnapshot -A --all
+oc delete volumesnapshotcontent --all
+oc delete replicationdestination -n <protected-ns> --all
+----

--- a/modules/oadp-backup-restore-cr-issues.adoc
+++ b/modules/oadp-backup-restore-cr-issues.adoc
@@ -91,7 +91,7 @@ $ oc label volumesnapshotclass/<snapclass_name> velero.io/csi-volumesnapshot-cla
 
 [NOTE]
 ====
-Applies to OADP 1.1.x and newer.
+Applies to OADP 1.1.
 ====
 
 Datamover may leave behind some older snapshots in the bucket, causing the system to recover an older backup. To prevent recovering an outdated backup, delete the folder with old snapshot before creating a new snapshot.
@@ -114,6 +114,10 @@ volumeSnapshotBackup/VolumeSnapshotRestore CRs are still in the application name
 [source, text]
 ----
 oc delete vsb -n <app-ns> --all
+oc delete volumesnapshot -A --all
+oc delete volumesnapshotcontent --all
+oc delete pvc -n <protected-ns> --all
+oc delete replicationsource -n <protected-ns> --all
 ----
 
 * Datamover restore:

--- a/modules/oadp-backup-restore-cr-issues.adoc
+++ b/modules/oadp-backup-restore-cr-issues.adoc
@@ -86,7 +86,7 @@ $ oc label volumesnapshotclass/<snapclass_name> velero.io/csi-volumesnapshot-cla
 
 . Create a new `Backup` CR.
 
-[id="backup-cr-remains-partiallyfailed_{context}"]
+[id="datamover-backup-cleanup_{context}"]
 == Datamover backup cleanup
 
 [NOTE]


### PR DESCRIPTION
@anarnold97

GH# : 
OCPBUGS# : [OADP-1919](https://issues.redhat.com//browse/OADP-1919)
OSDOCS# : [OADP-1919](https://issues.redhat.com//browse/OADP-1919)

Added a procedure at the end to remove old snapshots from the DataMover bucket.


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 1.1.x and newer
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OADP-1919](https://issues.redhat.com//browse/OADP-1919) OADP-1.1: Data Mover can restore from incorrect snapshot when >1 VSR for the restore name and PVC name exists.
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
