### PR TITLE
OCPBUGS-9989: Add comment to minimum vCPU requirement for Assisted In…

### DIFF
--- a/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
+++ b/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
@@ -14,7 +14,7 @@ Installing {product-title} on a single node alleviates some of the requirements 
 
 * *Supported platforms:* Installing {product-title} on a single node is supported on bare metal, vSphere, AWS, Red Hat OpenStack, and Red Hat Virtualization platforms. In all cases, you must specify the `platform.none: {}` parameter in the `install-config.yaml` configuration file.
 
-* *Production-grade server:* Installing {product-title} on a single node requires a server with sufficient resources to run {product-title} services and a production workload.
+* *Production-grade server:* Installing {product-title} on a single node requires a server with sufficient resources to run {product-title} services and a production workload. 
 +
 .Minimum resource requirements
 [options="header"]
@@ -25,12 +25,14 @@ Installing {product-title} on a single node alleviates some of the requirements 
 +
 [NOTE]
 ====
-One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio:
-
+* One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio:
++
 (threads per core × cores) × sockets = vCPUs
+
+* Adding Operators during the installation process might increase the minimum resource requirements.
 ====
 +
-The server must have a Baseboard Management Controller (BMC) when booting with virtual media.
+The server must have a Baseboard Management Controller (BMC) when booting with virtual media. 
 
 * *Networking:* The server must have access to the internet or access to a local registry if it is not connected to a routable network. The server must have a DHCP reservation or a static IP address for the Kubernetes API, ingress route, and cluster node domain names. You must configure the DNS to resolve the IP address to each of the following fully qualified domain names (FQDN):
 +


### PR DESCRIPTION
Version(s):
4.12, 4.13, 4.14, main 

Issue:
(https://issues.redhat.com/browse/OCPBUGS-9989)

Reviewers:
SME: Nick Carboni, Paul Maidment
QE: TBD

Link to docs preview:
https://60421--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-preparing-to-install-sno.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Summary of changes:
Added this sentence to the **Production-grade server** bullet: _Additional operators might increase the vCPU requirement._
