### PR TITLE
TELCODOCS-432: RN for RHACM 2.8 release with 4.13 z-stream

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2913,3 +2913,14 @@ $ oc adm release info 4.13.2 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-13-ipxe-ztp"]
+==== Support for iPXE network booting with ZTP
+{ztp-first} uses the Bare Metal Operator (BMO) to boot {op-system-first} on the target host as part of the deployment of spoke clusters. With this update, {ztp} leverages the capabilities of the BMO by adding the option of Preboot Execution Environment (iPXE) network booting for these RHCOS installations.
+
+[NOTE]
+====
+To use iPXE network booting, you must use {rh-rhacm-first} 2.8 or later.
+====
+
+For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and {ztp}].


### PR DESCRIPTION
[TELCODOCS-432](https://issues.redhat.com//browse/TELCODOCS-432): In tandem with RHACM 2.8 release, you can now use iPXE network booting to deploy OS on spoke clusters in ZTP.

Version(s):
4.13.3 (needs confirmation)

Issue:
https://issues.redhat.com/browse/TELCODOCS-432

Link to docs preview:
https://file.emea.redhat.com/rohennes/TELCODOCS-432-RN-rhacm2-8/release_notes/ocp-4-13-release-notes.html#ocp-4-13-ipxe-ztp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Peer review required only. The RN text will be added to 4.13.3 asynchronous release section.  
