### PR TITLE
CNV-16554: DOC: Remove TP note from CNV backup/restore

### DIFF
--- a/virt/backup_restore/virt-backup-restore-overview.adoc
+++ b/virt/backup_restore/virt-backup-restore-overview.adoc
@@ -6,10 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: OADP for {VirtProductName}
-include::snippets/technology-preview.adoc[]
-
-You back up and restore virtual machines by using the xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[OpenShift API for Data Protection (OADP)].
+Back up and restore virtual machines by using the xref:../../backup_and_restore/index.adoc#application-backup-restore-operations-overview[OpenShift API for Data Protection (OADP)].
 
 .Prerequisites
 


### PR DESCRIPTION
Version(s): 4.14

Issue: [CNV-16554
](https://issues.redhat.com/browse/CNV-16554)

Link to docs preview: [Backing up and restoring virtual machines](https://61312--docspreview.netlify.app/openshift-enterprise/latest/virt/backup_restore/virt-backup-restore-overview.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

