### PR TITLE
Adjust topic-map check

### DIFF
--- a/scripts/check-asciidoctor-build.sh
+++ b/scripts/check-asciidoctor-build.sh
@@ -31,7 +31,8 @@ check_updated_assemblies () {
     # check that assemblies are in a topic_map
     for ASSEMBLY in $ALL_ASSEMBLIES; do
         # get the page name to search the topic_map
-        PAGE=$(basename "$ASSEMBLY" .adoc)
+        # search for files only, not folders
+        PAGE="File: $(basename "$ASSEMBLY" .adoc)"
         # don't validate the assembly if it is not in a topic map
         if grep -rq "$PAGE" --include "*.yml" _topic_maps ; then
             # validate the assembly


### PR DESCRIPTION
Previously, the check-asciidoctor script searched topic maps for assembly filenames. The script returned incorrect results if a folder was present that also had the same name. This update fixes the script to search for assembly files only. 

Merge to main, CP to enterprise-4.10+

Verified against https://github.com/openshift/openshift-docs/pull/61254