### PR TITLE
[RHACS] Added removing central-attached PV instructions

### DIFF
--- a/modules/remove-central-attached-pv-helm.adoc
+++ b/modules/remove-central-attached-pv-helm.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-helm.adoc
+:_content-type: PROCEDURE
+[id="remove-central-attached-pv-operator_{context}"]
+= Remove Central-attached PV using Helm
+
+[role="_abstract"]
+Remove the Central-attached persistent volume claim (PVC) `stackrox-db` to free up storage space.
+
+.Procedure
+* Run the following command:
++
+[source,terminal]
+----
+$ helm upgrade -n stackrox stackrox-central-services \
+    rhacs/central-services --version <current-rhacs-version> \
+    --set central.persistence.none=true
+----
+
+.Verification
+* Run the following command:
++
+[source,terminal]
+----
+$ oc -n stackrox describe pvc stackrox-db | grep -i 'Used By'
+Used By: <none> <1>
+----
+<1> Wait until you see `Used By: <none>`. It may take a few minutes.

--- a/modules/remove-central-attached-pv-operator.adoc
+++ b/modules/remove-central-attached-pv-operator.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-operator.adoc
+:_content-type: PROCEDURE
+[id="remove-central-attached-pv-operator_{context}"]
+= Remove Central-attached PV using the {product-title-short} Operator
+
+[role="_abstract"]
+Remove the Central-attached persistent volume claim (PVC) `stackrox-db` to free up storage space.
+
+.Procedure
+* Add the following annotation to Central:
++
+[source,yaml]
+----
+annotations:
+  platform.stackrox.io/obsolete-central-pvc: "true"
+----
+
+.Verification
+* Run the following command:
++
+[source,terminal]
+----
+$ oc -n stackrox describe pvc stackrox-db | grep -i 'Used By'
+Used By: <none> <1>
+----
+<1> Wait until you see `Used By: <none>`. It might take a few minutes.

--- a/modules/remove-central-attached-pv-overview.adoc
+++ b/modules/remove-central-attached-pv-overview.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-operator.adoc
+:_content-type: CONCEPT
+[id="remove-central-attached-pv-overview_{context}"]
+= Remove Central-attached PV
+
+[role="_abstract"]
+Kubernetes and {ocp} do not delete persistent volumes (PV) automatically. When you upgrade {product-title-short} from earlier versions, the Central PV called `stackrox-db` remains mounted. However, in {product-title-short} 4.1, Central does not need the previously attached PV anymore.
+
+The PV has data and persistent files used by earlier {product-title-short} versions. You can use the PV to roll back to an earlier version before {product-title-short} 4.1. Or, if you have a large RocksDB backup bundle for Central, you can use the PV to restore that data.
+
+If you do not plan to roll back or restore from earlier RocksDB backups, you can remove the Central-attached persistent volume claim (PVC) to free up the storage.
+
+[WARNING]
+====
+After removing PVC, you cannot roll back Central to an earlier version before {product-title-short} 4.1 or restore large RocksDB backups created with RocksDB.
+====

--- a/modules/remove-central-attached-pv-roxctl.adoc
+++ b/modules/remove-central-attached-pv-roxctl.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * upgrading/upgrade-helm.adoc
+:_content-type: PROCEDURE
+[id="remove-central-attached-pv-roxctl_{context}"]
+= Remove Central-attached PV using the `roxctl` CLI
+
+[role="_abstract"]
+Remove the Central-attached persistent volume claim (PVC) `stackrox-db` to free up storage space.
+
+.Procedure
+* Run the following command:
++
+[source,terminal]
+----
+$ oc get deployment central -n stackrox -o json | jq '(.spec.template.spec.volumes[] | select(.name=="stackrox-db"))={"name": "stackrox-db", "emptyDir": {}}' | oc apply -f -
+----
++
+It replaces the `stackrox-db`` entry in the `spec.template.spec.volumes` to a local emptyDir.
+
+.Verification
+* Run the following command:
++
+[source,terminal]
+----
+$ oc -n stackrox describe pvc stackrox-db | grep -i 'Used By'
+Used By: <none> <1>
+----
+<1> Wait until you see `Used By: <none>`. It might take a few minutes.

--- a/upgrading/upgrade-helm.adoc
+++ b/upgrading/upgrade-helm.adoc
@@ -42,4 +42,8 @@ include::modules/updating-helm-repository.adoc[leveloffset=+1]
 
 include::modules/upgrade-helm-chart.adoc[leveloffset=+1]
 
+include::modules/remove-central-attached-pv-overview.adoc[leveloffset=+1]
+
+include::modules/remove-central-attached-pv-helm.adoc[leveloffset=+2]
+
 include::modules/rollback-helm-upgrade.adoc[leveloffset=+1]

--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -32,6 +32,10 @@ include::modules/operator-upgrade-modify-central-custom-resource-tech-preview.ad
 
 include::modules/operator-upgrade-change-subscription-channel.adoc[leveloffset=+1]
 
+include::modules/remove-central-attached-pv-overview.adoc[leveloffset=+1]
+
+include::modules/remove-central-attached-pv-operator.adoc[leveloffset=+2]
+
 [id="rollback-operator-upgrade"]
 == Rolling back an Operator upgrade
 

--- a/upgrading/upgrade-roxctl.adoc
+++ b/upgrading/upgrade-roxctl.adoc
@@ -82,6 +82,10 @@ include::modules/rhcos-enable-node-scan.adoc[leveloffset=+2]
 .Additional resources
 * xref:../operating/manage-vulnerabilities/scan-rhcos-node-host.html#scan-rhcos-node-host[Scanning RHCOS node hosts]
 
+include::modules/remove-central-attached-pv-overview.adoc[leveloffset=+1]
+
+include::modules/remove-central-attached-pv-roxctl.adoc[leveloffset=+2]
+
 [id="rollback-central"]
 == Rolling back Central
 


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-17651

Preview:
1. https://61082--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-operator.html#remove-central-attached-pv-overview_upgrade-operator
2. https://61082--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-helm.html#remove-central-attached-pv-overview_upgrade-helm
3. https://61082--docspreview.netlify.app/openshift-acs/latest/upgrading/upgrade-roxctl.html#remove-central-attached-pv-overview_upgrade-roxctl

Cherry-pick:
- `rhacs-docs-4.1`