### PR TITLE
OCPBUGS-9989-412: Add comment to minimum vCPU requirement for Assiste…

### DIFF
--- a/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
+++ b/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
@@ -11,7 +11,7 @@ Installing {product-title} on a single node alleviates some of the requirements 
 
 * *Supported platforms:* Installing {product-title} on a single node is supported on bare metal and link:https://access.redhat.com/articles/973163[Certified third-party hypervisors]. In all cases, you must specify the `platform.none: {}` parameter in the `install-config.yaml` configuration file.
 
-* *Production-grade server:* Installing {product-title} on a single node requires a server with sufficient resources to run {product-title} services and a production workload.
+* *Production-grade server:* Installing {product-title} on a single node requires a server with sufficient resources to run {product-title} services and a production workload. Additional operators might increase the vCPU requirement.
 +
 .Minimum resource requirements
 [options="header"]


### PR DESCRIPTION
Version(s):
4.12,
TBD: Correct or from 4.12 onwards?

Issue:
(https://issues.redhat.com/browse/OCPBUGS-9989)

Reviewers:
SME: TBD
QE: TBD

Link to docs preview:
https://60421--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-preparing-to-install-sno.html

QE review:

Summary of changes:
Added this sentence to the Production-grade server bullet: Additional operators might increase the vCPU requirement.