### PR TITLE
RHDEVDOCS-5384: Fix formatting in the migrating procedure for Tekton Hub in Pipelines doc

### DIFF
--- a/modules/op-migrating-tekton-hub-data-to-an-existing-crunchy-postgres-database.adoc
+++ b/modules/op-migrating-tekton-hub-data-to-an-existing-crunchy-postgres-database.adoc
@@ -19,7 +19,7 @@
 ----
 $ pg_dump -Ft -h localhost -U postgres hub -f /tmp/hub.dump
 ----
-
++
 . Copy the file containing the data dump to your local system.
 +
 .Command format
@@ -27,12 +27,13 @@ $ pg_dump -Ft -h localhost -U postgres hub -f /tmp/hub.dump
 ----
 $ oc cp -n <namespace> <podName>:<path-to-hub.dump> <path-to-local-system>
 ----
++
 .Example
 [source,terminal]
 ----
 $ oc cp -n openshift-pipelines tekton-hub-db-7d6d888c67-p7mdr:/tmp/hub.dump /home/test_user/Downloads/hub.dump
 ----
-
++
 . Copy the file that contains the data dump from the local system to the pod running the external Crunchy Postgres database.
 +
 .Command format
@@ -40,26 +41,29 @@ $ oc cp -n openshift-pipelines tekton-hub-db-7d6d888c67-p7mdr:/tmp/hub.dump /hom
 ----
 $ oc cp -n <namespace> <path-to-local-system> <podName>:<path-to-hub.dump>
 ----
++
 .Example
 [source,terminal]
 ----
 $ oc cp -n openshift-operators /home/test_user/Downloads/hub.dump test-instance1-spnz-0:/tmp/hub.dump
 ----
-
-. Restore the data in the Crunchy Postgres database. 
++
+. Restore the data in the Crunchy Postgres database.
++
 .Command format
 [source,terminal]
 ----
 $ pg_restore -d <database-name> -h localhost -U postgres <path-where-file-is-copied>
 ----
++
 .Example
 [source,terminal]
 ----
 $ pg_restore -d test -h localhost -U postgres /tmp/hub.dump
 ----
-
++
 . Get into the Crunchy Postgres pod.
-.Example: Get into the `test-instance1-m7hh-0` pod 
+.Example: Get into the `test-instance1-m7hh-0` pod
 +
 [source,terminal]
 ----
@@ -71,22 +75,22 @@ sh-4.4$ psql -U postgres
 psql (14.4)
 Type "help" for help.
 ----
-
++
 . Find the `pg_hba.conf` file.
 +
 [source,terminal]
 ----
 postgres=# SHOW hba_file;
-         hba_file         
+         hba_file
 --------------------------
  /pgdata/pg14/pg_hba.conf
 (1 row)
 
 postgres=#
 ----
-
++
 . Exit from the database.
-
++
 . Check if the `pg_hba.conf` file has the entry `host all all 0.0.0.0/0 md5`, which is necessary for accessing all incoming connections. If necessary, add the entry at the end of the `pg_hba.conf` file.
 +
 .Example: `pg_hba.conf` file
@@ -103,7 +107,7 @@ host all "_crunchyrepl" all reject
 hostssl all all all md5
 host  all  all 0.0.0.0/0 md5
 ----
-
++
 . Save the `pg_hba.conf` file and reload the database.
 +
 [source,terminal]
@@ -113,7 +117,7 @@ psql (14.4)
 Type "help" for help.
 
 postgres=# SHOW hba_file;
-         hba_file         
+         hba_file
 --------------------------
  /pgdata/pg14/pg_hba.conf
 (1 row)
@@ -124,10 +128,9 @@ postgres=# SELECT pg_reload_conf();
  t
 (1 row)
 ----
-
++
 . Exit the database.
-
-. Verify that a secret named `tekton-hub-db` in the target namespace has the following keys: 
+. Verify that a secret named `tekton-hub-db` in the target namespace has the following keys:
 * `POSTGRES_HOST`
 * `POSTGRES_DB`
 * `POSTGRES_USER`
@@ -145,10 +148,10 @@ metadata:
     app: tekton-hub-db
 type: Opaque
 stringData:
-  POSTGRES_HOST: test-primary.openshift-operators.svc 
+  POSTGRES_HOST: test-primary.openshift-operators.svc
   POSTGRES_DB: test
   POSTGRES_USER: test
-  POSTGRES_PASSWORD: woXOisU5>ocJiTF7y{{;1[Q( 
+  POSTGRES_PASSWORD: woXOisU5>ocJiTF7y{{;1[Q(
   POSTGRES_PORT: '5432'
 ...
 ----
@@ -156,18 +159,18 @@ stringData:
 [NOTE]
 ====
 The value of the `POSTGRES_HOST` field is encoded as a secret. You can decode the value of the Crunchy Postgres host by using the following example.
-+
-.Example: Decode the secret value of a Crunchy Postgres host 
+
+.Example: Decode the secret value of a Crunchy Postgres host
 [source,terminal]
 ----
 $ echo 'aGlwcG8tcHJpbWFyeS5vcGVuc2hpZnQtb3BlcmF0b3JzLnN2YyA=' | base64 --decode
 test-primary.openshift-operators.svc
 ----
 ====
-
++
 . Verify that in the `TektonHub` CR, the value of the database secret attribute is `tekton-hub-db`.
 +
-.Example: TektonHub CR with the name of the database secret 
+.Example: TektonHub CR with the name of the database secret
 [source,yaml]
 ----
 apiVersion: operator.tekton.dev/v1alpha1
@@ -176,18 +179,18 @@ metadata:
   name: hub
 spec:
   targetNamespace: openshift-pipelines
-  db:                      
-    secret: tekton-hub-db 
+  db:
+    secret: tekton-hub-db
 ...
 ----
-
++
 . To associate the external Crunchy Postgres database with {tekton-hub}, replace any existing `TektonHub` CR with the updated `TektonHub` CR.
 +
 [source,terminal]
 ----
 $ oc replace -f <updated-tekton-hub-cr>.yaml
 ----
-
++
 . Check the status of the {tekton-hub}. The updated `TektonHub` CR might take some time to attain a steady state.
 +
 [source,terminal]
@@ -201,6 +204,3 @@ $ oc get tektonhub.operator.tekton.dev
 NAME   VERSION   READY   REASON   APIURL                    UIURL
 hub    v1.9.0    True             https://api.route.url/    https://ui.route.url/
 ----
-
-
-


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12+

NOTE: Earlier 4.11 was mentioned by mistake, but this PR is not applicable to 4.11

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/RHDEVDOCS-5384

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://60994--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-tekton-hub-with-openshift-pipelines.html#migrating-tekton-hub-data-to-an-existing-crunchy-postgres-database_using-tekton-hub-with-openshift-pipelines

QE review: NOT REQUIRED, this is strictly a formatting change
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Step numbering was broken in a procedure. There is no change in this PR except adding/removing + signs between lines.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
