### PR TITLE
OCPBUGS-14131 update v4.{product-version} to read v4{product-version}

### DIFF
--- a/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
+++ b/modules/cnf-configure_for_irq_dynamic_load_balancing.adoc
@@ -51,7 +51,7 @@ metadata:
 spec:
   containers:
   - name: dynamic-irq-pod
-    image: "registry.redhat.io/openshift4/cnf-tests-rhel8:v4.{product-version}"
+    image: "registry.redhat.io/openshift4/cnf-tests-rhel8:v{product-version}"
     command: ["sleep", "10h"]
     resources:
       requests:


### PR DESCRIPTION
[OCPBUGS-14131]: Update configuring a node for IRQ dynamic load balancing

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13, 4.12, 4.11, 4.14 main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-14131
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://60989--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#configuring_for_irq_dynamic_load_balancing_cnf-master
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
