### PR TITLE
[enterprise-4.11] OCPBUGS#9988: Addressed doc bug for  Generating the discovery ISO wit…

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -16,6 +16,11 @@ To install {product-title} on a single node, use the web-based Assisted Installe
 
 include::modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../virt/about-virt.adoc#virt-what-you-can-do-with-virt_about-virt[What you can do with OpenShift Virtualization]
+
 include::modules/install-sno-installing-with-the-assisted-installer.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Cherry Picked from 5d4797e56ff18f6ca8ce943685c1e7870033c42c [OCPBUGS-9988](https://github.com/openshift/openshift-docs/pull/60276)

I removed the following link from this PR as the targeted module does not exist in 4.11:

* xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#persistent-storage-using-lvms_logical-volume-manager-storage[Persistent storage using logical volume manager storage]

[Preview link](https://60537--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html#install-sno-generating-the-discovery-iso-with-the-assisted-installer_install-sno-installing-sno-with-the-assisted-installer)