### PR TITLE
Fixed supported ocp version variable

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -54,8 +54,7 @@ endif::[]
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
 :rhacs-version: 4.0.2
-:ocp-supported-version: 4.5
-:rhacs-operator-min-ocp-version: 4.10
+:ocp-supported-version: 4.10
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 4.0
 :product-title-short: RHACS

--- a/modules/install-acs-operator-cloud.adoc
+++ b/modules/install-acs-operator-cloud.adoc
@@ -10,7 +10,7 @@ Using the OperatorHub provided with {ocp} is the easiest way to install the {pro
 
 .Prerequisites
 * You have access to an {ocp} cluster using an account with Operator installation permissions.
-* You must be using {ocp} {rhacs-operator-min-ocp-version} or later. For more information, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
+* You must be using {ocp} {ocp-supported-version} or later. For more information, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
 
 .Procedure
 . Navigate in the web console to the *Operators* -> *OperatorHub* page.

--- a/modules/install-acs-operator.adoc
+++ b/modules/install-acs-operator.adoc
@@ -10,7 +10,7 @@ Using the OperatorHub provided with {ocp} is the easiest way to install {product
 
 .Prerequisites
 * You have access to an {ocp} cluster using an account with Operator installation permissions.
-* You must be using {ocp} 4.10 or later. For more information, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
+* You must be using {ocp} {ocp-supported-version} or later. For more information, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
 
 .Procedure
 . Navigate in the web console to the *Operators* -> *OperatorHub* page.

--- a/modules/install-central-operator-tech-preview.adoc
+++ b/modules/install-central-operator-tech-preview.adoc
@@ -17,7 +17,7 @@ When you install {product-title} for the first time, you must first install the 
 ====
 
 .Prerequisites
-* You must be using {ocp} 4.10 or later. For more information, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
+* You must be using {ocp} {ocp-supported-version} or later. For more information, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
 * You must provision a database that supports PostgreSQL 13 and you must only use it for {product-title-short}.
 * You must have a superuser role with permissions to create and delete databases.
 

--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -14,7 +14,7 @@ When you install {product-title} for the first time, you must first install the 
 ====
 
 .Prerequisites
-* You must be using {ocp} 4.10 or later. For more information, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
+* You must be using {ocp} {ocp-supported-version} or later. For more information, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
 
 .Procedure
 . On the {ocp} web console, navigate to the *Operators* -> *Installed Operators* page.

--- a/modules/install-secured-cluster-operator.adoc
+++ b/modules/install-secured-cluster-operator.adoc
@@ -20,7 +20,7 @@ When you install secured cluster services, Collector is also installed. To insta
 ====
 
 .Prerequisites
-* If you are using {ocp}, you must install version 4.10 or later.
+* If you are using {ocp}, you must install version {ocp-supported-version} or later.
 * You have installed the {product-title-short} Operator.
 * You have generated an init bundle and applied it to the cluster.
 

--- a/modules/installation-methods-for-different-architectures.adoc
+++ b/modules/installation-methods-for-different-architectures.adoc
@@ -25,6 +25,6 @@ a|Operator (preferred), Helm charts, or `roxctl` CLI (not recommended)
 
 | s390x ({ibm-zsystems} and {ibm-linuxone})
 |No
-|Yes ({ocp} versions 4.10, 4.12 and later)
+|Yes ({ocp} versions {ocp-supported-version}, 4.12 and later)
 
 |===

--- a/modules/rhcos-enable-node-scan.adoc
+++ b/modules/rhcos-enable-node-scan.adoc
@@ -9,7 +9,7 @@
 If you use {ocp}, you can enable scanning of {op-system-first} nodes for vulnerabilities by using {rh-rhacs-first}.
 
 .Prerequisites
-* For scanning {op-system} node hosts of the Secured cluster, you must have installed Secured cluster on {ocp} 4.10 or later. For more information on supported managed and self-managed {ocp} versions, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
+* For scanning {op-system} node hosts of the Secured cluster, you must have installed Secured cluster on {ocp} {ocp-supported-version} or later. For more information on supported managed and self-managed {ocp} versions, see link:https://access.redhat.com/node/5822721[{product-title} Support Policy].
 
 .Procedure
 . Run one of the following commands to update the compliance container.

--- a/release_notes/40-release-notes.adoc
+++ b/release_notes/40-release-notes.adoc
@@ -133,7 +133,7 @@ To view a list of {op-system-base} versions for {ocp} and {op-system}, see link:
 
 [NOTE]
 ====
-{ocp}/{op-system} 4.10 or later is supported.
+{ocp}/{op-system} {ocp-supported-version} or later is supported.
 ====
 
 For more information about vulnerability scanning, see xref:../operating/manage-vulnerabilities/scan-rhcos-node-host.adoc#scan-rhcos-node-host[Scanning RHCOS node hosts].


### PR DESCRIPTION
Follow up for https://github.com/openshift/openshift-docs/pull/60483

- Fixes supported version for OCP

Cherrypick:
- `rhacs-docs-4.0`
- `rhacs-docs-4.1`