### PR TITLE
Adding release notes for OADP1.2.0 for OADP-1181

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-release-notes.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 The release notes for OpenShift API for Data Protection (OADP) describe new features and enhancements, deprecated features, product recommendations, known issues, and resolved issues.
 
+
+include::modules/oadp-release-notes-1-2-0.adoc[leveloffset=+1]
+
 include::modules/oadp-release-notes-1-1-4.adoc[leveloffset=+1]
 
 include::modules/oadp-release-notes-1-1-2.adoc[leveloffset=+1]

--- a/modules/oadp-release-notes-1-2-0.adoc
+++ b/modules/oadp-release-notes-1-2-0.adoc
@@ -1,0 +1,81 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/oadp-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="migration-oadp-release-notes-1-2-0_{context}"]
+= OADP 1.2.0 release notes
+
+The OADP 1.2.0 release notes include information about new features, bug fixes, and known issues.
+
+[id="new-features_{context}"]
+== New features
+
+.link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.12/html/backup_and_restore/application-backup-and-restore#installing-oadp-aws[Resource timeouts]
+The new `resourceTimeout` option specifies the timeout duration in minutes for waiting on various Velero resources. This option applies to resources such as Velero CRD availability, `volumeSnapshot` deletion, and backup repository availability. The default duration is ten minutes.
+
+.link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.11/html/backup_and_restore/application-backup-and-restore#oadp-s3-compatible-backup-storage-providers_about-installing-oadp[AWS S3 compatible backup storage providers]
+You can back up objects and snapshots on AWS S3 compatible providers.
+
+[id="new-features-tech-preview-1-2-0_{context}"]
+=== Technical preview features
+
+.link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.9/html/backup_and_restore/application-backup-and-restore#installing-and-configuring-oadp[Data Mover]
+The OADP Data Mover enables you to back up Container Storage Interface (CSI) volume snapshots to a remote object store. When you enable Data Mover, you can restore stateful applications using CSI volume snapshots pulled from the object store in case of accidental cluster deletion, cluster failure, or data corruption.
+
+:FeatureName: OADP Data Mover
+include::snippets/technology-preview.adoc[]
+
+[id="fixed-bugs-1-2-0_{context}"]
+== Fixed bugs
+
+The following bugs have been fixed in this release:
+
+* link:https://issues.redhat.com/browse/OADP-144[OADP-144]
+* link:https://issues.redhat.com/browse/OADP-639[OADP-639]
+* link:https://issues.redhat.com/browse/OADP-1741[OADP-1741]
+* link:https://issues.redhat.com/browse/OADP-1152[OADP-1152]
+* link:https://issues.redhat.com/browse/OADP-1143[OADP-1143]
+* link:https://issues.redhat.com/browse/OADP-1931[OADP-1931]
+* link:https://issues.redhat.com/browse/OADP-148[OADP-148]
+* link:https://issues.redhat.com/browse/OADP-1067[OADP-1067]
+* link:https://issues.redhat.com/browse/OADP-1332[OADP-1332]
+* link:https://issues.redhat.com/browse/OADP-1164[OADP-1164]
+* link:https://issues.redhat.com/browse/OADP-1105[OADP-1105]
+* link:https://issues.redhat.com/browse/OADP-2009[OADP-2009]
+* link:https://issues.redhat.com/browse/OADP-1370[OADP-1370]
+* link:https://issues.redhat.com/browse/OADP-969[OADP-969]
+* link:https://issues.redhat.com/browse/OADP-1672[OADP-1672]
+* link:https://issues.redhat.com/browse/OADP-1151[OADP-1151]
+* link:https://issues.redhat.com/browse/OADP-988[OADP-988]
+* link:https://issues.redhat.com/browse/OADP-1941[OADP-1941]
+* link:https://issues.redhat.com/browse/OADP-1830[OADP-1830]
+* link:https://issues.redhat.com/browse/OADP-1821[OADP-1821]
+* link:https://issues.redhat.com/browse/OADP-1783[OADP-1783]
+* link:https://issues.redhat.com/browse/OADP-1719[OADP-1719]
+* link:https://issues.redhat.com/browse/OADP-1833[OADP-1833]
+* link:https://issues.redhat.com/browse/OADP-1872[OADP-1872]
+* link:https://issues.redhat.com/browse/OADP-2047[OADP-2047]
+* link:https://issues.redhat.com/browse/OADP-1932[OADP-1932]
+* link:https://issues.redhat.com/browse/OADP-1844[OADP-1844]
+* link:https://issues.redhat.com/browse/OADP-1182[OADP-1182]
+* link:https://issues.redhat.com/browse/OADP-1183[OADP-1183]
+* link:https://issues.redhat.com/browse/OADP-1798[OADP-1798]
+* link:https://issues.redhat.com/browse/OADP-1726[OADP-1726]
+* link:https://issues.redhat.com/browse/OADP-821[OADP-821]
+* link:https://issues.redhat.com/browse/OADP-1833[OADP-1781]
+* link:https://issues.redhat.com/browse/OADP-697[OADP-697]
+* link:https://issues.redhat.com/browse/OADP-1281[OADP-1281]
+* link:https://issues.redhat.com/browse/OADP-1077[OADP-1077]
+* link:https://issues.redhat.com/browse/OADP-1076[OADP-1076]
+* link:https://issues.redhat.com/browse/OADP-1670[OADP-1670]
+* link:https://issues.redhat.com/browse/OADP-1307[OADP-1307]
+* link:https://issues.redhat.com/browse/OADP-1640[OADP-1640]
+* link:https://issues.redhat.com/browse/OADP-1987[OADP-1987]
+* link:https://issues.redhat.com/browse/OADP-1934[OADP-1934]
+
+[id="known-issues-1-2-0_{context}"]
+== Known issues
+
+This release does not have any known issues.
+


### PR DESCRIPTION
OCPBUGS# : [OADP-1181](https://issues.redhat.com//browse/OADP-1181)
OSDDOCS# : [OADP-1181](https://issues.redhat.com//browse/OADP-1181)

OADP 1.2.0 release notes

Version(s): OADP 1.2.0
OCP 4.10+

Issue: https://issues.redhat.com/browse/OADP-1181

Link to docs preview: https://61318--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-release-notes.html

QE review: 

 QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
