### PR TITLE
OSDOCS#14494: Removed references to FIP across the doc set

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
@@ -18,9 +18,9 @@ The Agent-based Installer can also optionally generate or accept Zero Touch Prov
 
 include::modules/understanding-agent-install.adoc[leveloffset=+1]
 
-include::modules/agent-installer-fips-compliance.adoc[leveloffset=+1]
+// include::modules/agent-installer-fips-compliance.adoc[leveloffset=+1]
 
-include::modules/agent-installer-configuring-fips-compliance.adoc[leveloffset=+1]
+// include::modules/agent-installer-configuring-fips-compliance.adoc[leveloffset=+1]
 
 [discrete]
 [role="_additional-resources"]

--- a/modules/cluster-logging-feature-reference.adoc
+++ b/modules/cluster-logging-feature-reference.adoc
@@ -18,16 +18,19 @@ The following outputs are supported:
 == Enabling Vector
 Vector is not enabled by default. Use the following steps to enable Vector on your {product-title} cluster.
 
+////
 [IMPORTANT]
 ====
 Vector does not support FIPS Enabled Clusters.
 ====
+////
+
 
 .Prerequisites
 
 * {product-title}: 4.13
 * {logging-title-uc}: 5.4
-* FIPS disabled
+// * FIPS disabled
 
 .Procedure
 

--- a/modules/cluster-logging-vector-tech-preview.adoc
+++ b/modules/cluster-logging-vector-tech-preview.adoc
@@ -23,16 +23,18 @@ The following outputs are supported:
 == Enabling Vector
 Vector is not enabled by default. Use the following steps to enable Vector on your {product-title} cluster.
 
+////
 [IMPORTANT]
 ====
 Vector does not support FIPS Enabled Clusters.
 ====
+////
 
 .Prerequisites
 
 * {product-title}: 4.13
 * {logging-title-uc}: 5.4
-* FIPS disabled
+// * FIPS disabled
 
 .Procedure
 

--- a/modules/compliance-filtering-results.adoc
+++ b/modules/compliance-filtering-results.adoc
@@ -51,18 +51,15 @@ nist-moderate-modified-master-configure-crypto-policy          FAIL     high
 nist-moderate-modified-master-coreos-pti-kernel-argument       FAIL     high
 nist-moderate-modified-master-disable-ctrlaltdel-burstaction   FAIL     high
 nist-moderate-modified-master-disable-ctrlaltdel-reboot        FAIL     high
-nist-moderate-modified-master-enable-fips-mode                 FAIL     high
 nist-moderate-modified-master-no-empty-passwords               FAIL     high
 nist-moderate-modified-master-selinux-state                    FAIL     high
 nist-moderate-modified-worker-configure-crypto-policy          FAIL     high
 nist-moderate-modified-worker-coreos-pti-kernel-argument       FAIL     high
 nist-moderate-modified-worker-disable-ctrlaltdel-burstaction   FAIL     high
 nist-moderate-modified-worker-disable-ctrlaltdel-reboot        FAIL     high
-nist-moderate-modified-worker-enable-fips-mode                 FAIL     high
 nist-moderate-modified-worker-no-empty-passwords               FAIL     high
 nist-moderate-modified-worker-selinux-state                    FAIL     high
 ocp4-moderate-configure-network-policies-namespaces            FAIL     high
-ocp4-moderate-fips-mode-enabled-on-all-nodes                   FAIL     high
 ----
 
 List all failing checks that must be remediated manually:

--- a/modules/ibmz-configure-nbde-with-static-ip.adoc
+++ b/modules/ibmz-configure-nbde-with-static-ip.adoc
@@ -77,12 +77,24 @@ endif::ibm-z-kvm[]
 ----
 ifdef::ibm-z-kvm[]
 <1>  The cipher option is only required if FIPS mode is enabled. Omit the entry if FIPS is disabled.
-<2> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<2> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
++
+[IMPORTANT]
+====
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 has not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
+====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 endif::ibm-z-kvm[]
 ifndef::ibm-z-kvm[]
 <1>  The cipher option is only required if FIPS mode is enabled. Omit the entry if FIPS is disabled.
 <2> For installations on DASD-type disks, replace with `device: /dev/disk/by-label/root`.
