### PR TITLE
TELCODOCS-1077 - remove outdated link from 4.13 release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -886,7 +886,7 @@ In {product-title} {product-version}, {lvms} is supported in dual-stack for IPv4
 
 [id="ocp-4-13-storage-lvms-in-zpt"]
 ==== Support for {lvms} in GitOps ZTP
-In {product-title} {product-version}, you can add and configure {lvms-first} through GitOps ZTP. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc#ztp-lvms-installing-using-web-console_ztp-manual-install[Intalling LVM Storage by using the web console], xref:../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-provisioning-lvm-storage_ztp-advanced-policy-config[Configuring LVM Storage using PolicyGenTemplate CRs], and xref:../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#lvms-configuring-lvms-on-sno_sno-configure-for-vdu[LVM Storage].
+In {product-title} {product-version}, you can add and configure {lvms-first} through {ztp}. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-provisioning-lvm-storage_ztp-advanced-policy-config[Configuring LVM Storage using PolicyGenTemplate CRs] and xref:../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#lvms-configuring-lvms-on-sno_sno-configure-for-vdu[LVM Storage].
 
 [id="ocp-4-13-storage-lvms-in-disconnected-env"]
 ==== Support for {lvms} in disconnected environments


### PR DESCRIPTION
Removes outdated link. Related to https://github.com/openshift/openshift-docs/pull/60812

QE/CM not required.  

Merge to enterprise-4.13

Preview: https://60813--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-storage-lvms-in-zpt