### PR TITLE
Oadp 1488 oadp 1 1 4 release notes hvider

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-1-4.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-1-2.adoc[leveloffset=+1]
 
 include::modules/oadp-release-notes-1-1-1.adoc[leveloffset=+1]

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -23,14 +23,11 @@ The following bugs have been fixed in this release:
 * link:https://issues.redhat.com/browse/OADP-1511[OADP-1511]
 * link:https://issues.redhat.com/browse/OADP-1642[OADP-1642]
 * link:https://issues.redhat.com/browse/OADP-1398[OADP-1398]
-* link:https://issues.redhat.com/browse/OADP-1789[OADP-1789]
 * link:https://issues.redhat.com/browse/OADP-1267[OADP-1267]
-* link:https://issues.redhat.com/browse/OADP-1389[OADP-1389]
 * link:https://issues.redhat.com/browse/OADP-1390[OADP-1390]
 * link:https://issues.redhat.com/browse/OADP-1650[OADP-1650]
 * link:https://issues.redhat.com/browse/OADP-1487[OADP-1487]
 * link:https://issues.redhat.com/browse/OADP-1668[OADP-1668]
-* link:https://issues.redhat.com/browse/OADP-1503[OADP-1503]
 
 // The issues and bugs that have been resolved in this version are listed in link:https://issues.redhat.com/browse/OADP-1398?jql=project%20%3D%20OADP%20AND%20status%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].
 

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -6,7 +6,7 @@
 [id="migration-oadp-release-notes-1-1-4_{context}"]
 = OADP 1.1.4 release notes
 
-The OADP 1.1.4 release notes lists any new features, resolve issues and bugs, and known issues.
+The OADP 1.1.4 release notes lists any new features, resolved issues and bugs, and known issues.
 
 [id="new-features1.1.4_{context}"]
 == New features
@@ -34,7 +34,7 @@ The following bugs have been fixed in this release:
 
 This release has the following known issues:
 
