### PR TITLE
OSDOCS-6027: Added the OIDC Configuration to ROSA content

### DIFF
--- a/_attributes/attributes-openshift-dedicated.adoc
+++ b/_attributes/attributes-openshift-dedicated.adoc
@@ -31,3 +31,5 @@
 :hcp: hosted control planes
 :hcp-title: ROSA with HCP
 :hcp-title-first: {product-title} (ROSA) with {hcp} (HCP)
+//ROSA CLI variables
+:word: Testing this variable let's go www.google.com

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -69,6 +69,8 @@ Topics:
     File: rosa-policy-process-security
 - Name: About IAM resources for ROSA with STS
   File: rosa-sts-about-iam-resources
+- Name: OpenID Connect Overview
+  File: rosa-oidc-overview
 - Name: Support for ROSA
   File: rosa-getting-support
 # - Name: Training for ROSA

--- a/modules/rosa-hcp-byo-oidc-options.adoc
+++ b/modules/rosa-hcp-byo-oidc-options.adoc
@@ -2,6 +2,7 @@
 //
 // * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
 // * rosa_getting_started/quickstart.adoc
+// * rosa_architecture/rosa-sts-about-iam-resources.adoc
 
 :_content-type: CONCEPT
 [id="rosa-hcp-byo-oidc-options_{context}"]

--- a/modules/rosa-hcp-byo-oidc.adoc
+++ b/modules/rosa-hcp-byo-oidc.adoc
@@ -1,6 +1,14 @@
 // Module included in the following assemblies:
 //
 // * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+// * rosa_architecture/rosa-sts-about-iam-resources.adoc
+
+ifeval::["{context}" == "rosa-hcp-sts-creating-a-cluster-quickly"]
+:rosa-hcp:
+endif::[]
+ifeval::["{context}" == "rosa-sts-about-iam-resources"]
+:rosa-classic:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="rosa-hcp-byo-oidc_{context}"]
@@ -10,7 +18,12 @@ When using a {hcp-title} cluster, you must create the OpenID Connect (OIDC) conf
 
 .Prerequisites
 
+ifdef::rosa-hcp[]
 * You have completed the AWS prerequisites for {hcp-title}.
+endif::rosa-hcp[]
+ifdef::rosa-classic[]
+* You have completed the AWS prerequisites for {product-title}.
+endif::rosa-classic[]
 * You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
 
 .Procedure

--- a/modules/rosa-oidc-config-overview.adoc
+++ b/modules/rosa-oidc-config-overview.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+// * rosa_architecture/rosa-sts-about-iam-resources.adoc
+
+[id="rosa-byo-odic-overview_{context}"]
+= Creating an OpenID Connect Configuration
+
+When using a cluster hosted by Red Hat, you can create a managed or unmanaged OpenID Connect (OIDC) configuration by using the ROSA CLI. A managed OIDC configuration is stored within Red Hat's AWS account, while a generated unmanaged OIDC configuration is stored within your AWS account. The OIDC configuration is registered to be used with {cluster-manager}. When creating an unmanaged OIDC configuration, the CLI provides the private key for you.

