### PR TITLE
[OSDOCS-6239]: CPMS for Nutanix: Support statements

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-about.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-about.adoc
@@ -25,7 +25,7 @@ The Control Plane Machine Set Operator has the following limitations:
 
 * The Operator requires the Machine API Operator to be operational and is therefore not supported on clusters with manually provisioned machines. When installing a {product-title} cluster with manually provisioned machines for a platform that creates an active generated `ControlPlaneMachineSet` custom resource (CR), you must remove the Kubernetes manifest files that define the control plane machine set as instructed in the installation process.
 
-* Only Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and VMware vSphere clusters are supported.
+* Only Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, Nutanix, and VMware vSphere clusters are supported.
 
 * Only clusters with three control plane machines are supported.
 

--- a/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
@@ -19,7 +19,7 @@ If you are uncertain about the state of the `ControlPlaneMachineSet` CR in your 
 [id="cpmso-platform-matrix_{context}"]
 == Supported cloud providers
 
-In {product-title} {product-version}, the control plane machine sets are supported for Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and VMware vSphere clusters.
+In {product-title} {product-version}, the control plane machine set is supported for Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, Nutanix, and VMware vSphere clusters.
 
 The status of the control plane machine set after installation depends on your cloud provider and the version of {product-title} that you installed on your cluster.
 
@@ -43,6 +43,11 @@ The status of the control plane machine set after installation depends on your c
 |X
 |
 
+|Nutanix
+|X
+|X
+|
+
 |VMware vSphere
 |
 |
@@ -54,7 +59,7 @@ The status of the control plane machine set after installation depends on your c
 2. GCP and Azure clusters that are upgraded from version 4.12 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
 --
 
-//Checking the Control Plane Machine Set Operator status
+//Checking the control plane machine set custom resource state
 include::modules/cpmso-checking-status.adoc[leveloffset=+1]
 
 //Activating the control plane machine set custom resource
@@ -62,14 +67,15 @@ include::modules/cpmso-activating.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-configuration[Control Plane Machine Set Operator configuration]
+* xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-configuration[Control plane machine set configuration]
 
 //Creating a control plane machine set custom resource
 include::modules/cpmso-creating-cr.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-configuration[Control Plane Machine Set Operator configuration]
+* xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-feat-config-update_cpmso-using[Updating the control plane configuration]
+* xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-configuration[Control plane machine set configuration]
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-aws_cpmso-configuration[Sample YAML for configuring Amazon Web Services clusters]
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-gcp_cpmso-configuration[Sample YAML for configuring Google Cloud Platform clusters]
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Sample YAML for configuring Microsoft Azure clusters]

--- a/machine_management/index.adoc
+++ b/machine_management/index.adoc
@@ -64,6 +64,8 @@ As a cluster administrator, you can perform the following actions:
 
 ** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-aws_cpmso-configuration[AWS]
 
+** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-gcp_cpmso-configuration[GCP]
+
 ** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Azure]
 
 ** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[vSphere]

--- a/modules/control-plane-machine-set-operator.adoc
+++ b/modules/control-plane-machine-set-operator.adoc
@@ -7,7 +7,7 @@
 
 [NOTE]
 ====
-This Operator is available for Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and VMware vSphere.
+This Operator is available for Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, Nutanix, and VMware vSphere.
 ====
 
 [discrete]

--- a/modules/cpmso-creating-cr.adoc
+++ b/modules/cpmso-creating-cr.adoc
@@ -64,9 +64,8 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ====
 Before you activate the CR, you must ensure that its configuration is correct for your cluster requirements.
 ====
-<3> Specify the update strategy for the cluster. The allowed values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`.
-//Todo: For more information about update strategies, see "Updating the control plane configuration".
-<4> Specify your cloud provider platform name. The allowed values are `AWS`, `Azure`, `GCP`, and `VSphere`.
+<3> Specify the update strategy for the cluster. Valid values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`. For more information about update strategies, see "Updating the control plane configuration".
+<4> Specify your cloud provider platform name. Valid values are `AWS`, `Azure`, `GCP`, `Nutanix`, and `VSphere`.
 <5> Add the `<platform_failure_domains>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample failure domain configuration for your cloud provider.
 +
 [NOTE]

--- a/modules/cpmso-failure-domains-provider.adoc
+++ b/modules/cpmso-failure-domains-provider.adoc
@@ -21,6 +21,11 @@ The control plane machine set concept of a failure domain is analogous to existi
 |X
 |link:https://cloud.google.com/compute/docs/regions-zones[zone]
 
+|Nutanix
+//link:https://portal.nutanix.com/page/documents/details?targetId=Web-Console-Guide-Prism-v6_1:arc-failure-modes-c.html[Availability domain]
+|
+|Not applicable ^[1]^
+
 |Microsoft Azure
 |X
 |link:https://learn.microsoft.com/en-us/azure/azure-web-pubsub/concept-availability-zones[Azure availability zone]
@@ -29,5 +34,9 @@ The control plane machine set concept of a failure domain is analogous to existi
 |
 |Not applicable
 |====
+[.small]
+--
+1. Nutanix has a failure domain concept, but {product-title} {product-version} does not include support for this feature.
+--
 
 The failure domain configuration in the control plane machine set custom resource (CR) is platform-specific. For more information about failure domain parameters in the CR, see the sample failure domain configuration for your provider.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-6237](https://issues.redhat.com//browse/OSDOCS-6237) > [OSDOCS-6239](https://issues.redhat.com//browse/OSDOCS-6239)

Link to docs preview:
- [Limitations](https://60568--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-about.html#cpmso-limitations_cpmso-about)
- [Supported cloud providers](https://60568--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-getting-started.html#cpmso-platform-matrix_cpmso-getting-started)
- [Failure domain platform support and configuration](https://60568--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-resiliency.html#cpmso-failure-domains-provider_cpmso-resiliency)
- [Control Plane Machine Set Operator reference](https://60568--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#control-plane-machine-set-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information:
Found a couple of things to tidy in here as well, all minor.