### PR TITLE
OSDOCS-4969: Support changing internal OVN-Kubernetes range

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1485,6 +1485,8 @@ Topics:
     File: rollback-to-openshift-sdn
   - Name: Converting to IPv4/IPv6 dual stack networking
     File: converting-to-dual-stack
+  - Name: Configuring internal subnets
+    File: configure-ovn-kubernetes-subnets
   - Name: Configure an external gateway on the default network
     File: configuring-secondary-external-gateway
   - Name: Configuring an egress IP address

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -254,6 +254,14 @@ ifdef::operator[]
 An object describing the IPsec mode for the cluster.
 endif::operator[]
 
+|`ipv4`
+|`object`
+|Specifies a configuration object for IPv4 settings.
+
+|`ipv6`
+|`object`
+|Specifies a configuration object for IPv6 settings.
+
 |`policyAuditConfig`
 |`object`
 |Specify a configuration object for customizing network policy audit logging. If unset, the defaults audit log settings are used.
@@ -267,19 +275,50 @@ endif::operator[]
 While migrating egress traffic, you can expect some disruption to workloads and service traffic until the Cluster Network Operator (CNO) successfully rolls out the changes.
 ====
 
-|`v4InternalSubnet`
+|`v6InternalSubnet`
+|
+|====
+
+.`ovnKubernetesConfig.ipv4` object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`internalTransitSwitchSubnet`
+|string
+|
+If your existing network infrastructure overlaps with the `100.88.0.0/16` IPv4 subnet, you can specify a different IP address range for internal use by OVN-Kubernetes. The subnet for the distributed transit switch that enables east-west traffic. This subnet cannot overlap with any other subnets used by OVN-Kubernetes or on the host itself. It must be large enough to accommodate one IP address per node in your cluster.
+
+The default value is `100.88.0.0/16`.
+
+|`internalJoinSubnet`
+|string
 |
 If your existing network infrastructure overlaps with the `100.64.0.0/16` IPv4 subnet, you can specify a different IP address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster. For example, if the `clusterNetwork.cidr` value is `10.128.0.0/14` and the `clusterNetwork.hostPrefix` value is `/23`, then the maximum number of nodes is `2^(23-14)=512`.
 
-This field cannot be changed after installation.
-|The default value is `100.64.0.0/16`.
+The default value is `100.64.0.0/16`.
 
-|`v6InternalSubnet`
+|====
+
+.`ovnKubernetesConfig.ipv6` object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`internalTransitSwitchSubnet`
+|string
 |
-If your existing network infrastructure overlaps with the `fd98::/48` IPv6 subnet, you can specify a different IP address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster.
+If your existing network infrastructure overlaps with the `fd97::/64` IPv6 subnet, you can specify a different IP address range for internal use by OVN-Kubernetes. The subnet for the distributed transit switch that enables east-west traffic. This subnet cannot overlap with any other subnets used by OVN-Kubernetes or on the host itself. It must be large enough to accommodate one IP address per node in your cluster.
 
-This field cannot be changed after installation.
-| The default value is `fd98::/48`.
+The default value is `fd97::/64`.
+
+|`internalJoinSubnet`
+|string
+|
+If your existing network infrastructure overlaps with the `fd98::/64` IPv6 subnet, you can specify a different IP address range for internal use by OVN-Kubernetes. You must ensure that the IP address range does not overlap with any other subnet used by your {product-title} installation. The IP address range must be larger than the maximum number of nodes that can be added to the cluster.
+
+The default value is `fd98::/64`.
+
 |====
 
 // tag::policy-audit[]
@@ -337,6 +376,40 @@ If you set this field to `true`, you do not receive the performance benefits of 
 |`object`
 |You can control IP forwarding for all traffic on OVN-Kubernetes managed interfaces by using the `ipForwarding` specification in the `Network` resource. Specify `Restricted` to only allow IP forwarding for Kubernetes related traffic. Specify `Global` to allow forwarding of all IP traffic. For new installations, the default is `Restricted`. For updates to {product-title} 4.14 or later, the default is `Global`.
 
+|`ipv4`
+|`object`
+|Optional: Specify an object to configure the internal OVN-Kubernetes masquerade address for host to service traffic for IPv4 addresses.
+
+|`ipv6`
+|`object`
+|Optional: Specify an object to configure the internal OVN-Kubernetes masquerade address for host to service traffic for IPv6 addresses.
+
+|====
+
+[id="gatewayconfig-ipv4-object_{context}"]
+.`gatewayConfig.ipv4` object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`internalMasqueradeSubnet`
+|`string`
+|
+The masquerade IPv4 addresses that are used internally to enable host to service traffic. The host is configured with these IP addresses as well as the shared gateway bridge interface. The default value is `169.254.169.0/29`.
+
+|====
+
+[id="gatewayconfig-ipv6-object_{context}"]
+.`gatewayConfig.ipv6` object
+[cols=".^2,.^2,.^6a",options="header"]
+|====
+|Field|Type|Description
+
+|`internalMasqueradeSubnet`
+|`string`
+|
+The masquerade IPv6 addresses that are used internally to enable host to service traffic. The host is configured with these IP addresses as well as the shared gateway bridge interface. The default value is `fd69::/125`.
+
 |====
 
 [id="nw-operator-cr-ipsec_{context}"]
@@ -356,7 +429,6 @@ a|Specifies the behavior of the IPsec implementation. Must be one of the followi
 --
 
 |====
