### PR TITLE
OSDOCS-6440: Documented the 4.11.43 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3515,7 +3515,7 @@ $ oc adm release info 4.11.38 --pullspecs
 [id="ocp-4-11-38-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-39"]
 === RHSA-2023:2014 - {product-title} 4.11.39 bug fix and security update
@@ -3538,7 +3538,7 @@ $ oc adm release info 4.11.39 --pullspecs
 [id="ocp-4-11-39-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-40"]
 === RHBA-2023:2694 - {product-title} 4.11.40 bug fix update
@@ -3561,7 +3561,7 @@ $ oc adm release info 4.11.40 --pullspecs
 [id="ocp-4-11-40-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-41"]
 === RHBA-2023:3213 - {product-title} 4.11.41 bug fix update
@@ -3580,7 +3580,7 @@ $ oc adm release info 4.11.41 --pullspecs
 [id="ocp-4-11-41-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster within a minor version by using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
 
 [id="ocp-4-11-42"]
 === RHSA-2023:3309 - {product-title} 4.11.42 bug fix and security update
@@ -3597,6 +3597,25 @@ $ oc adm release info 4.11.42 --pullspecs
 ----
 
 [id="ocp-4-11-42-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-43"]
+=== RHSA-2023:3542 {product-title} 4.11.43 bug fix and security update
+
+Issued: 2023-06-14
+
+{product-title} release 4.11.43, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:3542[RHSA-2023:3542] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3541[RHSA-2023:3541] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.43 --pullspecs
+----
+
+[id="ocp-4-11-43-upgrading"]
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-6440](https://issues.redhat.com/browse/OSDOCS-6440)

Version(s):
4.11

Link to docs preview:
[Release note preview](https://61085--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes.html#ocp-4-11-43)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
