### PR TITLE
OSDOCS-6084: Adding network policy for network observability

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1477,6 +1477,8 @@ Topics:
     File: understanding-network-observability-operator
   - Name: Configuring the Network Observability Operator
     File: configuring-operator
+  - Name: Network Policy
+    File: network-observability-network-policy
   - Name: Observing the network traffic
     File: observing-network-traffic
   - Name: Monitoring the Network Observability Operator

--- a/modules/network-observability-create-network-policy.adoc
+++ b/modules/network-observability-create-network-policy.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+
+// * networking/network_observability/network-observability-network-policy.adoc
+
+
+:_content-type: PROCEDURE
+[id="network-observability-network-policy_{context}"]
+= Creating a network policy for Network Observability
+You might need to create a network policy to secure ingress traffic to the `netobserv` namespace. In the web console, you can create a network policy using the form view.
+
+.Procedure
+. Navigate to *Networking* -> *NetworkPolicies*.
+. Select the `netobserv` project from the *Project* dropdown menu.
+. Name the policy. For this example, the policy name is `allow-ingress`.
+. Click *Add ingress rule* three times to create three ingress rules.
+. Specify the following in the form:
+.. Make the following specifications for the first *Ingress rule*:
+... From the *Add allowed source* dropdown menu, select *Allow pods from the same namespace*.
+.. Make the following specifications for the second *Ingress rule*:
+... From the *Add allowed source* dropdown menu, select *Allow pods from inside the cluster*. 
+... Click *+ Add namespace selector*. 
+... Add the label, `kubernetes.io/metadata.name`, and the selector, `openshift-console`. 
+.. Make the following specifications for the third *Ingress rule*:
+... From the *Add allowed source* dropdown menu, select *Allow pods from inside the cluster*.
+... Click *+ Add namespace selector*. 
+... Add the label, `kubernetes.io/metadata.name`, and the selector, `openshift-monitoring`.
+
+.Verification
+. Navigate to *Observe* -> *Network Traffic*. 
+. View the *Traffic Flows* tab, or any tab, to verify that the data is displayed.
+. Navigate to *Observe* -> *Dashboards*. In the NetObserv/Health selection, verify that the flows are being ingested and sent to Loki, which is represented in the first graph.

--- a/modules/network-observability-sample-network-policy-YAML.adoc
+++ b/modules/network-observability-sample-network-policy-YAML.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+
+// * networking/network_observability/network-observability-network-policy.adoc
+
+:_content-type: REFERENCE
+[id="network-observability-sample-network-policy_{context}"]
+= Example network policy
+The following annotates an example `NetworkPolicy` object for the `netobserv` namespace:
+
+[id="network-observability-network-policy-sample_{context}"]
+.Sample network policy
+[source, yaml]
+----
+kind: NetworkPolicy
+apiVersion: networking.k8s.io/v1
+metadata:
+  name: allow-ingress
+  namespace: netobserv
+spec:
+  podSelector: {}            <1>
+  ingress:
+    - from:
+        - podSelector: {}    <2>
+          namespaceSelector: <3>
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-console
+        - podSelector: {}
+          namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: openshift-monitoring
+  policyTypes:
+    - Ingress
+status: {}
+----
+<1> A selector that describes the pods to which the policy applies. The policy object can only select pods in the project that defines the `NetworkPolicy` object. In this documentation, it would be the project in which the Network Observability Operator is installed, which is the `netobserv` project.
+<2> A selector that matches the pods from which the policy object allows ingress traffic. The default is that the selector matches pods in the same namespace as the `NetworkPolicy`. 
+<3> When the `namespaceSelector` is specified, the selector matches pods in the specified namespace.

--- a/networking/network_observability/network-observability-network-policy.adoc
+++ b/networking/network_observability/network-observability-network-policy.adoc
@@ -1,0 +1,16 @@
+:_content-type: ASSEMBLY
+[id="network-observability-network-policy"]
+= Network Policy
+include::_attributes/common-attributes.adoc[]
+:context: network_observability
+
+toc::[]
+
+As a user with the `admin` role, you can create a network policy for the `netobserv` namespace.
+
+include::modules/network-observability-create-network-policy.adoc[leveloffset=+1]
+include::modules/network-observability-sample-network-policy-YAML.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+xref:../../networking/network_policy/creating-network-policy.adoc#nw-networkpolicy-object_creating-network-policy[Creating a network policy using the CLI]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.10+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-6084
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://60139--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/network-observability-network-policy.html
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
