### PR TITLE
[RHACS] ROX-17410: Configuring an authentication provider in Central

### DIFF
--- a/cli/getting-started-cli.adoc
+++ b/cli/getting-started-cli.adoc
@@ -30,15 +30,25 @@ include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
 include::modules/run-roxctl-from-container.adoc[leveloffset=+2]
 
 // Authenticating using CLI
+[id="authenticating-by-using-the-roxctl-cli_{context}"]
+== Authenticating by using the `roxctl` CLI
 
-[id="authenticating-cli"]
-== Authenticating using the roxctl CLI
+For authentication, you can use an API token, your administrator password, or `roxctl login` command.
 
-For authentication, you can use an authentication token or your administrator password.
-Use an authentication token in a production environment because each token is assigned specific access control permissions.
+* Use an API token in a production environment with continuous integration (CI). Each token is assigned specific access permissions, providing control over the actions it can perform. In addition, API tokens do not require interactive processes, such as browser-based logins, making them ideal for automated processes. These tokens have a time-to-live (TTL) of 1 year, providing a longer validity period for seamless integration and operational efficiency.
 
+* Use your administrator password only for testing purposes and not in the production environment.
+
+* Use the `roxctl login` command only for interactive use.
+
+//Creating an API token
 include::modules/create-api-token.adoc[leveloffset=+2]
+
+//Exporting and saving the authentication token
 include::modules/cli-authentication.adoc[leveloffset=+2]
+
+//Configuring an authentication provider in Central
+include::modules/configuring-an-authentication-provider-in-central.adoc[leveloffset=+2]
 
 // Using the CLI
 include::modules/using-cli.adoc[leveloffset=+1]

--- a/modules/configuring-an-authentication-provider-in-central.adoc
+++ b/modules/configuring-an-authentication-provider-in-central.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * cli/getting-started-cli.adoc
+:_content-type: PROCEDURE
+[id="configuring-an-authentication-provider-in-central_{context}"]
+= Configuring an authentication provider in Central
+
+[role="_abstract"]
+You can configure an authentication provider in Central and initiate the login process with the `roxctl` CLI.
+Set the `ROX _ENDPOINT` variable, initiate the login process with the `roxctl central login` command, select the authentication provider in a browser window, and retrieve the token information from the `roxctl` CLI as described in the following procedure.
+
+
+.Prerequisite
+
+. You selected an authentication provider of your choice, such as OpenID Connect (OIDC) with fragment or query mode.
+
+.Procedure
+
+. Run the following command to set the `ROX_ENDPOINT` variable to Central hostname and port:
++
+[source,terminal,subs="+quotes"]
+----
+export ROX_ENDPOINT=_<central_hostname:port>_
+----
+
+. Run the following command to initiate the login process to Central:
++
+[source,terminal,subs="+quotes"]
+----
+$ roxctl central login
+----
+
+. Within the `roxctl` CLI, a URL is printed as output and you are redirected to a browser window where you can select the authentication provider you want to use.
+
+. Log in with your authentication provider.
++
+After you have successfully logged in, the browser window indicates that authentication was successful and you can close the browser window.
+
+. The `roxctl` CLI displays your token information including details such as the access token, the expiration time of the access token, the refresh token if one has been issued, and notification that these values are stored locally.
++
+.Example output
++
+[source,terminal]
+----
+Please complete the authorization flow in the browser with an auth provider of your choice.
+If no browser window opens, please click on the following URL:
+        http://127.0.0.1:xxxxx/login
+
+INFO:	Received the following after the authorization flow from Central:
+INFO:	Access token: <redacted> <1>
+INFO:	Access token expiration: 2023-04-19 13:58:43 +0000 UTC <2>
+INFO:	Refresh token: <redacted> <3>
+INFO:	Storing these values under $HOME/.roxctl/login… <4>
+----
+<1> The access token.
+<2> The expiration time of the access token.
+<3> The refresh token.
+<4> The directory where values of the access token, the access token expiration time, and the refresh token are stored locally.
++
+[IMPORTANT]
+====
+Ensure that you set the environment to determine the directory where the configuration is stored. By default, the configuration is stored in the `$HOME/.roxctl/roxctl-config` directory.
+
+* If you set the `$ROX_CONFIG_DIR` environment variable, the configuration is stored in the `$ROX_CONFIG_DIR/roxctl-config` directory. This option has the highest priority.
+
+* If you set the `$XDG_RUNTIME_DIR` environment variable and the `$ROX_CONFIG_DIR` variable is not set, the configuration is stored in the `$XDG_RUNTIME_DIR /roxctl-config` directory.
+
+* If you do not set the `$ROX_CONFIG_DIR` or `$XDG_RUNTIME_DIR` environment variable, the configuration is stored in the `$HOME/.roxctl/roxctl-config` directory.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.1
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-17410
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://60780--docspreview.netlify.app/openshift-acs/latest/cli/getting-started-cli.html#authenticating-using-the-roxctl-cli_cli-getting-started
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Merge into `rhacs-docs` and cherry-pick into:
- `rhacs-docs-4.1`
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
