### PR TITLE
CNV-29398_2: [2212293] "Usage and examples" in OpenShift Virtualization must gather is wrong

### DIFF
--- a/modules/virt-must-gather-options.adoc
+++ b/modules/virt-must-gather-options.adoc
@@ -10,7 +10,7 @@ You can specify a combination of scripts and environment variables for the follo
 
 * Collecting detailed virtual machine (VM) information from a namespace
 * Collecting detailed information about specified VMs
-* Collecting image and image stream information
+* Collecting image, image-stream, and image-stream-tags information
 * Limiting the maximum number of parallel processes used by the `must-gather` tool
 
 [id="parameters"]
@@ -33,13 +33,13 @@ Using too many parallel processes can cause performance issues. Increasing the m
 
 .Scripts
 
-Each script is only compatible with certain environment variable combinations.
+Each script is compatible only with certain environment variable combinations.
 
-`gather_vms_details`:: Collect VM log files, VM definitions, and namespaces (and their child objects) that belong to {VirtProductName} resources. If you use this parameter without specifying a namespace or VM, the `must-gather` tool collects this data for all VMs in the cluster. This script is compatible with all environment variables, but you must specify a namespace if you use the `VM` variable.
+`/usr/bin/gather`:: Use the default `must-gather` script, which collects cluster data from all namespaces and includes only basic VM information. This script is compatible only with the `PROS` variable.
 
-`gather`:: Use the default `must-gather` script, which collects cluster data from all namespaces and includes only basic VM information. This script is only compatible with the `PROS` variable.
+`/usr/bin/gather --vms_details`:: Collect VM log files, VM definitions, control-plane logs, and namespaces that belong to {VirtProductName} resources. Specifying namespaces includes their child objects. If you use this parameter without specifying a namespace or VM, the `must-gather` tool collects this data for all VMs in the cluster. This script is compatible with all environment variables, but you must specify a namespace if you use the `VM` variable.
 
-`gather_images`:: Collect image and image stream custom resource information. This script is only compatible with the `PROS` variable.
+`/usr/bin/gather --images`:: Collect image, image-stream, and image-stream-tags custom resource information. This script is compatible only with the `PROS` variable.
 
 [id="usage-and-examples_{context}"]
 == Usage and examples
@@ -50,20 +50,23 @@ Environment variables are optional. You can run a script by itself or with one o
 .Compatible parameters
 |===
 |Script |Compatible environment variable
-|`gather_vms_details`
+|`/usr/bin/gather`   |* `PROS=<number_of_processes>`
+|`/usr/bin/gather --vms_details`
 |* For a namespace: `NS=<namespace_name>`
 
 * For a VM: `VM=<vm_name> NS=<namespace_name>`
 
 * `PROS=<number_of_processes>`
 
-|`gather`   |* `PROS=<number_of_processes>`
-|`gather_images`   |* `PROS=<number_of_processes>`
+
+|`/usr/bin/gather --images`   |* `PROS=<number_of_processes>`
 |===
 
-To customize the data that `must-gather` collects, you append a double dash (`--`) to the command, followed by a space and one or more compatible parameters.
+
 
 .Syntax
+
+
 
 [source,terminal,subs="attributes+"]
 ----
@@ -71,6 +74,19 @@ $ oc adm must-gather \
   --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion} \
   -- <environment_variable_1> <environment_variable_2> <script_name>
 ----
+
+.Default data collection parallel processes
+
+By default, five processes run in parallel. 
+
+[source,terminal,subs="attributes+"]
+----
+$ oc adm must-gather \
+  --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion} \
+  -- PROS=5 /usr/bin/gather <1>
+----
+<1> You can modify the number of parallel processes by changing the default.
+
 
 .Detailed VM information
 
@@ -80,28 +96,18 @@ The following command collects detailed VM information for the `my-vm` VM in the
 ----
 $ oc adm must-gather \
   --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion} \
-  -- NS=mynamespace VM=my-vm gather_vms_details <1>
+  -- NS=mynamespace VM=my-vm /usr/bin/gather --vms_details <1>
 ----
 <1> The `NS` environment variable is mandatory if you use the `VM` environment variable.
 
-.Default data collection limited to three parallel processes
 
-The following command collects default `must-gather` information by using a maximum of three parallel processes:
+.Image, image-stream, and image-stream-tags information
 
-[source,terminal,subs="attributes+"]
-----
-$ oc adm must-gather \
-  --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion} \
-  -- PROS=3 gather
-----
-
-.Image and image stream information
-
-The following command collects image and image stream information from the cluster:
+The following command collects image, image-stream, and image-stream-tags information from the cluster:
 
 [source,terminal,subs="attributes+"]
 ----
 $ oc adm must-gather \
   --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion} \
-  -- gather_images
+  /usr/bin/gather --images
 ----

--- a/modules/virt-using-virt-must-gather.adoc
+++ b/modules/virt-using-virt-must-gather.adoc
@@ -23,6 +23,7 @@ The default data collection includes information about the following resources:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image-stream=openshift/must-gather \
-  --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion}
+$ oc adm must-gather 
+  --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion} \
+  -- /usr/bin/gather 
 ----

--- a/virt/support/virt-collecting-virt-data.adoc
+++ b/virt/support/virt-collecting-virt-data.adoc
@@ -54,7 +54,7 @@ Collecting data about malfunctioning virtual machines (VMs) minimizes the time r
 
 .Procedure
 
-. xref:../../virt/support/virt-collecting-virt-data.adoc#virt-must-gather-options_virt-collecting-virt-data[Collect must-gather data for the VMs] using the `gather_vms_details` script.
+. xref:../../virt/support/virt-collecting-virt-data.adoc#virt-must-gather-options_virt-collecting-virt-data[Collect must-gather data for the VMs] using the `/usr/bin/gather` script.
 . Collect screenshots of VMs that have crashed _before_ you restart them.
 . xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#vm-memory-dump-commands_virt-using-the-cli-tools[Collect memory dumps from VMs] _before_ remediation attempts.
 . Record factors that the malfunctioning VMs have in common. For example, the VMs have the same host or network.


### PR DESCRIPTION
Version(s): 4.12+

Issue: [CNV-29398](https://issues.redhat.com/browse/CNV-29398)

Link to docs preview: Please review updates throughout these topics:

- [Using the must-gather tool for OpenShift VIrtualization](https://61181--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html#virt-using-virt-must-gather_virt-collecting-virt-data) 

- [must-gather tool options ](https://61181--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html#virt-must-gather-options_virt-collecting-virt-data)

- [Parameters](https://61181--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html#parameters) 

- [Usage and examples](https://61181--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html#usage-and-examples_virt-collecting-virt-data) 

QE review:
- [x] QE has approved this change.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
