### PR TITLE
[OSDOCS-6155] added what's new for ROSA hosted control planes

### DIFF
--- a/rosa_release_notes/_attributes
+++ b/rosa_release_notes/_attributes
@@ -1,0 +1,1 @@
+../_attributes

--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -15,6 +15,13 @@ include::modules/rosa-update-cli-tool.adoc[]
 [id="rosa-new-changes-and-updates_{context}"]
 == New changes and updates
 
+[id="rosa-q2-2023_{context}"]
+=== Q2 2023
+
+include::snippets/rosa-hcp-rn.adoc[leveloffset=+1]
+:featureName: ROSA with HCP
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
 [id="rosa-q1-2023_{context}"]
 === Q1 2023
 

--- a/rosa_release_notes/snippets
+++ b/rosa_release_notes/snippets
@@ -1,0 +1,1 @@
+../snippets

--- a/snippets/rosa-hcp-rn.adoc
+++ b/snippets/rosa-hcp-rn.adoc
@@ -3,4 +3,4 @@
 // * rosa_release_notes/rosa-release-notes.adoc
 
 :_content-type: SNIPPET
-* With the latest version of {product-title}, {product-title} allows you to create a {hcp-title} cluster. This functionality offers a lower-cost, reliable ROSA option for small-scale usage. For more information, see link:https://docs.openshift.com/rosa-hcp/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[Creating hosted control planes for ROSA cluster using the default options].
+* {hcp-title-first} clusters are now available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] feature. This new architecture provides a lower-cost, more resilient ROSA architecture. For more information, see link:https://docs.openshift.com/rosa/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html[Creating {hcp-title} clusters using the default options].


### PR DESCRIPTION
[OSDOCS-6155] added what's new for ROSA hosted control planes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-6155

Link to docs preview:
https://60290--docspreview.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes.html#rosa-q2-2023_rosa-whats-new

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
