### PR TITLE
SRVCOM-2431 copying version templates to serverless

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -45,6 +45,8 @@
 
     unsupported_versions_acs = ["3.65", "3.66", "3.67", "3.68", "3.69", "3.70", "3.71", "3.72"];
 
+    unsupported_versions_serverless = [];
+
     unsupported_versions_origin = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "3.11", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"];
 
   %>
@@ -59,7 +61,7 @@
       </span>
       <% end %>
 
-      <% if (version == "4.13") && (distro_key != "openshift-webscale" && distro_key != "openshift-dpu") %>
+      <% if (version == "4.14") && (distro_key != "openshift-webscale" && distro_key != "openshift-dpu") %>
       <span>
         <div class="alert alert-danger" role="alert" id="support-alert">
           <strong>This documentation is a work in progress that aligns to preview releases of the next pending OpenShift Container Platform version 4 minor release. It might not be complete or fully tested, and some features and content might be removed before the next release. </strong>For the most recent released and supported version, see <a href="https://docs.openshift.com/container-platform/latest/welcome/index.html" style="color: #545454 !important" class="link-primary">[4]</a>.
@@ -82,6 +84,16 @@
         <span>
           <div class="alert alert-danger" role="alert" id="support-alert">
             <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/acs/welcome/index.html" style="color: #545454 !important" class="link-primary">latest RHACS docs</a>.
