### PR TITLE
OCPBUGS#14600 Changes the description of HPA Scaling policy

### DIFF
--- a/modules/nodes-pods-autoscaling-policies.adoc
+++ b/modules/nodes-pods-autoscaling-policies.adoc
@@ -5,7 +5,7 @@
 [id="nodes-pods-autoscaling-policies_{context}"]
 = Scaling policies
 
-The `autoscaling/v2` API allows you to add _scaling policies_ to a horizontal pod autoscaler. A scaling policy controls how the {product-title} horizontal pod autoscaler (HPA) scales pods. Scaling policies allow you to restrict the rate that HPAs scale pods up or down by setting a specific number or specific percentage to scale in a specified period of time. You can also define a _stabilization window_, which uses previously computed desired states to control scaling if the metrics are fluctuating. You can create multiple policies for the same scaling direction, and determine which policy is used, based on the amount of change. You can also restrict the scaling by timed iterations. The HPA scales pods during an iteration, then performs scaling, as needed, in further iterations. 
+The `autoscaling/v2` API allows you to add _scaling policies_ to a horizontal pod autoscaler. A scaling policy controls how the {product-title} horizontal pod autoscaler (HPA) scales pods. Scaling policies allow you to restrict the rate that HPAs scale pods up or down by setting a specific number or specific percentage to scale in a specified period of time. You can also define a _stabilization window_, which uses previously computed desired states to control scaling if the metrics are fluctuating. You can create multiple policies for the same scaling direction, and determine which policy is used, based on the amount of change. You can also restrict the scaling by timed iterations. The HPA scales pods during an iteration, then performs scaling, as needed, in further iterations.
 
 .Sample HPA object with a scaling policy
 [source, yaml]
@@ -40,16 +40,16 @@ spec:
 ...
 ----
 <1> Specifies the direction for the scaling policy, either `scaleDown` or `scaleUp`. This example creates a policy for scaling down.
-<2> Defines the scaling policy. 
+<2> Defines the scaling policy.
 <3> Determines if the policy scales by a specific number of pods or a percentage of pods during each iteration. The default value is `pods`.
-<4> Determines the amount of scaling, either the number of pods or percentage of pods, during each iteration. There is no default value for scaling down by number of pods.
+<4> Limits the amount of scaling, either the number of pods or percentage of pods, during each iteration. There is no default value for scaling down by number of pods.
 <5> Determines the length of a scaling iteration. The default value is `15` seconds.
 <6> The default value for scaling down by percentage is 100%.
 <7> Determines which policy to use first, if multiple policies are defined. Specify `Max` to use the policy that allows the highest amount of change, `Min` to use the policy that allows the lowest amount of change, or `Disabled` to prevent the HPA from scaling in that policy direction. The default value is `Max`.
 <8> Determines the time period the HPA should look back at desired states. The default value is `0`.
 <9> This example creates a policy for scaling up.
-<10> The amount of scaling up by the number of pods. The default value for scaling up the number of pods is 4%.
-<11> The amount of scaling up by the percentage of pods. The default value for scaling up by percentage is 100%.
+<10> Limits the amount of scaling up by the number of pods. The default value for scaling up the number of pods is 4%.
+<11> Limits the amount of scaling up by the percentage of pods. The default value for scaling up by percentage is 100%.
 
 .Example policy for scaling down
 [source,yaml]
@@ -78,7 +78,7 @@ spec:
       selectPolicy: Disabled
 ----
 
-In this example, when the number of pods is greater than 40, the percent-based policy is used for scaling down, as that policy results in a larger change, as required by the `selectPolicy`. 
+In this example, when the number of pods is greater than 40, the percent-based policy is used for scaling down, as that policy results in a larger change, as required by the `selectPolicy`.
 
 If there are 80 pod replicas, in the first iteration the HPA reduces the pods by 8, which is 10% of the 80 pods (based on the `type: Percent` and `value: 10` parameters), over one minute (`periodSeconds: 60`). For the next iteration, the number of pods is 72. The HPA calculates that 10% of the remaining pods is 7.2, which it rounds up to 8 and scales down 8 pods. On each subsequent iteration, the number of pods to be scaled is re-calculated based on the number of remaining pods. When the number of pods falls below 40, the pods-based policy is applied, because the pod-based number is greater than the percent-based number. The HPA reduces 4 pods at a time (`type: Pods` and `value: 4`), over 30 seconds (`periodSeconds: 30`), until there are 20 replicas remaining (`minReplicas`).
 


### PR DESCRIPTION
Version(s):
4.10+

Issue:
[OCPBUGS-14600](https://issues.redhat.com/browse/OCPBUGS-14600)

Link to docs preview:
[Preview](https://60908--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling.html#nodes-pods-autoscaling-policies_nodes-pods-autoscaling)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
