### PR TITLE
OSDOCS-3366: Adding steps to check kubelet cert expirations

### DIFF
--- a/modules/graceful-shutdown.adoc
+++ b/modules/graceful-shutdown.adoc
@@ -33,18 +33,68 @@ If your cluster fails to recover, follow the steps to restore to a previous clus
 
 .Procedure
 
-. If you are shutting the cluster down for an extended period, determine the date on which certificates expire.
+. If you plan to shut down the cluster for an extended period of time, determine the date that cluster certificates expire.
++
+You must restart the cluster prior to the date that certificates expire. As the cluster restarts, the process might require you to manually approve the pending certificate signing requests (CSRs) to recover kubelet certificates.
+
+.. Check the expiration date for the `kube-apiserver-to-kubelet-signer` CA certificate:
 +
 [source,terminal]
 ----
-$ oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-signer -o jsonpath='{.metadata.annotations.auth\.openshift\.io/certificate-not-after}'
+$ oc -n openshift-kube-apiserver-operator get secret kube-apiserver-to-kubelet-signer -o jsonpath='{.metadata.annotations.auth\.openshift\.io/certificate-not-after}{"\n"}'
 ----
 +
 .Example output
+[source,terminal]
 ----
-2022-08-05T14:37:50Zuser@user:~ $ <1>
+2023-08-05T14:37:50Z
 ----
-<1> To ensure that the cluster can restart gracefully, plan to restart it on or before the specified date. As the cluster restarts, the process might require you to manually approve the pending certificate signing requests (CSRs) to recover kubelet certificates.
+
+.. Check the expiration date for the kubelet certificates:
+
+... Start a debug session for a control plane node by running the following command:
++
+[source,terminal]
+----
+$ oc debug node/<node_name>
+----
+
+... Change your root directory to `/host` by running the following command:
++
+[source,terminal]
+----
+sh-4.4# chroot /host
+----
+
+... Check the kubelet client certificate expiration date by running the following command:
++
+[source,terminal]
+----
+sh-5.1# openssl x509 -in /var/lib/kubelet/pki/kubelet-client-current.pem -noout -enddate
+----
++
+.Example output
+[source,terminal]
+----
+notAfter=Jun  6 10:50:07 2023 GMT
+----
+
+... Check the kubelet server certificate expiration date by running the following command:
++
+[source,terminal]
+----
+sh-5.1# openssl x509 -in /var/lib/kubelet/pki/kubelet-server-current.pem -noout -enddate
+----
++
+.Example output
+[source,terminal]
+----
+notAfter=Jun  6 10:50:07 2023 GMT
+----
+
+... Exit the debug session.
+
+... Repeat these steps to check certificate expiration dates on all control plane nodes. To ensure that the cluster can restart gracefully, plan to restart it before the earliest certificate expiration date.
 
 . Shut down all of the nodes in the cluster. You can do this from your cloud provider's web console, or run the following loop:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-3366

Link to docs preview:
Preview: https://60860--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/graceful-cluster-shutdown.html#graceful-shutdown_graceful-shutdown-cluster

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
