### PR TITLE
OSDOCS-6186: hardcoded 4.14 version number bump

### DIFF
--- a/authentication/assuming-an-aws-iam-role-for-a-service-account.adoc
+++ b/authentication/assuming-an-aws-iam-role-for-a-service-account.adoc
@@ -37,5 +37,5 @@ include::modules/verifying-the-assumed-iam-role-in-your-pod.adoc[leveloffset=+2]
 * For more information about installing and using the AWS Boto3 SDK for Python, see the link:https://boto3.amazonaws.com/v1/documentation/api/latest/index.html[AWS Boto3 documentation].
 
 ifdef::openshift-rosa,openshift-dedicated[]
-* For general information about webhook admission plugins for OpenShift, see link:https://docs.openshift.com/container-platform/4.13/architecture/admission-plug-ins.html#admission-webhooks-about_admission-plug-ins[Webhook admission plugins] in the OpenShift Container Platform documentation.
+* For general information about webhook admission plugins for OpenShift, see link:https://docs.openshift.com/container-platform/4.14/architecture/admission-plug-ins.html#admission-webhooks-about_admission-plug-ins[Webhook admission plugins] in the OpenShift Container Platform documentation.
 endif::openshift-rosa,openshift-dedicated[]

--- a/microshift_cli_ref/microshift-cli-tools-introduction.adoc
+++ b/microshift_cli_ref/microshift-cli-tools-introduction.adoc
@@ -26,6 +26,6 @@ Commands for multi-node deployments, projects, and developer tooling are not sup
 
 * xref:..//microshift_cli_ref/microshift-oc-cli-install.adoc#microshift-oc-cli-install[Installing the OpenShift CLI tool for MicroShift].
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/cli_tools/openshift-cli-oc[Detailed description of the OpenShift CLI (oc)].
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/cli_tools/openshift-cli-oc[Detailed description of the OpenShift CLI (oc)].
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9[Red Hat Enterprise Linux (RHEL) documentation for specific use cases].

--- a/microshift_storage/understanding-persistent-storage-microshift.adoc
+++ b/microshift_storage/understanding-persistent-storage-microshift.adoc
@@ -13,7 +13,7 @@ include::modules/storage-persistent-storage-overview.adoc[leveloffset=+1]
 [id="additional-resources_understanding-persistent-storage-microshift"]
 [role="_additional-resources"]
 .Additional resources
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/storage/understanding-persistent-storage#pv-access-modes_understanding-persistent-storage[Access modes for persistent storage]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/storage/understanding-persistent-storage#pv-access-modes_understanding-persistent-storage[Access modes for persistent storage]
 
 include::modules/storage-persistent-storage-lifecycle.adoc[leveloffset=+1]
 

--- a/modules/about-developer-perspective.adoc
+++ b/modules/about-developer-perspective.adoc
@@ -31,4 +31,4 @@ The *Developer* perspective provides workflows specific to developer use cases, 
 You can use the *Topology* view to display applications, components, and workloads of your project. If you have no workloads in the project, the *Topology* view will show some links to create or import them. You can also use the *Quick Search* to import components directly.
 
 .Additional Resources
-See link:https://docs.openshift.com/container-platform/4.13/applications/odc-viewing-application-composition-using-topology-view.html[Viewing application composition using the Topology] view for more information on using the *Topology* view in *Developer* perspective.
+See link:https://docs.openshift.com/container-platform/4.14/applications/odc-viewing-application-composition-using-topology-view.html[Viewing application composition using the Topology] view for more information on using the *Topology* view in *Developer* perspective.

--- a/modules/ai-adding-worker-nodes-to-cluster.adoc
+++ b/modules/ai-adding-worker-nodes-to-cluster.adoc
@@ -101,7 +101,7 @@ $ curl -s "$API_URL/api/assisted-install/v2/infra-envs/$INFRA_ENV_ID" -H "Author
 .Example output
 [source,terminal]
 ----
-https://api.openshift.com/api/assisted-images/images/41b91e72-c33e-42ee-b80f-b5c5bbf6431a?arch=x86_64&image_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTYwMjYzNzEsInN1YiI6IjQxYjkxZTcyLWMzM2UtNDJlZS1iODBmLWI1YzViYmY2NDMxYSJ9.1EX_VGaMNejMhrAvVRBS7PDPIQtbOOc8LtG8OukE1a4&type=minimal-iso&version=4.13
+https://api.openshift.com/api/assisted-images/images/41b91e72-c33e-42ee-b80f-b5c5bbf6431a?arch=x86_64&image_token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE2NTYwMjYzNzEsInN1YiI6IjQxYjkxZTcyLWMzM2UtNDJlZS1iODBmLWI1YzViYmY2NDMxYSJ9.1EX_VGaMNejMhrAvVRBS7PDPIQtbOOc8LtG8OukE1a4&type=minimal-iso&version=$VERSION
 ----
 
 . Download the ISO:

--- a/modules/architecture-machine-roles.adoc
+++ b/modules/architecture-machine-roles.adoc
@@ -14,9 +14,9 @@ The cluster also contains the definition for the `bootstrap` role. Because the b
 
 == Control plane and node host compatibility
 
-The {product-title} version must match between control plane host and node host. For example, in a 4.13 cluster, all control plane hosts must be 4.13 and all nodes must be 4.13.
+The {product-title} version must match between control plane host and node host. For example, in a {product-version} cluster, all control plane hosts must be {product-version} and all nodes must be {product-version}.
 
-Temporary mismatches during cluster upgrades are acceptable. For example, when upgrading from {product-title} 4.12 to 4.13, some nodes will upgrade to 4.13 before others. Prolonged skewing of control plane hosts and node hosts might expose older compute machines to bugs and missing features. Users should resolve skewed control plane hosts and node hosts as soon as possible.
+Temporary mismatches during cluster upgrades are acceptable. For example, when upgrading from the previous {product-title} version to {product-version}, some nodes will upgrade to {product-version} before others. Prolonged skewing of control plane hosts and node hosts might expose older compute machines to bugs and missing features. Users should resolve skewed control plane hosts and node hosts as soon as possible.
 
 The `kubelet` service must not be newer than `kube-apiserver`, and can be up to two minor versions older depending on whether your {product-title} version is odd or even. The table below shows the appropriate version compatibility:
 

--- a/modules/cli-installing-cli-rpm.adoc
+++ b/modules/cli-installing-cli-rpm.adoc
@@ -45,9 +45,9 @@ For {op-system-base-full}, you can install the OpenShift CLI (`oc`) as an RPM if
 
 . Enable the repositories required by {product-title} {product-version}.
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-# subscription-manager repos --enable="rhocp-4.13-for-rhel-8-x86_64-rpms"
+# subscription-manager repos --enable="rhocp-{product-version}-for-rhel-8-x86_64-rpms"
 ----
 +
 [NOTE]

--- a/modules/cluster-logging-feature-reference.adoc
+++ b/modules/cluster-logging-feature-reference.adoc
@@ -25,7 +25,7 @@ Vector does not support FIPS Enabled Clusters.
 
 .Prerequisites
 
-* {product-title}: 4.13
+* {product-title}: {product-version}
 * {logging-title-uc}: 5.4
 * FIPS disabled
 

--- a/modules/cluster-logging-loki-tech-preview.adoc
+++ b/modules/cluster-logging-loki-tech-preview.adoc
@@ -20,7 +20,7 @@ You can use the {product-title} web console to install the Loki Operator.
 
 .Prerequisites
 
-* {product-title}: 4.13
+* {product-title}: {product-version}
 * {logging-title-uc}: 5.4
 
 To install the Loki Operator using the {product-title} web console:

--- a/modules/cluster-logging-systemd-scaling.adoc
+++ b/modules/cluster-logging-systemd-scaling.adoc
@@ -25,10 +25,10 @@ and other settings.
 See "Creating machine configs with Butane" for information about Butane.
 ====
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 40-worker-custom-journald
   labels:

--- a/modules/cluster-logging-vector-tech-preview.adoc
+++ b/modules/cluster-logging-vector-tech-preview.adoc
@@ -30,7 +30,7 @@ Vector does not support FIPS Enabled Clusters.
 
 .Prerequisites
 
-* {product-title}: 4.13
+* {product-title}: {product-version}
 * {logging-title-uc}: 5.4
 * FIPS disabled
 

