### PR TITLE
Fixed incorrect redirect for RHACS Vuln Mgmt topic

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -146,7 +146,7 @@ AddType text/vtt                            vtt
     RewriteRule ^acs/(\D.*)$ /acs/4.0/$1 [NE,R=301]
     RewriteRule ^acs/(3\.65|3\.66|3\.67|3\.68|3\.69|3\.70|3\.71|3\.72|3\.73|3\.74|4\.0)/?$ /acs/$1/welcome/index.html [L,R=301]
     #redirect for 4.0 Manage vulneribility page
-    RewriteRule ^(acs/(?:\d\.\d+/)?)?operating/manage-vulnerabilities\.html$ /acs/4.0/operating/manage-vulnerabilities/vulnerability-management.html [NE,R=301]
+    RewriteRule ^(acs/(?:4\.0/)?)?operating/manage-vulnerabilities\.html$ /acs/4.0/operating/manage-vulnerabilities/vulnerability-management.html [NE,R=301]
 
     # this pipeline redirect has to come before the latest kicks in generically
     RewriteRule ^container-platform/latest/pipelines/creating-applications-with-cicd-pipelines.html /container-platform/4.7/cicd/pipelines/creating-applications-with-cicd-pipelines.html [NE,R=301]


### PR DESCRIPTION
There was an error in PR https://github.com/openshift/openshift-docs/pull/59560 which accidentally redirected all requests for `https://docs.openshift.com/acs/operating/manage-vulnerabilities.html` to the new URL. However, it should have been redirected only for 4.0

This PR fixes the issues, so that it only redirects the following links:
- `https://docs.openshift.com/acs/operating/manage-vulnerabilities.html`
- `https://docs.openshift.com/acs/4.0/operating/manage-vulnerabilities.html`

and not `https://docs.openshift.com/acs/3.7x/operating/manage-vulnerabilities.html` ones.