### PR TITLE
OSDOCS#4029: Filtering a FBC image

### DIFF
--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -27,6 +27,11 @@ endif::[]
 
 Adding a catalog source to an {product-title} cluster enables the discovery and installation of Operators for users. Cluster administrators can create a `CatalogSource` object that references an index image. OperatorHub uses catalog sources to populate the user interface.
 
+[TIP]
+====
+Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, update, delete, disable, and enable individual sources.
+====
+
 .Prerequisites
 
 * An index image built and pushed to a registry.

--- a/modules/olm-filtering-fbc.adoc
+++ b/modules/olm-filtering-fbc.adoc
@@ -1,0 +1,155 @@
+// Module included in the following assemblies:
+//
+// * operators/admin/olm-managing-custom-catalogs.adoc
+
+ifdef::openshift-origin[]
+:registry-image: quay.io/operator-framework/opm:latest
+endif::[]
+ifndef::openshift-origin[]
+:registry-image: registry.redhat.io/openshift4/ose-operator-registry:v{product-version}
+endif::[]
+
+:_content-type: PROCEDURE
+[id="olm-filtering-fbc_{context}"]
+= Filtering a file-based catalog image
+
+You can use the `opm` CLI to filter, or prune, a catalog image that uses the file-based catalog format. By extracting and updating the contents of an existing catalog image, you can remove one or more Operator packages from the catalog, and then rebuild the image as an updated version.
+
+[NOTE]
+====
+Alternatively, if you already have a catalog image on a mirror registry, you can use the oc-mirror CLI plugin to automatically prune any removed images from an updated source version of that catalog image while mirroring it to the target registry.
+
+For more information about the oc-mirror plugin and this use case, see the "Keeping your mirror registry content updated" section, and specifically the "Pruning images" subsection, of "Mirroring images for a disconnected installation using the oc-mirror plugin".
+====
+
+.Prerequisites
+
+* `opm` CLI.
+* `podman` version 1.9.3+.
+* A file-based catalog image.
+* A catalog directory structure recently initialized on your workstation related to this catalog.
++
+If you do not have an initialized catalog directory, create the directory and generate the Dockerfile. For more information, see the "Initialize the catalog" step from the "Creating a file-based catalog image" procedure.
+
+.Procedure
+
+. Extract the contents of the catalog image in YAML format to an `index.yaml` file in your catalog directory:
++
+[source,terminal]
+----
+$ opm render <registry>/<namespace>/<catalog_image_name>:<tag> \
+    -o yaml > <catalog_dir>/index.yaml
+----
++
+[NOTE]
+====
+Alternatively, you can use the `-o json` flag to output in JSON format.
+====
+
+. Modify the contents of the resulting `index.yaml` file to remove one or more Operator packages.
++
+[IMPORTANT]
+====
+After a bundle has been published in a catalog, assume that one of your users has installed it. Ensure that all previously published bundles in a catalog have an update path to the current or newer channel head to avoid stranding users that have that version installed.
+====
++
+The following example lists a set of `olm.package`, `olm.channel`, and `olm.bundle` blobs which must be deleted to remove an Operator package from the catalog:
++
+.Example removed entries
+[%collapsible]
+====
+[source,yaml]
+----
+---
+defaultChannel: release-2.7
+icon:
+  base64data: <base64_string>
+  mediatype: image/svg+xml
+name: example-operator
+schema: olm.package
+---
+entries:
+- name: example-operator.v2.7.0
+  skipRange: '>=2.6.0 <2.7.0'
+- name: example-operator.v2.7.1
+  replaces: example-operator.v2.7.0
+  skipRange: '>=2.6.0 <2.7.1'
+- name: example-operator.v2.7.2
+  replaces: example-operator.v2.7.1
+  skipRange: '>=2.6.0 <2.7.2'
+- name: example-operator.v2.7.3
+  replaces: example-operator.v2.7.2
+  skipRange: '>=2.6.0 <2.7.3'
+- name: example-operator.v2.7.4
+  replaces: example-operator.v2.7.3
+  skipRange: '>=2.6.0 <2.7.4'
+name: release-2.7
+package: example-operator
+schema: olm.channel
+---
+image: example.com/example-inc/example-operator-bundle@sha256:<digest>
+name: example-operator.v2.7.0
+package: example-operator
+properties:
+- type: olm.gvk
+  value:
+    group: example-group.example.io
+    kind: MyObject
+    version: v1alpha1
+- type: olm.gvk
+  value:
+    group: example-group.example.io
+    kind: MyOtherObject
+    version: v1beta1
+- type: olm.package
+  value:
+    packageName: example-operator
+    version: 2.7.0
+- type: olm.bundle.object
+  value:
+    data: <base64_string>
+- type: olm.bundle.object
+  value:
+    data: <base64_string>
+relatedImages:
+- image: example.com/example-inc/example-related-image@sha256:<digest>
+  name: example-related-image
+schema: olm.bundle
+---
+----
+====
+
+. Save your changes to the `index.yaml` file.
+
+. Validate the catalog:
++
+[source,terminal]
+----
+$ opm validate <catalog_dir>
+----
+
+. Rebuild the catalog:
++
+[source,terminal]
+----
+$ podman build . \
+    -f <catalog_dir>.Dockerfile \
+    -t <registry>/<namespace>/<catalog_image_name>:<tag>
+----
+
+. Push the updated catalog image to a registry:
++
+[source,terminal]
+----
+$ podman push <registry>/<namespace>/<catalog_image_name>:<tag>
+----
+
+.Verification
+
+. In the web console, navigate to the OperatorHub configuration resource in the *Administration* -> *Cluster Settings* -> *Configuration* page.
+
+. Add the catalog source or update the existing catalog source to use the pull spec for your updated catalog image.
++
+For more information, see "Adding a catalog source to a cluster" in the "Additional resources" of this section.
+
+. After the catalog source is in a *READY* state, navigate to the *Operators* -> *OperatorHub* page and check that the Operator package that you removed no longer appears.

