### PR TITLE
SRVCOM-2381 Info on selecting channel for Serverless operator other than stable

### DIFF
--- a/modules/serverless-install-cli.adoc
+++ b/modules/serverless-install-cli.adoc
@@ -46,7 +46,7 @@ spec:
   source: redhat-operators <3>
   sourceNamespace: openshift-marketplace <4>
 ----
-<1> The channel name of the Operator. The `stable` channel enables installation of the most recent stable version of the {ServerlessOperatorName}.
+<1> The channel name of the Operator. The `stable` channel enables installation of the most recent stable version of the {ServerlessOperatorName}. To install another version, specify the corresponding `stable-x.y` channel, for example `stable-1.29`.
 <2> The name of the Operator to subscribe to. For the {ServerlessOperatorName}, this is always `serverless-operator`.
 <3> The name of the CatalogSource that provides the Operator. Use `redhat-operators` for the default OperatorHub catalog sources.
 <4> The namespace of the CatalogSource. Use `openshift-marketplace` for the default OperatorHub catalog sources.

--- a/modules/serverless-install-web-console.adoc
+++ b/modules/serverless-install-web-console.adoc
@@ -30,6 +30,11 @@ You can install the {ServerlessOperatorName} from the OperatorHub by using the {
 
 .. The *Installed Namespace* is `openshift-serverless`.
 
+.. Select an *Update Channel*.
++
+* The *stable* channel enables installation of the latest stable release of the {ServerlessOperatorName}. The *stable* channel is the default.
+* To install another version, specify the corresponding *stable-x.y* channel, for example *stable-1.29*.
+
 .. Select the *stable* channel as the *Update Channel*. The *stable* channel will enable installation of the latest stable release of the {ServerlessOperatorName}.
 
 .. Select *Automatic* or *Manual* approval strategy.


### PR DESCRIPTION
Version(s):
Serverless 1.29+

Issue:
https://issues.redhat.com/browse/SRVCOM-2381

Link to docs preview:
Step 4c in procedure: https://60662--docspreview.netlify.app/openshift-serverless/latest/install/install-serverless-operator.html#serverless-install-web-console_install-serverless-operator
First item in the description of the snippet: https://60662--docspreview.netlify.app/openshift-serverless/latest/install/install-serverless-operator.html#serverless-install-cli_install-serverless-operator

QE review:
- [x] QE has approved this change.