### PR TITLE
Remove multi-arch docs from OKD

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -563,7 +563,8 @@ Topics:
 - Name: Bare metal configuration
   File: bare-metal-configuration
 - Name: Configuring multi-architecture compute machines on an OpenShift cluster
-  File: multi-architecture-configuration
+  Distros: openshift-enterprise
+  File: multi-architecture-configuration 
 - Name: Enabling encryption on a vSphere cluster
   File: vsphere-post-installation-encryption
 - Name: Machine configuration tasks


### PR DESCRIPTION
**For Versions:** 4.12+ 
**Issue:** [OKD docs #1632 ](https://github.com/okd-project/okd/issues/1631)

**Description:** Multi-arch is not supported on OKD yet, removing the multi-arch section from the OKD docs. 

**Preview:** 
- [OpenShift enterprise docs where the "Configuring multi-architecture compute machines" section is present](https://61135--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/multi-architecture-configuration.html)
- [OKD docs where the where the "Configuring multi-architecture compute machines" section is not present](https://kelbrown20.github.io/Docs-previews/previews/remove-multi-arch-from-okd/post_installation_configuration/configuring-private-cluster.html)
