### PR TITLE
OSDOCS#6374: Update the GCP without workload identity section

### DIFF
--- a/modules/cert-manager-configure-cloud-credentials-gcp-non-sts.adoc
+++ b/modules/cert-manager-configure-cloud-credentials-gcp-non-sts.adoc
@@ -3,7 +3,7 @@
 // * security/cert_manager_operator/cert-manager-authenticate-non-sts-gcp.adoc
 
 :_content-type: PROCEDURE
-[id="cert-manager-prepare-cloud-credentials-gcp-non-sts_{context}"]
+[id="cert-manager-configure-cloud-credentials-gcp-non-sts_{context}"]
 = Configuring cloud credentials for the {cert-manager-operator} on GCP
 
 To configure the cloud credentials for the {cert-manager-operator} on a GCP cluster you must create a `CredentialsRequest` object, and allow the Cloud Credential Operator to generate the cloud credentials secret.
@@ -36,6 +36,15 @@ spec:
   serviceAccountNames:
   - cert-manager
 ----
++
+[NOTE]
+====
+The `dns.admin` role provides admin privileges to the service account for managing Google Cloud DNS resources. To ensure that the cert-manager runs with the service account that has the least privilege, you can create a custom role with the following permissions:
+
+* `dns.resourceRecordSets.*`
+* `dns.changes.*`
+* `dns.managedZones.list`
+====
 
 . Create a `CredentialsRequest` resource by running the following command:
 +
@@ -67,7 +76,7 @@ NAME                                       READY   STATUS    RESTARTS   AGE
 cert-manager-bd7fbb9fc-wvbbt               1/1     Running   0          15m39s
 ----
 
-. Verify that the cert-manager controller pod is updated with GCP workload identity credential volumes that are mounted under the path specified in `mountPath` by running the following command:
+. Verify that the cert-manager controller pod is updated with GCP credential volumes that are mounted under the path specified in `mountPath` by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6374
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://60808--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-authenticate-non-sts-gcp.html#cert-manager-configure-cloud-credentials-gcp-non-sts_cert-manager-authenticate-non-sts-gcp



<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
