### PR TITLE
Remove field trial language from RHACS Cloud Service 3.73

### DIFF
--- a/installing/getting-started-rhacs-cloud-ocp.adoc
+++ b/installing/getting-started-rhacs-cloud-ocp.adoc
@@ -11,9 +11,6 @@ toc::[]
 
 This topic provides instructions to get started using {product-title-managed-short} on {osp}, including {ocp}, OpenShift Kubernetes Engine (OKE), Red Hat OpenShift Dedicated (OSD), Azure Red Hat OpenShift (ARO), and Red Hat OpenShift Service on Amazon Web Services (ROSA). See the inline notes for information that differs for {product-title-managed-short} on other Kubernetes platforms.
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 This installation example shows you how to set up {product-title-managed-short} on {ocp} using the Operator. It does not cover installations using Helm charts or the `roxctl` CLI.
 
 .Prerequisites
@@ -23,7 +20,7 @@ This installation example shows you how to set up {product-title-managed-short} 
 [id="accessing-acs-console"]
 == Accessing the ACS Console
 
-. In the {cloud-console}, from the navigation menu, select *Advanced Cluster Security* -> *ACS Instances*, and then select the instance that you want connected to your secured clusters. 
+. In the {cloud-console}, from the navigation menu, select *Advanced Cluster Security* -> *ACS Instances*, and then select the instance that you want connected to your secured clusters.
 * In the *Instance Details* section, note the *Central API Endpoint*. You use this address when creating secured clusters.
 . Click *Open ACS Console*. You need your Red Hat Single Sign-On (RH-SSO) credentials, or credentials for another identity provider if that has been configured.
 
@@ -68,7 +65,7 @@ For non-OpenShift Kubernetes clusters, enter the comparable `kubectl` commands t
 [id="installing-secured-cluster-resources-on-each-cluster"]
 == Installing secured cluster resources on each cluster
 
-These steps assume that you are installing resources by using the Operator. 
+These steps assume that you are installing resources by using the Operator.
 [NOTE]
 ====
 For installation on non-OpenShift Kubernetes clusters, you must use Helm charts or the `roxctl` CLI to install secured cluster resources.
@@ -99,13 +96,13 @@ For installation on non-OpenShift Kubernetes clusters, you must use Helm charts 
 === Creating Secured Cluster resources
 
 . On your cluster, navigate to *Operators* -> *Installed Operators*.
-. Click the *Project* menu and select the `stackrox` namespace. 
+. Click the *Project* menu and select the `stackrox` namespace.
 . Under *Provided APIs*, select *Secured Cluster*.
 . In the *SecuredClusters* page, click *Create SecuredCluster*.
-. Select *Form view*. 
+. Select *Form view*.
 . Enter the new project name by accepting or editing the default name. The default value is *stackrox-secured-cluster-services*.
-. Optional: Add any labels for the cluster. 
-. Enter a unique name for your `SecuredCluster` custom resource. 
+. Optional: Add any labels for the cluster.
+. Enter a unique name for your `SecuredCluster` custom resource.
 . Enter the *Central API Endpoint*, including the address and the port number. You can view this information again in the {cloud-console} console by choosing *Advanced Cluster Security* -> *ACS Instances*, and then clicking the ACS instance you created.
 . Click *Create*.
 

--- a/installing/installing_cloud_ocp/cloud-create-instance-ocp.adoc
+++ b/installing/installing_cloud_ocp/cloud-create-instance-ocp.adoc
@@ -8,7 +8,4 @@ include::modules/common-attributes.adoc[]
 [role="_abstract"]
 Access {product-title-managed} ({product-title-managed-short}) by selecting an instance in the {cloud-console}. An *ACS instance* contains the {product-title-managed-short} management interface and services that Red Hat configures and manages for you. The management interface connects to your secured clusters, which contain the services that scan and collect information about vulnerabilities. One instance can connect to and monitor multiple clusters.
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 include::modules/cloud-create-instance-steps.adoc[leveloffset=+1]

