### PR TITLE
Installation of OADP on multiple namespaces

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -46,6 +46,7 @@ include::modules/oadp-configuring-noobaa-for-dr.adoc[leveloffset=+1]
 * link:https://{velero-domain}/docs/v{velero-version}/locations/[Overview of backup and snapshot locations in the Velero documentation]
 
 include::modules/about-oadp-update-channels.adoc[leveloffset=+1]
+include::modules/about-installing-oadp-on-multiple-namespaces.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/about-installing-oadp-on-multiple-namespaces.adoc
+++ b/modules/about-installing-oadp-on-multiple-namespaces.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/installing/about-installing-oadp.adoc
+
+
+:_content-type: CONCEPT
+[id="about-installing-oadp-on-multiple-namespaces_{context}"]
+= Installation of OADP on multiple namespaces
+
+You can install OADP into multiple namespaces on the same cluster so that multiple project owners can manage their own OADP instance. This use case has been validated with Restic and CSI.
+
+You install each instance of OADP as specified by the per-platform procedures contained in this document with the following additional requirements:
+
+* All deployments of OADP on the same cluster must be the same version, for example, 1.1.4. Installing different versions of OADP on the same cluster is *not* supported.
+* Each individual deployment of OADP must have a unique set of credentials and a unique `BackupStorageLocation` configuration.
+* By default, each OADP deployment has cluster-level access across namespaces. {product-title} administrators need to review security and RBAC settings carefully and make any necessary changes to them to ensure that each OADP instance has the correct permissions.
+
+
+
+


### PR DESCRIPTION
OADP 1.1.4, 1.2 OCP 4.10+

Resolves https://issues.redhat.com/browse/OADP-1449 by adding a new section, "Installation of OADP on multiple namespaces" to "4.3.1. About installing OADP".

Preview: https://60124--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html [last subsection] 