### PR TITLE
CNV-26734: updates to VM latency checkup's documentation

### DIFF
--- a/modules/virt-measuring-latency-vm-secondary-network.adoc
+++ b/modules/virt-measuring-latency-vm-secondary-network.adoc
@@ -108,17 +108,17 @@ metadata:
   name: kubevirt-vm-latency-checkup-config
 data:
   spec.timeout: 5m
-  spec.param.network_attachment_definition_namespace: <target_namespace>
-  spec.param.network_attachment_definition_name: "blue-network" <1>
-  spec.param.max_desired_latency_milliseconds: "10" <2>
-  spec.param.sample_duration_seconds: "5" <3>
-  spec.param.source_node: "worker1" <4>
-  spec.param.target_node: "worker2" <5>
+  spec.param.networkAttachmentDefinitionNamespace: <target_namespace>
+  spec.param.networkAttachmentDefinitionName: "blue-network" <1>
+  spec.param.maxDesiredLatencyMilliseconds: "10" <2>
+  spec.param.sampleDurationSeconds: "5" <3>
+  spec.param.sourceNode: "worker1" <4>
+  spec.param.targetNode: "worker2" <5>
 ----
 <1> The name of the `NetworkAttachmentDefinition` object.
 <2> Optional: The maximum desired latency, in milliseconds, between the virtual machines. If the measured latency exceeds this value, the checkup fails.
 <3> Optional: The duration of the latency check, in seconds.
-<4> Optional: When specified, latency is measured from this node to the target node. If the source node is specified, the `spec.param.target_node` field cannot be empty.
+<4> Optional: When specified, latency is measured from this node to the target node. If the source node is specified, the `spec.param.targetNode` field cannot be empty.
 <5> Optional: When specified, latency is measured from the source node to this node.
 
 . Apply the config map manifest in the target namespace:
@@ -158,6 +158,10 @@ spec:
               value: <target_namespace>
             - name: CONFIGMAP_NAME
               value: kubevirt-vm-latency-checkup-config
+            - name: POD_UID
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.uid
 ----
 
 . Apply the `Job` manifest:
@@ -174,7 +178,7 @@ $ oc apply -n <target_namespace> -f <latency_job>.yaml
 $ oc wait job kubevirt-vm-latency-checkup -n <target_namespace> --for condition=complete --timeout 6m
 ----
 
-. Review the results of the latency checkup by running the following command. If the maximum measured latency is greater than the value of the `spec.param.max_desired_latency_milliseconds` attribute, the checkup fails and returns an error.
+. Review the results of the latency checkup by running the following command. If the maximum measured latency is greater than the value of the `spec.param.maxDesiredLatencyMilliseconds` attribute, the checkup fails and returns an error.
 +
 [source,terminal]
 ----
@@ -191,12 +195,12 @@ metadata:
   namespace: <target_namespace>
 data:
   spec.timeout: 5m
-  spec.param.network_attachment_definition_namespace: <target_namespace>
-  spec.param.network_attachment_definition_name: "blue-network"
-  spec.param.max_desired_latency_milliseconds: "10"
-  spec.param.sample_duration_seconds: "5"
-  spec.param.source_node: "worker1"
-  spec.param.target_node: "worker2"
+  spec.param.networkAttachmentDefinitionNamespace: <target_namespace>
+  spec.param.networkAttachmentDefinitionName: "blue-network"
+  spec.param.maxDesiredLatencyMilliseconds: "10"
+  spec.param.sampleDurationSeconds: "5"
+  spec.param.sourceNode: "worker1"
+  spec.param.targetNode: "worker2"
   status.succeeded: "true"
   status.failureReason: ""
   status.completionTimestamp: "2022-01-01T09:00:00Z"


### PR DESCRIPTION
**Version(s):**
4.13+

**Issue:**
https://issues.redhat.com/browse/CNV-26734

**Link to docs preview:**
https://60437--docspreview.netlify.app/openshift-enterprise/latest/virt/support/monitoring/virt-running-cluster-checkups.html

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
NA