### PR TITLE
Tweaks term item to match better

### DIFF
--- a/.vale/styles/Vocab/OpenShiftDocs/accept.txt
+++ b/.vale/styles/Vocab/OpenShiftDocs/accept.txt
@@ -3,7 +3,7 @@
 
 [Pp]assthrough
 Assisted Installer
-Control Plane Machine Set
+Control Plane Machine Set Operator
 custom resource
 custom resources
 MetalLB


### PR DESCRIPTION
Issue: The inclusion of `Control Plane Machine Set` was causing Vale to suggest changing "control plane machine set" to "Control Plane Machine Set", which is incorrect. The idea of including `Control Plane Machine Set` was to stop Vale suggesting "Control plane machine set" (sentence case) when parsing the phrase "Control Plane Machine Set Operator". 

Fix: By updating `Control Plane Machine Set` to `Control Plane Machine Set Operator` in the accept list, Vale leaves "control plane machine set" alone and stops trying to make "Control Plane Machine Set Operator" sentence case.

Needs cherrypick to all versions.