### PR TITLE
update vale.ini

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -8,7 +8,7 @@ Vocab = OpenShiftDocs
 
 # Ignore files in dirs starting with `.` to avoid raising errors for `.vale/fixtures/*/testinvalid.adoc` files
 [[!.]*.adoc]
-BasedOnStyles = RedHat, AsciiDoc
+BasedOnStyles = RedHat, AsciiDoc, OpenShiftAsciiDoc
 
 # Optional: pass doc attributes to asciidoctor before linting
 #[asciidoctor]
@@ -20,3 +20,8 @@ RedHat.ReleaseNotes = NO
 # Use local OpenShiftDocs Vocab terms
 Vale.Terms = YES
 Vale.Avoid = YES
+
+# Disable module specific rules
+OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO
+OpenShiftAsciiDoc.NoNestingInModules = NO
+OpenShiftAsciiDoc.NoXrefInModules = NO


### PR DESCRIPTION
There are a number of rules in the `OpenShiftAsciiDoc` rule set that are equally applicable to assemblies and modules. This PR updates the root `.vale.ini` file to apply applicable rules to assemblies. This does not affect the lower level `modules/.vale.ini`.

Merge to main, CP to enterprise-4.10+