### PR TITLE
OSDOCS-6236: adds 4.13.1 to RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2833,3 +2833,29 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.0 --pullspecs
 ----
 //replace 4.y.z for the correct values for the release. You do not need to update oc to run this command.
+[id="ocp-4-13-1"]
+=== RHSA-2023:3304 - {product-title} 4.13.1 bug fix and security update
+
+Issued: 2023-05-30
+
+{product-title} release 4.13.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3304[RHSA-2023:3304] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3303[RHSA-2023:3303] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.1 --pullspecs
+----
+
+[id="ocp-4-13-1-bug-fixes"]
+==== Bug fixes
+* Previously, assisted installations could encounter a transient error. If that error occurred, the installation failed to recover. With this update, transient errors are re-tried correctly. (link:https://issues.redhat.com/browse/OCPBUGS-13138[*OCPBUGS-13138*])
+
+* Previously, oc-mirror OpenShift CLI (`oc`) plugin would fail with a `401 unauthorized` error for some registries when a nested path exceeded the expected maximum path-components. With this update, the default integer of the `--max-nested-paths` flag is set to 0 (no limit). As a result, the generated `ImageContentSourcePolicy` will contain source and mirror references up to the repository level as opposed to the namespace level used by default. (link:https://issues.redhat.com/browse/OCPBUGS-13591[*OCPBUGS-13591*])
+
+[id="ocp-4-13-1-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-6236](https://issues.redhat.com//browse/OSDOCS-6236): adds 4.13.1 to RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-6236
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://joealdinger.github.io/openshift-docs/OSDOCS-6236/release_notes/ocp-4-13-release-notes.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
