### PR TITLE
Fixing conditional error in CLI update doc

### DIFF
--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -56,11 +56,14 @@ include::modules/update-upgrading-cli.adoc[leveloffset=+1]
 include::modules/update-conditional-updates.adoc[leveloffset=+1]
 
 // OKD removed the section that this link points to.
-ifndef::openshift-origin
+
+ifndef::openshift-origin[]
+
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Upgrade channels and release paths]
-endif::openshift-origin
+
+endif::openshift-origin[]
 
 include::modules/update-changing-update-server-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.10+

This PR correctly formats an "ifndef" conditional statement in the CLI Update doc, where the broken formatting failed to conditionalize text and had "ifndef" and "endif" show up in the live, rendered docs.

Link to live docs:
- [OCP Enterprise](https://docs.openshift.com/container-platform/4.10/updating/updating-cluster-cli.html#update-conditional-upgrade-pathupdating-cluster-cli)
- [OKD](https://docs.okd.io/4.13/updating/updating-cluster-cli.html#update-conditional-upgrade-pathupdating-cluster-cli) (where the conditionalized text incorrectly shows up and provides a broken link on the site)

Preview:
- [Updating along a conditional upgrade path](https://60739--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-cli.html#update-conditional-upgrade-pathupdating-cluster-cli)
- [OKD](http://file.bos.redhat.com/skopacz/update_doc_conditional_fix/updating/updating-cluster-cli.html#update-conditional-upgrade-pathupdating-cluster-cli)