### PR TITLE
[OSDOCS-5529]: Updating links to RHACM docs

### DIFF
--- a/architecture/control-plane.adoc
+++ b/architecture/control-plane.adoc
@@ -63,13 +63,9 @@ include::modules/hosted-control-planes-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hypershift-addon-intro[HyperShift add-on (Technology Preview)]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hypershift-addon-intro[HyperShift add-on (Technology Preview)]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosted-control-planes-intro[Hosted control planes for Red Hat OpenShift Container Platform (Technology Preview)]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-intro[Hosted control planes (Technology Preview)]
 
 
 include::modules/hosted-control-planes-version-support.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-* For more information about the `HostedCluster` and `NodePool` resources, see the link:https://hypershift-docs.netlify.app/reference/api/[HyperShift API Reference].

--- a/architecture/mce-overview-ocp.adoc
+++ b/architecture/mce-overview-ocp.adoc
@@ -22,7 +22,7 @@ When you enable multicluster engine on {product-title}, you gain the following c
 * Infrastructure Operator, which manages the deployment of the Assisted Service to orchestrate on-premise bare metal and vSphere installations of {product-title}, such as SNO on bare metal. The Infrastructure Operator includes xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-challenges-of-far-edge-deployments_ztp-deploying-far-edge-clusters-at-scale[{ztp-first}], which fully automates cluster creation on bare metal and vSphere provisioning with GitOps workflows to manage deployments and configuration changes.
 * Open cluster management, which provides resources to manage Kubernetes clusters.
 
-The multicluster engine is included with your {product-title} support subscription and is delivered separately from the core payload. To start to use multicluster engine, you deploy the {product-title} cluster and then install the operator. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#mce-install-intro[the installation documentation].
+The multicluster engine is included with your {product-title} support subscription and is delivered separately from the core payload. To start to use multicluster engine, you deploy the {product-title} cluster and then install the operator. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#mce-install-intro[Installing and upgrading multicluster engine operator].
 
 [id="mce-on-rhacm"]
 == Cluster management with Red Hat Advanced Cluster Management
@@ -32,4 +32,4 @@ If you need cluster management capabilities beyond what {product-title} with mul
 [id="mce-additional-resources-ocp"]
 == Additional resources
 
-For the complete documentation for multicluster engine, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#doc-wrapper[multicluster engine documentation], which is part of the product documentation for Red Hat Advanced Cluster Management.
+For the complete documentation for multicluster engine, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#doc-wrapper[Cluster lifecycle with multicluster engine documentation], which is part of the product documentation for Red Hat Advanced Cluster Management.

--- a/hosted_control_planes/hcp-configuring.adoc
+++ b/hosted_control_planes/hcp-configuring.adoc
@@ -16,18 +16,19 @@ You can view the procedures by selecting from one of the following providers:
 [id="hcp-configuring-aws"]
 == Amazon Web Services (AWS)
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring the hosted cluster on AWS]: The tasks to configure a hosted cluster on AWS include creating the AWS S3 OIDC secret, creating a routable public zone, enabling external DNS, enabling AWS PrivateLink, enabling the hosted control planes feature, and installing the hosted control planes CLI.
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosted-control-planes-manage-aws[Managing hosted control plane clusters on AWS]: Management tasks include creating, importing, accessing, or deleting a hosted cluster on AWS.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring the hosting cluster on AWS (Technology Preview)]: The tasks to configure a hosted cluster on AWS include creating the AWS S3 OIDC secret, creating a routable public zone, enabling external DNS, enabling AWS PrivateLink, enabling the hosted control planes feature, and installing the hosted control planes CLI.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-manage-aws[Managing hosted control plane clusters on AWS (Technology Preview)]: Management tasks include creating, importing, accessing, or deleting a hosted cluster on AWS.
 
 [id="hcp-configuring-bm"]
 == Bare metal
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-configure-bm[Configuring the hosted cluster on bare metal]: Configure DNS before you create a hosted cluster. 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal]: Create a hosted cluster, create an `InfraEnv` resource, add agents, access the hosted cluster, scale the `NodePool` object, handle Ingress, enable node auto-scaling, or delete a hosted cluster.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-configure-bm[Configuring the hosting cluster on bare metal (Technology Preview)]: Configure DNS before you create a hosted cluster. 
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal (Technology Preview)]: Create a hosted cluster, create an `InfraEnv` resource, add agents, access the hosted cluster, scale the `NodePool` object, handle Ingress, enable node auto-scaling, or delete a hosted cluster.
 
