### PR TITLE
Adds trustedCA to image reg table

### DIFF
--- a/modules/registry-operator-configuration-resource-overview-aws-s3.adoc
+++ b/modules/registry-operator-configuration-resource-overview-aws-s3.adoc
@@ -7,7 +7,7 @@
 
 The following configuration parameters are available for AWS S3 registry storage.
 
-`ImageRegistryConfigStorageS3` holds the information to configure the registry to use the AWS S3 service for back-end storage. See the link:https://docs.docker.com/registry/storage-drivers/s3/[S3 storage driver documentation] for more information.
+The image registry `spec.storage.s3` configuration parameter holds the information to configure the registry to use the AWS S3 service for back-end storage. See the link:https://docs.docker.com/registry/storage-drivers/s3/[S3 storage driver documentation] for more information.
 
 [cols="3a,8a",options="header"]
 |===
@@ -42,6 +42,8 @@ true, or this parameter is ignored.
 |CloudFront configures Amazon Cloudfront as the storage middleware in a registry.
 It is optional.
 
+|`trustedCA`
+|The namespace for the config map referenced by `trustedCA` is `openshift-config`. The key for the bundle in the config map is `ca-bundle.crt`. It is optional. 
 |===
 
 [NOTE]


### PR DESCRIPTION
Adds trustedCA to image registry table. 

Version(s):
4.10+ 

Issue:
https://issues.redhat.com/browse/OCPBUGS-9417

Link to docs preview:
https://60528--docspreview.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-aws-user-infrastructure.html#registry-operator-configuration-resource-overview-aws-s3_configuring-registry-storage-aws-user-infrastructure

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Found here: 

https://github.com/openshift/api/blob/f6e7dffe5f27fe10a21940fcf90a48d56e5e0ab9/imageregistry/v1/types.go#L65

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
