### PR TITLE
OSDOCS-6235: Documented the 4.12.19 z-stream release

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3694,3 +3694,22 @@ $ oc adm release info 4.12.18 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-12-19"]
+=== RHSA-2023:3287 - {product-title} 4.12.19 bug fix update and security update
+
+Issued: 2023-05-31
+
+{product-title} release 4.12.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3287[RHSA-2023:3287] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:3286[RHBA-2023:3286] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.19 --pullspecs
+----
+
+[id="ocp-4-12-19-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-6235](https://issues.redhat.com/browse/OSDOCS-6235)

Version(s):
4.12

Link to docs preview:

[Preview link](https://60646--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-19)
