### PR TITLE
IDMS and ITMS are supported since 4.13, not 4.8

### DIFF
--- a/snippets/node-icsp-no-drain.adoc
+++ b/snippets/node-icsp-no-drain.adoc
@@ -1,7 +1,7 @@
 // Text snippet included in the following modules:
 //
-// * modules/about-crio.adoc
-// * modules/nodes-containers-using.adoc
+// * modules/understanding-machine-config-operator.adoc
+// * modules/troubleshooting-disabling-autoreboot-mco.adoc
 
 :_content-type: SNIPPET
 
@@ -13,7 +13,7 @@ The following modifications do not trigger a node reboot:
 ** Changes to the global pull secret or pull secret in the `openshift-config` namespace.
 ** Automatic rotation of the `/etc/kubernetes/kubelet-ca.crt` certificate authority (CA) by the Kubernetes API Server Operator.
 
-* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageDigestMirrorSet` or `ImageTagMirrorSet` object, it drains the corresponding nodes, applies the changes, and uncordons the nodes.The node drain does not happen for the following changes:
+* When the MCO detects changes to the `/etc/containers/registries.conf` file, such as adding or editing an `ImageContentSourcePolicy` (ICSP) object, it drains the corresponding nodes, applies the changes, and uncordons the nodes.The node drain does not happen for the following changes:
 ** The addition of a registry with the `pull-from-mirror = "digest-only"` parameter set for each mirror.
 ** The addition of a mirror with the `pull-from-mirror = "digest-only"` parameter set in a registry.
 ** The addition of items to the `unqualified-search-registries` list.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-11634

ImageDigestMirrorSet and ImageTagMirrorSet are supported since OCP 4.13, we should remove the related description and add ICSP since OCP 4.8.  I backported https://github.com/openshift/openshift-docs/pull/57440/ in error.

Previews:
[About the Machine Config Operator](http://file.rdu.redhat.com/mburke/mco-remove-idms-itms/architecture/control-plane.html#about-machine-config-operator_control-plane) IMPORTANT admonition
[Disabling the Machine Config Operator from automatically rebooting](http://file.rdu.redhat.com/mburke/mco-remove-idms-itms/support/troubleshooting/troubleshooting-operator-issues.html#troubleshooting-disabling-autoreboot-mco_troubleshooting-operator-issues) NOTE admonition

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
