### PR TITLE
OSDOCS-5280: Add release note for multiple external gateway support

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -745,6 +745,18 @@ For more information, see xref:../networking/enable-cluster-wide-proxy.adoc#conf
 [id="ocp-4-14-networking"]
 === Networking
 
+[id="ocp-4-14-multiple-external-gateway-support-ovn-kubernetes-network-plugin"]
+==== Multiple external gateway support for the OVN-Kubernetes network plugin
+
+The OVN-Kubernetes network plugin supports defining additional default gateways for specific workloads. Both IPv4 and IPv6 address families are supported. You define each default gateway using the `AdminPolicyBasedExternalRoute` object, in which you can specify two types of next hops, static and dynamic:
+
+- Static next hop: One or more IP addresses of external gateways
+- Dynamic next hop: A combination of pod and namespace selectors for pod selection, and a network attachment definition name previously associated with the selected pods.
+
+The next hops that you define are scoped by a namespace selector that you specify. This enables you to use the external gateway for specific workloads that match the namespace selector.
+
+For more information, refer to xref:../networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.adoc#configuring-secondary-external-gateway[Configure an external gateway through a secondary network interface].
+
 [id="ocp-4-14-ingress-node-firewall-operator-ga"]
 ==== Ingress Node Firewall Operator is generally available
 Ingress Node Firewall Operator was made a technology preview in {product-title} 4.12. With this release, Ingress Node Firewall Operator is generally available. You can now configure firewall rules at the node level. For more information, see xref:../networking/networking-operators-overview.adoc#networking-operators-overview[Ingress Node Firewall Operator].


### PR DESCRIPTION
For the OVN-Kubernetes network plugin, it is possible to define additional network gateways. A new CRD allows scoping to specific namespaces and external gateway pods.

- https://issues.redhat.com/browse/OSDOCS-5280

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://61112--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-multiple-external-gateway-support-ovn-kubernetes-network-plugin
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
