### PR TITLE
documenting TELCODOCS-1357 SNO reboot behaviour

### DIFF
--- a/modules/ztp-sno-node-reboot-scenarios.adoc
+++ b/modules/ztp-sno-node-reboot-scenarios.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+
+:_content-type: CONCEPT
+[id="ztp-sno-node-reboot-scenarios_{context}"]
+= SNO node reboot scenario
+
+On a {sno-caps} cluster and in {product-title} clusters generally a situation might arise in case a node reboot occurs without node drain where an application pod requesting devices fails with the `UnexpectedAdmissionError` error. deployment, replicaset, or daemonset  error is reported due to the fact that application pods requiring devices can start before the pod serving those devices, as there is no way to control the order of pod restarts.
+
+While this behavior is expected, it can lead to a pod remaining on the cluster even when it has failed to deploy successfully and will continue to report `UnexpectedAdmissionError`. The presence of this issue is mitigated since application pods are typically included in a deployment, replicaset, or daemonset. Having a pod in this state is of little concern as another instance should be running. Being part of a deployment, replicaset, or daemonset guarantees the successful creation and execution of subsequent pods and ensures the successful deployment of the application.
+
+There is ongoing work upstream to ensure that such pods are gracefully terminated. Until that is resolved run the following command in a {sno-caps} deployment to remove the failed pods:
+
+[source,terminal]
+----
+$ kubectl delete pods --field-selector status.phase=Failed -n <POD_NAMESPACE>
+----
+
+[NOTE]
+====
+The option to drain the node is unavailable in a {sno-caps} deployment.
+====

--- a/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
@@ -86,7 +86,12 @@ include::modules/ztp-sno-du-configuring-lvms.adoc[leveloffset=+2]
 
 include::modules/ztp-sno-du-disabling-network-diagnostics.adoc[leveloffset=+2]
 
+include::modules/ztp-sno-node-reboot-scenarios.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
+
+* xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-evacuating_nodes-nodes-working[Understanding how to evacuate pods on nodes
+]
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-far-edge-sites[Deploying far edge sites using ZTP]


### PR DESCRIPTION
[TELCODOCS-1357]: SNO Restarting a node changes the CPU cores pinning in the pod
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.13, 4.12 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1357 addresses https://issues.redhat.com/browse/OCPBUGS-2180
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://61221--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-node-reboot-scenarios_sno-configure-for-vdu
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
