### PR TITLE
Fix the `autopreview.sh` script

### DIFF
--- a/autopreview.sh
+++ b/autopreview.sh
@@ -1,31 +1,68 @@
 #!/bin/bash
-set -ev
 
-#ALLOWED_USERS=("aireilly" "mburke5678" "vikram-redhat" "abrennan89" "ahardin-rh" "kalexand-rh" "adellape" "bmcelvee" "ousleyp" "lamek" "JStickler" "rh-max" "bergerhoffer" "sheriff-rh" "jboxman" "bobfuru" "aburdenthehand" "boczkowska" "Preeticp" "neal-timpe" "codyhoag" "apinnick" "bgaydosrh" "lmandavi" "maxwelldb" "pneedle-rh" "lbarbeevargas" "jeana-redhat" "RichardHoch" "johnwilkins" "sjhala-ccs" "mgarrellRH" "SNiemann15" "sfortner-RH" "jonquilwilliams" "ktania46" "wking" "
-#jc-berger" "rishumehra" "iranzo" "abhatt-rh" "@mohit-sheth" "stoobie" "emarcusRH" "kquinn1204" "mikemckiernan" "skrthomas" "sagidlow" "rolfedh")
+set -e
 
-if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then #to make sure it only runs on PRs and not all merges
-    USERNAME=${TRAVIS_PULL_REQUEST_SLUG::-15}
-    # COMMIT_HASH="$(git rev-parse @~)"
-    # mapfile -t FILES_CHANGED < <(git diff --name-only "$COMMIT_HASH")
+# Define colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
 
-    if [ "${TRAVIS_PULL_REQUEST_BRANCH}" != "main" ] ; then # to make sure it does not run for direct main changes
-        # if [[ " ${FILES_CHANGED[*]} " = *".adoc"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_topic_map.yml"* ]] || [[ " ${FILES_CHANGED[*]} " = *"_distro_map.yml"* ]] ; then # to make sure this doesn't run for general modifications
-            if [ "$USERNAME" != "openshift-cherrypick-robot" ] ; then # to make sure it doesn't run for USERNAME openshift-cherrypick-robot
-                echo "{\"PR_BRANCH\":\"${TRAVIS_PULL_REQUEST_BRANCH}\",\"BASE_REPO\":\"${TRAVIS_REPO_SLUG}\",\"PR_NUMBER\":\"${TRAVIS_PULL_REQUEST}\",\"USER_NAME\":\"${USERNAME}\",\"BASE_REF\":\"${TRAVIS_BRANCH}\",\"REPO_NAME\":\"${TRAVIS_PULL_REQUEST_SLUG}\",\"SHA\":\"${TRAVIS_PULL_REQUEST_SHA}\"}" > buildset.json
+USERNAME=${TRAVIS_PULL_REQUEST_SLUG::-15}
 
-                curl -H 'Content-Type: application/json' --request POST --data @buildset.json "https://ocpdocs-preview-receiver.vercel.app/api/buildPreview"
+if [[ "$USERNAME" == "openshift-cherrypick-robot" ]]; then
+    echo -e "${YELLOW}🤖 PR by openshift-cherrypick-robot. Skipping the preview.${NC}"
+    exit 0
+fi
 
-                echo -e "\\n\\033[0;32m[✓] Sent request for building a preview.\\033[0m"
+if [[ "$TRAVIS_PULL_REQUEST" ]]; then
+    # Check if modified files meet the conditions
+    COMMIT_HASH="$(git rev-parse @~)"
+    modified_files=$(git diff --name-only "$COMMIT_HASH")
+    send_request=false
+
+    for file in $modified_files; do
+        if [[ $file == *.adoc || $file == "_topic_map.yml" || $file == "_distro_map.yml" ]]; then
+            send_request=true
+            break
+        fi
+    done
+
+    if [ "$send_request" = true ]; then
+        # Build the JSON
+        json_data=$(
+            cat <<EOF
+{
+"PR_BRANCH": "${TRAVIS_PULL_REQUEST_BRANCH}",
+"BASE_REPO": "${TRAVIS_REPO_SLUG}",
+"PR_NUMBER": "${TRAVIS_PULL_REQUEST}",
+"USER_NAME": "${USERNAME}",
+"BASE_REF": "${TRAVIS_BRANCH}",
+"REPO_NAME": "${TRAVIS_PULL_REQUEST_SLUG}",
+"SHA": "${TRAVIS_PULL_REQUEST_SHA}"
+}
+EOF
+        )
+
+        # Send the curl request
+        if response=$(curl -s -X POST -H "Content-Type: application/json" --data "$json_data" https://ocpdocs-preview-receiver.vercel.app/api/buildPreview); then
+            if echo "$response" | jq -e '.message == "Invalid data!"' >/dev/null; then
+                echo -e "${RED}❌😔 Curl request failed: Invalid data!${NC}"
+                echo -e "${YELLOW}$json_data${NC}"
+                exit 1
             else
-                echo -e "\\n\\033[0;32m[✓] Skipping preview build for openshift-cherrypick-robot.\\033[0m"
+                echo -e "${GREEN}✅🥳 $response${NC}"
             fi
-        # else
-        #     echo -e "\\n\\033[1;33m[!] No .adoc files modified, not building a preview.\\033[0m"
-        # fi
+        else
+            echo -e "${RED}❌😬 Curl request failed: $response${NC}"
+            echo -e "${YELLOW}$json_data${NC}"
+            exit 1
+        fi
+
+        echo -e "${GREEN}🚀🎉 Request sent successfully!${NC}"
     else
-        echo -e "\\n\\033[1;33m[!] Direct PR for main branch, not building a preview.\\033[0m"
+        echo -e "${YELLOW}⚠️🤔 No .adoc files, _topic_map.yml, or _distro_map.yml modified. Skipping the preview.${NC}"
     fi
 else
-    echo -e "\\n\\033[1;33m[!] Not a PR, not building a preview.\\033[0m"
+    echo -e "${YELLOW}❗🙅‍♀️ Not a Pull request. Skipping the preview.${NC}"
 fi


### PR DESCRIPTION
**Changes**
- Updated the `autopreview.sh` script to:
  - Check for the response and fail the job if the server responds with `Invalid data` or if the `curl` request fails.
  - Updated the logic to skip quickly if preview is not required.
  - Cleaned out commented unwanted lines
  - Added emojis 🥳 

Chery-pick into:
- `enterprise-4.12`
- `enterprise-4.13`
- `enterprise-4.14`