### PR TITLE
Adding some OCP terms for Vale

### DIFF
--- a/.vale/styles/Vocab/OpenShiftDocs/accept.txt
+++ b/.vale/styles/Vocab/OpenShiftDocs/accept.txt
@@ -3,6 +3,7 @@
 
 [Pp]assthrough
 Assisted Installer
+Control Plane Machine Set
 custom resource
 custom resources
 MetalLB

--- a/.vale/styles/Vocab/OpenShiftDocs/reject.txt
+++ b/.vale/styles/Vocab/OpenShiftDocs/reject.txt
@@ -8,6 +8,8 @@
 [Tt]hree [Nn]ode OpenShift
 AI
 configuration maps?
+MachineSets
+machinesets?
 minions?
 operators?
 SNO


### PR DESCRIPTION
[accept] Valid things Vale flags as problems:
* Control Plane Machine Set
* ~machine~ (update: would rather remove as an invalid term from VRH)
* ~machines~
* ~Nutanix~ (update: was already done in VRH)
* ~VMware~ (update: would like to add VRH pascal case fix here)

[reject] Common misuses:
* MachineSets
* machineset
* machinesets
* ~VMWare~
* ~Vsphere~ (update: was already done in VRH)

[reject] Should be an attribute:
* ~OpenShift Container Platform~ (update: trying to move to a rule to replace with an attribute)