### PR TITLE
CNV-27208: OKD virt installation procedures

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -109,15 +109,23 @@ endif::[]
 :VirtVersion: 4.13
 :KubeVirtVersion: v0.59.0
 :HCOVersion: 4.13.0
+:CNVNamespace: openshift-cnv
+:CNVOperatorDisplayName: OpenShift Virtualization Operator
+:CNVSubscriptionSpecSource: redhat-operators
+:CNVSubscriptionSpecName: kubevirt-hyperconverged
 :delete: image:delete.png[title="Delete"]
 ifdef::openshift-origin[]
 :VirtProductName: OKD Virtualization
+:CNVNamespace: kubevirt-hyperconverged
+:CNVOperatorDisplayName: KubeVirt HyperConverged Cluster Operator
+:CNVSubscriptionSpecSource: community-operators
+:CNVSubscriptionSpecName: community-kubevirt-hyperconverged
 endif::[]
 //distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing
 :DTShortName: distributed tracing
 :DTProductVersion: 2.8
-:JaegerName: Red Hat OpenShift distributed tracing platform
+:JaegerName: Red Hat OpenShift distributed tracing platform 
 :JaegerShortName: distributed tracing platform
 :JaegerVersion: 1.42.0
 :OTELName: Red Hat OpenShift distributed tracing data collection

--- a/modules/virt-about-node-placement-virtualization-components.adoc
+++ b/modules/virt-about-node-placement-virtualization-components.adoc
@@ -43,11 +43,11 @@ apiVersion: operators.coreos.com/v1beta1
 kind: Subscription
 metadata:
   name: hco-operatorhub
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
-  source: redhat-operators
+  source: {CNVSubscriptionSpecSource}
   sourceNamespace: openshift-marketplace
-  name: kubevirt-hyperconverged
+  name: {CNVSubscriptionSpecName}
   startingCSV: kubevirt-hyperconverged-operator.v{HCOVersion}
   channel: "stable"
   config: <1>
@@ -59,13 +59,13 @@ spec:
 
 To specify the nodes where {VirtProductName} deploys its components, you can include the `nodePlacement` object in the HyperConverged Cluster custom resource (CR) file that you create during {VirtProductName} installation. You can include `nodePlacement` under the `spec.infra` and `spec.workloads` fields, as shown in the following example:
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   infra:
     nodePlacement: <1>

--- a/modules/virt-deploying-operator-cli.adoc
+++ b/modules/virt-deploying-operator-cli.adoc
@@ -10,19 +10,19 @@ You can deploy the {VirtProductName} Operator by using the `oc` CLI.
 
 .Prerequisites
 
-* An active subscription to the {VirtProductName} catalog in the `openshift-cnv` namespace.
+* An active subscription to the {VirtProductName} catalog in the `{CNVNamespace}` namespace.
 
 .Procedure
 
 . Create a YAML file that contains the following manifest:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
 ----
 
@@ -35,11 +35,11 @@ $ oc apply -f <file_name>.yaml
 
 .Verification
 
-* Ensure that {VirtProductName} deployed successfully by watching the `PHASE` of the cluster service version (CSV) in the `openshift-cnv` namespace. Run the following command:
+* Ensure that {VirtProductName} deployed successfully by watching the `PHASE` of the cluster service version (CSV) in the `{CNVNamespace}` namespace. Run the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ watch oc get csv -n openshift-cnv
+$ watch oc get csv -n {CNVNamespace}
 ----
 +
 The following output displays if deployment was successful:

--- a/modules/virt-example-node-placement-affinity-hyperconverged-cr.adoc
+++ b/modules/virt-example-node-placement-affinity-hyperconverged-cr.adoc
@@ -7,13 +7,13 @@
 
 In this example, `affinity` is configured so that infrastructure resources are placed on nodes that are labeled with `example.io/example-infra-key = example-value` and workloads are placed on nodes labeled with `example.io/example-workloads-key = example-workloads-value`. Nodes that have more than eight CPUs are preferred for workloads, but if they are not available, pods are still scheduled.
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   infra:
     nodePlacement:

--- a/modules/virt-example-node-placement-node-selector-hyperconverged-cr.adoc
+++ b/modules/virt-example-node-placement-node-selector-hyperconverged-cr.adoc
@@ -7,13 +7,13 @@
 
 In this example, `nodeSelector` is configured so that infrastructure resources are placed on nodes that are labeled with `example.io/example-infra-key = example-infra-value` and workloads are placed on nodes labeled with `example.io/example-workloads-key = example-workloads-value`.
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   infra:
     nodePlacement:

