### PR TITLE
RHDEVDOCS-5147:Doc; [ODC] Document column management for the TaskRuns and PipelineRuns list pages

### DIFF
--- a/modules/op-interacting-with-pipelines-using-the-developer-perspective.adoc
+++ b/modules/op-interacting-with-pipelines-using-the-developer-perspective.adoc
@@ -53,6 +53,11 @@ The *Details* section of the *Pipeline Run Details* page displays a *Log Snippet
 * On the *Pipeline Run details* page, click the *Task Runs* tab to see the completed, running, and failed runs for the task.
 +
 The *Task Runs* tab provides information about the task run along with the links to its task and pod, and also the status and duration of the task run. Use the Options menu {kebab} to delete a task run.
++
+[NOTE]
+====
+The *TaskRuns* list page features a *Manage columns* button, which you can also use to add a *Duration* column.
+====
 * Click the required task run to see the *Task Run details* page. The results for successful runs are displayed under the *Task Run results* pane at the bottom of the page.
 +
 [NOTE]


### PR DESCRIPTION
Change type: Doc update; [ODC] Document column management for the TaskRuns and PipelineRuns list pages
Doc JIRA: https://issues.redhat.com/browse/RHDEVDOCS-5147
Dev JIRAs: https://issues.redhat.com/browse/ODC-7281
Fix Version: Openshift 4.14 Freeze

Doc Preview: https://61267--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/working-with-pipelines-using-the-developer-perspective.html#op-interacting-with-pipelines-using-the-developer-perspective_working-with-pipelines-using-the-developer-perspective

SME Review: @vikram-raj 
QE Review: @jerolimov
Peer Review: @max-cx 