### PR TITLE
OCPBUGS#9379: Fixed bug on Automatically allocating resources for nod…

### DIFF
--- a/modules/nodes-nodes-resources-configuring-auto.adoc
+++ b/modules/nodes-nodes-resources-configuring-auto.adoc
@@ -47,7 +47,7 @@ metadata:
 +
 [TIP]
 ====
-If the label is not present, add a key/value pair such as:
+If an appropriate label is not present, add a key/value pair such as:
 
 ----
 $ oc label machineconfigpool worker custom-kubelet=small-pods
@@ -73,7 +73,7 @@ spec:
 ----
 <1> Assign a name to CR.
 <2> Add the `autoSizingReserved` parameter set to `true` to allow {product-title} to automatically determine and allocate the `system-reserved` resources on the nodes associated with the specified label. To disable automatic allocation on those nodes, set this parameter to `false`.
-<3> Specify the label from the machine config pool.
+<3> Specify the label from the machine config pool that you configured in the "Prerequisites" section. You can choose any desired labels for the machine config pool, such as `custom-kubelet: small-pods`, or the default label, `pools.operator.machineconfiguration.openshift.io/worker: ""`.
 +
 The previous example enables automatic resource allocation on all worker nodes. {product-title} drains the nodes, applies the kubelet config, and restarts the nodes.
 


### PR DESCRIPTION
[OCPBUGS-9379](https://issues.redhat.com/browse/OCPBUGS-9379)

Version(s):
4.14 through to 4.10

Link to docs preview:
[Preview link](https://60245--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-resources-configuring.html#nodes-nodes-resources-configuring-auto_nodes-nodes-resources-configuring)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
