### PR TITLE
Replaced a variable in a header

### DIFF
--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="rosa-hcp-sts-creating-a-cluster-quickly"]
-= Creating {hcp-title} cluster using the default options
+= Creating ROSA with HCP clusters using the default options
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-hcp-sts-creating-a-cluster-quickly
 


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR replaces a variable in a header showing incorrectly in Customer Portal.

![image](https://github.com/openshift/openshift-docs/assets/16167833/f91b7324-6c90-4bf6-a228-e15150043d24)