### PR TITLE
OSDOCS-3986

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -100,6 +100,36 @@ Topics:
 - Name: Deleting an OpenShift Dedicated cluster
   File: osd-deleting-a-cluster
 ---
+Name: CLI tools
+Dir: cli_reference
+Distros: openshift-dedicated
+Topics:
+- Name: CLI tools overview
+  File: index
+- Name: OpenShift CLI (oc)
+  Dir: openshift_cli
+  Topics:
+  - Name: Getting started with the OpenShift CLI
+    File: getting-started-cli
+  - Name: Configuring the OpenShift CLI
+    File: configuring-cli
+  - Name: Usage of oc and kubectl commands
+    File: usage-oc-kubectl
+  - Name: Managing CLI profiles
+    File: managing-cli-profiles
+  - Name: Extending the OpenShift CLI with plugins
+    File: extending-cli-plugins
+  #Commenting out the following section as it is still in "preview" phase.
+  #Can be added back in when fully available.
+  #- Name: Managing CLI plugins with Krew
+    #File: managing-cli-plugins-krew
+   # Distros: openshift-dedicated
+  - Name: OpenShift CLI developer command reference
+    File: developer-cli-commands
+  - Name: OpenShift CLI administrator command reference
+    File: administrator-cli-commands
+    Distros: openshift-dedicated
+---
 Name: Cluster administration
 Dir: osd_cluster_admin
 Distros: openshift-dedicated

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -119,10 +119,8 @@ Topics:
     File: managing-cli-profiles
   - Name: Extending the OpenShift CLI with plugins
     File: extending-cli-plugins
-  #Commenting out the following section as it is still in "preview" phase.
-  #Can be added back in when fully available.
-  #- Name: Managing CLI plugins with Krew
-    #File: managing-cli-plugins-krew
+  # - Name: Managing CLI plugins with Krew
+    # File: managing-cli-plugins-krew
    # Distros: openshift-dedicated
   - Name: OpenShift CLI developer command reference
     File: developer-cli-commands

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -183,11 +183,9 @@ Topics:
     File: managing-cli-profiles
   - Name: Extending the OpenShift CLI with plugins
     File: extending-cli-plugins
-  #Commenting out the following section as it is still in "preview" phase.
-  #Can be added back in when fully available.
-  #- Name: Managing CLI plugins with Krew
-    #File: managing-cli-plugins-krew
-    #Distros: openshift-rosa
+  # - Name: Managing CLI plugins with Krew
+    # File: managing-cli-plugins-krew
+    # Distros: openshift-rosa
   - Name: OpenShift CLI developer command reference
     File: developer-cli-commands
   - Name: OpenShift CLI administrator command reference

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -164,20 +164,47 @@ Topics:
   - Name: Command quick reference for creating clusters and users
     File: rosa-quickstart
 ---
-Name: ROSA CLI
-Dir: rosa_cli
+Name: CLI tools
+Dir: cli_reference
 Distros: openshift-rosa
 Topics:
+- Name: CLI tools overview
+  File: index
+- Name: OpenShift CLI (oc)
+  Dir: openshift_cli
+  Topics:
+  - Name: Getting started with the OpenShift CLI
+    File: getting-started-cli
+  - Name: Configuring the OpenShift CLI
+    File: configuring-cli
+  - Name: Usage of oc and kubectl commands
+    File: usage-oc-kubectl
+  - Name: Managing CLI profiles
+    File: managing-cli-profiles
+  - Name: Extending the OpenShift CLI with plugins
+    File: extending-cli-plugins
+  #Commenting out the following section as it is still in "preview" phase.
+  #Can be added back in when fully available.
+  #- Name: Managing CLI plugins with Krew
+    #File: managing-cli-plugins-krew
+    #Distros: openshift-rosa
+  - Name: OpenShift CLI developer command reference
+    File: developer-cli-commands
+  - Name: OpenShift CLI administrator command reference
+    File: administrator-cli-commands
+    Distros: openshift-rosa
+- Name: ROSA CLI (rosa)
+  Dir: rosa_cli
 # - Name: CLI and web console
 #   File: rosa-cli-openshift-console
-- Name: Getting started with the ROSA CLI
-  File: rosa-get-started-cli
-- Name: Managing objects with the ROSA CLI
-  File: rosa-manage-objects-cli
-- Name: Checking account and version information with the ROSA CLI
-  File: rosa-checking-acct-version-cli
-- Name: Checking logs with the ROSA CLI
-  File: rosa-checking-logs-cli
+  - Name: Getting started with the ROSA CLI
+    File: rosa-get-started-cli
+  - Name: Managing objects with the ROSA CLI
+    File: rosa-manage-objects-cli
+  - Name: Checking account and version information with the ROSA CLI
+    File: rosa-checking-acct-version-cli
+  - Name: Checking logs with the ROSA CLI
+    File: rosa-checking-logs-cli
 ---
 Name: Red Hat OpenShift Cluster Manager
 Dir: ocm

