### PR TITLE
OADP: matchLabels should be a map of {key,value} pairs

### DIFF
--- a/modules/oadp-creating-backup-cr.adoc
+++ b/modules/oadp-creating-backup-cr.adoc
@@ -58,26 +58,22 @@ spec:
   storageLocation: <velero-sample-1> <4>
   ttl: 720h0m0s
   labelSelector: <5>
-  - matchLabels:
+    matchLabels:
       app=<label_1>
-  - matchLabels:
       app=<label_2>
-  - matchLabels:
       app=<label_3>
-  orlabelSelectors: <6>
+  orLabelSelectors: <6>
   - matchLabels:
       app=<label_1>
-  - matchLabels:
       app=<label_2>
-  - matchLabels:
       app=<label_3>
 ----
 <1> Specify an array of namespaces to back up.
 <2> Optional: Specify an array of resources to include in the backup. Resources might be shortcuts (for example, 'po' for 'pods') or fully-qualified. If unspecified, all resources are included.
 <3> Optional: Specify an array of resources to exclude from the backup. Resources might be shortcuts (for example, 'po' for 'pods') or fully-qualified.
 <4> Specify the name of the `backupStorageLocations` CR.
-<5> Backup resources that have all of the specified labels.
-<6> Backup resources that have one or more of the specified labels.
+<5> Map of {key,value} pairs of backup resources that have *all* of the specified labels.
+<6> Map of {key,value} pairs of backup resources that have *one or more* of the specified labels.
 
 . Verify that the status of the `Backup` CR is `Completed`:
 +


### PR DESCRIPTION
OADP 1.1+; OCP 4.10+

Resolves https://issues.redhat.com/browse/OADP-1739 by correcting the Backup CR in https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/virtualization/backup-and-restore#oadp-creating-backup-cr_virt-backing-up-vms and https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/backup_and_restore/index#oadp-creating-backup-cr_backing-up-applications

Previews: [Identical passages, one in _Backup and Restore_, the other in _Virtualization_ .]

1 https://60294--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-creating-backup-cr_backing-up-applications

2. https://60294--docspreview.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backing-up-vms.html#oadp-creating-backup-cr_virt-backing-up-vms

QE approved; please merge when approved by merge review team (no need to wait for 1.2 GA). 
