### PR TITLE
[WIP] Updated check-with-vale script to ignore ifdefs and likes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -85,7 +85,7 @@ jobs:
       env:
         - CAN_FAIL=true
       language: minimal
-      if: type IN (pull_request) AND branch IN (main, enterprise-4.12, enterprise-4.13) AND sender != "openshift-cherrypick-robot"
+      if: type IN (pull_request) AND branch IN (main, enterprise-4.13, enterprise-4.14) AND sender != "openshift-cherrypick-robot"
       script:
         - chmod +x autopreview.sh && ./autopreview.sh
 


### PR DESCRIPTION
The script passes the `.adoc` file directly to the `vale` command. Which means that the content between `ifdef` and likes doesn’t get checked. 

The workaround suggested in this PR:
1. Copies the file to be checked in a temp dir.
2. Removes `ifdefs` and likes.
3. Run vale check.
4. delete the temp dir and files.

**thought:** (not part of the PR yet)
 Instead of showing suggestions by default, should we allow user to pass an argument to control the output. Because the amount of `suggestions` can be overwhelming. So maybe:
- `./scripts/check-with-vale.sh error`, or `./scripts/check-with-vale.sh warning` or `./scripts/check-with-vale.sh suggestion` 
- if not specified, maybe report `errors` only.