### PR TITLE
OCPBUGS-12982 making clarification about iDRAC firmware version

### DIFF
--- a/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
+++ b/modules/ipi-install-bmc-addressing-for-dell-idrac.adoc
@@ -125,9 +125,7 @@ platform:
 
 [NOTE]
 ====
-There is a known issue on Dell iDRAC 9 with firmware version `04.40.00.00` or later for installer-provisioned installations on bare metal deployments. The Virtual Console plugin defaults to eHTML5, an enhanced version of HTML5, which causes problems with the *InsertVirtualMedia* workflow. Set the plugin to use HTML5 to avoid this issue. The menu path is *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
+There is a known issue on Dell iDRAC 9 with firmware version `04.40.00.00` and all releases up to including the `5.xx` series for installer-provisioned installations on bare metal deployments. The virtual console plugin defaults to eHTML5, an enhanced version of HTML5, which causes problems with the *InsertVirtualMedia* workflow. Set the plugin to use HTML5 to avoid this issue. The menu path is *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
 
 Ensure the {product-title} cluster nodes have *AutoAttach* enabled through the iDRAC console. The menu path is: *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* .
-
-The `redfish://` URL protocol corresponds to the `redfish` hardware type in Ironic.
 ====

--- a/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
+++ b/modules/ipi-install-firmware-requirements-for-installing-with-virtual-media.adoc
@@ -13,7 +13,7 @@ The installation program for installer-provisioned {product-title} clusters vali
 Red Hat does not test every combination of firmware, hardware, or other third-party components. For further information about third-party support, see link:https://access.redhat.com/third-party-software-support[Red Hat third-party support policy]. For information about updating the firmware, see the hardware documentation for the nodes or contact the hardware vendor.
 ====
 
-.Firmware compatibility for HP hardware with Redfish virtual media 
+.Firmware compatibility for HP hardware with Redfish virtual media
 [frame="topbot", options="header"]
 [cols="1,1,1"]
 |====
@@ -37,5 +37,5 @@ Red Hat does not test every combination of firmware, hardware, or other third-pa
 [NOTE]
 ====
 
-For Dell servers, ensure the {product-title} cluster nodes have *AutoAttach* enabled through the iDRAC console. The menu path is *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* . With iDRAC 9 firmware version `04.40.00.00` or later, the Virtual Console plugin defaults to eHTML5, an enhanced version of HTML5, which causes problems with the *InsertVirtualMedia* workflow. Set the plugin to use HTML5 to avoid this issue. The menu path is *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
+For Dell servers, ensure the {product-title} cluster nodes have *AutoAttach* enabled through the iDRAC console. The menu path is *Configuration* -> *Virtual Media* -> *Attach Mode* -> *AutoAttach* . With iDRAC 9 firmware version `04.40.00.00` and all releases up to including the `5.xx` series, the virtual console plugin defaults to eHTML5, an enhanced version of HTML5, which causes problems with the *InsertVirtualMedia* workflow. Set the plugin to use HTML5 to avoid this issue. The menu path is *Configuration* -> *Virtual console* -> *Plug-in Type* -> *HTML5* .
 ====


### PR DESCRIPTION
[OCPBUGS-12982]: Update note about iDRAC Plugin

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10, 4.11, 4.12, 4.13, 4.14, main

Issue:
https://issues.redhat.com/browse/OCPBUGS-12982

Link to docs preview: https://60978--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#ipi-install-firmware-requirements-for-installing-with-virtual-media_ipi-install-prerequisites

https://60978--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#bmc-addressing-for-dell-idrac_ipi-install-installation-workflow


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
