### PR TITLE
OCPBUGS-10969 Disabling CPU CFS quota pod example has wrong api version

### DIFF
--- a/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
+++ b/modules/cnf-managing-device-interrupt-processing-for-guaranteed-pod-isolated-cpus.adoc
@@ -21,7 +21,7 @@ To reduce CPU throttling for individual guaranteed pods, create a pod specificat
 
 [source,yaml]
 ----
-apiVersion: performance.openshift.io/v2
+apiVersion: v1
 kind: Pod
 metadata:
   annotations:


### PR DESCRIPTION
[OCPBUGS-10969]: Disabling CPU CFS quota pod example has wrong api version

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
 4.11,4.12,4.13,4.14 and main

Issue:
https://issues.redhat.com/browse/OCPBUGS-10969
Link to docs preview:
https://60976--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#disabling-cpu-cfs-quota_cnf-master
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
