### PR TITLE
TELCODOCS-950: Adding release note for networking pinning

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -95,6 +95,19 @@ A new oc command line interface (CLI) flag, `--import-mode`, has been added to t
 == Ingress Node Firewall Operator is generally available
 Ingress Node Firewall Operator was made a technology preview in {product-title} 4.12. With this release, Ingress Node Firewall Operator is generally available. You can now configure firewall rules at the node level. For more information, see xref:../networking/networking-operators-overview.adoc#networking-operators-overview[Ingress Node Firewall Operator].
 
+[id="ocp-4-14-networking-kernal-network-pinning"]
+== Dynamic use of non-reserved CPUs for OVS
+
+With this release, the Open vSwitch (OVS) networking stack can dynamically use non-reserved CPUs. 
+This dynamic use of non-reserved CPUs occurs by default in performance-tuned clusters with a CPU manager policy set to `static`. 
+The dynamic use of available, non-reserved CPUs maximizes compute resources for OVS and minimizes network latency for workloads during periods of high demand. 
+OVS remains unable to dynamically use isolated CPUs assigned to containers in `Guaranteed` QoS pods. This separation avoids disruption to critical application workloads. 
+
+[NOTE]
+====
+When the Node Tuning Operator recognizes the performance conditions to activate the use of non-reserved CPUs, there is a several second delay while OVN-Kubernetes configures the CPU affinity alignment of OVS daemons running on the CPUs. During this window, if a `Guaranteed` QoS pod starts, it can experience a latency spike. 
+====
+
 [id="ocp-4-14-storage"]
 === Storage
 


### PR DESCRIPTION
[TELCODOCS-950](https://issues.redhat.com//browse/TELCODOCS-950): For networking workloads, you can dynaimically use non-reserved CPUS.


Version(s):
4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-950

Link to docs preview:
https://file.emea.redhat.com/rohennes/TELCODOCS-950-network-pinning/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-kernal-network-pinning

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
