### PR TITLE
OCPBUG#14320: Added a section related to oc-mirror supporting multi-arch images for…

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -63,6 +63,17 @@ User-defined tags for Microsoft Azure was previously introduced as Technology Pr
 [id="ocp-4-14-web-console"]
 === Web console
 
+[id="ocp-4-14-openshift-cli"]
+=== OpenShift CLI (oc)
+
+.Supporting multi-arch OCI local images for catalogs with oc-mirror
+
+With {product-title} {product-version}, oc-mirror supports multi-arch OCI local images for catalogs.
+
+OCI layouts consist of an `index.json` file that identifies the images held within them on disk. This `index.json` file can reference any number of single or multi-arch images. However, oc-mirror only references a single image at a time in a given OCI layout. The image stored in the OCI layout can be a single-arch image, that is, an image manifest or a multi-arch image, that is, a manifest list.
+
+The `ImageSetConfiguration` stores the OCI images. After processing the catalog, the catalog content adds new layers representing the content of all images in the layout. The ImageBuilder is modified to handle image updates for both single-arch and multi-arch images.
+
 [id="ocp-4-14-developer-perspective"]
 ==== Developer Perspective
 


### PR DESCRIPTION
Version(s): 4.14

Issue:
[OCPBUG14320](https://issues.redhat.com/browse/OCPBUGS-14320)

Link to docs preview: [Doc Preview](https://60959--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-openshift-cli)


QE review:
- [x] QE has approved this change.


Additional information:
[CFE-783](https://github.com/openshift/oc-mirror/pull/611)
