### PR TITLE
Add release note for configuring hybrid networking

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -926,6 +926,11 @@ With this update, you can switch the BlueField-2 network device from data proces
 
 For more information, see xref:../networking/hardware_networks/switching-bf2-nic-dpu.adoc#switching-bf2-nic-dpu[Switching Bluefield-2 from DPU to NIC].
 
+[id="ocp-4-12-enable-hybrid-networking-windows-nodes-ovn-kubernetes"]
+==== Enable hybrid networking to support Windows nodes with OVN-Kubernetes
+
+You can enable the hybrid networking overlay after cluster installation to support Windows nodes on an existing cluster. Previously, hybrid networking could be enabled only during cluster installation. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[Configuring hybrid networking].
+
 [id="ocp-4-12-storage"]
 === Storage
 


### PR DESCRIPTION
Previously, this needed to be done at installation time. Now it can be done after installation.

- https://issues.redhat.com/browse/OSDOCS-4799

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://61111--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-enable-hybrid-networking-windows-nodes-ovn-kubernetes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
