### PR TITLE
RHDEVDOCS-5371: Correct the namespace in Pipelines as Code chapter

### DIFF
--- a/modules/op-customizing-pipelines-as-code-configuration.adoc
+++ b/modules/op-customizing-pipelines-as-code-configuration.adoc
@@ -7,7 +7,7 @@
 = Customizing {pac} configuration 
 
 [role="_abstract"]
-To customize {pac}, cluster administrators can configure the following parameters using the `pipelines-as-code` config map in the `pipelines-as-code` namespace:
+To customize {pac}, cluster administrators can configure the following parameters using the `pipelines-as-code` config map in the `openshift-pipelines` namespace:
 
 .Customizing {pac} configuration
 [options="header"]
@@ -17,7 +17,7 @@ To customize {pac}, cluster administrators can configure the following parameter
 
 | `application-name` | The name of the application. For example, the name displayed in the GitHub Checks labels. | `"Pipelines as Code CI"`
 
-| `max-keep-days` | The number of the days for which the executed pipeline runs are kept in the `pipelines-as-code` namespace. 
+| `max-keep-days` | The number of the days for which the executed pipeline runs are kept in the `openshift-pipelines` namespace. 
 
 Note that this `ConfigMap` setting does not affect the cleanups of a user's pipeline runs, which are controlled by the annotations on the pipeline run definition in the user's GitHub repository. |  NA
 

--- a/modules/op-pipelines-as-code-command-reference.adoc
+++ b/modules/op-pipelines-as-code-command-reference.adoc
@@ -55,7 +55,7 @@ By default, `tkn pac bootstrap` detects the OpenShift route, which is automatica
 
 If you do not have an {product-title} cluster, it asks you for the public URL that points to the ingress endpoint.
 
-| `tkn pac bootstrap github-app` | Create a GitHub application and secrets in the `pipelines-as-code` namespace.
+| `tkn pac bootstrap github-app` | Create a GitHub application and secrets in the `openshift-pipelines` namespace.
 
 |===
 

--- a/modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc
+++ b/modules/op-using-pipelines-as-code-with-bitbucket-cloud.adoc
@@ -69,7 +69,7 @@ $ tkn pac create repo
 +
 [source,terminal]
 ----
-$ echo https://$(oc get route -n pipelines-as-code pipelines-as-code-controller -o jsonpath='{.spec.host}')
+$ echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controller -o jsonpath='{.spec.host}')
 ----
 
 ... On Bitbucket Cloud, perform the following steps:
@@ -120,8 +120,8 @@ spec:
 * The `tkn pac create` and `tkn pac bootstrap` commands are not supported on Bitbucket Cloud.
 
 * Bitbucket Cloud does not support webhook secrets. To secure the payload and prevent hijacking of the CI, {pac} fetches the list of Bitbucket Cloud IP addresses and ensures that the webhook receptions come only from those IP addresses.
-** To disable the default behavior, set the `bitbucket-cloud-check-source-ip key` to `false` in the {pac} config map for the `pipelines-as-code` namespace.
-** To allow additional safe IP addresses or networks, add them as comma separated values to the `bitbucket-cloud-additional-source-ip` key in the {pac} config map for the `pipelines-as-code` namespace.
+** To disable the default behavior, set the `bitbucket-cloud-check-source-ip key` to `false` in the {pac} config map for the `openshift-pipelines` namespace.
+** To allow additional safe IP addresses or networks, add them as comma separated values to the `bitbucket-cloud-additional-source-ip` key in the {pac} config map for the `openshift-pipelines` namespace.
 ====
 
 . Optional: For an existing `Repository` CR, add multiple Bitbucket Cloud Webhook secrets or provide a substitute for a deleted secret.

--- a/modules/op-using-pipelines-as-code-with-bitbucket-server.adoc
+++ b/modules/op-using-pipelines-as-code-with-bitbucket-server.adoc
@@ -29,7 +29,7 @@ If your organization or project uses Bitbucket Server as the preferred platform,
 +
 [source,terminal]
 ----
-$ echo https://$(oc get route -n pipelines-as-code pipelines-as-code-controller -o jsonpath='{.spec.host}')
+$ echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controller -o jsonpath='{.spec.host}')
 ----
 
 . On Bitbucket Server, perform the following steps:

--- a/modules/op-using-pipelines-as-code-with-github-webhook.adoc
+++ b/modules/op-using-pipelines-as-code-with-github-webhook.adoc
@@ -95,7 +95,7 @@ $ tkn pac create repo
 +
 [source,terminal]
 ----
-$ echo https://$(oc get route -n pipelines-as-code pipelines-as-code-controller -o jsonpath='{.spec.host}')
+$ echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controller -o jsonpath='{.spec.host}')
 ----
 
 ... On your GitHub repository or organization, perform the following steps:

--- a/modules/op-using-pipelines-as-code-with-gitlab.adoc
+++ b/modules/op-using-pipelines-as-code-with-gitlab.adoc
@@ -66,7 +66,7 @@ $ tkn pac create repo
 +
 [source,terminal]
 ----
-$ echo https://$(oc get route -n pipelines-as-code pipelines-as-code-controller -o jsonpath='{.spec.host}')
+$ echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controller -o jsonpath='{.spec.host}')
 ----
 
 ... On your GitLab project, perform the following steps:


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: enterprise-4.11 and later
• **JIRA issue**: [RHDEVDOCS-5371](https://issues.redhat.com/browse/RHDEVDOCS-5371)
• **Preview page**: [Using Pipelines as Code](https://61080--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-pipelines-as-code.html)
• **SME Review**: Completed by @vdemeester 
• **QE review**: Completed by @VeereshAradhya 
• **Peer-review**: Completed by @Srivaralakshmi 