--- a/modules/cluster-node-tuning-operator-verify-profiles.adoc
+++ b/modules/cluster-node-tuning-operator-verify-profiles.adoc
@@ -39,10 +39,10 @@ $ oc get co/node-tuning -n openshift-cluster-node-tuning-operator
 ----
 
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME          VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-node-tuning   4.13.1    True        False         True       60m     1/5 Profiles with bootcmdline conflict
+node-tuning   {product-version}.1    True        False         True       60m     1/5 Profiles with bootcmdline conflict
 ----
 
 If either the `ClusterOperator/node-tuning` or a profile object's status is `DEGRADED`, additional information is provided in the Operator or operand logs.

--- a/modules/configmap-removing-ca.adoc
+++ b/modules/configmap-removing-ca.adoc
@@ -41,12 +41,12 @@ $ rosa describe cluster -c <cluster_name>
 +
 Before removal, the Additional trust bundle section appears, redacting its value for security purposes:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 Name:                       <cluster_name>
 ID:                         <cluster_internal_id>
 External ID:                <cluster_external_id>
-OpenShift Version:          4.13.0
+OpenShift Version:          {product-version}.0
 Channel Group:              stable
 DNS:                        <dns>
 AWS Account:                <aws_account_id>
@@ -71,12 +71,12 @@ Additional trust bundle:    REDACTED
 +
 After removing the proxy, the Additional trust bundle section is removed:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 Name:                       <cluster_name>
 ID:                         <cluster_internal_id>
 External ID:                <cluster_external_id>
-OpenShift Version:          4.13.0
+OpenShift Version:          {product-version}.0
 Channel Group:              stable
 DNS:                        <dns>
 AWS Account:                <aws_account_id>

--- a/modules/containers-signature-verify-enable.adoc
+++ b/modules/containers-signature-verify-enable.adoc
@@ -16,10 +16,10 @@ Enabling container signature validation for Red Hat Container Registries require
 See "Creating machine configs with Butane" for information about Butane.
 ====
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 51-worker-rh-registry-trust
   labels:

--- a/modules/coreos-layering-configuring.adoc
+++ b/modules/coreos-layering-configuring.adoc
@@ -24,7 +24,7 @@ When you configure a custom layered image, {product-title} no longer automatical
 You should use the same base {op-system} image that is installed on the rest of your cluster. Use the `oc adm release info --image-for rhel-coreos` command to obtain the base image being used in your cluster.
 ====
 +
-For example, the following Containerfile creates a custom layered image from an {product-title} 4.13 image and a Hotfix package:
+For example, the following Containerfile creates a custom layered image from an {product-title} {product-version} image and a Hotfix package:
 +
 .Example Containerfile for a custom layer image
 [source,yaml]
@@ -123,13 +123,13 @@ $ oc describe mc rendered-master-4e8be63aef68b843b546827b6ebe0913
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 Name:         rendered-master-4e8be63aef68b843b546827b6ebe0913
 Namespace:
 Labels:       <none>
 Annotations:  machineconfiguration.openshift.io/generated-by-controller-version: 8276d9c1f574481043d3661a1ace1f36cd8c3b62
-              machineconfiguration.openshift.io/release-image-version: 4.13.0-ec.3
+              machineconfiguration.openshift.io/release-image-version: {product-version}.0-ec.3
 API Version:  machineconfiguration.openshift.io/v1
 Kind:         MachineConfig
 ...

--- a/modules/customizing-the-jenkins-image-stream-tag.adoc
+++ b/modules/customizing-the-jenkins-image-stream-tag.adoc
@@ -23,7 +23,7 @@ To override the current upgrade value for existing deployments, change the value
 
 .Prerequisites
 
-* You are running OpenShift Jenkins on {product-title} 4.13.
+* You are running OpenShift Jenkins on {product-title} {product-version}.
 * You know the namespace where OpenShift Jenkins is deployed.
 
 .Procedure

--- a/modules/developer-cli-odo-installing-odo-on-linux-rpm.adoc
+++ b/modules/developer-cli-odo-installing-odo-on-linux-rpm.adoc
@@ -37,9 +37,9 @@ For {op-system-base-full}, you can install the `{odo-title}` CLI as an RPM.
 
 . Enable the repositories required by `{odo-title}`:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-# subscription-manager repos --enable="ocp-tools-4.13-for-rhel-8-x86_64-rpms"
+# subscription-manager repos --enable="ocp-tools-{product-version}-for-rhel-8-x86_64-rpms"
 ----
 
 . Install the `{odo-title}` package:

--- a/modules/eco-node-maintenance-operator-installation-cli.adoc
+++ b/modules/eco-node-maintenance-operator-installation-cli.adoc
@@ -99,10 +99,10 @@ $ oc get csv -n openshift-operators
 +
 .Example output
 
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME                               DISPLAY                     VERSION   REPLACES  PHASE
-node-maintenance-operator.v4.13    Node Maintenance Operator   4.13                Succeeded
+node-maintenance-operator.v{product-version}    Node Maintenance Operator   {product-version}                Succeeded
 ----
 . Verify that the Node Maintenance Operator is running:
 +

