### PR TITLE
OSDOCS-6150: adds 4.10.60 to RNs

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -3959,7 +3959,7 @@ $ oc adm release info 4.10.57 --pullspecs
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
 
 [id="ocp-4-10-58"]
-=== RHBA-2023:1867 - {product-title} 4.10.58 bug fix update and security update
+=== RHBA-2023:1867 - {product-title} 4.10.58 bug fix and security update
 
 Issued: 2023-04-26
 
@@ -3998,6 +3998,45 @@ $ oc adm release info 4.10.59 --pullspecs
 * Previously, when creating a `Secret`, the *Start Pipeline* model created an invalid JSON value. As a result, the `Secret` was unusable and the `PipelineRun` could fail. With this fix, the *Start Pipeline* model creates a valid JSON value for the secret. Now, you can create valid secrets while starting a pipeline. (link:https://issues.redhat.com/browse/OCPBUGS-7961[*OCPBUGS-7961*])
 
 [id="ocp-4-10-59-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-60"]
+=== RHBA-2023:3217 - {product-title} 4.10.60 bug fix and security update
+
+Issued: 2023-05-24
+
+{product-title} release 4.10.60, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:3217[RHBA-2023:3217] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3216[RHSA-2023:3216] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.60 --pullspecs
+----
+
+[id="ocp-4-10-60-features"]
+==== Features
+
+[id="ocp-4-10-60-control-for-verbosity-MetalLB-logs"]
+===== Controls for the verbosity of MetalLB logs
+* With this release, you can control the verbosity of MetalLB logs. You can control logging levels by using the following values for the `logLevel` specification in the MetalLB custom resource (CR):
++
+--
+** all
+** debug
+** info
+** warn
+** error
+** none
+--
+For example, you can specify the `debug` value to include diagnostic logging information that is helpful for troubleshooting.
+
++
+For more information about logging levels for MetalLB, see xref:../networking/metallb/metallb-troubleshoot-support.adoc#nw-metallb-setting-metalb-logging-levels_metallb-troubleshoot-support[Setting the MetalLB logging levels] (link:https://issues.redhat.com/browse/OCPBUGS-11861[*OCPBUGS-11861*])
+
+[id="ocp-4-10-60-upgrading"]
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
OSDOCS#6150: adds 4.10.60 to RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://joealdinger.github.io/openshift-docs/OSDOCS-6150/release_notes/ocp-4-10-release-notes.html#ocp-4-10-60
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
