### PR TITLE
[OSDOCS-6241]: CPMS for Nutanix: YAML samples

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-configuration.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-configuration.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-These example YAML file and snippets demonstrate the base structure for a control plane machine set custom resource (CR) and platform-specific samples for provider specification and failure domain configurations.
+These example YAML snippets show the base structure for a control plane machine set custom resource (CR) and platform-specific samples for provider specification and failure domain configurations.
 
 //Sample YAML for a control plane machine set custom resource
 include::modules/cpmso-yaml-sample-cr.adoc[leveloffset=+1]
@@ -29,12 +29,14 @@ The `<platform_provider_spec>` and `<platform_failure_domains>` sections of the 
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Sample YAML snippets for configuring Microsoft Azure clusters]
 
+* xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-nutanix_cpmso-configuration[Sample YAML snippets for configuring Nutanix clusters]
+
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[Sample YAML snippets for configuring VMware vSphere clusters]
 
 [id="cpmso-sample-yaml-aws_{context}"]
 == Sample YAML for configuring Amazon Web Services clusters
 
-Some sections of the control plane machine set CR are provider-specific. The example YAML in this section show provider specification and failure domain configurations for an Amazon Web Services (AWS) cluster.
+Some sections of the control plane machine set CR are provider-specific. The following example YAML snippets show provider specification and failure domain configurations for an Amazon Web Services (AWS) cluster.
 
 //Sample AWS provider specification
 include::modules/cpmso-yaml-provider-spec-aws.adoc[leveloffset=+2]
@@ -49,7 +51,7 @@ include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+2]
 [id="cpmso-sample-yaml-gcp_{context}"]
 == Sample YAML for configuring Google Cloud Platform clusters
 
-Some sections of the control plane machine set CR are provider-specific. The example YAML in this section show provider specification and failure domain configurations for a Google Cloud Platform (GCP) cluster.
+Some sections of the control plane machine set CR are provider-specific. The following example YAML snippets show provider specification and failure domain configurations for a Google Cloud Platform (GCP) cluster.
 
 //Sample GCP provider specification
 include::modules/cpmso-yaml-provider-spec-gcp.adoc[leveloffset=+2]
@@ -65,7 +67,7 @@ include::modules/cpmso-yaml-failure-domain-gcp.adoc[leveloffset=+2]
 [id="cpmso-sample-yaml-azure_{context}"]
 == Sample YAML for configuring Microsoft Azure clusters
 
-Some sections of the control plane machine set CR are provider-specific. The example YAML in this section show provider specification and failure domain configurations for an Azure cluster.
+Some sections of the control plane machine set CR are provider-specific. The following example YAML snippets show provider specification and failure domain configurations for an Azure cluster.
 
 //Sample Azure provider specification
 include::modules/cpmso-yaml-provider-spec-azure.adoc[leveloffset=+2]
@@ -77,10 +79,18 @@ include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-supported-features-azure_cpmso-using[Enabling Microsoft Azure features for control plane machines]
 
+[id="cpmso-sample-yaml-nutanix_{context}"]
+== Sample YAML for configuring Nutanix clusters
+
+Some sections of the control plane machine set CR are provider-specific. The following example YAML snippet shows a provider specification configuration for a Nutanix cluster.
+
+//Sample Nutanix provider specification
+include::modules/cpmso-yaml-provider-spec-nutanix.adoc[leveloffset=+2]
+
 [id="cpmso-sample-yaml-vsphere_{context}"]
 == Sample YAML for configuring VMware vSphere clusters
 
-Some sections of the control plane machine set CR are provider-specific. The example YAML in this section shows a provider specification configuration for a VMware vSphere cluster.
+Some sections of the control plane machine set CR are provider-specific. The following example YAML snippet shows a provider specification configuration for a VMware vSphere cluster.
 
 //Sample VMware vSphere provider specification
 include::modules/cpmso-yaml-provider-spec-vsphere.adoc[leveloffset=+2]

--- a/machine_management/index.adoc
+++ b/machine_management/index.adoc
@@ -68,6 +68,8 @@ As a cluster administrator, you can perform the following actions:
 
 ** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Azure]
 
+** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-nutanix_cpmso-configuration[Nutanix]
+
 ** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[vSphere]
 
 * Configure and deploy a xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[machine health check] to automatically recover unhealthy control plane machines.

--- a/modules/cpmso-yaml-provider-spec-aws.adoc
+++ b/modules/cpmso-yaml-provider-spec-aws.adoc
@@ -6,7 +6,7 @@
 [id="cpmso-yaml-provider-spec-aws_{context}"]
 = Sample AWS provider specification
 
-When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane `machine` CR that is created by the installation program. You can omit any field that is set in the failure domain section of the CR.
+When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane machine custom resource (CR) that is created by the installation program. You can omit any field that is set in the failure domain section of the CR.
 
 In the following example, `<cluster_id>` is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 
@@ -62,10 +62,10 @@ providerSpec:
 <3> Specifies the secret name for the cluster. Do not change this value.
 <4> Specifies the AWS Identity and Access Management (IAM) instance profile. Do not change this value.
 <5> Specifies the AWS instance type for the control plane.
-<6> Specifies the cloud provider platform type. Do not change this value. 
+<6> Specifies the cloud provider platform type. Do not change this value.
 <7> Specifies the internal (`int`) and external (`ext`) load balancers for the cluster.
