### PR TITLE
OSDOCS-6264: OVN as Secondary Network GA

### DIFF
--- a/modules/configuration-ovnk-multi-network-policy.adoc
+++ b/modules/configuration-ovnk-multi-network-policy.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_content-type: CONCEPT
+[id="compatibility-with-multi-network-policy_{context}"]
+= Compatibility with multi-network policy
+
+The multi-network policy API, which is provided by the `MultiNetworkPolicy` custom resource definition (CRD) in the `k8s.cni.cncf.io` API group, is compatible with an OVN-Kubernetes secondary network. When defining a network policy, the network policy rules that can be used depend on whether the OVN-Kubernetes secondary network defines the `subnets` field. Refer to the following table for details:
+
+.Supported multi-network policy selectors based on `subnets` CNI configuration
+[cols=".^3,.^7",options="header"]
+|====
+a|`subnets` field specified|Allowed multi-network policy selectors
+
+|
+Yes
+a|
+* `podSelector` and `namespaceSelector`
+* `ipBlock`
+
+|
+No
+a|
+* `ipBlock`
+
+|====
+
+For example, the following multi-network policy is valid only if the `subnets` field is defined in the additional network CNI configuration for the additional network named `blue2`:
+
+.Example multi-network policy that uses a pod selector
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  name: allow-same-namespace
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: blue2
+spec:
+  podSelector:
+  ingress:
+  - from:
+    - podSelector: {}
+----
+
+The following example uses the `ipBlock` network policy selector, which is always valid for an OVN-Kubernetes additional network:
+
+.Example multi-network policy that uses an IP block selector
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1beta1
+kind: MultiNetworkPolicy
+metadata:
+  name:  ingress-ipblock
+  annotations:
+    k8s.v1.cni.cncf.io/policy-for: default/flatl2net
+spec:
+  podSelector: 
+    matchLabels:
+      name: access-control
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - ipBlock:
+        cidr: 10.200.0.0/30
+----

--- a/modules/configuration-ovnk-network-plugin-json-object.adoc
+++ b/modules/configuration-ovnk-network-plugin-json-object.adoc
@@ -11,40 +11,55 @@ The following table describes the configuration parameters for the OVN-Kubernete
 
 |`cniVersion`
 |`string`
-|The CNI specification version. The required value is `0.3.1`.
+|
+The CNI specification version. The required value is `0.3.1`.
 
 |`name`
 |`string`
-|The name of the network. These networks are not namespaced. For example, you can have a network named
+|
+The name of the network. These networks are not namespaced. For example, you can have a network named
 `l2-network` referenced from two different `NetworkAttachmentDefinitions` that exist on two different
 namespaces. This ensures that pods making use of the `NetworkAttachmentDefinition` on their own different
 namespaces can communicate over the same secondary network. However, those two different `NetworkAttachmentDefinitions` must also share the same network specific parameters such as `topology`, `subnets`, `mtu`, and `excludeSubnets`.
 
 |`type`
 |`string`
-|The name of the CNI plugin to configure. The required value is `ovn-k8s-cni-overlay`.
+|
+The name of the CNI plugin to configure. This value must be set to `ovn-k8s-cni-overlay`.
 
 |`topology`
 |`string`
-|The topological configuration for the network. The required value is `layer2`.
+|
+The topological configuration for the network. Must be one of `layer2` or `localnet`.
 
 |`subnets`
 |`string`
-| The subnet to use for the network across the cluster. When specifying `layer2` for the `topology`, only include the CIDR for the node. For example, `10.100.200.0/24`.
+|
+The subnet to use for the network across the cluster. When specifying `layer2` for the `topology`, only include the CIDR for the node. For example, `10.100.200.0/24`.
 
 For `"topology":"layer2"` deployments, IPv6 (`2001:DBB::/64`) and dual-stack (`192.168.100.0/24,2001:DBB::/64`) subnets are supported.
 
+When omitted, the logical switch implementing the network only provides layer 2 communication, and users must configure IP addresses for the pods. Port security only prevents MAC spoofing.
+
 |`mtu`
 |`string`
-|The maximum transmission unit (MTU) to the specified value. The default value, `1300`, is automatically set by the kernel.
+|
+The maximum transmission unit (MTU). The default value, `1300`, is automatically set by the kernel.
 
 |`netAttachDefName`
 |`string`
