### PR TITLE
Fix git rev parse error to enable preview builds

### DIFF
--- a/autopreview.sh
+++ b/autopreview.sh
@@ -6,11 +6,11 @@ set -ev
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then #to make sure it only runs on PRs and not all merges
     USERNAME=${TRAVIS_PULL_REQUEST_SLUG::-15}
-    COMMIT_HASH="$(git rev-parse @~)"
-    mapfile -t FILES_CHANGED < <(git diff --name-only "$COMMIT_HASH")
+    # COMMIT_HASH="$(git rev-parse @~)"
+    # mapfile -t FILES_CHANGED < <(git diff --name-only "$COMMIT_HASH")
 
     if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "main" ] ; then # to make sure it does not run for direct main changes
-        if [[ " ${FILES_CHANGED[*]} " = *".adoc"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_topic_map.yml"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_distro_map.yml"* ]] ; then # to make sure this doesn't run for general modifications
+        # if [[ " ${FILES_CHANGED[*]} " = *".adoc"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_topic_map.yml"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_distro_map.yml"* ]] ; then # to make sure this doesn't run for general modifications
             if [ "$USERNAME" != "openshift-cherrypick-robot" ] ; then # to make sure it doesn't run for USERNAME openshift-cherrypick-robot
                 echo "{\"PR_BRANCH\":\"${TRAVIS_PULL_REQUEST_BRANCH}\",\"BASE_REPO\":\"${TRAVIS_REPO_SLUG}\",\"PR_NUMBER\":\"${TRAVIS_PULL_REQUEST}\",\"USER_NAME\":\"${USERNAME}\",\"BASE_REF\":\"${TRAVIS_BRANCH}\",\"REPO_NAME\":\"${TRAVIS_PULL_REQUEST_SLUG}\",\"SHA\":\"${TRAVIS_PULL_REQUEST_SHA}\"}" > buildset.json
 
@@ -20,9 +20,9 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then #to make sure it only runs on PR
             else
                 echo -e "\\n\\033[0;32m[✓] Skipping preview build for openshift-cherrypick-robot.\\033[0m"
             fi
-        else
-            echo -e "\\n\\033[1;33m[!] No .adoc files modified, not building a preview.\\033[0m"
-        fi
+        # else
+        #     echo -e "\\n\\033[1;33m[!] No .adoc files modified, not building a preview.\\033[0m"
+        # fi
     else
         echo -e "\\n\\033[1;33m[!] Direct PR for main branch, not building a preview.\\033[0m"
     fi


### PR DESCRIPTION
**Issue**
PR [preview builds were failing](https://app.travis-ci.com/github/openshift/openshift-docs/jobs/602287312#L178-L179) because the command `git rev-parse @~` which previously worked fine started failing. 
```
git rev-parse @~
fatal: ambiguous argument '@~': unknown revision or path not in the working tree.
```

**Temp Fix**
Skip the part where it checks if only `*.adoc` files are modified. 

