### PR TITLE
SRVCOM-2432 change product title - add Red Hat

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -1,6 +1,6 @@
 ---
 openshift-serverless:
-  name: OpenShift Serverless
+  name: Red Hat OpenShift Serverless
   author: OpenShift documentation team <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation


### PR DESCRIPTION
Version(s):
Serverless docs 1.28+

Issue:
[SRVCOM-2432](https://issues.redhat.com//browse/SRVCOM-2432)

Link to docs preview:
https://60155--docspreview.netlify.app/openshift-serverless/latest/about/about-serverless.html

Adds "Red Hat"  at front of product title
