### PR TITLE
OSSM-4089: [DOC] 2.3.4 Z Stream Release Notes, Known Issues and Bug Fixes for OSSM

### DIFF
--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -18,10 +18,18 @@ The following issues been resolved in the current release:
 
 [id="ossm-rn-fixed-issues-ossm_{context}"]
 == {SMProductShortName} fixed issues
+//NEWNEWNEWNEW
+* https://issues.redhat.com/browse/OSSM-4009[OSSM-4009] Previously, when you upgraded a Kiali Custom Resource (CR) from one `spec.version` to another, a variable sometimes caused the upgrade to fail. Now, the variable has been renamed and the upgrade completes as expected.
+
+//NEWNEWNEW
+* https://issues.redhat.com/browse/OSSM-3993[OSSM-3993] Previously, Kiali only supported OpenShift OAuth via a proxy on the standard HTTPS port of `443`. Now, Kiali supports it over a non-standard HTTPS port. To enable it, you must define `spec.server.web_port` in the Kiali CR to the proxy's non-standard HTTPS port.
 
 * https://issues.redhat.com/browse/OSSM-3644[OSSM-3644] Previously, the federation egress-gateway received the wrong update of network gateway endpoints, causing extra endpoint entries. Now, the federation-egress gateway has been updated on the server side so it receives the correct network gateway endpoints.
 
 * https://issues.redhat.com/browse/OSSM-3595[OSSM-3595] Previously, the `istio-cni` plugin sometimes failed on {op-system-base} because SELinux did not allow the utility `iptables-restore` to open files in the `/tmp` directory. Now, SELinux passes `iptables-restore` via `stdin` input stream instead of via a file.
+
+//NEWNEWNEWNEW
+* https://issues.redhat.com/browse/OSSM-3586[OSSM-3586] Previously, Istio proxies were slow to startup when Google Cloud Platform (GCP) metadata servers were not available. Now, Istio proxies startup as expected.
 
 * https://issues.redhat.com/browse/OSSM-3025[OSSM-3025] Istiod sometimes fails to become ready. Sometimes, when a mesh contained many member namespaces, the Istiod pod did not become ready due to a deadlock within Istiod. The deadlock is now resolved and the pod now starts as expected.
 


### PR DESCRIPTION
[OSSM-4089](https://issues.redhat.com//browse/OSSM-4089): [DOC] 2.3.4 Z Stream Release Notes, Known Issues and Bug Fixes for OSSM

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSSM-4089

Link to docs preview:
https://60949--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#ossm-rn-fixed-issues-ossm_ossm-release-notes

Only review to these 3 additions:

[OSSM-4009](https://issues.redhat.com//browse/OSSM-4009)
[OSSM-3993](https://issues.redhat.com//browse/OSSM-3993)
[OSSM-3586](https://issues.redhat.com//browse/OSSM-3586)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
