### PR TITLE
OCPBUGS#13396 Add cpuPartitioningMode to Optional config params

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -591,6 +591,10 @@ Optional installation configuration parameters are described in the following ta
 |Extends the set of optional capabilities beyond what you specify in `baselineCapabilitySet`. You may specify multiple capabilities in this parameter.
 |String array
 
+|`cpuPartitioningMode`
+|Enables workload partitioning, which isolates {product-title} services, cluster management workloads, and infrastructure pods to run on a reserved set of CPUs. Workload partitioning can only be enabled during installation and cannot be disabled after installation. While this field enables workload partitioning, it does not configure workloads to use specific CPUs. For more information, see the _Workload partitioning_ page in the _Scalability and Performance_ section.
+|`None` or `AllNodes`. `None` is the default value.
+
 |`compute`
 |The configuration for the machines that comprise the compute nodes.
 |Array of `MachinePool` objects.


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-13396

Link to docs preview:
https://60819--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations.html#installation-configuration-parameters-optional_installing-aws-customizations

QE review:
- [x] QE has approved this change.
