### PR TITLE
OBSDOCS-191: Remove TP status and update API version for alert relabelings and overrides

### DIFF
--- a/modules/monitoring-creating-new-alerting-rules.adoc
+++ b/modules/monitoring-creating-new-alerting-rules.adoc
@@ -6,7 +6,7 @@
 [id="creating-new-alerting-rules_{context}"]
 = Creating new alerting rules
 
-As a cluster administrator, you can create new alerting rules based on platform metrics. 
+As a cluster administrator, you can create new alerting rules based on platform metrics.
 These alerting rules trigger alerts based on the values of chosen metrics.
 
 [NOTE]
@@ -25,12 +25,12 @@ If you create a customized `AlertingRule` resource based on an existing platform
 
 . Create a new YAML configuration file named `example-alerting-rule.yaml` in the `openshift-monitoring` namespace.
 
-. Add an `AlertingRule` resource to the YAML file. 
+. Add an `AlertingRule` resource to the YAML file.
 The following example creates a new alerting rule named `example`, similar to the default `watchdog` alert:
 +
 [source,yaml]
 ----
-apiVersion: monitoring.openshift.io/v1alpha1
+apiVersion: monitoring.openshift.io/v1
 kind: AlertingRule
 metadata:
   name: example

--- a/modules/monitoring-managing-core-platform-alerting-rules.adoc
+++ b/modules/monitoring-managing-core-platform-alerting-rules.adoc
@@ -6,9 +6,6 @@
 [id="managing-core-platform-alerting-rules_{context}"]
 = Managing alerting rules for core platform monitoring
 
-:FeatureName: Creating and modifying alerting rules for core platform monitoring
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
 {product-title} {product-version} monitoring ships with a large set of default alerting rules for platform metrics.
 As a cluster administrator, you can customize this set of rules in two ways:
 
@@ -23,6 +20,6 @@ For example, you can change the `severity` label for an alert from `warning` to 
 
 * You can only add and modify alerting rules. You cannot create new recording rules or modify existing recording rules.
 
-* If you modify existing platform alerting rules by using an `AlertRelabelConfig` object, your modifications are not reflected in the Prometheus alerts API. 
-Therefore, any dropped alerts still appear in the {product-title} web console even though they are no longer forwarded to Alertmanager. 
+* If you modify existing platform alerting rules by using an `AlertRelabelConfig` object, your modifications are not reflected in the Prometheus alerts API.
+Therefore, any dropped alerts still appear in the {product-title} web console even though they are no longer forwarded to Alertmanager.
 Additionally, any modifications to alerts, such as a changed `severity` label, do not appear in the web console.

--- a/modules/monitoring-modifying-core-platform-alerting-rules.adoc
+++ b/modules/monitoring-modifying-core-platform-alerting-rules.adoc
@@ -6,7 +6,7 @@
 [id="modifying-core-platform-alerting-rules_{context}"]
 = Modifying core platform alerting rules
 
-As a cluster administrator, you can modify core platform alerts before Alertmanager routes them to a receiver. 
+As a cluster administrator, you can modify core platform alerts before Alertmanager routes them to a receiver.
 For example, you can change the severity label of an alert, add a custom label, or exclude an alert from being sent to Alertmanager.
 
 .Prerequisites
@@ -20,12 +20,12 @@ For example, you can change the severity label of an alert, add a custom label, 
 
 . Create a new YAML configuration file named `example-modified-alerting-rule.yaml` in the `openshift-monitoring` namespace.
 
-. Add an `AlertRelabelConfig` resource to the YAML file. 
-The following example modifies the `severity` setting to `critical` for the default platform `watchdog` alerting rule: 
+. Add an `AlertRelabelConfig` resource to the YAML file.
+The following example modifies the `severity` setting to `critical` for the default platform `watchdog` alerting rule:
 +
 [source,yaml]
 ----
-apiVersion: monitoring.openshift.io/v1alpha1
+apiVersion: monitoring.openshift.io/v1
 kind: AlertRelabelConfig
 metadata:
   name: watchdog
@@ -42,7 +42,7 @@ spec:
 <2> The regular expression against which the value of `sourceLabels` is matched.
 <3> The target label of the value you want to modify.
 <4> The new value to replace the target label.
-<5> The relabel action that replaces the old value based on regex matching. 
+<5> The relabel action that replaces the old value based on regex matching.
 The default action is `Replace`.
 Other possible values are `Keep`, `Drop`, `HashMod`, `LabelMap`, `LabelDrop`, and `LabelKeep`.
 


### PR DESCRIPTION
Summary: This PR removes the technology preview admonition from the docs for alert relabelings and alert overrides for the 4.14 release. It also updates the APIversion to v1 in the sample config map code. It also removes some trailing spaces from the Asciidoc code

- Aligned team: DevTools
- For branches: 4.14
- Jira: https://issues.redhat.com/browse/OBSDOCS-191
- Direct link to doc preview: https://60911--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts.html#managing-core-platform-alerting-rules_managing-alerts
- SME review: @jan--f (approved)
- QE review: @juzhao (approved)
- Peer review: @gwynnemonahan (approved)