### PR TITLE
OSDOCS-6438: adds 4.13.3 to RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2913,3 +2913,45 @@ $ oc adm release info 4.13.2 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-13-3"]
+=== RHSA-2023:3537 - {product-title} 4.13.3 bug fix and security update
+
+Issued: 2023-06-13
+
+{product-title} release 4.13.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3537[RHSA-2023:3537] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3536[RHSA-2023:3536] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.3 --pullspecs
+----
+
+[id="ocp-4-13-3-features"]
+==== Features
+
+[id="ocp-4-13-ipxe-ztp"]
+===== Support for iPXE network booting with ZTP
+{ztp-first} uses the Bare Metal Operator (BMO) to boot {op-system-first} on the target host as part of the deployment of spoke clusters. With this update, {ztp} leverages the capabilities of the BMO by adding the option of Preboot Execution Environment (iPXE) network booting for these RHCOS installations.
+
+[NOTE]
+====
+To use iPXE network booting, you must use {rh-rhacm-first} 2.8 or later.
+====
+
+For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and {ztp}].
+
+[id="ocp-4-13-3-bug-fixes"]
+==== Bug fixes
+
+* Previously on {sno}, in case of node reboot there was a race condition that could result in admission of application pods requesting devices on the node even if devices were unhealthy or unavailable to be allocate. This resulted in runtime failures when the application tried to access devices. With this update, the resources requested by the pod are only allocated if the device plugin has registered itself to Kubelet and healthy devices are present on the node to be allocated.
++
+If these conditions are not met, the pod can fail at admission with `UnexpectedAdmissionError` error, which is an expected behavior. If the application pod is part of deployments, in case of failure subsequent pods are spun up and ultimately successfully run when devices are suitable to be allocated. (link:https://issues.redhat.com/browse/OCPBUGS-14438[*OCPBUGS-14438*])
+
+[id="ocp-4-13-3-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-6438](https://issues.redhat.com//browse/OSDOCS-6438): adds 4.13.3 to RNs
 <!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-6438
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://61133--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-3
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
