### PR TITLE
Update travis validate step to use version 4.14

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -27,7 +27,7 @@ jobs:
         - pip3 install pyyaml
         - pip3 install aura.tar.gz
       script:
-        - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.13 --no-upstream-fetch && python3 makeBuild.py
+        - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.14 --no-upstream-fetch && python3 makeBuild.py
     - # stage name not required, will continue to use `build`
       if: branch IN (main, enterprise-4.13, enterprise-4.14)
       name: "Build openshift-dedicated distro"


### PR DESCRIPTION
Based on comments at https://github.com/openshift/openshift-docs/pull/60957#pullrequestreview-1468862182

Cherry-pick in `enterprise-4.14`