-|The metadata `namespace` and `name` of the network attachment definition object where this
+|
+The metadata `namespace` and `name` of the network attachment definition object where this
 configuration is included. For example, if this configuration is defined in a `NetworkAttachmentDefinition` in namespace `ns1` named `l2-network`, this should be set to `ns1/l2-network`.
 
 |`excludeSubnets`
 |`string`
-|A comma-separated list of CIDRs and IPs. IPs are removed from the assignable IP pool, and are never passed to the pods. When omitted, the logical switch implementing the network only provides layer 2 communication, and users must configure IPs for the pods. Port security only prevents MAC spoofing.
+|
+A comma-separated list of CIDRs and IP addresses. IP addresses are removed from the assignable IP address pool and are never passed to the pods.
+
+|`vlanID`
+|`integer`
+|
+If topology is set to `localnet`, the specified VLAN tag is assigned to traffic from this additional network. The default is to not assign a VLAN tag.
 
 |====

--- a/modules/configuring-layer-two-switched-topology.adoc
+++ b/modules/configuring-layer-two-switched-topology.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: CONCEPT
 [id="configuration-layer-two-switched-topology_{context}"]
-= Configuration for a switched topology
+= Configuration for a layer 2 switched topology
 
 The switched (layer 2) topology networks interconnect the workloads through a cluster-wide logical switch. This configuration can be used for IPv6 and dual-stack deployments.
 
@@ -13,18 +13,18 @@ The switched (layer 2) topology networks interconnect the workloads through a cl
 Layer 2 switched topology networks only allow for the transfer of data packets between pods within a cluster.
 ====
 
-The following `NetworkAttachmentDefinition` custom resource definition (CRD) YAML describes the fields needed to configure a switched secondary network.
+The following JSON example configures a switched secondary network:
 
-[source,yaml]
+[source,json]
 ----
-    {
-            "cniVersion": "0.3.1",
-            "name": "l2-network",
-            "type": "ovn-k8s-cni-overlay",
-            "topology":"layer2",
-            "subnets": "10.100.200.0/24",
-            "mtu": 1300,
-            "netAttachDefName": "ns1/l2-network",
-            "excludeSubnets": "10.100.200.0/29"
-    }
+{
+  "cniVersion": "0.3.1",
+  "name": "l2-network",
+  "type": "ovn-k8s-cni-overlay",
+  "topology":"layer2",
+  "subnets": "10.100.200.0/24",
+  "mtu": 1300,
+  "netAttachDefName": "ns1/l2-network",
+  "excludeSubnets": "10.100.200.0/29"
+}
 ----

--- a/modules/configuring-localnet-switched-topology.adoc
+++ b/modules/configuring-localnet-switched-topology.adoc
@@ -6,22 +6,103 @@
 [id="configuration-localnet-switched-topology_{context}"]
 = Configuration for a localnet switched topology
 
+// To accommodate a link to the NMstate Operator, the content in this module
+// is split with tags. The tag includes don't pull in the module header above.
+
+// tag::localnet-intro[]
 The switched (localnet) topology interconnects the workloads through a cluster-wide logical switch to a physical network.
+// end::localnet-intro[]
 
-The following `NetworkAttachmentDefinition` custom resource definition (CRD) YAML describes the fields needed to configure a localnet secondary network.
+// tag::localnet-content[]
+You must map an additional network to the OVN bridge to use it as an OVN-Kubernetes additional network. Bridge mappings allow network traffic to reach the physical network. A bridge mapping associates a physical network name, also known as an interface label, to a bridge created with Open vSwitch (OVS).
 
+You can create an `NodeNetworkConfigurationPolicy` object, part of the `nmstate.io/v1` API group, to declaratively create the mapping. This API is provided by the NMState Operator. By using this API you can apply the bridge mapping to nodes that match your specified `nodeSelector` expression, such as `node-role.kubernetes.io/worker: ''`.
+
+When attaching an additional network, you can either use the existing `br-ex` bridge or create a new bridge. Which approach to use depends on your specific network infrastructure.
+
+- If your nodes include only a single network interface, you must use the existing bridge. This network interface is owned and managed by OVN-Kubernetes and you must not remove it from the `br-ex` bridge or alter the interface configuration. If you remove or alter the network interface, your cluster network will stop working correctly.
+- If your nodes include several network interfaces, you can attach a different network interface to a new bridge, and use that for your additional network. This approach provides for traffic isolation from your primary cluster network.
+
+The `localnet1` network is mapped to the `br-ex` bridge in the following example:
+
+.Example mapping for sharing a bridge
 [source,yaml]
 ----
