### PR TITLE
Add an attribute for the first instance of `oc`

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -42,6 +42,7 @@ endif::openshift-origin[]
 :insights-advisor-url: link:https://console.redhat.com/openshift/insights/advisor/[Insights Advisor]
 :hybrid-console: Red Hat Hybrid Cloud Console
 :hybrid-console-second: Hybrid Cloud Console
+:oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
 :rh-storage-first: Red Hat OpenShift Data Foundation
 :rh-storage: OpenShift Data Foundation


### PR DESCRIPTION
Version(s):
4.10+

Issue:
Proposed in [Slack](https://redhat-internal.slack.com/archives/C85JYPHL3/p1686334200967689)

Additional information:
Hope to use this to make some Vale checks for attribute usage