### PR TITLE
Fix OpenShift Container Platform product title in ROSA Welcome link

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -18,7 +18,7 @@ endif::[]
 ifdef::openshift-rosa[]
 To navigate the ROSA documentation, use the left navigation bar.
 
-For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[{product-title} documentation].
+For documentation that is not ROSA-specific, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
 endif::[]
 
 ifndef::openshift-rosa[]


### PR DESCRIPTION
Version(s):
4.13+ 

Issue:
No issue

Link to docs preview:
https://60409--docspreview.netlify.app/openshift-rosa/latest/welcome/index.html

QE review:
- [ ] QE has approved this change.
No QE review required. This is essentially a typo fix. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
