### PR TITLE
Added a note for Ironic

### DIFF
--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -52,7 +52,7 @@ platform:
           password: <password>
         bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
-         deviceName: "/dev/disk/by-id/<disk_id>" <5>
+         deviceName: "<installation_disk_drive_path>" <5>
       - name: <openshift_master_1>
         role: master
         bmc:
@@ -61,7 +61,7 @@ platform:
           password: <password>
         bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
-         deviceName: "/dev/disk/by-id/<disk_id>" <5>
+         deviceName: "<installation_disk_drive_path>" <5>
       - name: <openshift_master_2>
         role: master
         bmc:
@@ -70,7 +70,7 @@ platform:
           password: <password>
         bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
-         deviceName: "/dev/disk/by-id/<disk_id>" <5>
+         deviceName: "<installation_disk_drive_path>" <5>
       - name: <openshift_worker_0>
         role: worker
         bmc:
@@ -86,20 +86,35 @@ platform:
           password: <password>
         bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
-         deviceName: "/dev/disk/by-id/<disk_id>" <5>
+         deviceName: "<installation_disk_drive_path>" <5>
 pullSecret: '<pull_secret>'
 sshKey: '<ssh_pub_key>'
 ----
 +
+--
 <1> Scale the worker machines based on the number of worker nodes that are part of the {product-title} cluster. Valid options for the `replicas` value are `0` and integers greater than or equal to `2`. Set the number of replicas to `0` to deploy a three-node cluster, which contains only three control plane machines. A three-node cluster is a smaller, more resource-efficient cluster that can be used for testing, development, and production. You cannot install the cluster with only one worker.
 <2> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticIP` configuration setting to specify the static IP address of the bootstrap VM when there is no DHCP server on the `baremetal` network.
 <3> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticGateway` configuration setting to specify the gateway IP address for the bootstrap VM when there is no DHCP server on the `baremetal` network.
 <4> See the BMC addressing sections for more options.
-<5> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
+<5> To set the path to the installation disk drive, enter the kernel name of the disk. For example, `/dev/sda`.
++
+[IMPORTANT]
+====
+Because the disk discovery order is not guaranteed, the kernel name of the disk can change across booting options for machines with multiple disks. For instance, `/dev/sda` becomes `/dev/sdb` and vice versa.
+To avoid this issue, you must use persistent disk attributes, such as the disk World Wide Name (WWN). To use the disk WWN, replace the `deviceName` parameter with the `wwnWithExtension` parameter. Depending on the parameter that you use, enter the disk name, for example, `/dev/sda` or the disk WWN, for example, `"0x64cd98f04fde100024684cf3034da5c2"`. Ensure that you enter the disk WWN value within quotes so that it is used as a string value and not a hexadecimal value.
+
+Failure to meet these requirements for the `rootDeviceHints` parameter might result in the following error:
+
+[source,text]
+----
+ironic-inspector inspection failed: No disks satisfied root device hints
+----
+====
+--
 
 [NOTE]
 ====
-Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or and IPv6 address for the `apiVIP` and `ingressVIP` configuration settings. In {product-title} 4.12 and later, these configuration settings are deprecated. Instead, use a list format in the `apiVIPs` and `ingressVIPs` configuration settings to specify IPv4 addresses, IPv6 addresses or both IP address formats. 
+Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or and IPv6 address for the `apiVIP` and `ingressVIP` configuration settings. In {product-title} 4.12 and later, these configuration settings are deprecated. Instead, use a list format in the `apiVIPs` and `ingressVIPs` configuration settings to specify IPv4 addresses, IPv6 addresses or both IP address formats.
 ====
 
 . Create a directory to store the cluster configuration:


### PR DESCRIPTION
[TELCODOCS-1256]: Adds info about Ironic for using `rootDeviceHints` correctly.

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1256

Link to docs preview:
http://file.rdu.redhat.com/avbhatt/td-1256/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-installation-workflow

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- Created [OCPBUGS-15261](https://issues.redhat.com/browse/OCPBUGS-15261) to tackle the resused callout numbering issue on the Customer Portal.
- While working on this PR, I discovered a bug and created https://issues.redhat.com/browse/OCPBUGS-16269 to get it fixed