-* Issues restoring an OADP backup, with the application unable to access data. UID / GID range may have changed on the cluster where the application has been restored, with the result that OADP does not backup and restore OpenShift UID/GID range metadata. If the backed application requires a specific UUID, ensure the range is available when restored. Workaround: Allowing OADP to create the namespace while restoring may avoid the issue.
+* OADP backups might fail because a UID/GID range might have changed on the cluster where the application has been restored, with the result that OADP does not backup and restore OpenShift UID/GID range metadata.If the backed application requires a specific UUID, ensure the range is available when restored. Additional workaround: Allow OADP to create the namespace in the restore operation.
 
 * It is possible that the restore will fail if ArgoCD is used during the restore. This failure could be caused by a label used by ArgoCD `app.kubernetes.io/instance`. This label is used to identify which resources ArgoCD needs to manage, which can create conflict with OADP managing resources on restore. Workaround: setting `.spec.resourceTrackingMethod` on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning the restore, and enable when the restore has completed.
 

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="migration-oadp-release-notes-1-1-4_{context}"]
+= OADP 1.1.4 release notes
+
+The OADP 1.1.4 release notes lists any new features, resolved issues and bugs, and known issues.
+
+[id="new-features1.1.4_{context}"]
+== New features
+
+This version of OADP is a service release. No new features are added to this version.
+
+[id="resolved-issues1.1.4_{context}"]
+== Fixed bugs
+
+The following bugs have been fixed in this release:
+
+* link:https://issues.redhat.com/browse/OADP-1557[OADP-1557]
+* link:https://issues.redhat.com/browse/OADP-1822[OADP-1822]
+* link:https://issues.redhat.com/browse/OADP-1511[OADP-1511]
+* link:https://issues.redhat.com/browse/OADP-1642[OADP-1642]
+* link:https://issues.redhat.com/browse/OADP-1398[OADP-1398]
+* link:https://issues.redhat.com/browse/OADP-1267[OADP-1267]
+* link:https://issues.redhat.com/browse/OADP-1390[OADP-1390]
+* link:https://issues.redhat.com/browse/OADP-1650[OADP-1650]
+* link:https://issues.redhat.com/browse/OADP-1487[OADP-1487]
+
+
+[id="known-issues1.1.4_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+* OADP backups might fail because a UID/GID range might have changed on the cluster where the application has been restored, with the result that OADP does not back up and restore {product-title} UID/GID range metadata. To avoid the issue, if the backed application requires a specific UUID, ensure the range is available when restored. An additional workaround is to allow OADP to create the namespace in the restore operation.
+
+* A restoration might fail if ArgoCD is used during the process due to a label used by ArgoCD, `app.kubernetes.io/instance`. This label identifies which resources ArgoCD needs to manage, which can create a conflict with OADP's procedure for managing resources on restoration. To work around this issue, set the `.spec.resourceTrackingMethod` <put_a_noun_here> on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning to restore, and enable it again when restoration is finished.
+

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -8,12 +8,12 @@
 
 The OADP 1.1.4 release notes lists any new features, resolve issues and bugs, and known issues.
 
-[id="new-features_{context}"]
+[id="new-features1.1.4_{context}"]
 == New features
 
 This version of OADP is a service release. No new features are added to this version.
 
-[id="resolved-issues_{context}"]
+[id="resolved-issues1.1.4_{context}"]
 == Fixed bugs
 
 The following bugs have been fixed in this release:
@@ -34,7 +34,7 @@ The following bugs have been fixed in this release:
 
 // The issues and bugs that have been resolved in this version are listed in link:https://issues.redhat.com/browse/OADP-1398?jql=project%20%3D%20OADP%20AND%20status%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].
 
-[id="known-issues_{context}"]
+[id="known-issues1.1.4_{context}"]
 == Known issues
 
 This release has the following known issues:

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -34,8 +34,14 @@ The following bugs have been fixed in this release:
 
 This release has the following known issues:
 
-* OADP backups might fail because a UID/GID range might have changed on the cluster where the application has been restored, with the result that OADP does not backup and restore OpenShift UID/GID range metadata.If the backed application requires a specific UUID, ensure the range is available when restored. Additional workaround: Allow OADP to create the namespace in the restore operation.
+* OADP backups might fail because a UID/GID range might have changed on the cluster where the application has been restored, with the result that OADP does not back up and restore OpenShift UID/GID range metadata.
 
-* It is possible that the restore will fail if ArgoCD is used during the restore. This failure could be caused by a label used by ArgoCD `app.kubernetes.io/instance`. This label is used to identify which resources ArgoCD needs to manage, which can create conflict with OADP managing resources on restore. Workaround: setting `.spec.resourceTrackingMethod` on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning the restore, and enable when the restore has completed.
+  To avoid the issue: If the backed application requires a specific UUID, ensure the range is available when restored.
+
+  Additional workaround: Allow OADP to create the namespace in the restore operation.
+
+* A restore might fail if ArgoCd is used during the restore, due to a label used by ArgoCD, `app.kubernetes.io/instance`. This label identifies which resources ArgoCD needs to manage, which can create a conflict with OADP's procedure for managing resources on restore.
+
+  Workaround: Set `.spec.resourceTrackingMethod` on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning the restore, and enable it again when the restore has completed.
 
 

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="migration-oadp-release-notes-1-1-4_{context}"]
+= OADP 1.1.4 release notes
+
+The OADP 1.1.4 release notes lists any new features, resolve issues and bugs, and known issues.
+
+[id="new-features_{context}"]
+== New features
+
+This version of OADP is a service release. No new features are added to this version.
+
+[id="resolved-issues_{context}"]
+== Resolved issues
+
+The issues and bugs that have been resolved in this version are listed in link:https://issues.redhat.com/browse/OADP-1398?jql=project%20%3D%20OADP%20AND%20status%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].
+
+[id="known-issues_{context}"]
+== Known issues
+
+The issues and bugs that are known in this version are listed in link:https://issues.redhat.com/browse/OADP-1619?jql=project%20%3D%20OADP%20AND%20status%20not%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -27,9 +27,7 @@ The following bugs have been fixed in this release:
 * link:https://issues.redhat.com/browse/OADP-1390[OADP-1390]
 * link:https://issues.redhat.com/browse/OADP-1650[OADP-1650]
 * link:https://issues.redhat.com/browse/OADP-1487[OADP-1487]
-* link:https://issues.redhat.com/browse/OADP-1668[OADP-1668]
 
-// The issues and bugs that have been resolved in this version are listed in link:https://issues.redhat.com/browse/OADP-1398?jql=project%20%3D%20OADP%20AND%20status%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].
 
 [id="known-issues1.1.4_{context}"]
 == Known issues
@@ -40,4 +38,4 @@ This release has the following known issues:
 
 * It is possible that the restore will fail if ArgoCD is used during the restore. This failure could be caused by a label used by ArgoCD `app.kubernetes.io/instance`. This label is used to identify which resources ArgoCD needs to manage, which can create conflict with OADP managing resources on restore. Workaround: setting `.spec.resourceTrackingMethod` on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning the restore, and enable when the restore has completed.
 
-//The issues and bugs that are known in this version are listed in link:https://issues.redhat.com/browse/OADP-1619?jql=project%20%3D%20OADP%20AND%20status%20not%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].
+

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -14,11 +14,33 @@ The OADP 1.1.4 release notes lists any new features, resolve issues and bugs, an
 This version of OADP is a service release. No new features are added to this version.
 
 [id="resolved-issues_{context}"]
-== Resolved issues
+== Fixed bugs
 
