### PR TITLE
OADP-1488: Release notes for version 1.1.4

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+include::modules/oadp-release-notes-1-1-4.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-1-2.adoc[leveloffset=+1]
 
 include::modules/oadp-release-notes-1-1-1.adoc[leveloffset=+1]

--- a/modules/oadp-release-notes-1-1-4.adoc
+++ b/modules/oadp-release-notes-1-1-4.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="migration-oadp-release-notes-1-1-4_{context}"]
+= OADP 1.1.4 release notes
+
+The OADP 1.1.4 release notes lists any new features, resolved issues and bugs, and known issues.
+
+[id="new-features1.1.4_{context}"]
+== New features
+
+This version of OADP is a service release. No new features are added to this version.
+
+[id="resolved-issues1.1.4_{context}"]
+== Fixed bugs
+
+The following bugs have been fixed in this release:
+
+* link:https://issues.redhat.com/browse/OADP-1557[OADP-1557]
+* link:https://issues.redhat.com/browse/OADP-1822[OADP-1822]
+* link:https://issues.redhat.com/browse/OADP-1511[OADP-1511]
+* link:https://issues.redhat.com/browse/OADP-1642[OADP-1642]
+* link:https://issues.redhat.com/browse/OADP-1398[OADP-1398]
+* link:https://issues.redhat.com/browse/OADP-1267[OADP-1267]
+* link:https://issues.redhat.com/browse/OADP-1390[OADP-1390]
+* link:https://issues.redhat.com/browse/OADP-1650[OADP-1650]
+* link:https://issues.redhat.com/browse/OADP-1487[OADP-1487]
+
+
+[id="known-issues1.1.4_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+* OADP backups might fail because a UID/GID range might have changed on the cluster where the application has been restored, with the result that OADP does not back up and restore {product-title} UID/GID range metadata. To avoid the issue, if the backed application requires a specific UUID, ensure the range is available when restored. An additional workaround is to allow OADP to create the namespace in the restore operation.
+
+* A restoration might fail if ArgoCD is used during the process due to a label used by ArgoCD, `app.kubernetes.io/instance`. This label identifies which resources ArgoCD needs to manage, which can create a conflict with OADP's procedure for managing resources on restoration. To work around this issue, set `.spec.resourceTrackingMethod` on the ArgoCD YAML to `annotation+label` or `annotation`. If the issue continues to persist, then disable ArgoCD before beginning to restore, and enable it again when restoration is finished.
+


### PR DESCRIPTION
 OADP 1.1.4; OCP 4.10+

Version(s):
OADP 1.1.4; OCP 4.10+

Issue:
[OADP-1488](https://issues.redhat.com/browse/OADP-1488)

Link to docs preview:

https://60136--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-release-notes.html
QE review:

    QE has approved this change.

Additional information:

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
