### PR TITLE
Removed TP note per Gaurav

### DIFF
--- a/nodes/cma/nodes-cma-autoscaling-custom.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom.adoc
@@ -8,9 +8,6 @@ toc::[]
 
 As a developer, you can use Custom Metrics Autoscaler Operator for Red Hat OpenShift to specify how {product-title} should automatically increase or decrease the number of pods for a deployment, stateful set, custom resource, or job based on custom metrics that are not based only on CPU or memory.
 
-:FeatureName: Scaling by using a scaled job
-include::snippets/technology-preview.adoc[]
-
 The Custom Metrics Autoscaler Operator is an optional operator, based on the Kubernetes Event Driven Autoscaler (KEDA), that allows workloads to be scaled using additional metrics sources other than pod metrics.
 
 The custom metrics autoscaler currently supports only the Prometheus, CPU, memory, and Apache Kafka metrics.


### PR DESCRIPTION
The Tech Preview note regarding Scaled Jobs in the Custom Metrics Autoscaler docs is confusing to customers. This PR removes that TP note.