--- a/installing/installing_cloud_ocp/install-rhacs-cloud-ocp.adoc
+++ b/installing/installing_cloud_ocp/install-rhacs-cloud-ocp.adoc
@@ -9,9 +9,6 @@ toc::[]
 [role="_abstract"]
 {product-title-managed} ({product-title-managed-short}) provides security services for your Kubernetes clusters, such as OpenShift Kubernetes Engine (OKE), Red Hat OpenShift Dedicated (OSD), Azure Red Hat OpenShift (ARO), and Red Hat OpenShift Service on Amazon Web Services (ROSA).
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 For information about configuring {product-title-managed-short} for other platforms, such as Amazon Elastic Kubernetes Service (EKS), Google Kubernetes Engine (GKE), and Microsoft Azure Kubernetes Service (AKS), see xref:../../installing/installing_cloud_other/install-rhacs-cloud-other.adoc#install-rhacs-cloud-other[Overview of installing RHACS Cloud Service on other platforms].
 
 
@@ -23,7 +20,7 @@ For information about configuring {product-title-managed-short} for other platfo
 
 To set up {product-title-managed-short}:
 
-. In the {cloud-console}, from the navigation menu, select *Advanced Cluster Security* -> *ACS Instances*, and then select the instance that you want to connect to your secured clusters. 
+. In the {cloud-console}, from the navigation menu, select *Advanced Cluster Security* -> *ACS Instances*, and then select the instance that you want to connect to your secured clusters.
 * In the *Instance Details* section, note the *Central API Endpoint*. You use this address when creating secured clusters.
 . Click *Open ACS Console*. You will need your Red Hat Single Sign-On (RH-SSO) credentials, or credentials for another identity provider if that has been configured.
 . In the ACS console, xref:../installing_cloud_ocp/init-bundle-cloud-ocp.adoc#portal-generate-init-bundle_init-bundle-cloud-ocp[generate an init bundle].

--- a/installing/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
+++ b/installing/installing_cloud_ocp/install-secured-cluster-cloud-ocp.adoc
@@ -9,9 +9,6 @@ toc::[]
 [role="_abstract"]
 You can install {product-title-managed-short} on your secured clusters by using the Operator.
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 Ensure that you have performed the following steps:
 
 * Created your {ocp} cluster and installed the Operator on it.

--- a/installing/installing_cloud_ocp/prerequisites-cloud-ocp.adoc
+++ b/installing/installing_cloud_ocp/prerequisites-cloud-ocp.adoc
@@ -10,9 +10,6 @@ toc::[]
 [role="_abstract"]
 You must complete prerequisites before installing {product-title-managed} for Red Hat OpenShift on secured clusters.
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 include::modules/acs-requirements.adoc[leveloffset=+1]
 include::modules/scanner-requirements.adoc[leveloffset=+1]
 include::modules/sensor-requirements.adoc[leveloffset=+1]

--- a/installing/installing_cloud_ocp/verify-installation-cloud-ocp.adoc
+++ b/installing/installing_cloud_ocp/verify-installation-cloud-ocp.adoc
@@ -9,9 +9,6 @@ toc::[]
 [role="_abstract"]
 After installing {product-title-managed-short}, you can perform some steps to verify that the installation was successful.
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 To verify installation, access your ACS Console from the {cloud-console}. The Dashboard will display the number of clusters that {product-title-managed-short} is monitoring, along with information about nodes, deployments, images, and violations.
 
 If no data appears in the ACS Console:

--- a/installing/installing_cloud_other/cloud-create-instance-other.adoc
+++ b/installing/installing_cloud_other/cloud-create-instance-other.adoc
@@ -8,9 +8,6 @@ include::modules/common-attributes.adoc[]
 [role="_abstract"]
 Access {product-title-managed} ({product-title-managed-short}) by selecting an instance in the {cloud-console}. An *ACS instance* contains the {product-title-managed-short} management interface and services that Red Hat configures and manages for you. The management interface connects to your secured clusters, which contain the services that scan and collect information about vulnerabilities. One instance can connect to and monitor multiple clusters.
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 include::modules/cloud-create-instance-steps.adoc[leveloffset=+1]
 
 

