### PR TITLE
CNV- 28046: Adding KubeVirtDeprecatedAPIsRequested runbook

### DIFF
--- a/modules/virt-runbook-kubevirtdeprecatedapisrequested.adoc
+++ b/modules/virt-runbook-kubevirtdeprecatedapisrequested.adoc
@@ -1,0 +1,44 @@
+// Do not edit this module. It is generated with a script.
+// Do not reuse this module. The anchor IDs do not contain a context statement.
+// Module included in the following assemblies:
+//
+// * virt/support/virt-runbooks.adoc
+
+:_content-type: REFERENCE
+[id="virt-runbook-KubeVirtDeprecatedAPIsRequested"]
+= KubeVirtDeprecatedAPIsRequested
+
+[discrete]
+[id="meaning-kubevirtdeprecatedapisrequested"]
+== Meaning
+
+This alert fires when a deprecated  {VirtProductName} API is used.
+
+[discrete]
+[id="impact-kubevirtdeprecatedapisrequested"]
+== Impact
+
+Using a deprecated API is not recommended because the request will
+fail when the API is removed in a future release.
+
+[discrete]
+[id="diagnosis-kubevirtdeprecatedapisrequested"]
+== Diagnosis
+
+* Check the *Description* and *Summary* sections of the alert to identify the
+deprecated API as in the following example:
++
+*Description*
++
+`Detected requests to the deprecated virtualmachines.kubevirt.io/v1alpha3 API.`
++
+*Summary*
++
+`2 requests were detected in the last 10 minutes.`
+
+[discrete]
+[id="mitigation-kubevirtdeprecatedapisrequested"]
+== Mitigation
+
+Use fully supported APIs. The alert resolves itself after 10 minutes if the deprecated
+API is not used.

--- a/virt/support/virt-runbooks.adoc
+++ b/virt/support/virt-runbooks.adoc
@@ -37,6 +37,8 @@ include::modules/virt-runbook-kubevirtcomponentexceedsrequestedcpu.adoc[leveloff
 
 include::modules/virt-runbook-kubevirtcomponentexceedsrequestedmemory.adoc[leveloffset=+1]
 
+include::modules/virt-runbook-kubevirtdeprecatedapisrequested.adoc[leveloffset=+1]
+
 include::modules/virt-runbook-kubevirthyperconvergedclusteroperatorcrmodification.adoc[leveloffset=+1]
 
 include::modules/virt-runbook-kubevirthyperconvergedclusteroperatorinstallationnotcompletedalert.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-28046](https://issues.redhat.com//browse/CNV-28046)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [KubeVirtDeprecatedAPIsRequested](https://60498--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-runbooks.html#virt-runbook-KubeVirtDeprecatedAPIsRequested)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
