### PR TITLE
TELCODOCS-1215 - Adding GitOps ZTP managed cluster maximums info

### DIFF
--- a/.vale/styles/Vocab/OpenShiftDocs/accept.txt
+++ b/.vale/styles/Vocab/OpenShiftDocs/accept.txt
@@ -1,14 +1,15 @@
 # Regex terms added to accept.txt are ignored by the Vale linter and override RedHat Vale rules.
 # Add terms that have a corresponding incorrectly capitalized form to reject.txt.
 
+[Ff]ronthaul
+[Mm]idhaul
 [Pp]assthrough
+[Rr]ealtime
 Assisted Installer
 Control Plane Machine Set Operator
 custom resource
 custom resources
+Mbps
 MetalLB
 Operator
 Operators
-[Ff]ronthaul
-[Mm]idhaul
-[Rr]ealtime

--- a/modules/ztp-gitops-ztp-max-spoke-clusters.adoc
+++ b/modules/ztp-gitops-ztp-max-spoke-clusters.adoc
@@ -1,0 +1,98 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc]
+
+:_content-type: REFERENCE
+[id="ztp-gitops-ztp-max-spoke-clusters_{context}"]
+= Recommended hub cluster specifications and managed cluster limits for {ztp}
+
+With {ztp-first}, you can manage thousands of clusters in geographically dispersed regions and networks.
+The Red Hat Performance and Scale lab successfully created and managed 3500 virtual {sno} clusters with a reduced DU profile from a single {rh-rhacm-first} hub cluster in a lab environment.
+
+In real-world situations, the scaling limits for the number of clusters that you can manage will vary depending on various factors affecting the hub cluster.
+For example:
+
+Hub cluster resources::
+Available hub cluster host resources (CPU, memory, storage) are an important factor in determining how many clusters the hub cluster can manage.
+The more resources allocated to the hub cluster, the more managed clusters it can accommodate.
+
+Hub cluster storage::
+The hub cluster host storage IOPS rating and whether the hub cluster hosts use NVMe storage can affect hub cluster performance and the number of clusters it can manage.
+
+Network bandwidth and latency::
+Slow or high-latency network connections between the hub cluster and managed clusters can impact how the hub cluster manages multiple clusters.
+
+Managed cluster size and complexity::
+The size and complexity of the managed clusters also affects the capacity of the hub cluster.
+Larger managed clusters with more nodes, namespaces, and resources require additional processing and management resources.
+Similarly, clusters with complex configurations such as the RAN DU profile or diverse workloads can require more resources from the hub cluster.
+
+Number of managed policies::
+The number of policies managed by the hub cluster scaled over the number of managed clusters bound to those policies is an important factor that determines how many clusters can be managed.
+
+Monitoring and management workloads::
+{rh-rhacm} continuously monitors and manages the managed clusters.
+The number and complexity of monitoring and management workloads running on the hub cluster can affect its capacity.
+Intensive monitoring or frequent reconciliation operations can require additional resources, potentially limiting the number of manageable clusters.
+
+{rh-rhacm} version and configuration::
+Different versions of {rh-rhacm} can have varying performance characteristics and resource requirements.
+Additionally, the configuration settings of {rh-rhacm}, such as the number of concurrent reconciliations or the frequency of health checks, can affect the managed cluster capacity of the hub cluster.
+
+Use the following representative configuration and network specifications to develop your own Hub cluster and network specifications.
+
+[IMPORTANT]
+====
+The following guidelines are based on internal lab benchmark testing only and do not represent a complete real-world host specification.
+====
+
+.Representative three-node hub cluster machine specifications
+[cols=2*, width="90%", options="header"]
+|====
+|Requirement
+|Description
+
+|{product-title} version
+|version 4.13
+
+|{rh-rhacm} version
+|version 2.7
+
+|{cgu-operator-first}
+|version 4.13
+
+|Server hardware
+|3 x Dell PowerEdge R650 rack servers
+
+|NVMe hard disks
+a|* 50 GB disk for `/var/lib/etcd`
+* 2.9 TB disk for `/var/lib/containers`
+
+|SSD hard disks
+a|* 1 SSD split into 15 200GB thin-provisioned logical volumes provisioned as `PV` CRs
+* 1 SSD serving as an extra large `PV` resource
+
+|Number of applied DU profile policies
+|5
+|====
+
+[IMPORTANT]
+====
+The following network specifications are representative of a typical real-world RAN network and were applied to the scale lab environment during testing.
+====
+
+.Simulated lab environment network specifications
+[cols=2*, width="90%", options="header"]
+|====
+|Specification
+|Description
+
+|Round-trip time (RTT) latency
+|50 ms
+
+|Packet loss
+|0.02% packet loss
+
+|Network bandwidth limit
+|20 Mbps
+|====

--- a/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
@@ -10,6 +10,13 @@ To use {rh-rhacm} in a disconnected environment, create a mirror registry that m
 
 include::modules/ztp-telco-ran-software-versions.adoc[leveloffset=+1]
 
+include::modules/ztp-gitops-ztp-max-spoke-clusters.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/install/installing#single-node[Creating and managing {sno} clusters with {rh-rhacm}]
+
 include::modules/ztp-acm-installing-disconnected-rhacm.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Adding GitOps ZTP managed cluster limits details. 

Version(s):
main, enterprise-4.12, enterprise-4.13, enterprise-4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-1215

Link to docs preview:
https://60615--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-gitops-ztp-max-spoke-clusters_ztp-preparing-the-hub-cluster

QE review:
- [x] QE has approved this change.