### PR TITLE
Fix OpenShift Container Platform product title in OSD Welcome link

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -46,7 +46,7 @@ endif::[]
 ifdef::openshift-dedicated[]
 To navigate the {product-title} documentation, use the left navigation bar.
 
-For documentation that is not specific to {product-title}, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[{product-title} documentation].
+For documentation that is not specific to {product-title}, see the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
 endif::[]
 
 ifdef::microshift[]


### PR DESCRIPTION
Version(s):
4.13+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-6262

Link to docs preview:
https://60573--docspreview.netlify.app/openshift-dedicated/latest/welcome/index.html

QE review:
- [ ] QE has approved this change.
No QE review required. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
