### PR TITLE
[enterprise-4.12] RHDEVDOCS-5271 - Logging 5.6.6 Release Notes to 4.12

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -15,6 +15,8 @@ include::modules/logging-rn-5.7.1.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-rn-5.7.0.adoc[leveloffset=+1]
 
+include::modules/logging-rn-5.6.6.adoc[leveloffset=+1]
+
 include::modules/cluster-logging-rn-5.6.5.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-rn-5.6.4.adoc[leveloffset=+1]

--- a/logging/v5_6/logging-5-6-release-notes.adoc
+++ b/logging/v5_6/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-rn-5.6.6.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.6.5.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.4.adoc[leveloffset=+1]

--- a/modules/logging-rn-5.6.6.adoc
+++ b/modules/logging-rn-5.6.6.adoc
@@ -1,0 +1,36 @@
+//module included in logging-release-notes.adoc
+:_content-type: REFERENCE
+[id="logging-rn-5-6-6_{context}"]
+= Logging 5.6.6
+This release includes link:https://access.redhat.com/errata/RHBA-2023:3194[OpenShift Logging Bug Fix Release 5.6.6].
+
+[id="logging-5-6-6-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, dropping of messages occurred when configuring the `ClusterLogForwarder` custom resource to write to a Kafka output topic that matched a key in the payload due to an error. With this update, the issue is resolved by prefixing Fluentd's buffer name with an underscore. (link:https://issues.redhat.com/browse/LOG-3458[LOG-3458])
+
+* Before this update, premature closure of watches occurred in Fluentd when inodes were reused and there were multiple entries with the same inode. With this update, the issue of premature closure of watches in the Fluentd position file is resolved. (link:https://issues.redhat.com/browse/LOG-3629[LOG-3629])
+
+* Before this update, the detection of JavaScript client multi-line exceptions by Fluentd failed, resulting in printing them as multiple lines. With this update, exceptions are output as a single line, resolving the issue.(link:https://issues.redhat.com/browse/LOG-3761[LOG-3761])
+
+* Before this update, direct upgrades from the Red Hat Openshift Logging Operator version 4.6 to version 5.6 were allowed, resulting in functionality issues. With this update, upgrades must be within two versions, resolving the issue. (link:https://issues.redhat.com/browse/LOG-3837[LOG-3837])
+
+* Before this update, metrics were not displayed for Splunk or Google Logging outputs. With this update, the issue is resolved by sending metrics for HTTP endpoints.(link:https://issues.redhat.com/browse/LOG-3932[LOG-3932])
+
+* Before this update, when the `ClusterLogForwarder` custom resource was deleted, collector pods remained running. With this update, collector pods do not run when log forwarding is not enabled. (link:https://issues.redhat.com/browse/LOG-4030[LOG-4030])
+
+* Before this update, a time range could not be selected in the {Product-Title} web console by clicking and dragging over the logs histogram. With this update, clicking and dragging can be used to successfully select a time range. (link:https://issues.redhat.com/browse/LOG-4101[LOG-4101])
+
+* Before this update, Fluentd hash values for watch files were generated using the paths to log files, resulting in a non unique hash upon log rotation. With this update, hash values for watch files are created with inode numbers, resolving the issue. (link:https://issues.redhat.com/browse/LOG-3633[LOG-3633])
+
+* Before this update, clicking on the *Show Resources* link in the {Product-Title} web console did not produce any effect. With this update, the issue is resolved by fixing the functionality of the *Show Resources* link to toggle the display of resources for each log entry. (link:https://issues.redhat.com/browse/LOG-4118[LOG-4118])
+
+[id="logging-5-6-6-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-21930[CVE-2023-21930]
+* link:https://access.redhat.com/security/cve/CVE-2023-21937[CVE-2023-21937]
+* link:https://access.redhat.com/security/cve/CVE-2023-21938[CVE-2023-21938]
+* link:https://access.redhat.com/security/cve/CVE-2023-21939[CVE-2023-21939]
+* link:https://access.redhat.com/security/cve/CVE-2023-21954[CVE-2023-21954]
+* link:https://access.redhat.com/security/cve/CVE-2023-21967[CVE-2023-21967]
+* link:https://access.redhat.com/security/cve/CVE-2023-21968[CVE-2023-21968]
+* link:https://access.redhat.com/security/cve/CVE-2023-28617[CVE-2023-28617]


### PR DESCRIPTION
Manual CP of https://github.com/openshift/openshift-docs/pull/60174 to 4.12