--- a/modules/enabling-baseline-capability-set.adoc
+++ b/modules/enabling-baseline-capability-set.adoc
@@ -20,6 +20,6 @@ As a cluster administrator, you can enable the capabilities by setting `baseline
 $ oc patch clusterversion version --type merge -p '{"spec":{"capabilities":{"baselineCapabilitySet":"vCurrent"}}}' <1>
 ----
 +
-<1> For `baselineCapabilitySet` you can specify `vCurrent`, `v4.12`, `v4.13`, or `None`.
+<1> For `baselineCapabilitySet` you can specify `vCurrent`, `v{product-version}`, or `None`.
 
 include::snippets/capabilities-table.adoc[]

--- a/modules/graceful-restart.adoc
+++ b/modules/graceful-restart.adoc
@@ -116,17 +116,17 @@ $ oc get clusteroperators
 +
 Check that there are no cluster Operators with the `DEGRADED` condition set to `True`.
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
-authentication                             4.13.0    True        False         False      59m
-cloud-credential                           4.13.0    True        False         False      85m
-cluster-autoscaler                         4.13.0    True        False         False      73m
-config-operator                            4.13.0    True        False         False      73m
-console                                    4.13.0    True        False         False      62m
-csi-snapshot-controller                    4.13.0    True        False         False      66m
-dns                                        4.13.0    True        False         False      76m
-etcd                                       4.13.0    True        False         False      76m
+authentication                             {product-version}.0    True        False         False      59m
+cloud-credential                           {product-version}.0    True        False         False      85m
+cluster-autoscaler                         {product-version}.0    True        False         False      73m
+config-operator                            {product-version}.0    True        False         False      73m
+console                                    {product-version}.0    True        False         False      62m
+csi-snapshot-controller                    {product-version}.0    True        False         False      66m
+dns                                        {product-version}.0    True        False         False      76m
+etcd                                       {product-version}.0    True        False         False      76m
 ...
 ----
 

--- a/modules/ibmz-configure-nbde-with-static-ip.adoc
+++ b/modules/ibmz-configure-nbde-with-static-ip.adoc
@@ -36,10 +36,10 @@ Enabling NBDE disk encryption in an {ibmzProductName} or {linuxoneProductName} e
 +
 The following example of a Butane configuration for a control plane node creates a file named `master-storage.bu` for disk encryption:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: master-storage
   labels:

--- a/modules/insights-operator-one-time-gather.adoc
+++ b/modules/insights-operator-one-time-gather.adoc
@@ -21,7 +21,7 @@ You must run a gather operation to create an Insights Operator archive.
 +
 [source,yaml]
 ----
-include::https://raw.githubusercontent.com/openshift/insights-operator/release-4.13/docs/gather-job.yaml[]
+include::https://raw.githubusercontent.com/openshift/insights-operator/release-4.14/docs/gather-job.yaml[]
 ----
 . Copy your `insights-operator` image version:
 +

--- a/modules/installation-aws-upload-custom-rhcos-ami.adoc
+++ b/modules/installation-aws-upload-custom-rhcos-ami.adoc
@@ -58,7 +58,7 @@ variable:
 ----
 $ export RHCOS_VERSION=<version> <1>
 ----
-<1> The {op-system} VMDK version, like `4.13.0`.
+<1> The {op-system} VMDK version, like `{product-version}.0`.
 
 . Export the Amazon S3 bucket name as an environment variable:
 +

--- a/modules/installation-complete-user-infra.adoc
+++ b/modules/installation-complete-user-infra.adoc
@@ -59,40 +59,40 @@ $ watch -n5 oc get clusteroperators
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
-authentication                             4.13.0    True        False         False      19m
-baremetal                                  4.13.0    True        False         False      37m
-cloud-credential                           4.13.0    True        False         False      40m
-cluster-autoscaler                         4.13.0    True        False         False      37m
-config-operator                            4.13.0    True        False         False      38m
-console                                    4.13.0    True        False         False      26m
-csi-snapshot-controller                    4.13.0    True        False         False      37m
-dns                                        4.13.0    True        False         False      37m
-etcd                                       4.13.0    True        False         False      36m
-image-registry                             4.13.0    True        False         False      31m
-ingress                                    4.13.0    True        False         False      30m
-insights                                   4.13.0    True        False         False      31m
-kube-apiserver                             4.13.0    True        False         False      26m
-kube-controller-manager                    4.13.0    True        False         False      36m
-kube-scheduler                             4.13.0    True        False         False      36m
-kube-storage-version-migrator              4.13.0    True        False         False      37m
-machine-api                                4.13.0    True        False         False      29m
-machine-approver                           4.13.0    True        False         False      37m
-machine-config                             4.13.0    True        False         False      36m
-marketplace                                4.13.0    True        False         False      37m
-monitoring                                 4.13.0    True        False         False      29m
-network                                    4.13.0    True        False         False      38m
-node-tuning                                4.13.0    True        False         False      37m
-openshift-apiserver                        4.13.0    True        False         False      32m
-openshift-controller-manager               4.13.0    True        False         False      30m
-openshift-samples                          4.13.0    True        False         False      32m
-operator-lifecycle-manager                 4.13.0    True        False         False      37m
-operator-lifecycle-manager-catalog         4.13.0    True        False         False      37m
-operator-lifecycle-manager-packageserver   4.13.0    True        False         False      32m
-service-ca                                 4.13.0    True        False         False      38m
-storage                                    4.13.0    True        False         False      37m
+authentication                             {product-version}.0    True        False         False      19m
+baremetal                                  {product-version}.0    True        False         False      37m
+cloud-credential                           {product-version}.0    True        False         False      40m
+cluster-autoscaler                         {product-version}.0    True        False         False      37m
+config-operator                            {product-version}.0    True        False         False      38m
+console                                    {product-version}.0    True        False         False      26m
+csi-snapshot-controller                    {product-version}.0    True        False         False      37m
+dns                                        {product-version}.0    True        False         False      37m
+etcd                                       {product-version}.0    True        False         False      36m
+image-registry                             {product-version}.0    True        False         False      31m
+ingress                                    {product-version}.0    True        False         False      30m
+insights                                   {product-version}.0    True        False         False      31m
+kube-apiserver                             {product-version}.0    True        False         False      26m
+kube-controller-manager                    {product-version}.0    True        False         False      36m
+kube-scheduler                             {product-version}.0    True        False         False      36m
+kube-storage-version-migrator              {product-version}.0    True        False         False      37m
+machine-api                                {product-version}.0    True        False         False      29m
+machine-approver                           {product-version}.0    True        False         False      37m
+machine-config                             {product-version}.0    True        False         False      36m
+marketplace                                {product-version}.0    True        False         False      37m
+monitoring                                 {product-version}.0    True        False         False      29m
+network                                    {product-version}.0    True        False         False      38m
+node-tuning                                {product-version}.0    True        False         False      37m
+openshift-apiserver                        {product-version}.0    True        False         False      32m
+openshift-controller-manager               {product-version}.0    True        False         False      30m
+openshift-samples                          {product-version}.0    True        False         False      32m
+operator-lifecycle-manager                 {product-version}.0    True        False         False      37m
+operator-lifecycle-manager-catalog         {product-version}.0    True        False         False      37m
+operator-lifecycle-manager-packageserver   {product-version}.0    True        False         False      32m
+service-ca                                 {product-version}.0    True        False         False      38m
+storage                                    {product-version}.0    True        False         False      37m
 ----
 +
 Alternatively, the following command notifies you when all of the clusters are available. It also retrieves and displays credentials:

--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -83,10 +83,10 @@ $ ls $HOME/clusterconfig/openshift/
 
 . Create a Butane config that configures the additional partition. For example, name the file `$HOME/clusterconfig/98-var-partition.bu`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This example places the `/var` directory on a separate partition:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker

--- a/modules/installation-disk-partitioning.adoc
+++ b/modules/installation-disk-partitioning.adoc
@@ -82,10 +82,10 @@ $ ls $HOME/clusterconfig/openshift/
 
 . Create a Butane config that configures the additional partition. For example, name the file `$HOME/clusterconfig/98-var-partition.bu`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This example places the `/var` directory on a separate partition:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker

--- a/modules/installation-operators-config.adoc
+++ b/modules/installation-operators-config.adoc
@@ -31,39 +31,39 @@ $ watch -n5 oc get clusteroperators
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME                                       VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
-authentication                             4.13.0    True        False         False      19m
-baremetal                                  4.13.0    True        False         False      37m
-cloud-credential                           4.13.0    True        False         False      40m
-cluster-autoscaler                         4.13.0    True        False         False      37m
-config-operator                            4.13.0    True        False         False      38m
-console                                    4.13.0    True        False         False      26m
-csi-snapshot-controller                    4.13.0    True        False         False      37m
-dns                                        4.13.0    True        False         False      37m
-etcd                                       4.13.0    True        False         False      36m
-image-registry                             4.13.0    True        False         False      31m
-ingress                                    4.13.0    True        False         False      30m
-insights                                   4.13.0    True        False         False      31m
-kube-apiserver                             4.13.0    True        False         False      26m
-kube-controller-manager                    4.13.0    True        False         False      36m
-kube-scheduler                             4.13.0    True        False         False      36m
-kube-storage-version-migrator              4.13.0    True        False         False      37m
-machine-api                                4.13.0    True        False         False      29m
-machine-approver                           4.13.0    True        False         False      37m
-machine-config                             4.13.0    True        False         False      36m
-marketplace                                4.13.0    True        False         False      37m
-monitoring                                 4.13.0    True        False         False      29m
-network                                    4.13.0    True        False         False      38m
-node-tuning                                4.13.0    True        False         False      37m
-openshift-apiserver                        4.13.0    True        False         False      32m
-openshift-controller-manager               4.13.0    True        False         False      30m
-openshift-samples                          4.13.0    True        False         False      32m
-operator-lifecycle-manager                 4.13.0    True        False         False      37m
-operator-lifecycle-manager-catalog         4.13.0    True        False         False      37m
-operator-lifecycle-manager-packageserver   4.13.0    True        False         False      32m
-service-ca                                 4.13.0    True        False         False      38m
-storage                                    4.13.0    True        False         False      37m
+authentication                             {product-version}.0    True        False         False      19m
+baremetal                                  {product-version}.0    True        False         False      37m
+cloud-credential                           {product-version}.0    True        False         False      40m
+cluster-autoscaler                         {product-version}.0    True        False         False      37m
+config-operator                            {product-version}.0    True        False         False      38m
+console                                    {product-version}.0    True        False         False      26m
+csi-snapshot-controller                    {product-version}.0    True        False         False      37m
+dns                                        {product-version}.0    True        False         False      37m
+etcd                                       {product-version}.0    True        False         False      36m
+image-registry                             {product-version}.0    True        False         False      31m
+ingress                                    {product-version}.0    True        False         False      30m
+insights                                   {product-version}.0    True        False         False      31m
+kube-apiserver                             {product-version}.0    True        False         False      26m
+kube-controller-manager                    {product-version}.0    True        False         False      36m
+kube-scheduler                             {product-version}.0    True        False         False      36m
+kube-storage-version-migrator              {product-version}.0    True        False         False      37m
+machine-api                                {product-version}.0    True        False         False      29m
+machine-approver                           {product-version}.0    True        False         False      37m
+machine-config                             {product-version}.0    True        False         False      36m
+marketplace                                {product-version}.0    True        False         False      37m
+monitoring                                 {product-version}.0    True        False         False      29m
+network                                    {product-version}.0    True        False         False      38m
+node-tuning                                {product-version}.0    True        False         False      37m
+openshift-apiserver                        {product-version}.0    True        False         False      32m
+openshift-controller-manager               {product-version}.0    True        False         False      30m
+openshift-samples                          {product-version}.0    True        False         False      32m
+operator-lifecycle-manager                 {product-version}.0    True        False         False      37m
+operator-lifecycle-manager-catalog         {product-version}.0    True        False         False      37m
+operator-lifecycle-manager-packageserver   {product-version}.0    True        False         False      32m
+service-ca                                 {product-version}.0    True        False         False      38m
+storage                                    {product-version}.0    True        False         False      37m
 ----
 . Configure the Operators that are not available.

--- a/modules/installation-special-config-butane-create.adoc
+++ b/modules/installation-special-config-butane-create.adoc
@@ -16,10 +16,10 @@ You can use Butane to produce a `MachineConfig` object so that you can configure
 
 . Create a Butane config file. The following example creates a file named `99-worker-custom.bu` that configures the system console to show kernel debug messages and specifies custom settings for the chrony time service:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 99-worker-custom
   labels:

--- a/modules/installation-special-config-chrony.adoc
+++ b/modules/installation-special-config-chrony.adoc
@@ -35,10 +35,10 @@ to your nodes as a machine config.
 See "Creating machine configs with Butane" for information about Butane.
 ====
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 99-worker-chrony <1>
   labels:

--- a/modules/installation-special-config-kmod.adoc
+++ b/modules/installation-special-config-kmod.adoc
@@ -385,10 +385,10 @@ $ cd .. && rm -rf kmod-tree && cp -Lpr ${FAKEROOT} kmod-tree
 See "Creating machine configs with Butane" for information about Butane.
 ====
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 99-simple-kmod
   labels:

--- a/modules/installation-special-config-raid.adoc
+++ b/modules/installation-special-config-raid.adoc
@@ -24,10 +24,10 @@ Butane is a command-line utility that {product-title} uses to provide convenient
 * To configure a data volume with RAID 1 on the same disks that are used for a mirrored boot disk, create a `$HOME/clusterconfig/raid1-storage.bu` file, for example:
 +
 .RAID 1 on mirrored boot disk
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: raid1-storage
   labels:
@@ -67,10 +67,10 @@ storage:
 * To configure a data volume with RAID 1 on secondary disks, create a `$HOME/clusterconfig/raid1-alt-storage.bu` file, for example:
 +
 .RAID 1 on secondary disks
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: raid1-alt-storage
   labels:

--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -59,10 +59,10 @@ For example, the `threshold` value of `2` in the following configuration can be 
 
 .Example Butane configuration for disk encryption
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: worker-storage
   labels:
@@ -205,11 +205,11 @@ $ ./openshift-install create manifests --dir <installation_directory> <1>
 . Create a Butane config that configures disk encryption, mirroring, or both.
 For example, to configure storage for compute nodes, create a `$HOME/clusterconfig/worker-storage.bu` file.
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 .Butane config example for a boot device
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: worker-storage <1>
   labels:

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -129,10 +129,10 @@ $ openshift-install create manifests --dir <installation_directory>
 
 . Create a Butane config that configures the additional partition. For example, name the file `$HOME/clusterconfig/98-var-partition.bu`, change the disk device name to the name of the storage device on the `worker` systems, and set the storage size as appropriate. This example places the `/var` directory on a separate partition:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker

--- a/modules/installing-ocp-agent-verify.adoc
+++ b/modules/installing-ocp-agent-verify.adoc
@@ -66,14 +66,14 @@ If you are using the optional method of {ztp} manifests, you can configure IP ad
 IPv6 is supported only on bare metal platforms.
 ====
 .Example of dual-stack networking
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVIP: 192.168.11.3
 ingressVIP: 192.168.11.4
 clusterDeploymentRef:
   name: mycluster
 imageSetRef:
-  name: openshift-4.13
+  name: openshift-{product-version}
 networking:
   clusterNetwork:
   - cidr: 172.21.0.0/16

--- a/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
+++ b/modules/ipi-install-configuring-ntp-for-disconnected-clusters.adoc
@@ -31,11 +31,11 @@ image::152_OpenShift_Config_NTP_0421.png[Configuring NTP for disconnected cluste
 See "Creating machine configs with Butane" for information about Butane.
 ====
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 .Butane config example
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 99-master-chrony-conf-override
   labels:
@@ -89,11 +89,11 @@ $ butane 99-master-chrony-conf-override.bu -o 99-master-chrony-conf-override.yam
 
 . Create a Butane config, `99-worker-chrony-conf-override.bu`, including the contents of the `chrony.conf` file for the worker nodes that references the NTP servers on the control plane nodes.
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 .Butane config example
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 99-worker-chrony-conf-override
   labels:

--- a/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
+++ b/modules/ipi-install-troubleshooting-ntp-out-of-sync.adoc
@@ -63,10 +63,10 @@ System clock synchronized: no
 See "Creating machine configs with Butane" for information about Butane.
 ====
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 99-master-chrony
   labels:

--- a/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
+++ b/modules/k8s-nmstate-deploying-nmstate-CLI.adoc
@@ -96,8 +96,8 @@ oc get clusterserviceversion -n openshift-nmstate \
 ----
 +
 .Example output
-[source, terminal]
+[source, terminal,subs="attributes+"]
 ----
 Name                                             Phase
-kubernetes-nmstate-operator.4.13.0-202210210157   Succeeded
+kubernetes-nmstate-operator.{product-version}.0-202210210157   Succeeded
 ----

--- a/modules/machineconfig-modify-journald.adoc
+++ b/modules/machineconfig-modify-journald.adoc
@@ -24,10 +24,10 @@ This procedure describes how to modify `journald` rate limiting settings in the 
 See "Creating machine configs with Butane" for information about Butane.
 ====
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 40-worker-custom-journald
   labels:

--- a/modules/nodes-cluster-resource-override-deploy-cli.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-cli.adoc
@@ -77,7 +77,7 @@ $ oc create -f cro-og.yaml
 
 .. Create a `Subscription` object YAML file (for example, cro-sub.yaml) for the Cluster Resource Override Operator:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -85,7 +85,7 @@ metadata:
   name: clusterresourceoverride
   namespace: clusterresourceoverride-operator
 spec:
-  channel: "4.13"
+  channel: "{product-version}"
   name: clusterresourceoverride
   source: redhat-operators
   sourceNamespace: openshift-marketplace

--- a/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-gcp-adding-a-gpu-node.adoc
@@ -211,16 +211,16 @@ $ oc get machineset myclustername-2pt9p-worker-a -n openshift-machine-api -o jso
 * Rename the machine set `name` by inserting the substring `gpu` in `metadata.name` and in both instances of `machine.openshift.io/cluster-api-machineset`.
 * Change the `machineType` of the new `MachineSet` definition to `a2-highgpu-1g`, which includes an NVIDIA A100 GPU.
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-jq .spec.template.spec.providerSpec.value.machineType ocp_4.13_machineset-a2-highgpu-1g.json
+jq .spec.template.spec.providerSpec.value.machineType ocp_{product-version}_machineset-a2-highgpu-1g.json
 
 "a2-highgpu-1g"
 ----
 +
-The `<output_file.json>` file is saved as `ocp_4.13_machineset-a2-highgpu-1g.json`.
+The `<output_file.json>` file is saved as `ocp_{product-version}_machineset-a2-highgpu-1g.json`.
 
-. Update the following fields in `ocp_4.13_machineset-a2-highgpu-1g.json`:
+. Update the following fields in `ocp_{product-version}_machineset-a2-highgpu-1g.json`:
 +
 * Change `.metadata.name` to a name containing `gpu`.
 
@@ -242,9 +242,9 @@ to match the new `.metadata.name`.
 
 . To verify your changes, perform a `diff` of the original compute definition and the new GPU-enabled node definition by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get machineset/myclustername-2pt9p-worker-a -n openshift-machine-api -o json | diff ocp_4.13_machineset-a2-highgpu-1g.json -
+$ oc get machineset/myclustername-2pt9p-worker-a -n openshift-machine-api -o json | diff ocp_{product-version}_machineset-a2-highgpu-1g.json -
 ----
 +
 .Example output
@@ -272,9 +272,9 @@ $ oc get machineset/myclustername-2pt9p-worker-a -n openshift-machine-api -o jso
 
 . Create the GPU-enabled compute machine set from the definition file by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc create -f ocp_4.13_machineset-a2-highgpu-1g.json
+$ oc create -f ocp_{product-version}_machineset-a2-highgpu-1g.json
 ----
 +
 .Example output

--- a/modules/nw-configuring-lb-allowed-source-ranges-migration.adoc
+++ b/modules/nw-configuring-lb-allowed-source-ranges-migration.adoc
@@ -53,7 +53,7 @@ spec:
 ...
 ----
 
-. Update your cluster to {product-title} 4.13.
+. Update your cluster to {product-title} {product-version}.
 
 . Set the allowed source ranges API for the `ingresscontroller` by running the following command:
 +

--- a/modules/nw-infw-operator-installing.adoc
+++ b/modules/nw-infw-operator-installing.adoc
@@ -76,10 +76,10 @@ $ oc get ip -n openshift-ingress-node-firewall
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME            CSV                                         APPROVAL    APPROVED
-install-5cvnz   ingress-node-firewall.4.13.0-202211122336   Automatic   true
+install-5cvnz   ingress-node-firewall.{product-version}.0-202211122336   Automatic   true
 ----
 
 . To verify the version of the Operator, enter the following command:
@@ -91,10 +91,10 @@ $ oc get csv -n openshift-ingress-node-firewall
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME                                        DISPLAY                          VERSION               REPLACES                                    PHASE
-ingress-node-firewall.4.13.0-202211122336   Ingress Node Firewall Operator   4.13.0-202211122336   ingress-node-firewall.4.13.0-202211102047   Succeeded
+ingress-node-firewall.{product-version}.0-202211122336   Ingress Node Firewall Operator   {product-version}.0-202211122336   ingress-node-firewall.{product-version}.0-202211102047   Succeeded
 ----
 
 [id="install-operator-web-console_{context}"]

--- a/modules/nw-metalLB-monitor-upgrading.adoc
+++ b/modules/nw-metalLB-monitor-upgrading.adoc
@@ -31,11 +31,11 @@ $ oc get csv
 
 . Review the output, checking the `PHASE` field. For example:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 VERSION     REPLACES                                         PHASE
-4.13.0      metallb-operator.4.13-nnnnnnnnnnnn               Installing
-4.13.0                                                       Replacing
+{product-version}.0      metallb-operator.{product-version}-nnnnnnnnnnnn               Installing
+{product-version}.0                                                       Replacing
 ----
 
 . Run `get csv` again to verify the output:
@@ -46,8 +46,8 @@ $ oc get csv
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME                                 DISPLAY                      VERSION   REPLACES                            PHASE
-metallb-operator.4.13-nnnnnnnnnnnn   MetalLB   4.13.0     metallb-operator.v4.13.0   Succeeded
+metallb-operator.{product-version}-nnnnnnnnnnnn   MetalLB   {product-version}.0     metallb-operator.v{product-version}.0   Succeeded
 ----

--- a/modules/nw-ptp-installing-operator-cli.adoc
+++ b/modules/nw-ptp-installing-operator-cli.adoc
@@ -96,8 +96,8 @@ $ oc get csv -n openshift-ptp -o custom-columns=Name:.metadata.name,Phase:.statu
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 Name                         Phase
-4.13.0-202301261535          Succeeded
+{product-version}.0-202301261535          Succeeded
 ----

--- a/modules/nw-rosa-proxy-remove-cli.adoc
+++ b/modules/nw-rosa-proxy-remove-cli.adoc
@@ -45,12 +45,12 @@ $ rosa describe cluster -c <cluster_name>
 +
 Before removal, the proxy IP displays in a proxy section:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 Name:                       <cluster_name>
 ID:                         <cluster_internal_id>
 External ID:                <cluster_external_id>
-OpenShift Version:          4.13.0
+OpenShift Version:          {product-version}.0
 Channel Group:              stable
 DNS:                        <dns>
 AWS Account:                <aws_account_id>
@@ -75,12 +75,12 @@ Additional trust bundle:    REDACTED
 +
 After removing the proxy, the proxy section is removed:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 Name:                       <cluster_name>
 ID:                         <cluster_internal_id>
 External ID:                <cluster_external_id>
-OpenShift Version:          4.13.0
+OpenShift Version:          {product-version}.0
 Channel Group:              stable
 DNS:                        <dns>
 AWS Account:                <aws_account_id>

--- a/modules/nw-sriov-installing-operator.adoc
+++ b/modules/nw-sriov-installing-operator.adoc
@@ -89,10 +89,10 @@ $ oc get csv -n openshift-sriov-network-operator \
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 Name                                         Phase
-sriov-network-operator.4.13.0-202310121402   Succeeded
+sriov-network-operator.{product-version}.0-202310121402   Succeeded
 ----
 
 [id="install-operator-web-console_{context}"]

--- a/modules/oadp-installing-oadp-rosa-sts.adoc
+++ b/modules/oadp-installing-oadp-rosa-sts.adoc
@@ -16,7 +16,7 @@ Restic is not supported in the OADP on ROSA with AWS STS environment. Ensure the
 .Prerequisites
 
 * A ROSA OpenShift Cluster with the required access and tokens.
-* link:https://docs.openshift.com/container-platform/4.13/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-creating-default-secret_installing-oadp-aws[A default Secret], if your backup and snapshot locations use the same credentials, or if you do not require a snapshot location.
+* link:https://docs.openshift.com/container-platform/4.14/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws.html#oadp-creating-default-secret_installing-oadp-aws[A default Secret], if your backup and snapshot locations use the same credentials, or if you do not require a snapshot location.
 
 .Procedure
 
@@ -122,6 +122,6 @@ You are now ready to backup and restore OpenShift applications, as described in 
 * link:https://docs.openshift.com/rosa/rosa_architecture/rosa-understanding.html[Understanding ROSA with STS]
 * link:https://docs.openshift.com/rosa/rosa_getting_started/rosa-sts-getting-started-workflow.html[Getting started with ROSA STS]
 * link:https://docs.openshift.com/rosa/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html[Creating a ROSA cluster with STS]
-* link:https://docs.openshift.com/container-platform/4.13/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html[About installing OADP]
-* link:https://docs.openshift.com/container-platform/4.13/storage/container_storage_interface/persistent-storage-csi.html[Configuring CSI volumes]
+* link:https://docs.openshift.com/container-platform/4.14/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html[About installing OADP]
+* link:https://docs.openshift.com/container-platform/4.14/storage/container_storage_interface/persistent-storage-csi.html[Configuring CSI volumes]
 * link:https://docs.openshift.com/rosa/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-storage_rosa-service-definition[ROSA storage options]

--- a/modules/oauth-configuring-token-inactivity-timeout.adoc
+++ b/modules/oauth-configuring-token-inactivity-timeout.adoc
@@ -55,10 +55,10 @@ $ oc get clusteroperators authentication
 Do not continue to the next step until `PROGRESSING` is listed as `False`, as shown in the following output:
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME             VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
-authentication   4.13.0    True        False         False      145m
+authentication   {product-version}.0    True        False         False      145m
 ----
 
 . Check that a new revision of the Kubernetes API server pods has rolled out. This will take several minutes.
@@ -71,10 +71,10 @@ $ oc get clusteroperators kube-apiserver
 Do not continue to the next step until `PROGRESSING` is listed as `False`, as shown in the following output:
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME             VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE
-kube-apiserver   4.13.0     True        False         False      145m
+kube-apiserver   {product-version}.0     True        False         False      145m
 ----
 +
 If `PROGRESSING` is showing `True`, wait a few minutes and try again.

--- a/modules/oc-mirror-creating-image-set-config.adoc
+++ b/modules/oc-mirror-creating-image-set-config.adoc
@@ -32,7 +32,7 @@ $ oc mirror init --registry example.com/mirror/oc-mirror-metadata > imageset-con
 
 . Edit the file and adjust the settings as necessary:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -44,11 +44,11 @@ storageConfig:                                                      <2>
 mirror:
   platform:
     channels:
-    - name: stable-4.13                                             <4>
+    - name: stable-{product-version}                                             <4>
       type: ocp
     graph: true                                                     <5>
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13  <6>
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}  <6>
     packages:
     - name: serverless-operator                                     <7>
       channels:

--- a/modules/oc-mirror-imageset-config-params.adoc
+++ b/modules/oc-mirror-imageset-config-params.adoc
@@ -109,10 +109,10 @@ repositories:
 |The Operators configuration of the image set.
 |Array of objects. For example:
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
     packages:
       - name: elasticsearch-operator
         minVersion: '2.4.0'
@@ -120,7 +120,7 @@ operators:
 
 |`mirror.operators.catalog`
 |The Operator catalog to include in the image set.
-|String. For example: `registry.redhat.io/redhat/redhat-operator-index:v4.13`.
+|String. For example: `registry.redhat.io/redhat/redhat-operator-index:v4.14`.
 
 |`mirror.operators.full`
 |When `true`, downloads the full catalog, Operator package, or Operator channel.
@@ -130,10 +130,10 @@ operators:
 |The Operator packages configuration.
 |Array of objects. For example:
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
     packages:
       - name: elasticsearch-operator
         minVersion: '5.2.3-31'
@@ -149,7 +149,7 @@ operators:
 
 |`mirror.operators.packages.channels.name`
 |The Operator channel name, unique within a package, to include in the image set.
-|String. For example: `fast` or `stable-v4.13`.
+|String. For example: `fast` or `stable-v4.14`.
 
 |`mirror.operators.packages.channels.maxVersion`
 |The highest version of the Operator mirror across all channels in which it exists.
@@ -209,11 +209,11 @@ architectures:
 |The platform channel configuration of the image set.
 |Array of objects. For example:
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 channels:
   - name: stable-4.10
-  - name: stable-4.13
+  - name: stable-{product-version}
 ----
 
 |`mirror.platform.channels.full`
@@ -222,7 +222,7 @@ channels:
 
 |`mirror.platform.channels.name`
 |The name of the release channel.
-|String. For example: `stable-4.13`
+|String. For example: `stable-4.14`
 
 |`mirror.platform.channels.minVersion`
 |The minimum version of the referenced platform to be mirrored.
@@ -230,7 +230,7 @@ channels:
 
 |`mirror.platform.channels.maxVersion`
 |The highest version of the referenced platform to be mirrored.
-|String. For example: `4.13.1`
+|String. For example: `4.14.1`
 
 |`mirror.platform.channels.shortestPath`
 |Toggles shortest path mirroring or full range mirroring.

--- a/modules/oc-mirror-oci-format.adoc
+++ b/modules/oc-mirror-oci-format.adoc
@@ -37,7 +37,7 @@ If you used the Technology Preview OCI local catalogs feature for the oc-mirror 
 +
 The following example image set configuration mirrors an OCI catalog on disk along with an {product-title} release and a UBI image from `registry.redhat.io`.
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -47,7 +47,7 @@ storageConfig:
 mirror:
   platform:
     channels:
-    - name: stable-4.13                                                      <2>
+    - name: stable-{product-version}                                                      <2>
       type: ocp
     graph: false
   operators:
@@ -55,7 +55,7 @@ mirror:
     targetCatalog: my-namespace/redhat-operator-index                        <4>
     packages:
     - name: aws-load-balancer-operator
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13           <5>
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}           <5>
     packages:
     - name: rhacs-operator
   additionalImages:

--- a/modules/odc-accessing-perspectives.adoc
+++ b/modules/odc-accessing-perspectives.adoc
@@ -13,7 +13,7 @@ You can access the *Administrator* and *Developer* perspective from the web cons
 To access a perspective, ensure that you have logged in to the web console. Your default perspective is automatically determined by the permission of the users. The *Administrator* perspective is selected for users with access to all projects, while the *Developer* perspective is selected for users with limited access to their own projects
 
 .Additional Resources
-See link:https://docs.openshift.com/container-platform/4.13/web_console/adding-user-preferences.html[Adding User Preferences] for more information on changing perspectives.
+See link:https://docs.openshift.com/container-platform/4.14/web_console/adding-user-preferences.html[Adding User Preferences] for more information on changing perspectives.
 
 
 .Procedure

--- a/modules/olm-catalogsource-image-template.adoc
+++ b/modules/olm-catalogsource-image-template.adoc
@@ -12,7 +12,7 @@ endif::[]
 [id="olm-catalogsource-image-template_{context}"]
 = Image template for custom catalog sources
 
-Operator compatibility with the underlying cluster can be expressed by a catalog source in various ways. One way, which is used for the default Red Hat-provided catalog sources, is to identify image tags for index images that are specifically created for a particular platform release, for example {product-title} 4.14.
+Operator compatibility with the underlying cluster can be expressed by a catalog source in various ways. One way, which is used for the default Red Hat-provided catalog sources, is to identify image tags for index images that are specifically created for a particular platform release, for example {product-title} {product-version}.
 
 During a cluster upgrade, the index image tag for the default Red Hat-provided catalog sources are updated automatically by the Cluster Version Operator (CVO) so that Operator Lifecycle Manager (OLM) pulls the updated version of the catalog. For example during an upgrade from {product-title} 4.13 to 4.14, the `spec.image` field in the `CatalogSource` object for the `redhat-operators` catalog is updated from:
 
@@ -77,7 +77,7 @@ If the `spec.image` field and the `olm.catalogImageTemplate` annotation are both
 If the `spec.image` field is not set and the annotation does not resolve to a usable pull spec, OLM stops reconciliation of the catalog source and sets it into a human-readable error condition.
 ====
 
-For an {product-title} 4.14 cluster, which uses Kubernetes 1.27, the `olm.catalogImageTemplate` annotation in the preceding example resolves to the following image reference:
+For an {product-title} {product-version} cluster, which uses Kubernetes 1.27, the `olm.catalogImageTemplate` annotation in the preceding example resolves to the following image reference:
 
 [source,terminal]
 ----

--- a/modules/olm-deleting-po.adoc
+++ b/modules/olm-deleting-po.adoc
@@ -58,8 +58,8 @@ $ oc get co platform-operators-aggregated
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME                            VERSION     AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-platform-operators-aggregated   4.13.0-0    True        False         False      70s
+platform-operators-aggregated   {product-version}.0-0    True        False         False      70s
 ----

--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -79,7 +79,7 @@ Red Hat does not provide direct guidance on sizing your {product-title} cluster.
 [id="cluster-maximums-major-releases-example-scenario_{context}"]
 == Example scenario
 
-As an example, 500 worker nodes (m5.2xl) were tested, and are supported, using {product-title} 4.13, the OVN-Kubernetes network plugin, and the following workload objects:
+As an example, 500 worker nodes (m5.2xl) were tested, and are supported, using {product-title} {product-version}, the OVN-Kubernetes network plugin, and the following workload objects:
 
 * 200 namespaces, in addition to the defaults
 * 60 pods per node; 30 server and 30 client pods (30k total)

--- a/modules/preparing-an-inital-cluster-deployment-for-mce-connected.adoc
+++ b/modules/preparing-an-inital-cluster-deployment-for-mce-connected.adoc
@@ -233,14 +233,14 @@ $ oc wait localvolume -n openshift-local-storage assisted-service --for conditio
 +
 .Example `clusterimageset.yaml`
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
   apiVersion: hive.openshift.io/v1
   kind: ClusterImageSet
   metadata:
-    name: "4.13"
+    name: "{product-version}"
   spec:
-    releaseImage: quay.io/openshift-release-dev/ocp-release:4.13.0-x86_64
+    releaseImage: quay.io/openshift-release-dev/ocp-release:{product-version}.0-x86_64
 ----
 
 . Create a manifest to import the agent installed cluster (that hosts the multicluster engine and the Assisted Service) as the hub cluster.

--- a/modules/preparing-an-inital-cluster-deployment-for-mce-disconnected.adoc
+++ b/modules/preparing-an-inital-cluster-deployment-for-mce-disconnected.adoc
@@ -23,7 +23,7 @@ To mirror your {product-title} image repository to your mirror registry, you can
 +
 .Example `ImageSetConfiguration.yaml`
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
   kind: ImageSetConfiguration
   apiVersion: mirror.openshift.io/v1alpha2
@@ -36,12 +36,12 @@ To mirror your {product-title} image repository to your mirror registry, you can
       architectures:
         - "amd64"
       channels:
-        - name: stable-4.13 <4>
+        - name: stable-{product-version} <4>
           type: ocp
     additionalImages:
       - name: registry.redhat.io/ubi9/ubi:latest
     operators:
-      - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13 <5>
+      - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version} <5>
         packages: <6>
           - name: multicluster-engine <7>
           - name: local-storage-operator <8>

--- a/modules/psap-driver-toolkit-pulling.adoc
+++ b/modules/psap-driver-toolkit-pulling.adoc
@@ -43,9 +43,6 @@ $ oc adm release info quay.io/openshift-release-dev/ocp-release:{product-version
 --
 +
 .Example output
-
-The output for the `ocp-release:4.13.0-x86_64` image is as follows:
-+ 
 [source,terminal]
 ----
 quay.io/openshift-release-dev/ocp-v4.0-art-dev@sha256:b53883ca2bac5925857148c4a1abc300ced96c222498e3bc134fe7ce3a1dd404

--- a/modules/psap-using-node-feature-discovery-operator.adoc
+++ b/modules/psap-using-node-feature-discovery-operator.adoc
@@ -26,7 +26,7 @@ As a cluster administrator, you can create a `NodeFeatureDiscovery` CR instance 
 
 . Create the following `NodeFeatureDiscovery` Custom Resource (CR), and then save the YAML in the `NodeFeatureDiscovery.yaml` file:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: nfd.openshift.io/v1
 kind: NodeFeatureDiscovery
@@ -37,7 +37,7 @@ spec:
   instance: "" # instance is empty by default
   topologyupdater: false # False by default
   operand:
-    image: registry.redhat.io/openshift4/ose-node-feature-discovery:v4.13
+    image: registry.redhat.io/openshift4/ose-node-feature-discovery:v{product-version}
     imagePullPolicy: Always
   workerConfig:
     configData: |

--- a/modules/registry-configuring-storage-baremetal.adoc
+++ b/modules/registry-configuring-storage-baremetal.adoc
@@ -113,10 +113,10 @@ $ oc get clusteroperator image-registry
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME             VERSION              AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-image-registry   4.13                 True        False         False      6h50m
+image-registry   {product-version}                 True        False         False      6h50m
 ----
 +
 . Ensure that your registry is set to managed to enable building and pushing of images.

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -310,10 +310,10 @@ $ oc get clusteroperator baremetal
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-baremetal   4.13.0    True        False         False      3d15h
+baremetal   {product-version}.0    True        False         False      3d15h
 ----
 
 . Remove the old `BareMetalHost` object by running the following command:

--- a/modules/rhcos-load-firmware-blobs.adoc
+++ b/modules/rhcos-load-firmware-blobs.adoc
@@ -18,10 +18,10 @@ See "Creating machine configs with Butane" for information about Butane.
 ====
 .Butane config file for custom firmware blob
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   labels:
     machineconfiguration.openshift.io/role: worker

--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -50,10 +50,10 @@ By default, the base OS RHEL with "Minimal" installation option enables firewall
 . Enable the repositories that are required for {product-title} {product-version}:
 .. On the machine that you run the Ansible playbooks, update the required repositories:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 # subscription-manager repos --disable=rhocp-4.11-for-rhel-8-x86_64-rpms \
-                             --enable=rhocp-4.13-for-rhel-8-x86_64-rpms
+                             --enable=rhocp-{product-version}-for-rhel-8-x86_64-rpms
 ----
 +
 [IMPORTANT]
@@ -70,10 +70,10 @@ As of {product-title} 4.11, the Ansible playbooks are provided only for {op-syst
 
 .. On each {op-system-base} compute node, update the required repositories:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 # subscription-manager repos --disable=rhocp-4.11-for-rhel-8-x86_64-rpms \
-                             --enable=rhocp-4.13-for-rhel-8-x86_64-rpms
+                             --enable=rhocp-{product-version}-for-rhel-8-x86_64-rpms
 ----
 
 . Update a {op-system-base} worker machine:

--- a/modules/rhel-preparing-node.adoc
+++ b/modules/rhel-preparing-node.adoc
@@ -70,12 +70,12 @@ Note that this might take a few minutes if you have a large number of available 
 
 . Enable only the repositories required by {product-title} {product-version}:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 # subscription-manager repos \
     --enable="rhel-8-for-x86_64-baseos-rpms" \
     --enable="rhel-8-for-x86_64-appstream-rpms" \
-    --enable="rhocp-4.13-for-rhel-8-x86_64-rpms" \
+    --enable="rhocp-{product-version}-for-rhel-8-x86_64-rpms" \
     --enable="fast-datapath-for-rhel-8-x86_64-rpms"
 ----
 

--- a/modules/rhel-preparing-playbook-machine.adoc
+++ b/modules/rhel-preparing-playbook-machine.adoc
@@ -58,12 +58,12 @@ If you use SSH key-based authentication, you must manage the key with an SSH age
 
 . Enable the repositories required by {product-title} {product-version}:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 # subscription-manager repos \
     --enable="rhel-8-for-x86_64-baseos-rpms" \
     --enable="rhel-8-for-x86_64-appstream-rpms" \
-    --enable="rhocp-4.13-for-rhel-8-x86_64-rpms"
+    --enable="rhocp-{product-version}-for-rhel-8-x86_64-rpms"
 ----
 
 . Install the required packages, including `openshift-ansible`:

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -60,7 +60,7 @@ $ rosa create account-roles --interactive \ <1>
 +
 --
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 I: Logged in as '<red_hat_username>' on 'https://api.openshift.com'
 I: Validating AWS credentials...
@@ -68,7 +68,7 @@ I: AWS credentials are valid!
 I: Validating AWS quota...
 I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
 I: Verifying whether OpenShift command-line tool is available...
-I: Current OpenShift Client Version: 4.13.0
+I: Current OpenShift Client Version: {product-version}.0
 I: Creating account roles
 ? Role prefix: ManagedOpenShift <1>
 ? Permissions boundary ARN (optional): <2>

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -150,7 +150,7 @@ $ rosa create account-roles
 +
 --
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 I: Logged in as '<red_hat_username>' on 'https://api.openshift.com'
 I: Validating AWS credentials...
@@ -158,7 +158,7 @@ I: AWS credentials are valid!
 I: Validating AWS quota...
 I: AWS quota ok. If cluster installation fails, validate actual AWS resource usage against https://docs.openshift.com/rosa/rosa_getting_started/rosa-required-aws-service-quotas.html
 I: Verifying whether OpenShift command-line tool is available...
-I: Current OpenShift Client Version: 4.13.0
+I: Current OpenShift Client Version: {product-version}.0
 I: Creating account roles
 ? Role prefix: ManagedOpenShift <1>
 ? Permissions boundary ARN (optional): <2>

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -23,7 +23,7 @@ The following table describes the interactive cluster creation mode options:
 |Create an OpenShift cluster that uses the AWS Security Token Service (STS) to allocate temporary, limited-privilege credentials for component-specific AWS Identity and Access Management (IAM) roles. The service enables cluster components to make AWS API calls using secure cloud resource management practices. The default is `Yes`.
 
 |`OpenShift version`
-|Select the version of OpenShift to install, for example `4.13`. The default is the latest version.
+|Select the version of OpenShift to install, for example {product-version}. The default is the latest version.
 
 |`Installer role ARN`
 |If you have more than one set of account roles in your AWS account for your cluster version, a list of installer role ARNs are provided. Select the ARN for the installer role that you want to use with your cluster. The cluster uses the account-wide roles and policies that relate to the selected installer role.

--- a/modules/sample-ztp-custom-resources.adoc
+++ b/modules/sample-ztp-custom-resources.adoc
@@ -12,7 +12,7 @@ You can customize the following {ztp} custom resources to specify more details a
 
 *agent-cluster-install.yaml*
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
   apiVersion: extensions.hive.openshift.io/v1beta1
   kind: AgentClusterInstall
@@ -23,7 +23,7 @@ You can customize the following {ztp} custom resources to specify more details a
     clusterDeploymentRef:
       name: ostest
     imageSetRef:
-      name: openshift-4.13
+      name: openshift-{product-version}
     networking:
       clusterNetwork:
       - cidr: 10.128.0.0/14
@@ -66,14 +66,14 @@ spec:
 
 *cluster-image-set.yaml*
 
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hive.openshift.io/v1
 kind: ClusterImageSet
 metadata:
-  name: openshift-4.13
+  name: openshift-{product-version}
 spec:
-  releaseImage: registry.ci.openshift.org/ocp/release:4.13.0-0.nightly-2022-06-06-025509
+  releaseImage: registry.ci.openshift.org/ocp/release:{product-version}.0-0.nightly-2022-06-06-025509
 ----
 
 *infra-env.yaml*

--- a/modules/serverless-quarkus-template.adoc
+++ b/modules/serverless-quarkus-template.adoc
@@ -45,7 +45,7 @@ Both `http` and `event` trigger functions have the same template structure:
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.13</version>
+      <version>4.14</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/modules/sriov-operator-hosted-control-planes.adoc
+++ b/modules/sriov-operator-hosted-control-planes.adoc
@@ -38,9 +38,9 @@ spec:
   - openshift-sriov-network-operator
 ----
 
-. Create a subscription to the SR-IOV Operator: 
+. Create a subscription to the SR-IOV Operator:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -48,7 +48,7 @@ metadata:
   name: sriov-network-operator-subsription
   namespace: openshift-sriov-network-operator
 spec:
-  channel: "4.13"
+  channel: "{product-version}"
   name: sriov-network-operator
   config:
     nodeSelector:
@@ -67,10 +67,10 @@ $ oc get csv -n openshift-sriov-network-operator
 ----
 +
 .Example output
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 NAME                                         DISPLAY                   VERSION               REPLACES                                     PHASE
-sriov-network-operator.4.13.0-202211021237   SR-IOV Network Operator   4.13.0-202211021237   sriov-network-operator.4.13.0-202210290517   Succeeded
+sriov-network-operator.{product-version}.0-202211021237   SR-IOV Network Operator   {product-version}.0-202211021237   sriov-network-operator.{product-version}.0-202210290517   Succeeded
 ----
 
 . To verify that the SR-IOV pods are deployed, run the following command:

--- a/modules/troubleshooting-enabling-kdump-day-one.adoc
+++ b/modules/troubleshooting-enabling-kdump-day-one.adoc
@@ -25,10 +25,10 @@ Create a `MachineConfig` object for cluster-wide configuration:
 
 . Create a Butane config file, `99-worker-kdump.bu`, that configures and enables kdump:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 99-worker-kdump <1>
   labels:

--- a/modules/update-network-sysctl-allowlist.adoc
+++ b/modules/update-network-sysctl-allowlist.adoc
@@ -24,7 +24,7 @@ $ oc get cm -n openshift-multus cni-sysctl-allowlist -oyaml
 +
 .Expected output
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 apiVersion: v1
 data:
@@ -48,7 +48,7 @@ metadata:
   annotations:
     kubernetes.io/description: |
       Sysctl allowlist for nodes.
-    release.openshift.io/version: 4.13.0-0.nightly-2022-11-16-003434
+    release.openshift.io/version: {product-version}.0-0.nightly-2022-11-16-003434
   creationTimestamp: "2022-11-17T14:09:27Z"
   name: cni-sysctl-allowlist
   namespace: openshift-multus

--- a/modules/virt-binding-devices-vfio-driver.adoc
+++ b/modules/virt-binding-devices-vfio-driver.adoc
@@ -32,10 +32,10 @@ See "Creating machine configs with Butane" for information about Butane.
 ====
 +
 .Example
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 variant: openshift
-version: 4.13.0
+version: {product-version}.0
 metadata:
   name: 100-worker-vfiopci
   labels:

--- a/modules/virt-measuring-latency-vm-secondary-network.adoc
+++ b/modules/virt-measuring-latency-vm-secondary-network.adoc
@@ -131,7 +131,7 @@ $ oc apply -n <target_namespace> -f <latency_config_map>.yaml
 . Create a `Job` manifest to run the checkup:
 +
 .Example job manifest
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: batch/v1
 kind: Job
@@ -145,7 +145,7 @@ spec:
       restartPolicy: Never
       containers:
         - name: vm-latency-checkup
-          image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup-rhel9:v4.13.0
+          image: registry.redhat.io/container-native-virtualization/vm-network-latency-checkup-rhel9:v{product-version}.0
           securityContext:
             allowPrivilegeEscalation: false
             capabilities:

--- a/storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
+++ b/storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.adoc
@@ -16,7 +16,7 @@ This procedure is specific to the Amazon Web Services Elastic File System (AWS E
 
 {product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for AWS Elastic File Service (EFS).
 
-Familiarity with link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/storage/index#persistent-storage-overview_understanding-persistent-storage[persistent storage] and link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/storage/index#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
+Familiarity with link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/storage/index#persistent-storage-overview_understanding-persistent-storage[persistent storage] and link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/storage/index#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
 
 After installing the AWS EFS CSI Driver Operator, {product-title} installs the AWS EFS CSI Operator and the AWS EFS CSI driver by default in the `openshift-cluster-csi-drivers` namespace. This allows the AWS EFS CSI Driver Operator to create CSI-provisioned PVs that mount to AWS EFS assets.
 
@@ -87,5 +87,5 @@ include::modules/persistent-storage-csi-olm-operator-uninstall.adoc[leveloffset=
 [role="_additional-resources"]
 == Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/storage/index#persistent-storage-csi[Configuring CSI volumes]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/storage/index#persistent-storage-csi[Configuring CSI volumes]
 

--- a/storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc
+++ b/storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc
@@ -16,7 +16,7 @@ This procedure is specific to the Amazon Web Services Elastic File System (AWS E
 
 {product-title} is capable of provisioning persistent volumes (PVs) using the Container Storage Interface (CSI) driver for AWS Elastic File Service (EFS).
 
-Familiarity with link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/storage/index#persistent-storage-overview_understanding-persistent-storage[persistent storage] and link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/storage/index#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
+Familiarity with link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/storage/index#persistent-storage-overview_understanding-persistent-storage[persistent storage] and link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/storage/index#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI Operator and driver.
 
 After installing the AWS EFS CSI Driver Operator, {product-title} installs the AWS EFS CSI Operator and the AWS EFS CSI driver by default in the `openshift-cluster-csi-drivers` namespace. This allows the AWS EFS CSI Driver Operator to create CSI-provisioned PVs that mount to AWS EFS assets.
 
@@ -51,7 +51,7 @@ include::modules/persistent-storage-csi-efs-sts.adoc[leveloffset=+1]
 * xref:../../storage/persistent_storage/rosa-persistent-storage-aws-efs-csi.adoc#persistent-storage-csi-olm-operator-install_rosa-persistent-storage-aws-efs-csi[Installing the AWS EFS CSI Driver Operator]
 
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/authentication_and_authorization/index#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/authentication_and_authorization/index#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]
 
 :StorageClass: AWS EFS
 :Provisioner: efs.csi.aws.com
@@ -80,5 +80,5 @@ include::modules/persistent-storage-csi-olm-operator-uninstall.adoc[leveloffset=
 [role="_additional-resources"]
 == Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/storage/index#persistent-storage-csi[Configuring CSI volumes]
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/storage/index#persistent-storage-csi[Configuring CSI volumes]
 

--- a/virt/support/virt-collecting-virt-data.adoc
+++ b/virt/support/virt-collecting-virt-data.adoc
@@ -34,7 +34,7 @@ Collecting data about your environment minimizes the time required to analyze an
 .Procedure
 
 . xref:../../support/gathering-cluster-data.adoc#support_gathering_data_gathering-cluster-data[Collect must-gather data for the cluster].
-. link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.13/html-single/troubleshooting_openshift_data_foundation/index#downloading-log-files-and-diagnostic-information_rhodf[Collect must-gather data for {rh-storage-first}], if necessary.
+. link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.14/html-single/troubleshooting_openshift_data_foundation/index#downloading-log-files-and-diagnostic-information_rhodf[Collect must-gather data for {rh-storage-first}], if necessary.
 . xref:../../virt/support/virt-collecting-virt-data.adoc#virt-using-virt-must-gather_virt-collecting-virt-data[Collect must-gather data for {VirtProductName}].
 . xref:../../monitoring/managing-metrics.adoc#querying-metrics-for-all-projects-as-an-administrator_managing-metrics[Collect Prometheus metrics for the cluster].
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-6186

Link to docs preview (VPN required):
[Creating machine configs with Butane](https://file.rdu.redhat.com/antaylor/OSDOCS-6186/installing/install_config/installing-customizing.html#installation-special-config-butane_installing-customizing) (7 different modules with attributes on this page in yaml. Will say "Branch Build")
[Initial Operator configuration](https://file.rdu.redhat.com/antaylor/OSDOCS-6186/installing/installing_bare_metal/installing-bare-metal.html#installation-operators-config_installing-bare-metal) (Table with multiple entries. This assembly has 74 "Branch Build" references on it)
[Installing the Kubernetes NMState Operator using the CLI](https://file.rdu.redhat.com/antaylor/OSDOCS-6186/networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.html#installing-the-kubernetes-nmstate-operator-CLI_k8s-nmstate-operator) (Verification last step, mid-line "Branch Build")
[Installing the Cluster Resource Override Operator using the CLI](https://file.rdu.redhat.com/antaylor/OSDOCS-6186/post_installation_configuration/node-tasks.html#nodes-cluster-resource-override-deploy-cli_post-install-node-tasks) (step 3 in quotation marks)
[Creating the image set configuration](https://file.rdu.redhat.com/antaylor/OSDOCS-6186/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-creating-image-set-config_installing-mirroring-disconnected) (Step 2)
[Preparing an agent-based cluster deployment for the multicluster engine for Kubernetes Operator while disconnected](https://file.rdu.redhat.com/antaylor/OSDOCS-6186/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.html#preparing-an-inital-cluster-deployment-for-mce-connected_preparing-an-agent-based-installed-cluster-for-mce) (Step 2)

Additional information:
* I added `{product-version}` attributes where possible to prevent the amount of manual intervention in future releases.
* Build preview will say **"Branch Build"** in preview. All columns will line up where needed in outputs in production after merging.
* The only thing I couldn't attribute-ize are hard links to OCP docs from ROSA and other distributions. It may be worth exploring some sort of script to bump these versions automatically in the future?
