### PR TITLE
OCPBUGS-9347-RE:Removed block statement for 3rd party vSphere CSI Driver

### DIFF
--- a/modules/compute-vsphere-nodes.adoc
+++ b/modules/compute-vsphere-nodes.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere.adoc
+// * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * machine_management/user_infra/adding-vsphere-compute-user-infra.adoc
+
+ifeval::["{context}" == "installing-vsphere"]
+:three-node-cluster:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="machine-vsphere-machines_{context}"]
+= Adding more compute machines to a cluster in vSphere
+
+You can add more compute machines to a user-provisioned {product-title} cluster on VMware vSphere.
+
+ifdef::three-node-cluster[]
+[NOTE]
+====
+If you are installing a three-node cluster, skip this step. A three-node cluster consists of three control plane machines, which also act as compute machines.
+====
+endif::three-node-cluster[]
+
+.Prerequisites
+
+* Obtain the base64-encoded Ignition file for your compute machines.
+* You have access to the vSphere template that you created for your cluster.
+
+.Procedure
+
+. After the template deploys, deploy a VM for a machine in the cluster.
+.. Right-click the template's name and click *Clone* -> *Clone to Virtual Machine*.
+.. On the *Select a name and folder* tab, specify a name for the VM. You might include the machine type in the name, such as `compute-1`.
++
+[NOTE]
+====
+Ensure that all virtual machine names across a vSphere installation are unique.
+====
+.. On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
+.. On the *Select a compute resource* tab, select the name of a host in your datacenter.
+.. Optional: On the *Select storage* tab, customize the storage options.
+.. On the *Select clone options*, select *Customize this virtual machine's hardware*.
+.. On the *Customize hardware* tab, click *VM Options* -> *Advanced*.
+*** From the *Latency Sensitivity* list, select *High*.
+*** Click *Edit Configuration*, and on the *Configuration Parameters* window, click *Add Configuration Params*. Define the following parameter names and values:
+**** `guestinfo.ignition.config.data`: Paste the contents of the base64-encoded compute Ignition config file for this machine type.
+**** `guestinfo.ignition.config.data.encoding`: Specify `base64`.
+**** `disk.EnableUUID`: Specify `TRUE`.
+.. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the machine type. Also, make sure to select the correct network under *Add network adapter* if there are multiple networks available.
+.. Complete the configuration and power on the VM.
+
+. Continue to create more compute machines for your cluster.
+
+ifeval::["{context}" == "installing-vsphere"]
+:!three-node-cluster:
+endif::[]

--- a/modules/persistent-storage-csi-vsphere-install-issues.adoc
+++ b/modules/persistent-storage-csi-vsphere-install-issues.adoc
@@ -3,22 +3,37 @@
 // persistent-storage-csi-vsphere.adoc
 //
 
+:_content-type: PROCEDURE
 [id="persistent-storage-csi-vsphere-install-issues_{context}"]
 = Removing a third-party vSphere CSI Operator Driver
 
-{product-title} 4.10 includes a built-in version of the vSphere Container Storage Interface (CSI) Operator Driver that is supported by Red Hat. If you have installed a vSphere CSI driver provided by the community or another vendor, upgrades will be prevented in a future release of {product-title}.
+{product-title} {product-version} includes a built-in version of the vSphere Container Storage Interface (CSI) Operator Driver that is supported by Red Hat.
 
-If you remove the third-party vSphere CSI driver, you do not need to delete associated persistent volume (PV) objects, and no data loss should occur.
+If you have installed a vSphere CSI driver provided by the community or another vendor, which is considered a third-party vSphere CSI driver, and you continue with upgrading to the next subsequent major version of {product-title}, the `oc` CLI prompts you with the following message: 
 
-[NOTE]
+[source,terminal]
+----
+VSphereCSIDriverOperatorCRUpgradeable: VMwareVSphereControllerUpgradeable:
+found existing unsupported csi.vsphere.vmware.com driver
+----
+
+The previous message informs you that Red Hat does not support the third-party vSphere CSI driver during an {product-title} upgrade operation. You can choose to ignore this message and continue with the upgrade operation.
+
+The instructions outlined in the procedure demonstrate an example of how to uninstall a third-party vSphere CSI Driver. Consult the vendor's or community provider's uninstall guide for more detailed instructions on removing the driver and its components.
+
+[IMPORTANT]
 ====
-These instructions may not be complete, so consult the vendor or community provider uninstall guide to ensure removal of the driver and components.
+When removing a third-party vSphere CSI driver, you do not need to delete the associated persistent volume (PV) objects. Data loss typically does not occur, but Red Hat does not take any responsibility if data loss does occur.
 ====
 
-To uninstall the third-party vSphere CSI Driver:
+After you have removed the third-party vSphere CSI Driver from the {product-title} cluster, installation of Red Hat's vSphere CSI Operator Driver automatically resumes. If you had existing vSphere CSI PV objects, their lifecycle is now managed by Red Hat's vSphere CSI Operator Driver.
+
+.Procedure
 
 . Delete the third-party vSphere CSI Driver (VMware vSphere Container Storage Plugin) Deployment and Daemonset objects.
+
 . Delete the configmap and secret objects that were installed previously with the third-party vSphere CSI Driver.
+
 . Delete the third-party vSphere CSI driver `CSIDriver` object:
 +
 [source,terminal]
@@ -30,5 +45,3 @@ To uninstall the third-party vSphere CSI Driver:
 ----
 csidriver.storage.k8s.io "csi.vsphere.vmware.com" deleted
 ----
-
-After you have removed the third-party vSphere CSI Driver from the {product-title} cluster, installation of Red Hat's vSphere CSI Operator Driver automatically resumes, and any conditions that could block upgrades to {product-title} 4.11, or later, are automatically removed. If you had existing vSphere CSI PV objects, their lifecycle is now managed by Red Hat's vSphere CSI Operator Driver.

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -28,9 +28,15 @@ To install the vSphere CSI Driver Operator, the following requirements must be m
 * Virtual machines of hardware version 15 or later
 * No third-party vSphere CSI driver already installed in the cluster
 
-If a third-party vSphere CSI driver is present in the cluster, {product-title} does not overwrite it. The presence of a third-party vSphere CSI driver prevents {product-title} from updating to {product-title} 4.13 or later.
-
-[NOTE]
+[IMPORTANT]
 ====
-The VMware vSphere CSI Driver Operator is supported only on clusters deployed with `platform: vsphere` in the installation manifest.
+If a third-party vSphere CSI driver is present in the cluster, {product-title} does not overwrite it. If you continue with the third-party vSphere CSI driver when upgrading to the next subsequent major version of {product-title}, the `oc` CLI prompts you with the following message: 
+
+[source,terminal]
+----
+VSphereCSIDriverOperatorCRUpgradeable: VMwareVSphereControllerUpgradeable:
+found existing unsupported csi.vsphere.vmware.com driver
+----
+
+The previous message informs you that Red Hat does not support the third-party vSphere CSI driver during an {product-title} upgrade operation. You can choose to ignore this message and continue with the upgrade operation.
 ====


### PR DESCRIPTION
[OCPBUGS-9347](https://issues.redhat.com/browse/OCPBUGS-9347)

Version(s):
4.11 and 4.10

Link to docs preview:
* [VMware vSphere CSI Driver Operator requirements](https://61084--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#vsphere-csi-driver-reqs_installing-vsphere-installer-provisioned-customizations)
* [Removing a third-party vSphere CSI Operator Driver](https://dfitzmau.github.io/previews/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Slack](https://redhat-internal.slack.com/archives/CBQHQFU0N/p1686324089585079) - contact Hemant