-<3> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<3> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
++
+[IMPORTANT]
+====
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 has not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
+====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 endif::ibm-z-kvm[]
 
 . Create a customized initramfs file to boot the machine, by running the following command:

--- a/modules/images-other-jenkins-env-var.adoc
+++ b/modules/images-other-jenkins-env-var.adoc
@@ -92,8 +92,7 @@ By default, the JVM sets the initial heap size.
 |Default:
 `image-registry.openshift-image-registry.svc:5000/openshift/java:latest`
 
-|`JAVA_FIPS_OPTIONS`
-|Setting this value controls how the JVM operates when running on a FIPS node. For more information, see link:https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk[Configure OpenJDK 11 in FIPS mode].
-|Default: `-Dcom.redhat.fips=false`
-
+// |`JAVA_FIPS_OPTIONS`
+// |Setting this value controls how the JVM operates when running on a FIPS node. For more information, see link:https://access.redhat.com/documentation/en-us/openjdk/11/html-single/configuring_openjdk_11_on_rhel_with_fips/index#config-fips-in-openjdk[Configure OpenJDK 11 in FIPS mode].
+// |Default: `-Dcom.redhat.fips=false`
 |===

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -359,12 +359,18 @@ an unknown AWS region. The endpoint URL must use the `https` protocol and the
 host must trust the certificate.
 <12> The ID of your existing Route 53 private hosted zone. Providing an existing hosted zone requires that you supply your own VPC and the hosted zone is already associated with the VPC prior to installing your cluster. If undefined, the installation program creates a new hosted zone.
 ifndef::openshift-origin[]
-<13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+//====
 <14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -375,12 +381,18 @@ ifndef::vpc,restricted,aws-outposts[]
 <9> The ID of the AMI used to boot machines for the cluster. If set, the AMI must belong to the same region as the cluster.
 <10> The AWS service endpoints. Custom endpoints are required when installing to an unknown AWS region. The endpoint URL must use the `https` protocol and the host must trust the certificate.
 ifndef::openshift-origin[]
-<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -209,12 +209,18 @@ ifdef::gov[]
 endif::gov[]
 ifdef::vnet[]
 ifndef::openshift-origin[]
-<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+//====
 <15> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -223,12 +229,18 @@ endif::openshift-origin[]
 endif::vnet[]
 ifdef::private[]
 ifndef::openshift-origin[]
-<15> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<15> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} ///deployments on the `x86_64` architecture.
+//====
 <16> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -237,12 +249,18 @@ endif::openshift-origin[]
 endif::private[]
 ifdef::gov[]
 ifndef::openshift-origin[]
-<16> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<16> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <17> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -251,12 +269,18 @@ endif::openshift-origin[]
 endif::gov[]
 ifndef::vnet,private,gov[]
 ifndef::openshift-origin[]
-<10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -91,12 +91,18 @@ endif::openshift-origin[]
 <9> Specify the Azure Stack Hub environment as your target platform.
 <10> Specify the pull secret required to authenticate your cluster.
 ifndef::openshift-origin[]
-<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <12> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
 <13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
@@ -184,12 +190,18 @@ endif::openshift-origin[]
 <11> The URL of a storage blob in the Azure Stack environment that contains an {op-system} VHD.
 <12> The pull secret required to authenticate your cluster.
 ifndef::openshift-origin[]
-<13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-bare-metal-agent-installer-config-yaml.adoc
+++ b/modules/installation-bare-metal-agent-installer-config-yaml.adoc
@@ -92,13 +92,18 @@ platform:
     - 2001:DB8::5
 ----
 ====
-<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
-
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <12> This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
 <13> The SSH public key for the `core` user in {op-system-first}.
 +

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -258,12 +258,18 @@ ifdef::rhv[RHV infrastructure.]
 Clusters that are installed with the platform type `none` are unable to use some features, such as managing compute machines with the Machine API. This limitation applies even if the compute machines that are attached to the cluster are installed on a platform that would normally support the feature. This parameter cannot be changed after installation.
 ====
 ifndef::openshift-origin[]
