### PR TITLE
RHDEVDOCS-5170: Updating 1.9 and 1.10 RNs to clearly mention compatib…

### DIFF
--- a/modules/op-release-notes-1-10.adoc
+++ b/modules/op-release-notes-1-10.adoc
@@ -5,7 +5,7 @@
 [id="op-release-notes-1-10_{context}"]
 = Release notes for {pipelines-title} General Availability 1.10
 
-With this update, {pipelines-title} General Availability (GA) 1.10 is available on {product-title} 4.11 and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.10 is available on {product-title} 4.11, 4.12, and 4.13.
 
 [id="new-features-1-10_{context}"]
 == New features
@@ -66,7 +66,10 @@ To enable or disable this update, set the value of the `githubOwners` parameter 
 
 
 [id="chains-new-features-1-10_{context}"]
-=== Tekton Chains
+=== {tekton-chains}
+
+:FeatureName: {tekton-chains}
+include::snippets/technology-preview.adoc[]
 
 * This update adds annotations and labels to the `PipelineRun` and `TaskRun` attestations.
 * This update adds a new format named `slsa/v1`, which generates the same provenance as the one generated when requesting in the `in-toto` format.
@@ -76,6 +79,9 @@ To enable or disable this update, set the value of the `githubOwners` parameter 
 
 [id="tekton-hub-new-features-1-10_{context}"]
 === {tekton-hub}
+
+:FeatureName: {tekton-hub}
+include::snippets/technology-preview.adoc[]
 
 * This update supports installing, upgrading, or downgrading Tekton resources of the `v1` API version on the cluster.
 * This update supports adding a custom logo in place of the {tekton-hub} logo in UI.
@@ -157,7 +163,7 @@ $ oc get tektoninstallersets.operator.tekton.dev | awk '/pipeline-main-static/ {
 [id="release-notes-1-10-1_{context}"]
 == Release notes for {pipelines-title} General Availability 1.10.1
 
-With this update, {pipelines-title} General Availability (GA) 1.10.1 is available on {product-title} 4.11 and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.10.1 is available on {product-title} 4.11, 4.12, and 4.13.
 
 [id="fixed-issues-1-10-1_{context}"]
 === Fixed issues for {pac}
@@ -170,7 +176,7 @@ With this update, {pipelines-title} General Availability (GA) 1.10.1 is availabl
 [id="release-notes-1-10-2_{context}"]
 == Release notes for {pipelines-title} General Availability 1.10.2
 
-With this update, {pipelines-title} General Availability (GA) 1.10.2 is available on {product-title} 4.11 and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.10.2 is available on {product-title} 4.11, 4.12, and 4.13.
 
 [id="fixed-issues-1-10-2_{context}"]
 === Fixed issues

--- a/modules/op-release-notes-1-9.adoc
+++ b/modules/op-release-notes-1-9.adoc
@@ -5,7 +5,7 @@
 [id="op-release-notes-1-9_{context}"]
 = Release notes for {pipelines-title} General Availability 1.9
 
-With this update, {pipelines-title} General Availability (GA) 1.9 is available on {product-title} 4.11 and later versions.
+With this update, {pipelines-title} General Availability (GA) 1.9 is available on {product-title} 4.11, 4.12, and 4.13.
 
 [id="new-features-1-9_{context}"]
 == New features
@@ -79,7 +79,7 @@ In addition to the fixes and stability improvements, the following sections high
 
 * With this update, {pac} is installed by default. You can disable {pac} by using the `-p` flag:
 +
-[source,yaml]
+[source,terminal]
 ----
 $ oc patch tektonconfig config --type="merge" -p '{"spec": {"platforms": {"openshift":{"pipelinesAsCode": {"enable": false}}}}}'
 ----
@@ -376,7 +376,7 @@ spec:
 [id="release-notes-1-9-1_{context}"]
 == Release notes for {pipelines-title} General Availability 1.9.1
 
-With this update, {pipelines-title} General Availability (GA) 1.9.1 is available on {product-title} 4.11 and later.
+With this update, {pipelines-title} General Availability (GA) 1.9.1 is available on {product-title} 4.11, 4.12, and 4.13.
 
 [id="fixed-issues-1-9-1_{context}"]	
 == Fixed issues	
@@ -428,7 +428,7 @@ Workaround: None. You can track the issue link:https://issues.redhat.com/browse/
 [id="release-notes-1-9-2_{context}"]
 == Release notes for {pipelines-title} General Availability 1.9.2
 
-With this update, {pipelines-title} General Availability (GA) 1.9.2 is available on {product-title} 4.11 and later.
+With this update, {pipelines-title} General Availability (GA) 1.9.2 is available on {product-title} 4.11, 4.12, and 4.13.
 
 [id="fixed-issues-1-9-2_{context}"]
 == Fixed issues


### PR DESCRIPTION
Aligned team: Dev Tools

Purpose: To resolve the following issues:
https://issues.redhat.com/browse/RHDEVDOCS-5170

OCP version this PR applies to: enterprise 4.11 and later versions

Link to docs preview: 
1.10 RN: https://60643--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#op-release-notes-1-10_op-release-notes
1.9 RN: https://60643--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#op-release-notes-1-9_op-release-notes


Need an ACK from Eng: @concaf 
Need an ACK from PM: @koustavsaha
Need an ACK from Product experience: @RickJWagner 
Need an ACK from QE: @ppitonak   
Need an ACK from CS: @Preeticp  
Need an ACK from DPM: @pmkovar 
Peer review: @Srivaralakshmi 