### PR TITLE
[RHACS] ROX-14958: Adding steps to Configure proxy for on prem Secured Cluster services

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -62,6 +62,8 @@ Topics:
     File: cloud-install-operator
   - Name: Installing secured cluster services from RHACS Cloud Service
     File: install-secured-cluster-cloud-ocp
+  - Name: Configuring the proxy for secured cluster services in RHACS Cloud Service
+    File: configuring-the-proxy-for-secured-cluster-services-in-rhacs-cloud-service
   - Name: Verifying installation of secured clusters
     File: verify-installation-cloud-ocp
 - Name: Setting up RHACS Cloud Service with Kubernetes secured clusters

--- a/cloud_service/installing_cloud_ocp/configuring-the-proxy-for-secured-cluster-services-in-rhacs-cloud-service.adoc
+++ b/cloud_service/installing_cloud_ocp/configuring-the-proxy-for-secured-cluster-services-in-rhacs-cloud-service.adoc
@@ -1,0 +1,13 @@
+:_content-type: ASSEMBLY
+[id="configuring-the-proxy-for-secured-cluster-services-in-rhacs-cloud-service"]
+= Configuring the proxy for secured cluster services in {product-title-managed-short}
+include::modules/common-attributes.adoc[]
+:context: configure-secured-cluster-proxy
+
+toc::[]
+
+[role="_abstract"]
+You must configure the proxy settings for secured cluster services within the {rh-rhacscs-first} environment to establish a connection between the Secured Cluster and the specified proxy server. This ensures reliable data collection and transmission.
+
+//Specifying the environment variables
+include::modules/specifying-the-environment-variables-in-the-securedcluster-cr.adoc[leveloffset=+1]

--- a/modules/specifying-the-environment-variables-in-the-securedcluster-cr.adoc
+++ b/modules/specifying-the-environment-variables-in-the-securedcluster-cr.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * cloud_service/installing_cloud_ocp/configuring-the-proxy-for-collector-in-rhacs-cloud-service.adoc
+:_content-type: PROCEDURE
+[id="specifying-the-environment-variables-in-the-securedcluster-cr_{context}"]
+= Specifying the environment variables in the SecuredCluster CR
+
+[role="_abstract"]
+To configure an egress proxy, you can either use the cluster-wide {osp} proxy or specify the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables within the SecuredCluster Custom Resource (CR) configuration file to ensure proper use of the proxy and bypass for internal requests within the specified domain.
+
+The proxy configuration applies to all running services: Sensor, Collector, Admission Controller and Scanner.
+
+
+.Procedure
+
+* Specify the `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables under the customize specification in the SecuredCluster CR configuration file:
++
+For example:
++
+[source,yaml]
+----
+# proxy collector
+customize:
+  envVars:
+    HTTP_PROXY: http://egress-proxy.stackrox.svc:xxxx <1>
+    HTTPS_PROXY: http://egress-proxy.stackrox.svc:xxxx <2>
+    NO_PROXY: .stackrox.svc <3>
+----
+<1> The variable `HTTP_PROXY` is set to the value `\http://egress-proxy.stackrox.svc:xxxx`. This is the proxy server used for HTTP connections.
+<2> The variable `HTTPS_PROXY` is set to the value `\http://egress-proxy.stackrox.svc:xxxx`. This is the proxy server used for HTTPS connections.
+<3> The variable `NO _PROXY` is set to `.stackrox.svc`. This variable is used to define the hostname or IP address that should not be accessed through the proxy server.
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.0, 4.1
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-14958
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://60706--docspreview.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/configuring-the-proxy-for-secured-cluster-services-in-rhacs-cloud-service.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Merge into `rhacs-docs` and cherry-pick into:
- `rhacs-docs-4.1`
- `rhacs-docs-4.0`
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
