### PR TITLE
TELCODOCS-1077 - Remove misplaced topics in "Manually installing a single-node OpenShift cluster with ZTP" book

### DIFF
--- a/scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc
@@ -38,17 +38,12 @@ include::modules/ztp-manually-install-a-single-managed-cluster.adoc[leveloffset=
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-managed-cluster-network-prereqs_sno-configure-for-vdu[Connectivity prerequisites for managed cluster networks]
 
+* xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-preface-sno-ran_logical-volume-manager-storage[Deploying LVM Storage on single-node OpenShift clusters]
+
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-provisioning-lvm-storage_ztp-advanced-policy-config[Configuring LVM Storage using PolicyGenTemplate CRs]
+
 include::modules/ztp-checking-the-managed-cluster-status.adoc[leveloffset=+1]
 
 include::modules/ztp-troubleshooting-the-managed-cluster.adoc[leveloffset=+1]
-
-include::modules/ztp-lvms-installing-lvms-web-console.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-preface-sno-ran_logical-volume-manager-storage[Deploying LVM Storage on single-node OpenShift clusters]
-
-include::modules/ztp-lvms-installing-lvms-cli.adoc[leveloffset=+1]
 
 include::modules/ztp-installation-crs.adoc[leveloffset=+1]


### PR DESCRIPTION
https://issues.redhat.com/browse/TELCODOCS-1077

Two modules were mistakenly added to the `ztp_far_edge/ztp-manual-install.adoc` assembly.

* modules/ztp-lvms-installing-lvms-cli.adoc
* modules/ztp-lvms-installing-lvms-web-console.adoc

This removed content is also found in https://docs.openshift.com/container-platform/4.13/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html

Though related, they do not belong in this assembly.

QE/CM not required.

Merge to main, CP to enterprise-4.13+

Preview: 
https://60812--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-manual-install.html