### PR TITLE
MCO-647: docs/machine-config-operator-certificates: Expand significantly

### DIFF
--- a/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
+++ b/security/certificate_types_descriptions/machine-config-operator-certificates.adoc
@@ -8,7 +8,15 @@ toc::[]
 
 == Purpose
 
-Machine Config Operator certificates are used to secure connections between the Red Hat Enterprise Linux CoreOS (RHCOS) nodes and the Machine Config Server.
+This certificate authority is used to secure connections from nodes to Machine Config Server during initial provisioning.
+
+There are two certificates: a self-signed CA ("the MCS CA") as well as a derived certificate ("the MCS cert").
+
+=== Provisioning details
+
+OpenShift installations using {op-system-first} are installed using Ignition.  This Ignition configuration is split into two parts; the first part is a "pointer" config which is just a reference to a URL for the full configuration served by the Machine Config Server (MCS).
+
+The "pointer" Ignition config manifests as e.g. the `worker.ign` file created by `openshift-install` for User Provisioned Infrastucture installs. For Installer Provisioned Infrastructure (IPI) installs using the Machine API Operator, this configuration appears as the `worker-user-data` secret.
 
 include::snippets/mcs-endpoint-limitation.adoc[]
 
@@ -16,13 +24,24 @@ include::snippets/mcs-endpoint-limitation.adoc[]
 
 * xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[About the OpenShift SDN network plugin].
 
+=== Provisioning chain of trust
+
+The MCS CA is injected into the pointer configuration under the Ignition `security.tls.certificateAuthorities` configuration option. The Machine Config Server provides its "full" Ignition configuration via a webserver using the "MCS cert".
+
+Hence, this combination ensures that the client (Ignition running on a machine in the initramfs) is accessing the correct server because it validates that the MCS cert presented by the server has a chain of trust to an authority ("the MCS CA") it recognizes.
+
+=== Key material inside a cluster
+
+The "MCS CA" appears in cluster as a configmap under the `kube-system` namespace, object `root-ca` and with key `ca.crt`.  The private key is not stored in cluster and is discarded after an installation is complete.
+
+The "MCS cert" appears in cluster as a secret under the `openshift-machine-config-operator` namespace, object `machine-config-server-tls` with keys `tls.crt` and `tls.key`.
 
 == Management
 
-These certificates are managed by the system and not the user.
+At this time, modifying either of these certificates directly is not supported.
 
 == Expiration
-This CA is valid for 10 years.
+The MCS CA is valid for 10 years.
 
 The issued serving certificates are valid for 10 years.
 


### PR DESCRIPTION
Add a lot more details about what these certificates are, why they exist etc.


Version(s):
At least back to 4.11, and really most of this all the way back to 4.1.

Issue: https://issues.redhat.com/browse/MCO-642

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
