### PR TITLE
OCPBUGS-14116: Improving registries.conf explanation

### DIFF
--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -6,7 +6,7 @@
 [id="ztp-configuring-the-cluster-for-a-disconnected-environment_{context}"]
 = Configuring the hub cluster to use a disconnected mirror registry
 
-You can configure the hub cluster to use a disconnected mirror registry for a disconnected environment. 
+You can configure the hub cluster to use a disconnected mirror registry for a disconnected environment.
 
 .Prerequisites
 
@@ -28,23 +28,32 @@ If you enable TLS for the HTTP server, you must confirm the root certificate is 
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: assisted-installer-mirror-config
-  namespace: assisted-installer
+  name: assisted-installer-config-map
+  namespace: "<infrastructure_operator_namespace>" <1>
   labels:
     app: assisted-service
 data:
-  ca-bundle.crt: <certificate> <1>
-  registries.conf: |  <2>
+  ca-bundle.crt: | <2>
+    -----BEGIN CERTIFICATE-----
+    <certificate_contents>
+    -----END CERTIFICATE-----
+
+  registries.conf: | <3>
     unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
 
     [[registry]]
-      location = <mirror_registry_url>  <3>
-      insecure = false
-      mirror-by-digest-only = true
+       prefix = ""
+       location = "quay.io/example-repository" <4>
+       mirror-by-digest-only = true
+
+       [[registry.mirror]]
+       location = "mirror1.registry.corp.com:5000/example-repository" <5>
 ----
-<1> The mirror registry’s certificate used when creating the mirror registry.
-<2> The configuration file for the mirror registry. The mirror registry configuration adds mirror information to `/etc/containers/registries.conf` in the Discovery image. The mirror information is stored in the `imageContentSources` section of the `install-config.yaml` file when passed to the installation program. The Assisted Service pod running on the HUB cluster fetches the container images from the configured mirror registry.  
-<3> The URL of the mirror registry.
+<1> The `ConfigMap` namespace must be the same as the namespace of the Infrastructure Operator.
+<2> The mirror registry’s certificate that is used when creating the mirror registry.
+<3> The configuration file for the mirror registry. The mirror registry configuration adds mirror information to the `/etc/containers/registries.conf` file in the discovery image. The mirror information is stored in the `imageContentSources` section of the `install-config.yaml` file when the information is passed to the installation program. The Assisted Service pod that runs on the hub cluster fetches the container images from the configured mirror registry.
+<4> The URL of the mirror registry. You must use the URL from the `imageContentSources` section by running the `oc adm release mirror` command when you configure the mirror registry. For more information, see the _Mirroring the OpenShift Container Platform image repository_ section.
+<5> The registries defined in the `registries.conf` file must be scoped by repository, not by registry. In this example, both the `quay.io/example-repository` and the `mirror1.registry.corp.com:5000/example-repository` repositories are scoped by the `example-repository` repository.
 +
 This updates `mirrorRegistryRef` in the `AgentServiceConfig` custom resource, as shown below:
 +

--- a/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
@@ -34,6 +34,11 @@ include::modules/ztp-enabling-assisted-installer-service-on-bare-metal.adoc[leve
 
 include::modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the OpenShift Container Platform image repository]
+
 include::modules/ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries.adoc[leveloffset=+1]
 
 include::modules/ztp-preparing-the-hub-cluster-for-ztp.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:  https://issues.redhat.com/browse/OCPBUGS-14116
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://60878--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-preparing-the-hub-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
