### PR TITLE
attempting to fix logging book on the portal

### DIFF
--- a/logging/v5_7/logging-5-7-getting-started.adoc
+++ b/logging/v5_7/logging-5-7-getting-started.adoc
@@ -4,4 +4,4 @@
 = Getting started with logging 5.7
 
 :context: logging-5-7-getting-started
-include::modules/logging-getting-started.adoc[lines=5..39]
+include::modules/logging-getting-started.adoc[lines=5..38]


### PR DESCRIPTION
http://file.rdu.redhat.com/kalexand/4.13_build_errors/logging/v5_7/logging-5-7-getting-started.html and http://file.rdu.redhat.com/kalexand/4.13_build_errors/logging/v5_7/logging-5-7-architecture.html should look just like the live versions at https://docs.openshift.com/container-platform/4.13/logging/v5_7/logging-5-7-getting-started.html and https://docs.openshift.com/container-platform/4.13/logging/v5_7/logging-5-7-architecture.html. This should fix https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html-single/logging/index#logging-getting-started-5-7.