### PR TITLE
OCPBUGS#14365: clarifying platform support for agent

### DIFF
--- a/modules/understanding-agent-install.adoc
+++ b/modules/understanding-agent-install.adoc
@@ -60,6 +60,11 @@ Recommended cluster resources for the following topologies:
 
 The following platforms are supported:
 
-* `none`
 * `baremetal`
 * `vsphere`
+* `none`
++
+[NOTE]
+====
+The `none` option is supported for only single-node OpenShift clusters with an `OVNKubernetes` network type.
+====


### PR DESCRIPTION
[OCPBUGS-14365](https://issues.redhat.com/browse/OCPBUGS-14365)

Version(s): 4.12+

This PR clarifies that the Platform `none` option for the agent-based installer is only supported for single node clusters.

QE review:
- [x] QE has approved this change.
 
Docs preview: [Recommended resources for topologies](https://60738--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#recommended-resources-for-topologies)
