### PR TITLE
OCPBUGS#5794: Removed broken link as networking interfaces module lin…

### DIFF
--- a/installing/installing_on_prem_assisted/assisted-installer-installing.adoc
+++ b/installing/installing_on_prem_assisted/assisted-installer-installing.adoc
@@ -16,7 +16,6 @@ include::modules/assisted-installer-configuring-host-network-interfaces.adoc[lev
 
 [role="_additional_resources"]
 .Additional resources
-* xref:../installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-host-network-interfaces-in-the-install-config-yaml-file_ipi-install-installation-workflow[Configuring network interfaces]
 
 * link:http://nmstate.io[NMState version 2.1.4]
 

--- a/modules/installation-alibaba-config-yaml.adoc
+++ b/modules/installation-alibaba-config-yaml.adoc
@@ -37,25 +37,25 @@ metadata:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OpenShiftSDN
+  networkType: OpenShiftSDN <2>
   serviceNetwork:
   - 172.30.0.0/16
 platform:
   alibabacloud:
-    defaultMachinePlatform: <2>
+    defaultMachinePlatform: <3>
       instanceType: ecs.g6.xlarge
       systemDiskCategory: cloud_efficiency
       systemDiskSize: 200
     region: ap-southeast-1 <4>
     resourceGroupID: rg-acfnw6j3hyai <5>
-    vpcID: vpc-0xifdjerdibmaqvtjob2b <8>
+    vpcID: vpc-0xifdjerdibmaqvtjob2b
     vswitchIDs: <8>
     - vsw-0xi8ycgwc8wv5rhviwdq5
     - vsw-0xiy6v3z2tedv009b4pz2
 publish: External
-pullSecret: '{"auths": {"cloud.openshift.com": {"auth": ... }' <5>
+pullSecret: '{"auths": {"cloud.openshift.com": {"auth": ... }' <6>
 sshKey: |
-  ssh-rsa AAAA... <6>
+  ssh-rsa AAAA... <7>
 ----
 <1> Required. The installation program prompts you for a cluster name.
 <2> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.


### PR DESCRIPTION
[OCPBUGS-5794](https://issues.redhat.com/browse/OCPBUGS-5794)

Version(s):
4.11 and 4.10

Link to docs preview:
* [Fixed callouts build error preview](http://file.emea.redhat.com/dfitzmau/OCPBUGS-5794/installing/installing_alibaba/installing-alibaba-customizations.html#installation-alibaba-config-yaml_installing-alibaba-customizations)
* [Configuring host network interfaces](http://file.emea.redhat.com/dfitzmau/OCPBUGS-5794/installing/installing_on_prem_assisted/assisted-installer-installing.html#configuring-host-network-interfaces_assisted-installer-installing)

QE review:
- [X] QE has approved this change. *Not required for a low-level DDF*

Additional information:

