### PR TITLE
OSDOCS-4459

### DIFF
--- a/modules/rosa-sdpolicy-am-aws-compute-types.adoc
+++ b/modules/rosa-sdpolicy-am-aws-compute-types.adoc
@@ -345,3 +345,18 @@ Support for the GPU instance type software stack is provided by AWS. Ensure that
 ====
 Virtual instance types initialize faster than ".metal" instance types.
 ====
+
+.High memory
+[%collapsible]
+====
+- u-3tb1.56xlarge (224 vCPU, 3,072 GiB)
+- u-6tb1.56xlarge (224 vCPU, 6,144 GiB)
+- u-6tb1.112xlarge (448 vCPU, 6,144 GiB)
+- u-6tb1.metal (448 vCPU, 6,144 GiB)
+- u-9tb1.112xlarge (448 vCPU, 9,216 GiB)
+- u-9tb1.metal (448 vCPU, 9,216 GiB)
+- u-12tb1.112xlarge (448 vCPU, 12,288 GiB)
+- u-12tb1.metal (448 vCPU, 12,288 GiB)
+- u-18tb1.metal (448 vCPU, 18,432 GiB)
+- u-24tb1.metal (448 vCPU, 24,576 GiB)
+====

--- a/modules/sdpolicy-am-aws-compute-types-ccs.adoc
+++ b/modules/sdpolicy-am-aws-compute-types-ccs.adoc
@@ -344,3 +344,18 @@ Support for the GPU instance type software stack is provided by AWS. Ensure that
 ====
 Virtual instance types initialize faster than ".metal" instance types.
 ====
+
+.High memory
+[%collapsible]
+====
+- u-3tb1.56xlarge (224 vCPU, 3,072 GiB)
+- u-6tb1.56xlarge (224 vCPU, 6,144 GiB)
+- u-6tb1.112xlarge (448 vCPU, 6,144 GiB)
+- u-6tb1.metal (448 vCPU, 6,144 GiB)
+- u-9tb1.112xlarge (448 vCPU, 9,216 GiB)
+- u-9tb1.metal (448 vCPU, 9,216 GiB)
+- u-12tb1.112xlarge (448 vCPU, 12,288 GiB)
+- u-12tb1.metal (448 vCPU, 12,288 GiB)
+- u-18tb1.metal (448 vCPU, 18,432 GiB)
+- u-24tb1.metal (448 vCPU, 24,576 GiB)
+====


### PR DESCRIPTION
[OSDOCS-4459](https://issues.redhat.com//browse/OSDOCS-4459): Add high memory instance types to ROSA and OSD

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-4459

Link to docs preview:
OSD: https://60534--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition.html#instance-types_osd-service-definition
ROSA: https://60534--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-instance-types_rosa-service-definition

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