-The issues and bugs that have been resolved in this version are listed in link:https://issues.redhat.com/browse/OADP-1398?jql=project%20%3D%20OADP%20AND%20status%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].
+The following bugs have been fixed in this release:
+
+* link:https://issues.redhat.com/browse/OADP-1557[OADP-1557]
+* link:https://issues.redhat.com/browse/OADP-1822[OADP-1822]
+* link:https://issues.redhat.com/browse/OADP-1511[OADP-1511]
+* link:https://issues.redhat.com/browse/OADP-1642[OADP-1642]
+* link:https://issues.redhat.com/browse/OADP-1398[OADP-1398]
+* link:https://issues.redhat.com/browse/OADP-1789[OADP-1789]
+* link:https://issues.redhat.com/browse/OADP-1267[OADP-1267]
+* link:https://issues.redhat.com/browse/OADP-1389[OADP-1389]
+* link:https://issues.redhat.com/browse/OADP-1390[OADP-1390]
+* link:https://issues.redhat.com/browse/OADP-1650[OADP-1650]
+* link:https://issues.redhat.com/browse/OADP-1487[OADP-1487]
+* link:https://issues.redhat.com/browse/OADP-1668[OADP-1668]
+* link:https://issues.redhat.com/browse/OADP-1503[OADP-1503]
+
+// The issues and bugs that have been resolved in this version are listed in link:https://issues.redhat.com/browse/OADP-1398?jql=project%20%3D%20OADP%20AND%20status%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].
 
 [id="known-issues_{context}"]
 == Known issues
 
-The issues and bugs that are known in this version are listed in link:https://issues.redhat.com/browse/OADP-1619?jql=project%20%3D%20OADP%20AND%20status%20not%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].
+This release has the following known issues:
+
+* Issues restoring an OADP backup, with the application unable to access data. UID / GID range may have changed on the cluster where the application has been restored, with the result that OADP does not backup and restore OpenShift UID/GID range metadata. If the backed application requires a specific UUID, ensure the range is available when restored. Workaround: Allowing OADP to create the namespace while restoring may avoid the issue.
+
+* It is possible that the restore will fail if ArgoCD is used during the restore. This failure could be caused by a label used by ArgoCD `app.kubernetes.io/instance`. This label is used to identify which resources ArgoCD needs to manage, which can create conflict with OADP managing resources on restore. Workaround: setting `.spec.resourceTrackingMethod` on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning the restore, and enable when the restore has completed.
+
+//The issues and bugs that are known in this version are listed in link:https://issues.redhat.com/browse/OADP-1619?jql=project%20%3D%20OADP%20AND%20status%20not%20in%20(Closed%2C%20Verified%2C%20%22Release%20Pending%22)%20AND%20priority%20in%20(Blocker%2C%20Critical%2C%20Major)%20AND%20fixVersion%20in%20(%22OADP%201.1.4%22%2C%20%22OADP%201.1.4%22)%20AND%20assignee%20not%20in%20(rhn-support-hvider%2C%20rhn-support-anarnold%2C%20rhn-support-cwisemon%2C%20richard.hoch%2C%20rhn-support-sbeskin)%20ORDER%20BY%20description%20ASC[this page].

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -34,14 +34,7 @@ The following bugs have been fixed in this release:
 
 This release has the following known issues:
 
-* OADP backups might fail because a UID/GID range might have changed on the cluster where the application has been restored, with the result that OADP does not back up and restore OpenShift UID/GID range metadata.
+* OADP backups might fail because a UID/GID range might have changed on the cluster where the application has been restored, with the result that OADP does not back up and restore {product-title} UID/GID range metadata. To avoid the issue, if the backed application requires a specific UUID, ensure the range is available when restored. An additional workaround is to allow OADP to create the namespace in the restore operation.
 
-  To avoid the issue: If the backed application requires a specific UUID, ensure the range is available when restored.
-
-  Additional workaround: Allow OADP to create the namespace in the restore operation.
-
-* A restore might fail if ArgoCd is used during the restore, due to a label used by ArgoCD, `app.kubernetes.io/instance`. This label identifies which resources ArgoCD needs to manage, which can create a conflict with OADP's procedure for managing resources on restore.
-
-  Workaround: Set `.spec.resourceTrackingMethod` on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning the restore, and enable it again when the restore has completed.
-
+* A restoration might fail if ArgoCD is used during the process due to a label used by ArgoCD, `app.kubernetes.io/instance`. This label identifies which resources ArgoCD needs to manage, which can create a conflict with OADP's procedure for managing resources on restoration. To work around this issue, set the `.spec.resourceTrackingMethod` <put_a_noun_here> on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning to restore, and enable it again when restoration is finished.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> ---> OADP 1.1.4; OCP 4.10+

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.
OADP 1.1.4; OCP 4.10+
* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> OADP 1.1.4; OCP 4.10+


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. ---> [OADP-1488](https://issues.redhat.com/browse/OADP-1488)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://60136--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-release-notes.html
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