-<12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on `x86_64`, `ppc64le`, and `s390x` architectures.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on `x86_64`, `ppc64le`, and `s390x` architectures.
+//====
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -734,19 +734,23 @@ Not all CCO modes are supported for all cloud providers. For more information ab
 If your AWS account has service control policies (SCP) enabled, you must configure the `credentialsMode` parameter to `Mint`, `Passthrough` or `Manual`.
 ====
 |`Mint`, `Passthrough`, `Manual` or an empty string (`""`).
-ifndef::openshift-origin,ibm-power-vs[]
-|`fips`
-|Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+// ifndef::openshift-origin,ibm-power-vs[]
+// |`fips`
+// |Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+////
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on `x86_64`, `ppc64le`, and `s390x` architectures.
 ====
+////
+////
 [NOTE]
 ====
 If you are using Azure File storage, you cannot enable FIPS mode.
 ====
-|`false` or `true`
-endif::openshift-origin,ibm-power-vs[]
+////
+// |`false` or `true`
+// endif::openshift-origin,ibm-power-vs[]
 |`imageContentSources`
 |Sources and repositories for the release-image content.
 |Array of objects. Includes a `source` and, optionally, `mirrors`, as described in the following rows of this table.
@@ -900,7 +904,7 @@ belong to the same region as the cluster. This is required for regions that requ
 
 |`platform.aws.serviceEndpoints.name`
 |The AWS service endpoint name. Custom endpoints are only required for cases
-where alternative AWS endpoints, like FIPS, must be used. Custom API endpoints
+where alternative AWS endpoints must be used. Custom API endpoints
 can be specified for EC2, S3, IAM, Elastic Load Balancing, Tagging, Route 53,
 and STS AWS services.
 |Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] name.
@@ -925,13 +929,13 @@ You can add up to 25 user defined tags during installation. The remaining 25 tag
 
 
 |`platform.aws.subnets`
-|If you provide the VPC instead of allowing the installation program to create the VPC for you, specify the subnet for the cluster to use. The subnet must be part of the same `machineNetwork[].cidr` ranges that you specify. 
+|If you provide the VPC instead of allowing the installation program to create the VPC for you, specify the subnet for the cluster to use. The subnet must be part of the same `machineNetwork[].cidr` ranges that you specify.
 
-For a standard cluster, specify a public and a private subnet for each availability zone. 
+For a standard cluster, specify a public and a private subnet for each availability zone.
 
-For a private cluster, specify a private subnet for each availability zone. 
+For a private cluster, specify a private subnet for each availability zone.
 
-For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to this list to ensure edge machine pool creation. 
+For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to this list to ensure edge machine pool creation.
 |Valid subnet IDs.
 
 |====
@@ -1121,9 +1125,9 @@ For more information about the support scope of Red Hat Technology Preview featu
 // Undefine {FeatureName} attribute, so that any mistakes are easily spotted
 :!FeatureName:
 
-{rh-openstack-first} deployments do not have a single implementation of failure domains. Instead, availability zones are defined individually for each service, such as the compute service, Nova; the networking service, Neutron; and the storage service, Cinder. 
+{rh-openstack-first} deployments do not have a single implementation of failure domains. Instead, availability zones are defined individually for each service, such as the compute service, Nova; the networking service, Neutron; and the storage service, Cinder.
 
-Beginning with {product-title} 4.13, there is a unified definition of failure domains for {rh-openstack} deployments that covers all supported availability zone types. You can use failure domains to control related aspects of Nova, Neutron, and Cinder configurations from a single place. 
+Beginning with {product-title} 4.13, there is a unified definition of failure domains for {rh-openstack} deployments that covers all supported availability zone types. You can use failure domains to control related aspects of Nova, Neutron, and Cinder configurations from a single place.
 
 In {rh-openstack}, a port describes a network connection and maps to an interface inside a compute machine. A port also:
 

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -202,12 +202,18 @@ ifdef::restricted[]
 endif::restricted[]
 ifdef::vpc[]
 ifndef::openshift-origin[]