--- a/modules/rosa-oidc-understanding.adoc
+++ b/modules/rosa-oidc-understanding.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/rosa-sts-about-iam-resources.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-oidc-overview.adoc
+
+:_content-type: CONCEPT
+[id=rosa-oidc-understanding_{context}]
+= Understanding the OIDC verification options
+
+There are three options for OIDC verification:
+
+* Unregistered, managed OIDC configuration
++
+An unregistered, managed OIDC configuration is created for you during the cluster installation process. The configuration is hosted under Red Hat's AWS account. This option does not give you the ID that links to the OIDC configuration, so you can only use this type of OIDC configuration on a single cluster.
+
+* Registered, managed OIDC configuration
++    
+You create a registered, managed OIDC configuration before you start creating your clusters. This configuration is hosted under Red Hat's AWS account like the unregistered managed OIDC configuration. When you use this option for your OIDC configuration, you receive an ID that links to the OIDC configuration. Red Hat uses this ID to identify the issuer URL and private key. You can then use this URL and private key to create an identity provider and Operator roles. These resources are created under your AWS account by using Identity and Access Management (IAM) AWS services. You can also use the OIDC configuration ID during the cluster creation process.
+
+* Registered, unmanaged OIDC configuration
++
+You can create a registered, unmanaged OIDC configuration before you start creating your clusters. This configuration is hosted under your AWS account. When you use this option, you are responsible for managing the private key. You can register the configuration with {cluster-manager-first} by storing the private key in an AWS secrets file by using the AWS Secrets Manager (SM) service and the issuer URL which hosts the configuration. You can use the ROSA CLI to create a registered, unmanaged OIDC configuration with the `rosa create oidc-config --managed=false` command. This command creates and hosts the configuration under your account and creates the necessary files and private secret key. This command also registers the configuration with {cluster-manager}.
+
+The registered options can be used to create the required IAM resources before you start creating a cluster. This option results in faster install times since there is a waiting period during cluster creation where the installation pauses until you create an OIDC provider and Operator roles. 
+
+For ROSA Classic, you may use any of the OIDC configuration options. If you are using {hcp-title}, you must create registered OIDC configuration, either as managed or unmanaged. You can share the registered OIDC configurations with other clusters. This ability to share the configuration also allows you to share the provider and Operator roles. 
+
+[NOTE]
+====
+Reusing the OIDC configurations, OIDC provider, and Operator roles between clusters is not recommended for production clusters since the authentication verification is used throughout all of these clusters. Red Hat advises to only reuse resources on non-production test environments.
+====

--- a/modules/rosa-sts-oidc-provider-command.adoc
+++ b/modules/rosa-sts-oidc-provider-command.adoc
@@ -1,22 +1,33 @@
 // Module included in the following assemblies:
 //
 // * rosa_architecture/rosa-sts-about-iam-resources.adoc
+// * rosa_architecture/rosa_policy_service_definition/rosa-oidc-overview.adoc
 
+:_content-type: PROCEDURE
 [id="rosa-sts-oidc-provider-for-operators-aws-cli_{context}"]
-= OIDC provider AWS CLI reference
+= Creating an OIDC provider using the CLI
 
-This section lists the `aws` CLI command that is shown in the terminal when you run the following `rosa` command using `manual` mode:
+You can create an OIDC provider that is hosted in your AWS account with the ROSA CLI.
 
+.Prerequisites
+
+* You have installed the latest version of the ROSA CLI.
+
+.Procedure
+
+* To create an OIDC provider, by using an unregistered or a registered OIDC configuration.
+** Unregistered OIDC configurations require you to create the OIDC provider through the cluster. Run the following to create the OIDC provider:
++
 [source,terminal]
 ----
 $ rosa create oidc-provider --mode manual --cluster <cluster_name>
 ----
-
++
 [NOTE]
 ====
 When using `manual` mode, the `aws` command is printed to the terminal for your review. After reviewing the `aws` command, you must run it manually. Alternatively, you can specify `--mode auto` with the `rosa create` command to run the `aws` command immediately.
 ====
-
++
 .Command output
 [source,terminal]
 ----
@@ -26,3 +37,17 @@ aws iam create-open-id-connect-provider \
 	--thumbprint-list <thumbprint> <1>
 ----
 <1> The thumbprint is generated automatically when you run the `rosa create oidc-provider` command. For more information about using thumbprints with AWS Identity and Access Management (IAM) OpenID Connect (OIDC) identity providers, see link:https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_oidc_verify-thumbprint.html[the AWS documentation].
+
+** Registered OIDC configurations use an OIDC configuration ID. Run the following command with your OIDC configuration ID:
++
+[source,terminal]
+----
+$ rosa create oidc-provider --oidc-config-id <oidc_config_id> --mode auto -y
+----
++
+.Command output
+[source,terminal]
+----
+I: Creating OIDC provider using 'arn:aws:iam::4540112244:user/userName'
+I: Created OIDC provider with ARN 'arn:aws:iam::4540112244:oidc-provider/dvbwgdztaeq9o.cloudfront.net/241rh9ql5gpu99d7leokhvkp8icnalpf'
+----

