### PR TITLE
Telcodocs-1038 updating IRQ lb guidance

### DIFF
--- a/modules/cnf-about-irq-affinity-setting.adoc
+++ b/modules/cnf-about-irq-affinity-setting.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// scalability_and_performance/cnf-low-latency-tuning.adoc
+
+:_content-type: CONCEPT
+[id="about_irq_affinity_setting_{context}"]
+= About support of IRQ affinity setting
+
+Some IRQ controllers lack support for IRQ affinity setting and will always expose all online CPUs as the IRQ mask. These IRQ controllers effectively run on CPU 0.
+
+The following are examples of drivers and hardware that Red Hat are aware lack support for IRQ affinity setting. The list is, by no means, exhaustive:
+
+* Some RAID controller drivers, such as `megaraid_sas`
+* Many non-volatile memory express (NVMe) drivers
+* Some LAN on motherboard (LOM) network controllers
+* The driver uses `managed_irqs`
+
+[NOTE]
+====
+The reason they do not support IRQ affinity setting might be associated with factors such as the type of processor, the IRQ controller, or the circuitry connections in the motherboard.
+====
+
+If the effective affinity of any IRQ is set to an isolated CPU, it might be a sign of some hardware or driver not supporting IRQ affinity setting. To find the effective affinity, log in to the host and run the following command:
+
+[source,terminal]
+----
+$ find /proc/irq/ -name effective_affinity -exec sh -c 'i="$1"; mask=$(cat $i); file=$(echo $i); echo $file: $mask' _ {} \;
+----
+
+.Example output
+
+[source,terminal]
+----
+/proc/irq/0/effective_affinity: 1
+/proc/irq/1/effective_affinity: 8
+/proc/irq/2/effective_affinity: 0
+/proc/irq/3/effective_affinity: 1
+/proc/irq/4/effective_affinity: 2
+/proc/irq/5/effective_affinity: 1
+/proc/irq/6/effective_affinity: 1
+/proc/irq/7/effective_affinity: 1
+/proc/irq/8/effective_affinity: 1
+/proc/irq/9/effective_affinity: 2
+/proc/irq/10/effective_affinity: 1
+/proc/irq/11/effective_affinity: 1
+/proc/irq/12/effective_affinity: 4
+/proc/irq/13/effective_affinity: 1
+/proc/irq/14/effective_affinity: 1
+/proc/irq/15/effective_affinity: 1
+/proc/irq/24/effective_affinity: 2
+/proc/irq/25/effective_affinity: 4
+/proc/irq/26/effective_affinity: 2
+/proc/irq/27/effective_affinity: 1
+/proc/irq/28/effective_affinity: 8
+/proc/irq/29/effective_affinity: 4
+/proc/irq/30/effective_affinity: 4
+/proc/irq/31/effective_affinity: 8
+/proc/irq/32/effective_affinity: 8
+/proc/irq/33/effective_affinity: 1
+/proc/irq/34/effective_affinity: 2
+----
+
+Some drivers use `managed_irqs`, whose affinity is managed internally by the kernel and userspace cannot change the affinity. In some cases, these IRQs might be assigned to isolated CPUs. For more information about `managed_irqs`, see link:https://access.redhat.com/solutions/4819541[Affinity of managed interrupts cannot be changed even if they target isolated CPU].

--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -2,6 +2,7 @@
 //
 // scalability_and_performance/cnf-low-latency-tuning.adoc
 
+:_content-type: PROCEDURE
 [id="configuring_for_irq_dynamic_load_balancing_{context}"]
 = Configuring a node for IRQ dynamic load balancing
 
@@ -9,7 +10,7 @@ Configure a cluster node for IRQ dynamic load balancing to control which cores c
 
 .Prerequisites
 
-* For core isolation, all server hardware components must support IRQ affinity. For more information, see the _Additional resources_ section. 
+* For core isolation, all server hardware components must support IRQ affinity. To check if the hardware components of your server support IRQ affinity, view the server's hardware specifications or contact your hardware provider.
 
 .Procedure
 
@@ -94,7 +95,7 @@ $ oc exec -it dynamic-irq-pod -- /bin/bash -c "grep Cpus_allowed_list /proc/self
 ----
 Cpus_allowed_list:  2-3
 ----
-. Ensure the node configuration is applied correctly. SSH into the node to verify the configuration.
+. Ensure the node configuration is applied correctly. Log in to the node to verify the configuration.
 +
 [source,terminal]
 ----
@@ -176,15 +177,3 @@ find /proc/irq/ -name smp_affinity_list -exec sh -c 'i="$1"; mask=$(cat $i); fil
 /proc/irq/29/smp_affinity_list: 0
 /proc/irq/30/smp_affinity_list: 0-5
 ----
-
-Some IRQ controllers do not support IRQ re-balancing and will always expose all online CPUs as the IRQ mask. These IRQ controllers effectively run on CPU 0. For more information on the host configuration, SSH into the host and run the following, replacing `<irq-num>` with the CPU number that you want to query:
-
-[source,terminal]
-----
-$ cat /proc/irq/<irq-num>/effective_affinity
-----
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#ref_hardware-compatibility-with-irq-affinity_cnf-master[Hardware compatibility with IRQ affinity]

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -39,7 +39,7 @@ include::modules/cnf-allocating-multiple-huge-page-sizes.adoc[leveloffset=+2]
 
 include::modules/cnf-configure_for_irq_dynamic_load_balancing.adoc[leveloffset=+2]
 
-include::modules/ref_hardware-compatibility-with-irq-affinity.adoc[leveloffset=+3]
+include::modules/cnf-about-irq-affinity-setting.adoc[leveloffset=+2]
 
 include::modules/configuring_hyperthreading_for_a_cluster.adoc[leveloffset=+2]
 


### PR DESCRIPTION
[TELCODOCS-1038]: updating IRQ lb guidance

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.13, 4.12, main

Issue:
https://issues.redhat.com/browse/TELCODOCS-1038

Link to docs preview:
https://60123--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#configuring_for_irq_dynamic_load_balancing_cnf-master

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
