### PR TITLE
ROX-16454: Kernel Module removal and Collector Logs adjustment

### DIFF
--- a/modules/failing-to-load-the-kernel-driver.adoc
+++ b/modules/failing-to-load-the-kernel-driver.adoc
@@ -11,28 +11,29 @@ Consider the following Collector log:
 
 [source,terminal]
 ----
-[INFO    2022/10/13 14:25:13] Hostname: 'hostname'
+[INFO    2023/05/13 14:25:13] Hostname: 'hostname'
 [...]
-[INFO    2022/10/13 14:25:13] Successfully downloaded and decompressed /module/collector.ko
-[INFO    2022/10/13 14:25:13]
-[INFO    2022/10/13 14:25:13] This product uses kernel module and ebpf subcomponents licensed under the GNU
-[INFO    2022/10/13 14:25:13] GENERAL PURPOSE LICENSE Version 2 outlined in the /kernel-modules/LICENSE file.
-[INFO    2022/10/13 14:25:13] Source code for the kernel module and ebpf subcomponents is available upon
-[INFO    2022/10/13 14:25:13] request by contacting support@stackrox.com.
-[INFO    2022/10/13 14:25:13]
+[INFO    2023/05/13 14:25:13] Successfully downloaded and decompressed /module/collector.o
+[INFO    2023/05/13 14:25:13]
+[INFO    2023/05/13 14:25:13] This product uses ebpf subcomponents licensed under the GNU
+[INFO    2023/05/13 14:25:13] GENERAL PURPOSE LICENSE Version 2 outlined in the /kernel-modules/LICENSE file.
+[INFO    2023/05/13 14:25:13] Source code for the ebpf subcomponents is available at
+[INFO    2023/05/13 14:25:13] https://github.com/stackrox/falcosecurity-libs/
+[INFO    2023/05/13 14:25:13]
+-- BEGIN PROG LOAD LOG --
 [...]
-[INFO    2022/10/13 14:25:13] Inserting kernel module /module/collector.ko with indefinite removal and retry if required.
-[ERROR   2022/10/13 14:25:13] Error inserting kernel module: /module/collector.ko: Operation not permitted. Aborting...
-[ERROR   2022/10/13 14:25:13] Failed to insert kernel module
-[ERROR   2022/10/13 14:25:13] Failed to setup Kernel module
-[INFO    2022/10/13 14:25:13]
-[INFO    2022/10/13 14:25:13] == Collector Startup Diagnostics: ==
-[INFO    2022/10/13 14:25:13]  Connected to Sensor?       true
-[INFO    2022/10/13 14:25:13]  Kernel driver available?   true
-[INFO    2022/10/13 14:25:13]  Driver loaded into kernel? false
-[INFO    2022/10/13 14:25:13] ====================================
-[INFO    2022/10/13 14:25:13]
-[FATAL   2022/10/13 14:25:13] Failed to initialize collector kernel components.
+-- END PROG LOAD LOG --
+[WARNING 2023/05/13 14:25:13] libscap: bpf_load_program() event=tracepoint/syscalls/sys_enter_chdir: Operation not permitted
+[ERROR   2023/05/13 14:25:13] Failed to setup collector-ebpf-6.2.0-20-generic.o
+[ERROR   2023/05/13 14:25:13] Failed to initialize collector kernel components.
+[INFO    2023/05/13 14:25:13]
+[INFO    2023/05/13 14:25:13] == Collector Startup Diagnostics: ==
+[INFO    2023/05/13 14:25:13]  Connected to Sensor?       true
+[INFO    2023/05/13 14:25:13]  Kernel driver candidates:
+[INFO    2023/05/13 14:25:13]    collector-ebpf-6.2.0-20-generic.o (available)
+[INFO    2023/05/13 14:25:13] ====================================
+[INFO    2023/05/13 14:25:13]
+[FATAL   2023/05/13 14:25:13] Failed to initialize collector kernel components.
 ----
 
 If you encounter this kind of error, it is unlikely that you can fix it yourself. So instead, report it to {product-title} ({product-title-short}) support team or create a link:https://github.com/stackrox/collector/issues[GitHub issue].

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -171,7 +171,7 @@ These components are Collector and Compliance.
 The default value is `EBPF`.
 Red Hat recommends using `EBPF` for data collection.
 If you select `NoCollection`, Collector does not report any information about the network activity and the process executions.
-Available options are `NoCollection`, `EBPF`, and `KernelModule`.
+Available options are `NoCollection`, `EBPF`, and `CORE_BPF`.
 
 | `perNode.collector.imageFlavor`
 | The image type to use for Collector. You can specify it as `Regular` or `Slim`.

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -69,7 +69,7 @@
 | Tag of `collector` image to use.
 
 | `collector.collectionMethod`
