### PR TITLE
OSDOCS-5702:updates ovn-k docs to include egressIP config object

### DIFF
--- a/modules/nw-egress-ips-config-object.adoc
+++ b/modules/nw-egress-ips-config-object.adoc
@@ -1,0 +1,34 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/assigning-egress-ips-ovn.adoc
+
+[id="nw-egress-ips-config-object_{context}"]
+= EgressIPconfig object
+As a feature of egress IP, the `reachabilityTotalTimeoutSeconds` parameter configures the total timeout for checks that are sent by probes to egress IP nodes. The `egressIPConfig` object allows users to set the `reachabilityTotalTimeoutSeconds` `spec`. If the EgressIP node cannot be reached within this timeout, the node is declared down.
+
+You can increase this value if your network is not stable enough to handle the current default value of 1 second.
+
+The following YAML describes changing the `reachabilityTotalTimeoutSeconds` from the default 1 second probes to 5 second probes:
+
+[source,yaml]
+----
+apiVersion: k8s.ovn.org/v1
+kind: EgressIP
+  name: networks.operator.openshift.io
+  spec:
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  defaultNetwork:
+    ovnKubernetesConfig:
+      egressIPConfig: <1>
+        reachabilityTotalTimeoutSeconds: 5 <2>
+      gatewayConfig:
+        routingViaHost: false
+      genevePort: 6081
+----
+<1> The `egressIPConfig` holds the configurations for the options of the `EgressIP` object. Changing these configurations allows you to extend the `EgressIP` object.
+
+<2> The value for `reachabilityTotalTimeoutSeconds` accepts integer values from `0` to `60`. A value of 0 disables the reachability check of the egressIP node. Values of `1` to `60` correspond to the duration in seconds between probes sending the reachability check for the node.
+
+

--- a/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc
@@ -12,6 +12,8 @@ include::modules/nw-egress-ips-about.adoc[leveloffset=+1]
 
 include::modules/nw-egress-ips-object.adoc[leveloffset=+1]
 
+include::modules/nw-egress-ips-config-object.adoc[leveloffset=+1]
+
 include::modules/nw-egress-ips-node.adoc[leveloffset=+1]
 
 [id="configuring-egress-ips-next-steps"]


### PR DESCRIPTION
[OSDOCS-5702](https://issues.redhat.com//browse/OSDOCS-5702):updates ovn-k docs to include `egressIPConfig` object
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5702
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://60822--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.html#nw-egress-ips-config-object_configuring-egress-ips-ovn
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
