### PR TITLE
fixing a link that PV1 is mad about

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -859,7 +859,7 @@ For clusters that run on {rh-openstack} and use OVN-Kubernetes, manually reassig
 [id="ocp-4-13-networking-supported-hardware-for-sr-iov"]
 ==== Supported hardware for SR-IOV (Single Root I/O Virtualization)
 
-{product-title} {product-version} adds support for the following SR-IOV devices: 
+{product-title} {product-version} adds support for the following SR-IOV devices:
 
 * Intel E810-XXVDA4T
 
@@ -1377,7 +1377,7 @@ For more information, see xref:../updating/updating-restricted-network-cluster/r
 [id="ocp-4-13-ocm-nodeip-configuration-service"]
 === The nodeip-configuration service is now enabled on a vSphere user-provisioned infrastructure cluster
 
-In {product-title} {product-version}, the `nodeip-configuration` service is now enabled on a vSphere user-provisioned infrastructure cluster. This service determines the network interface controller (NIC) that {product-title} uses for communication with the Kubernetes API server when the node boots. In rare circumstances, the service might select an incorrect node IP after an upgrade. If this happens, you can use the `NODEIP_HINT` feature to restore the original node IP. See xref:../support/troubleshooting/troubleshooting-network-issues.adoc_troubleshooting-network-issues[Troubleshooting network issues].
+In {product-title} {product-version}, the `nodeip-configuration` service is now enabled on a vSphere user-provisioned infrastructure cluster. This service determines the network interface controller (NIC) that {product-title} uses for communication with the Kubernetes API server when the node boots. In rare circumstances, the service might select an incorrect node IP after an upgrade. If this happens, you can use the `NODEIP_HINT` feature to restore the original node IP. See xref:../support/troubleshooting/troubleshooting-network-issues.adoc#troubleshooting-network-issues[Troubleshooting network issues].
 
 [discrete]
 [id="ocp-4-13-operator-sdk-1-28-z"]


### PR DESCRIPTION
http://file.rdu.redhat.com/kalexand/4.13_build_errors/release_notes/ocp-4-13-release-notes.html#ocp-4-13-ocm-nodeip-configuration-service