### PR TITLE
CNV-22625: Update doc HCO variable 4.12.3

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -105,7 +105,7 @@ endif::[]
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.12
 :KubeVirtVersion: v0.58.0
-:HCOVersion: 4.12.2
+:HCOVersion: 4.12.3
 :delete: image:delete.png[title="Delete"]
 ifdef::openshift-origin[]
 :VirtProductName: OKD Virtualization


### PR DESCRIPTION
Version(s): 4.12.3

Issue: [CNV-22625](https://issues.redhat.com/browse/CNV-22625)

Link to docs preview: To verify HCO variable update to 4.12.3, see the Files changed in this PR.

QE review: N/A

Additional information: This PR must not be merged until errata has been shipped.

