### PR TITLE
OCPBUGS-14078: Port 80 no longer used by metal components from 4.13

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -161,4 +161,4 @@ You can reconfigure the control plane nodes to act as NTP servers on disconnecte
 [id='network-requirements-out-of-band_{context}']
 == Port access for the out-of-band management IP address
 
-The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the provisioner during installation, the out-of-band management IP address must be granted access to port `80` on the bootstrap host and port `6180` on the {product-title} control plane hosts. TLS port `6183` is required for virtual media installation, for example, via Redfish.
+The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the provisioner during installation, the out-of-band management IP address must be granted access to port `6180` on the bootstrap host and on the {product-title} control plane hosts. TLS port `6183` is required for virtual media installation, for example, via Redfish.


### PR DESCRIPTION
OCPBUGS-14078: Starting with 4.13, we have unified the ports, so port 6180 is now required on both bootstrap host and control plane nodes. Port 80 is no longer used by the metal components on bootstrap.

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-14078

Link to docs preview:
https://file.emea.redhat.com/rohennes/OCPBUGS-14078-port80/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-out-of-band_ipi-install-prerequisites

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
