### PR TITLE
Formatting and consistency in Data Mover cleanup section

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -40,12 +40,12 @@ The cleanup consists of deleting the following resources:
 include::modules/oadp-cleaning-up-after-data-mover-snapshots.adoc[leveloffset=+2]
 
 [id="deleting-cluster-resources"]
-== Deleting cluster resources
+=== Deleting cluster resources
 
 Data Mover might leave cluster resources whether or not it successfully backs up your container storage interface (CSI) volume snapshots to a remote object store.
 
-include::modules/oadp-deleting-cluster-resources-following-success.adoc[leveloffset=+2]
-include::modules/oadp-deleting-cluster-resources-following-failure.adoc[leveloffset=+2]
+include::modules/oadp-deleting-cluster-resources-following-success.adoc[leveloffset=+3]
+include::modules/oadp-deleting-cluster-resources-following-failure.adoc[leveloffset=+3]
 
 include::modules/oadp-vsb-cleanup-after-scheduler.adoc[leveloffset=+2]
 

--- a/modules/oadp-cleaning-up-after-data-mover-snapshots.adoc
+++ b/modules/oadp-cleaning-up-after-data-mover-snapshots.adoc
@@ -10,7 +10,7 @@ Data Mover might leave one or more snapshots in a bucket after a backup. You can
 
 .Procedure
 
-* To delete all snapshots in your bucket, delete the `/<protected-ns>` folder that is specified in the Data Protection Application (DPA) `.spec.backupLocation.objectStorage.bucket` resource.
+* To delete all snapshots in your bucket, delete the `/<protected_namespace>` folder that is specified in the Data Protection Application (DPA) `.spec.backupLocation.objectStorage.bucket` resource.
 *  To delete an individual snapshot:
-. Browse to the `/<protected-ns>` folder that is specified in the DPA `.spec.backupLocation.objectStorage.bucket` resource.
+. Browse to the `/<protected_namespace>` folder that is specified in the DPA `.spec.backupLocation.objectStorage.bucket` resource.
 . Delete the appropriate folders that are prefixed with `/<volumeSnapshotContent name>-pvc` where `<VolumeSnapshotContent_name>` is the `VolumeSnapshotContent` created by Data Mover per PVC.

--- a/modules/oadp-deleting-cluster-resources-following-failure.adoc
+++ b/modules/oadp-deleting-cluster-resources-following-failure.adoc
@@ -6,7 +6,7 @@
 [id="oadp-deleting-cluster-resources-following-failure_{context}"]
 = Deleting cluster resources following a partially successful or a failed backup and restore that used Data Mover
 
-If your backup and restore operation that uses Data Mover either fails or only partially succeeds, you must clean up any `VolumeSnapshotBackup` (VSB) or `VolumeSnapshotrestore` custom resource definitions (CRDs) that exist in the application namespace, and clean up any extra resources created by these controllers.
+If your backup and restore operation that uses Data Mover either fails or only partially succeeds, you must clean up any `VolumeSnapshotBackup` (VSB) or `VolumeSnapshotRestore` custom resource definitions (CRDs) that exist in the application namespace, and clean up any extra resources created by these controllers.
 
 .Procedure
 


### PR DESCRIPTION
OADP 1.1 and 1.2; OCP 4.10+ 

[no Jira]: This PR fixes a few small errors in https://github.com/openshift/openshift-docs/pull/59894 (inconsistent naming of one resource, a misformatted CR name, and a less than ideal hierarchy).

Preview: https://60831--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-cleaning-up-after-data-mover-1-1-backup

No procedures have been changed in the PR beyond the formatting of some entities, so I did not ask QE to check it.    