### PR TITLE
OSDOCS#6465: Adds notes for 4.13.3 MS release

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -170,6 +170,20 @@ For the `TopoLVM image`, read link:https://catalog.redhat.com/software/container
 
 Issued: 2023-05-30
 
-{product-title} release 4.13.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3307[RHBA-2023:3307] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3304[RHSA-2023:3304] advisory.
+{product-title} release 4.13.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3307[RHBA-2023:3307] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3304[RHSA-2023:3304] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-3-dp"]
+=== RHSA-2023:3540 - {product-title} 4.13.3 bug fix and security update
+
+Issued: 2023-06-13
+
+{product-title} release 4.13.3, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3540[RHSA-2023:3540] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3537[RHSA-2023:3537] advisory.
+
+[id="microshift-4-13-3-bug-fixes"]
+==== Bug Fixes
+
+* Previously, when the operating system was not set to the default route, OVN-Kubernetes caused the cluster to function improperly. With this update, the default routes were removed and the OVN-Kubernetes pod runs as expected. (link:https://issues.redhat.com/browse/OCPBUGS-13548)([*OCPBUGS-13548*])
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
OSDOCS#6465: Adds notes for 4.13.3 MS release

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-6465

Link to docs preview:
https://opayne1.github.io/previews/OSDOCS6465/microshift_release_notes/microshift-4-13-release-notes.html#microshift-4-13-3-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
