### PR TITLE
[OSDOCS-6145]-Update Structure of Configuring machine pools/local zones for machine pools in ROSA docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -216,10 +216,10 @@ Topics:
   Topics:
   - Name: About machine pools
     File: rosa-nodes-machinepools-about
-  - Name: Configuring machine pools
-    File: rosa-nodes-machinepools-configuring
   - Name: Managing compute nodes
     File: rosa-managing-worker-nodes
+  - Name: Configuring machine pools in Local Zones
+    File: rosa-nodes-machinepools-configuring
     Distros: openshift-rosa
   - Name: About autoscaling nodes on a cluster
     File: rosa-nodes-about-autoscaling-nodes
@@ -643,7 +643,7 @@ Topics:
     - Name: Resolving image tags to digests
       File: resolving-image-tags-to-digests
     - Name: Configuring TLS authentication
-      File: serverless-config-tls          
+      File: serverless-config-tls
     - Name: Restrictive network policies
       File: restrictive-network-policies
   - Name: Traffic splitting
@@ -818,7 +818,7 @@ Topics:
     Dir: tuning
     Topics:
     - Name: Overriding deployment configurations
-      File: overriding-config-eventing    
+      File: overriding-config-eventing
     - Name: High availability
       File: serverless-ha
 - Name: Functions

--- a/modules/rosa-nodes-machine-pools-local-zones.adoc
+++ b/modules/rosa-nodes-machine-pools-local-zones.adoc
@@ -5,13 +5,13 @@
 
 :_content-type: PROCEDURE
 [id="rosa-nodes-machine-pools-local-zones_{context}"]
-= Configuring Local Zones for machine pools
+= Configuring machine pools in Local Zones
 
-Use the following steps to configure Local Zones for machine pools.
+Use the following steps to configure machine pools in Local Zones.
 
 [IMPORTANT]
 ====
-AWS Local Zones are supported on Red Hat OpenShift Service on AWS 4.12. See the link:https://access.redhat.com/articles/6989889[Red Hat Knowledgebase article] for information on how to enable Local Zones. 
+AWS Local Zones are supported on Red Hat OpenShift Service on AWS 4.12. See the link:https://access.redhat.com/articles/6989889[Red Hat Knowledgebase article] for information on how to enable Local Zones.
 ====
 .Prerequisites
 
@@ -21,7 +21,7 @@ AWS Local Zones are supported on Red Hat OpenShift Service on AWS 4.12. See the 
 +
 [IMPORTANT]
 ====
-Generally, the Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. See link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation. 
+Generally, the Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. See link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation.
 The cluster network MTU must always be less than the EC2 MTU to account for the overhead. The specific overhead is determined by your network plugin, for example:
 
 - OVN-Kubernetes: `100 bytes`
@@ -41,7 +41,7 @@ The network plugin could provide additional features that may also decrease the 
 +
 [source,terminal]
 ----
-$ rosa create machinepool -c <cluster-name> -i 
+$ rosa create machinepool -c <cluster-name> -i
 ----
 +
 . Add the subnet and instance type for the machine pool in ROSA CLI. After several minutes, the cluster will provision the nodes.

--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.adoc
@@ -1,10 +1,10 @@
 :_content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
 [id="rosa-nodes-machinepools-configuring"]
-= Configuring machine pools
+= Configuring machine pools in Local Zones
 :context: rosa-nodes-machinepools-configuring
 
 toc::[]
-This document describes how to configure machine pools with {product-title} (ROSA).
+This document describes how to configure Local Zones in machine pools with {product-title} (ROSA).
 
 include::modules/rosa-nodes-machine-pools-local-zones.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-6145
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://60227--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-configuring.html
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
QE N/A
Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
