### PR TITLE
OCPBUGS-13768: Updated SPO profilerecording procedures

### DIFF
--- a/modules/spo-container-profile-instances.adoc
+++ b/modules/spo-container-profile-instances.adoc
@@ -7,11 +7,13 @@ ifeval::["{context}" == "spo-seccomp"]
 :seccomp:
 :type: seccomp
 :kind: SeccompProfile
+:object: seccompprofiles
 endif::[]
 ifeval::["{context}" == "spo-selinux"]
 :selinux:
 :type: SELinux
 :kind: SelinuxProfile
+:object: selinuxprofiles
 endif::[]
 
 :_content-type: PROCEDURE
@@ -83,32 +85,34 @@ $ oc delete profilerecording test-recording
 
 . To start the merge operation and generate the results profile, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get sp -lspo.x-k8s.io/recording-id=test-recording
+$ oc get {object} -lspo.x-k8s.io/recording-id=test-recording
 ----
 +
 .Example output
 [source,terminal]
 ----
-NAME                          STATUS      AGE
-test-recording-nginx-record   Installed   17m
+NAME                          USAGE                                         STATE
+test-recording-nginx-record   test-recording-nginx-record_mytest1.process   Installed
 ----
 
-. To view the syscalls used by any of the containers, run the following command:
+. To view the permissions used by any of the containers, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get sp test-recording-nginx-record -o yaml
+$ oc get {object} test-recording-nginx-record -o yaml
 ----
 
 ifeval::["{context}" == "spo-seccomp"]
 :!seccomp:
 :!type:
 :!kind:
+:!object:
 endif::[]
 ifeval::["{context}" == "spo-selinux"]
 :!selinux:
 :!type:
 :!kind:
+:!object:
 endif::[]

--- a/modules/spo-recording-profiles.adoc
+++ b/modules/spo-recording-profiles.adoc
@@ -7,12 +7,15 @@ ifeval::["{context}" == "spo-seccomp"]
 :seccomp:
 :type: seccomp
 :kind: SeccompProfile
+:object: seccompprofiles
 endif::[]
 ifeval::["{context}" == "spo-selinux"]
 :selinux:
 :type: SELinux
 :kind: SelinuxProfile
+:object: selinuxprofiles
 endif::[]
+
 
 :_content-type: PROCEDURE
 [id="spo-recording-profiles_{context}"]
@@ -94,10 +97,9 @@ $ oc -n openshift-security-profiles logs --since=1m --selector name=spod -c log-
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-…
-I0705 12:08:18.729660 1843190 enricher.go:136] log-enricher "msg"="audit"  "container"="redis" "executable"="/usr/local/bin/redis-server" "namespace"="default" "node"="127.0.0.1" "pid"=1847839 "pod"="my-pod" "syscallID"=232 "syscallName"="epoll_wait" "timestamp"="1625486870.273:187492" "type"="{type}"
+I0517 13:55:36.383187  348295 enricher.go:376] log-enricher "msg"="audit" "container"="redis" "namespace"="my-namespace" "node"="ip-10-0-189-53.us-east-2.compute.internal" "perm"="name_bind" "pod"="my-pod" "profile"="test-recording_redis_6kmrb_1684331729" "scontext"="system_u:system_r:selinuxrecording.process:s0:c4,c27" "tclass"="tcp_socket" "tcontext"="system_u:object_r:redis_port_t:s0" "timestamp"="1684331735.105:273965" "type"="{type}"
 ----
 
 .Verification
@@ -111,26 +113,28 @@ $ oc -n openshift-security-profiles delete pod my-pod
 
 . Confirm the Security Profiles Operator reconciles the two {type} profiles:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc -n openshift-security-profiles get sp
+$ oc get {object} -n my-namespace
 ----
 +
 .Example output
 [source,terminal]
 ----
-NAME                   STATUS      AGE
-test-recording-nginx   Installed   15s
-test-recording-redis   Installed   15s
+NAME                   USAGE                                       STATE
+test-recording-nginx   test-recording-nginx_my-namespace.process   Installed
+test-recording-redis   test-recording-redis_my-namespace.process   Installed
 ----
 
 ifeval::["{context}" == "spo-seccomp"]
 :!seccomp:
 :!type:
 :!kind:
+:!object:
 endif::[]
 ifeval::["{context}" == "spo-selinux"]
 :!selinux:
 :!type:
 :!kind:
+:!object:
 endif::[]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-13768

Link to docs preview:
[Recording profiles from workloads (SELinux)](http://file.rdu.redhat.com/antaylor/OCPBUGS-13768/security/security_profiles_operator/spo-selinux.html#spo-recording-profiles_spo-selinux)
[Recording profiles from workload (seccomp)](http://file.rdu.redhat.com/antaylor/OCPBUGS-13768/security/security_profiles_operator/spo-seccomp.html#spo-recording-profiles_spo-seccomp)

[Merging per-container profile instances (SELinux)](http://file.rdu.redhat.com/antaylor/OCPBUGS-13768/security/security_profiles_operator/spo-selinux.html#spo-container-profile-instances_spo-selinux)
[Merging per-container profile instances (seccomp)](http://file.rdu.redhat.com/antaylor/OCPBUGS-13768/security/security_profiles_operator/spo-seccomp.html#spo-container-profile-instances_spo-seccomp)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I added a variable to distinguish between seccomp and SELinux profiles in commands (eg, `oc get`), as these modules are shared between two assemblies.