### PR TITLE
OCPBUGS#9295: Updated the --insecure flag desc. in installation docs

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -404,7 +404,7 @@ a|`--save-partindex <id>...`
 a|Save partitions with this number or range.
 
 a|`--insecure`
-a|Skip signature verification.
+a|Skip {op-system} image signature verification.
 
 a|`--insecure-ignition`
 a|Allow Ignition URL without HTTPS or hash.


### PR DESCRIPTION
[OCPBUGS-9295](https://issues.redhat.com/browse/OCPBUGS-9295)

Version(s):
4.10 through to 4.14

Links to docs preview:
* [Installing a user-provisioned cluster on bare metal](https://60591--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal.html#installation-user-infra-machines-coreos-installer-options_installing-bare-metal)
* [Installing a user-provisioned bare metal cluster on a restricted network](https://60591--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-user-infra-machines-coreos-installer-options_installing-restricted-networks-bare-metal)
* [Installing a user-provisioned bare metal cluster on a restricted network](https://60591--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html#installation-user-infra-machines-coreos-installer-options_installing-bare-metal-network-customizations)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
