### PR TITLE
OSDOCS#5020: Fixed the docs bug for non-recovery control plane node

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -12,7 +12,7 @@ You can use a saved etcd backup to restore a previous cluster state or restore a
 
 [NOTE]
 ====
-If your cluster uses a control plane machine set, see "Troubleshooting the control plane machine set" for a more simple etcd recovery procedure. 
+If your cluster uses a control plane machine set, see "Troubleshooting the control plane machine set" for a more simple etcd recovery procedure.
 ====
 
 [IMPORTANT]
@@ -290,7 +290,8 @@ etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          
 ----
 +
 If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
-
++
+.. Optional: For each lost control plane host, repeat the steps for verifying that the single member control plane has started successfully.
 +
 [NOTE]
 ====
@@ -303,6 +304,8 @@ Perform the following step only if you are using `OVNKubernetes` network plugin.
 ----
 $ oc delete node <non-recovery-controlplane-host-1> <non-recovery-controlplane-host-2>
 ----
+
+. Optional: For any remaining non-recovery control plane nodes, delete and recreate each non-recovery control plane node.
 
 . Verify that the Cluster Network Operator (CNO) redeploys the OVN-Kubernetes control plane and that it no longer references the wrong controller IP addresses. To verify this result, regularly check the output of the following command. Wait until it returns an empty result before you proceed with the next step.
 +
@@ -379,7 +382,7 @@ $ oc get  pods -n openshift-ovn-kubernetes | grep ovnkube-node
 
 . Delete and re-create other non-recovery, control plane machines, one by one. After the machines are re-created, a new revision is forced and etcd automatically scales up.
 +
-** If you use a user-provisioned bare metal installation, you can re-create a control plane machine by using the same method that you used to originally create it. For more information, see "Installing a user-provisioned cluster on bare metal". 
+** If you use a user-provisioned bare metal installation, you can re-create a control plane machine by using the same method that you used to originally create it. For more information, see "Installing a user-provisioned cluster on bare metal".
 +
 [WARNING]
 ====
@@ -712,4 +715,21 @@ etcd-ip-10-0-173-171.ec2.internal                2/2     Running     0          
 
 To ensure that all workloads return to normal operation following a recovery procedure, restart each pod that stores Kubernetes API information. This includes {product-title} components such as routers, Operators, and third-party components.
 
-Note that it might take several minutes after completing this procedure for all services to be restored. For example, authentication by using `oc login` might not immediately work until the OAuth server pods are restarted.
+[NOTE]
+====
+On completion of the previous procedural steps, you might need to wait a few minutes for all services to return to their restored state. For example, authentication by using `oc login` might not immediately work until the OAuth server pods are restarted.
+
+Consider using the `system:admin` `kubeconfig` file for immediate authentication. This method basis its authentication on SSL/TLS client certificates as against OAuth tokens. You can authenticate with this file by issuing the following command:
+
+[source,terminal]
+----
+$ export KUBECONFIG=<installation_directory>/auth/kubeconfig
+----
+
+Issue the following command to display your authenticated user name:
+
+[source,terminal]
+----
+$ oc whoami
+----
+====


### PR DESCRIPTION
[OSDOCS-5020](https://issues.redhat.com/browse/OSDOCS-5020)

Version(s):
4.14, 4.13, 4.12, 4.11, and 4.10

Link to docs preview:
[Restoring to a previous cluster state](https://60789--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state)

QE review:
- [x] QE has approved this change on the Jira.

Additional information:
* https://access.redhat.com/solutions/4845381
* Posted comment on [Slack 1](https://redhat-internal.slack.com/archives/C0144ECKUJ0/p1685699380929229) and [Slack 2](https://redhat-internal.slack.com/archives/C027U68LP/p1685723199074069)