-| Either `EBPF`, `KERNEL_MODULE`, or `NO_COLLECTION`.
+| Either `EBPF`, `CORE_BPF`, or `NO_COLLECTION`.
 
 | `collector.imagePullPolicy`
 | Image pull policy for the Collector container.

--- a/modules/unable-to-connect-to-the-sensor.adoc
+++ b/modules/unable-to-connect-to-the-sensor.adoc
@@ -9,24 +9,22 @@ When starting, first check if you can connect to Sensor. Sensor is responsible f
 
 [source,terminal]
 ----
-Collector Version: 3.12.0
+Collector Version: 3.15.0
 OS: Ubuntu 20.04.4 LTS
 Kernel Version: 5.4.0-126-generic
 Starting StackRox Collector...
-[INFO    2022/10/13 12:20:43] Hostname: 'hostname'
+[INFO    2023/05/13 12:20:43] Hostname: 'hostname'
 [...]
-[INFO    2022/10/13 12:20:43] Sensor configured at address: sensor.stackrox.svc:9998
-[INFO    2022/10/13 12:20:43] Attempting to connect to Sensor
-[INFO    2022/10/13 12:21:13]
-[INFO    2022/10/13 12:21:13] == Collector Startup Diagnostics: ==
-[INFO    2022/10/13 12:21:13]  Connected to Sensor?       false
-[INFO    2022/10/13 12:21:13]  Kernel driver available?   false
-[INFO    2022/10/13 12:21:13]  Driver loaded into kernel? false
-[INFO    2022/10/13 12:21:13] ====================================
-[INFO    2022/10/13 12:21:13]
-[FATAL   2022/10/13 12:21:13] Unable to connect to Sensor.
+[INFO    2023/05/13 12:20:43] Sensor configured at address: sensor.stackrox.svc:9998
+[INFO    2023/05/13 12:20:43] Attempting to connect to Sensor
+[INFO    2023/05/13 12:21:13]
+[INFO    2023/05/13 12:21:13] == Collector Startup Diagnostics: ==
+[INFO    2023/05/13 12:21:13]  Connected to Sensor?       false
+[INFO    2023/05/13 12:21:13]  Kernel driver candidates:
+[INFO    2023/05/13 12:21:13] ====================================
+[INFO    2023/05/13 12:21:13]
+[FATAL   2023/05/13 12:21:13] Unable to connect to Sensor.
 ----
-
 
 This error could mean that Sensor has not started correctly or that Collector configuration is incorrect. To fix this issue, you must verify Collector configuration to ensure that Sensor address is correct and that the Sensor pod is running correctly.
 

--- a/modules/unavailability-of-the-kernel-driver.adoc
+++ b/modules/unavailability-of-the-kernel-driver.adoc
@@ -9,39 +9,37 @@ Collector determines if it has a kernel driver for the node's kernel version. Co
 
 [source,terminal]
 ----
-Collector Version: 3.12.0
-OS: Alpine Linux v3.14
-Kernel Version: 5.10.109-0-virt
+Collector Version: 3.15.0
+OS: Alpine Linux v3.16
+Kernel Version: 5.15.82-0-virt
 Starting StackRox Collector...
