### PR TITLE
Add link to SSG for admonitions

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1650,6 +1650,8 @@ Text for admonition
 ====
 ....
 
+See the link:https://redhat-documentation.github.io/supplementary-style-guide/#admonitions[Red Hat Supplementary style guide] for the valid admonition types and their definitions.
+
 [id="api-object-formatting"]
 == API object formatting
 


### PR DESCRIPTION
Add a link to the Supplementary Style Guide for definitions of Admonitions.

Preview: [Admonitions](https://github.com/openshift/openshift-docs/blob/e445b2cd207c396eeb35dd1b0a992d8a0adadb1d/contributing_to_docs/doc_guidelines.adoc#admonitions)