### PR TITLE
[multiple]: AWS and Azure CCMs TP to GA

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-This Operator is General Availability for Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and VMware vSphere.
+The status of this Operator is General Availability for Amazon Web Services (AWS), global Microsoft Azure, Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and VMware vSphere.
 
-It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud, IBM Cloud Power VS, and Microsoft Azure.
+The Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Google Cloud Platform (GCP), IBM Cloud, and IBM Cloud Power VS.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-5772](https://issues.redhat.com//browse/OSDOCS-5772) (AWS)
~[OSDOCS-6092](https://issues.redhat.com//browse/OSDOCS-6092) (GCP)~
[OSDOCS-5769](https://issues.redhat.com//browse/OSDOCS-5769) (Azure)

Link to docs preview:
[Cluster Cloud Controller Manager Operator](https://60107--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information:
Cluster Operators reference updates for AWS, GCP, and Azure CCMs going GA. Subtasks of [OSDOCS-5770](https://issues.redhat.com//browse/OSDOCS-5770), ~[OSDOCS-6090](https://issues.redhat.com//browse/OSDOCS-6090),~ and [OSDOCS-5767](https://issues.redhat.com//browse/OSDOCS-5767) respectively.