### PR TITLE
[no jira][virt] unsupported update path note in update assembly

### DIFF
--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Learn how Operator Lifecycle Manager (OLM) delivers z-stream and minor version updates for {VirtProductName}.
 
+[IMPORTANT]
+====
+Updating to {VirtProductName} 4.13 from {VirtProductName} 4.12.2 is not supported.
+====
+
 [NOTE]
 ====
 * The Node Maintenance Operator (NMO) is no longer shipped with {VirtProductName}. You can *install the NMO* from the *OperatorHub* in the {product-title} web console, or by using the OpenShift CLI (`oc`). For more information on remediation, fencing, and maintaining nodes, see the link:https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift/23.2/html-single/remediation_fencing_and_maintenance/index#about-remediation-fencing-maintenance[Workload Availability for Red Hat OpenShift] documentation.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): CP to 4.13 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: no jira
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/pousley/unsupported-update-path-main/virt/upgrading-virt.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR is necessary for 4.13 GA due to a late-breaking discovery that it is possible to update via an unsupported update path.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