-<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default ///Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -216,12 +222,18 @@ endif::openshift-origin[]
 endif::vpc[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -230,12 +242,18 @@ endif::openshift-origin[]
 endif::restricted[]
 ifndef::vpc,restricted[]
 ifndef::openshift-origin[]
-<8> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<8> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -86,12 +86,18 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 <7> Specify the main project where the VM instances reside.
 <8> Specify the region that your VPC network is in.
 ifndef::openshift-origin[]
-<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+//====
 <10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -87,12 +87,18 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 ====
 <5> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
 ifndef::openshift-origin[]
-<6> Enables or disables FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<6> Enables or disables FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+//====
 <7> Optional: provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -175,12 +181,18 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 <10> Specify the name of the existing subnets to which to deploy the control plane machines. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
 <11> Specify the name of the existing subnets to which to deploy the compute machines. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
 ifndef::openshift-origin[]
-<12> Enables or disables FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<12> Enables or disables FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <13> Optional: provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -265,12 +277,18 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 <12> Specify the name of the existing subnets to which to deploy the compute machines. The subnets must belong to the VPC that you specified. Specify a subnet for each availability zone in the region.
 <13> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster. The default value is `External`.
 ifndef::openshift-origin[]
-<14> Enables or disables FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<14> Enables or disables FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <15> Optional: provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]

--- a/modules/installation-nutanix-config-yaml.adoc
+++ b/modules/installation-nutanix-config-yaml.adoc
@@ -117,12 +117,18 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 ifndef::openshift-origin[]
 <7> Optional: Specify a project with which VMs are associated. Specify either `name` or `uuid` for the project type, and then provide the corresponding UUID or project name. You can associate projects to compute machines, control plane machines, or all machines.
 <8> Optional: By default, the installation program downloads and installs the {op-system-first} image. If Prism Central does not have internet access, you can override the default behavior by hosting the {op-system} image on any HTTP server and pointing the installation program to the image.
-<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <10> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
@@ -260,12 +266,18 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 <9> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
 ifndef::openshift-origin[]
-<10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 <11> Optional: You can provide the `sshKey` value that you use to access the machines in your cluster.
 +
 [NOTE]

--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -44,7 +44,8 @@ This feature:
 * Is supported on {op-system-first} systems only
 * Sets up disk encryption during the manifest installation phase, encrypting all data written to disk, from first boot forward
 * Requires no user intervention for providing passphrases
-* Uses AES-256-XTS encryption, or AES-256-CBC if FIPS mode is enabled
+* Uses AES-256-XTS encryption
+//or AES-256-CBC if FIPS mode is enabled
 
 [id="installation-special-config-encryption-threshold_{context}"]
 === Configuring an encryption threshold
@@ -78,13 +79,14 @@ boot_device:
         thumbprint: VCJsvZFjBSIHSldw78rOrq7h2ZF
     threshold: 2 <4>
 openshift:
-  fips: true
+  fips: true <5>
 ----
 <1> Set this field to the instruction set architecture of the cluster nodes.
 Some examples include, `x86_64`, `aarch64`, or `ppc64le`.
 <2> Include this field if you want to use a Trusted Platform Module (TPM) to encrypt the root file system.
 <3> Include this section if you want to use one or more Tang servers.
 <4> Specify the minimum number of TPM v2 and Tang encryption conditions required for decryption to occur.
