### PR TITLE
OSDOCS-6331: Add ROSA Interactive Walkthrough link to documentation

### DIFF
--- a/rosa_architecture/rosa-understanding.adoc
+++ b/rosa_architecture/rosa-understanding.adoc
@@ -17,6 +17,7 @@ You subscribe to the service directly from your AWS account. After the clusters 
 You receive OpenShift updates with new feature releases and a shared, common source for alignment with OpenShift Container Platform. ROSA supports the same versions of OpenShift as Red Hat OpenShift Dedicated and OpenShift Container Platform to achieve version consistency.
 
 image::291_OpenShift_on_AWS_Intro_1122_docs.png[{product-title}]
+For additional information on ROSA installation, see link:https://www.redhat.com/en/products/interactive-walkthrough/install-rosa[Installing Red Hat Openshift Service on AWS (ROSA) interactive walkthrough].
 
 [id="rosa-understanding-credential-modes_{context}"]
 == Credential modes

--- a/rosa_getting_started/rosa-quickstart-guide-ui.adoc
+++ b/rosa_getting_started/rosa-quickstart-guide-ui.adoc
@@ -8,7 +8,7 @@ toc::[]
 
 [NOTE]
 ====
-If you are looking for a comprehensive getting started guide for ROSA, see xref:../rosa_getting_started/rosa-getting-started.adoc#rosa-getting-started[Comprehensive guide to getting started with {product-title}].
+If you are looking for a comprehensive getting started guide for ROSA, see xref:../rosa_getting_started/rosa-getting-started.adoc#rosa-getting-started[Comprehensive guide to getting started with {product-title}]. For additional information on ROSA installation, see link:https://www.redhat.com/en/products/interactive-walkthrough/install-rosa[Installing Red Hat Openshift Service on AWS (ROSA) interactive walkthrough].
 ====
 
 Follow this guide to quickly create a {product-title} (ROSA) cluster using the {cluster-manager-first} {hybrid-console-second}, grant user access, deploy your first application, and learn how to revoke user access and delete your cluster.


### PR DESCRIPTION
Version(s):
4.13+

Issue:
[OSDOCS-6331](https://issues.redhat.com/browse/OSDOCS-6331)

Link to docs preview:
[About ROSA](https://61004--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-understanding.html#rosa-understanding-about_rosa-understanding)
[ROSA quickstart guide](https://61004--docspreview.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart-guide-ui.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
