### PR TITLE
OCPBUGS-11113 making clarification about add the annotation cpu-quota…

### DIFF
--- a/modules/cnf-configuring-workload-hints.adoc
+++ b/modules/cnf-configuring-workload-hints.adoc
@@ -26,3 +26,8 @@
 ----
 <1> If `highPowerConsumption` is `true`, the node is tuned for very low latency at the cost of increased power consumption.
 <2> Disables some debugging and monitoring features that can affect system latency.
+
+[NOTE]
+====
+When the `realTime` workload hint flag is set to `true` in a performance profile, add the `cpu-quota.crio.io: disable` annotation to every guaranteed pod with pinned CPUs. This annotation is necessary to prevent the degradation of the process performance within the pod.
+====

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -48,9 +48,14 @@ include::modules/cnf-understanding-workload-hints.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* For information on using the Performance Profile Creator (PPC) to generate a performance profile, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
+* For information about using the Performance Profile Creator (PPC) to generate a performance profile, see xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-create-performance-profiles[Creating a performance profile].
 
 include::modules/cnf-configuring-workload-hints.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For information about reducing CPU throttling for individual guaranteed pods, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#disabling-cpu-cfs-quota_cnf-master[Disabling CPU CFS quota].
 
 include::modules/cnf-cpu-infra-container.adoc[leveloffset=+2]
 


### PR DESCRIPTION
[OCPBUGS-11113]: Disabling CPU CFS quota annotation mandatory for performance profile with workloadHints: realTime: True

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue: https://issues.redhat.com/browse/OCPBUGS-11113
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://61043--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning#configuring-workload-hints_cnf-master
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
