### PR TITLE
OSDOCS-6205: Added note for default OperatorHub source pods

### DIFF
--- a/modules/disabling-catalogsource-objects.adoc
+++ b/modules/disabling-catalogsource-objects.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * admin/olm-cs-podsched.adoc
+
+:_content-type: PROCEDURE
+[id="disabling-catalogsource-objects_{context}"]
+= Disabling default CatalogSource objects at a local level
+
+You can apply persistent changes to a `CatalogSource` object, such as catalog source pods, at a local level, by disabling a default `CatalogSource` object. Consider the default configuration in situations where the default `CatalogSource` object's configuration does not meet your organization's needs. By default, if you modify fields in the `spec.grpcPodConfig` section of the   `CatalogSource` object, the Marketplace Operator automatically reverts these changes.
+
+The Marketplace Operator, `openshift-marketplace`, manages the default custom resources (CRs) of the `OperatorHub`. The `OperatorHub` manages `CatalogSource` objects. 
+
+To apply persistent changes to `CatalogSource` object, you must first disable a default `CatalogSource` object.
+
+.Procedure
+
+* To disable all the default `CatalogSource` objects at a local level, enter the following command:
++
+[source,terminal]
+----
+$ oc patch operatorhub cluster -p '{"spec": {"disableAllDefaultSources": true}}' --type=merge
+----
++
+[NOTE]
+====
+You can also configure the default `OperatorHub` CR to either disable all `CatalogSource` objects or disable a specific object.
+====

--- a/operators/admin/olm-cs-podsched.adoc
+++ b/operators/admin/olm-cs-podsched.adoc
@@ -6,32 +6,51 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-When an Operator Lifecycle Manager (OLM) catalog source of source type `grpc` defines a `spec.image`, the Catalog Operator creates a pod that serves the defined image content. By default, this pod defines the following in its spec:
+When an Operator Lifecycle Manager (OLM) catalog source of source type `grpc` defines a `spec.image`, the Catalog Operator creates a pod that serves the defined image content. By default, this pod defines the following in its specification:
 
-* Only the `kubernetes.io/os=linux` node selector
-* No priority class name
-* No tolerations
+* Only the `kubernetes.io/os=linux` node selector.
+* The default priority class name: `system-cluster-critical`.
+* No tolerations.
 
 As an administrator, you can override these values by modifying fields in the `CatalogSource` object's optional `spec.grpcPodConfig` section.
+
+[IMPORTANT]
+====
+The Marketplace Operator, `openshift-marketplace`, manages the default `OperatorHub` custom resource's (CR). This CR manages `CatalogSource` objects. If you attempt to modify fields in the `CatalogSource` object’s `spec.grpcPodConfig` section, the Marketplace Operator automatically reverts these modifications.By default, if you modify fields in the `spec.grpcPodConfig` section of the   `CatalogSource` object, the Marketplace Operator automatically reverts these changes.
+
+To apply persistent changes to `CatalogSource` object, you must first disable a default `CatalogSource` object.
+====
 
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource_olm-understanding-olm[OLM concepts and resources -> Catalog source]
 
+include::modules/disabling-catalogsource-objects.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/understanding/olm-understanding-operatorhub.adoc#olm-operatorhub-arch-operatorhub_crd_olm-understanding-operatorhub[OperatorHub custom resource]
+
+* xref:../../operators/admin/olm-restricted-networks.html#olm-restricted-networks-operatorhub_olm-restricted-networks[Disabling the default OperatorHub catalog sources]
+
 include::modules/olm-node-selector.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
 
 include::modules/olm-priority-class-name.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/pods/nodes-pods-priority.adoc#admin-guide-priority-preemption-priority-class_nodes-pods-priority[Pod priority classes]
 
 include::modules/olm-tolerations.adoc[leveloffset=+1]
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
[OSDCOS-6205](https://issues.redhat.com/browse/OSDOCS-6205)

Version(s):
4.14 and 4.13

Link to docs preview:
[Catalog source pod scheduling](https://60979--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-cs-podsched.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [Slack](https://redhat-internal.slack.com/archives/C3VS0LV41/p1686234260442919)
* [OCPBUGS-15384](https://issues.redhat.com/browse/OCPBUGS-15384)
