### PR TITLE
Adding OpenShiftDocs Vocab

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,6 @@ dev_guide/builds/images/chained-build.png.cache
 bin
 commercial_package
 .vscode
-.vale
+.vale/styles/AsciiDoc
+.vale/styles/OpenShiftAsciiDoc
+.vale/styles/RedHat

--- a/.vale.ini
+++ b/.vale.ini
@@ -4,13 +4,19 @@ MinAlertLevel = suggestion
 
 Packages = RedHat, https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/AsciiDoc.zip, https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/OpenShiftAsciiDoc.zip
 
-#ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
+Vocab = OpenShiftDocs
+
+# Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
 BasedOnStyles = RedHat, AsciiDoc
 
-#optional: pass doc attributes to asciidoctor before linting
+# Optional: pass doc attributes to asciidoctor before linting
 #[asciidoctor]
 #openshift-enterprise = YES
 
 # Disabling rules (NO)
 RedHat.ReleaseNotes = NO
+
+# Use local OpenShiftDocs Vocab terms
+Vale.Terms = YES
+Vale.Avoid = YES

--- a/.vale/styles/Vocab/OpenShiftDocs/accept.txt
+++ b/.vale/styles/Vocab/OpenShiftDocs/accept.txt
@@ -1,0 +1,10 @@
+# Regex terms added to accept.txt are ignored by the Vale linter and override RedHat Vale rules.
+# Add terms that have a corresponding incorrectly capitalized form to reject.txt.
+
+[Pp]assthrough
+Assisted Installer
+custom resource
+custom resources
+MetalLB
+Operator
+Operators

--- a/.vale/styles/Vocab/OpenShiftDocs/reject.txt
+++ b/.vale/styles/Vocab/OpenShiftDocs/reject.txt
@@ -1,0 +1,13 @@
+# Regex terms added to reject.txt are highlighted as errors by the Vale linter and override RedHat Vale rules.
+# Add terms that have a corresponding correctly capitalized form to accept.txt.
+
+[Dd]eployment [Cc]onfigs?
+[Dd]eployment [Cc]onfigurations?
+[Oo]peratorize
+[Ss]ingle [Nn]ode OpenShift
+[Tt]hree [Nn]ode OpenShift
+AI
+configuration maps?
+minions?
+operators?
+SNO

--- a/modules/.vale.ini
+++ b/modules/.vale.ini
@@ -2,5 +2,11 @@ StylesPath = ../.vale/styles
 
 MinAlertLevel = suggestion
 
+Vocab = OpenShiftDocs
+
 [[!.]*.adoc]
 BasedOnStyles = OpenShiftAsciiDoc, AsciiDoc, RedHat
+
+# Use local OpenShiftDocs Vocab terms
+Vale.Terms = YES
+Vale.Avoid = YES


### PR DESCRIPTION
Adding a Vale Vocab allows for OpenShift project specific terms to be maintained with the OCP docs repo, separate to the main Red Hat Vale style. Vocab accept and reject terms override Vale styles entries.

Merge to main, CP to enterprise 4.10+

https://vale.sh/docs/topics/vocab/

![image](https://github.com/openshift/openshift-docs/assets/74046732/4cb9f5d1-177d-4cac-ae93-4836f94ef47c)