-// To be added after ACM 2.8 goes live:
+[id="hcp-configuring-virt"]
+== {VirtProductName}
 
-//{VirtProductName}
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on OpenShift Virtualization (Technology Preview)]: Create {product-title} clusters with worker nodes that are hosted by KubeVirt virtual machines. 
 
 // To be added after ACM 2.9 goes live:
 

--- a/hosted_control_planes/hcp-managing.adoc
+++ b/hosted_control_planes/hcp-managing.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 After you configure your environment for hosted control planes and create a hosted cluster, you can further manage your clusters and nodes.
 
+:FeatureName: Hosted control planes
+include::snippets/technology-preview.adoc[]
+
 include::modules/updates-for-hosted-control-planes.adoc[leveloffset=+1]
 include::modules/updating-node-pools-for-hcp.adoc[leveloffset=+1]
 include::modules/configuring-node-pools-for-hcp.adoc[leveloffset=+1]
@@ -17,6 +20,7 @@ include::modules/configuring-node-pools-for-hcp.adoc[leveloffset=+1]
 //using service-level DNS for control plane services
 //configuring metrics sets
 include::modules/node-tuning-hosted-cluster.adoc[leveloffset=+1]
+include::modules/sriov-operator-hosted-control-planes.adoc[leveloffset=+1]
 //automated machine management
 include::modules/delete-hosted-cluster.adoc[leveloffset=+1]
 

--- a/hosted_control_planes/index.adoc
+++ b/hosted_control_planes/index.adoc
@@ -12,14 +12,9 @@ include::modules/hosted-control-planes-overview.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hypershift-addon-intro[HyperShift add-on (Technology Preview)]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hypershift-addon-intro[HyperShift add-on (Technology Preview)]
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosted-control-planes-intro[Hosted control planes for Red Hat OpenShift Container Platform (Technology Preview)]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-intro[Hosted control planes (Technology Preview)]
 
 
 include::modules/hosted-control-planes-version-support.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* link:https://hypershift-docs.netlify.app/reference/api/[HyperShift API Reference]

--- a/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
@@ -11,7 +11,7 @@ The following procedure is partially automated and requires manual steps after t
 
 == Prerequisites
 * You have read the following documentation:
-** link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview[Cluster lifecycle with multicluster engine operator overview].
+** link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview[Cluster lifecycle with multicluster engine operator overview].
 ** xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-local.adoc#persistent-storage-using-local-volume[Persistent storage using local volumes].
 ** xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc#about-ztp_ztp-deploying-far-edge-clusters-at-scale[Using ZTP to provision clusters at the network far edge].
 ** xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#preparing-to-install-with-agent-based-installer[Preparing to install with the Agent-based Installer].

--- a/modules/delete-hosted-cluster.adoc
+++ b/modules/delete-hosted-cluster.adoc
@@ -10,10 +10,12 @@ The steps to delete a hosted cluster differ depending on which provider you use.
 
 .Procedure
 
-* If the cluster is on AWS, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-aws[Destroying a hosted cluster on AWS].
+* If the cluster is on AWS, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-aws[Destroying a hosted cluster on AWS].
 
-* If the cluster is on bare metal, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-bm[Destroying a hosted cluster on bare metal].
+* If the cluster is on bare metal, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-bm[Destroying a hosted cluster on bare metal].
+
+* If the cluster is on {VirtProductName}, follow the instructions in link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hypershift-cluster-destroy-kubevirt[Destroying a hosted cluster on OpenShift Virtualization].
 
 .Next steps
 
-If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].
+If you want to disable the hosted control plane feature, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#disable-hosted-control-planes[Disabling the hosted control plane feature].

--- a/modules/hosted-control-planes-overview.adoc
+++ b/modules/hosted-control-planes-overview.adoc
@@ -10,7 +10,7 @@
 
 You can use hosted control planes for Red Hat {product-title} to reduce management costs, optimize cluster deployment time, and separate management and workload concerns so that you can focus on your applications.
 
