### PR TITLE
SRVCOM-2437 Update Serverless redirects to 1.29 release

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -202,22 +202,22 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12)/serverless/develop/serverless-traffic-management.html /container-platform/$1/serverless/knative-serving/traffic-splitting/traffic-splitting-overview.html [NE,R=302]
 
 
-    # redirect latest to 1.28
+    # redirect latest to 1.29
     RewriteRule ^serverless/?$ /serverless/latest [R=302]
-    RewriteRule ^serverless/latest/?(.*)$ /serverless/1\.28/$1 [NE,R=302]
+    RewriteRule ^serverless/latest/?(.*)$ /serverless/1\.29/$1 [NE,R=302]
 
     # redirect top-level without filespec to the about file
     RewriteRule ^serverless/(1\.28|1\.29)/?$ /serverless/$1/about/about-serverless.html [L,R=302]
 
     # redirect rel notes
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/serverless-release-notes.html$ /serverless/1.28/about/serverless-release-notes.html [L,R=302]
-    RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.28/about/serverless-release-notes.html [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/serverless-release-notes.html$ /serverless/1.29/about/serverless-release-notes.html [L,R=302]
+    RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.29/about/serverless-release-notes.html [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/?(.*)$ /serverless/1.28/$2  [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/?(.*)$ /serverless/1.29/$2  [L,R=302]
 
-    # redirect any links to existing OCP embedded content to standalone equivalent
-    RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.28/$2  [L,R=302]
+    # redirect any links to existing ROSA/Dedicated embedded content to standalone equivalent
+    RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.29/$2  [L,R=302]
 
 
     # OSD redirects for new content


### PR DESCRIPTION
Version(s):
main

Issue:
[SRVCOM-2437](https://issues.redhat.com//browse/SRVCOM-2437)

NOTE: Do not merge until Serverless 1.29 is releases (proposed date - Monday 5th June 2023)
