### PR TITLE
OCPBUGS-9194: Workaround for inconsistency in IPv6 addresses for SLAAC dual clusters

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -48,6 +48,8 @@ include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-
 
 include::modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc[leveloffset=+2]
 
+include::modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc[leveloffset=+2]
+
 include::modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc
@@ -1,0 +1,62 @@
+// This is included in the following assemblies:
+//
+// ipi-install-configuration-files.adoc
+
+:_content-type: PROCEDURE
+[id='ipi-install-modifying-install-config-for-slaac-dual-stack-network_{context}']
+= Optional: Configuring address generation modes for SLAAC in dual-stack networks
+
+For dual-stack clusters that use Stateless Address AutoConfiguration (SLAAC), you must specify a global value for the `ipv6.addr-gen-mode` network setting. You can set this value using NMState to configure the ramdisk and the cluster configuration files. If you don't configure a consistent `ipv6.addr-gen-mode` in these locations, IPv6 address mismatches can occur between CSR resources and `BareMetalHost` resources in the cluster. 
+
+.Prerequisites 
+
+* Install the NMState CLI (`nmstate`).
+
+.Procedure
+
+. Optional: Consider testing the NMState YAML syntax with the `nmstatectl gc` command before including it in the `install-config.yaml` file because the installation program will not check the NMState YAML syntax.
+
+.. Create an NMState YAML file:
++
+[source,yaml]
+----
+interfaces:
+- name: eth0 
+  ipv6:
+    addr-gen-mode: <address_mode> <1>
+----
+<1> Replace `<address_mode>` with the type of address generation mode required for IPv6 addresses in the cluster. Valid values are `eui64`, `stable-privacy`, or `random`.
+
+.. Test the configuration file by running the following command:
++
+[source,terminal]
+----
+$ nmstatectl gc <nmstate_yaml_file> <1>
+----
+<1> Replace `<nmstate_yaml_file>` with the name of the test configuration file.
+
+. Add the NMState configuration to the `hosts.networkConfig` section within the install-config.yaml file:
++
+[source,yaml]
+----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
+          username: <user>
+          password: <password>
+          disableCertificateVerification: null
+        bootMACAddress: <NIC1_mac_address>
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: "/dev/sda"
+        networkConfig: 
+          interfaces:
+          - name: eth0
+            ipv6:
+              addr-gen-mode: <address_mode> <1>
+...
+
+----
+<1> Replace `<address_mode>` with the type of address generation mode required for IPv6 addresses in the cluster. Valid values are `eui64`, `stable-privacy`, or `random`.


### PR DESCRIPTION
OCPBUGS-9194:  The IPv6 address in the BMH resource is not the same as the IPv6 address for the CSR in dual-stack clusters using SLAAC. This workaround states you must explicitly set these values in the ramdisk and the node instance to avoid this issue. 

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-9194

Link to docs preview:
https://60903--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#ipi-install-modifying-install-config-for-slaac-dual-stack-network_ipi-install-installation-workflow

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
