### PR TITLE
OCPBUGS-13944 updating performance-addon-rhel8-operator:v4.13

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -368,10 +368,10 @@ annotations:
 
 . Generate a `PerformanceProfile` with `per-pod-power-management` set to `true`:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ podman run --entrypoint performance-profile-creator -v \
-/must-gather:/must-gather:z registry.redhat.io/openshift4/performance-addon-rhel8-operator:v4.12 \
+/must-gather:/must-gather:z registry.redhat.io/openshift4/ose-cluster-node-tuning-operator:v{product-version} \
 --mcp-name=worker-cnf --reserved-cpu-count=20 --rt-kernel=true \
 --split-reserved-cpus-across-numa=false --topology-manager-policy=single-numa-node \
 --must-gather-dir-path /must-gather -power-consumption-mode=low-latency \ <1>


### PR DESCRIPTION
OCPBUGS-13944: Update to ose-cluster-node-tuning-operator:v{product-version}

Version(s):
4.12,
Issue:
https://issues.redhat.com/browse/OCPBUGS-13944

Link to docs preview: 

All merged and reviewed under https://github.com/openshift/openshift-docs/pull/60540. However, CP to 4.12 failed so creating this separate PR to track and get into 4.12.
