### PR TITLE
Revert "Revert "RHDEVDOCS-5069: Adding 4.13 version to GitOps v1.8 RN after OCP 4.13 …""

### DIFF
--- a/modules/gitops-release-notes-1-8-0.adoc
+++ b/modules/gitops-release-notes-1-8-0.adoc
@@ -6,7 +6,7 @@
 [id="gitops-release-notes-1-8-0_{context}"]
 = Release notes for {gitops-title} 1.8.0
 
-{gitops-title} 1.8.0 is now available on {product-title} 4.10, 4.11, and 4.12.
+{gitops-title} 1.8.0 is now available on {product-title} 4.10, 4.11, 4.12, and 4.13.
 
 [id="new-features-1-8-0_{context}"]
 == New features

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -18,7 +18,7 @@ In the table, features are marked with the following statuses:
 |*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
 
 |*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |
-|1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
+|1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
 |1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
 |1.6.0    |0.0.46 TP |3.8.1 GA|4.4.1 GA   |2.4.5 GA |GA and included in ArgoCD component    |2.30.3 GA |7.5.1 GA |4.8-4.11
 |1.5.0    |0.0.42 TP|3.8.0 GA|4.4.1 GA   |2.3.3 GA |0.4.1 TP       |2.30.3 GA |7.5.1 GA |4.8-4.11


### PR DESCRIPTION
Reverts the revert PR: openshift/openshift-docs#58131 **in order to merge the original commit: #57764**
• OCP version for cherry-picking: enterprise-4.10 and later