### PR TITLE
[enterprise-4.12] OCPBUGS13384: Examples for layering custom content should not have invalid image links

### DIFF
--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -30,13 +30,13 @@ For example, the following Containerfile creates a custom layered image from an 
 [source,yaml]
 ----
 # Using a 4.12.0 image
-FROM quay.io/openshift-release/ocp-release@sha256:6499bc69a0707fcad481c3cb73225b867d <1>
+FROM quay.io/openshift-release/ocp-release@sha256... <1>
 #Install hotfix rpm
 RUN rpm-ostree override replace https://example.com/hotfixes/haproxy-1.0.16-5.el8.src.rpm && \ <2>
     rpm-ostree cleanup -m && \
     ostree container commit
 ----
-<1> Specifies an {product-title} release image.
+<1> Specifies the {op-system} base image of your cluster.
 <2> Specifies the path to the Hotfix package.
 +
 [NOTE]
@@ -63,7 +63,7 @@ metadata:
     machineconfiguration.openshift.io/role: worker <1>
   name: os-layer-hotfix
 spec:
-  osImageURL: quay.io/my-registry/custom-image@sha256:306b606615dcf8f0e5e7d87fee3 <2>
+  osImageURL: quay.io/my-registry/custom-image@sha256... <2>
 ----
 <1> Specifies the machine config pool to apply the custom layered image.
 <2> Specifies the path to the custom layered image in the repository.
@@ -133,7 +133,7 @@ Annotations:  machineconfiguration.openshift.io/generated-by-controller-version:
 API Version:  machineconfiguration.openshift.io/v1
 Kind:         MachineConfig
 ...
-  Os Image URL: quay.io/my-registry/custom-image@sha256:306b606615dcf8f0e5e7d87fee3
+  Os Image URL: quay.io/my-registry/custom-image@sha256...
 ----
 
 .. Check that the associated machine config pool is updating with the new machine config:
@@ -199,7 +199,7 @@ sh-4.4# sudo rpm-ostree status
 ----
 State: idle
 Deployments:
-* ostree-unverified-registry:quay.io/my-registry/custom-image@sha256:306b606615dcf8f0e5e7d87fee3
-                   Digest: sha256:306b606615dcf8f0e5e7d87fee3
+* ostree-unverified-registry:quay.io/my-registry/...
+                   Digest: sha256:...
 ----
 

--- a/post_installation_configuration/coreos-layering.adoc
+++ b/post_installation_configuration/coreos-layering.adoc
@@ -60,7 +60,7 @@ To apply a custom layered image, you create a Containerfile that references an {
 [source,yaml]
 ----
 # Using a 4.12.0 image
-FROM quay.io/openshift-release-dev/ocp-release@sha256:6499bc69a0707fcad481c3cb73225b867d
+FROM quay.io/openshift-release-dev/ocp-release@sha256...
 #Install hotfix rpm
 RUN rpm-ostree override replace https://example.com/myrepo/haproxy-1.0.16-5.el8.src.rpm && \
     rpm-ostree cleanup -m && \


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/60258