### PR TITLE
RHDEVDOCS-5248: Pruner configuration documentation

### DIFF
--- a/modules/op-annotations-for-automatic-pruning-taskruns-pipelineruns.adoc
+++ b/modules/op-annotations-for-automatic-pruning-taskruns-pipelineruns.adoc
@@ -4,35 +4,39 @@
 
 :_content-type: REFERENCE
 [id="annotations-for-automatic-pruning-taskruns-pipelineruns_{context}"]
-= Annotations for automatically pruning task runs and pipeline runs 
+= Annotations for automatically pruning task runs and pipeline runs
 
-To automatically prune the resources associated with task runs and pipeline runs in a namespace, you can set the following annotations in the namespace:
+To modify the configuration for automatic pruning of task runs and pipeline runs in a namespace, you can set annotations in the namespace.
 
-* `operator.tekton.dev/prune.schedule`: If the value of this annotation is different from the value specified in the `TektonConfig` custom resource definition, a new cron job in that namespace is created.
+The following namespace annotations have the same meanings as the corresponding keys in the `TektonConfig` custom resource:
 
-* `operator.tekton.dev/prune.skip`: When set to `true`, the namespace for which it is configured is not pruned.
+* `operator.tekton.dev/prune.schedule`
+* `operator.tekton.dev/prune.resources`
+* `operator.tekton.dev/prune.keep`
+* `operator.tekton.dev/prune.prune-per-resource`
+* `operator.tekton.dev/prune.keep-since`
 
-* `operator.tekton.dev/prune.resources`: This annotation accepts a comma-separated list of resources. To prune a single resource such as a pipeline run, set this annotation to `"pipelinerun"`. To prune multiple resources, such as task run and pipeline run, set this annotation to `"taskrun, pipelinerun"`.
-
-* `operator.tekton.dev/prune.keep`: Use this annotation to retain a resource without pruning.
-
-* `operator.tekton.dev/prune.keep-since`: Use this annotation to retain resources based on their age. The value for this annotation must be equal to the age of the resource in minutes. For example, to retain resources which were created not more than five days ago, set `keep-since` to `7200`.
-+
 [NOTE]
 ====
-The `keep` and `keep-since` annotations are mutually exclusive. For any resource, you must configure only one of them.
+The `operator.tekton.dev/prune.resources` annotation accepts a comma-separated list. To prune both task runs and pipeline runs, set this annotation to `"taskrun, pipelinerun"`.
 ====
 
+The following additional namespace annotations are available:
+
+* `operator.tekton.dev/prune.skip`: When set to `true`, the namespace for which the annotation is configured is not pruned.
 * `operator.tekton.dev/prune.strategy`: Set the value of this annotation to either `keep` or `keep-since`.
 
-For example, consider the following annotations that retain all task runs and pipeline runs created in the last five days, and deletes the older resources: 
+For example, the following annotations retain all task runs and pipeline runs created in the last five days and delete the older resources:
 
 .Example of auto-pruning annotations
 [source,yaml]
 ----
-...
-  annotations: 
+kind: Namespace
+apiVersion: v1
+# ...
+spec:
+  annotations:
     operator.tekton.dev/prune.resources: "taskrun, pipelinerun"
     operator.tekton.dev/prune.keep-since: 7200
-...
+# ...
 ----

--- a/modules/op-automatic-pruning-taskrun-pipelinerun.adoc
+++ b/modules/op-automatic-pruning-taskrun-pipelinerun.adoc
@@ -4,12 +4,11 @@
 
 :_content-type: CONCEPT
 [id="op-automatic-pruning-taskrun-pipelinerun_{context}"]
-= Automatic pruning of task runs and pipeline runs 
+= Automatic pruning of task runs and pipeline runs
 
-Stale `TaskRun` and `PipelineRun` objects and their executed instances occupy physical resources that can be used for active runs. For optimal utilization of these resources, {pipelines-title} provides annotations that cluster administrators can use to automatically prune the unused objects and their instances in various namespaces.
+Stale `TaskRun` and `PipelineRun` objects and their executed instances occupy physical resources that can be used for active runs. For optimal utilization of these resources, {pipelines-title} provides a pruner component that automatically removes unused objects and their instances in various namespaces.
 
 [NOTE]
 ====
-Configuring automatic pruning by specifying annotations affects the entire namespace. You cannot selectively auto-prune an individual task run or pipeline run in a namespace.
+You can configure the pruner for your entire installation by using the `TektonConfig` custom resource and modify configuration for a namespace by using namespace annotations. However, you cannot selectively auto-prune an individual task run or pipeline run in a namespace.
 ====
-

--- a/modules/op-default-pruner-configuration.adoc
+++ b/modules/op-default-pruner-configuration.adoc
@@ -4,25 +4,54 @@
 
 :_content-type: REFERENCE
 [id="default-pruner-configuration_{context}"]
-= Default pruner configuration
+= Configuring the pruner
 
-The default configuration for periodic pruning of resources associated with pipeline runs is as follows:
+You can use the `TektonConfig` custom resource to configure periodic pruning of resources associated with pipeline runs and task runs.
 
-.Example of the default configuration
+The following example corresponds to the default configuration:
+
+.Example of the pruner configuration
 [source,yaml]
 ----
 apiVersion: operator.tekton.dev/v1alpha1
 kind: TektonConfig
 metadata:
   name: config
-...
+# ...
 spec:
   pruner:
-    keep: 100
     resources:
-    - pipelinerun
-    schedule: 0 8 * * *
-...
+      - taskrun
+      - pipelinerun
+    keep: 100
+    prune-per-resource: false
+    schedule: "* 8 * * *"
+# ...
 ----
 
-You can override the default pruner configuration for a namespace by using annotations on namespace.
+.Supported parameters for pruner configuration
+|===
+| Parameter | Description
+
+|`schedule`
+|The Cron schedule for running the pruner process. The default schedule runs the process at 08:00 every day. For more information about the Cron schedule syntax, see link:https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/#cron-schedule-syntax[Cron schedule syntax] in the Kubernetes documentation.
+
+|`resources`
+|The resource types to which the pruner applies. The available resource types are `taskrun` and `pipelinerun`
+
+|`keep`
+|The number of most recent resources of every type to keep.
+
+|`prune-per-resource`
+|If set to `false`, the value for the `keep` parameter denotes the total number of task runs or pipeline runs. For example, if `keep` is set to `100`, then the pruner keeps 100 most recent task runs and 100 most recent pipeline runs and removes all other resources.
+
+If set to `true`, the value for the `keep` parameter is calculated separately for pipeline runs referencing each pipeline and for task runs referencing each task. For example, if `keep` is set to `100`, then the pruner keeps 100 most recent pipeline runs for `Pipeline1`, 100 most recent pipeline runs for `Pipeline2`, 100 most recent task runs for `Task1`, and so on, and removes all other resources.
+
+|`keep-since`
+|The maximum time for which to keep resources, in minutes. For example, to retain resources which were created not more than five days ago, set `keep-since` to `7200`.
+|===
+
+[NOTE]
+====
+The `keep` and `keep-since` parameters are mutually exclusive. Use only one of them in your configuration.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/RHDEVDOCS-5248 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://60817--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/customizing-configurations-in-the-tektonconfig-cr.html#op-automatic-pruning-taskrun-pipelinerun_customizing-configurations-in-the-tektonconfig-cr

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
