### PR TITLE
OSDOCS-3864 - Added the "no-proxy" parameter to cluster-wide proxy

### DIFF
--- a/modules/configuring-a-proxy-after-installation-cli.adoc
+++ b/modules/configuring-a-proxy-after-installation-cli.adoc
@@ -30,17 +30,27 @@ $ rosa edit cluster \
  --cluster $CLUSTER_NAME \
  --additional-trust-bundle-file <path_to_ca_bundle_file> \ <1> <2> <3>
  --http-proxy http://<username>:<password>@<ip>:<port> \ <1> <4>
- --https-proxy http(s)://<username>:<password>@<ip>:<port> <1> <4>
+ --https-proxy https://<username>:<password>@<ip>:<port> \ <1> <4>
+  --no-proxy example.com <5>
 ----
++
+--
 <1> The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
 <2> If you use the `additional-trust-bundle-file` argument without an `http-proxy` or `https-proxy` argument, the trust bundle is added to the trust store and used to verify cluster system egress traffic. In that scenario, the bundle is not configured to be used with a proxy.
 <3> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` parameter is required unless the identity certificate of the proxy is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
-<4> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
 +
 [NOTE]
 ====
 You should not attempt to change the proxy or additional trust bundle configuration on the cluster directly. These changes must be applied by using the ROSA CLI (`rosa`) or {cluster-manager-first}. Any changes that are made directly to the cluster will be reverted automatically.
 ====
+<4> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
+<5> A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
++
+Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
+If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
++
+This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.
+--
 
 .Verification
 

--- a/modules/configuring-a-proxy-during-installation-cli.adoc
+++ b/modules/configuring-a-proxy-during-installation-cli.adoc
@@ -24,9 +24,19 @@ $ rosa create cluster \
  <other_arguments_here> \
  --additional-trust-bundle-file <path_to_ca_bundle_file> \ <1> <2> <3>
  --http-proxy http://<username>:<password>@<ip>:<port> \ <1> <4>
- --https-proxy http(s)://<username>:<password>@<ip>:<port> <1> <4>
+ --https-proxy https://<username>:<password>@<ip>:<port> \ <1> <4>
+ --no-proxy example.com <5>
 ----
++
+--
 <1> The `additional-trust-bundle-file`, `http-proxy`, and `https-proxy` arguments are all optional.
 <2> If you use the `additional-trust-bundle-file` argument without an `http-proxy` or `https-proxy` argument, the trust bundle is added to the trust store and used to verify cluster system egress traffic. In that scenario, the bundle is not configured to be used with a proxy.
 <3> The `additional-trust-bundle-file` argument is a file path pointing to a bundle of PEM-encoded X.509 certificates, which are all concatenated together. The `additionalTrustBundle` parameter is required unless the identity certificate of the proxy is signed by an authority from the {op-system} trust bundle. If you use an MITM transparent proxy network that does not require additional proxy configuration but requires additional CAs, you must provide the MITM CA certificate.
 <4> The `http-proxy` and `https-proxy` arguments must point to a valid URL.
+<5> A comma-separated list of destination domain names, IP addresses, or network CIDRs to exclude proxying.
++
+Preface a domain with `.` to match subdomains only. For example, `.y.com` matches `x.y.com`, but not `y.com`. Use `*` to bypass proxy for all destinations.
+If you scale up workers that are not included in the network defined by the `networking.machineNetwork[].cidr` field from the installation configuration, you must add them to this list to prevent connection issues.
++ 
+This field is ignored if neither the `httpProxy` or `httpsProxy` fields are set.
+--


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-3864](https://issues.redhat.com/browse/OSDOCS-3864)

Link to docs preview:
- [Configuring a proxy during installation](https://60226--docspreview.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy.html#configuring-a-proxy-during-installation-cli_configuring-a-cluster-wide-proxy)
- [Configuring a proxy after installation](https://60226--docspreview.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy.html#configuring-a-proxy-after-installation-cli_configuring-a-cluster-wide-proxy)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the `--no-proxy` parameter to the cluster-wide proxy documentation.