### PR TITLE
OCPBUGS#14621: Updated Restoring to a previous cluster state example

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -347,7 +347,7 @@ $ sudo rm -f /var/lib/ovn/etc/*.db
 $ oc delete pods -l app=ovnkube-master -n openshift-ovn-kubernetes
 ----
 
-.. Ensure that all the OVN-Kubernetes control plane pods are deployed again and are in a `Running` state by running the following command:
+.. Ensure that any OVN-Kubernetes control plane pods are deployed again and are in a `Running` state by running the following command:
 +
 [source,terminal]
 ----
@@ -359,8 +359,6 @@ $ oc get pods -l app=ovnkube-master -n openshift-ovn-kubernetes
 ----
 NAME                   READY   STATUS    RESTARTS   AGE
 ovnkube-master-nb24h   4/4     Running   0          48s
-ovnkube-master-rm8kw   4/4     Running   0          47s
-ovnkube-master-zbqnh   4/4     Running   0          56s
 ----
 
 .. Delete all `ovnkube-node` pods by running the following command:


### PR DESCRIPTION
[OCPBUGS-14621](https://issues.redhat.com/browse/OCPBUGS-14621)

Version(s):
4.14 through 4.10

Link to docs preview:
[Restoring to a previous cluster state](https://61225--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [Slack](https://redhat-internal.slack.com/archives/CH76YSYSC/p1686812061944539)