### PR TITLE
RHDEVDOCS-5366: Remove embedded-status field and TP for resolvers in …

### DIFF
--- a/modules/op-configuring-pipeline-resolvers.adoc
+++ b/modules/op-configuring-pipeline-resolvers.adoc
@@ -6,9 +6,6 @@
 [id="op-configuring-pipeline-resolvers_{context}"]
 = Configuring pipeline resolvers
 
-:FeatureName: resolvers
-include::snippets/technology-preview.adoc[]
-
 You can configure pipeline resolvers in the `TektonConfig` custom resource (CR). You can enable or disable these pipeline resolvers:
 
 * `enable-bundles-resolver`

--- a/modules/op-configuring-pipelines-control-plane.adoc
+++ b/modules/op-configuring-pipelines-control-plane.adoc
@@ -43,7 +43,6 @@ spec:
     enable-tekton-oci-bundles: false
     metrics.taskrun.level: task
     metrics.pipelinerun.level: pipeline
-    embedded-status: both
     enable-api-fields: stable
     enable-provenance-in-status: false
     enable-custom-tasks: true

--- a/modules/op-modifiable-fields-with-default-values.adoc
+++ b/modules/op-modifiable-fields-with-default-values.adoc
@@ -25,19 +25,6 @@ For clusters that use injected sidecars, setting this field to `false` can lead 
 
 * `enable-tekton-oci-bundles` (default: `false`): Set this field to `true` to enable the use of an experimental alpha feature named Tekton OCI bundle.
 
-* `embedded-status` (default: `both`): This field has three acceptable values:
-
-** `full`: Enables full embedding of `Run` and `TaskRun` statuses in the `PipelineRun` status
-
-** `minimal`: Populates the `ChildReferences` field with information, such as name, kind, and API version for each run and task run in the`PipelineRun` status
-
-** `both`: Applies both, `full` and `minimal` values
-+
-[NOTE]
-====
-The `embedded-status` field is deprecated and will be removed in a future release. In addition, the pipeline default embedded status will be changed to `minimal`.
-====
-
 * `enable-api-fields` (default: `stable`): Setting this field determines which features are enabled. Acceptable value is `stable`, `beta`, or `alpha`.
 +
 [NOTE]


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: enterprise-4.12 and later
• **JIRA issue**: [RHDEVDOCS-5366](https://issues.redhat.com/browse/RHDEVDOCS-5366)
• **Preview page**: [Configuring pipeline resolvers](https://60767--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/customizing-configurations-in-the-tektonconfig-cr.html#op-configuring-pipeline-resolvers_customizing-configurations-in-the-tektonconfig-cr), [Modifiable fields with default values](https://60767--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/customizing-configurations-in-the-tektonconfig-cr.html#op-modifiable-fields-with-default-values_customizing-configurations-in-the-tektonconfig-cr)
• **SME Review**: Completed by @vdemeester 
• **QE review**: Completed by @ppitonak 
• **Peer-review**: Completed by @Srivaralakshmi 
**These changes are for Pipelines version 1.11.**