### PR TITLE
OCPBUGS#12884: Removed extra load typo

### DIFF
--- a/modules/nw-ingress-setting-internal-lb.adoc
+++ b/modules/nw-ingress-setting-internal-lb.adoc
@@ -25,7 +25,7 @@ image::202_OpenShift_Ingress_0222_load_balancer.png[{product-title} Ingress Load
 
 The preceding graphic shows the following concepts pertaining to {product-title} Ingress LoadBalancerService endpoint publishing strategy:
 
-* You can load load balance externally, using the cloud provider load balancer, or internally, using the OpenShift Ingress Controller Load Balancer.
+* You can load balance externally, using the cloud provider load balancer, or internally, using the OpenShift Ingress Controller Load Balancer.
 * You can use the single IP address of the load balancer and more familiar ports, such as 8080 and 4200 as shown on the cluster depicted in the graphic.
 * Traffic from the external load balancer is directed at the pods, and managed by the load balancer, as depicted in the instance of a down node.
 See the link:https://kubernetes.io/docs/concepts/services-networking/service/#internal-load-balancer[Kubernetes Services documentation]


### PR DESCRIPTION
Version(s): 4.10+

Issue: https://issues.redhat.com/browse/OCPBUGS-12884

Link to docs preview: https://60306--docspreview.netlify.app/openshift-enterprise/latest/networking/ingress-operator.html#nw-ingress-setting-internal-lb_configuring-ingress

QE review:
- [ ] QE has approved this change. - N/A since this is a minor typo