### PR TITLE
Small guidelines update related to external file includes

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -830,6 +830,19 @@ Embedding external files is restricted for files that change frequently, like te
 You must get approval from the Engineering, QE, and Docs teams before embedding an external file.
 ====
 
+In some cases, you might not want the docs to be updated automatically as the included external file is changed.
+To point to an external file at an singular point in its history, use the URL for the raw file that includes the specific commit ID.
+For example:
+
+[source,terminal]
+-----
+.`01_vnet.json` ARM template
+[source,json]
+----
+\include::https://raw.githubusercontent.com/openshift/installer/ddaf08fa97c4cdeac8ed48dbee82c97dc429d0d2/upi/azure/01_vnet.json[]
+----
+-----
+
 == Embedding a local YAML file
 
 You can embed local YAML files in AsciiDoc modules.


### PR DESCRIPTION
Small update to the docs guidelines outlining how you can include external files at a specific point in their history.

Preview demonstrating an include to a file at a specific point in its history: 

https://file.emea.redhat.com/aireilly/adjust-yaml-include-guidelines/scalability_and_performance/enabling-workload-partitioning.html

```
[source,json]
----
include::https://raw.githubusercontent.com/openshift/installer/ddaf08fa97c4cdeac8ed48dbee82c97dc429d0d2/upi/azure/01_vnet.json[]
----
```