### PR TITLE
OSDOCS-6315: Updated Terraform VPC path

### DIFF
--- a/modules/rosa-hcp-byo-oidc.adoc
+++ b/modules/rosa-hcp-byo-oidc.adoc
@@ -32,7 +32,7 @@ endif::rosa-classic[]
 +
 [source,terminal]
 ----
-$ rosa create oidc-config --mode=auto
+$ rosa create oidc-config --mode=auto  --yes
 ----
 +
 This command returns the following information.
@@ -52,6 +52,27 @@ I: Created OIDC provider with ARN 'arn:aws:iam::4540112244:oidc-provider/dvbwgdz
 ----
 +
 When creating your cluster, you must supply the OIDC config ID. The CLI output provides this value for `--mode auto`, otherwise you must determine these values based on `aws` CLI output for `--mode manual`.
+
+* Optional: you can save the OIDC configuration ID as a variable to use later. Run the following command to save the variable:
++
+[source,terminal]
+----
+$ export OIDC_ID=30f5dqmk
+----
+
+. View the value of the variable by running with the following command:
++
+[source,terminal]
+----
+$ echo $OIDC_ID
+----
++
+.Sample output
++
+[source,terminal]
+----
+$ 30f5dqmk
+----
 
 .Verification
 

--- a/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
@@ -17,8 +17,9 @@ When using {product-title} (ROSA) CLI (`rosa`) to create a cluster, you can sele
 +
 [NOTE]
 ====
-To successfully install ROSA clusters, use the latest version of the ROSA CLI (`rosa`).
+To successfully install ROSA clusters, use the latest version of the ROSA CLI (`rosa`). Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
 ====
+
 * You have logged in to your Red Hat account by using the ROSA CLI.
 * You have created an OIDC configuration.
 * You have verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.
@@ -50,6 +51,13 @@ $ rosa create cluster --cluster-name=<cluster_name> \
 ----
 $ rosa create cluster --private --cluster-name=<cluster_name> \
     --sts --mode=auto --hosted-cp --subnet-ids=<private-subnet-id>
+----
+
+** If you used variables like `OIDC_ID` and `SUBNET_IDS`, you can use those references when creating your cluster. For example, run the following command:
++
+[source,terminal]
+----
+$ rosa create cluster --hosted-cp --subnet-ids=$SUBNET_IDS --oidc-config-id=$OIDC_ID --cluster-name=<cluster_name>
 ----
 
 . Check the status of your cluster by running the following command:

--- a/modules/rosa-hcp-vpc-terraform.adoc
+++ b/modules/rosa-hcp-vpc-terraform.adoc
@@ -10,32 +10,26 @@ Terraform is a tool that allows you to create various resources using an establi
 
 .Prerequisites
 
-* You have installed Terraform on your machine.
+* You have installed Terraform version 1.4.0 or newer on your machine.
+* You have installed Git on your machine.
 
 .Procedure
 
-. Open a shell prompt and create a directory for your Terraform files by running the following command:
+. Open a shell prompt and clone the Terraform VPC repository by running the following command:
 +
 [source,terminal]
 ----
-$ mkdir hypershift-tf
+$ git clone https://github.com/openshift-cs/terraform-vpc-example
 ----
 
 . Navigate to the created directory by running the following command:
 +
 [source,terminal]
 ----
-$ cd hypershift-tf
+$ cd terraform-vpc-example
 ----
 
-. Download the VPC setup Terraform file by running the following command:
-+
-[source,terminal]
-----
-$ curl -s -o setup-vpc.tf https://raw.githubusercontent.com/openshift-cs/OpenShift-Troubleshooting-Templates/master/rosa-hcp-terraform/setup-vpc.tf
-----
-
-. After the template has downloaded, initiate the Terraform file by running the following command: 
+. Initiate the Terraform file by running the following command: 
 +
 [source,terminal]
 ----
@@ -44,37 +38,39 @@ $ terraform init
 +
 A message confirming the initialization appears when this process completes.
 
-. To build your VPC Terraform plan based off of the downloaded template, run the `plan` command. You must include your AWS region. Optionally, you can specify a cluster name.
+. To build your VPC Terraform plan based on the existing Terraform template, run the `plan` command. You must include your AWS region. You can choose to specify a cluster name. A `rosa.tfplan` file is added to the `hypershift-tf` directory after the `terraform plan` completes. For more detailed options, see the link:https://github.com/openshift-cs/terraform-vpc-example/blob/main/README.md[Terraform VPC repository's README file].
 +
 [source,terminal]
 ----
