### PR TITLE
OCPBUGS#13971: Fixes consistency in xrefs

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -46,7 +46,7 @@ This release adds improvements related to the following components and concepts.
 
 [id="microshift-4-13-installation"]
 === Installation
-This release includes integration with the greenboot health check framework. Greenboot assesses system health and automates a rollback to the last healthy state in the event of software trouble. You can add the optional greenboot RPM to your installation. For more information, read the xref:../microshift_running_apps/microshift-greenboot.adoc#microshirt-greenboot[Greenboot documentation].
+This release includes integration with the greenboot health check framework. Greenboot assesses system health and automates a rollback to the last healthy state in the event of software trouble. You can add the optional greenboot RPM to your installation. For more information, read the xref:../microshift_running_apps/microshift-greenboot.adoc#microshift-greenboot[Greenboot documentation].
 
 //[id="microshift-4-13-new-feature-for-use-at-installation"]
 //==== New feature for use during installation here
@@ -59,14 +59,14 @@ This release includes integration with the greenboot health check framework. Gre
 ==== {product-title} sos reports
 With this release you can run an `sos` report to collect troubleshooting information about a host. The report generates a detailed report with data from all enabled plugins and different components and applications in a system.
 
-For more information, see xref:../microshift_support/microshift-sos-report.adoc#about-microshift-sos-reports_microshift-sos-report[About MicroShift sos reports].
+For more information, read xref:../microshift_support/microshift-sos-report.adoc#about-microshift-sos-reports_microshift-sos-report[About MicroShift sos reports].
 
 [id="microshift-4-13-etcd"]
 ==== {product-title} etcd
 
 With this release, {product-title} etcd is run as a separate process whose lifecycle is managed automatically by {product-title}. You can gather `journalctl` logs to observe and debug the etcd server logs.
 
-For more information, see xref:../microshift_support/microshift-etcd.html#microshift-observe-debug-etcd-server_microshift-etcd[Observe and debug the MicroShift etcd server].
+For more information, read xref:../microshift_support/microshift-etcd.html#microshift-observe-debug-etcd-server_microshift-etcd[Observe and debug the MicroShift etcd server].
 
 //[id="microshift-4-13-post-installation"]
 //=== Post-installation configuration
@@ -86,7 +86,7 @@ For more information, see xref:../microshift_support/microshift-etcd.html#micros
 [id="microshift-4-13-load-balancer"]
 ==== Deploying network load balancers on {product-title}
 
-{product-title} now offers a built-in implementation of network load balancers. For more details, see xref:../microshift_networking/microshift-networking.adoc#microshift-deploying-a-load-balancer_microshift-networking[Deploying a TCP load balancer on a workload].
+{product-title} now offers a built-in implementation of network load balancers. For more details, read xref:../microshift_networking/microshift-networking.adoc#microshift-deploying-a-load-balancer_microshift-networking[Deploying a TCP load balancer on a workload].
 
 [id="microshift-4-13-storage"]
 === Storage
@@ -163,4 +163,4 @@ Issued: 2023-05-17
 
 {product-title} release 4.13.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1329[RHSA-2023:1329] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1326[RHSA-2023:1326] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the `TopoLVM image`, read link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
OCPBUGS#6171: Fixes consistency in xrefs

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-13971

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I know the [SSG ](https://redhat-documentation.github.io/supplementary-style-guide/#_s)says to use "see", but in order to remain consistent in Microshift docs changing these to "read" 
