### PR TITLE
[OSDOCS-6213]: Azure CAPI TP supported platform statements

### DIFF
--- a/machine_management/capi-machine-management.adoc
+++ b/machine_management/capi-machine-management.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: Managing machines with the Cluster API
 include::snippets/technology-preview.adoc[]
 
-The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for Amazon Web Services (AWS) and Google Cloud Platform (GCP) clusters. You can use the Cluster API to create and manage compute machine sets and machines in your {product-title} cluster. This capability is in addition or an alternative to managing machines with the Machine API. 
+The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for Amazon Web Services (AWS), Google Cloud Platform (GCP), and Microsoft Azure clusters. You can use the Cluster API to create and manage compute machine sets and compute machines in your {product-title} cluster. This capability is in addition or an alternative to managing machines with the Machine API.
 
 For {product-title} {product-version} clusters, you can use the Cluster API to perform node host provisioning management actions after the cluster installation finishes. This system enables an elastic, dynamic provisioning method on top of public or private cloud infrastructure.
 
@@ -27,7 +27,7 @@ By using the Cluster API, {product-title} users and developers are able to reali
 
 * The ability to use the same set of Kubernetes tools for infrastructure management in {product-title}.
 
-* The ability to create compute machine sets using the Cluster API that support features that are not available with the Machine API.
+* The ability to create compute machine sets by using the Cluster API that support features that are not available with the Machine API.
 
 [discrete]
 [id="capi-tech-preview-limitations"]
@@ -35,13 +35,13 @@ By using the Cluster API, {product-title} users and developers are able to reali
 
 Using the Cluster API to manage machines is a Technology Preview feature and has the following limitations:
 
-* Only AWS and GCP clusters are supported.
+* Only AWS, GCP, and Azure clusters are supported.
 
-* To use this feature, you must enable the `ClusterAPIEnabled` xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[feature gate] in the `TechPreviewNoUpgrade` feature set. Enabling this feature set cannot be undone and prevents minor version updates. 
+* To use this feature, you must enable the `ClusterAPIEnabled` xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[feature gate] in the `TechPreviewNoUpgrade` feature set. Enabling this feature set cannot be undone and prevents minor version updates.
 
 * You must create the primary resources that the Cluster API requires manually.
 
-* Control plane machines cannot be managed by the Cluster API.
+* You cannot manage control plane machines by using the Cluster API.
 
 * Migration of existing compute machine sets created by the Machine API to Cluster API compute machine sets is not supported.
 
@@ -57,7 +57,7 @@ include::modules/cluster-api-architecture.adoc[leveloffset=+1]
 [id="capi-sample-yaml-files"]
 == Sample YAML files
 
-For the Cluster API Technology Preview, you must create the primary resources that the Cluster API requires manually. The example YAML files in this section demonstrate how to make these resources work together and configure settings for the machines that they create that are appropriate for your environment.
+For the Cluster API Technology Preview, you must create the primary resources that the Cluster API requires manually. The following example YAML files show how to make these resources work together and configure settings for the machines that they create that are appropriate for your environment.
 
 //Sample YAML for a CAPI cluster resource
 include::modules/capi-yaml-cluster.adoc[leveloffset=+2]
@@ -71,7 +71,7 @@ The remaining Cluster API resources are provider-specific. Refer to the example 
 [id="capi-sample-yaml-files-aws"]
 === Sample YAML files for configuring Amazon Web Services clusters
 
-Some Cluster API resources are provider-specific. The example YAML files in this section show configurations for an Amazon Web Services (AWS) cluster.
+Some Cluster API resources are provider-specific. The following example YAML files show configurations for an Amazon Web Services (AWS) cluster.
 
 //Sample YAML for a CAPI AWS provider resource
 include::modules/capi-yaml-infrastructure-aws.adoc[leveloffset=+3]
@@ -85,7 +85,7 @@ include::modules/capi-yaml-machine-set-aws.adoc[leveloffset=+3]
 [id="capi-sample-yaml-files-gcp"]
 === Sample YAML files for configuring Google Cloud Platform clusters
 
-Some Cluster API resources are provider-specific. The example YAML files in this section show configurations for a Google Cloud Platform (GCP) cluster.
+Some Cluster API resources are provider-specific. The following example YAML files show configurations for a Google Cloud Platform (GCP) cluster.
 
 //Sample YAML for a CAPI GCP provider resource
 include::modules/capi-yaml-infrastructure-gcp.adoc[leveloffset=+3]

--- a/modules/cluster-capi-operator.adoc
+++ b/modules/cluster-capi-operator.adoc
@@ -7,7 +7,7 @@
 
 [NOTE]
 ====
-This Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS) and Google Cloud Platform (GCP).
+This Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS), Google Cloud Platform (GCP), and Microsoft Azure clusters.
 ====
 
 [discrete]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-5774](https://issues.redhat.com//browse/OSDOCS-5774) > [OSDOCS-6213](https://issues.redhat.com//browse/OSDOCS-6213)

Link to docs preview:
(This PR contains updates to supported platform statements only)
- [Cluster CAPI Operator](https://60522--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-capi-operator_cluster-operators-ref)
- [Managing machines with the Cluster API](https://60522--docspreview.netlify.app/openshift-enterprise/latest/machine_management/capi-machine-management.html)

QE review:
- [x] QE has approved this change.

Additional information:
Includes a few reworded items from Vale suggestions.