### PR TITLE
OCPBUGS-9321 adding xref to creating AWS resources individually

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -31,6 +31,8 @@ If you do not need to review the JSON files that the `ccoctl` tool creates befor
 
 Otherwise, you can create the AWS resources individually.
 
+* xref:../modules/cco-ccoctl-creating-individually.adoc#creating-individually[Create the AWS resources individually]
+
 //to-do if possible: xref to modules/cco-ccoctl-creating-individually.adoc for `create the AWS resources individually`
 endif::aws-sts[]
 ifdef::google-cloud-platform[]
@@ -65,7 +67,7 @@ endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 . Set the `$RELEASE_IMAGE` variable by running the following command:
 +
-[source,terminal] 
+[source,terminal]
 ----
 $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
 ----


### PR DESCRIPTION
Version(s):
4.10+

Issue:
[OCPBUGS-9321](https://issues.redhat.com/browse/OCPBUGS-9321)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
