### PR TITLE
TRACING-3193: Add OTLP metrics docs

### DIFF
--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
@@ -11,5 +11,9 @@ The {OTELName} Operator uses a custom resource definition (CRD) file that define
 include::modules/distr-tracing-config-otel-collector.adoc[leveloffset=+1]
 
 include::modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc[leveloffset=+1]
-Refer to xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
+
+[role="_additional-resources"]
+[id="additional-resources_deploy-otel"]
+== Additional resources
+* xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
 configure monitoring stack.

--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
@@ -10,7 +10,7 @@ The {OTELName} Operator uses a custom resource definition (CRD) file that define
 
 include::modules/distr-tracing-config-otel-collector.adoc[leveloffset=+1]
 
-include::modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc[leveloffset=+1]
+include::modules/distr-tracing-config-otel-send-metrics-monitoring-stack.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [id="additional-resources_deploy-otel"]

--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
@@ -15,4 +15,4 @@ include::modules/distr-tracing-config-otel-send-metrics-monitoring-stack.adoc[le
 [role="_additional-resources"]
 [id="additional-resources_deploy-otel"]
 == Additional resources
-* xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[Enable monitoring stack for user defined projects.]
+* xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[Enabling monitoring for user-defined projects.]

--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
@@ -9,4 +9,9 @@ toc::[]
 The {OTELName} Operator uses a custom resource definition (CRD) file that defines the architecture and configuration settings to be used when creating and deploying the {OTELName} resources. You can either install the default configuration or modify the file to better suit your business requirements. 
 
 include::modules/distr-tracing-config-otel-collector.adoc[leveloffset=+1]
+
+The metrics from {OTELName} can be consumed by the in-cluster monitoring stack. Refer to
+xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
+configure monitoring stack.
+
 include::modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc[leveloffset=+1]

--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
@@ -10,8 +10,6 @@ The {OTELName} Operator uses a custom resource definition (CRD) file that define
 
 include::modules/distr-tracing-config-otel-collector.adoc[leveloffset=+1]
 
-The metrics from {OTELName} can be consumed by the in-cluster monitoring stack. Refer to
-xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
-configure monitoring stack.
-
 include::modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc[leveloffset=+1]
+Refer to xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
+configure monitoring stack.

--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
@@ -9,3 +9,4 @@ toc::[]
 The {OTELName} Operator uses a custom resource definition (CRD) file that defines the architecture and configuration settings to be used when creating and deploying the {OTELName} resources. You can either install the default configuration or modify the file to better suit your business requirements. 
 
 include::modules/distr-tracing-config-otel-collector.adoc[leveloffset=+1]
+include::modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc[leveloffset=+1]

--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
@@ -15,5 +15,4 @@ include::modules/distr-tracing-config-otel-send-metrics-monitoring-stack.adoc[le
 [role="_additional-resources"]
 [id="additional-resources_deploy-otel"]
 == Additional resources
-* xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
-configure monitoring stack.
+* xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[Enable monitoring stack for user defined projects.]

--- a/modules/distr-tracing-config-otel-collector.adoc
+++ b/modules/distr-tracing-config-otel-collector.adoc
@@ -29,6 +29,10 @@ metadata:
   namespace: tracing-system
 spec:
   mode: deployment
+  ports:
+  - name: promexporter
+    port: 8889
+    protocol: TCP
   config: |
     receivers:
       otlp:
@@ -41,12 +45,20 @@ spec:
         endpoint: jaeger-production-collector-headless.tracing-system.svc:14250
         tls:
           ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        resource_to_telemetry_conversion:
+          enabled: true # by default resource attributes are dropped
     service:
       pipelines:
         traces:
           receivers: [otlp]
           processors: []
           exporters: [jaeger]
+        metrics:
+          receivers: [otlp]
+          processors: []
+          exporters: [prometheus]
 ----
 
 [NOTE]
@@ -77,7 +89,7 @@ If a component is configured, but not defined within the `service` section then 
 
 |exporters:
 |An exporter sends data to one or more backends/destinations. By default, no exporters are configured. There must be at least one enabled exporter for a configuration to be considered valid. Exporters are enabled by being added to a pipeline. Exporters may come with default settings, but many require configuration to specify at least the destination and security settings.
-|`logging`, `jaeger`
+|`logging`, `jaeger`, `prometheus`,
 |None
 
 |exporters:
@@ -123,6 +135,30 @@ If a component is configured, but not defined within the `service` section then 
     traces:
       exporters:
 |You enable exporters for tracing by adding them under `service.pipelines.traces`.
+|
+|None
+
+|service:
+  pipelines:
+    metrics:
+      receivers:
+|You enable receivers for metrics by adding them under `service.pipelines.metrics`.
+|
+|None
+
+|service:
+  pipelines:
+    metrics:
+      processors:
+|You enable processors for metircs by adding them under `service.pipelines.metrics`.
+|
+|None
+
+|service:
+  pipelines:
+    metrics:
+      exporters:
+|You enable exporters for metrics by adding them under `service.pipelines.metrics`.
 |
 |None
 |===

--- a/modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc
+++ b/modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc
@@ -6,10 +6,6 @@ This module included in the following assemblies:
 [id="distr-tracing-config-otel-collector_monitoring_{context}"]
 = Sending metrics to the monitoring stack
 
-The metrics from {OTELName} can be consumed by the in-cluster monitoring stack. Refer to
-xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
-configure monitoring stack.
-
 .Sample `+PodMonitor+` that configures monitoring stack to scrape OpenTelemetry collector and removes duplicated labels.
 [source,yaml]
 ----

--- a/modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc
+++ b/modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc
@@ -6,7 +6,7 @@ This module included in the following assemblies:
 [id="distr-tracing-config-otel-collector_monitoring_{context}"]
 = Sending metrics to the monitoring stack
 
-The metrics from the {OTELName} can be consumed by the in-cluster monitoring stack. Refer to
+The metrics from {OTELName} can be consumed by the in-cluster monitoring stack. Refer to
 xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
 configure monitoring stack.
 
@@ -22,8 +22,8 @@ spec:
     matchLabels:
       app.kubernetes.io/name: otel-collector
   podMetricsEndpoints:
-  - port: metrics
-  - port: promexporter
+  - port: metrics <1>
+  - port: promexporter <2>
     relabelings:
     - action: labeldrop
       regex: pod
@@ -37,3 +37,5 @@ spec:
     - action: labeldrop
       regex: job
 ----
+<1> Collector's internal metrics port
+<2> Collector's Prometheus exporter port

--- a/modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc
+++ b/modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc
@@ -1,0 +1,39 @@
+////
+This module included in the following assemblies:
+-distr_tracing_install/distributed-tracing-deploying-otel.adoc
+////
+:_content-type: REFERENCE
+[id="distr-tracing-config-otel-collector_monitoring_{context}"]
+= Sending metrics to the monitoring stack
+
+The metrics from the {OTELName} can be consumed by the in-cluster monitoring stack. Refer to
+xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
+configure monitoring stack.
+
+.Sample `+PodMonitor+` that configures monitoring stack to scrape OpenTelemetry collector Prometheus exporter, internal metrics endpoint and removes duplicated labels.
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: otel-collector
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: otel-collector
+  podMetricsEndpoints:
+  - port: metrics
+  - port: promexporter
+    relabelings:
+    - action: labeldrop
+      regex: pod
+    - action: labeldrop
+      regex: container
+    - action: labeldrop
+      regex: endpoint
+    metricRelabelings:
+    - action: labeldrop
+      regex: instance
+    - action: labeldrop
+      regex: job
+----

--- a/modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc
+++ b/modules/distr-tracing-config-otel-send-data-to-monitoring-stack.adoc
@@ -10,7 +10,7 @@ The metrics from {OTELName} can be consumed by the in-cluster monitoring stack. 
 xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[enable monitoring for user defined projects] how to
 configure monitoring stack.
 
-.Sample `+PodMonitor+` that configures monitoring stack to scrape OpenTelemetry collector Prometheus exporter, internal metrics endpoint and removes duplicated labels.
+.Sample `+PodMonitor+` that configures monitoring stack to scrape OpenTelemetry collector and removes duplicated labels.
 [source,yaml]
 ----
 apiVersion: monitoring.coreos.com/v1

--- a/modules/distr-tracing-config-otel-send-metrics-monitoring-stack.adoc
+++ b/modules/distr-tracing-config-otel-send-metrics-monitoring-stack.adoc
@@ -3,10 +3,13 @@ This module included in the following assemblies:
 -distr_tracing_install/distributed-tracing-deploying-otel.adoc
 ////
 :_content-type: REFERENCE
-[id="distr-tracing-config-otel-collector_monitoring_{context}"]
+[id="distr-tracing-send-metrics-monitoring-stack_{context}"]
 = Sending metrics to the monitoring stack
 
-.Sample `+PodMonitor+` that configures monitoring stack to scrape OpenTelemetry collector and removes duplicated labels.
+The following example shows how to configure the monitoring stack to scrape OpenTelemetry collector metrics endpoints and removes
+duplicated labels added by the monitoring stack during scraping.
+
+.Sample `+PodMonitor+` that configures the monitoring stack to scrape collector metrics.
 [source,yaml]
 ----
 apiVersion: monitoring.coreos.com/v1
@@ -33,5 +36,5 @@ spec:
     - action: labeldrop
       regex: job
 ----
-<1> Collector's internal metrics port
-<2> Collector's Prometheus exporter port
+<1> The OpenTelemetry collector internal metrics port name. The port name is always `+metrics+`.
+<2> The OpenTelemetry collector Prometheus exporter port name. The port name is defined in the `+.spec.ports+` section of the OpenTelemetry collector CR.

--- a/modules/distr-tracing-config-otel-send-metrics-monitoring-stack.adoc
+++ b/modules/distr-tracing-config-otel-send-metrics-monitoring-stack.adoc
@@ -1,15 +1,15 @@
 ////
-This module included in the following assemblies:
--distr_tracing_install/distributed-tracing-deploying-otel.adoc
+This module is included in the following assemblies:
+- distr_tracing_install/distributed-tracing-deploying-otel.adoc
 ////
 :_content-type: REFERENCE
 [id="distr-tracing-send-metrics-monitoring-stack_{context}"]
 = Sending metrics to the monitoring stack
 
-The following example shows how to configure the monitoring stack to scrape OpenTelemetry collector metrics endpoints and removes
-duplicated labels added by the monitoring stack during scraping.
+You can configure the monitoring stack to scrape OpenTelemetry collector metrics endpoints and to remove
+duplicated labels that the monitoring stack has added during scraping.
 
-.Sample `+PodMonitor+` that configures the monitoring stack to scrape collector metrics.
+.Sample `+PodMonitor+` that configures the monitoring stack to scrape collector metrics
 [source,yaml]
 ----
 apiVersion: monitoring.coreos.com/v1
@@ -36,5 +36,5 @@ spec:
     - action: labeldrop
       regex: job
 ----
-<1> The OpenTelemetry collector internal metrics port name. The port name is always `+metrics+`.
-<2> The OpenTelemetry collector Prometheus exporter port name. The port name is defined in the `+.spec.ports+` section of the OpenTelemetry collector CR.
+<1> The name of the internal metrics port for the OpenTelemetry collector. This port name is always `+metrics+`.
+<2> The name of the Prometheus exporter port for the OpenTelemetry collector. This port name is defined in the `+.spec.ports+` section of the OpenTelemetry collector CR.


### PR DESCRIPTION
Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

All supported OCP versions

4.10+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/TRACING-3193

Link to docs preview:
https://60953--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.html#distr-tracing-config-otel-collector_monitoring_deploying-distr-tracing-data-collection

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

**This PR should be merged or the changes should be available once RHOSDT 2.9 is released - https://issues.redhat.com/browse/TRACING-3156.** 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
