### PR TITLE
[OSDOCS-6391]: Adds & fixes Nutanix compute machine set YAML params

### DIFF
--- a/modules/machineset-yaml-nutanix.adoc
+++ b/modules/machineset-yaml-nutanix.adoc
@@ -20,6 +20,19 @@ ifndef::infra[`<role>`]
 ifdef::infra[`<infra>`]
 is the node label to add.
 
+[discrete]
+[id="machineset-yaml-nutanix-oc_{context}"]
+== Values obtained by using the OpenShift CLI
+
+In the following example, you can obtain some of the values for your cluster by using the OpenShift CLI (`oc`).
+
+Infrastructure ID:: The `<infrastructure_id>` string is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
@@ -29,12 +42,12 @@ metadata:
     machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
 ifndef::infra[]
     machine.openshift.io/cluster-api-machine-role: <role> <2>
-    machine.openshift.io/cluster-api-machine-type: <role> <2>
+    machine.openshift.io/cluster-api-machine-type: <role>
   name: <infrastructure_id>-<role>-<zone> <3>
 endif::infra[]
 ifdef::infra[]
     machine.openshift.io/cluster-api-machine-role: <infra> <2>
-    machine.openshift.io/cluster-api-machine-type: <infra> <2>
+    machine.openshift.io/cluster-api-machine-type: <infra>
   name: <infrastructure_id>-<infra>-<zone> <3>
 endif::infra[]
   namespace: openshift-machine-api
@@ -45,26 +58,26 @@ spec:
   replicas: 3
   selector:
     matchLabels:
-      machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra[]
 ifdef::infra[]
-      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<zone> <3>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<zone>
 endif::infra[]
   template:
     metadata:
       labels:
-        machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
 ifndef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <role> <2>
-        machine.openshift.io/cluster-api-machine-type: <role> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <3>
+        machine.openshift.io/cluster-api-machine-role: <role>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone>
 endif::infra[]
 ifdef::infra[]
-        machine.openshift.io/cluster-api-machine-role: <infra> <2>
-        machine.openshift.io/cluster-api-machine-type: <infra> <2>
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<zone> <3>
+        machine.openshift.io/cluster-api-machine-role: <infra>
+        machine.openshift.io/cluster-api-machine-type: <infra>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<infra>-<zone>
 endif::infra[]
     spec:
       metadata:
@@ -78,36 +91,38 @@ endif::infra[]
       providerSpec:
         value:
           apiVersion: machine.openshift.io/v1
-          cluster:
+          bootType: "" <5>
+          categories: <6>
+          - key: <category_name>
+            value: <category_value>
+          cluster: <7>
             type: uuid
             uuid: <cluster_uuid>
           credentialsSecret:
             name: nutanix-creds-secret
           image:
-            name: <infrastructure_id>-rhcos <5>
+            name: <infrastructure_id>-rhcos <8>
             type: name
           kind: NutanixMachineProviderConfig
-          memorySize: 16Gi <6>
+          memorySize: 16Gi <9>
+          project: <10>
+            type: name
+            name: <project_name>
           subnets:
           - type: uuid
             uuid: <subnet_uuid>
-          systemDiskSize: 120Gi <7>
+          systemDiskSize: 120Gi <11>
           userDataSecret:
-            name: <user_data_secret> <8>
-          vcpuSockets: 4 <9>
-          vcpusPerSocket: 1 <10>
+            name: <user_data_secret> <12>
+          vcpuSockets: 4 <13>
+          vcpusPerSocket: 1 <14>
 ifdef::infra[]
-      taints: <11>
+      taints: <15>
       - key: node-role.kubernetes.io/infra
         effect: NoSchedule
 endif::infra[]
 ----
-<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI (`oc`) installed, you can obtain the infrastructure ID by running the following command:
-+
-[source,terminal]
-----
-$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
-----
+<1>  For `<infrastructure_id>`, specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster.
 ifndef::infra[]
 <2> Specify the node label to add.
 <3> Specify the infrastructure ID, node label, and zone.
@@ -117,14 +132,23 @@ ifdef::infra[]
 <3> Specify the infrastructure ID, `<infra>` node label, and zone.
 endif::infra[]
 <4> Annotations for the cluster autoscaler.
-<5> Specify the image to use. Use an image from an existing default compute machine set for the cluster.
-<6> Specify the amount of memory for the cluster in Gi.
-<7> Specify the size of the system disk in Gi.
-<8> Specify the name of the secret in the user data YAML file that is in the `openshift-machine-api` namespace. Use the value that the installer populates in the default compute machine set.
-<9> Specify the number of vCPU sockets.
-<10> Specify the number of vCPUs per socket.
+<5> Specifies the boot type that the compute machines use. For more information about boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment]. Valid values are `Legacy`, `SecureBoot`, or `UEFI`. The default is `Legacy`.
++
+[NOTE]
+====
+You must use the `Legacy` boot type in {product-title} {product-version}.
+====
+<6> Specify one or more Nutanix Prism categories to apply to compute machines. This stanza requires `key` and `value` parameters for a category key-value pair that exists in Prism Central. For more information about categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
+<7> Specify a Nutanix Prism Element cluster configuration. In this example, the cluster type is `uuid`, so there is a `uuid` stanza.
+<8> Specify the image to use. Use an image from an existing default compute machine set for the cluster.
+<9> Specify the amount of memory for the cluster in Gi.
+<10> Specify the Nutanix project that you use for your cluster. In this example, the project type is `name`, so there is a `name` stanza.
+<11> Specify the size of the system disk in Gi.
+<12> Specify the name of the secret in the user data YAML file that is in the `openshift-machine-api` namespace. Use the value that installation program populates in the default compute machine set.
+<13> Specify the number of vCPU sockets.
+<14> Specify the number of vCPUs per socket.
 ifdef::infra[]
-<11> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+<15> Specify a taint to prevent user workloads from being scheduled on infra nodes.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OSDOCS-6391](https://issues.redhat.com//browse/OSDOCS-6391)

Link to docs preview:
[Sample YAML for a compute machine set custom resource on Nutanix](https://60941--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-nutanix.html#machineset-yaml-nutanix_creating-machineset-nutanix)

QE review:
- [x] QE has approved this change.

Additional information:
- Added params from ticket, as well as a definition from the CPMS work
- Removed repeat callouts for Portal build compatibility