### PR TITLE
OCPBUGS-12280: clarifying cpumanager-enabled diction

### DIFF
--- a/modules/setting-up-topology-manager.adoc
+++ b/modules/setting-up-topology-manager.adoc
@@ -7,7 +7,7 @@
 [id="seting_up_topology_manager_{context}"]
 = Setting up Topology Manager
 
-To use Topology Manager, you must configure an allocation policy in the `cpumanager-enabled` custom resource (CR). This file might exist if you have set up CPU Manager. If the file does not exist, you can create the file.
+To use Topology Manager, you must configure an allocation policy in the `KubeletConfig` custom resource (CR) named `cpumanager-enabled`. This file might exist if you have set up CPU Manager. If the file does not exist, you can create the file.
 
 .Prequisites
 
@@ -17,7 +17,7 @@ To use Topology Manager, you must configure an allocation policy in the `cpumana
 
 To activate Topololgy Manager:
 
-. Configure the Topology Manager allocation policy in the `cpumanager-enabled` custom resource (CR).
+. Configure the Topology Manager allocation policy in the custom resource.
 +
 [source,terminal]
 ----

--- a/modules/topology-manager-policies.adoc
+++ b/modules/topology-manager-policies.adoc
@@ -8,7 +8,7 @@
 
 Topology Manager aligns `Pod` resources of all Quality of Service (QoS) classes by collecting topology hints from Hint Providers, such as CPU Manager and Device Manager, and using the collected hints to align the `Pod` resources.
 
-Topology Manager supports four allocation policies, which you assign in the `cpumanager-enabled` custom resource (CR):
+Topology Manager supports four allocation policies, which you assign in the `KubeletConfig` custom resource (CR) named `cpumanager-enabled`:
 
 `none` policy::
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Current
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-12280
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.12/scalability_and_performance/using-cpu-manager.html#topology_manager_policies_using-cpu-manager-and-topology_manager

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
