### PR TITLE
OCPBUGS-5892 adding late breaking known issue to 4.13

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2741,6 +2741,9 @@ The following code provides an example of the policy updates with both names bei
 
 ----
 
+* Resetting a MAC address on an SR-IOV virtual function (VF) upon pod deletion might fail for Intel E810 NICs.
+As a result, creating a pod with an SR-IOV VF might take up to 2 minutes on Intel E810 NIC cards. (link:https://issues.redhat.com/browse/OCPBUGS-5892[*OCPBUGS-5892*])
+
 [id="ocp-4-13-ran-known-issues"]
 * If you specify an invalid subscription channel in the subscription policy that you use to perform a cluster upgrade, the {cgu-operator-first} indicates that the upgrade is successful immediately after {cgu-operator} enforces the policy because the `Subscription` resource remains in the `AtLatestKnown` state.
 (link:https://issues.redhat.com/browse/OCPBUGS-9239[*OCPBUGS-9239*])


### PR DESCRIPTION
OCPBUGS-5892: SRIOV: Intel E810: Creating a pod takes up to 2 minutes.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13 RN
Issue:
https://issues.redhat.com/browse/OCPBUGS-5892

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
