### PR TITLE
OCPBUGS#12919: The MCD has a non-functional pivot command that should  be deprecated

### DIFF
--- a/modules/machine-config-daemon-metrics.adoc
+++ b/modules/machine-config-daemon-metrics.adoc
@@ -7,16 +7,11 @@
 
 Beginning with {product-title} 4.3, the Machine Config Daemon provides a set of metrics. These metrics can be accessed using the Prometheus Cluster Monitoring stack.
 
-The following table describes this set of metrics.
+The following table describes this set of metrics. Some entries contain commands for getting specific logs. Hpwever, the most comprehensive set of logs is available using the `oc adm must-gather` command.
 
 [NOTE]
 ====
-Metrics marked with `\*` in the *Name* and *Description* columns represent serious errors that might cause performance problems. Such problems might prevent updates and upgrades from proceeding.
-====
-
-[NOTE]
-====
-While some entries contain commands for getting specific logs, the most comprehensive set of logs is available using the `oc adm must-gather` command.
+Metrics marked with `+*+` in the *Name* and *Description* columns represent serious errors that might cause performance problems. Such problems might prevent updates and upgrades from proceeding.
 ====
 
 [cols="1,1,2,2", options="header"]
@@ -55,11 +50,7 @@ For further investigation, see the logs by running:
 |Logs errors encountered during pivot. *
 |Pivot errors might prevent OS upgrades from proceeding.
 
-For further investigation, run this command to access the node and see all its logs:
-
-`$ oc debug node/<node> -- chroot /host journalctl -u pivot.service`
-
-Alternatively, you can run this command to only see the logs from the `machine-config-daemon` container:
+For further investigation, run this command to see the logs from the `machine-config-daemon` container:
 
 `$ oc logs -f -n openshift-machine-config-operator machine-config-daemon-<hash> -c machine-config-daemon`
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-12919

Removed a command for _further information_ that no longer works in 4.12+ (Table 1, 3rd row, under Notes). Also fixed formatting.  

Current [Machine Config Daemon metrics](https://docs.openshift.com/container-platform/4.13/nodes/nodes/nodes-nodes-machine-config-daemon-metrics.html)
Preview: [Machine Config Daemon metrics](https://60289--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-machine-config-daemon-metrics.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

