### PR TITLE
OSDOCS-6320 z-stream release notes 4.10.61

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -4040,3 +4040,22 @@ For more information about logging levels for MetalLB, see xref:../networking/me
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+
+[id="ocp-4-10-61"]
+=== RHSA-2023:3363 - {product-title} 4.10.61 bug fix and security update
+
+Issued: 2023-06-07
+
+{product-title} release 4.10.61, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:3363[RHSA-2023:3363] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3362[RHSA-2023:3362] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.61 --pullspecs
+----
+
+[id="ocp-4-10-61-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OSDOCS-6320

Link to docs preview:
[preview](https://file.rdu.redhat.com/cbippley/OSDOCS-6320/release_notes/ocp-4-10-release-notes.html#ocp-4-10-61)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Z-stream release notes for 4.10.61. [OSDOCS-6320](https://issues.redhat.com/browse/OSDOCS-6320)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
