### PR TITLE
Update ingresscontroller-operator-openshift-io-v1.adoc

### DIFF
--- a/rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.adoc
+++ b/rest_api/operator_apis/ingresscontroller-operator-openshift-io-v1.adoc
@@ -96,6 +96,10 @@ Type::
    AWS:      LoadBalancerService (with External scope)   Azure:    LoadBalancerService (with External scope)   GCP:      LoadBalancerService (with External scope)   IBMCloud: LoadBalancerService (with External scope)   Libvirt:  HostNetwork 
  Any other platform types (including None) default to HostNetwork. 
  endpointPublishingStrategy cannot be updated.
+ 
+| `httpCompression`
+| `object`
+| httpCompression defines a policy for HTTP traffic compression. By default, there is no HTTP compression.
 
 | `httpEmptyRequestsPolicy`
 | `string`
@@ -519,6 +523,29 @@ Type::
 
 
 
+=== .spec.httpCompression
+Description::
++
+--
+httpCompression defines a policy for HTTP traffic compression. By default, there is no HTTP compression.
+--
+
+Type::
+  `object`
+
+
+
+
+[cols="1,1,1",options="header"]
+|===
+| Property | Type | Description
+
+| `mimeTypes`
+| `array (string)`
+| mimeTypes is a list of MIME types that should have compression applied. This list can be empty, in which case the ingress controller does not apply compression. 
+ Note: Not all MIME types benefit from compression, but HAProxy will still use resources to try to compress if instructed to.  Generally speaking, text (html, css, js, etc.) formats benefit from compression, but formats that are already compressed (image, audio, video, etc.) benefit little in exchange for the time and cpu spent on compressing again. See https://joehonton.medium.com/the-gzip-penalty-d31bd697f1a2
+
+|===
 === .spec.httpErrorCodePages
 Description::
 +


### PR DESCRIPTION
Adding the API documentation in OCP 4.10 version about httpCompression. 

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OCPBUGS-13570

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
