### PR TITLE
OCPBUGS-9096: [DDF] when trying this on a customer cluster, we also needed to define api-int.. for the workers to be able to resolve

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
@@ -36,9 +36,11 @@ include::modules/ipi-install-troubleshooting-bootstrap-vm-inspecting-logs.adoc[l
 include::modules/ipi-install-troubleshooting-cluster-nodes-will-not-pxe.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting_unable-to-discover-new-bare-metal-hosts-using-the-bmc.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-api-not-accessible.adoc[leveloffset=+1]
+include::modules/ipi-install-troubleshooting_proc_worker-nodes-cannot-join-the-cluster.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-cleaning-up-previous-installations.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-registry-issues.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-misc-issues.adoc[leveloffset=+1]
 include::modules/ipi-install-troubleshooting-failed-ignition-during-firstboot.adoc[leveloffset=+2]
 include::modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc[leveloffset=+2]
 include::modules/ipi-install-troubleshooting-reviewing-the-installation.adoc[leveloffset=+1]
+

--- a/modules/ipi-install-troubleshooting_proc_worker-nodes-cannot-join-the-cluster.adoc
+++ b/modules/ipi-install-troubleshooting_proc_worker-nodes-cannot-join-the-cluster.adoc
@@ -1,0 +1,47 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-troubleshooting.adoc
+
+:_content-type: PROCEDURE
+[id="worker-nodes-cannot-join-the-cluster_{context}"]
+= Troubleshooting worker nodes that cannot join the cluster
+
+Installer-provisioned clusters deploy with a DNS server that includes a DNS entry for the `api-int.<cluster_name>.<base_domain>` URL. If the nodes within the cluster use an external or upstream DNS server to resolve the `api-int.<cluster_name>.<base_domain>` URL and there is no such entry, worker nodes might fail to join the cluster. Ensure that all nodes in the cluster can resolve the domain name. 
+
+.Procedure
+
+. Add a DNS A/AAAA or CNAME record to internally identify the API load balancer. For example, when using dnsmasq, modify the `dnsmasq.conf` configuration file:
++
+[source,terminal,options="nowrap",role="white-space-pre"]
+----
+$ sudo nano /etc/dnsmasq.conf
+----
++
+[source,terminal,options="nowrap",role="white-space-pre"]
+----
+address=/api-int.<cluster_name>.<base_domain>/<IP_address>
+address=/api-int.mycluster.example.com/192.168.1.10
+address=/api-int.mycluster.example.com/2001:0db8:85a3:0000:0000:8a2e:0370:7334
+----
+
+. Add a DNS PTR record to internally identify the API load balancer. For example, when using dnsmasq, modify the `dnsmasq.conf` configuration file: 
++
+[source,terminal,options="nowrap",role="white-space-pre"]
+----
+$ sudo nano /etc/dnsmasq.conf
+----
++
+[source,terminal,options="nowrap",role="white-space-pre"]
+----
+ptr-record=<IP_address>.in-addr.arpa,api-int.<cluster_name>.<base_domain>
+ptr-record=10.1.168.192.in-addr.arpa,api-int.mycluster.example.com
+----
+
+. Restart the DNS server. For example, when using dnsmasq, execute the following command:
++
+[source,terminal,subs="+quotes",options="nowrap",role="white-space-pre"]
+----
+$ sudo systemctl restart dnsmasq
+----
+
+These records must be resolvable from all the nodes within the cluster.


### PR DESCRIPTION
Added a troubleshooting module for api-int when using an external or upstream DNS.

Fixes: OCPBUGS-9096
See https://issues.redhat.com/browse/OCPBUGS-9096 for additional details.
Preview URL: http://184.23.213.161:8080/OCPBUGS-9096/installing/installing_bare_metal_ipi/ipi-install-troubleshooting.html#worker-nodes-cannot-join-the-cluster_ipi-install-troubleshooting

For release(s): 4.14, 4.13, 4.12, 4.11, 4.10, 4.9
QE Review:
- [x] QE has approved this change.

Signed-off-by: John Wilkins <jowilkin@redhat.com>