### PR TITLE
Revert "[enterprise-4.14] OSDOCS#6374: Update the GCP without workload identity section"

### DIFF
--- a/modules/cert-manager-configure-cloud-credentials-gcp-non-sts.adoc
+++ b/modules/cert-manager-configure-cloud-credentials-gcp-non-sts.adoc
@@ -3,7 +3,7 @@
 // * security/cert_manager_operator/cert-manager-authenticate-non-sts-gcp.adoc
 
 :_content-type: PROCEDURE
-[id="cert-manager-configure-cloud-credentials-gcp-non-sts_{context}"]
+[id="cert-manager-prepare-cloud-credentials-gcp-non-sts_{context}"]
 = Configuring cloud credentials for the {cert-manager-operator} on GCP
 
 To configure the cloud credentials for the {cert-manager-operator} on a GCP cluster you must create a `CredentialsRequest` object, and allow the Cloud Credential Operator to generate the cloud credentials secret.
@@ -36,15 +36,6 @@ spec:
   serviceAccountNames:
   - cert-manager
 ----
-+
-[NOTE]
-====
-The `dns.admin` role provides admin privileges to the service account for managing Google Cloud DNS resources. To ensure that the cert-manager runs with the service account that has the least privilege, you can create a custom role with the following permissions:
-
-* `dns.resourceRecordSets.*`
-* `dns.changes.*`
-* `dns.managedZones.list`
-====
 
 . Create a `CredentialsRequest` resource by running the following command:
 +
@@ -76,7 +67,7 @@ NAME                                       READY   STATUS    RESTARTS   AGE
 cert-manager-bd7fbb9fc-wvbbt               1/1     Running   0          15m39s
 ----
 
-. Verify that the cert-manager controller pod is updated with GCP credential volumes that are mounted under the path specified in `mountPath` by running the following command:
+. Verify that the cert-manager controller pod is updated with GCP workload identity credential volumes that are mounted under the path specified in `mountPath` by running the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Reverts openshift/openshift-docs#60896