--- a/cli_reference/index.adoc
+++ b/cli_reference/index.adoc
@@ -23,7 +23,7 @@ These tools expose simple commands to manage the applications, as well as intera
 The following set of CLI tools are available in {product-title}:
 
 * xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[OpenShift CLI (oc)]: This is the most commonly used CLI tool by {product-title} users. It helps both cluster administrators and developers to perform end-to-end operations across {product-title} using the terminal. Unlike the web console, it allows the user to work directly with the project source code using command scripts.
-
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../cli_reference/kn-cli-tools.adoc#kn-cli-tools[Knative CLI (kn)]: The Knative (`kn`) CLI tool provides simple and intuitive terminal commands that can be used to interact with OpenShift Serverless components, such as Knative Serving and Eventing.
 
 * xref:../cli_reference/tkn_cli/installing-tkn.adoc#installing-tkn[Pipelines CLI (tkn)]: OpenShift Pipelines is a continuous integration and continuous delivery (CI/CD) solution in {product-title}, which internally uses Tekton. The `tkn` CLI tool provides simple and intuitive commands to interact with OpenShift Pipelines using the terminal.
@@ -31,3 +31,7 @@ The following set of CLI tools are available in {product-title}:
 * xref:../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[opm CLI]: The `opm` CLI tool helps the Operator developers and cluster administrators to create and maintain the catalogs of Operators from the terminal.
 
 * xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Operator SDK]: The Operator SDK, a component of the Operator Framework, provides a CLI tool that Operator developers can use to build, test, and deploy an Operator from the terminal. It simplifies the process of building Kubernetes-native applications, which can require deep, application-specific operational knowledge.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa[]
+* xref:../rosa_cli/rosa-get-started-cli.adoc[ROSA CLI (rosa)]: Use the `rosa` CLI to create, update, manage, and delete {product-title} clusters and resources.
+endif::openshift-rosa[]

--- a/cli_reference/index.adoc
+++ b/cli_reference/index.adoc
@@ -32,6 +32,3 @@ ifndef::openshift-rosa,openshift-dedicated[]
 
 * xref:../cli_reference/osdk/cli-osdk-install.adoc#cli-osdk-install[Operator SDK]: The Operator SDK, a component of the Operator Framework, provides a CLI tool that Operator developers can use to build, test, and deploy an Operator from the terminal. It simplifies the process of building Kubernetes-native applications, which can require deep, application-specific operational knowledge.
 endif::openshift-rosa,openshift-dedicated[]
-ifdef::openshift-rosa[]
-* xref:../rosa_cli/rosa-get-started-cli.adoc[ROSA CLI (rosa)]: Use the `rosa` CLI to create, update, manage, and delete {product-title} clusters and resources.
-endif::openshift-rosa[]

--- a/cli_reference/openshift_cli/managing-cli-profiles.adoc
+++ b/cli_reference/openshift_cli/managing-cli-profiles.adoc
@@ -7,9 +7,9 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 A CLI configuration file allows you to configure different profiles, or contexts, for use with the xref:../../cli_reference/index.adoc#cli-tools-overview[CLI tools overview]. A context consists of
-ifndef::microshift[]
+ifndef::microshift,openshift-dedicated,openshift-rosa[]
 xref:../../authentication/understanding-authentication.adoc#understanding-authentication[user authentication]
-endif::[]
+endif::microshift,openshift-dedicated,openshift-rosa[]
 ifdef::microshift[]
 user authentication
 endif::[]

--- a/cli_reference/openshift_cli/usage-oc-kubectl.adoc
+++ b/cli_reference/openshift_cli/usage-oc-kubectl.adoc
@@ -16,14 +16,16 @@ Resources such as `DeploymentConfig`, `BuildConfig`, `Route`, `ImageStream`, and
 +
 * **Authentication**
 +
-ifndef::microshift[]
+ifndef::openshift-rosa,openshift-dedicated[]
+ifndef::microshift
 The `oc` binary offers a built-in `login` command for authentication and lets you work with {product-title} projects, which map Kubernetes namespaces to authenticated users.
 Read xref:../../authentication/understanding-authentication.adoc#understanding-authentication[Understanding authentication] for more information.
-endif::[]
+endif::microshift, openshift-dedicated, openshift-rosa[]
 +
 ifdef::microshift[]
 The `oc` binary offers a built-in `login` command for authentication to {product-title}.
 endif::[]
+endif::openshift-rosa,openshift-dedicated[]
 +
 * **Additional commands**
 +

--- a/modules/cli-installing-cli-web-console-windows.adoc
+++ b/modules/cli-installing-cli-web-console-windows.adoc
@@ -6,7 +6,7 @@ endif::[]
 [id="cli-installing-cli-web-console-macos-windows_{context}"]
 = Installing the OpenShift CLI on Windows using the web console
 
-You can install the OpenShift CLI (`oc`) binary on Winndows by using the following procedure.
+You can install the OpenShift CLI (`oc`) binary on Windows by using the following procedure.
 
 .Procedure
 


### PR DESCRIPTION
[OSDOCS-3986](https://issues.redhat.com//browse/OSDOCS-3986): Content Port for "CLI Tools" Book to OSD and ROSA

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-3986

Link to docs preview:
OSD: https://60951--docspreview.netlify.app/openshift-dedicated/latest/cli_reference/index.html
ROSA: https://60951--docspreview.netlify.app/openshift-rosa/latest/cli_reference/index.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