--- a/modules/virt-example-node-placement-node-selector-olm-subscription.adoc
+++ b/modules/virt-example-node-placement-node-selector-olm-subscription.adoc
@@ -13,11 +13,11 @@ apiVersion: operators.coreos.com/v1beta1
 kind: Subscription
 metadata:
   name: hco-operatorhub
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
-  source: redhat-operators
+  source: {CNVSubscriptionSpecSource}
   sourceNamespace: openshift-marketplace
-  name: kubevirt-hyperconverged
+  name: {CNVSubscriptionSpecName}
   startingCSV: kubevirt-hyperconverged-operator.v{HCOVersion}
   channel: "stable"
   config:

--- a/modules/virt-example-node-placement-tolerations-hyperconverged-cr.adoc
+++ b/modules/virt-example-node-placement-tolerations-hyperconverged-cr.adoc
@@ -7,13 +7,13 @@
 
 In this example, nodes that are reserved for {VirtProductName} components are labeled with the `key=virtualization:NoSchedule` taint. Only pods with the matching tolerations are scheduled to these nodes.
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   workloads:
     nodePlacement:

--- a/modules/virt-example-node-placement-tolerations-olm-subscription.adoc
+++ b/modules/virt-example-node-placement-tolerations-olm-subscription.adoc
@@ -13,11 +13,11 @@ apiVersion: operators.coreos.com/v1beta1
 kind: Subscription
 metadata:
   name: hco-operatorhub
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
-  source: redhat-operators
+  source:  {CNVSubscriptionSpecSource}
   sourceNamespace: openshift-marketplace
-  name: kubevirt-hyperconverged
+  name: {CNVSubscriptionSpecName}
   startingCSV: kubevirt-hyperconverged-operator.v{HCOVersion}
   channel: "stable"
   config:

--- a/modules/virt-installing-virt-operator.adoc
+++ b/modules/virt-installing-virt-operator.adoc
@@ -17,9 +17,9 @@ You can install the {VirtProductName} Operator from the {product-title} web cons
 
 . From the *Administrator* perspective, click *Operators* -> *OperatorHub*.
 
-. In the *Filter by keyword* field, type *{VirtProductName}*.
+. In the *Filter by keyword* field, type *{CNVOperatorDisplayName}*.
 
-. Select the *{VirtProductName}* tile.
+. Select the *{CNVOperatorDisplayName}* tile.
 
 . Read the information about the Operator and click *Install*.
 
@@ -27,11 +27,11 @@ You can install the {VirtProductName} Operator from the {product-title} web cons
 
 .. Select *stable* from the list of available *Update Channel* options. This ensures that you install the version of {VirtProductName} that is compatible with your {product-title} version.
 
-.. For *Installed Namespace*, ensure that the *Operator recommended namespace* option is selected. This installs the Operator in the mandatory `openshift-cnv` namespace, which is automatically created if it does not exist.
+.. For *Installed Namespace*, ensure that the *Operator recommended namespace* option is selected. This installs the Operator in the mandatory `{CNVNamespace}` namespace, which is automatically created if it does not exist.
 +
 [WARNING]
 ====
-Attempting to install the {VirtProductName} Operator in a namespace other than `openshift-cnv` causes the installation to fail.
+Attempting to install the {VirtProductName} Operator in a namespace other than `{CNVNamespace}` causes the installation to fail.
 ====
 
 .. For *Approval Strategy*, it is highly recommended that you select *Automatic*, which is the default value, so that {VirtProductName} automatically updates when a new version is available in the *stable* update channel.
@@ -43,7 +43,7 @@ While it is possible to select the *Manual* approval strategy, this is inadvisab
 Because {VirtProductName} is only supported when used with the corresponding {product-title} version, missing {VirtProductName} updates can cause your cluster to become unsupported.
 ====
 
-. Click *Install* to make the Operator available to the `openshift-cnv` namespace.
+. Click *Install* to make the Operator available to the `{CNVNamespace}` namespace.
 
 . When the Operator installs successfully, click *Create HyperConverged*.
 

--- a/modules/virt-subscribing-cli.adoc
+++ b/modules/virt-subscribing-cli.adoc
@@ -6,12 +6,48 @@
 [id="virt-subscribing-cli_{context}"]
 = Subscribing to the {VirtProductName} catalog by using the CLI
 
