### PR TITLE
Reorganizing netobserv release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -735,10 +735,6 @@ For more information, see xref:../security/encrypting-etcd.adoc#etcd-encryption-
 ==== Enhancements to networking alerts
 * OVN Kubernetes retries a claim up to 15 times before dropping it. With this update, if this failure happens, {product-title} alerts the cluster administrator. A description of each alert can be viewed in the console.
 
-[id="ocp-4-13-network-observability-1_1-1_2"]
-==== Network Observability Operator
-The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, rolling stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator can be found in the xref:../networking/network_observability/network-observability-operator-release-notes.adoc[Network Observability release notes].
-
 [id="ocp-4-13-noovnmasterleader"]
 ===== NoOvnMasterLeader
 * Summary: There is no ovn-kubernetes master leader.
@@ -768,6 +764,10 @@ Netlink messages dropped by OVS vSwitch daemon due to netlink socket buffer over
 ----
 Netlink messages dropped by OVS kernel module due to netlink socket buffer overflow. This will result in packet loss.
 ----
+
+[id="ocp-4-13-network-observability-1_1-1_2"]
+==== Network Observability Operator
+The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, rolling stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator can be found in the xref:../networking/network_observability/network-observability-operator-release-notes.adoc[Network Observability release notes].
 
 [id="ocp-4-13-nw-metallb-ipaddresspool-assignment"]
 ==== Assign IP addresses in MetalLB IPAddressPool resources to specific namespaces and services


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Per @kalexand-rh , this does not need SME review since it is a small reorg change, not a technical change. 
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
I accidentally interrupted a list of release notes with the Network Observability release note, so I needed to reorg it under the list that I interrupted. 
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Preview is not working for like 2 hours now, so I screen-captured the local preview I got with asciibinder build. See comment below.
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
