### PR TITLE
MIG-1330 Issue in file migrating_from_ocp_3_to_4/installing-restricted-3-4.adoc

### DIFF
--- a/modules/migration-installing-legacy-operator.adoc
+++ b/modules/migration-installing-legacy-operator.adoc
@@ -38,14 +38,14 @@ endif::[]
 +
 [source,terminal]
 ----
-$ sudo podman login registry.redhat.io
+$ podman login registry.redhat.io
 ----
 
 . Download the `operator.yml` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo podman cp $(sudo podman create \
+$ podman cp $(podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/operator.yml ./
 ----
 
@@ -53,7 +53,7 @@ $ sudo podman cp $(sudo podman create \
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo podman cp $(sudo podman create \
+$ podman cp $(podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/controller.yml ./
 ----
 

--- a/modules/migration-upgrading-mtc-with-legacy-operator.adoc
+++ b/modules/migration-upgrading-mtc-with-legacy-operator.adoc
@@ -28,14 +28,14 @@ endif::[]
 +
 [source,terminal]
 ----
-$ sudo podman login registry.redhat.io
+$ podman login registry.redhat.io
 ----
 
 . Download the `operator.yml` file by entering the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo podman cp $(sudo podman create \
+$ podman cp $(podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/operator.yml ./
 ----
 
@@ -71,7 +71,7 @@ $ oc -o yaml -n openshift-migration get deployment/migration-operator | grep ima
 +
 [source,terminal,subs="attributes+"]
 ----
-$ sudo podman cp $(sudo podman create \
+$ podman cp $(podman create \
   registry.redhat.io/rhmtc/openshift-migration-legacy-rhel8-operator:v{mtc-version}):/controller.yml ./
 ----
 


### PR DESCRIPTION
Resolves: 
https://issues.redhat.com/browse/MIG-1330
https://github.com/openshift/openshift-docs/issues/50593

OCP 4.10+


Preview:
https://61274--docspreview.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/installing-3-4.html#migration-installing-legacy-operator_installing-3-4
https://61274--docspreview.netlify.app/openshift-enterprise/latest/migrating_from_ocp_3_to_4/upgrading-3-4.html#migration-upgrading-mtc-with-legacy-operator_upgrading-3-4
