### PR TITLE
BZ#2024126: Added note about concurrent live migrations

### DIFF
--- a/virt/install/preparing-cluster-for-virt.adoc
+++ b/virt/install/preparing-cluster-for-virt.adoc
@@ -67,6 +67,18 @@ Live migration has the following requirements:
 * Sufficient RAM and network bandwidth.
 * If the virtual machine uses a host model CPU, the nodes must support the virtual machine's host model CPU.
 
+[NOTE]
+====
+You must ensure that there is enough memory request capacity in the cluster to support node drains that result in live migrations. You can determine the approximate required spare memory by using the following calculation:
+
+----
+Product of (Maximum number of nodes that can drain in parallel) and (Highest total VM memory request allocations across nodes)
+----
+
+The default xref:../../virt/live_migration/virt-live-migration-limits.adoc#virt-live-migration-limits[number of migrations that can run in parallel] in the cluster is 5.
+====
+
+
 // The HA section actually belongs to OpenShift, not Virt
 [id="cluster-high-availability-options_{context}"]
 == Cluster high-availability options


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://bugzilla.redhat.com/show_bug.cgi?id=2024126
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://60910--docspreview.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html#live-migration_preparing-cluster-for-virt
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
