### PR TITLE
SRVCOM-2474 Add docs on locking kn CLI version, and on upgrading after locking

### DIFF
--- a/install/installing-kn.adoc
+++ b/install/installing-kn.adoc
@@ -22,6 +22,8 @@ Ensure that you are using the latest Knative (`kn`) CLI version for your {Server
 
 include::modules/serverless-installing-cli-web-console.adoc[leveloffset=+1]
 include::modules/serverless-installing-cli-linux-rpm-package-manager.adoc[leveloffset=+1]
+include::modules/serverless-locking-version-for-cli-installed-with-rpm-package-manager.adoc[leveloffset=+1]
+include::modules/serverless-upgrading-cli-with-locked-version.adoc[leveloffset=+1]
 include::modules/serverless-installing-cli-linux.adoc[leveloffset=+1]
 include::modules/serverless-installing-cli-macos.adoc[leveloffset=+1]
 include::modules/serverless-installing-cli-windows.adoc[leveloffset=+1]

--- a/modules/serverless-locking-version-for-cli-installed-with-rpm-package-manager.adoc
+++ b/modules/serverless-locking-version-for-cli-installed-with-rpm-package-manager.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/serverless-upgrades.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-locking-version-for-cli-installed-with-rpm-package-manager_{context}"]
+= Locking version for the Knative CLI installed with RPM package manager
+
+You might require to use Knative (`kn`) CLI version that is not the most recent, but is in Maintenance Phase. You can achieve that by locking the version of `kn`, which prevents it from being upgraded.
+
+.Procedure
+
+. Install the `versionlock` plugin for the DNF package manager:
++
+[source,terminal]
+----
+# dnf install 'dnf-command(versionlock)'
+----
+
+. Lock the version of `kn` by running:
++
+[source,terminal]
+----
+# dnf versionlock add --raw 'openshift-serverless-clients-1.7.*'
+----
++
+This command locks `kn` to be the version based on Knative 1.7, which is in Maintenance Phase at the time of release of {ServerlessProductName} 1.29.

--- a/modules/serverless-upgrading-cli-with-locked-version.adoc
+++ b/modules/serverless-upgrading-cli-with-locked-version.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * /serverless/install/serverless-upgrades.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-upgrading-cli-with-locked-version_{context}"]
+= Upgrading the Knative CLI with locked version
+
+You can manually upgrade the Knative (`kn`) CLI version that has previously been version-locked.
+
+.Procedure
+
+
+. Check whether upgraded packages are available:
++
+[source,terminal]
+----
+# dnf search --showduplicates openshift-serverless-clients
+----
+
+. Remove the version lock of `kn`:
+[source,terminal]
+----
+# dnf versionlock delete openshift-serverless-clients
+----
+
+. Lock `kn` to the new version:
+[source,terminal]
+----
+# dnf versionlock add --raw 'openshift-serverless-clients-1.8.*'
+----
++
+This example uses the `kn` version that is based on Knative 1.8.
+
+. Upgrade to the new available version:
++
+[source,terminal]
+----
+# dnf install --upgrade openshift-serverless-clients
+----


### PR DESCRIPTION
Version(s):
Serverless 1.29+

Issue:
https://issues.redhat.com/browse/SRVCOM-2474

Link to docs preview:
Two sections back-to-back: https://60663--docspreview.netlify.app/openshift-serverless/latest/install/installing-kn.html#serverless-locking-version-for-cli-installed-with-rpm-package-manager_installing-kn

QE review:
- [x] QE has approved this change.