### PR TITLE
OSDOCS-6297: Removed dual stack limitation note

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -2,9 +2,6 @@
 //
 // ipi-install-configuration-files.adoc
 // installing-vsphere-installer-provisioned-network-customizations.adoc
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
-:vSphere:
-endif::[]
 
 :_content-type: PROCEDURE
 [id='modifying-install-config-for-dual-stack-network_{context}']
@@ -41,19 +38,7 @@ platform:
       - <wildcard_ipv6>
 ----
 
-ifdef::vSphere[]
-[IMPORTANT]
-====
-You can configure dual-stack networking on a single interface only.
-====
-
 [NOTE]
 ====
-* In a vSphere cluster configured for dual-stack networking, the node custom resource object has only the IP address from the primary network listed in `Status.addresses` field.
-* In the pod that uses the host networking with dual-stack connectivity, the `Status.podIP` and `Status.podIPs` fields contain only the IP address from the primary network.
+For a cluster with dual-stack networking configuration, you must assign both IPv4 and IPv6 addresses to the same interface.
 ====
-endif::vSphere[]
-
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
-:!vSphere:
-endif::[]

--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -64,7 +64,7 @@ endif::[]
 
 2. Egress router for OVN-Kubernetes supports only redirect mode.
 
-3. IPv6 is supported only on bare metal, IBM Power, and {ibmzProductName} clusters.
+3. IPv6 is supported only on bare metal, vSphere, IBM Power, and {ibmzProductName} clusters.
 
 4. IPv6 single stack does not support xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState].
 --


### PR DESCRIPTION
Version(s):4.14

Issue: https://issues.redhat.com/browse/OSDOCS-6297

Link to docs preview: https://61150--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#modifying-install-config-for-dual-stack-network_installing-vsphere-installer-provisioned-network-customizations

QE review:
- [x] QE has approved this change. @rbbratta 
- [x] SME has approved this change. @cybertron / @mkowalski  