### PR TITLE
[no jira][virt] RN note re: unsupported update path

### DIFF
--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -28,6 +28,10 @@ xref:../virt/install/preparing-cluster-for-virt.adoc#preparing-cluster-for-virt[
 
 include::modules/virt-supported-cluster-version.adoc[leveloffset=+2]
 
+[IMPORTANT]
+====
+Updating to {VirtProductName} 4.13 from {VirtProductName} 4.12.2 is not supported.
+====
 
 [id="virt-guest-os"]
 === Supported guest operating systems


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): no CP for this one (RN)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: no jira
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/pousley/unsupported-update-path-rn/virt/virt-4-13-release-notes.html#virt-supported-cluster-version_virt-4-13-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR is necessary for 4.13 GA due to a late-breaking discovery that it is possible to update via an unsupported update path.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
