### PR TITLE
[OSDOCS#6098]: Add egress IP support on Nutanix 

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -51,6 +51,7 @@ Support for the egress IP address functionality on various platforms is summariz
 | {ibmzProductName} and {linuxoneProductName} | Yes
 | {ibmzProductName} and {linuxoneProductName} for {op-system-base-full} KVM | Yes
 | {ibmpowerProductName} | Yes
+| Nutanix | Yes
 
 |===
 


### PR DESCRIPTION
[OSDOCS-6098](https://issues.redhat.com//browse/OSDOCS-6098)

Version(s): 4.14+

Link to docs preview: https://60574--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-platform-support_configuring-egress-ips-ovn

QE review:
- [x ] QE has approved this change.

