### PR TITLE
OSDOCS-6344: updates MTU parameter for InFw operator for 4.14

### DIFF
--- a/modules/nw-infw-operator-cr.adoc
+++ b/modules/nw-infw-operator-cr.adoc
@@ -14,7 +14,7 @@ You configure `rules` of the `IngressNodeFirewall` CR and apply them to clusters
 ====
 The Ingress Node Firewall Operator supports only stateless firewall rules.
 
-The maximum transmission units (MTU) parameter is 4Kb (kilobytes) in {product-title} {product-version}.
-
 Network interface controllers (NICs) that do not support native XDP drivers will run at a lower performance.
+
+For {product-title} 4.14, you must run Ingress Node Firewall Operator on {op-system-base} 9.0 or later.
 ====


### PR DESCRIPTION
[OSDOCS-6344](https://issues.redhat.com//browse/OSDOCS-6344): updates MTU parameter for InFw operator for 4.14
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-6344
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://60740--docspreview.netlify.app/openshift-enterprise/latest/networking/ingress-node-firewall-operator.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @msherif1234 
https://github.com/openshift/openshift-docs/pull/60836/files
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
