### PR TITLE
Added a missing symlink to ROSA with HCP

### DIFF
--- a/rosa_hcp/snippets
+++ b/rosa_hcp/snippets
@@ -1,0 +1,1 @@
+../snippets/


### PR DESCRIPTION
Added a missing snippets symlink that was breaking subsequent builds.

[Preview Build for Tech Preview Snippet](https://60622--docspreview.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html)