### PR TITLE
CNV-28750: uncommenting RHEL 9 module

### DIFF
--- a/virt/upgrading-virt.adoc
+++ b/virt/upgrading-virt.adoc
@@ -13,8 +13,7 @@ Learn how Operator Lifecycle Manager (OLM) delivers z-stream and minor version u
 Updating to {VirtProductName} 4.13 from {VirtProductName} 4.12.2 is not supported.
 ====
 
-// todo: uncomment when z-stream releases
-//include::modules/virt-rhel-9.adoc[leveloffset=+1]
+include::modules/virt-rhel-9.adoc[leveloffset=+1]
 
 include::modules/virt-about-upgrading-virt.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-28750](https://issues.redhat.com//browse/CNV-28750)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: http://file.rdu.redhat.com/pousley/cnv-28750-main/virt/upgrading-virt.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Note to self/CNV team: HOLD until 4.12.3 releases. Then, merge this PR. Finally, merge its companion: #60413
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