+          </div>
+        </span>
+
+      <% end %>
+
+      <% if ((unsupported_versions_serverless.include? version) && (distro_key == "openshift-serverless")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/serverless/latest/about/about-serverless.html" style="color: #545454 !important" class="link-primary">latest Serverless docs</a>.
           </div>
         </span>
 
@@ -113,6 +125,7 @@
             </a>
           <% end %>
           <select id="version-selector" onchange="versionSelector(this);">
+              <option value="4.13">4.13</option>
               <option value="4.12">4.12</option>
               <option value="4.11">4.11</option>
               <option value="4.10">4.10</option>
@@ -137,12 +150,12 @@
               <option value="3.1">3.1</option>
               <option value="3.0">3.0</option>
           </select>
-        <% else %>
-          <% if (distro_key == "openshift-acs") %>
+        <% elsif (distro_key == "openshift-acs") %>
             <a href="https://docs.openshift.com/acs/<%= version %>/welcome/index.html">
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="4.0">4.0</option>
               <option value="3.74">3.74</option>
               <option value="3.73">3.73</option>
               <option value="3.72">3.72</option>
@@ -154,30 +167,36 @@
               <option value="3.66">3.66</option>
               <option value="3.65">3.65</option>
             </select>
-        <% else %>
-              <% if (distro_key == "openshift-origin") %>
-                <a href="https://docs.okd.io/<%= version %>/welcome/index.html">
+        <% elsif (distro_key == "openshift-serverless") %>
+            <a href="https://docs.openshift.com/serverless/<%= version %>/about/about-serverless.html">
               <%= distro %>
-              </a>
-              <select id="version-selector" onchange="versionSelector(this);">
-                <option value="latest">latest</option>
-                <option value="4.12">4.12</option>
-                <option value="4.11">4.11</option>
-                <option value="4.10">4.10</option>
-                <option value="4.9">4.9</option>
-                <option value="4.8">4.8</option>
-                <option value="4.7">4.7</option>
-                <option value="4.6">4.6</option>
-                <option value="3.11">3.11</option>
-                <option value="3.10">3.10</option>
-                <option value="3.9">3.9</option>
-                <option value="3.7">3.7</option>
-                <option value="3.6">3.6</option>
-              </select>
-              <% else %>
-                <%= breadcrumb_root %>
-              <% end %>
-        <% end %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.29">1.29</option>
+              <option value="1.28">1.28</option>
+            </select>
+        <% elsif (distro_key == "openshift-origin") %>
+              <a href="https://docs.okd.io/<%= version %>/welcome/index.html">
+            <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="latest">latest</option>
+              <option value="4.13">4.13</option>
+              <option value="4.12">4.12</option>
+              <option value="4.11">4.11</option>
+              <option value="4.10">4.10</option>
+              <option value="4.9">4.9</option>
+              <option value="4.8">4.8</option>
+              <option value="4.7">4.7</option>
+              <option value="4.6">4.6</option>
+              <option value="3.11">3.11</option>
+              <option value="3.10">3.10</option>
+              <option value="3.9">3.9</option>
+              <option value="3.7">3.7</option>
+              <option value="3.6">3.6</option>
+            </select>
+        <% else %>
+          <%= breadcrumb_root %>
         <% end %>
       </li>
       <li class="hidden-xs active">
@@ -188,7 +207,7 @@
       <li class="hidden-xs active">
         <%= breadcrumb_topic %>
       </li>
-      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs") %>
+      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs"  && distro_key != "openshift-serverless") %>
       <span text-align="right" style="float: right !important">
         <a href="https://github.com/openshift/openshift-docs/commits/<%=
         ((distro_key == "openshift-enterprise") ? "enterprise-#{version}"
@@ -219,24 +238,38 @@
         <% end %>
         <% end %>
       </span>
-      <% else %>
-        <% if (distro_key == "openshift-acs") %>
-          <span text-align="right" style="float: right !important">
-            <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-acs") ? "rhacs-docs-#{version}" : "rhacs-docs" %>/<%= repo_path %>">
-              <span class="material-icons-outlined" title="Page history">history
+      <% elsif (distro_key == "openshift-acs") %>
+        <span text-align="right" style="float: right !important">
+          <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-acs") ? "rhacs-docs-#{version}" : "rhacs-docs" %>/<%= repo_path %>">
+            <span class="material-icons-outlined" title="Page history">history
+            </span>
+          </a>
+          <% unless (unsupported_versions_acs.include? version) %>
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12331224&issuetype=1&components=12366876&priority=4&summary=<%= "[rhacs-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+              <span class="material-icons-outlined" title="Open an issue">bug_report
               </span>
             </a>
-            <% unless (unsupported_versions_acs.include? version) %>
-              <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12331224&issuetype=1&components=12366876&priority=4&summary=<%= "[rhacs-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
-                <span class="material-icons-outlined" title="Open an issue">bug_report
-                </span>
-              </a>
-              <a href="javascript: void(0);" onclick="window.print()">
-                <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
-              </a>
-            <% end %>
-          </span>
-        <% end %>
+            <a href="javascript: void(0);" onclick="window.print()">
+              <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
+            </a>
+          <% end %>
+        </span>
+      <% elsif (distro_key == "openshift-serverless") %>
+        <span text-align="right" style="float: right !important">
+          <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-serverless") ? "serverless-docs-#{version}" : "serverless-docs" %>/<%= repo_path %>">
+            <span class="material-icons-outlined" title="Page history">history
+            </span>
+          </a>
+          <% unless (unsupported_versions_serverless.include? version) %>
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12323143&issuetype=1&components=12334030&priority=4&summary=<%= "[serverless-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+              <span class="material-icons-outlined" title="Open an issue">bug_report
+              </span>
+            </a>
+            <a href="javascript: void(0);" onclick="window.print()">
+              <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
+            </a>
+          <% end %>
+        </span>
       <% end %>
     </ol>
     <div class="row row-offcanvas row-offcanvas-left">
@@ -316,7 +349,8 @@
     'openshift-enterprise': ['docs_cp', version],
     'openshift-aro' : ['docs_aro', version],
     'openshift-rosa' : ['docs_rosa'],
-    'openshift-acs' : ['docs_acs', version]
+    'openshift-acs' : ['docs_acs', version],
+    'openshift-serverless' : ['docs_serverless', version]
   };
 
   // only OSD v3 docs have the version variable specified


### PR DESCRIPTION

Version(s):
serverless-docs 1.28+

Issue:
[SRVCOM-2431](https://issues.redhat.com//browse/SRVCOM-2431)  erb templates for versions
