### PR TITLE
Add release note for OVN-Kubernetes secondary network GA

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -281,6 +281,12 @@ For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-no
 Support for the Broadcom BCM57504 network interface controller is now available for the SR-IOV Network Operator. 
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
+[id="ocp-4-14-networking-ovn-kubernetes-secondary-network"]
+==== OVN-Kubernetes is available as a secondary network
+
+With this release, the {openshift-networking} OVN-Kubernetes network plugin allows the configuration of secondary network interfaces for pods. As a secondary network, OVN-Kubernetes supports both layer 2 switched and localnet switched topology networks.
+
+For more information about OVN-Kubernetes as a secondary network, see xref:../networking/multiple_networks/configuring-additional-network.adoc#configuration-ovnk-additional-networks_configuring-additional-network[Configuration for an OVN-Kubernetes additional network].
 
 [id="ocp-4-14-storage"]
 === Storage
@@ -1037,7 +1043,7 @@ In the following tables, features are marked with the following statuses:
 |OVN-Kubernetes network plugin as secondary network
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |Updating the interface-specific safe sysctls list
 |Technology Preview


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-6264

Adds release note, touches TP table.

(TP notice in content is removed in a separate feature PR: https://github.com/openshift/openshift-docs/pull/61110)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://61113--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-networking-ovn-kubernetes-secondary-network

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
