### PR TITLE
SRVCOM-2320 Add Serverless 1.29.0 release notes, update feature tables

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,13 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-29-0.adoc[leveloffset=+1]
+// 1.29.0 additional resources
+[role="_additional-resources"]
+.Additional resources
+* link:https://openshift-knative.github.io/docs/docs/latest/serverless-logic/about.html[Red Hat OpenShift Serverless Logic documentation]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-28-0.adoc[leveloffset=+1]
 
 // OCP + OSD + ROSA

--- a/knative-serving/config-applications/multi-container-support-for-serving.adoc
+++ b/knative-serving/config-applications/multi-container-support-for-serving.adoc
@@ -6,8 +6,5 @@ include::_attributes/common-attributes.adoc[]
 
 You can deploy a multi-container pod by using a single Knative service. This method is useful for separating application responsibilities into smaller, specialized parts.
 
-:FeatureName: Multi-container support for Serving
-include::snippets/technology-preview.adoc[leveloffset=+2]
-
 // Multi-container support
 include::modules/serverless-configuring-multi-container-service.adoc[leveloffset=+1]

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -15,17 +15,17 @@ For the most recent list of major functionality deprecated and removed within {S
 .Deprecated and removed features tracker for {ocp-product-title} and {dedicated-product-title}
 [cols="3,1,1,1,1,1",options="header"]
 |====
-|Feature |1.20|1.21|1.22 to 1.26|1.27|1.28
+|Feature |1.21|1.22 to 1.26|1.27|1.28|1.29
 
 |`KafkaBinding` API
 |Deprecated
-|Deprecated
+|Removed
 |Removed
 |Removed
 |Removed
 
 |`kn func emit` (`kn func invoke` in 1.21+)
-|Deprecated
+|Removed
 |Removed
 |Removed
 |Removed
@@ -34,15 +34,15 @@ For the most recent list of major functionality deprecated and removed within {S
 |Serving and Eventing `v1alpha1` API
 |-
 |-
-|-
 |Deprecated
 |Deprecated
+|Removed
 
 |`enable-secret-informer-filtering` annotation
 |-
 |-
 |-
-|-
+|Deprecated
 |Deprecated
 
 |====
@@ -51,11 +51,12 @@ For the most recent list of major functionality deprecated and removed within {S
 // ROSA table
 
 .Deprecated and removed features tracker for {rosa-product-title}
-[cols="3,1,1,1",options="header"]
+[cols="3,1,1,1,1",options="header"]
 |====
-|Feature |1.23 to 1.26|1.27|1.28
+|Feature |1.23 to 1.26|1.27|1.28|1.29
 
 |`KafkaBinding` API
+|Removed
 |Removed
 |Removed
 |Removed
@@ -64,11 +65,13 @@ For the most recent list of major functionality deprecated and removed within {S
 |Removed
 |Removed
 |Removed
+|Removed
 
 |Serving and Eventing `v1alpha1` API
 |-
 |Deprecated
 |Deprecated
+|Removed
 
 |====
 

--- a/modules/serverless-rn-1-29-0.adoc
+++ b/modules/serverless-rn-1-29-0.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-29-0_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.29
+
+{ServerlessProductName} 1.29 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-1-29-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.8.
+* {ServerlessProductName} now uses Knative Eventing 1.8.
+* {ServerlessProductName} now uses Kourier 1.8.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.8.
+* {ServerlessProductName} now uses Knative for Apache Kafka 1.8.
+* The `kn func` CLI plug-in now uses `func` 1.10.
+
+* Beginning with {ServerlessProductName} 1.29, the different product versions are available as follows:
+** The latest release is available through the `stable` channel.
+** Releases older than the latest are available through the version-based channels.
++
+To use these, update the channel parameter in the subscription object YAML file from `stable` to the corresponding version-based channel, such as `stable-1.29`.
++
+This change allows you to receive updates not only for the latest release, but also for releases in the Maintenance phase.
++
+Additionally, you can lock the version of the Knative (`kn`) CLI. For details, see section "Installing the Knative CLI".
+
+* You can now create {ServerlessProductName} functions through developer console using {product-title} Pipelines.
+
+* Multi-container support for Knative Serving is now generally available (GA). This feature allows you to use a single Knative service to deploy a multi-container pod.
+
+* {ServerlessProductName} functions can now override the `readiness` and `liveness` probe values in the `func.yaml` file for individual Node.js and TypeScript functions.
+
+* You can now configure your function to re-deploy automatically to the cluster when its source code changes in the GitHub repository. This allows for more seamless CI/CD integration.
+
+* Eventing integration with Service Mesh is now available as developer preview feature. The integration includes: `PingSource`, `ApiServerSource`, Knative Source for Apache Kafka, Knative Broker for Apache Kafka, Knative Sink for Apache Kafka, `ContainerSource`, and `SinkBinding`.
+
+* This release includes the upgraded Developer Preview for {ServerlessProductName} Logic.
+
+* A `PodDistruptionBudget` and a `HorizontalPodAutoscaler` have been added for the `3scale-kourier-gateway` deployment.
+** `PodDistruptionBudget` is used to define the minimum availability requirements for pods in a deployment.
+** `HorizontalPodAutoscaler` is used to automatically scale the number of pods in the deployment based on demand or on your custom metrics.
+
+* API version `v1alpha1` of the Knative Operator Serving and Eventings CRDs has been removed. You need to use the `v1beta1` version instead. This does not affect the existing installations, because CRDs are updated automatically when upgrading the Serverless Operator.
+
+[id="known-issues-1-29-0_{context}"]
+== Known issues
+
+* When updating the secret specified in DomainMapping, simply updating the secret does not trigger the reconcile loop. You need to either rename the secret or delete the Knative Ingress resource to trigger the reconcile loop.
+
+* Webhook Horizontal Pod Autoscaler (HPA) settings are overridden by the {ServerlessOperatorName}. As a result, it fails to scale for higher workloads. To work around this issue, manually set the initial replica value that corresponds to your workload.
+
+
+
+
+
+
+

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -14,10 +14,70 @@ The following table provides information about which {ServerlessProductName} fea
 .Generally Available and Technology Preview features tracker for {ocp-product-title} and {dedicated-product-title}
 [cols="2,1,1,1",options="header"]
 |====
-|Feature |1.26|1.27|1.28
+|Feature |1.27|1.28|1.29
 
-|`kn func`
+|`multi-container support`
+|-
+|TP
 |GA
+
+|Namespace-scoped brokers
+|TP
+|TP
+|TP
+
+|TLS for internal traffic
+|TP
+|TP
+|TP
+
+|PVC support for Knative services
+|GA
+|GA
+|GA
+
+|Init containers support for Knative services
+|GA
+|GA
+|GA
+
+|Kafka sink
+|GA
+|GA
+|GA
+
+|Kafka broker
+|GA
+|GA
+|GA
+
+|HTTPS redirection
+|GA
+|GA
+|GA
+
+|`emptyDir` volumes
+|GA
+|GA
+|GA
+
+|Service Mesh mTLS
+|GA
+|GA
+|GA
+
+|Python functions
+|-
+|TP
+|TP
+
+|TypeScript functions
+|TP
+|GA
+|GA
+
+|Node.js functions
+|TP
 |GA
 |GA
 
@@ -26,134 +86,74 @@ The following table provides information about which {ServerlessProductName} fea
 |GA
 |GA
 
-|Node.js functions
-|TP
-|TP
-|GA
-
-|TypeScript functions
-|TP
-|TP
-|GA
-
-|Python functions
-|-
-|-
-|TP
-
-|Service Mesh mTLS
-|GA
-|GA
-|GA
-
-|`emptyDir` volumes
-|GA
-|GA
-|GA
-
-|HTTPS redirection
-|GA
-|GA
-|GA
-
-|Kafka broker
-|GA
-|GA
-|GA
-
-|Kafka sink
-|GA
-|GA
-|GA
-
-|Init containers support for Knative services
-|GA
-|GA
-|GA
-
-|PVC support for Knative services
-|GA
-|GA
-|GA
-
-|TLS for internal traffic
-|TP
-|TP
-|TP
-
-|Namespace-scoped brokers
-|-
-|TP
-|TP
-
-|`multi-container support`
-|-
-|-
-|TP
-
-|====
-
-
-// ROSA table
-
-.Generally Available and Technology Preview features tracker for {rosa-product-title}
-[cols="2,1,1,1",options="header"]
-|====
-|Feature |1.26|1.27|1.28
-
 |`kn func`
 |GA
 |GA
 |GA
 
-|Service Mesh mTLS
-|GA
-|GA
-|GA
-
-|`emptyDir` volumes
-|GA
-|GA
-|GA
-
-|HTTPS redirection
-|GA
-|GA
-|GA
-
-|Kafka broker
-|GA
-|GA
-|GA
-
-|Kafka sink
-|TP
-|TP
-|TP
-
-|Init containers support for Knative services
-|GA
-|GA
-|GA
-
-|PVC support for Knative services
-|GA
-|GA
-|GA
-
-|TLS for internal traffic
-|TP
-|TP
-|TP
-
-|Namespace-scoped brokers
-|-
-|TP
-|TP
-
-|`multi-container support`
-|-
-|-
-|TP
-
 |====
+
+
+// // ROSA table
+
+// .Generally Available and Technology Preview features tracker for {rosa-product-title}
+// [cols="2,1,1,1",options="header"]
+// |====
+// |Feature |1.27|1.28|1.29
+
+// |`multi-container support`
+// |-
+// |TP
+// |GA
+
+// |Namespace-scoped brokers
+// |TP
+// |TP
+// |TP
+
+// |TLS for internal traffic
+// |TP
+// |TP
+// |TP
+
+// |PVC support for Knative services
+// |GA
+// |GA
+// |GA
+
+// |Init containers support for Knative services
+// |GA
+// |GA
+// |GA
+
+// |Kafka sink
+// |TP
+// |TP
+// |TP
+
+// |Kafka broker
+// |GA
+// |GA
+// |GA
+
+// |HTTPS redirection
+// |GA
+// |GA
+// |GA
+
+// |`emptyDir` volumes
+// |GA
+// |GA
+// |GA
+
+// |Service Mesh mTLS
+// |GA
+// |GA
+// |GA
+
+// |`kn func`
+// |GA
+// |GA
+// |GA
+
+// |====


### PR DESCRIPTION
Version(s):
Serverless 1.29

Issue:
https://issues.redhat.com/browse/SRVCOM-2320

Link to docs preview:
https://60650--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-29-0_serverless-release-notes

QE review:
- [ ] QE has approved this change.

Notes:
* @nainaz Note that for both GA/TP table and the deprecated/removed table, I have trimmed 1 oldest version off, as discussed previously. Let me know if there has been a change in this decision.