### PR TITLE
[RHACS] Release Notes for 3.74.4 patch

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -52,7 +52,7 @@ endif::[]
 :osp: Red Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 3.74.3
+:rhacs-version: 3.74.4
 :ocp-supported-version: 4.5
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 3.74

--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -16,6 +16,7 @@ toc::[]
 |`3.74.1` | 20 March 2023
 |`3.74.2` | 13 April 2023
 |`3.74.3` | 2 May 2023
+|`3.74.4` | 5 June 2023
 |====
 
 [id="about-this-release-374"]
@@ -378,6 +379,16 @@ Release date: 2 May 2023
 
 * This release of {product-title-short} includes a fix for link:https://access.redhat.com/security/cve/CVE-2023-28617[CVE-2023-28617] for {op-system-base}.
 * This release includes a fix for an issue with migration to the PostgreSQL database (Technology Preview).
+
+[id="resolved-in-version-3744"]
+=== Resolved in version 3.74.4
+
+Release date: 5 June 2023
+
+* {product-title-short} 3.74.4 is built with updated Golang to fix the following CVEs:
+** link:https://access.redhat.com/security/cve/cve-2023-24540[CVE-2023-24540]
+** link:https://nvd.nist.gov/vuln/detail/cve-2023-24539[CVE-2023-24539]
+** link:https://nvd.nist.gov/vuln/detail/cve-2023-29400[CVE-2023-29400]
 
 [id="known-issues-374"]
 === Known issues


### PR DESCRIPTION
Includes release notes update for patch release 3.74.4
Preview: https://60642--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes.html#resolved-in-version-3744

For https://issues.redhat.com/browse/ROX-17168

No cherrypicks required.

> **NOTE**
> Do not merge yet. It will release on 2023-06-05

