### PR TITLE
Fixing a typo in agent installer config yaml

### DIFF
--- a/modules/installing-ocp-agent-boot.adoc
+++ b/modules/installing-ocp-agent-boot.adoc
@@ -40,7 +40,7 @@ cat << EOF > ./my-cluster/install-config.yaml
 apiVersion: v1
 baseDomain: test.example.com
 compute:
-  architecture: amd64 <1>
+- architecture: amd64 <1>
   hyperthreading: Enabled
   name: worker
   replicas: 0


### PR DESCRIPTION
Version(s): 4.13 only

This PR fixes a small typo in the install-config.yaml file shown in the 4.13 agent docs, where `architecture` is missing a preceding hyphen and is thus incorrectly represented as a dictionary instead of a list.

Link to docs preview:

QE review:
- [x] QE has approved this change.
