### PR TITLE
Update KubeVirtDeprecatedAPIRequested runbook name

### DIFF
--- a/modules/virt-runbook-kubevirtdeprecatedapirequested.adoc
+++ b/modules/virt-runbook-kubevirtdeprecatedapirequested.adoc
@@ -5,24 +5,24 @@
 // * virt/support/virt-runbooks.adoc
 
 :_content-type: REFERENCE
-[id="virt-runbook-KubeVirtDeprecatedAPIsRequested"]
-= KubeVirtDeprecatedAPIsRequested
+[id="virt-runbook-KubeVirtDeprecatedAPIRequested"]
+= KubeVirtDeprecatedAPIRequested
 
 [discrete]
-[id="meaning-kubevirtdeprecatedapisrequested"]
+[id="meaning-kubevirtdeprecatedapirequested"]
 == Meaning
 
 This alert fires when a deprecated `KubeVirt` API is used.
 
 [discrete]
-[id="impact-kubevirtdeprecatedapisrequested"]
+[id="impact-kubevirtdeprecatedapirequested"]
 == Impact
 
 Using a deprecated API is not recommended because the request will
 fail when the API is removed in a future release.
 
 [discrete]
-[id="diagnosis-kubevirtdeprecatedapisrequested"]
+[id="diagnosis-kubevirtdeprecatedapirequested"]
 == Diagnosis
 
 * Check the *Description* and *Summary* sections of the alert to identify the
@@ -37,7 +37,7 @@ deprecated API as in the following example:
 `2 requests were detected in the last 10 minutes.`
 
 [discrete]
-[id="mitigation-kubevirtdeprecatedapisrequested"]
+[id="mitigation-kubevirtdeprecatedapirequested"]
 == Mitigation
 
 Use fully supported APIs. The alert resolves itself after 10 minutes if the deprecated

--- a/virt/support/virt-runbooks.adoc
+++ b/virt/support/virt-runbooks.adoc
@@ -37,7 +37,7 @@ include::modules/virt-runbook-kubevirtcomponentexceedsrequestedcpu.adoc[leveloff
 
 include::modules/virt-runbook-kubevirtcomponentexceedsrequestedmemory.adoc[leveloffset=+1]
 
-include::modules/virt-runbook-kubevirtdeprecatedapisrequested.adoc[leveloffset=+1]
+include::modules/virt-runbook-kubevirtdeprecatedapirequested.adoc[leveloffset=+1]
 
 include::modules/virt-runbook-kubevirthyperconvergedclusteroperatorcrmodification.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: None
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [KubeVirtDeprecatedAPIRequested](https://61087--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-runbooks.html#virt-runbook-KubeVirtDeprecatedAPIRequested)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Update for [CNV-28863](https://issues.redhat.com//browse/CNV-28863)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
