### PR TITLE
OCPBUGS-1874-post: Fixed code block guideline issues for shared VPC O…

### DIFF
--- a/modules/installation-creating-gcp-bootstrap.adoc
+++ b/modules/installation-creating-gcp-bootstrap.adoc
@@ -51,6 +51,10 @@ $ export CLUSTER_IMAGE=(`gcloud compute images describe ${INFRA_ID}-rhcos-image 
 [source,terminal]
 ----
 $ gsutil mb gs://${INFRA_ID}-bootstrap-ignition
+----
++
+[source,terminal]
+----
 $ gsutil cp <installation_directory>/bootstrap.ign gs://${INFRA_ID}-bootstrap-ignition/
 ----
 

--- a/modules/installation-creating-gcp-control-plane.adoc
+++ b/modules/installation-creating-gcp-control-plane.adoc
@@ -95,7 +95,15 @@ Manager, so you must add the control plane machines manually.
 [source,terminal]
 ----
 $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_0}-ig --zone=${ZONE_0} --instances=${INFRA_ID}-master-0
+----
++
+[source,terminal]
+----
 $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_1}-ig --zone=${ZONE_1} --instances=${INFRA_ID}-master-1
+----
++
+[source,terminal]
+----
 $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZONE_2}-ig --zone=${ZONE_2} --instances=${INFRA_ID}-master-2
 ----
 
@@ -104,7 +112,15 @@ $ gcloud compute instance-groups unmanaged add-instances ${INFRA_ID}-master-${ZO
 [source,terminal]
 ----
 $ gcloud compute target-pools add-instances ${INFRA_ID}-api-target-pool --instances-zone="${ZONE_0}" --instances=${INFRA_ID}-master-0
+----
++
+[source,terminal]
+----
 $ gcloud compute target-pools add-instances ${INFRA_ID}-api-target-pool --instances-zone="${ZONE_1}" --instances=${INFRA_ID}-master-1
+----
++
+[source,terminal]
+----
 $ gcloud compute target-pools add-instances ${INFRA_ID}-api-target-pool --instances-zone="${ZONE_2}" --instances=${INFRA_ID}-master-2
 ----
 

--- a/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
+++ b/modules/installation-gcp-user-infra-wait-for-bootstrap.adoc
@@ -45,7 +45,19 @@ has initialized.
 [source,terminal]
 ----
 $ gcloud compute backend-services remove-backend ${INFRA_ID}-api-internal-backend-service --region=${REGION} --instance-group=${INFRA_ID}-bootstrap-ig --instance-group-zone=${ZONE_0}
+----
++
+[source,terminal]
+----
 $ gsutil rm gs://${INFRA_ID}-bootstrap-ignition/bootstrap.ign
+----
++
+[source,terminal]
+----
 $ gsutil rb gs://${INFRA_ID}-bootstrap-ignition
+----
++
+[source,terminal]
+----
 $ gcloud deployment-manager deployments delete ${INFRA_ID}-bootstrap
 ----


### PR DESCRIPTION
[OCPBUGS-1874](https://issues.redhat.com/browse/OCPBUGS-1874)

Version(s):
4.14 through to 4.10

Link to docs preview:
* [Creating the bootstrap machine in GCP](https://60682--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-creating-gcp-bootstrap_installing-gcp-user-infra-vpc)
* [Creating the control plane machine in GCP](https://60682--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-creating-gcp-control-plane_installing-gcp-user-infra-vpc)
* [Wait for bootstrap completion and remove bootstrap resources in GCP](https://60682--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-user-infra-vpc.html#installation-gcp-user-infra-wait-for-bootstrap_installing-gcp-user-infra-vpc)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
