### PR TITLE
Remove misleading verify deployment from OTEL

### DIFF
--- a/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
+++ b/distr_tracing/distr_tracing_install/distr-tracing-deploying-otel.adoc
@@ -9,8 +9,3 @@ toc::[]
 The {OTELName} Operator uses a custom resource definition (CRD) file that defines the architecture and configuration settings to be used when creating and deploying the {OTELName} resources. You can either install the default configuration or modify the file to better suit your business requirements. 
 
 include::modules/distr-tracing-config-otel-collector.adoc[leveloffset=+1]
-
-[id="validating-your-otel-deployment"]
-== Validating your deployment
-
-include::modules/distr-tracing-accessing-jaeger-console.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

The section is misleading, the verification of OTEL deployment should be done differently. The section was copied from Jaeger.

Version(s):
all supporter OCP versions 

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

@IshwarKanse 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
