### PR TITLE
OSDOCS#6051: Known Issue for Nutanix 4.13 update

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2787,6 +2787,8 @@ To workaround the issue, delete the `cloud-event-proxy-store-storage-class-http-
 +
 This affects the achievable latency of such clusters and might prevent proper operation of low latency workloads. (link:https://issues.redhat.com/browse/OCPBUGS-13163[*OCPBUGS-13163*])
 
+* {product-title} 4.12 clusters on the Nutanix platform may have an `Upgradeable=False` condition if they are missing configuration needed for the Nutanix Cloud Control Manager (CCM). To resolve this condition, see: link:https://access.redhat.com/solutions/7014068[How to create the ConfigMaps and Secrets needed to upgrade to OpenShift 4.13 when using Nutanix as a Platform].
+
 [id="ocp-4-13-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
[OSDOCS-6051](https://issues.redhat.com/browse/OSDOCS-6051)

This PR adds a known issue to the 4.13 Release Notes, regarding 4.12 Nutanix clusters that report as Upgradeable=False due to missing configuration needed to integrate Nutanix CCM. This issue only applies to Nutanix clusters updating from 4.12 to 4.13. Once the configuration is made, further updates should not encounter this same condition. Nutanix clusters installed on 4.13 also should not have this issue.

This PR will go through change management in addition to the typical review cycle.

🚨 **_Note to all reviewers_**  🚨

The corresponding bug ticket ([OCPBUGS-7898](https://issues.redhat.com/browse/OCPBUGS-7898)) linked in [OSDOCS-6051](https://issues.redhat.com//browse/OSDOCS-6051) has a Red Hat Employee level of security, and thus will not be linked in the RN entry since customers won't be able to read it anyways. Please let me know if there is a bug ticket that I should link to instead.

One possible alternative would be [OCPBUGS-9984](https://issues.redhat.com/browse/OCPBUGS-9984), which was closed as a duplicate of 7898 but does not have the same security level. Would this be an acceptable substitution? 

QE review:
- [x] QE has approved this change.

Preview: http://file.bos.redhat.com/skopacz/OSDOCS-6051/release_notes/ocp-4-13-release-notes.html#ocp-4-13-known-issues:~:text=OCPBUGS%2D13163)-,OpenShift%20Container%20Platform%204.12%20clusters,-on%20the%20Nutanix (Preview hosted on file.bos.redhat.com, VPN connection may be required to access)
