### PR TITLE
OSDOCS-6148: adds 4.12.18 to RNs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3664,3 +3664,29 @@ $ oc adm release info 4.12.17 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-12-18"]
+=== RHBA-2023:3208 - {product-title} 4.12.18 bug fix update
+
+Issued: 2023-05-23
+
+{product-title} release 4.12.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3208[RHBA-2023:3208] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:3207[RHBA-2023:3207] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.18 --pullspecs
+----
+
+[id="ocp-4-12-18-bug-fixes"]
+==== Bug fixes
+
+* Previously, the *Samples* page in the {product-title} did not allow distinguishing between the types of samples listed. With this fix, you can identify the sample from the badges displayed on the *Samples* page. (link:https://issues.redhat.com/browse/OCPBUGS-7446[*OCPBUGS-7446*])
+
+* Previously, when viewing resource consumption for a specific pod, graphs displaying `CPU usage` and `Memory Usage` metrics were stacked even though these metrics are static values, which should be displayed as a static line across the graph. With this update, {product-title} correctly displays the values for `CPU Usage` and `Memory Usage` in the monitoring dashboard. (link:https://issues.redhat.com/browse/OCPBUGS-5353[*OCPBUGS-5353*])
+
+[id="ocp-4-12-18-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
OSDOCS#6148: adds 4.12.18 to RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-6148
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
http://file.rdu.redhat.com/jaldinge/OSDOCS-6148/release_notes/ocp-4-12-release-notes.html#ocp-4-12-18
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
