### PR TITLE
[enterprise-4.13] CNV-28557: RN notes for rxbounce workaround

### DIFF
--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -278,3 +278,6 @@ $ oc patch storageprofile <storage_profile> --type=merge -p '{"spec": {"claimPro
 
 //CNV-26301/BZ2151169 Leave in per Kedar
 * In a heterogeneous cluster with different compute nodes, virtual machines that have HyperV Reenlightenment enabled cannot be scheduled on nodes that do not support timestamp-counter scaling (TSC) or have the appropriate TSC frequency. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2151169[*BZ#2151169*])
+
+//CNV-28577
+* If you deploy {VirtProductName} with {rh-storage-first}, you must create a dedicated storage class for Windows virtual machine disks. See link:https://access.redhat.com/articles/6978371[Optimizing ODF PersistentVolumes for Windows VMs] for details.


### PR DESCRIPTION
**Version(s):**
4.13

**Issue:**
https://issues.redhat.com/browse/CNV-28577

**Link to docs preview:**
https://danielclowers.github.io/rh-previews/CNV-28557-RN/virt/virt-4-13-release-notes.html#virt-4-13-known-issues

**QE review:**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->