### PR TITLE
ROX-17282: Remove old instruction that no longer applies to install

### DIFF
--- a/installing/installing_ocp/install-secured-cluster-ocp.adoc
+++ b/installing/installing_ocp/install-secured-cluster-ocp.adoc
@@ -70,7 +70,6 @@ include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 To install {product-title-short} on secured clusters by using the CLI, perform the following steps:
 
 . Install the `roxctl` CLI
-. Install Scanner.
 . Install Sensor.
 
 [id="installing-roxctl-cli-sc"]

--- a/installing/installing_other/install-secured-cluster-other.adoc
+++ b/installing/installing_other/install-secured-cluster-other.adoc
@@ -59,7 +59,6 @@ include::modules/change-config-options-after-deployment.adoc[leveloffset=+2]
 To install {product-title-short} on secured clusters by using the CLI, perform the following steps:
 
 . Install the `roxctl` CLI
-. Install Scanner.
 . Install Sensor.
 
 [id="installing-roxctl-cli-sc-other"]


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-3.73`
- Cherry pick to `rhacs-docs-3.74`
- Cherry pick to `rhacs-docs-4.0`
- Cherry pick to `rhacs-docs-4.1`

[Issue](https://issues.redhat.com/browse/ROX-17282)

Link to docs preview:

- https://60605--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp.html#installing-sc-roxctl
- https://60605--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other.html#installing-sc-roxctl-sc-other

QE review:
- [x] QE has approved this change. (**N/A**: RHACS has no QE; approved by SME.)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
