### PR TITLE
ROX-17267: Ability to remove default compliance info from scan results

### DIFF
--- a/modules/run-compliance-scan.adoc
+++ b/modules/run-compliance-scan.adoc
@@ -36,7 +36,10 @@ If any of the associated check fails for a control, the entire control state is 
 
 .Procedure
 
-. Navigate to the RHACS portal and open the compliance dashboard by selecting *Compliance* from the navigation menu.
+. Navigate to the {product-title-short} portal and open the compliance dashboard by selecting *Compliance* from the navigation menu.
+. Optional: By default, information under all standards is displayed in the compliance results. To view only information from specific standards, perform the following steps:
+.. Click *Manage standards*.
+.. By default, all standards are selected. Clear the checkbox for any specific standard that you do not want to display, and then click *Save*. Standards that are not selected do not appear in the dashboard display (including widgets), compliance results tables that are accessed from the dashboard, and PDF files created using the *Export* button. However, all default standards are included when results are exported as a CSV file.
 . Click *Scan environment*.
 +
 [NOTE]


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.1`
<!--- Specify the version or versions of OpenShift your PR applies to. -->

[Issue](https://issues.redhat.com/browse/ROX-17267)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview
](https://60704--docspreview.netlify.app/openshift-acs/latest/operating/manage-compliance.html#run-compliance-scan_manage-compliance)

QE review:
- [x] QE has approved this change. (**ACS has no QE, approved by SME**)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
