### PR TITLE
OSDOCS-5746

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -206,6 +206,11 @@ You can reference the ARN of your KMS key when you create the cluster in the nex
 
 . Create a cluster with STS using custom installation options. You can use the `--interactive` mode to interactively specify custom settings:
 +
+[IMPORTANT]
+====
+To avoid cluster failure issues, do not install a ROSA cluster in an existing VPC created by the previous cluster's ROSA installer. If the cluster that created the VPC during the installation is deleted, the associated installer-created VPC also gets deleted, resulting in the failure of all the clusters installed in the same VPC.
+====
++
 [source,terminal]
 ----
 $ rosa create cluster --interactive --sts

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -284,6 +284,11 @@ If you are using private API endpoints, you cannot access your cluster until you
 
 . Optional: If you opted to use public API endpoints, by default a new VPC is created for your cluster. If you want to install your cluster in an existing VPC instead, select *Install into an existing VPC*.
 +
+[IMPORTANT]
+====
+To avoid cluster failure issues, do not install a ROSA cluster in an existing VPC created by the previous cluster's ROSA installer. If the cluster that created the VPC during the installation is deleted, the associated installer-created VPC also gets deleted, resulting in the failure of all the clusters installed in the same VPC.
+====
++
 [NOTE]
 ====
 If you opted to use private API endpoints, you must use an existing VPC and PrivateLink and the *Install into an existing VPC* and *Use a PrivateLink* options are automatically selected. With these options, the Red Hat Site Reliability Engineering (SRE) team can connect to the cluster to assist with support by using only AWS PrivateLink endpoints.


### PR DESCRIPTION
[OSDOCS-5746](https://issues.redhat.com/browse/OSDOCS-5746): Hive deprovisioner removed load balancers on second cluster in VPC

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OSDOCS-5746](https://issues.redhat.com/browse/OSDOCS-5746)
Preview pages: [Click here to see the build preview in your browser](https://60117--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html)
SME Review **completed**: @oarribas
QE review **completed**: @xueli181114 
Peer-review **completed**: @GroceryBoyJr