### PR TITLE
OSDOCS#6477:Changed default value from '2' to '0' for '--max-nested-paths'.

### DIFF
--- a/modules/oc-mirror-command-reference.adoc
+++ b/modules/oc-mirror-command-reference.adoc
@@ -72,7 +72,7 @@ The following tables describe the `oc mirror` subcommands and flags:
 |Generate manifests for `ImageContentSourcePolicy` objects to configure a cluster to use the mirror registry, but do not actually mirror any images. To use this flag, you must pass in an image set archive with the `--from` flag.
 
 |`--max-nested-paths <int>`
-|Specify the maximum number of nested paths for destination registries that limit nested paths. The default is `2`.
+|Specify the maximum number of nested paths for destination registries that limit nested paths. The default is `0`.
 
 |`--max-per-registry <int>`
 |Specify the number of concurrent requests allowed per registry. The default is `6`.


### PR DESCRIPTION
Version(s): 4.13+

Issue: [OSDOCS-6477](https://issues.redhat.com/browse/OSDOCS-6477)

Link to docs preview: The default value for `max-nested-path` is changed to 0. [Doc Preview](https://61204--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-command-reference_installing-mirroring-disconnected)

QE review:
- [ ] QE has approved this change.
