### PR TITLE
OSDOCS-6293: Added overriding default IP section for SDN migration

### DIFF
--- a/modules/overriding-default-node-ip-selection-logic.adoc
+++ b/modules/overriding-default-node-ip-selection-logic.adoc
@@ -1,11 +1,19 @@
 // This is included in the following assemblies:
 //
 // * troubleshooting-network-issues.adoc
+ifeval::["{context}"=="migrate-from-openshift-sdn"]
+:migratefromsdn:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="overriding-default-node-ip-selection-logic_{context}"]
+ifndef::migratefromsdn[]
 = Optional: Overriding the default node IP selection logic
-
+endif::migratefromsdn[]
+ifdef::migratefromsdn[]
+[discrete]
+= Overriding the default node IP selection logic
+endif::[]
 To override the default IP selection logic, you can create a hint file that includes the `NODEIP_HINT` variable to override the default IP selection logic. Creating a hint file allows you to select a specific node IP address from the interface in the subnet of the IP address specified in the `NODEIP_HINT` variable.
 
 For example, if a node has two interfaces, `eth0` with an address of `10.0.0.10/24`, and `eth1` with an address of `192.0.2.5/24`, and the default route points to `eth0` (`10.0.0.10`),the node IP address would normally use the `10.0.0.10` IP address.
@@ -16,7 +24,7 @@ The following procedure shows how to override the default node IP selection logi
 
 .Procedure
 
-. Add a hint file to your `/etc/default/nodeip-configuration` file, for example: 
+. Add a hint file to your `/etc/default/nodeip-configuration` file, for example:
 +
 [source,text]
 ----
@@ -95,3 +103,6 @@ spec:
 . Save the manifest to the directory where you store your cluster configuration, for example, `~/clusterconfigs`.
 
 . Deploy the cluster.
+ifeval::["{context}"=="migrate-from-openshift-sdn"]
+:!migratefromsdn:
+endif::[]

--- a/modules/overriding-default-node-ip-selection-logic.adoc
+++ b/modules/overriding-default-node-ip-selection-logic.adoc
@@ -103,6 +103,7 @@ spec:
 . Save the manifest to the directory where you store your cluster configuration, for example, `~/clusterconfigs`.
 
 . Deploy the cluster.
+
 ifeval::["{context}"=="migrate-from-openshift-sdn"]
 :!migratefromsdn:
 endif::[]

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -11,7 +11,7 @@ As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 
 include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
-include::modules/overriding-default-node-ip-selection-logic.adoc[leveloffset=+2]
+include::modules/overriding-default-node-ip-selection-logic.adoc[leveloffset=+3]
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
 include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
 

--- a/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.adoc
@@ -11,8 +11,8 @@ As a cluster administrator, you can migrate to the OVN-Kubernetes network plugin
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].
 
 include::modules/nw-ovn-kubernetes-migration-about.adoc[leveloffset=+1]
+include::modules/overriding-default-node-ip-selection-logic.adoc[leveloffset=+2]
 include::modules/nw-network-plugin-migration-process.adoc[leveloffset=+2]
-
 include::modules/nw-ovn-kubernetes-migration.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s): 4.14

Issue: [OSDOCS-6293](https://issues.redhat.com/browse/OSDOCS-6293)

Link to docs preview: https://61208--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#considerations-migrating-ovn-kubernetes-network-provider_migrate-from-openshift-sdn

QE review:
- [ ] QE has approved this change. @weliang1 can you please review this?
- [x] SME has approved this change.  @pliurh