-Before you install {VirtProductName}, you must subscribe to the {VirtProductName} catalog. Subscribing gives the `openshift-cnv` namespace access to the {VirtProductName} Operators.
+Before you install {VirtProductName}, you must subscribe to the {VirtProductName} catalog. Subscribing gives the `{CNVNamespace}` namespace access to the {VirtProductName} Operators.
 
 To subscribe, configure `Namespace`, `OperatorGroup`, and `Subscription` objects by applying a single manifest to your cluster.
 
 .Procedure
+ifdef::openshift-enterprise[]
+. Create a YAML file that contains the following manifest:
+//Note that there are two versions of the following YAML file; the first one is for openshift-enterprise and the second is for openshift-origin (aka OKD).
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: {CNVNamespace}
+---
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: kubevirt-hyperconverged-group
+  namespace: {CNVNamespace}
+spec:
+  targetNamespaces:
+    - {CNVNamespace}
+---
+apiVersion: operators.coreos.com/v1beta1
+kind: Subscription
+metadata:
+  name: hco-operatorhub
+  namespace: {CNVNamespace}
+spec:
+  source: {CNVSubscriptionSpecSource}
+  sourceNamespace: openshift-marketplace
+  name: {CNVSubscriptionSpecName}
+  startingCSV: kubevirt-hyperconverged-operator.v{HCOVersion}
+  channel: "stable" <1>
+----
+<1> Using the `stable` channel ensures that you install the version of
+{VirtProductName} that is compatible with your {product-title} version.
+endif::openshift-enterprise[]
 
+ifdef::openshift-origin[]
 . Create a YAML file that contains the following manifest:
 +
 [source,yaml,subs="attributes+"]
@@ -19,31 +55,30 @@ To subscribe, configure `Namespace`, `OperatorGroup`, and `Subscription` objects
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: openshift-cnv
+  name: {CNVNamespace}
 ---
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
   name: kubevirt-hyperconverged-group
-  namespace: openshift-cnv
-spec:
-  targetNamespaces:
-    - openshift-cnv
+  namespace: {CNVNamespace}
+spec: {}
 ---
 apiVersion: operators.coreos.com/v1beta1
 kind: Subscription
 metadata:
   name: hco-operatorhub
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
-  source: redhat-operators
+  source: {CNVSubscriptionSpecSource}
   sourceNamespace: openshift-marketplace
-  name: kubevirt-hyperconverged
+  name: {CNVSubscriptionSpecName}
   startingCSV: kubevirt-hyperconverged-operator.v{HCOVersion}
   channel: "stable" <1>
 ----
 <1> Using the `stable` channel ensures that you install the version of
 {VirtProductName} that is compatible with your {product-title} version.
+endif::openshift-origin[]
 
 . Create the required `Namespace`, `OperatorGroup`, and `Subscription` objects
 for {VirtProductName} by running the following command:


### PR DESCRIPTION
Version(s): 4.13+


Issue: [CNV-27208 ](https://issues.redhat.com/browse/CNV-27208)

Link to docs preview: See links below.

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

The following files have changed for OKD/openshift-origin (links to the openshift-enterprise version also included after OKD links for comparison):

**OKD/openshift-origin version**

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/installing-virt-web.html#virt-installing-virt-operator_installing-virt-web

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/installing-virt-cli.html#virt-subscribing-cli_installing-virt-cli

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/installing-virt-cli.html#virt-deploying-operator-cli_installing-virt-cli

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#node-placement-olm-subscription_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#node-placement-hco_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-tolerations-olm-subscription_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-node-selector-olm-subscription_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-node-selector-hyperconverged-cr_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-tolerations-hyperconverged-cr_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/okd/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-affinity-hyperconverged-cr_virt-specifying-nodes-for-virtualization-components


**openshift-enterprise version**

- https://aspauldi.github.io/previews/CNV-27208/virt/install/installing-virt-cli.html#virt-subscribing-cli_installing-virt-cli

- https://aspauldi.github.io/previews/CNV-27208/virt/install/installing-virt-cli.html#virt-deploying-operator-cli_installing-virt-cli

- https://aspauldi.github.io/previews/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#node-placement-olm-subscription_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#node-placement-hco_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-tolerations-olm-subscription_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-node-selector-olm-subscription_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-node-selector-hyperconverged-cr_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-tolerations-hyperconverged-cr_virt-specifying-nodes-for-virtualization-components

- https://aspauldi.github.io/previews/CNV-27208/virt/install/virt-specifying-nodes-for-virtualization-components.html#virt-example-node-placement-affinity-hyperconverged-cr_virt-specifying-nodes-for-virtualization-components


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