-    {
-            "cniVersion": "0.3.1",
-            "name": "ns1-localnet-network",
-            "type": "ovn-k8s-cni-overlay",
-            "topology":"localnet",
-            "subnets": "202.10.130.112/28",
-            "vlanID": 33,
-            "mtu": 1500,
-            "netAttachDefName": "ns1/localnet-network"
-            "excludeSubnets": "10.100.200.0/29"
-
-    }
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: mapping <1>
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: '' <2>
+  desiredState:
+    ovn:
+      bridge-mappings:
+      - localnet: localnet1 <3>
+        bridge: br-ex <4>
+        state: present <5>
 ----
+<1> The name for the configuration object.
+<2> A node selector that specifies the nodes to apply the node network configuration policy to.
+<3> The name for the additional network from which traffic is forwarded to the OVS bridge. This additional network must match the name of the `spec.config.name` field of the `NetworkAttachmentDefinition` object that defines the OVN-Kubernetes additional network.
+<4> The name of the OVS bridge on the node. This value is required only if you specify `state: present`.
+<5> The state for the mapping. Must be either `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
+
+In the following example, the `localnet2` network interface is attached to the `ovs-br1` bridge. Through this attachment, the network interface is available to the OVN-Kubernetes network plugin as an additional network.
+
+.Example mapping for nodes with multiple interfaces
+[source,yaml]
+----
+apiVersion: nmstate.io/v1
+kind: NodeNetworkConfigurationPolicy
+metadata:
+  name: ovs-br1-multiple-networks <1>
+spec:
+  nodeSelector:
+    node-role.kubernetes.io/worker: '' <2>
+  desiredState:
+    interfaces:
+    - name: ovs-br1 <3>
+      description: |-
+        A dedicated OVS bridge with eth1 as a port
+        allowing all VLANs and untagged traffic
+      type: ovs-bridge
+      state: up
+      bridge:
+        options:
+          stp: true
+        port:
+        - name: eth1 <4>
+    ovn:
+      bridge-mappings:
+      - localnet: localnet2 <5>
+        bridge: ovs-br1 <6>
+        state: present <7>
+----
+<1> The name for the configuration object.
+<2> A node selector that specifies the nodes to apply the node network configuration policy to.
+<3> A new OVS bridge, separate from the default bridge used by OVN-Kubernetes for all cluster traffic.
+<4> A network device on the host system to associate with this new OVS bridge.
+<5> The name for the additional network from which traffic is forwarded to the OVS bridge. This additional network must match the name of the `spec.config.name` field of the `NetworkAttachmentDefinition` object that defines the OVN-Kubernetes additional network.
+<6> The name of the OVS bridge on the node. This value is required only if you specify `state: present`.
+<7> The state for the mapping. Must be either `present` to add the bridge or `absent` to remove the bridge. The default value is `present`.
+
+This declarative approach is recommended because the NMState Operator applies additional network configuration to all nodes specified by the node selector automatically and transparently.
+
+The following JSON example configures a localnet secondary network:
+
+[source,json]
+----
+{
+  "cniVersion": "0.3.1",
+  "name": "ns1-localnet-network",
+  "type": "ovn-k8s-cni-overlay",
+  "topology":"localnet",
+  "subnets": "202.10.130.112/28",
+  "vlanID": 33,
+  "mtu": 1500,
+  "netAttachDefName": "ns1/localnet-network"
+  "excludeSubnets": "10.100.200.0/29"
+}
+----
+// end::localnet-content[]

--- a/modules/configuring-ovnk-additional-networks.adoc
+++ b/modules/configuring-ovnk-additional-networks.adoc
@@ -6,14 +6,28 @@
 [id="configuration-ovnk-additional-networks_{context}"]
 = Configuration for an OVN-Kubernetes additional network
 
-The {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. To configure secondary network interfaces, you must define the configurations in the `NetworkAttachmentDefinition` custom resource definition (CRD).
+The {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. To configure secondary network interfaces, you must define the configurations in the `NetworkAttachmentDefinition` custom resource (CR).
 
-:FeatureName: Configuration for an OVN-Kubernetes additional network
-include::snippets/technology-preview.adoc[]
+You can configure an OVN-Kubernetes additional network in either _layer 2_ or _localnet_ topologies.
+
+- A layer 2 topology supports east-west cluster traffic, but does not allow access to the underlying physical network.
+- A localnet topology allows connections to the physical network, but requires additional configuration of the underlying Open vSwitch (OVS) bridge on cluster nodes.
 
 The following sections provide example configurations for each of the topologies that OVN-Kubernetes currently allows for secondary networks.
 
 [NOTE]
 ====
-Networks names must be unique. For example, creating multiple `NetworkAttachmentDefinition` CRDs with different configurations that reference the same network is unsupported.
+Networks names must be unique. For example, creating multiple `NetworkAttachmentDefinition` CRs with different configurations that reference the same network is unsupported.
 ====
+
+[id="configuration-additional-network-types-supported-platforms_{context}"]
+== Supported platforms for OVN-Kubernetes additional network
+
+You can use an OVN-Kubernetes additional network with the following supported platforms:
+
+- Bare metal
+- {ibmpowerProductName}
+- {ibmzProductName}
+- {linuxoneProductName}
+- VMware vSphere
+- {rh-openstack-first}

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -139,13 +139,32 @@ include::modules/nw-multus-tap-object.adoc[leveloffset=+2]
 
 * For more information about enabling an SELinux boolean on a node, see xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-working-setting-booleans_nodes-nodes-managing[Setting SELinux booleans]
 
+// Set of includes pertains to OVN-Kubernetes additional network
 include::modules/configuring-ovnk-additional-networks.adoc[leveloffset=+2]
 include::modules/configuration-ovnk-network-plugin-json-object.adoc[leveloffset=+3]
+include::modules/configuration-ovnk-multi-network-policy.adoc[leveloffset=+3]
+
 //include::modules/configuring-layer-three-routed-topology.adoc[leveloffset=+3]
 include::modules/configuring-layer-two-switched-topology.adoc[leveloffset=+3]
-//include::modules/configuring-localnet-switched-topology.adoc[leveloffset=+3]
+
+[id="{context}_ovn-kubernetes-configuration-for-a-localnet-topology"]
+==== Configuration for a localnet topology
+
+include::modules/configuring-localnet-switched-topology.adoc[tag=localnet-intro]
+
+// Workaround lack of xref in modules
+[id="{context}_configuration-additional-network-types-prerequisites"]
+===== Prerequisites for configuring OVN-Kubernetes additional network
+
+- The NMState Operator is installed. For more information, see xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[About the Kubernetes NMState Operator].
+
+[id="{context}_configuration-additional-network-interface"]
+===== Configuration for an OVN-Kubernetes additional network mapping
+
+include::modules/configuring-localnet-switched-topology.adoc[tag=localnet-content]
 include::modules/configuring-pods-secondary-network.adoc[leveloffset=+3]
 include::modules/configuring-pods-static-ip.adoc[leveloffset=+3]
+// end OVN-Kubernetes includes
 
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
 

--- a/networking/multiple_networks/configuring-multi-network-policy.adoc
+++ b/networking/multiple_networks/configuring-multi-network-policy.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can configure multi-network for additional networks. You can specify multi-network policy for SR-IOV and macvlan additional networks. Macvlan additional networks are fully supported. Other types of additional networks, such as ipvlan, are not supported.
+As a cluster administrator, you can configure multi-network for additional networks. You can specify multi-network policy for SR-IOV, macvlan, and OVN-Kubernetes additional networks. Macvlan additional networks are fully supported. Other types of additional networks, such as ipvlan, are not supported.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-6264

This removes the TP notice for this, as of now, and includes 'localnet'.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- [Configuration for an OVN-Kubernetes additional network](https://61110--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network#configuration-ovnk-additional-networks_configuring-additional-network)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
