### PR TITLE
OCPBUGS#9988: Addressed doc bug for  Generating the discovery ISO wit…

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -16,6 +16,12 @@ To install {product-title} on a single node, use the web-based Assisted Installe
 
 include::modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#persistent-storage-using-lvms_logical-volume-manager-storage[Persistent storage using logical volume manager storage]
+* xref:../../virt/about-virt.adoc#virt-what-you-can-do-with-virt_about-virt[What you can do with OpenShift Virtualization]
+
 include::modules/install-sno-installing-with-the-assisted-installer.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
[OCPBUGS-9988](https://issues.redhat.com/browse/OCPBUGS-9988)

Version(s):
4.10 through to 4.14

Links:
[Generating the discovery ISO with the Assisted Installer](https://60276--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#install-sno-generating-the-discovery-iso-with-the-assisted-installer_install-sno-installing-sno-with-the-assisted-installer)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Slack](https://redhat-internal.slack.com/archives/CUPJTHQ5P/p1684772480826279)