### PR TITLE
[SRVCOM-2490] Add the FIPS note to 1.29 release notes

### DIFF
--- a/modules/serverless-rn-1-29-0.adoc
+++ b/modules/serverless-rn-1-29-0.adoc
@@ -8,6 +8,11 @@
 
 {ServerlessProductName} 1.29 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
 
+[IMPORTANT]
+====
+{ocp-product-title} 4.13 is based on {op-system-base-full} 9.2.  {op-system-base} 9.2 is yet to be submitted for Federal Information Processing Standards (FIPS) validation. Although Red Hat cannot commit to a specific timeframe, we expect to obtain FIPS validation for {op-system-base} 9.0 and {op-system-base} 9.2 modules, and later even minor releases of {op-system-base} 9.x. Information on updates will be available in the link:https://access.redhat.com/articles/2918071[Compliance Activities and Government Standards Knowledgebase article].
+====
+
 [id="new-features-1-29-0_{context}"]
 == New features
 


### PR DESCRIPTION
Version(s):
Serverless 1.29

Issue:
https://issues.redhat.com/browse/SRVCOM-2490

Link to docs preview:
https://60876--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-29-0_serverless-release-notes

QE review:
- [x] QE has approved this change.