### PR TITLE
OSDOCS#6390: Delete deployments running under the cert-manager namespace

### DIFF
--- a/modules/cert-manager-remove-resources-console.adoc
+++ b/modules/cert-manager-remove-resources-console.adoc
@@ -6,7 +6,7 @@
 [id="cert-manager-remove-resources-console_{context}"]
 = Removing {cert-manager-operator} resources
 
-Optionally, after uninstalling the {cert-manager-operator}, you can remove its related resources from your cluster.
+Once you have uninstalled the {cert-manager-operator}, you have the option to eliminate its associated resources from your cluster.
 
 .Prerequisites
 
@@ -17,7 +17,26 @@ Optionally, after uninstalling the {cert-manager-operator}, you can remove its r
 
 . Log in to the {product-title} web console.
 
-. Remove CRDs that were installed by the {cert-manager-operator}:
+. Remove the deployments of the cert-manager components, such as `cert-manager`, `cainjector`, and `webhook`, present in the `cert-manager` namespace.
+
+.. Click the *Project* drop-down menu to see a list of all available projects, and select the *cert-manager* project.
+
+.. Navigate to *Workloads* -> *Deployments*.
+
+.. Select the deployment that you want to delete.
+
+.. Click the *Actions* drop-down menu, and select *Delete Deployment* to see a confirmation dialog box.
+
+.. Click *Delete* to delete the deployment.
+
+.. Alternatively, delete deployments of the cert-manager components such as `cert-manager`, `cainjector` and `webhook` present in the `cert-manager` namespace by using the command-line interface (CLI).
++
+[source,terminal]
+----
+$ oc delete deployment -n cert-manager -l app.kubernetes.io/instance=cert-manager
+----
+
+. Optional: Remove the custom resource definitions (CRDs) that were installed by the {cert-manager-operator}:
 
 .. Navigate to *Administration* -> *CustomResourceDefinitions*.
 
@@ -33,7 +52,7 @@ Optionally, after uninstalling the {cert-manager-operator}, you can remove its r
 *** `Issuer`
 *** `Order`
 
-. Remove the `cert-manager-operator` namespace.
+. Optional: Remove the `cert-manager-operator` namespace.
 .. Navigate to *Administration* -> *Namespaces*.
 .. Click the Options menu {kebab} next to the *cert-manager-operator* and select *Delete Namespace*.
 .. In the confirmation dialog, enter `cert-manager-operator` in the field and click *Delete*.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6390
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://60837--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-uninstall.html#cert-manager-remove-resources-console_cert-manager-operator-uninstall
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
