### PR TITLE
OCPBUGS#13924: Add Operator deletion/reinstall guidance & warnings

### DIFF
--- a/modules/olm-reinstall.adoc
+++ b/modules/olm-reinstall.adoc
@@ -1,0 +1,105 @@
+// Module included in the following assemblies:
+//
+// * support/troubleshooting/troubleshooting-operator-issues.adoc
+
+:_content-type: PROCEDURE
+[id="olm-reinstall_{context}"]
+= Reinstalling Operators after failed uninstallation
+
+You must successfully and completely uninstall an Operator prior to attempting to reinstall the same Operator. Failure to fully uninstall the Operator properly can leave resources, such as a project or namespace, stuck in a "Terminating" state and cause "error resolving resource" messages. For example:
+
+.Example `Project` resource description
+----
+...
+    message: 'Failed to delete all resource types, 1 remaining: Internal error occurred:
+      error resolving resource'
+...
+----
+
+These types of issues can prevent an Operator from being reinstalled successfully.
+
+[WARNING]
+====
+Forced deletion of a namespace is not likely to resolve "Terminating" state issues and can lead to unstable or unpredictable cluster behavior, so it is better to try to find related resources that might be preventing the namespace from being deleted. For more information, see the link:https://access.redhat.com/solutions/4165791[Red Hat Knowledgebase Solution #4165791], paying careful attention to the cautions and warnings.
+====
+
+The following procedure shows how to troubleshoot when an Operator cannot be reinstalled because an existing custom resource definition (CRD) from a previous installation of the Operator is preventing a related namespace from deleting successfully.
+
+.Procedure
+
+. Check if there are any namespaces related to the Operator that are stuck in "Terminating" state:
++
+[source,terminal]
+----
+$ oc get namespaces
+----
++
+.Example output
+----
+operator-ns-1                                       Terminating
+----
+
+. Check if there are any CRDs related to the Operator that are still present after the failed uninstallation:
++
+[source,terminal]
+----
+$ oc get crds
+----
++
+[NOTE]
+====
+CRDs are global cluster definitions; the actual custom resource (CR) instances related to the CRDs could be in other namespaces or be global cluster instances.
+====
+
+. If there are any CRDs that you know were provided or managed by the Operator and that should have been deleted after uninstallation, delete the CRD:
++
+[source,terminal]
+----
+$ oc delete crd <crd_name>
+----
+
+. Check if there are any remaining CR instances related to the Operator that are still present after uninstallation, and if so, delete the CRs:
+
+.. The type of CRs to search for can be difficult to determine after uninstallation and can require knowing what CRDs the Operator manages. For example, if you are troubleshooting an uninstallation of the etcd Operator, which provides the `EtcdCluster` CRD, you can search for remaining `EtcdCluster` CRs in a namespace:
++
+[source,terminal]
+----
+$ oc get EtcdCluster -n <namespace_name>
+----
++
+Alternatively, you can search across all namespaces:
++
+[source,terminal]
+----
+$ oc get EtcdCluster --all-namespaces
+----
+
+.. If there are any remaining CRs that should be removed, delete the instances:
++
+[source,terminal]
+----
+$ oc delete <cr_name> <cr_instance_name> -n <namespace_name>
+----
+
+. Check that the namespace deletion has successfully resolved:
++
+[source,terminal]
+----
+$ oc get namespace <namespace_name>
+----
++
+[IMPORTANT]
+====
+If the namespace or other Operator resources are still not uninstalled cleanly, contact Red Hat Support.
+====
+
+. Reinstall the Operator using OperatorHub in the web console.
+
+.Verification
+
+* Check that the Operator has been reinstalled successfully:
++
+[source,terminal]
+----
+$ oc get sub,csv,installplan -n <namespace>
+----

--- a/operators/admin/olm-deleting-operators-from-cluster.adoc
+++ b/operators/admin/olm-deleting-operators-from-cluster.adoc
@@ -1,12 +1,17 @@
 :_content-type: ASSEMBLY
-[id='olm-deleting-operators-from-a-cluster']
+[id="olm-deleting-operators-from-a-cluster"]
 = Deleting Operators from a cluster
 include::_attributes/common-attributes.adoc[]
 :context: olm-deleting-operators-from-a-cluster
 
 toc::[]
 
-The following describes how to delete Operators that were previously installed using Operator Lifecycle Manager (OLM) on your {product-title} cluster.
+The following describes how to delete, or uninstall, Operators that were previously installed using Operator Lifecycle Manager (OLM) on your {product-title} cluster.
+
+[IMPORTANT]
+====
+You must successfully and completely uninstall an Operator prior to attempting to reinstall the same Operator. Failure to fully uninstall the Operator properly can leave resources, such as a project or namespace, stuck in a "Terminating" state and cause "error resolving resource" messages to be observed when trying to reinstall the Operator. For more information, see xref:../../support/troubleshooting/troubleshooting-operator-issues.adoc#olm-reinstall_troubleshooting-operator-issues[Reinstalling Operators after failed uninstallation].
+====
 
 include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
 include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]

--- a/support/troubleshooting/troubleshooting-operator-issues.adoc
+++ b/support/troubleshooting/troubleshooting-operator-issues.adoc
@@ -43,3 +43,14 @@ include::modules/troubleshooting-disabling-autoreboot-mco-cli.adoc[leveloffset=+
 
 // Refreshing failing subscriptions
 include::modules/olm-refresh-subs.adoc[leveloffset=+1]
+
+// Reinstalling Operators after failed uninstallation
+include::modules/olm-reinstall.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]
+* xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
+
+
+


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-13924

4.10+

Previews:

* `[IMPORTANT]` admonition at top of [Deleting Operators from a cluster](https://60481--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-deleting-operators-from-cluster.html)
* New _Troubleshooting_ topic [Reinstalling Operators after failed uninstallation](https://60481--docspreview.netlify.app/openshift-enterprise/latest/support/troubleshooting/troubleshooting-operator-issues.html#olm-reinstall_troubleshooting-operator-issues)