### PR TITLE
OCPBUGS#13668: Added note on SDN and plain OVN are not supported

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -37,8 +37,12 @@ a|* Windows Server 2022, OS Build link:https://support.microsoft.com/en-us/topic
 
 == Supported networking
 
-Hybrid networking with OVN-Kubernetes is the only supported networking configuration. See the additional resources below for more information on this functionality. The following tables outline the type of networking configuration and Windows Server versions to use based on your platform. You must specify the network configuration when you install the cluster. Be aware that OpenShift SDN networking is the default network for {product-title} clusters. However, OpenShift SDN is not supported by WMCO.
+Hybrid networking with OVN-Kubernetes is the only supported networking configuration. See the additional resources below for more information on this functionality. The following tables outline the type of networking configuration and Windows Server versions to use based on your platform. You must specify the network configuration when you install the cluster. 
 
+[NOTE]
+====
+The WMCO does not support OVN-Kubernetes without hybrid networking or OpenShift SDN.
+====
 
 .Platform networking support
 [cols="2",options="header"]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-13668?

Removed sentence that SDN is the default.  Added note that OVN with hydrid and SDN are not supported. 

Current: WMCO release notes -> [Supported networking](https://docs.openshift.com/container-platform/4.12/windows_containers/windows-containers-release-notes-7-x.html#supported-networking)
Preview: WMCO release notes -> [Supported networking](http://file.rdu.redhat.com/mburke/wmco-clarify-networking-412/windows_containers/windows-containers-release-notes-7-x.html#supported-networking)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
