### PR TITLE
OCPBUGS#13279: Update the explanation of graph:true field in ocp 4.11

### DIFF
--- a/modules/oc-mirror-creating-image-set-config.adoc
+++ b/modules/oc-mirror-creating-image-set-config.adoc
@@ -61,7 +61,7 @@ mirror:
 <2> Set the back-end location to save the image set metadata to. This location can be a registry or local directory. It is required to specify `storageConfig` values.
 <3> Set the registry URL for the storage backend.
 <4> Set the channel to retrieve the {product-title} images from.
-<5> Add `graph: true` to generate the OpenShift Update Service (OSUS) graph image to allow for an improved cluster update experience when using the web console. For more information, see _About the OpenShift Update Service_.
+<5> Add `graph: true` to build and push the graph-data image to the mirror registry. The graph-data image is required to create OpenShift Update Service (OSUS). The `graph: true` field also generates the `UpdateService` custom resource manifest. The `oc` command-line interface (CLI) can use the `UpdateService` custom resource manifest to create OSUS. For more information, see _About the OpenShift Update Service_.
 <6> Set the Operator catalog to retrieve the {product-title} images from.
 <7> Specify only certain Operator packages to include in the image set. Remove this field to retrieve all packages in the catalog.
 <8> Specify only certain channels of the Operator packages to include in the image set. You must always include the default channel for the Operator package even if you do not use the bundles in that channel. You can find the default channel by running the following command: `oc mirror list operators --catalog=<catalog_name> --package=<package_name>`.


### PR DESCRIPTION
Version(s): 4.11

Issue: https://issues.redhat.com/browse/OCPBUGS-13279

Link to docs preview: http://file.rdu.redhat.com/sdudhgao/411-graph-true/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-creating-image-set-config_installing-mirroring-disconnected

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
