### PR TITLE
Added tech preview and optional secured cluster settings for Operator

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -114,6 +114,8 @@ Topics:
     File: init-bundle-ocp
   - Name: Installing secured cluster services for RHACS on Red Hat OpenShift
     File: install-secured-cluster-ocp
+  - Name: Optional - Configuring Secured cluster configuration options for RHACS using the Operator
+    File: install-secured-cluster-config-options-ocp
   - Name: Verifying installation of RHACS on Red Hat OpenShift
     File: verify-installation-rhacs-ocp
 - Name: Installing RHACS on other platforms

--- a/installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc
+++ b/installing/installing_ocp/install-secured-cluster-config-options-ocp.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+[id="install-secured-cluster-config-options-ocp"]
+= Optional - Configuring Secured cluster configuration options for RHACS using the Operator
+:context: install-secured-cluster-config-options-ocp
+include::modules/common-attributes.adoc[]
+
+toc::[]
+
+[role="_abstract"]
+This topic provides information about optional configuration settings that you can make using the Operator.
+
+include::modules/secured-cluster-configuration-options-operator.adoc[leveloffset=+1]

--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -172,6 +172,7 @@ The default value is `EBPF`.
 Red Hat recommends using `EBPF` for data collection.
 If you select `NoCollection`, Collector does not report any information about the network activity and the process executions.
 Available options are `NoCollection`, `EBPF`, and `CORE_BPF`.
+The `CORE_BPF` collection method is a Technology Preview feature only.
 
 | `perNode.collector.imageFlavor`
 | The image type to use for Collector. You can specify it as `Regular` or `Slim`.
@@ -191,6 +192,9 @@ If you use the `Slim` image type, you must ensure that your Central instance is 
 | Use this parameter to override the default resource limits for Compliance.
 
 |===
+
+:FeatureName: The `CORE_BPF` collection method
+include::snippets/technology-preview.adoc[]
 
 [id="taint-tolerations-settings_{context}"]
 == Taint Tolerations settings

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -70,6 +70,7 @@
 
 | `collector.collectionMethod`
 | Either `EBPF`, `CORE_BPF`, or `NO_COLLECTION`.
+The `CORE_BPF` collection method is a Technology Preview feature only.
 
 | `collector.imagePullPolicy`
 | Image pull policy for the Collector container.
@@ -269,6 +270,9 @@ Otherwise, you must ensure that Central can access the online probe repository h
 | The CPU limit for the Scanner DB container. Use this parameter to override the default value.
 
 |===
+
+:FeatureName: The `CORE_BPF` collection method
+include::snippets/technology-preview.adoc[]
 
 [id="secured-cluster-services-environment-variables_{context}"]
 == Environment variables


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-15875

Preview: 
- https://61032--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-config-options-ocp.html#per-node-settings_install-secured-cluster-config-options-ocp
- https://61032--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-secured-cluster-ocp.html#secured-cluster-services-config_install-secured-cluster-ocp

Cherrypick:
- `rhacs-docs-4.1`