### PR TITLE
OCPBUG#11043: Reverted the changes from 'oc-mirror' to 'oc mirror'.

### DIFF
--- a/modules/oc-mirror-installing-plugin.adoc
+++ b/modules/oc-mirror-installing-plugin.adoc
@@ -53,5 +53,5 @@ $ sudo mv oc-mirror /usr/local/bin/.
 +
 [source,terminal]
 ----
-$ oc-mirror help
+$ oc mirror help
 ----


### PR DESCRIPTION
Version(s): 4.10+

Reverted the changes done in [PR-58034](https://github.com/openshift/openshift-docs/pull/58034). "$oc-mirror help" command corrected to "$oc mirror help" in the section 'Installing the oc-mirror OpenShift CLI plugin'.

Issue:
[OCPBUG-11043](https://issues.redhat.com/browse/OCPBUGS-11043)

Link to docs preview:
[Preview](https://60305--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#installation-oc-mirror-installing-plugin_installing-mirroring-disconnected)

QE review:

- [x] QE has approved the change