### PR TITLE
OSDOCS#6280: Adds notes for MS 4.12.19 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -221,3 +221,12 @@ Issued: 2023-05-23
 {product-title} release 4.12.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3211[RHBA-2023:3211] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:3208[RHBA-2023:3208] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-19-dp"]
+=== RHBA-2023:3290 - {product-title} 4.12.19 bug fix and security update
+
+Issued: 2023-05-31
+
+{product-title} release 4.12.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3290[RHBA-2023:3290] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3287[RHSA-2023:3287] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#6280: Adds notes for MS 4.12.19 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-6280

Link to docs preview:
https://opayne1.github.io/previews/OSDOCS-6280/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-19-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