-[INFO    2022/10/13 13:32:57] Hostname: 'alpine'
-[...]
-[INFO    2022/10/13 13:32:57] Sensor configured at address: sensor.stackrox.svc:9999
-[INFO    2022/10/13 13:32:57] Attempting to connect to Sensor
-[INFO    2022/10/13 13:32:57] Successfully connected to Sensor.
-[INFO    2022/10/13 13:32:57] Module version: 2.2.0
-[INFO    2022/10/13 13:32:57] Attempting to find kernel module - Candidate kernel versions:
-[INFO    2022/10/13 13:32:57] 5.10.109-0-virt
-[INFO    2022/10/13 13:32:57] Local storage does not contain collector-5.10.109-0-virt.ko
-[...]
-[INFO    2022/10/13 13:32:57] Attempting to download kernel object from https://sensor.stackrox.svc/kernel-objects/2.2.0/collector-5.10.109-0-virt.ko.gz <1>
-[WARNING 2022/10/13 13:32:58] [Throttled] Unexpected HTTP request failure (HTTP 404) <2>
-[WARNING 2022/10/13 13:33:08] [Throttled] Unexpected HTTP request failure (HTTP 404)
-[WARNING 2022/10/13 13:33:18] [Throttled] Unexpected HTTP request failure (HTTP 404)
-[WARNING 2022/10/13 13:33:29] [Throttled] Unexpected HTTP request failure (HTTP 404)
-[WARNING 2022/10/13 13:33:35] Attempted to download collector-5.10.109-0-virt.ko.gz 30 time(s)
-[WARNING 2022/10/13 13:33:35] Failed to download from collector-5.10.109-0-virt.ko.gz
-[WARNING 2022/10/13 13:33:35] Unable to download kernel object collector-5.10.109-0-virt.ko to /module/collector.ko.gz
-[ERROR   2022/10/13 13:33:35] Error getting kernel object: collector-5.10.109-0-virt.ko
-[INFO    2022/10/13 13:33:35]
-[INFO    2022/10/13 13:33:35] == Collector Startup Diagnostics: ==
-[INFO    2022/10/13 13:33:35]  Connected to Sensor?       true
-[INFO    2022/10/13 13:33:35]  Kernel driver available?   false
-[INFO    2022/10/13 13:33:35]  Driver loaded into kernel? false
-[INFO    2022/10/13 13:33:35] ====================================
-[INFO    2022/10/13 13:33:35]
-[FATAL   2022/10/13 13:33:35]  No suitable kernel object downloaded for kernel 5.10.109-0-virt <3>
+[INFO    2023/05/30 12:00:33] Hostname: 'alpine'
+[INFO    2023/05/30 12:00:33] User configured collection-method=ebpf
+[INFO    2023/05/30 12:00:33] Afterglow is enabled
+[INFO    2023/05/30 12:00:33] Sensor configured at address: sensor.stackrox.svc:443
+[INFO    2023/05/30 12:00:33] Attempting to connect to Sensor
+[INFO    2023/05/30 12:00:33] Successfully connected to Sensor.
+[INFO    2023/05/30 12:00:33] Module version: 2.5.0-rc1
+[INFO    2023/05/30 12:00:33] Config: collection_method:0, useChiselCache:1, scrape_interval:30, turn_off_scrape:0, hostname:alpine, processesListeningOnPorts:1, logLevel:INFO
+[INFO    2023/05/30 12:00:33] Attempting to find eBPF probe - Candidate versions:
+[INFO    2023/05/30 12:00:33] collector-ebpf-5.15.82-0-virt.o
+[INFO    2023/05/30 12:00:33] Attempting to download collector-ebpf-5.15.82-0-virt.o
+[INFO    2023/05/30 12:00:33] Attempting to download kernel object from https://sensor.stackrox.svc:443/kernel-objects/2.5.0/collector-ebpf-5.15.82-0-virt.o.gz <1>
+[INFO    2023/05/30 12:00:33] HTTP Request failed with error code 404 <2>
+[WARNING 2023/05/30 12:02:03] Attempted to download collector-ebpf-5.15.82-0-virt.o.gz 90 time(s)
+[WARNING 2023/05/30 12:02:03] Failed to download from collector-ebpf-5.15.82-0-virt.o.gz
+[WARNING 2023/05/30 12:02:03] Unable to download kernel object collector-ebpf-5.15.82-0-virt.o to /module/collector-ebpf.o.gz
+[WARNING 2023/05/30 12:02:03] No suitable kernel object downloaded for collector-ebpf-5.15.82-0-virt.o
+[ERROR   2023/05/30 12:02:03] Failed to initialize collector kernel components.
+[INFO    2023/05/30 12:02:03]
+[INFO    2023/05/30 12:02:03] == Collector Startup Diagnostics: ==
+[INFO    2023/05/30 12:02:03]  Connected to Sensor?       true
+[INFO    2023/05/30 12:02:03]  Kernel driver candidates:
+[INFO    2023/05/30 12:02:03]    collector-ebpf-5.15.82-0-virt.o (unavailable)
+[INFO    2023/05/30 12:02:03] ====================================
+[INFO    2023/05/30 12:02:03]
+[FATAL   2023/05/30 12:02:03] Failed to initialize collector kernel components. <3>
 ----
-
 
 <1> The logs display attempts to locate the module first, followed by any efforts to download the driver from Sensor. 
 <2> The 404 errors indicate that the node's kernel does not have a kernel driver.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
RHACS 4.1

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/ROX-16454

Link to docs preview:

- https://60665--docspreview.netlify.app/openshift-acs/latest/troubleshooting/commonly-occurring-error-conditions.html#failing-to-load-the-kernel-driver_error-conditions
- https://60665--docspreview.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_other/install-secured-cluster-cloud-other.html#secured-cluster-services-config_install-secured-cluster-cloud-other

QE review:
- [x] QE has approved this change. (ACS has no QE; approved by SME)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Primarily this removes references to the KERNEL-MODULE collection method and updates some log examples in the collector troubleshooting pages with newer versions (the logging has subtly changed in latest versions of collector) 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
