### PR TITLE
OSDOCS#6466: Adds notes for 4.12.21 microshift release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -227,6 +227,15 @@ For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers
 
 Issued: 2023-05-31
 
-{product-title} release 4.12.19 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3290[RHBA-2023:3290] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3287[RHSA-2023:3287] advisory.
+{product-title} release 4.12.19, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3290[RHBA-2023:3290] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3287[RHSA-2023:3287] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-21-dp"]
+=== RHBA-2023:3549 - {product-title} 4.12.21 bug fix update
+
+Issued: 2023-06-14
+
+{product-title} release 4.12.21 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3549[RHBA-2023:3549] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:3546[RHBA-2023:3546] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#6466: Adds notes for 4.12.21 microshift release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-6466

Link to docs preview:
https://opayne1.github.io/previews/OSDOCS-6466/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-21-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
