### PR TITLE
OBSDOCS-185: Add definitions for Alertmanager notification interval fields

### DIFF
--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -30,9 +30,9 @@ $ oc -n openshift-monitoring get secret alertmanager-main --template='{{ index .
 global:
   resolve_timeout: 5m
 route:
-  group_wait: 30s
-  group_interval: 5m
-  repeat_interval: 12h
+  group_wait: 30s <1>
+  group_interval: 5m <2>
+  repeat_interval: 12h <3>
   receiver: default
   routes:
   - matchers:
@@ -40,20 +40,29 @@ route:
     repeat_interval: 5m
     receiver: watchdog
   - matchers:
-    - "service=<your_service>" <1>
+    - "service=<your_service>" <4>
     routes:
     - matchers:
-      - <your_matching_rules> <2>
-      receiver: <receiver> <3>
+      - <your_matching_rules> <5>
+      receiver: <receiver> <6>
 receivers:
 - name: default
 - name: watchdog
 - name: <receiver>
 #  <receiver_configuration>
 ----
-<1> `service` specifies the service that fires the alerts.
-<2> `<your_matching_rules>` specifies the target alerts.
-<3> `receiver` specifies the receiver to use for the alert.
+<1> The `group_wait` value specifies how long Alertmanager waits before sending an initial notification for a group of alerts.
+This value controls how long Alertmanager waits while collecting initial alerts for the same group before sending a notification.
+The default value is 30 seconds (`30s`).
+<2> The `group_interval` value specifies how much time must elapse before Alertmanager sends a notification about new alerts added to a group of alerts for which an initial notification was already sent.
+The default is five minutes (`5m`).
+<3> The `repeat_interval` value specifies the minimum amount of time that must pass before an alert notification is repeated.
+The default is four hours (`4h`).
+If you want a notification to repeat at each group interval, set the `repeat_interval` value to less than the `group_interval` value.
+However, the repeated notification can still be delayed, for example, when certain Alertmanager pods are restarted or rescheduled.
+<4> The `service` value specifies the service that fires the alerts.
+<5> The `<your_matching_rules>` value specifies the target alerts.
+<6> The `receiver` value specifies the receiver to use for the alert.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Summary: This PR adds more detailed config info for Alertmanager settings, specifically the notification interval settings.

- Aligned team: DevTools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/OBSDOCS-185
- Direct link to doc preview: https://61260--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts.html#applying-custom-alertmanager-configuration_managing-alerts
- SME review: @simonpasquier (done)
- QE review: @juzhao  (done)
- Peer review: @deerskindoll (done)