### PR TITLE
fix(typo in hcp creation documentation)

### DIFF
--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -20,7 +20,7 @@ Create a {hcp-title} cluster quickly by using the default options and automatic 
 
 [IMPORTANT]
 ====
-Since it is not possible to upgrade or convert existing ROSA clusters to a {hcp} architecture, you must creata a new cluster to use {hcp-title} functionality.
+Since it is not possible to upgrade or convert existing ROSA clusters to a {hcp} architecture, you must create a new cluster to use {hcp-title} functionality.
 ====
 
 [NOTE]


### PR DESCRIPTION
Version(s):
enterprise-4.13+

Link to docs preview: https://60833--docspreview.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
