### PR TITLE
[no jira][virt] Removing outdated note from update docs

### DIFF
--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -13,16 +13,6 @@ Learn how Operator Lifecycle Manager (OLM) delivers z-stream and minor version u
 Updating to {VirtProductName} 4.13 from {VirtProductName} 4.12.2 is not supported.
 ====
 
-[NOTE]
-====
-* The Node Maintenance Operator (NMO) is no longer shipped with {VirtProductName}. You can *install the NMO* from the *OperatorHub* in the {product-title} web console, or by using the OpenShift CLI (`oc`). For more information on remediation, fencing, and maintaining nodes, see the link:https://access.redhat.com/documentation/en-us/workload_availability_for_red_hat_openshift/23.2/html-single/remediation_fencing_and_maintenance/index#about-remediation-fencing-maintenance[Workload Availability for Red Hat OpenShift] documentation.
-+
-You must perform one of the following tasks before updating to {VirtProductName} 4.11 from {VirtProductName} 4.10.2 and later releases:
-
-** Move all nodes out of maintenance mode.
-** Install the standalone NMO and replace the `nodemaintenances.nodemaintenance.kubevirt.io` custom resource (CR) with a `nodemaintenances.nodemaintenance.medik8s.io` CR.
-====
-
 // todo: uncomment when z-stream releases
 //include::modules/virt-rhel-9.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): CP to 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: no jira
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/pousley/remove-old-update-note/virt/upgrading-virt.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This outdated note was only meant for 4.11 and needs to be removed from 4.12+. Requesting an exception to merge this before 4.13 releases.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