-You can enable hosted control planes as a Technology Preview feature by using the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#doc-wrapper[multicluster engine for Kubernetes operator version 2.0 or later] on Amazon Web Services (AWS).
+You can enable hosted control planes as a Technology Preview feature by using the link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#cluster_mce_overview[multicluster engine for Kubernetes operator version 2.0 or later] on Amazon Web Services (AWS).
 
 :FeatureName: Hosted control planes
 include::snippets/technology-preview.adoc[]

--- a/modules/sriov-operator-hosted-control-planes.adoc
+++ b/modules/sriov-operator-hosted-control-planes.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/hardware_networks/configuring-sriov-operator.adoc
+// * hosted-control-planes/hcp-managing.adoc
 
 :_content-type: PROCEDURE
 [id="sriov-operator-hosted-control-planes_{context}"]
@@ -14,7 +15,7 @@ After you configure and deploy your hosting service cluster, you can create a su
 
 .Prerequisites
 
-You have link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosted-control-planes-configure[configured and deployed] the hosted cluster.
+You must configure and deploy the hosted cluster on AWS. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring the hosting cluster on AWS (Technology Preview)].
 
 .Procedure
 

--- a/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
+++ b/modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc
@@ -13,7 +13,7 @@
 
 * You have logged in to the hub cluster as a user with `cluster-admin` privileges.
 
-* You have enabled the assisted service on the hub cluster. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#enable-cim[Enabling the Central Infrastructure Management Service].
+* You have enabled the assisted service on the hub cluster. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#enable-cim[Enabling the Central Infrastructure Management service].
 
 .Procedure
 

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -201,7 +201,7 @@ For clusters managed by the Assisted Installer, you can add worker nodes by usin
 
 For clusters managed by the multicluster engine for Kubernetes, you can add worker nodes by using the dedicated multicluster engine console.
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#scale-hosts-infrastructure-env[Scaling hosts to an infrastructure environment]
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#scale-hosts-infrastructure-env[Scaling hosts to an infrastructure environment]
 
 ////
 [id="default-crds_{context}"]

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -30,4 +30,4 @@ include::modules/advanced-node-tuning-hosted-cluster.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-For more information about hosted control planes, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#hosted-control-planes-intro[Hosted control planes for Red Hat OpenShift Container Platform (Technology Preview)].
+For more information about hosted control planes, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-intro[Hosted control planes (Technology Preview)].

--- a/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
@@ -47,7 +47,7 @@ include::modules/ztp-site-cleanup.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For information about removing a cluster, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management].
+* For information about removing a cluster, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#remove-managed-cluster[Removing a cluster from management].
 
 include::modules/ztp-removing-obsolete-content.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
@@ -45,7 +45,7 @@ include::modules/ztp-precaching-downloading-artifacts.adoc[leveloffset=+1]
 
 * To access the online Red Hat registries, see link:https://console.redhat.com/openshift/downloads#tool-pull-secret[OpenShift installation customization tools].
 
-* For more information about using the multicluster engine, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.7/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with the multicluster engine operator].
+* For more information about using the multicluster engine, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#mce-intro[About cluster lifecycle with the multicluster engine operator].
 
 include::modules/ztp-precaching-ztp-config.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5529
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
Note: I didn't include a preview link to every file because in many cases, the only change was to change the version from 2.7 to 2.8 in the URL.
- https://60852--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/index.html
- https://60852--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-configuring.html#hcp-configuring-virt
- https://60852--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-managing.html#sriov-operator-hosted-control-planes_hcp-managing
- https://60852--docspreview.netlify.app/openshift-enterprise/latest/architecture/control-plane.html#hosted-control-planes-overview_control-plane
- https://60852--docspreview.netlify.app/openshift-enterprise/latest/architecture/mce-overview-ocp.html
- https://60852--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-managing.html#delete-hosted-cluster_hcp-managing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: The ACM docs team doesn't have dedicated QE, so I requested review from one of the writers. She approved this PR.
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR updates links from the OCP docs to the RHACM docs. The release schedule for RHACM is roughly a month behind the OCP schedule, so this PR ensures that any links in OCP point to the latest version of the RHACM docs, which went GA on June 15.

This PR also adds links to new hosted control planes docs that were published as part of RHACM 2.8. Also, I added the standard Technology Preview admonition to the "Managing hosted control planes" page, as it was missing.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
