### PR TITLE
OCPBUGS-13944 updating the power saving configuration

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -368,10 +368,10 @@ annotations:
 
 . Generate a `PerformanceProfile` with `per-pod-power-management` set to `true`:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ podman run --entrypoint performance-profile-creator -v \
-/must-gather:/must-gather:z registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.13 \
+/must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v{product-version} \
 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true \
 --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node \
 --must-gather-dir-path /must-gather -power-consumption-mode=low-latency \ <1>


### PR DESCRIPTION
OCPBUGS-13944: Update to ose-cluster-node-tuning-operator:v{product-version}
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.13 and main
Issue:
https://issues.redhat.com/browse/OCPBUGS-13944

Link to docs preview: https://60540--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#node-tuning-operator-pod-power-saving-config_cnf-master
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
