### PR TITLE
CNV-26737: RFE - Document how to enable plain ssh usage

### DIFF
--- a/modules/virt-using-openssh-and-virtctl-port-forward.adoc
+++ b/modules/virt-using-openssh-and-virtctl-port-forward.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-using-openssh-and-virtctl-port-forward.adoc
+
+:_content-type: PROCEDURE
+[id="virt-using-openssh-and-virtctl-port-forward_{context}"]
+= Using OpenSSH and virtctl port-forward
+
+You can use your local OpenSSH client and the `virtctl port-forward` command to connect to a running virtual machine (VM). You can use this method with Ansible to automate the configuration of VMs.
+
+This method is recommended for low-traffic applications because port-forwarding traffic is sent over the control plane. This method is not recommended for high-traffic applications such as Rsync or Remote Desktop Protocol because it places a heavy burden on the API server.
+
+.Prerequisites
+* You have installed the `virtctl` client.
+* The virtual machine you want to access is running.
+* The environment where you installed the `virtctl` tool has the cluster permissions required to access the VM. For example, you ran `oc login` or you set the `KUBECONFIG` environment variable.
+
+.Procedure
+
+. Add the following text to the `~/.ssh/config` file on your client machine:
++
+[source,terminal]
+----
+Host vm/*
+  ProxyCommand virtctl port-forward --stdio=true %h %p
+----
+
+. Connect to the VM by running the following command:
++
+[source,terminal]
+----
+$ ssh <user>@vm/<vm_name>.<namespace>
+----

--- a/virt/virtual_machines/virt-accessing-vm-consoles.adoc
+++ b/virt/virtual_machines/virt-accessing-vm-consoles.adoc
@@ -42,6 +42,8 @@ include::modules/virt-accessing-vmi-ssh.adoc[leveloffset=+2]
 * xref:../../virt/virtual_machines/vm_networking/virt-creating-service-vm.adoc#virt-creating-service-vm[Creating a service to expose a virtual machine]
 * xref:../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets-about_nodes-pods-secrets[Understanding secrets]
 
+include::modules/virt-using-openssh-and-virtctl-port-forward.adoc[leveloffset=+2]
+
 include::modules/virt-accessing-serial-console.adoc[leveloffset=+2]
 
 include::modules/virt-accessing-vnc-console.adoc[leveloffset=+2]


### PR DESCRIPTION
**Version(s):**
4.12+

**Issue:**
https://issues.redhat.com/browse/CNV-26737

**Link to docs preview:**
https://60827--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-consoles.html#virt-using-openssh-and-virtctl-port-forward_virt-accessing-vm-consoles

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
NA