+<5> {product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 
 [IMPORTANT]
 ====
@@ -250,10 +252,18 @@ For more details, see "About disk mirroring".
 +
 [IMPORTANT]
 ====
-If you are configuring nodes to use both disk encryption and mirroring, both features must be configured in the same Butane config.
-If you are configuring disk encryption on a node with FIPS mode enabled, you must include the `fips` directive in the same Butane config, even if FIPS mode is also enabled in a separate manifest.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
-
++
+[IMPORTANT]
+====
+If you are configuring nodes to use both disk encryption and mirroring, both features must be configured in the same Butane config.
+====
+//[IMPORTANT]
+//====
+//If you are configuring nodes to use both disk encryption and mirroring, both features must be configured in the same Butane config.
+//If you are configuring disk encryption on a node with FIPS mode enabled, you must include the `fips` directive in the same Butane config, even if FIPS mode is also enabled in a separate manifest.
+//====
 . Create a control plane or compute node manifest from the corresponding Butane config and save it to the `<installation_directory>/openshift` directory.
 For example, to create a manifest for the compute nodes, run the following command:
 +
@@ -332,7 +342,7 @@ In such situations, it is possible to access nodes using `ssh core@<node>.<clust
 <1> The encryption format.
 When the TPM v2 or Tang encryption modes are enabled, the {op-system} boot disks are encrypted using the LUKS2 format.
 <2> The encryption algorithm used to encrypt the LUKS2 volume.
-The `aes-cbc-essiv:sha256` cipher is used if FIPS mode is enabled.
+// The `aes-cbc-essiv:sha256` cipher is used if FIPS mode is enabled.
 <3> The device that contains the encrypted LUKS2 volume.
 If mirroring is enabled, the value will represent a software mirror device, for example `/dev/md126`.
 +

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -165,12 +165,18 @@ value must match the number of control plane machines that you deploy.
 <12> The password associated with the vSphere user.
 <13> The vSphere disk provisioning method.
 ifndef::openshift-origin[]
-<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
 ====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -50,19 +50,21 @@ The kinds of components that MCO can change include:
 +
 [IMPORTANT]
 ====
-* Changing SSH keys by using a machine config is supported only for the `core` user. 
+* Changing SSH keys by using a machine config is supported only for the `core` user.
 * Adding new users by using a machine config is not supported.
 ====
 * **kernelArguments**: Add arguments to the kernel command line when {product-title} nodes boot.
 * **kernelType**: Optionally identify a non-standard kernel to use instead of the standard kernel. Use `realtime` to use the RT kernel (for RAN). This is only supported on select platforms.
+////
 ifndef::openshift-origin[]
-* **fips**: Enable link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#using-the-system-wide-cryptographic-policies_security-hardening[FIPS] mode. FIPS should be set at installation-time setting and not a post-installation procedure.
+ * **fips**: Enable link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#using-the-system-wide-cryptographic-policies_security-hardening[FIPS] mode. FIPS should be set at installation-time setting and not a post-installation procedure.
 
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on `x86_64`, `ppc64le`, and `s390x` architectures.
 ====
 endif::openshift-origin[]
+////
 * **extensions**: Extend {op-system} features by adding selected pre-packaged software. For this feature, available extensions include link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#protecting-systems-against-intrusive-usb-devices_security-hardening[usbguard] and kernel modules.
 * **Custom resources (for `ContainerRuntime` and `Kubelet`)**: Outside of machine configs, MCO manages two special custom resources for modifying CRI-O container runtime settings (`ContainerRuntime` CR) and the Kubelet service (`Kubelet` CR).
 

--- a/modules/osdk-csv-manual-annotations.adoc
+++ b/modules/osdk-csv-manual-annotations.adoc
@@ -33,12 +33,14 @@ The following table lists Operator metadata annotations that can be manually def
 - `cnf`: Operator provides a Cloud-native Network Functions (CNF) Kubernetes plugin.
 - `cni`: Operator provides a Container Network Interface (CNI) Kubernetes plugin.
 - `csi`: Operator provides a Container Storage Interface (CSI) Kubernetes plugin.
-- `fips`: Operator accepts the FIPS mode of the underlying platform and works on nodes that are booted into FIPS mode.
+// - `fips`: Operator accepts the FIPS mode of the underlying platform and works on nodes that are booted into FIPS mode.
 
+////
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on `x86_64`, `ppc64le`, and `s390x` architectures.
 ====
+////
 - `proxy-aware`: Operator supports running on a cluster behind a proxy. Operator accepts the standard proxy environment variables  `HTTP_PROXY` and `HTTPS_PROXY`, which Operator Lifecycle Manager (OLM) provides to the Operator automatically when the cluster is configured to use a proxy. Required environment variables are passed down to Operands for managed workloads.
 
 |`operators.openshift.io/valid-subscription`

--- a/modules/rhcos-about.adoc
+++ b/modules/rhcos-about.adoc
@@ -25,7 +25,7 @@ The following list describes key features of the {op-system} operating system:
 
 * **CRI-O container runtime**: Although {op-system} contains features for running the OCI- and libcontainer-formatted containers that Docker requires, it incorporates the CRI-O container engine instead of the Docker container engine. By focusing on features needed by Kubernetes platforms, such as {product-title}, CRI-O can offer specific compatibility with different Kubernetes versions. CRI-O also offers a smaller footprint and reduced attack surface than is possible with container engines that offer a larger feature set. At the moment, CRI-O is the only engine available within {product-title} clusters.
 +
-CRI-O can use either the runC or crun container runtime to start and manage containers. For information about how to enable crun, see the documentation for creating a `ContainerRuntimeConfig` CR. 
+CRI-O can use either the runC or crun container runtime to start and manage containers. For information about how to enable crun, see the documentation for creating a `ContainerRuntimeConfig` CR.
 
 * **Set of container tools**: For tasks such as building, copying, and otherwise managing containers, {op-system} replaces the Docker CLI tool with a compatible set of container tools. The podman CLI tool supports many container runtime features, such as running, starting, stopping, listing, and removing containers and container images. The skopeo CLI tool can copy, authenticate, and sign images. You can use the `crictl` CLI tool to work with containers and pods from the CRI-O container engine. While direct use of these tools in {op-system} is discouraged, you can use them for debugging purposes.
 
@@ -64,7 +64,8 @@ Day-1 customizations can be done through Ignition configs and manifest files dur
 Here are examples of customizations you could do on day 1:
 
 * **Kernel arguments**: If particular kernel features or tuning is needed on nodes when the cluster first boots.
-* **Disk encryption**: If your security needs require that the root file system on the nodes are encrypted, such as with FIPS support.
+// * **Disk encryption**: If your security needs require that the root file system on the nodes are encrypted, such as with FIPS support.
+* **Disk encryption**: If your security needs require that the root file system on the nodes are encrypted.
 * **Kernel modules**: If a particular hardware device, such as a network card or video card, does not have a usable module available by default in the Linux kernel.
 * **Chronyd**: If you want to provide specific clock settings to your nodes, such as the location of time servers.
 

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -29,12 +29,14 @@ If you have {op-system-base} 7 compute machines that were previously supported i
 
 For the most recent list of major functionality that has been deprecated or removed within {product-title}, refer to the _Deprecated and removed features_ section of the {product-title} release notes.
 ====
-** If you deployed {product-title} in FIPS mode, you must enable FIPS on the {op-system-base} machine before you boot it. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in the {op-system-base} 8 documentation.
+// ** If you deployed {product-title} in FIPS mode, you must enable FIPS on the {op-system-base} machine before you boot it. See link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/security_hardening/assembly_installing-a-rhel-8-system-with-fips-mode-enabled_security-hardening[Installing a RHEL 8 system with FIPS mode enabled] in the {op-system-base} 8 documentation.
 
+////
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on `x86_64`, `ppc64le`, and `s390x` architectures.
 ====
+////
 endif::[]
 ** NetworkManager 1.0 or later.
 ** 1 vCPU.

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -73,12 +73,14 @@ The following table describes the interactive cluster creation mode options:
 |`Host prefix`
 |Specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine. For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes and 512 pods per node, both of which are beyond our supported maximums. For information on the supported maximums, see the Additional resources section below.
 
-|`fips (optional)`
-|Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with RHCOS instead.
+// |`fips (optional)`
+// |Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with RHCOS instead.
+////
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
+////
 
 |`Encrypt etcd data (optional)`
 |In {product-title}, the control plane storage is encrypted at rest by default and this includes encryption of the etcd volumes. You can additionally enable the `Encrypt etcd data` option to encrypt the key values for some resources in etcd, but not the keys.

--- a/modules/security-compliance-nist.adoc
+++ b/modules/security-compliance-nist.adoc
@@ -7,12 +7,15 @@
 [id="security-compliance-nist_{context}"]
 = Understanding compliance and risk management
 
+////
 ifeval::["{context}" == "understanding-sandboxed-containers"]
 {sandboxed-containers-first} can be used on FIPS enabled clusters.
 
 When running in FIPS mode, {sandboxed-containers-first} components, VMs, and VM images are adapted to comply with FIPS.
 endif::[]
+////
 
+////
 ifndef::openshift-origin[]
 FIPS compliance is one of the most critical components required in
 highly secure environments, to ensure that only supported cryptographic
@@ -23,6 +26,7 @@ technologies are allowed on nodes.
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 endif::openshift-origin[]
+////
 
 To understand Red Hat's view of {product-title} compliance frameworks, refer
 to the Risk Management and Regulatory Readiness chapter of the

--- a/modules/security-hosts-vms-openshift.adoc
+++ b/modules/security-hosts-vms-openshift.adoc
@@ -8,12 +8,13 @@ When you deploy {product-title}, you have the choice of an
 installer-provisioned infrastructure (there are several available platforms)
 or your own user-provisioned infrastructure.
 ifndef::openshift-origin[]
-Some low-level security-related configuration, such as enabling FIPS
-compliance or adding kernel modules required at first boot, might 
-benefit from a user-provisioned infrastructure.
+//Some low-level security-related configuration, such as enabling FIPS
+//compliance or adding kernel modules required at first boot, might
+//benefit from a user-provisioned infrastructure.
+Some low-level security-related configuration, such as adding kernel modules required at first boot, might benefit from a user-provisioned infrastructure.
 endif::[]
 ifdef::openshift-origin[]
-Some low-level security-related configuration, such as adding kernel modules required at first boot, might 
+Some low-level security-related configuration, such as adding kernel modules required at first boot, might
 benefit from a user-provisioned infrastructure.
 endif::[]
 Likewise, user-provisioned infrastructure is appropriate for disconnected {product-title} deployments.
@@ -34,7 +35,7 @@ Examples of security-related configuration changes you can do in this way includ
 
 * Adding kernel modules
 
-* Enabling support for FIPS cryptography
+// * Enabling support for FIPS cryptography
 
 * Configuring disk encryption
 

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -191,14 +191,13 @@ endif::openshift-origin[]
 $ ssh-keygen -t ed25519 -N '' -f <path>/<file_name> <1>
 ----
 <1> Specify the path and file name, such as `~/.ssh/id_ed25519`, of the new SSH key. If you have an existing key pair, ensure your public key is in the your `~/.ssh` directory.
-+
-ifndef::ibm-power-vs[]
-[NOTE]
-====
-If you plan to install an {product-title} cluster that uses FIPS Validated / Modules in Process cryptographic libraries on the `x86_64` architecture, do not create a key that uses the `ed25519` algorithm. Instead, create a key that uses the `rsa` or `ecdsa` algorithm.
-====
-endif::ibm-power-vs[]
-
+//+
+//ifndef::ibm-power-vs[]
+//[NOTE]
+//====
+//If you plan to install an {product-title} cluster that uses FIPS Validated / Modules in Process cryptographic libraries on the `x86_64` architecture, do not create a key that uses the `ed25519` algorithm. Instead, create a key that uses the `rsa` or `ecdsa` algorithm.
+//====
+//endif::ibm-power-vs[]
 . View the public SSH key:
 +
 [source,terminal]
@@ -232,13 +231,13 @@ $ eval "$(ssh-agent -s)"
 ----
 Agent pid 31874
 ----
-+
-ifndef::ibm-power-vs[]
-[NOTE]
-====
-If your cluster is in FIPS mode, only use FIPS-compliant algorithms to generate the SSH key. The key must be either RSA or ECDSA.
-====
-endif::ibm-power-vs[]
+//+
+//ifndef::ibm-power-vs[]
+//[NOTE]
+//====
+//If your cluster is in FIPS mode, only use FIPS-compliant algorithms to generate the SSH key. The key must be either RSA or ECDSA.
+//====
+//endif::ibm-power-vs[]
 
 . Add your SSH private key to the `ssh-agent`:
 +

--- a/rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.adoc
+++ b/rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.adoc
@@ -71,9 +71,9 @@ Type::
 | ``
 | List of additional features that can be enabled on host
 
-| `fips`
-| `boolean`
-| FIPS controls FIPS mode
+// | `fips`
+// | `boolean`
+// | FIPS controls FIPS mode
 
 | `kernelArguments`
 | ``
@@ -262,7 +262,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../machine_apis/machineconfig-machineconfiguration-openshift-io-v1.adoc#machineconfig-machineconfiguration-openshift-io-v1[`MachineConfig`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -331,7 +331,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.DeleteOptions[`DeleteOptions`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -403,7 +403,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../objects/index.adoc#io.k8s.apimachinery.pkg.apis.meta.v1.Patch[`Patch`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -444,7 +444,7 @@ Description::
 | Parameter | Type | Description
 | `body`
 | xref:../machine_apis/machineconfig-machineconfiguration-openshift-io-v1.adoc#machineconfig-machineconfiguration-openshift-io-v1[`MachineConfig`] schema
-| 
+|
 |===
 
 .HTTP responses
@@ -458,5 +458,3 @@ Description::
 | 401 - Unauthorized
 | Empty
 |===
-
-

--- a/security/container_security/security-hardening.adoc
+++ b/security/container_security/security-hardening.adoc
@@ -43,7 +43,8 @@ include::modules/security-hardening-how.adoc[leveloffset=+1]
 * xref:../../installing/install_config/installing-customizing.adoc#installing-customizing[Customizing nodes]
 * xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-kernel-arguments_nodes-nodes-managing[Adding kernel arguments to Nodes]
 ifndef::openshift-origin[]
-* xref:../../installing/installing_aws/installing-aws-customizations.adoc#installation-configuration-parameters_installing-aws-customizations[Installation configuration parameters] - see `fips`
+* xref:../../installing/installing_aws/installing-aws-customizations.adoc#installation-configuration-parameters_installing-aws-customizations[Installation configuration parameters]
+//- see `fips`
 * link:https://access.redhat.com/articles/3359851[{op-system-base} core crypto components]
 ////
  * xref:../../installing/installing-fips.adoc#installing-fips[Support for FIPS cryptography]

--- a/storage/container_storage_interface/persistent-storage-csi-azure-file.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-azure-file.adoc
@@ -23,7 +23,7 @@ Azure File CSI Driver Operator does not support:
 
 * Network File System (NFS): {product-title} does not deploy a NFS-backed storage class.
 
-* Running on nodes with FIPS mode enabled.
+// * Running on nodes with FIPS mode enabled.
 
 For more information about supported features, see xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#csi-drivers-supported_persistent-storage-csi[Supported CSI drivers and features].
 


### PR DESCRIPTION
Version(s):
4.13

Issue:
This issue addresses [ocpbugs-14494](https://issues.redhat.com/browse/OCPBUGS-14494). Two broad updates where made:
1. With the exception of installation topics that detailed large YAML samples, all inline references to FIPS, its support, and its configuration where commented out of the doc set.
2. In the case of the installation topics that detailed YAML samples [1], the reference to FIPS (typically a parameter that enabled it) was left in with an admonition that repeats the messaging in the release notes: OpenShift Container Platform Branch Build is based on Red Hat Enterprise Linux (RHEL) 9.2. RHEL 9.2 cryptographic modules have not yet been submitted for FIPS validation. A cross reference is provided to the OpenShift release notes.
This approach was taken in the interest of time. The YAML samples are single-sourced and highly conditioned. This approach was discussed with and approved by @knewcomerRH.

Link to docs preview:

While this PR removes references to FIPS in multiple locations, I am including two links as a point of reference for the types of updates that were made:

Content removed:
- [Understanding compliance](https://docs.openshift.com/container-platform/4.13/security/container_security/security-compliance.html) (currently published 4.13 docs)
- [Understanding compliance](https://mjpytlak.github.io/previews/ocpbugs-14494/security/container_security/security-compliance.html) (minus FIPS content)

Sample installation configuration files updated to reference release notes:
- [Sample customized install-config.yaml file for AWS](https://docs.openshift.com/container-platform/4.13/installing/installing_aws/installing-aws-customizations.html#installation-aws-config-yaml_installing-aws-customizations) (currently published 4.13 docs)
- [Sample customized install-config.yaml file for AWS](https://mjpytlak.github.io/previews/ocpbugs-14494/installing/installing_aws/installing-aws-customizations.html#installation-aws-config-yaml_installing-aws-customizations) (repeated messaging from OpenShift release notes in callout 11)

QE review:
- [N/A] QE has approved this change.