-<8> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain. 
+<8> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.
 <9> Specifies the AWS region for the cluster.
 <10> Specifies the control plane machines security group.
-<11> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain. 
+<11> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.
 <12> Specifies the control plane user data secret. Do not change this value.

--- a/modules/cpmso-yaml-provider-spec-gcp.adoc
+++ b/modules/cpmso-yaml-provider-spec-gcp.adoc
@@ -10,7 +10,7 @@ When you create a control plane machine set for an existing cluster, the provide
 
 [discrete]
 [id="cpmso-yaml-provider-spec-gcp-oc_{context}"]
-== Values obtained by using the  OpenShift CLI
+== Values obtained by using the OpenShift CLI
 
 In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
 

--- a/modules/cpmso-yaml-provider-spec-nutanix.adoc
+++ b/modules/cpmso-yaml-provider-spec-nutanix.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-configuration.adoc
+
+:_content-type: REFERENCE
+[id="cpmso-yaml-provider-spec-nutanix_{context}"]
+= Sample Nutanix provider specification
+
+When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane machine custom resource (CR) that is created by the installation program.
+
+[discrete]
+[id="cpmso-yaml-provider-spec-nutanix-oc_{context}"]
+== Values obtained by using the OpenShift CLI
+
+In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI.
+
+Infrastructure ID:: The `<cluster_id>` string is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+
+.Sample Nutanix `providerSpec` values
+[source,yaml]
+----
+providerSpec:
+  value:
+    apiVersion: machine.openshift.io/v1
+    bootType: "" <1>
+    categories: <2>
+    - key: <category_name>
+      value: <category_value>
+    cluster: <3>
+      type: uuid
+      uuid: <cluster_uuid>
+    credentialsSecret:
+      name: nutanix-credentials <4>
+    image: <5>
+      name: <cluster_id>-rhcos
+      type: name
+    kind: NutanixMachineProviderConfig <6>
+    memorySize: 16Gi <7>
+    metadata:
+      creationTimestamp: null
+    project: <8>
+      type: name
+      name: <project_name>
+    subnets: <9>
+    - type: uuid
+      uuid: <subnet_uuid>
+    systemDiskSize: 120Gi <10>
+    userDataSecret:
+      name: master-user-data <11>
+    vcpuSockets: 8 <12>
+    vcpusPerSocket: 1 <13>
+----
+<1> Specifies the boot type that the control plane machines use. For more information about boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment]. Valid values are `Legacy`, `SecureBoot`, or `UEFI`. The default is `Legacy`.
++
+[NOTE]
+====
+You must use the `Legacy` boot type in {product-title} {product-version}.
+====
+<2> Specifies one or more Nutanix Prism categories to apply to control plane machines. This stanza requires `key` and `value` parameters for a category key-value pair that exists in Prism Central. For more information about categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
+<3> Specifies a Nutanix Prism Element cluster configuration. In this example, the cluster type is `uuid`, so there is a `uuid` stanza.
+<4> Specifies the secret name for the cluster. Do not change this value.
+<5> Specifies the image that was used to create the disk.
+<6> Specifies the cloud provider platform type. Do not change this value.
+<7> Specifies the memory allocated for the control plane machines.
+<8> Specifies the Nutanix project that you use for your cluster. In this example, the project type is `name`, so there is a `name` stanza.
+<9> Specifies a subnet configuration. In this example, the subnet type is `uuid`, so there is a `uuid` stanza.
+<10> Specifies the VM disk size for the control plane machines.
+<11> Specifies the control plane user data secret. Do not change this value.
+<12> Specifies the number of vCPU sockets allocated for the control plane machines.
+<13> Specifies the number of vCPUs for each control plane vCPU socket.

--- a/modules/cpmso-yaml-provider-spec-vsphere.adoc
+++ b/modules/cpmso-yaml-provider-spec-vsphere.adoc
@@ -6,7 +6,7 @@
 [id="cpmso-yaml-provider-spec-vsphere_{context}"]
 = Sample vSphere provider specification
 
-When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane `machine` CR that is created by the installation program. 
+When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane machine custom resource (CR) that is created by the installation program.
 
 .Sample vSphere `providerSpec` values
 [source,yaml]
@@ -30,7 +30,7 @@ providerSpec:
     template: <vm_template_name> <8>
     userDataSecret:
       name: master-user-data <9>
-    workspace: 
+    workspace:
       datacenter: <vcenter_datacenter_name> <10>
       datastore: <vcenter_datastore_name> <11>
       folder: <path_to_vcenter_vm_folder> <12>
@@ -39,7 +39,7 @@ providerSpec:
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the VM disk size for the control plane machines.
-<3> Specifies the cloud provider platform type. Do not change this value. 
+<3> Specifies the cloud provider platform type. Do not change this value.
 <4> Specifies the memory allocated for the control plane machines.
 <5> Specifies the network on which the control plane is deployed.
 <6> Specifies the number of CPUs allocated for the control plane machines.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-6237](https://issues.redhat.com//browse/OSDOCS-6237) > [OSDOCS-6241](https://issues.redhat.com//browse/OSDOCS-6241)

Link to docs preview:
[Sample YAML for configuring Nutanix clusters](https://60572--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration.html#cpmso-sample-yaml-nutanix_cpmso-configuration)

QE review:
- [ ] QE has approved this change.

Additional information:
- Callouts are letters because that will be easier to replace with numbers when this info is final/confirmed
- Found a couple of things to tidy in here as well, all minor.