### PR TITLE
OCPBUGS#13383: affinity rules in the YAML correction

### DIFF
--- a/modules/virt-example-vm-node-placement-node-affinity.adoc
+++ b/modules/virt-example-vm-node-placement-node-affinity.adoc
@@ -17,24 +17,26 @@ metadata:
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution: <1>
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: example.io/example-key
-            operator: In
-            values:
-            - example-value-1
-            - example-value-2
-      preferredDuringSchedulingIgnoredDuringExecution: <2>
-      - weight: 1
-        preference:
-          matchExpressions:
-          - key: example-node-label-key
-            operator: In
-            values:
-            - example-node-label-value
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: <1>
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: example.io/example-key
+                operator: In
+                values:
+                - example-value-1
+                - example-value-2
+          preferredDuringSchedulingIgnoredDuringExecution: <2>
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: example-node-label-key
+                operator: In
+                values:
+                - example-node-label-value
 # ...
 ----
 <1> If you use the `requiredDuringSchedulingIgnoredDuringExecution` rule type, the VM is not scheduled if the constraint is not met.

--- a/modules/virt-example-vm-node-placement-pod-affinity.adoc
+++ b/modules/virt-example-vm-node-placement-pod-affinity.adoc
@@ -17,27 +17,29 @@ metadata:
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
-  affinity:
-    podAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution: <1>
-      - labelSelector:
-          matchExpressions:
-          - key: example-key-1
-            operator: In
-            values:
-            - example-value-1
-        topologyKey: kubernetes.io/hostname
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution: <2>
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: example-key-2
-              operator: In
-              values:
-              - example-value-2
-          topologyKey: kubernetes.io/hostname
+  template:
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: <1>
+          - labelSelector:
+              matchExpressions:
+              - key: example-key-1
+                operator: In
+                values:
+                - example-value-1
+            topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution: <2>
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: example-key-2
+                  operator: In
+                  values:
+                  - example-value-2
+              topologyKey: kubernetes.io/hostname
 # ...
 ----
 <1> If you use the `requiredDuringSchedulingIgnoredDuringExecution` rule type, the VM is not scheduled if the constraint is not met.


### PR DESCRIPTION
**Version(s):**
4.12+

**Issue:** OCPBUGS-13383

**Link to docs preview:**
https://danielclowers.github.io/rh-previews/OCPBUGS-13383/virt/virtual_machines/advanced_vm_management/virt-specifying-nodes-for-vms.html#virt-example-vm-node-placement-pod-affinity_virt-specifying-nodes-for-vms

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
NA