### PR TITLE
[enterprise-4.12][no jira][virt] Removing outdated note from update docs

### DIFF
--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -8,16 +8,6 @@ toc::[]
 
 Learn how Operator Lifecycle Manager (OLM) delivers z-stream and minor version updates for {VirtProductName}.
 
-[NOTE]
-====
-* The Node Maintenance Operator (NMO) is no longer shipped with {VirtProductName}. You can xref:../nodes/nodes/ecosystems/eco-node-maintenance-operator.adoc#node-maintenance-operator[install the NMO] from the *OperatorHub* in the {product-title} web console, or by using the OpenShift CLI (`oc`).
-+
-You must perform one of the following tasks before updating to {VirtProductName} 4.11 from {VirtProductName} 4.10.2 and later releases:
-
-** Move all nodes out of maintenance mode.
-** Install the standalone NMO and replace the `nodemaintenances.nodemaintenance.kubevirt.io` custom resource (CR) with a `nodemaintenances.nodemaintenance.medik8s.io` CR.
-====
-
 include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]
 
 include::modules/virt-about-workload-updates.adoc[leveloffset=+2]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Cherry Picked from 9af1e9e5ad807039c6d6575cf914c51b52fff456 xref: https://github.com/openshift/openshift-docs/pull/60103 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 only (manual CP)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: N/A
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
