### PR TITLE
OSDOCS#6283: Adds notes for MS 4.13.1 release

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -164,3 +164,12 @@ Issued: 2023-05-17
 {product-title} release 4.13.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1329[RHSA-2023:1329] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1326[RHSA-2023:1326] advisory.
 
 For the `TopoLVM image`, read link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-1-dp"]
+=== RHSA-2023:3307 - {product-title} 4.13.1 bug fix and security update
+
+Issued: 2023-05-30
+
+{product-title} release 4.13.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3307[RHBA-2023:3307] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3304[RHSA-2023:3304] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
OSDOCS#6283: Adds notes for MS 4.13.1 release

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-6283

Link to docs preview:
https://opayne1.github.io/previews/OSDOCS-6283/microshift_release_notes/microshift-4-13-release-notes.html#microshift-4-13-1-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
