### PR TITLE
OSDOCS-5881

### DIFF
--- a/modules/rosa-sdpolicy-am-compute.adoc
+++ b/modules/rosa-sdpolicy-am-compute.adoc
@@ -12,10 +12,10 @@ Multiple availability zone clusters require a minimum of 3 control plane nodes. 
 
 All {product-title} clusters support a maximum of 180 worker nodes.
 
-// [NOTE]
-// ====
-// The `Default` machine pool node type and size cannot be changed after the cluster is created. To change the `Default` machine pool node type and size, delete the current `Default` machine pool and then create a new `Default` machine pool with the desired settings. For more information regarding machine pools, see xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#rosa-managing-worker-nodes[Managing compute nodes].
-// ====
+[NOTE]
+====
+After the cluster is installed, the `Default` machine pool cannot be deleted, and its node type or size cannot be changed.
+====
 
 Control plane and infrastructure nodes are deployed and managed by Red Hat. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss. There are at least 3 control plane nodes that handle etcd- and API-related workloads. There are at least 2 infrastructure nodes that handle metrics, routing, the web console, and other workloads. You must not run any workloads on the control and infrastructure nodes. Any workloads you intend to run must be deployed on worker nodes. See the Red Hat Operator support section below for more information about Red Hat workloads that must be deployed on worker nodes.
 

--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
@@ -27,13 +27,21 @@ Machine pools are a higher level construct to compute machine sets.
 
 A machine pool creates compute machine sets that are all clones of the same configuration across availability zones. Machine pools perform all of the host node provisioning management actions on a worker node. If you need more machines or must scale them down, change the number of replicas in the machine pool to meet your compute needs. You can manually configure scaling or set autoscaling.
 
-By default, a cluster is created with one machine pool. You can add additional machine pools to an existing cluster, modify machine pools, and delete machine pools.
+By default, a cluster has one machine pool. During cluster installation, you can label this machine pool. After the cluster is installed, the `Default` machine pool cannot be deleted, and its node type or size cannot be changed.
 
+After a cluster's installation:
+
+* You can relabel a `Default` machine pool.
+* You can add additional machine pools to an existing cluster.
++
 [NOTE]
 ====
-You cannot change the instance type or availability zone for a machine pool after the machine pool is created.
+You cannot change the machine pool node type or size. The machine pool node type or size is specified during their creation only. If you need a different node type or size, you must re-create a machine pool and specify the required node type or size values.
 ====
-Multiple machine pools can exist on a single cluster, and they can each have different types or different size nodes.
+* You can add a label to each added machine pool.
+* You cannot delete the `Default` machine pool. However, you can delete the non-default machine pools. 
+
+Multiple machine pools can exist on a single cluster, and each machine pool can contain a unique node type and node size configuration.
 
 == Machine pools in multiple zone clusters
 When you create a machine pool in a multiple availability zone (Multi-AZ) cluster, that one machine pool has 3 zones. The machine pool, in turn, creates a total of 3 compute machine sets - one for each zone in the cluster. Each of those compute machine sets manages one or more machines in its respective availability zone.


### PR DESCRIPTION
[OSDOCS-5881](https://issues.redhat.com/browse/OSDOCS-5881): Inconsistent description of whether default machine pool can be changed in ROSA

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OSDOCS-5881](https://issues.redhat.com/browse/OSDOCS-5881)
Preview pages: [Click to see the build preview in your browser_1](https://60419--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html#machine-pools) and [Click to see the build preview in your browser_2](https://60419--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-instance-types_rosa-service-definition)
SME review **completed**: @arendej
QE review **completed**: @xueli181114
Peer review **completed**: @dfitzmau 