### PR TITLE
virt: Fix VM latency checkup's image name

### DIFF
--- a/modules/virt-measuring-latency-vm-secondary-network.adoc
+++ b/modules/virt-measuring-latency-vm-secondary-network.adoc
@@ -145,7 +145,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: vm-latency-checkup
-          image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup:v4.13.0
+          image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup-rhel9:v4.13.0
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Currently, the VM latency checkup's image name lacks the `-rhel9` suffix, and thus cannot be pulled.
Add the required suffix.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://60452--docspreview.netlify.app/openshift-enterprise/latest/virt/support/monitoring/virt-running-cluster-checkups.html

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
