### PR TITLE
[OSDOCS-6250]: Update to hosted control planes DR docs

### DIFF
--- a/modules/dr-hosted-cluster-within-aws-region-script.adoc
+++ b/modules/dr-hosted-cluster-within-aws-region-script.adoc
@@ -64,3 +64,5 @@ source <env_file>
 ----
 +
 where: `env_file` is the name of the file where you saved the script.
++
+The migration script is maintained at the following repository: link:https://github.com/openshift/hypershift/blob/main/contrib/migration/migrate-hcp.sh[https://github.com/openshift/hypershift/blob/main/contrib/migration/migrate-hcp.sh].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6250
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://60942--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-backup-restore-dr.html#dr-hosted-cluster-within-aws-region-script_hcp-backup-restore-dr
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds a link to where the migration script for disaster recovery for hosted control planes is sourced. Eric Rich and Dave Mulford have taken a look and stated that the link is OK to use while hosted control planes are in Tech Preview. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
