### PR TITLE
RHDEVDOCS-5245: Performance Tuning for Openshift Pipelines

### DIFF
--- a/cicd/pipelines/installing-pipelines.adoc
+++ b/cicd/pipelines/installing-pipelines.adoc
@@ -37,6 +37,8 @@ include::modules/op-installing-pipelines-operator-using-the-cli.adoc[leveloffset
 
 include::modules/op-pipelines-operator-in-restricted-environment.adoc[leveloffset=+1]
 
+include::modules/op-performance-tuning-using-tektonconfig-cr.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 == Additional resources
 

--- a/modules/op-performance-tuning-using-tektonconfig-cr.adoc
+++ b/modules/op-performance-tuning-using-tektonconfig-cr.adoc
@@ -1,0 +1,72 @@
+// This module is included in the following assembly:
+//
+// *openshift_pipelines/customizing-configurations-in-the-tektonconfig-cr.adoc
+
+:_content-type: CONCEPT
+[id="op-performance-tuning-using-tektonconfig-cr_{context}"]
+= Performance tuning using TektonConfig CR
+
+You can modify the fields under the `.spec.pipeline.performance` parameter in the `TektonConfig` custom resource (CR) to change high availability (HA) support and performance configuration for the {pipelines-shortname} controller.
+
+.Example: `TektonConfig` performance fields
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  pipeline:
+    performance:
+      disable-ha: false
+      buckets: 1
+      threads-per-controller: 2
+      kube-api-qps: 5.0
+      kube-api-burst: 10
+----
+
+The fields are optional. If you set them, the {pipelines-title} Operator includes most of the fields as arguments in the `openshift-pipelines-controller` deployment under the `openshift-pipelines-controller` container. The {pipelines-shortname} Operator also updates the `buckets` field in the `config-leader-election` configuration map under the `openshift-pipelines` namespace.
+
+If you do not specify the values, the {pipelines-shortname} Operator does not update those fields and applies the default values for the {pipelines-shortname} controller.
+
+[NOTE]
+====
+If you modify or remove any of the performance fields, the {pipelines-shortname} Operator updates the `openshift-pipelines-controller` deployment and the `config-leader-election` configuration map (if the `buckets` field changed) and re-creates `openshift-pipelines-controller` pods.
+====
+
+.Modifiable fields for tuning {pipelines-shortname} performance
+[options="header"]
+|===
+
+| Name | Description | Default value for the {pipelines-shortname} controller
+
+| `disable-ha` | Enable or disable the high availability (HA) support. By default, the HA support is enabled. | `false`
+
+| `buckets` | The number of buckets used to partition key space of each reconciler.
+
+Each of the replicas uses these buckets. The instance that owns a bucket handles the reconciling of the keys partitioned into that bucket. The maximum value is `10` | `1`
+
+| `threads-per-controller` | The number of threads (workers) to use when the workqueue of the {pipelines-shortname} controller is processed. | `2`
+
+| `kube-api-qps` | The maximum queries per second (QPS) to the cluster master from the REST client. | `5.0`
+
+| `kube-api-burst` | The maximum burst for throttle. | `10`
+
+|===
+
+[NOTE]
+====
+The {pipelines-shortname} Operator does not control the number of replicas of the {pipelines-shortname} controller. The `replicas` setting of the deployment determines the number of replicas. For example, to change the number of replicas to 3, enter the following command:
+
+[source,terminal]
+----
+$ oc --namespace openshift-pipelines scale deployment openshift-pipelines-controller --replicas=3
+----
+====
+
+[IMPORTANT]
+====
+The `kube-api-qps` and `kube-api-burst` fields are multiplied by 2 in the {pipelines-shortname} controller. For example, if the `kube-api-qps` and `kube-api-burst` values are `10`, the actual QPS and burst values become `20`.
+====
+
+


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**:  enterprise-4.12 and later
• **JIRA issue**: [RHDEVDOCS-5245](https://issues.redhat.com/browse/RHDEVDOCS-5245)
• **Preview page**:  [Performance tuning using TektonConfig CR](https://60648--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/installing-pipelines.html#op-performance-tuning-using-tektonconfig-cr_installing-pipelines)
• **SME Review**: Completed by @jkandasa 
• **QE review**: Completed by @ppitonak 
• **Peer-review**: Completed by @mramendi 