### PR TITLE
RHDEVDOCS-5240: Pipelines as Code, Split Logging By Namespace

### DIFF
--- a/cicd/pipelines/using-pipelines-as-code.adoc
+++ b/cicd/pipelines/using-pipelines-as-code.adoc
@@ -125,6 +125,8 @@ include::modules/op-customizing-pipelines-as-code-configuration.adoc[leveloffset
 
 include::modules/op-pipelines-as-code-command-reference.adoc[leveloffset=+1]
 
+include::modules/op-splitting-pipelines-as-code-logs-by-namespace.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 [id="additional-resources-pac"]
 == Additional resources

--- a/modules/op-splitting-pipelines-as-code-logs-by-namespace.adoc
+++ b/modules/op-splitting-pipelines-as-code-logs-by-namespace.adoc
@@ -1,0 +1,15 @@
+// This module is included in the following assembly:
+//
+// *cicd/pipelines/using-pipelines-as-code.adoc
+
+:_content-type: REFERENCE
+[id="splitting-pipelines-as-code-logs-by-namespace_{context}"]
+= Splitting {pac} logs by namespace
+
+The logs contain the namespace information to make it possible to filter logs or split the logs by a particular namespace. For example, to view the logs related to the `mynamespace` namespace, enter the following command:
+
+[source,terminal]
+----
+$ oc logs pipelines-as-code-controller-<unique-id> -n openshift-pipelines | grep mynamespace <1>
+----
+<1> Replace `pipelines-as-code-controller-<unique-id>` with the {pac} controller name.


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**:  enterprise-4.12 and later
• **JIRA issue**: [RHDEVDOCS-5240](https://issues.redhat.com/browse/RHDEVDOCS-5240)
• **Preview page**: [Splitting Pipelines as Code logs by namespace](https://60644--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-pipelines-as-code.html#splitting-pipelines-as-code-logs-by-namespace_using-pipelines-as-code)
• **SME Review**: Completed by @savitaashture 
• **QE review**:  Completed by @VeereshAradhya 
• **Peer-review**: Completed by @mramendi 