### PR TITLE
OCPBUGS#9257: Updating the Egress router modes module

### DIFF
--- a/modules/nw-egress-router-about.adoc
+++ b/modules/nw-egress-router-about.adoc
@@ -37,7 +37,12 @@ The egress router image is not compatible with Amazon AWS, Azure Cloud, or any o
 [id="nw-egress-router-about-modes_{context}"]
 == Egress router modes
 
-In _redirect mode_, an egress router pod configures `iptables` rules to redirect traffic from its own IP address to one or more destination IP addresses. Client pods that need to use the reserved source IP address must be modified to connect to the egress router rather than connecting directly to the destination IP.
+In _redirect mode_, an egress router pod configures `iptables` rules to redirect traffic from its own IP address to one or more destination IP addresses. Client pods that need to use the reserved source IP address must be configured to access the service for the egress router rather than connecting directly to the destination IP. You can access the destination service and port from the application pod by using the `curl` command. For example:
+
+[source, terminal]
+----
+$ curl <router_service_IP> <port>
+----
 
 ifdef::openshift-sdn[]
 In _HTTP proxy mode_, an egress router pod runs as an HTTP proxy on port `8080`. This mode only works for clients that are connecting to HTTP-based or HTTPS-based services, but usually requires fewer changes to the client pods to get them to work. Many programs can be told to use an HTTP proxy by setting an environment variable.

--- a/modules/nw-egress-router-redirect-mode.adoc
+++ b/modules/nw-egress-router-redirect-mode.adoc
@@ -6,7 +6,12 @@
 [id="nw-egress-router-redirect-mode_{context}"]
 = Deploying an egress router pod in redirect mode
 
-In _redirect mode_, an egress router pod sets up iptables rules to redirect traffic from its own IP address to one or more destination IP addresses. Client pods that need to use the reserved source IP address must be modified to connect to the egress router rather than connecting directly to the destination IP.
+In _redirect mode_, an egress router pod sets up iptables rules to redirect traffic from its own IP address to one or more destination IP addresses. Client pods that need to use the reserved source IP address must be configured to access the service for the egress router rather than connecting directly to the destination IP. You can access the destination service and port from the application pod by using the `curl` command. For example:
+
+[source, terminal]
+----
+$ curl <router_service_IP> <port>
+----
 
 .Prerequisites
 


### PR DESCRIPTION
[OCPBUGS-9257](https://issues.redhat.com/browse/OCPBUGS-9257)

Version(s):
4.14 through to 4.10

Link to docs preview:
[Egress router modes](https://60159--docspreview.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/using-an-egress-router.html#nw-egress-router-about-modes_using-an-egress-router)
[Deploying an egress router pod in redirect mode](https://60159--docspreview.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/deploying-egress-router-layer3-redirection.html#nw-egress-router-redirect-mode_deploying-egress-router-layer3-redirection)

QE review:
- [X] QE not required as the Jira was raised from a DDF with the solution provided on the Jira.
