### PR TITLE
CSS: breaks words in colists to prevent overruns on the page

### DIFF
--- a/_stylesheets/docs.css
+++ b/_stylesheets/docs.css
@@ -29,7 +29,7 @@ nav#main {
     filter: drop-shadow(0.6em 0.01em 0.2em);
   }
 }
-    
+
 .navbar.navbar-default.navbar-openshift .navbar-brand.origin {
   background: url("../_images/okd_logo.svg") no-repeat scroll 0% 95%;
   background-size: 140px;
@@ -2123,6 +2123,7 @@ ol.lowergreek {
   border: 0;
   background: none;
   margin-bottom: 0;
+  word-break: break-word;
 }
 
 .hdlist>table>tbody>tr, .colist>table>tbody>tr {


### PR DESCRIPTION
Fixes the below issue first surfaced in https://github.com/openshift/openshift-docs/pull/59707:
![image](https://github.com/openshift/openshift-docs/assets/74046732/581efa9f-0abc-4d93-a93d-22c3e7bea4f4)

Preview: https://file.emea.redhat.com/aireilly/OCPBUGS-10482-Fix/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#configuring-vsphere-regions-zones_installing-vsphere-installer-provisioned-network-customizations

Merge to main, CP to enterprise-4.1