-
 
 ifdef::operator[]
 [NOTE]

--- a/modules/nw-ovn-kuberentes-change-join-subnet.adoc
+++ b/modules/nw-ovn-kuberentes-change-join-subnet.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ovn-kubernetes-change-join-subnet_{context}"]
+= Configuring the OVN-Kubernetes join subnet
+
+You can change the join subnet used by OVN-Kubernetes to avoid conflicting with any existing subnets already in use in your environment.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster with a user with `cluster-admin` privileges.
+* Ensure that the cluster uses the OVN-Kubernetes network plugin.
+
+.Procedure
+
+. To change the OVN-Kubernetes join subnet, enter the following command:
++
+[source,terminal]
+----
+$ oc patch network.operator.openshift.io cluster --type='merge' \
+  -p='{"spec":{"defaultNetwork":{"ovnKubernetesConfig":
+    {"ipv4":{"internalJoinSubnet": "<join_subnet>"},
+    "ipv6":{"internalJoinSubnet": "<join_subnet>"}}}}}'
+----
++
+--
+where:
+
+`<join_subnet>`:: Specifies an IP address subnet for internal use by OVN-Kubernetes. The subnet must be larger than the number of nodes in the cluster and it must be large enough to accommodate one IP address per node in the cluster. This subnet cannot overlap with any other subnets used by {product-title} or on the host itself. The default value for IPv4 is `100.64.0.0/16` and the default value for IPv6 is `fd98::/64`.
+--
++
+.Example output
+[source,text]
+----
+network.operator.openshift.io/cluster patched
+----
+
+.Verification
+
+* To confirm that the configuration is active, enter the following command:
++
+[source,terminal]
+----
+$ oc get network.operator.openshift.io \
+  -o jsonpath="{.items[0].spec.defaultNetwork}"
+----
++
+It can take up to 30 minutes for this change to take effect.
++
+.Example output
+----
+{
+  "ovnKubernetesConfig": {
+    "ipv4": {
+      "internalJoinSubnet": "100.64.1.0/16"
+    },
+  },
+  "type": "OVNKubernetes"
+}
+----

--- a/modules/nw-ovn-kuberentes-change-transit-subnet.adoc
+++ b/modules/nw-ovn-kuberentes-change-transit-subnet.adoc
@@ -1,0 +1,63 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="nw-ovn-kubernetes-change-transit-subnet_{context}"]
+= Configuring the OVN-Kubernetes transit subnet
+
+You can change the transit subnet used by OVN-Kubernetes to avoid conflicting with any existing subnets already in use in your environment.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in to the cluster with a user with `cluster-admin` privileges.
+* Ensure that the cluster uses the OVN-Kubernetes network plugin.
+
+.Procedure
+
+. To change the OVN-Kubernetes transit subnet, enter the following command:
++
+[source,terminal]
+----
+$ oc patch network.operator.openshift.io cluster --type='merge' \
+  -p='{"spec":{"defaultNetwork":{"ovnKubernetesConfig":
+    {"ipv4":{"internalTransitSwitchSubnet": "<transit_subnet>"},
+    "ipv6":{"internalTransitSwitchSubnet": "<transit_subnet>"}}}}}'
+----
++
+--
+where:
+
+`<transit_subnet>`:: Specifies an IP address subnet for the distributed transit switch that enables east-west traffic. This subnet cannot overlap with any other subnets used by OVN-Kubernetes or on the host itself. The default value for IPv4 is `100.88.0.0/16` and the default value for IPv6 is `fd97::/64`.
+--
++
+.Example output
+[source,text]
+----
+network.operator.openshift.io/cluster patched
+----
+
+.Verification
+
+* To confirm that the configuration is active, enter the following command:
++
+[source,terminal]
+----
+$ oc get network.operator.openshift.io \
+  -o jsonpath="{.items[0].spec.defaultNetwork}"
+----
++
+It can take up to 30 minutes for this change to take effect.
++
+.Example output
+----
+{
+  "ovnKubernetesConfig": {
+    "ipv4": {
+      "internalTransitSwitchSubnet": "100.88.1.0/16"
+    },
+  },
+  "type": "OVNKubernetes"
+}
+----

--- a/networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc
+++ b/networking/ovn_kubernetes_network_provider/configure-ovn-kubernetes-subnets.adoc
@@ -1,0 +1,13 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="configure-ovn-kubernetes-subnets"]
+= Configuring OVN-Kubernetes internal IP address subnets
+include::_attributes/common-attributes.adoc[]
+:context: configure-ovn-kubernetes-subnets
+
+toc::[]
+
+[role="_abstract"]
+As a cluster administrator, you can change the IP address ranges that the OVN-Kubernetes network plugin uses for the join and transit subnets.
+
+include::modules/nw-ovn-kuberentes-change-join-subnet.adoc[leveloffset=+1]
+include::modules/nw-ovn-kuberentes-change-transit-subnet.adoc[leveloffset=+1]


### PR DESCRIPTION
This documents additional configuration fields for changing the internal IP address range used by OVN-Kubernetes for host to service traffic. This can be used to avoid collisions with existing IP address ranges.

So ultimately this is supported at cluster installation since 4.14 sometime, but the API for this is not available until 4.16.

- https://issues.redhat.com/browse/OSDOCS-4969

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.16+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

- [Cluster Network Operator configuration object](https://61109--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations#nw-operator-cr-cno-object_installing-aws-network-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
