### PR TITLE
[enterprise-4.12] OCPBUGS-13383_412: affinity rules in the YAML correction

### DIFF
--- a/modules/virt-example-vm-node-placement-node-affinity.adoc
+++ b/modules/virt-example-vm-node-placement-node-affinity.adoc
@@ -17,25 +17,27 @@ metadata:
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
-  affinity:
-    nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution: <1>
-        nodeSelectorTerms:
-        - matchExpressions:
-          - key: example.io/example-key
-            operator: In
-            values:
-            - example-value-1
-            - example-value-2
-      preferredDuringSchedulingIgnoredDuringExecution: <2>
-      - weight: 1
-        preference:
-          matchExpressions:
-          - key: example-node-label-key
-            operator: In
-            values:
-            - example-node-label-value
-...
+  template:
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: <1>
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: example.io/example-key
+                operator: In
+                values:
+                - example-value-1
+                - example-value-2
+          preferredDuringSchedulingIgnoredDuringExecution: <2>
+          - weight: 1
+            preference:
+              matchExpressions:
+              - key: example-node-label-key
+                operator: In
+                values:
+                - example-node-label-value
+# ...
 ----
 <1> If you use the `requiredDuringSchedulingIgnoredDuringExecution` rule type, the VM is not scheduled if the constraint is not met.
 <2> If you use the `preferredDuringSchedulingIgnoredDuringExecution` rule type, the VM is still scheduled if the constraint is not met, as long as all required constraints are met.

--- a/modules/virt-example-vm-node-placement-pod-affinity.adoc
+++ b/modules/virt-example-vm-node-placement-pod-affinity.adoc
@@ -17,28 +17,30 @@ metadata:
 apiVersion: kubevirt.io/v1
 kind: VirtualMachine
 spec:
-  affinity:
-    podAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution: <1>
-      - labelSelector:
-          matchExpressions:
-          - key: example-key-1
-            operator: In
-            values:
-            - example-value-1
-        topologyKey: kubernetes.io/hostname
-    podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution: <2>
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchExpressions:
-            - key: example-key-2
-              operator: In
-              values:
-              - example-value-2
-          topologyKey: kubernetes.io/hostname
-...
+  template:
+    spec:
+      affinity:
+        podAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution: <1>
+          - labelSelector:
+              matchExpressions:
+              - key: example-key-1
+                operator: In
+                values:
+                - example-value-1
+            topologyKey: kubernetes.io/hostname
+        podAntiAffinity:
+          preferredDuringSchedulingIgnoredDuringExecution: <2>
+          - weight: 100
+            podAffinityTerm:
+              labelSelector:
+                matchExpressions:
+                - key: example-key-2
+                  operator: In
+                  values:
+                  - example-value-2
+              topologyKey: kubernetes.io/hostname
+# ...
 ----
 <1> If you use the `requiredDuringSchedulingIgnoredDuringExecution` rule type, the VM is not scheduled if the constraint is not met.
 <2> If you use the `preferredDuringSchedulingIgnoredDuringExecution` rule type, the VM is still scheduled if the constraint is not met, as long as all required constraints are met.


### PR DESCRIPTION
**Version(s):**
4.12 only

**Issue:**
https://github.com/openshift/openshift-docs/pull/60090

**Additional information:**
Cherrypick for the above PR failed for 4.12. This is the manual PR.