### PR TITLE
[enterprise-4.10] OCPBUGS#9988-Ent10: Addressed doc bug for  Generating the discovery ISO wit…

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 ifndef::openshift-origin[]
 include::modules/install-sno-generating-the-discovery-iso-with-the-assisted-installer.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../virt/about-virt.adoc#virt-what-you-can-do-with-virt_about-virt[What you can do with OpenShift Virtualization]
 endif::openshift-origin[]
 
 include::modules/install-sno-generating-the-discovery-iso-manually.adoc[leveloffset=+1]


### PR DESCRIPTION
Cherry Picked from 5d4797e56ff18f6ca8ce943685c1e7870033c42c [OCPBUGS-9988](https://github.com/openshift/openshift-docs/pull/60276)

I removed the following link from this PR as the targeted module does not exist in 4.11:

* xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#persistent-storage-using-lvms_logical-volume-manager-storage[Persistent storage using logical volume manager storage]

[Preview link](https://60538--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno.html)