### PR TITLE
OCPBUGS 13867: Clarifying --manifests-only depends on --from

### DIFF
--- a/modules/oc-mirror-command-reference.adoc
+++ b/modules/oc-mirror-command-reference.adoc
@@ -69,7 +69,7 @@ The following tables describe the `oc mirror` subcommands and flags:
 |Enable mirroring for local OCI catalogs on disk to the target mirror registry.
 
 |`--manifests-only`
-|Generate manifests for `ImageContentSourcePolicy` objects to configure a cluster to use the mirror registry, but do not actually mirror any images.
+|Generate manifests for `ImageContentSourcePolicy` objects to configure a cluster to use the mirror registry, but do not actually mirror any images. To use this flag, you must pass in an image set archive with the `--from` flag.
 
 |`--max-nested-paths <int>`
 |Specify the maximum number of nested paths for destination registries that limit nested paths. The default is `2`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-13867

From this comment: https://github.com/openshift/openshift-docs/pull/60851#discussion_r1218770364

Link to docs preview:
https://60888--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-command-reference_installing-mirroring-disconnected

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Depends on #60851 being merged to be able to CP to 4.10
