### PR TITLE
CNV-28577: Document RXBounce option for Windows VM with ODF

### DIFF
--- a/modules/virt-about-storage-volumes-for-vm-disks.adoc
+++ b/modules/virt-about-storage-volumes-for-vm-disks.adoc
@@ -15,8 +15,7 @@ For best results, use `accessMode: ReadWriteMany` and `volumeMode: Block`. This 
 * The `Block` volume mode performs significantly better in comparison to the `Filesystem` volume mode. This is because the `Filesystem` volume mode uses more storage layers, including a file system layer and a disk image file. These layers are not necessary for VM disk storage.
 +
 For example, if you use {rh-storage-first}, Ceph RBD volumes are preferable to CephFS volumes.
-
-// the note below was in the original features-for-storage assembly
++
 [IMPORTANT]
 ====
 You cannot live migrate virtual machines that use:
@@ -27,3 +26,5 @@ You cannot live migrate virtual machines that use:
 
 Do not set the `evictionStrategy` field to `LiveMigrate` for these virtual machines.
 ====
+
+* If you deploy {VirtProductName} with OpenShift Data Foundation, you must create a dedicated storage class for Windows virtual machine disks. See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details. 

--- a/modules/virt-hardware-os-requirements.adoc
+++ b/modules/virt-hardware-os-requirements.adoc
@@ -30,6 +30,11 @@ endif::[]
 .Storage requirements
 * Supported by {product-title}
 
+[WARNING]
+====
+If you deploy {VirtProductName} with OpenShift Data Foundation, you must create a dedicated storage class for Windows virtual machine disks. See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details.
+====
+
 .Operating system requirements
 * {op-system-first} installed on worker nodes
 +


### PR DESCRIPTION
**Version(s):**
4.10+


**Issue:**
https://issues.redhat.com/browse/CNV-28577

**Link to docs preview:**
* https://61216--docspreview.netlify.app/openshift-enterprise/latest/virt/about-virt.html#virt-about-storage-volumes-for-vm-disks_about-virt
* https://61216--docspreview.netlify.app/openshift-enterprise/latest/virt/install/preparing-cluster-for-virt.html#virt-hardware-os-requirements_preparing-cluster-for-virt

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->