### PR TITLE
OSDOCS#6119: Minimum req permissions to deploy OpenShift on Nutanix

### DIFF
--- a/modules/installation-nutanix-installer-infra-reqs.adoc
+++ b/modules/installation-nutanix-installer-infra-reqs.adoc
@@ -11,7 +11,62 @@ Before you install an {product-title} cluster, review the following Nutanix AOS 
 [id="installation-nutanix-installer-infra-reqs-account_{context}"]
 == Required account privileges
 
-Installing a cluster to Nutanix requires an account with administrative privileges to read and create the required resources.
+The installation program requires access to a Nutanix account with the necessary permissions to deploy the cluster and to maintain the daily operation of it. The following options are available to you:
+
+* You can use a local Prism Central user account with administrative privileges. Using a local account is the quickest way to grant access to an account with the required permissions.
+* If your organization’s security policies require that you use a more restrictive set of permissions, use the permissions that are listed in the following table to create a custom Cloud Native role in Prism Central. You can then assign the role to a user account that is a member of a Prism Central authentication directory. When assigning entities to the role, ensure that the user can access only the Prism Element and subnet that are required to deploy the virtual machines.
++
+For more information, see the Nutanix documentation about creating a link:https://opendocs.nutanix.com/guides/cloud_native_role/[Custom Cloud Native role] and link:https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide:ssp-ssp-role-assignment-pc-t.html[assigning a role].
+
+.Required permissions for creating a Custom Cloud Native role
+[%collapsible]
+====
+[cols="3a,3a,3a",options="header"]
+|===
+|Nutanix Object
+|Required permissions in Nutanix API
+|Description
+
+|Categories
+|
+[%hardbreaks]
+`Create_Category_Mapping`
+`Create_Or_Update_Name_Category`
+`Create_Or_Update_Value_Category`
+`Delete_Category_Mapping`
+`Delete_Name_Category`
+`Delete_Value_Category`
+`View_Category_Mapping`
+`View_Name_Category`
+`View_Value_Category`
+|Create, read, and delete categories that are assigned to the {product-title} machines.
+
+
+|Images
+|
+[%hardbreaks]
+`Create_Image`
+`Delete_Image`
+`View_Image`
+|Create, read, and delete the operating system images used for the {product-title} machines.
+
+|Virtual Machines
+|
+[%hardbreaks]
+`Create_Virtual_Machine`
+`Delete_Virtual_Machine`
+`View_Virtual_Machine`
+|Create, read, and delete the {product-title} machines.
+
+|Clusters
+|`View_Cluster`
+|View the Prism Element clusters that host the {product-title} machines.
+
+|Subnets
+|`View_Subnet`
+|View the subnets that host the {product-title} machines.
+|===
+====
 
 [id="installation-nutanix-installer-infra-reqs-limits_{context}"]
 == Cluster limits


### PR DESCRIPTION
Version(s):
4.12

Issue:
This PR addresses [osdocs-6119](https://issues.redhat.com/browse/OSDOCS-6119).

Link to docs preview:
[Required account privileges](https://mjpytlak.github.io/previews/osdocs-6119-412/installing/installing_nutanix/preparing-to-install-on-nutanix.html#installation-nutanix-installer-infra-reqs-account_preparing-to-install-on-nutanix)


QE review:
- [ ] QE has approved this change.

Additional information:
Support for Nutanix projects was introduced in 4.13. This PR excludes the reference to Projects permissions.
