### PR TITLE
OSDOCS-4799: Configure OVNH post-install

### DIFF
--- a/modules/configuring-hybrid-ovnkubernetes.adoc
+++ b/modules/configuring-hybrid-ovnkubernetes.adoc
@@ -5,17 +5,22 @@
 // * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 // * networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
 
+ifeval::["{context}" == "configuring-hybrid-networking"]
+:post-install:
+endif::[]
+
 :_content-type: PROCEDURE
 [id="configuring-hybrid-ovnkubernetes_{context}"]
 = Configuring hybrid networking with OVN-Kubernetes
 
-You can configure your cluster to use hybrid networking with OVN-Kubernetes. This allows a hybrid cluster that supports different node networking configurations. For example, this is necessary to run both Linux and Windows nodes in a cluster.
+You can configure your cluster to use hybrid networking with the OVN-Kubernetes network plugin. This allows a hybrid cluster that supports different node networking configurations. 
 
-[IMPORTANT]
+[NOTE]
 ====
-You must configure hybrid networking with OVN-Kubernetes during the installation of your cluster. You cannot switch to hybrid networking after the installation process.
+This configuration is necessary to run both Linux and Windows nodes in the same cluster.
 ====
 
+ifndef::post-install[]
 .Prerequisites
 
 * You defined `OVNKubernetes` for the `networking.networkType` parameter in the `install-config.yaml` file. See the installation documentation for configuring {product-title} network customizations on your chosen cloud provider for more information.
@@ -87,3 +92,67 @@ Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 is not su
 . Optional: Back up the `manifests/cluster-network-03-config.yml` file. The
 installation program deletes the `manifests/` directory when creating the
 cluster.
+endif::post-install[]
+ifdef::post-install[]
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster with a user with `cluster-admin` privileges.
+* Ensure that the cluster uses the OVN-Kubernetes network plugin.
+
+.Procedure
+
+. To configure the OVN-Kubernetes hybrid network overlay, enter the following command:
++
+[source,terminal]
+----
+$ oc patch networks.operator.openshift.io cluster --type=merge \
+  -p '{
+    "spec":{
+      "defaultNetwork":{
+        "ovnKubernetesConfig":{
+          "hybridOverlayConfig":{
+            "hybridClusterNetwork":[
+              {
+                "cidr": "<cidr>",
+                "hostPrefix": <prefix>
+              }
+            ],
+            "hybridOverlayVXLANPort": <overlay_port>
+          }
+        }
+      }
+    }
+  }'
+----
++
+--
+where:
+
+`cidr`:: Specify the CIDR configuration used for nodes on the additional overlay network. This CIDR cannot overlap with the cluster network CIDR.
+`hostPrefix`:: Specifies the subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
+`hybridOverlayVXLANPort`:: Specify a custom VXLAN port for the additional overlay network. This is required for running Windows nodes in a cluster installed on vSphere, and must not be configured for any other cloud provider. The custom port can be any open port excluding the default `4789` port. For more information on this requirement, see the Microsoft documentation on link:https://docs.microsoft.com/en-us/virtualization/windowscontainers/kubernetes/common-problems#pod-to-pod-connectivity-between-hosts-is-broken-on-my-kubernetes-cluster-running-on-vsphere[Pod-to-pod connectivity between hosts is broken].
+
+[NOTE]
+====
+Windows Server Long-Term Servicing Channel (LTSC): Windows Server 2019 is not supported on clusters with a custom `hybridOverlayVXLANPort` value because this Windows server version does not support selecting a custom VXLAN port.
+====
+--
++
+.Example output
+[source,text]
+----
+network.operator.openshift.io/cluster patched
+----
+
+. To confirm that the configuration is active, enter the following command. It can take several minutes for the update to apply.
++
+[source,terminal]
+----
+$ oc get network.operator.openshift.io -o jsonpath="{.items[0].spec.defaultNetwork.ovnKubernetesConfig}"
+----
+endif::post-install[]
+
+ifdef::post-install[]
+:!post-install:
+endif::[]

--- a/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc
@@ -10,8 +10,6 @@ As a cluster administrator, you can configure the {openshift-networking} OVN-Kub
 
 include::modules/configuring-hybrid-ovnkubernetes.adoc[leveloffset=+1]
 
-Complete any further installation configurations, and then create your cluster. Hybrid networking is enabled when the installation process is finished.
-
 [role="_additional-resources"]
 [id="configuring-hybrid-networking-additional-resources"]
 == Additional resources


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-4799

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+ (possibly 4.12)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- [Configuring hybrid networking](https://61108--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.html)
- AWS installation: [Configuring hybrid networking with OVN-Kubernetes](https://61108--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations.html#configuring-hybrid-ovnkubernetes_installing-aws-network-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Needs _Need backport-risk-assessment label followed by cherry-pick-approval_.