### PR TITLE
SRVCOM-2437 Add info about versioned docs

### DIFF
--- a/about/about-serverless.adoc
+++ b/about/about-serverless.adoc
@@ -11,7 +11,13 @@ toc::[]
 
 [NOTE]
 ====
-Because {ServerlessProductName} releases on a different cadence from {ocp-product-title}, the {ServerlessProductName} documentation does not maintain separate documentation sets for minor versions of the product. The current documentation set applies to all currently supported versions of {ServerlessProductName} unless version-specific limitations are called out in a particular topic or for a particular feature.
+Because {ServerlessProductName} releases on a different cadence from {product-title}, the {ServerlessProductName} documentation is now available as separate documentation sets for each minor version of the product. 
+
+The {ServerlessProductName} documentation is available at link:https://docs.openshift.com/serverless/[].
+
+Documentation for specific versions is available using the version selector dropdown, or directly by adding the version to the URL, for example, link:https://docs.openshift.com/serverless/1.28[].
+
+In addition, the {ServerlessProductName} documentation is also available on the Red Hat Portal at https://access.redhat.com/documentation/en-us/red_hat_openshift_serverless/[].
 
 For additional information about the {ServerlessProductName} life cycle and supported platforms, refer to the link:https://access.redhat.com/support/policy/updates/openshift#ossrvless[Platform Life Cycle Policy].
 ====


### PR DESCRIPTION


Version(s):
serverless-docs 1.28+

Issue:
[SRVCOM-2437](https://issues.redhat.com//browse/SRVCOM-2437) 

Link to docs preview:


Additional information:

