### PR TITLE
Fix a field name cloudFront

### DIFF
--- a/modules/registry-operator-configuration-resource-overview-aws-s3.adoc
+++ b/modules/registry-operator-configuration-resource-overview-aws-s3.adoc
@@ -38,7 +38,7 @@ It is optional and defaults to false.
 |KeyID is the KMS key ID to use for encryption. It is optional. Encrypt must be
 true, or this parameter is ignored.
 
-|`ImageRegistryConfigStorageS3CloudFront`
+|`cloudFront`
 |CloudFront configures Amazon Cloudfront as the storage middleware in a registry.
 It is optional.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Half of https://issues.redhat.com/browse/OCPBUGS-9417

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

To be aligned with the code:
```console
oc explain config.spec.storage.s3 --api-version imageregistry.operator.openshift.io/v1
KIND:     Config
VERSION:  imageregistry.operator.openshift.io/v1

RESOURCE: s3 <Object>

DESCRIPTION:
     s3 represents configuration that uses Amazon Simple Storage Service.

FIELDS:
   bucket	<string>
     bucket is the bucket name in which you want to store the registry's data.
     Optional, will be generated if not provided.

   cloudFront	<Object>
     cloudFront configures Amazon Cloudfront as the storage middleware in a
     registry.

   encrypt	<boolean>
     encrypt specifies whether the registry stores the image in encrypted format
     or not. Optional, defaults to false.

   keyID	<string>
     keyID is the KMS key ID to use for encryption. Optional, Encrypt must be
     true, or this parameter is ignored.

   region	<string>
     region is the AWS region in which your bucket exists. Optional, will be set
     based on the installed AWS Region.

   regionEndpoint	<string>
     regionEndpoint is the endpoint for S3 compatible storage services. It
     should be a valid URL with scheme, e.g. https://s3.example.com. Optional,
     defaults based on the Region that is provided.

   trustedCA	<Object>
     trustedCA is a reference to a config map containing a CA bundle. The image
     registry and its operator use certificates from this bundle to verify S3
     server certificates. The namespace for the config map referenced by
     trustedCA is "openshift-config". The key for the bundle in the config map
     is "ca-bundle.crt".

   virtualHostedStyle	<boolean>
     virtualHostedStyle enables using S3 virtual hosted style bucket paths with
     a custom RegionEndpoint Optional, defaults to false.
```

/cc @openshift/team-documentation