### PR TITLE
RHDEVDOCS-4957: Comment out PR changes

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1954,8 +1954,8 @@ Topics:
     File: run-gitops-control-plane-workload-on-infra-nodes
   - Name: Sizing requirements for GitOps Operator
     File: about-sizing-requirements-gitops
-  - Name: Collecting debugging data for a support case
-    File: collecting-debugging-data-for-support
+#  - Name: Collecting debugging data for a support case
+#    File: collecting-debugging-data-for-support
   - Name: Troubleshooting issues in GitOps
     File: troubleshooting-issues-in-GitOps
 - Name: Jenkins


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-4957
https://github.com/openshift/openshift-docs/pull/56812

Link to docs preview:
https://56812--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/collecting-debugging-data-for-support.html section no longer shows up in https://60608--docspreview.netlify.app/openshift-enterprise/latest/welcome/index.html

QE review not required - commenting our PR that shouldn't have been merged yet.