### PR TITLE
Fail the build when Asciidoctor errors are encountered

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,21 @@ cache: pip
 # env:
 #   - PR_AUTHOR=${TRAVIS_PULL_REQUEST_SLUG::-15}
 git:
-  depth: 1
+  depth: 2
 jobs:
   allow_failures:
     env:
       - CAN_FAIL=true
   include:
+    # fail if asciidoctor encounters errors
+    - stage: validate
+      name: "Validate updated assemblies with Asciidoctor"
+      install:
+        - gem install asciidoctor
+        - gem install asciidoctor-diagram
+      script:
+        - chmod +x ./scripts/check-asciidoctor-build.sh
+        - ./scripts/check-asciidoctor-build.sh
     - stage: build
       name: "Build openshift-enterprise distro"
       before_install:
@@ -81,6 +90,7 @@ jobs:
         - chmod +x autopreview.sh && ./autopreview.sh
 
 stages:
+  - validate
   - build
   - netlify
   #- check-with-vale

--- a/scripts/check-asciidoctor-build.sh
+++ b/scripts/check-asciidoctor-build.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+set -e
+
+# ensure asciidoctor is installed
+if ! command -v asciidoctor &>/dev/null ;
+then
+    echo "Asciidoctor is not installed. Please install it and try again."
+    exit 127
+fi
+
+# get the *.adoc modules and assemblies in the pull request
+FILES=$(git diff --name-only HEAD~1 HEAD --diff-filter=d "*.adoc")
+
+REPO_PATH=$(git rev-parse --show-toplevel)
+
+# get the modules in the PR, search for assemblies that include them, and concat with any updated assemblies files
+check_updated_assemblies () {
+    MODULES=$(echo "$FILES" | awk '/modules\/(.*)\.adoc/')
+    if [ "${MODULES}" ]
+    then
+        # $UPDATED_ASSEMBLIES is the list of assemblies that contains changed modules
+        UPDATED_ASSEMBLIES=$(grep -rnwl "$REPO_PATH" --include=\*.adoc --exclude-dir={snippets,modules} -e "$MODULES")
+        # subtract $REPO_PATH from path with bash substring replacement
+        UPDATED_ASSEMBLIES=${UPDATED_ASSEMBLIES//"$REPO_PATH/"/}
+    fi
+    # $ASSEMBLIES is the list of modifed assemblies
+    ASSEMBLIES=$(echo "$FILES" | awk '!/modules\/(.*)\.adoc/')
+    # concatenate both lists and remove dupe entries
+    ALL_ASSEMBLIES=$(echo "$UPDATED_ASSEMBLIES $ASSEMBLIES" | tr ' ' '\n' | sort -u)
+    # validate the assemblies
+    echo "Validating updated assemblies. Validation will fail with FAILED, ERROR, or WARNING messages..."
+    asciidoctor $ALL_ASSEMBLIES -a icons! -o /dev/null -v --failure-level WARN
+}
+
+# check assemblies and fail if errors are reported
+if [ -n "${FILES}" ] ;
+then
+    check_updated_assemblies
+else
+    echo "No modified AsciiDoc files found."
+fi


### PR DESCRIPTION
Adds a script `check-asciidoctor-build.sh` that quickly checks AsciiDoc files for errors in the PR. This can be used to prevent broken content getting merged. 

the following errors will cause the build to fail: 

* `asciidoctor: FAILED`
* `asciidoctor: ERROR`
* `asciidoctor: WARNING`

It does not run a full build of the repo, so should not add more than a few seconds to the build.

Also updated the travis build to make use of the script and fail the build if AsciiDoc errors are found.

Example failed build log: https://app.travis-ci.com/github/openshift/openshift-docs/jobs/602375801#L272

In the example, the build failed because a leveloffset is out of whack.