--- a/installing/installing_cloud_other/install-rhacs-cloud-other.adoc
+++ b/installing/installing_cloud_other/install-rhacs-cloud-other.adoc
@@ -10,9 +10,6 @@ toc::[]
 [role="_abstract"]
 {product-title-managed} ({product-title-managed-short}) provides security services for your Kubernetes clusters. You can install {product-title-managed-short} on Kubernetes systems with secured clusters on managed platforms such as Amazon Elastic Kubernetes Service (EKS), Google Kubernetes Engine (GKE), and Microsoft Azure Kubernetes Service (AKS).
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 .Prerequisites
 
 * Understand the xref:../../installing/acs-installation-platforms.adoc#install-platforms-methods[installation platforms and methods].
@@ -21,7 +18,7 @@ include::snippets/field-trial.adoc[leveloffset=+1]
 
 To set up {product-title-managed-short} on other platforms:
 
-. In the {cloud-console}, from the navigation menu, select *Advanced Cluster Security* -> *ACS Instances* and select the instance that you want to connect to your secured clusters. 
+. In the {cloud-console}, from the navigation menu, select *Advanced Cluster Security* -> *ACS Instances* and select the instance that you want to connect to your secured clusters.
 * In the *Instance Details* section, note the *Central API Endpoint*. You use this address when creating secured clusters.
 . Click *Open ACS Console*. You need your Red Hat Single Sign-On (RH-SSO) credentials, or credentials for another identity provider if that has been configured.
 . In the ACS console, generate an xref:../installing_cloud_other/init-bundle-cloud-other.adoc#init-bundle-cloud-other[init bundle].

--- a/installing/installing_cloud_other/install-secured-cluster-cloud-other.adoc
+++ b/installing/installing_cloud_other/install-secured-cluster-cloud-other.adoc
@@ -13,9 +13,6 @@ You can install {product-title-managed-short} on your secured clusters by using 
 * By using Helm charts
 * By using the `roxctl` CLI (do not use this method unless you have a specific installation need that requires using it)
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 [id="installing-sc-helm-cloud-other"]
 == Installing {product-title-managed-short} on secured clusters by using Helm charts
 

--- a/installing/installing_cloud_other/prerequisites-cloud-other.adoc
+++ b/installing/installing_cloud_other/prerequisites-cloud-other.adoc
@@ -11,9 +11,6 @@ toc::[]
 
 You must complete prerequisites before installing {product-title-managed} for supported Kubernetes platforms.
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 include::modules/acs-requirements.adoc[leveloffset=+1]
 include::modules/scanner-requirements.adoc[leveloffset=+1]
 include::modules/sensor-requirements.adoc[leveloffset=+1]

--- a/installing/installing_cloud_other/verify-installation-cloud-other.adoc
+++ b/installing/installing_cloud_other/verify-installation-cloud-other.adoc
@@ -9,9 +9,6 @@ toc::[]
 [role="_abstract"]
 After installing {product-title-managed-short}, you can perform some steps to verify that the installation was successful.
 
-:FeatureName: {product-title-managed-short}
-include::snippets/field-trial.adoc[leveloffset=+1]
-
 To verify installation, access your ACS Console from the {cloud-console}. The Dashboard will display the number of clusters that {product-title-managed-short} is monitoring, along with information about nodes, deployments, images, and violations.
 
 If no data appears in the ACS Console:


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs-3.73`
- Cherry pick to `rhacs-docs-3.74`

Issue: none
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/getting-started-rhacs-cloud-ocp.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_ocp/install-rhacs-cloud-ocp.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_ocp/cloud-create-instance-ocp.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_ocp/install-secured-cluster-cloud-ocp.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_ocp/prerequisites-cloud-ocp.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_ocp/verify-installation-cloud-ocp.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_other/install-rhacs-cloud-other.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_other/prerequisites-cloud-other.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_other/cloud-create-instance-other.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_other/install-secured-cluster-cloud-other.html
- https://60468--docspreview.netlify.app/openshift-acs/latest/installing/installing_cloud_other/verify-installation-cloud-other.html

QE review: (**N/A** - RHACS has no QE)
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Approval via Slack was given by PM (Doron) & Support (Marina) to remove Field Trial snippet from 3.73 ACS release, because ACS is now LA for all customers and Field Trial snippet doesn't apply anymore. In addition, 3.73 docs were coming up in google searches, leading to customer confusion as to whether Cloud Service is still in field trial (it's not). 

Cloud Service is on a different release cycle than RHACS, but the gist of the issue is, it's in LA (not FT) for all customers now.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
