### PR TITLE
TELCODOCS-1338 - adding RAN 4.13 post-GA known issues

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2784,6 +2784,31 @@ mount: /var/lib/kubelet/plugins/kubernetes.io/local-volume/mounts/local-pv-bc42d
 To workaround the issue, delete the `cloud-event-proxy-store-storage-class-http-events` `PVC` CR and re-deploy the PTP Operator.
 (link:https://issues.redhat.com/browse/OCPBUGS-12358[*OCPBUGS-12358*])
 
+[id="ocp-4-13-ran-known-issues-post-ga"]
+* During {ztp-first} provisioning of a {sno} managed cluster with secure boot enabled in the `SiteConfig` CR, multiple `ProvisioningError` errors are reported for the `BareMetalHost` CR during host provisioning.
+The error indicates that the secure boot setting is successfully applied in the Baseboard Management Controller (BMC), but the host is not powered on after the `BareMetalHost` CR is applied.
+To workaround this issue, perform the following steps:
++
+. Reboot the host.
+This ensures that the {ztp} pipeline applies the secure boot setting.
+
+. Restart {ztp} provisioning of the cluster with the same configuration.
+
++
+(link:https://issues.redhat.com/browse/OCPBUGS-8434[*OCPBUGS-8434*])
+
+* After installing a dual-stack {ztp} hub cluster, enabling dual-stack Virtual IP addresses (VIPs), and enabling the `virtualMediaViaExternalNetwork` flag in a `Provisioning` CR, the `IRONIC_EXTERNAL_URL_V6` environment variable incorrectly gets assigned an IPv4 address.
+(link:https://issues.redhat.com/browse/OCPBUGS-4248[*OCPBUGS-4248*])
+
+* ZT servers have the `BiosRegistry` language set to `en-US` instead of `en`.
+This causes a problem during {ztp} provisioning of managed cluster hosts.
+The `FirmwareSchema` CR generated for the ZT server doesn't have the `allowable_values`, `attribute_type`, and `read_only` fields populated.
+(link:https://issues.redhat.com/browse/OCPBUGS-4388[*OCPBUGS-4388*])
+
+* In {product-title} version 4.13.0, an error occurs when you try to install a cluster with the Agent-based installer. After the read disk stage, an error is returned and the cluster installation gets stuck.
+This error has been detected on HPE ProLiant Gen10 servers.
+(link:https://issues.redhat.com/browse/OCPBUGS-13138[*OCPBUGS-13138*])
+
 * RFC2544 performance tests show that the `Max delay` value for a packet to traverse the network is over the minimum threshold. This regression is found in {product-title} 4.13 clusters running the Telco RAN DU profile.
 (link:https://issues.redhat.com/browse/OCPBUGS-13224[*OCPBUGS-13224*])
 


### PR DESCRIPTION
Adds RAN 4.13 post GA known issues. 

Version(s):
enterprise-4.13 only

Issue:
https://issues.redhat.com/browse/TELCODOCS-1338

Link to docs preview:
https://60566--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-ran-known-issues-post-ga

QE review:
- [x] QE has approved this change.