### PR TITLE
removing more attributes from anchor ids

### DIFF
--- a/modules/microshift-adding-containers-to-blueprint.adoc
+++ b/modules/microshift-adding-containers-to-blueprint.adoc
@@ -3,7 +3,7 @@
 // microshift/microshift-embed-into-rpm-ostree.adoc
 
 :_content-type: PROCEDURE
-[id="adding-{product-title}-container-images_{context}"]
+[id="adding-microshift-container-images_{context}"]
 = Adding the {product-title} container images
 
 You can embed {product-title}'s container images into the {op-system-ostree} images so that they are immediately available to the CRI-O container engine after booting. Embedded container images are not pulled over the network from a container registry. In Image Builder, a container image is embedded by adding a reference to it to the Image Builder blueprint.

--- a/modules/microshift-adding-repos-to-image-builder.adoc
+++ b/modules/microshift-adding-repos-to-image-builder.adoc
@@ -3,7 +3,7 @@
 // microshift/microshift-embed-into-rpm-ostree.adoc
 
 :_content-type: PROCEDURE
-[id="adding-{product-title}-repos-image-builder_{context}"]
+[id="adding-microshift-repos-image-builder_{context}"]
 = Adding {product-title} repositories to Image Builder
 
 Use the following procedure to add the {product-title} repositories to Image Builder on your build host.

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -3,7 +3,7 @@
 // microshift/microshift-embed-into-rpm-ostree.adoc
 
 :_content-type: CONCEPT
-[id="adding-{product-title}-service_{context}"]
+[id="adding-microshift-service_{context}"]
 = Example Image Builder blueprint with {product-title}
 
 Adding the {product-title} RPM package to an Image Builder blueprint enables the build of a {op-system-ostree} image with {product-title} embedded.


### PR DESCRIPTION
The portal build is still broken because there are more attributes in anchor IDs. This appears to remove the rest of them from `main`.