--- a/modules/olm-restricted-networks-configuring-operatorhub.adoc
+++ b/modules/olm-restricted-networks-configuring-operatorhub.adoc
@@ -52,7 +52,7 @@ $ oc patch OperatorHub cluster --type json \
 
 [TIP]
 ====
-Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, delete, disable, and enable individual sources.
+Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, update, delete, disable, and enable individual sources.
 ====
 
 ifeval::["{context}" == "olm-restricted-networks"]

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -45,6 +45,13 @@ include::modules/olm-creating-fb-catalog-image.adoc[leveloffset=+2]
 
 * xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[`opm` CLI reference]
 
+include::modules/olm-filtering-fbc.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#updating-mirror-registry-content[Mirroring images for a disconnected installation using the oc-mirror plugin -> Keeping your mirror registry content updated]
+* xref:../../operators/admin/olm-restricted-networks.adoc#olm-creating-catalog-from-index_olm-restricted-networks[Adding a catalog source to a cluster]
+
 [id="olm-managing-custom-catalogs-sqlite"]
 == SQLite-based catalogs
 

--- a/operators/understanding/olm/olm-understanding-operatorgroups.adoc
+++ b/operators/understanding/olm/olm-understanding-operatorgroups.adoc
@@ -21,7 +21,7 @@ include::modules/olm-operatorgroups-limitations.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../operators/understanding/olm/olm-colocation.adoc#olm-colocation[Operator Lifecycle Manager (OLM) -> Multitenancy and Operator colocation].
+* xref:../../../operators/understanding/olm/olm-colocation.adoc#olm-colocation[Operator Lifecycle Manager (OLM) -> Multitenancy and Operator colocation]
 * xref:../../../operators/understanding/olm-multitenancy.adoc#olm-multitenancy[Operators in multitenant clusters]
 * xref:../../../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allowing non-cluster administrators to install Operators]
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-4029

4.11+

Fills a docs gap for filtering/pruning a file-based catalog (FBC) image.

Preview:

* [Filtering a file-based catalog image](https://60519--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-filtering-fbc_olm-managing-custom-catalogs)