### PR TITLE
OSDOCS#6207: Installing a three-node Nutanix cluster

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -298,6 +298,8 @@ Topics:
     File: installing-nutanix-installer-provisioned
   - Name: Installing a cluster on Nutanix in a restricted network
     File: installing-restricted-networks-nutanix-installer-provisioned
+  - Name: Installing a three-node cluster on Nutanix
+    File: installing-nutanix-three-node
   - Name: Uninstalling a cluster on Nutanix
     File: uninstalling-cluster-nutanix
 - Name: Installing on bare metal

--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -3,6 +3,7 @@
 = Installing a cluster on Nutanix
 include::_attributes/common-attributes.adoc[]
 :context: installing-nutanix-installer-provisioned
+:platform: Nutanix
 
 toc::[]
 

--- a/installing/installing_nutanix/installing-nutanix-three-node.adoc
+++ b/installing/installing_nutanix/installing-nutanix-three-node.adoc
@@ -1,0 +1,14 @@
+:_content-type: ASSEMBLY
+[id="installing-nutanix-three-node"]
+= Installing a three-node cluster on Nutanix
+include::_attributes/common-attributes.adoc[]
+:context: installing-nutanix-three-node
+
+toc::[]
+
+In {product-title} version {product-version}, you can install a three-node cluster on Nutanix. A three-node cluster consists of three control plane machines, which also act as compute machines. This type of cluster provides a smaller, more resource efficient cluster, for cluster administrators and developers to use for testing, development, and production.
+
+include::modules/installation-three-node-cluster-cloud-provider.adoc[leveloffset=+1]
+
+== Next steps
+* xref:../../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installing-nutanix-installer-provisioned[Installing a cluster on Nutanix]

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -489,7 +489,7 @@ ifdef::three-node-cluster[]
 +
 [NOTE]
 ====
-If you are installing a three-node cluster, be sure to set the `compute.replicas` parameter to `0`. This ensures that cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on {platform}".
+If you are installing a three-node cluster, be sure to set the `compute.replicas` parameter to `0`. This ensures that the cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on {platform}".
 ====
 endif::three-node-cluster[]
 
@@ -673,6 +673,11 @@ ifdef::nutanix[]
 . Optional: Update one or more of the default configuration parameters in the `install.config.yaml` file to customize the installation.
 +
 For more information about the parameters, see "Installation configuration parameters".
++
+[NOTE]
+====
+If you are installing a three-node cluster, be sure to set the `compute.replicas` parameter to `0`. This ensures that cluster's control planes are schedulable. For more information, see "Installing a three-node cluster on {platform}".
+====
 endif::nutanix[]
 
 . Back up the `install-config.yaml` file so that you can use

--- a/modules/installation-three-node-cluster-cloud-provider.adoc
+++ b/modules/installation-three-node-cluster-cloud-provider.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_gcp/installing-gcp-three-node.adoc
 // * installing/installing_vsphere/installing-vsphere-three-node.adoc
 // * installing/installing_vmc/installing-vmc-three-node.adoc
+// * installing/installing_nutanix/installing-nutanix-three-node.adoc
 
 ifeval::["{context}" == "installing-aws-three-node"]
 :aws:
@@ -19,6 +20,9 @@ ifeval::["{context}" == "installing-vsphere-three-node"]
 endif::[]
 ifeval::["{context}" == "installing-vmc-three-node"]
 :vmc:
+endif::[]
+ifeval::["{context}" == "installing-nutanix-three-node"]
+:nutanix:
 endif::[]
 
 :_content-type: PROCEDURE
@@ -38,16 +42,26 @@ Because application workloads run from control plane nodes, additional subscript
 
 .Procedure
 
+ifdef::nutanix[]
+* Set the number of compute replicas to `0` in your `install-config.yaml` file, as shown in the following `compute` stanza:
+endif::nutanix[]
+
+ifndef::nutanix[]
 . Set the number of compute replicas to `0` in your `install-config.yaml` file, as shown in the following `compute` stanza:
+endif::nutanix[]
 +
+.Example `install-config.yaml` file for a three-node cluster
 [source,yaml]
 ----
+apiVersion: v1
+baseDomain: example.com
 compute:
 - name: worker
   platform: {}
   replicas: 0
+# ...
 ----
-ifndef::vsphere,vmc[]
+ifndef::vsphere,vmc,nutanix[]
 . If you are deploying a cluster with user-provisioned infrastructure:
 ** After you create the Kubernetes manifest files, make sure that the `spec.mastersSchedulable` parameter is set to `true` in `cluster-scheduler-02-config.yml` file. You can locate this file in `<installation_directory>/manifests`.
 ifdef::aws[]
@@ -60,7 +74,7 @@ ifdef::gcp[]
 For more information, see "Creating the Kubernetes manifest and Ignition config files" in "Installing a cluster on user-provisioned infrastructure in GCP by using Deployment Manager templates".
 endif::gcp[]
 ** Do not create additional worker nodes.
-endif::vsphere,vmc[]
+endif::vsphere,vmc,nutanix[]
 
 ifdef::vsphere,vmc[]
 . If you are deploying a cluster with user-provisioned infrastructure:
@@ -75,6 +89,7 @@ endif::vmc[]
 ** Do not create additional worker nodes.
 endif::vsphere,vmc[]
 
+ifndef::nutanix[]
 .Example `cluster-scheduler-02-config.yml` file for a three-node cluster
 [source,yaml]
 ----
@@ -89,6 +104,7 @@ spec:
     name: ""
 status: {}
 ----
+endif::nutanix[]
 
 ifeval::["{context}" == "installing-aws-three-node"]
 :!aws:
@@ -104,4 +120,7 @@ ifeval::["{context}" == "installing-vsphere-three-node"]
 endif::[]
 ifeval::["{context}" == "installing-vmc-three-node"]
 :!vmc:
+endif::[]
+ifeval::["{context}" == "installing-nutanix-three-node"]
+:!nutanix:
 endif::[]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
This PR addresses [osdocs-6278](https://issues.redhat.com/browse/OSDOCS-6278)

Link to docs preview:

- [Installing a three-node cluster on Nutanix](https://60612--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-three-node.html)
- [Creating the installation configuration file](https://60612--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#installation-initializing_installing-nutanix-installer-provisioned) (note under step 2).

QE review:
- [X] QE has approved this change.