### PR TITLE
OCPBUGS-11358 removing line about not supporting IPv6

### DIFF
--- a/networking/network_policy/about-network-policy.adoc
+++ b/networking/network_policy/about-network-policy.adoc
@@ -11,11 +11,6 @@ toc::[]
 
 As a cluster administrator, you can define network policies that restrict traffic to pods in your cluster.
 
-[NOTE]
-====
-Configured network policies are ignored in IPv6 networks.
-====
-
 include::modules/nw-networkpolicy-about.adoc[leveloffset=+1]
 
 include::modules/nw-networkpolicy-optimize.adoc[leveloffset=+1]


### PR DESCRIPTION
OCPBUGS-11358: removing line about not supported for IPv6

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12, 4.13, 4.14 and Main

Issue:
https://issues.redhat.com/browse/OCPBUGS-11358

Link to docs preview: https://60586--docspreview.netlify.app/openshift-enterprise/latest/networking/network_policy/about-network-policy.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
