### PR TITLE
RN-oc-4.13: oc attribute sweep

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -509,7 +509,7 @@ This release introduces support for the following features on {ibmpowerProductNa
 |Supported
 |Unsupported
 
-|OpenShift CLI (`oc`) plugins
+|{oc-first} plugins
 |Supported
 |Supported
 
@@ -1005,7 +1005,7 @@ This feature allows {product-title} to supply a pod's FSGroup to a Container Sto
 
 [id=ocp-4-13-olm-discover-operator-versions]
 ==== Finding Operator versions by using the OpenShift CLI
-In {product-title} 4.13, you can find which versions and channels of an Operator you can install on your system by running the following OpenShift CLI (`oc`) command:
+In {product-title} 4.13, you can find which versions and channels of an Operator you can install on your system by running the following {oc-first} command:
 
 .Example `oc describe` command syntax
 [source,terminal]
@@ -1375,7 +1375,7 @@ If you are receiving pod security violations, see the following resources:
 [id="ocp-4-13-oc-mirror-openshift-endpoint"]
 === The oc-mirror plugin now retrieves graph data container images from an OpenShift API endpoint
 
-The oc-mirror OpenShift CLI (`oc`) plugin now downloads the graph data tarball from an OpenShift API endpoint instead of downloading the entire graph data repository from GitHub. Retrieving this data from Red Hat instead of an external vendor is more suitable for users with stringent security and compliance restrictions on external content.
+The oc-mirror {oc-first} plugin now downloads the graph data tarball from an OpenShift API endpoint instead of downloading the entire graph data repository from GitHub. Retrieving this data from Red Hat instead of an external vendor is more suitable for users with stringent security and compliance restrictions on external content.
 
 The data that the oc-mirror plugin downloads now excludes content that is in the graph data repository but not needed by the OpenShift Update Service. The container also uses UBI Micro as the base image instead of UBI, resulting in a container image that is significantly smaller than before.
 
@@ -1996,7 +1996,7 @@ With this release, replacement control plane nodes are assigned to the correct i
 
 * Previously, the `oc-mirror` command built the catalog content in the console for OCI and FBC Operators from a mirrored disk image. Consequently, not all content of the catalog was mirrored so some content was missing from the catalog. With this update, the catalog image is built to reflect the mirrored content prior to pushing it to the destination registry resulting in a more complete catalog. (link:https://issues.redhat.com/browse/OCPBUGS-5805[*OCPBUGS-5805*])
 
-* Previously, the oc-mirror OpenShift CLI (`oc`) plugin added the Operator catalog as an entry in the `ImageContentSourcePolicy` resource. This resource does not require this entry, because the Operator catalog is consumed directly from the destination registry in the `CatalogSource` resource. This issue impacted the cluster from receiving the release image signature resources because of an unexpected entry in the `ImageContentSourcePolicy` resource. With this update, the oc-mirror plugin removes Operator catalog entry from the `ImageContentSourcePolicy` resource, so that a cluster receives signature resources from the Operator catalog in the `CatalogSource` resource. (link:https://issues.redhat.com/browse/OCPBUGS-10320[*OCPBUGS-10320*])
+* Previously, the oc-mirror {oc-first} plugin added the Operator catalog as an entry in the `ImageContentSourcePolicy` resource. This resource does not require this entry, because the Operator catalog is consumed directly from the destination registry in the `CatalogSource` resource. This issue impacted the cluster from receiving the release image signature resources because of an unexpected entry in the `ImageContentSourcePolicy` resource. With this update, the oc-mirror plugin removes Operator catalog entry from the `ImageContentSourcePolicy` resource, so that a cluster receives signature resources from the Operator catalog in the `CatalogSource` resource. (link:https://issues.redhat.com/browse/OCPBUGS-10320[*OCPBUGS-10320*])
 
 [discrete]
 [id="ocp-4-13-olm-bug-fixes"]
@@ -2886,7 +2886,7 @@ $ oc adm release info 4.13.1 --pullspecs
 ==== Bug fixes
 * Previously, assisted installations could encounter a transient error. If that error occurred, the installation failed to recover. With this update, transient errors are re-tried correctly. (link:https://issues.redhat.com/browse/OCPBUGS-13138[*OCPBUGS-13138*])
 
-* Previously, oc-mirror OpenShift CLI (`oc`) plugin would fail with a `401 unauthorized` error for some registries when a nested path exceeded the expected maximum path-components. With this update, the default integer of the `--max-nested-paths` flag is set to 0 (no limit). As a result, the generated `ImageContentSourcePolicy` will contain source and mirror references up to the repository level as opposed to the namespace level used by default. (link:https://issues.redhat.com/browse/OCPBUGS-13591[*OCPBUGS-13591*])
+* Previously, oc-mirror {oc-first} plugin would fail with a `401 unauthorized` error for some registries when a nested path exceeded the expected maximum path-components. With this update, the default integer of the `--max-nested-paths` flag is set to 0 (no limit). As a result, the generated `ImageContentSourcePolicy` will contain source and mirror references up to the repository level as opposed to the namespace level used by default. (link:https://issues.redhat.com/browse/OCPBUGS-13591[*OCPBUGS-13591*])
 
 [id="ocp-4-13-1-updating"]
 ==== Updating
@@ -2947,7 +2947,7 @@ For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-d
 [id="ocp-4-13-3-bug-fixes"]
 ==== Bug fixes
 
-* Previously on {sno}, in case of node reboot there was a race condition that could result in admission of application pods requesting devices on the node even if devices were unhealthy or unavailable to be allocate. This resulted in runtime failures when the application tried to access devices. With this update, the resources requested by the pod are only allocated if the device plugin has registered itself to Kubelet and healthy devices are present on the node to be allocated.
+* Previously on {sno}, in case of node reboot there was a race condition that could result in admission of application pods requesting devices on the node even if devices were unhealthy or unavailable to be allocated. This resulted in runtime failures when the application tried to access devices. With this update, the resources requested by the pod are only allocated if the device plugin has registered itself to kubelet and healthy devices are present on the node to be allocated.
 +
 If these conditions are not met, the pod can fail at admission with `UnexpectedAdmissionError` error, which is an expected behavior. If the application pod is part of deployments, in case of failure subsequent pods are spun up and ultimately successfully run when devices are suitable to be allocated. (link:https://issues.redhat.com/browse/OCPBUGS-14438[*OCPBUGS-14438*])
 


### PR DESCRIPTION
oc plugin sweeping the RN docs for the update made in the attribute file
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
Proposed in [Slack](https://redhat-internal.slack.com/archives/C85JYPHL3/p1686334200967689)
https://issues.redhat.com/browse/OSDOCS-6551
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://61259--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-ibm-z
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
attribute PR https://github.com/openshift/openshift-docs/pull/61060
Below are the PR that complete the sweep of the RNs
4.12 https://github.com/openshift/openshift-docs/pull/61295
4.11 https://github.com/openshift/openshift-docs/pull/61296
4.10 https://github.com/openshift/openshift-docs/pull/61297
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
