### PR TITLE
Removing includes added in error

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -42,6 +42,7 @@ endif::openshift-origin[]
 :insights-advisor-url: link:https://console.redhat.com/openshift/insights/advisor/[Insights Advisor]
 :hybrid-console: Red Hat Hybrid Cloud Console
 :hybrid-console-second: Hybrid Cloud Console
+:oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
 :rh-storage-first: Red Hat OpenShift Data Foundation
 :rh-storage: OpenShift Data Foundation


### PR DESCRIPTION
These `include` links were [added in error to this file](https://github.com/openshift/openshift-docs/pull/58186/files#diff-32cc22145012670da2376aa01a3f8bfa32f4c0244fa1b44f2c323752161c73c7) somehow. This PR removes them. 
I noticed as I was cherry-picking that PR. I will remove the includes in the 4.10+ branches. 