### PR TITLE
[OCPBUGS#14162]: Update OCP and ACS versions and style fix

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -37,8 +37,8 @@
 :ocp: OpenShift Container Platform
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:ocp-supported-version: 4.12
-:rhacs-version: 3.74
+:ocp-supported-version: 4.13
+:rhacs-version: 4.0
 :quay-version: 3.8
 :rhacm-version: 2.7
 :odf-version: 4.12

--- a/architecture/opp-architecture.adoc
+++ b/architecture/opp-architecture.adoc
@@ -5,12 +5,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-{product-title} is a single hybrid-cloud platform for enterprises. Use it to build, deploy, run, and manage intelligent applications securely across infrastructures. It is based on {op-system-base-full}, Kubernetes, and Red Hat {ocp}. It includes the following products:
+{product-title} is a single hybrid-cloud platform for enterprises. Use it to build, deploy, run, and manage intelligent applications securely for multiple infrastructures. It is based on {op-system-base-full}, Kubernetes, and Red Hat {ocp} and includes the following products:
 
 * {rh-rhacm} for Kubernetes - Controls clusters and applications from a single console.
 * {acs} for Kubernetes - Provides information about cluster security, visibility management, and security compliance.
 * {quay} - Stores, builds, and deploys container images.
-* {rh-storage-essentials-first} - Provides a permanent place to store data while clusters spin up and down across environments.
+* {rh-storage-essentials-first} - Provides a permanent place to store data while clusters start and stop for multiple environments.
 
 
 include::modules/opp-architecture-architecture.adoc[leveloffset=+1]

--- a/modules/opp-architecture-relnotes.adoc
+++ b/modules/opp-architecture-relnotes.adoc
@@ -8,8 +8,8 @@
 
 The release note information for each product is accessible from the following list:
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/release_notes/index[{ocp}]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/release_notes/index[{ocp}]
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/release_notes/red-hat-advanced-cluster-management-for-kubernetes-release-notes[{rh-rhacm} for Kubernetes]
 * link:https://access.redhat.com/documentation/en-us/red_hat_quay/3.8/html/red_hat_quay_release_notes/index[{quay} Release Notes]
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/3.74/html/release_notes/index[{acs} for Kubernetes 3.7.4]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_security_for_kubernetes/4.0/html/release_notes/index[{acs} for Kubernetes 4.0]
 * link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.12/html/4.12_release_notes/index[{rh-storage-data-foundation}]


### PR DESCRIPTION
OCPBUGS-14162

Version(s): This PR is based on the ‘opp-docs’ repo and when merged, it should be in that branch only. The OPP doc is not versioned. Add this PR to the ‘Continuous Release’ milestone.

Link to docs preview: https://file.rdu.redhat.com/tlove/opp-ocpbugs-14163-tlove/architecture/opp-architecture.html (Updated 6/6)

QE review:
- [ ] QE has approved this change.

Additional information:

