### PR TITLE
OCPBUGS#1874: Updated instance group name for GCP scripts

### DIFF
--- a/modules/installation-creating-gcp-bootstrap.adoc
+++ b/modules/installation-creating-gcp-bootstrap.adoc
@@ -113,7 +113,7 @@ Manager, so you must add the bootstrap machine manually.
 [source,terminal]
 ----
 $ gcloud compute instance-groups unmanaged add-instances \
-    ${INFRA_ID}-bootstrap-instance-group --zone=${ZONE_0} --instances=${INFRA_ID}-bootstrap
+    ${INFRA_ID}-bootstrap-ig --zone=${ZONE_0} --instances=${INFRA_ID}-bootstrap
 ----
 
 .. Add the bootstrap instance group to the internal load balancer backend service:
@@ -121,7 +121,7 @@ $ gcloud compute instance-groups unmanaged add-instances \
 [source,terminal]
 ----
 $ gcloud compute backend-services add-backend \
-    ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-instance-group --instance-group-zone=${ZONE_0}
+    ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-ig --instance-group-zone=${ZONE_0}
 ----
 endif::shared-vpc[]
 
@@ -130,14 +130,14 @@ ifdef::shared-vpc[]
 +
 [source,terminal]
 ----
-$ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-bootstrap-instance-group --zone=${ZONE_0} --instances=${INFRA_ID}-bootstrap
+$ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-bootstrap-ig --zone=${ZONE_0} --instances=${INFRA_ID}-bootstrap
 ----
 
 . Add the bootstrap instance group to the internal load balancer backend service:
 +
 [source,terminal]
 ----
-$ gcloud compute backend-services add-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-instance-group --instance-group-zone=${ZONE_0}
+$ gcloud compute backend-services add-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-ig --instance-group-zone=${ZONE_0}
 ----
 endif::shared-vpc[]
 

--- a/modules/installation-creating-gcp-control-plane.adoc
+++ b/modules/installation-creating-gcp-control-plane.adoc
@@ -94,9 +94,9 @@ Manager, so you must add the control plane machines manually.
 +
 [source,terminal]
 ----
-$ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_0}-instance-group --zone=${ZONE_0} --instances=${INFRA_ID}-master-0
-$ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_1}-instance-group --zone=${ZONE_1} --instances=${INFRA_ID}-master-1
-$ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_2}-instance-group --zone=${ZONE_2} --instances=${INFRA_ID}-master-2
+$ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_0}-ig --zone=${ZONE_0} --instances=${INFRA_ID}-master-0
+$ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_1}-ig --zone=${ZONE_1} --instances=${INFRA_ID}-master-1
+$ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_2}-ig --zone=${ZONE_2} --instances=${INFRA_ID}-master-2
 ----
 
 ** For an external cluster, you must also run the following commands to add the control plane machines to the target pools:

--- a/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
@@ -44,7 +44,7 @@ has initialized.
 +
 [source,terminal]
 ----
-$ gcloud compute backend-services remove-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-instance-group --instance-group-zone=${ZONE_0}
+$ gcloud compute backend-services remove-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-ig --instance-group-zone=${ZONE_0}
 $ gsutil rm gs://${INFRA_ID}-bootstrap-ignition/bootstrap.ign
 $ gsutil rb gs://${INFRA_ID}-bootstrap-ignition
 $ gcloud deployment-manager deployments delete ${INFRA_ID}-bootstrap


### PR DESCRIPTION
[OCPBUGS-1874](https://issues.redhat.com/browse/OCPBUGS-1874)

Version(s):
4.14 through to 4.10

Link to docs preview:
* [Creating the bootstrap machine in GCP](https://60304--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-creating-gcp-bootstrap_installing-gcp-user-infra-vpc)
* [Creating the control plane machine in GCP](https://60304--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-creating-gcp-control-plane_installing-gcp-user-infra-vpc)
* [Wait for bootstrap completion and remove bootstrap resources in GCP](https://60304--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-wait-for-bootstrap_installing-gcp-user-infra-vpc)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

