### PR TITLE
[Change] CCXDEV-10504 Insights Operator OpenShift 4.13 RN 

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1285,8 +1285,14 @@ An overview of etcd, including the benefits it provides and how it works, is now
 
 [id="ocp-4-13-insights-operator"]
 === Insights Operator
+In OpenShift Container Platform 4.13, the Insights Operator now collects the following information:
 // https://issues.redhat.com/browse/OCPBUGS-6832
-The Insights Operator can now collect the `openshift_apps_deploymentconfigs_strategy_total` metric. This metric gathers deployment strategy information from a deployment's configuration.
+
+* The `openshift_apps_deploymentconfigs_strategy_total` metric. This metric gathers deployment strategy information from a deployment's configuration.
+
+* Additional machine resource definitions to identify why machines are failing. 
+
+* The default `ingresscontroller.operator.openshift.io` resource to inform Insights if the Authentication Operator is degraded.
 
 [id="ocp-4-13-hcp"]
 === Hosted control planes (Technology Preview)


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
This PR includes two additions to the Insights Operator RN for 4.13. These are not new features, and were included in the release on May 17th 2023. 
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
`enterprise-4.13`
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/CCXDEV-10504

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.


