### PR TITLE
OSDOCS#6181: Amend references to `k8s.v1.cni.cncf.io/networks-status`

### DIFF
--- a/modules/cnf-associating-secondary-interfaces-metrics-to-network-attachments.adoc
+++ b/modules/cnf-associating-secondary-interfaces-metrics-to-network-attachments.adoc
@@ -58,7 +58,7 @@ The network name label is produced using the annotation added by Multus. It is t
 
 The new metric alone does not provide much value, but combined with the network related `container_network_*` metrics, it offers better support for monitoring secondary networks.
 
-Using a `promql` query like the following ones, it is possible to get a new metric containing the value and the network name retrieved from the `k8s.v1.cni.cncf.io/networks-status` annotation:
+Using a `promql` query like the following ones, it is possible to get a new metric containing the value and the network name retrieved from the `k8s.v1.cni.cncf.io/network-status` annotation:
 
 [source,bash]
 ----

--- a/modules/configuring-default-seccomp-profile.adoc
+++ b/modules/configuring-default-seccomp-profile.adoc
@@ -61,7 +61,7 @@ metadata:
           "default": true,
           "dns": {}
       }]
-    k8s.v1.cni.cncf.io/networks-status: |-
+    k8s.v1.cni.cncf.io/network-status: |-
       [{
           "name": "openshift-sdn",
           "interface": "eth0",

--- a/modules/getting-started-cli-examining-pod.adoc
+++ b/modules/getting-started-cli-examining-pod.adoc
@@ -63,7 +63,7 @@ Annotations:  k8s.v1.cni.cncf.io/network-status:
                     "default": true,
                     "dns": {}
                 }]
-              k8s.v1.cni.cncf.io/networks-status:
+              k8s.v1.cni.cncf.io/network-status:
                 [{
                     "name": "openshift-sdn",
                     "interface": "eth0",

--- a/modules/nw-multus-add-pod.adoc
+++ b/modules/nw-multus-add-pod.adoc
@@ -115,7 +115,7 @@ kind: Pod
 metadata:
   annotations:
     k8s.v1.cni.cncf.io/networks: macvlan-bridge
-    k8s.v1.cni.cncf.io/networks-status: |- <1>
+    k8s.v1.cni.cncf.io/network-status: |- <1>
       [{
           "name": "openshift-sdn",
           "interface": "eth0",
@@ -140,7 +140,7 @@ spec:
 status:
   ...
 ----
-<1> The `k8s.v1.cni.cncf.io/networks-status` parameter is a JSON array of
+<1> The `k8s.v1.cni.cncf.io/network-status` parameter is a JSON array of
 objects. Each object describes the status of an additional network attached
 to the pod. The annotation value is stored as a plain text value.
 

--- a/modules/nw-multus-advanced-annotations.adoc
+++ b/modules/nw-multus-advanced-annotations.adoc
@@ -92,7 +92,7 @@ $ oc exec -it <pod_name> -- ip route
 
 [NOTE]
 ====
-You may also reference the pod's `k8s.v1.cni.cncf.io/networks-status` to see which additional network has been
+You may also reference the pod's `k8s.v1.cni.cncf.io/network-status` to see which additional network has been
 assigned the default route, by the presence of the `default-route` key in the JSON-formatted list of objects.
 ====
 


### PR DESCRIPTION
The correct annotation is now `k8s.v1.cni.cncf.io/network-status`.

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-6181

Link to docs preview:
https://60529--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/attaching-pod.html#nw-multus-add-pod_attaching-pod

QE review:
- [x] QE has approved this change.

Additional information:
N/A