### PR TITLE
CNV-27916: [2184998] [DOC] Procedure to edit filesystemOverhead is wrong

### DIFF
--- a/modules/virt-overriding-default-fs-overhead-value.adoc
+++ b/modules/virt-overriding-default-fs-overhead-value.adoc
@@ -6,7 +6,7 @@
 [id="virt-overriding-default-fs-overhead-value_{context}"]
 = Overriding the default file system overhead value
 
-Change the amount of persistent volume claim (PVC) space that the {VirtProductName} reserves for file system overhead by editing the `spec.config.filesystemOverhead` attribute of the `HCO` object.
+Change the amount of persistent volume claim (PVC) space that the {VirtProductName} reserves for file system overhead by editing the `spec.filesystemOverhead` attribute of the `HCO` object.
 
 .Prerequisites
 
@@ -21,17 +21,16 @@ Change the amount of persistent volume claim (PVC) space that the {VirtProductNa
 $ oc edit hco -n openshift-cnv kubevirt-hyperconverged
 ----
 
-. Edit the `spec.config.filesystemOverhead` fields, populating them with your chosen values:
+. Edit the `spec.filesystemOverhead` fields, populating them with your chosen values:
 +
 [source,yaml]
 ----
 # ...
 spec:
-  config:
-    filesystemOverhead:
-      global: "<new_global_value>" <1>
-      storageClass:
-        <storage_class_name>: "<new_value_for_this_storage_class>" <2>
+  filesystemOverhead:
+    global: "<new_global_value>" <1>
+    storageClass:
+      <storage_class_name>: "<new_value_for_this_storage_class>" <2>
 ----
 <1> The default file system overhead percentage used for any storage classes that do not already have a set value. For example, `global: "0.07"` reserves 7% of the PVC for file system overhead.
 <2> The file system overhead percentage for the specified storage class. For example, `mystorageclass: "0.04"` changes the default overhead value for PVCs in the `mystorageclass` storage class to 4%.


### PR DESCRIPTION
Version(s): 4.11+cherrypicks


Issue: 

[CNV-27916](https://issues.redhat.com/browse/CNV-27916)  
[BZ2184998](https://bugzilla.redhat.com/show_bug.cgi?id=2184998)


Link to docs preview: https://60479--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-reserving-pvc-space-fs-overhead.html



QE review:
- [x] QE has approved this change.


Additional information:
Corrected indentation in sample file.

