### PR TITLE
CNV-19775: configuring the default CPU model

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3677,6 +3677,8 @@ Topics:
       File: virt-specifying-nodes-for-vms
     - Name: Configuring certificate rotation
       File: virt-configuring-certificate-rotation
+    - Name: Configuring the default CPU model
+      File: virt-configuring-default-cpu-model
     - Name: UEFI mode for virtual machines
       File: virt-uefi-mode-for-vms
     - Name: Configuring PXE booting for virtual machines

--- a/modules/virt-configuring-default-cpu-model.adoc
+++ b/modules/virt-configuring-default-cpu-model.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-configuring-default-cpu-model.adoc
+
+:_content-type: PROCEDURE
+[id="virt-configuring-default-cpu-model_{context}"]
+= Configuring the default CPU model
+
+Configure the `defaultCPUModel` by updating the `HyperConverged` custom resource (CR). You can change the `defaultCPUModel` while {VirtProductName} is running.
+
+[NOTE]
+====
+The `defaultCPUModel` is case sensitive.
+====
+
+.Prerequisites
+
+* Install the OpenShift CLI (oc).
+
+.Procedure
+
+. Open the `HyperConverged` CR by running the following command:
++
+[source,terminal]
+----
+$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+----
+
+. Add the `defaultCPUModel` field to the CR and set the value to the name of a CPU model that exists in the cluster:
+
++
+[source,yaml]
+----
+apiVersion: hco.kubevirt.io/v1beta1
+kind: HyperConverged
+metadata:
+ name: kubevirt-hyperconverged
+ namespace: openshift-cnv
+spec:
+  defaultCPUModel: "EPYC"
+----
+
+. Apply the YAML file to your cluster.

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model.adoc
@@ -1,0 +1,20 @@
+:_content-type: ASSEMBLY
+[id="virt-configuring-default-cpu-model"]
+= Configuring the default CPU model
+include::_attributes/common-attributes.adoc[]
+:context: virt-configuring-default-cpu-model
+
+Use the `defaultCPUModel` setting in the `HyperConverged` custom resource (CR) to define a cluster-wide default CPU model.
+
+The virtual machine (VM) CPU model depends on the availability of CPU models within the VM and the cluster.
+
+* If the VM does not have a defined CPU model:
+** The `defaultCPUModel` is automatically set using the CPU model defined at the cluster-wide level.
+* If both the VM and the cluster have a defined CPU model:
+** The VM’s CPU model takes precedence.
+* If neither the VM nor the cluster have a defined CPU model:
+** The host-model is automatically set using the CPU model defined at the host level.
+
+toc::[]
+
+include::modules/virt-configuring-default-cpu-model.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-19775](https://issues.redhat.com//browse/CNV-19775)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://60760--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
