### PR TITLE
WMCO Add note that WMCO 8.0.0 is not available

### DIFF
--- a/windows_containers/windows-containers-release-notes-8-x.adoc
+++ b/windows_containers/windows-containers-release-notes-8-x.adoc
@@ -33,6 +33,11 @@ endif::openshift-origin[]
 
 This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 8.0.0 were released in link:https://access.redhat.com/errata/RHSA-2023:1372[RHSA-2023:1372].
 
+[IMPORTANT]
+====
+Due to a link:https://issues.redhat.com/browse/OCPBUGS-14464[known issue], WMCO 8.0.0 is not available to download and use. The issue will be addressed in WMCO 8.0.1, which is planned for release. If you upgrade your cluster from {product-title} 4.12 to {product-title} 4.13, you can continue to use WMCO 7.0.x. However, you will not be able to use the new WMCO 8.0.0 functionality, as described in this section.
+==== 
+
 [id="wmco-8-0-0-new-features"]
 === New features and improvements
 


### PR DESCRIPTION
Based on [a Slack convrsation](https://redhat-internal.slack.com/archives/CM4ERHBJS/p1686152769878919), the WMCO 8.0.0 is not available for installation. This PR adds a release note to announce this. 

Change Management acks required:
- [x] Product Experience: Eric Rich
- [x] Product Manager: Duncan Hardie
- [x] Engineering: Russell Teague
- [x] QE: Aruna Naik
- [x] DPM: Kathryn Alexander
