### PR TITLE
OCPBUGS#568: Add `--dest-ignition` admonition for custom CA certs

### DIFF
--- a/modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc
@@ -32,6 +32,12 @@ $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
 ----
 endif::[]
 +
+[IMPORTANT]
+====
+The `coreos.inst.ignition_url` kernel parameter does not work with the `--ignition-ca` flag.
+You must use the `--dest-ignition` flag to create a customized image for each cluster.
+====
++
 [NOTE]
 ====
 Custom CA certificates affect how Ignition fetches remote resources but they do not affect the certificates installed onto the system.


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-568

Link to docs preview:
https://60527--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-advanced-customizing-live-iso-ca-certs_installing-bare-metal

QE review:
- [x] QE has approved this change.

Additional information:
N/A