--- a/modules/rosa-sts-oidc-provider.adoc
+++ b/modules/rosa-sts-oidc-provider.adoc
@@ -1,8 +1,0 @@
-// Module included in the following assemblies:
-//
-// * rosa_architecture/rosa-sts-about-iam-resources.adoc
-
-[id="rosa-sts-oidc-provider-requirements-for-operators_{context}"]
-= OIDC provider requirements for Operator authentication
-
-For ROSA installations that use STS, you must create a cluster-specific OIDC provider that is used by the cluster Operators to authenticate.

--- a/rosa_architecture/rosa-oidc-overview.adoc
+++ b/rosa_architecture/rosa-oidc-overview.adoc
@@ -1,0 +1,30 @@
+:_content-type: ASSEMBLY
+[id="rosa-oidc-overview"]
+= OpenID Connect Overview
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-oidc-overview
+
+toc::[]
+
+OpenID Connect (OIDC) uses Security Token Service (STS) to allow clients to provide a web identity token to gain access to multiple services. When a client signs into a service using STS, the token is validated against the OIDC identity provider.
+
+The OIDC protocol uses a configuration URL that contains the necessary information to authenticate a client's identity. The protocol responds to the provider with the credentials needed for the provider to validate the client and sign them in.
+
+{product-title} clusters use STS and OIDC to grant the in-cluster operators access to necessary AWS resources.
+
+include::modules/rosa-oidc-understanding.adoc[leveloffset=+1]
+
+include::modules/rosa-oidc-config-overview.adoc[leveloffset=+1]
+[discrete]
+include::modules/rosa-hcp-byo-oidc.adoc[leveloffset=+3]
+[discrete]
+include::modules/rosa-hcp-byo-oidc-options.adoc[leveloffset=+3]
+
+include::modules/rosa-sts-oidc-provider-command.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-oidc-config"]
+== Additional resources
+
+* See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-byo-odic-overview_rosa-sts-about-iam-resources[Creating an OpenID Connect Configuration] for the ROSA Classic instructions.
+* See xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-byo-oidc_rosa-hcp-sts-creating-a-cluster-quickly[Creating an OpenID Connect Configuration] for the {hcp-title} instructions.

--- a/rosa_architecture/rosa-sts-about-iam-resources.adoc
+++ b/rosa_architecture/rosa-sts-about-iam-resources.adoc
@@ -85,6 +85,17 @@ include::modules/rosa-sts-about-operator-role-prefixes.adoc[leveloffset=+2]
 
 * For steps to create the cluster-specific Operator IAM roles using a custom prefix, see xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster with customizations using the CLI] or xref:../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-creating-cluster-customizations-ocm_rosa-sts-creating-a-cluster-with-customizations[Creating a cluster with customizations by using {cluster-manager}].
 
-include::modules/rosa-sts-oidc-provider.adoc[leveloffset=+1]
+[id="rosa-sts-oidc-provider-requirements-for-operators_{context}"]
+== Open ID Connect (OIDC) requirements for Operator authentication
+
+For ROSA installations that use STS, you must create a cluster-specific OIDC provider that is used by the cluster Operators to authenticate or create your own OIDC configuration for your own OIDC provider.
+
 include::modules/rosa-sts-oidc-provider-command.adoc[leveloffset=+2]
+
+include::modules/rosa-oidc-config-overview.adoc[leveloffset=+2]
+[discrete]
+include::modules/rosa-hcp-byo-oidc.adoc[leveloffset=+3]
+[discrete]
+include::modules/rosa-hcp-byo-oidc-options.adoc[leveloffset=+3]
+
 include::modules/rosa-aws-scp.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-6027](https://issues.redhat.com/browse/OSDOCS-6027)

Link to docs preview:
- [ROSA STS Requirements](https://60225--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-sts-about-iam-resources.html#rosa-byo-odic-overview_rosa-sts-about-iam-resources)
- [ROSA HCP](https://60225--docspreview.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-byo-odic-overview_rosa-hcp-sts-creating-a-cluster-quickly) for comparison
- [OIDC overview](https://60225--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-oidc-overview.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Ported the ROSA with HCP OIDC Config information to ROSA Classic.