### PR TITLE
[SRVCOM-2273] Add the kube-rbac-proxy resource allocation config docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -33,6 +33,8 @@ Topics:
   File: installing-knative-eventing
 - Name: Configuring Knative for Apache Kafka
   File: serverless-kafka-admin
+- Name: Configuring kube-rbac-proxy resources for Knative for Apache Kafka
+  File: kube-rbac-proxy-kafka
 - Name: Configuring Serverless Functions
   File: configuring-serverless-functions
 - Name: Serverless upgrades
@@ -124,6 +126,8 @@ Topics:
     File: serverless-ossm-v2x-jwt
   - Name: Using JSON Web Token authentication with Service Mesh 1.x
     File: serverless-ossm-v1x-jwt
+- Name: Configuring kube-rbac-proxy resources for Serving
+  File: kube-rbac-proxy-serving
 - Name: Configuring custom domains for Knative services
   Dir: config-custom-domains
   Topics:
@@ -256,6 +260,8 @@ Topics:
     File: overriding-config-eventing
   - Name: High availability
     File: serverless-ha
+- Name: Configuring kube-rbac-proxy resources for Eventing
+  File: kube-rbac-proxy-eventing
 ---
 # Functions
 Name: Functions

--- a/eventing/kube-rbac-proxy-eventing.adoc
+++ b/eventing/kube-rbac-proxy-eventing.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="kube-rbac-proxy-eventing"]
+= Configuring kube-rbac-proxy for Eventing
+:context: kube-rbac-proxy-eventing
+
+toc::[]
+
+The `kube-rbac-proxy` component provides internal authentication and authorization capabilities for Knative Eventing.
+
+include::modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc[leveloffset=+1]

--- a/install/kube-rbac-proxy-kafka.adoc
+++ b/install/kube-rbac-proxy-kafka.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="kube-rbac-proxy-kafka"]
+= Configuring kube-rbac-proxy for Knative for Apache Kafka
+:context: kube-rbac-proxy-kafka
+
+toc::[]
+
+The `kube-rbac-proxy` component provides internal authentication and authorization capabilities for Knative for Apache Kafka.
+
+include::modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc[leveloffset=+1]

--- a/knative-serving/kube-rbac-proxy-serving.adoc
+++ b/knative-serving/kube-rbac-proxy-serving.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="kube-rbac-proxy-serving"]
+= Configuring kube-rbac-proxy for Serving
+:context: kube-rbac-proxy-serving
+
+toc::[]
+
+The `kube-rbac-proxy` component provides internal authentication and authorization capabilities for Knative Serving.
+
+include::modules/serverless-configuring-kube-rbac-proxy-resources-for-serving.adoc[leveloffset=+1]

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-eventing.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * eventing/kube-rbac-proxy-eventing.adoc
+
+:_content-type: REFERENCE
+[id="serverless-configuring-kube-rbac-proxy-resources-for-eventing_{context}"]
+= Configuring kube-rbac-proxy resources for Eventing
+
+You can globally override resource allocation for the `kube-rbac-proxy` container by using the {ServerlessOperatorName} CR.
+
+[NOTE]
+----
+You can also override resource allocation for a specific deployment.
+----
+
+The following configuration sets Knative Eventing `kube-rbac-proxy` minimum and maximum CPU and memory allocation:
+
+.KnativeEventing CR example
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing
+spec:
+  config:
+    deployment:
+      "kube-rbac-proxy-cpu-request": "10m" <1>
+      "kube-rbac-proxy-memory-request": "20Mi" <2>
+      "kube-rbac-proxy-cpu-limit": "100m" <3>
+      "kube-rbac-proxy-memory-limit": "100Mi" <4>
+----
+<1> Sets minimum CPU allocation.
+<2> Sets minimum RAM allocation.
+<3> Sets maximum CPU allocation.
+<4> Sets maximum RAM allocation.

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-kafka.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * install/kube-rbac-proxy-kafka.adoc
+
+:_content-type: REFERENCE
+[id="serverless-configuring-kube-rbac-proxy-resources-for-kafka_{context}"]
+= Configuring kube-rbac-proxy resources for Knative for Apache Kafka
+
+You can globally override resource allocation for the `kube-rbac-proxy` container by using the {ServerlessOperatorName} CR.
+
+[NOTE]
+----
+You can also override resource allocation for a specific deployment.
+----
+
+The following configuration sets Knative Kafka `kube-rbac-proxy` minimum and maximum CPU and memory allocation:
+
+.KnativeKafka CR example
+[source,yaml]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+  namespace: knative-kafka
+spec:
+  config:
+    workload:
+      "kube-rbac-proxy-cpu-request": "10m" <1>
+      "kube-rbac-proxy-memory-request": "20Mi" <2>
+      "kube-rbac-proxy-cpu-limit": "100m" <3>
+      "kube-rbac-proxy-memory-limit": "100Mi" <4>
+----
+<1> Sets minimum CPU allocation.
+<2> Sets minimum RAM allocation.
+<3> Sets maximum CPU allocation.
+<4> Sets maximum RAM allocation.

--- a/modules/serverless-configuring-kube-rbac-proxy-resources-for-serving.adoc
+++ b/modules/serverless-configuring-kube-rbac-proxy-resources-for-serving.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/kube-rbac-proxy-serving.adoc
+
+:_content-type: REFERENCE
+[id="serverless-configuring-kube-rbac-proxy-resources-for-serving_{context}"]
+= Configuring kube-rbac-proxy resources for Serving
+
+You can globally override resource allocation for the `kube-rbac-proxy` container by using the {ServerlessOperatorName} CR.
+
+[NOTE]
+----
+You can also override resource allocation for a specific deployment.
+----
+
+The following configuration sets Knative Serving `kube-rbac-proxy` minimum and maximum CPU and memory allocation:
+
+.KnativeServing CR example
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  config:
+    deployment:
+      "kube-rbac-proxy-cpu-request": "10m" <1>
+      "kube-rbac-proxy-memory-request": "20Mi" <2>
+      "kube-rbac-proxy-cpu-limit": "100m" <3>
+      "kube-rbac-proxy-memory-limit": "100Mi" <4>
+----
+<1> Sets minimum CPU allocation.
+<2> Sets minimum RAM allocation.
+<3> Sets maximum CPU allocation.
+<4> Sets maximum RAM allocation.


### PR DESCRIPTION
Version(s):
Serverless 1.28+

Issue:
https://issues.redhat.com/browse/SRVCOM-2273

Link to docs preview:
- Configuring kube-rbac-proxy for Serving https://60660--docspreview.netlify.app/openshift-serverless/latest/knative-serving/kube-rbac-proxy-serving.html
- Configuring kube-rbac-proxy for Eventing https://60660--docspreview.netlify.app/openshift-serverless/latest/eventing/kube-rbac-proxy-eventing.html
- Configuring kube-rbac-proxy for Kafka https://60660--docspreview.netlify.app/openshift-serverless/latest/install/kube-rbac-proxy-kafka.html

QE review:
- [x] QE has approved this change.