### PR TITLE
OCPBUGS-13855:Agent TUI release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -280,6 +280,13 @@ In {product-title} {product-version}, you can use projects and categories to org
 
 For more information, see xref:../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installation-configuration-parameters-additional-vsphere_installing-nutanix-installer-provisioned[Installing a cluster on Nutanix].
 
+[id="ocp-4-13-installation-agent-console-application"]
+==== Agent-based Installer now performs network connectivity checks
+
+For installations of {product-title} {product-version} using the Agent-based Installer, a console application (with a textual user interface) performs a pull check early in the installation process to verify that the current host can retrieve the configured release image. The console application supports troubleshooting issues by allowing users to directly modify network configurations.
+
+For more information, see xref:../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-tui_installing-with-agent-based-installer[Verifying that the current installation host can pull release images].
+
 [id="ocp-4-13-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
[OCPBUGS-13855](https://issues.redhat.com/browse/OCPBUGS-13855)

Version: 4.13 only

This PR adds a release note entry in the New features and enhancement section describing the agent-tui/agent console application that is now a part of Agent-based installations.

QE review:
- [x] QE has approved this change.

Preview: [Release Notes](http://file.bos.redhat.com/skopacz/OCPBUGS-13855/release_notes/ocp-4-13-release-notes.html#ocp-4-13-installation-agent-console-application)