-$ terraform plan -out rosa.plan -var aws_region=<region> [-var cluster_name=<cluster_name>]
+$ terraform plan -out rosa.tfplan -var region=<region> [-var cluster_name=<cluster_name>]
 ----
 
-. You should have a `rosa.plan` file in the directory that you created in the first step. Apply this plan file to build your VPC by running the following command:
+. Apply this plan file to build your VPC by running the following command:
 +
 [source,terminal]
 ----
-$ terraform apply rosa.plan
+$ terraform apply rosa.tfplan
 ----
 
 . Optional: You can capture the values of the Terraform-provisioned private, public, and machinepool subnet IDs as environment variables to use when creating your {hcp-title} cluster by running the following commands:
 +
-** For the private subnet ID:
+[source,terminal]
+----
+$ export SUBNET_IDS=$(terraform output -raw cluster-subnets-string)
+----
+
+.Verification
+
+* You can verify that the variables were correctly set with the following command:
 +
 [source,terminal]
 ----
-$ PRIVATE_SUBNET=`terraform output -raw cluster-private-subnet`
+$ echo $SUBNET_IDS
 ----
-** For the public subnet ID:
++
+.Sample output
 +
 [source,terminal]
 ----
-$ PUBLIC_SUBNET=`terraform output -raw cluster-public-subnet`
-----
-** For the machinepool subnet ID:
-+
-[source,terminal]
-----
-$ MACHINEPOOL_SUBNET=`terraform output -raw node-private-subnet`
+$ subnet-0a6a57e0f784171aa,subnet-078e84e5b10ecf5b0
 ----

--- a/modules/rosa-operator-config.adoc
+++ b/modules/rosa-operator-config.adoc
@@ -20,13 +20,20 @@ When using a {hcp-title} cluster, you must create the Operator IAM roles that ar
 +
 [source,terminal]
 ----
-$ rosa create operator-roles --prefix <prefix-name> <1>
+$ rosa create operator-roles --hosted-cp --prefix <prefix-name> --oidc-config-id <oidc-config-id>
+----
++
+The following breakdown provides options for the Operator role creation.
++
+[source,terminal]
+----
+$ rosa create operator-roles --hosted-cp 
+	--prefix <prefix-name> <1>
 	--oidc-config-id <oidc-config-id> <2>
-	--hosted-cp
 ----
 +
 --
-<1> You must supply a prefix when creating these Operator roles. Failing to do so produces an error.
+<1> You must supply a prefix when creating these Operator roles. Failing to do so produces an error. See the Additional resources of this section for information on the Operator prefix.
 <2> This value is the OIDC configuration ID that you created for your {hcp-title} cluster.
 --
 +

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -79,11 +79,18 @@ You must have a Virtual Private Cloud (VPC) to create {hcp-title} cluster. You c
 
 [NOTE]
 ====
-The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use.
+The Terraform instructions are for testing and demonstration purposes. Your own installation requires some modifications to the VPC for your own use. You should also ensure that when you use this Terraform script it is in the same region that you intend to install your cluster. In these examples, use `us-east-2`.
 ====
 
 [discrete]
 include::modules/rosa-hcp-vpc-terraform.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-vpc-terraform"]
+.Additional resources
+
+* See the link:https://github.com/openshift-cs/terraform-vpc-example[Terraform VPC] repository for a detailed list of all options available when customizing the VPC for your needs.
+
 [discrete]
 include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+3]
 
@@ -99,6 +106,12 @@ include::modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc[leve
 include::modules/rosa-hcp-byo-oidc.adoc[leveloffset=+2]
 
 include::modules/rosa-operator-config.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-hcp-operator-prefix"]
+.Additional resources
+
+* See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-operator-role-prefixes_rosa-sts-about-iam-resources[About custom Operator IAM role prefixes] for information on the Operator prefixes.
 
 include::modules/rosa-hcp-sts-creating-a-cluster-cli.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-6315](https://issues.redhat.com/browse/OSDOCS-6315)

Link to docs preview:
* [Terraform VPC](https://60702--docspreview.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-hcp-creating-vpc) instructions

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Update the VPC information for Terraform.