### PR TITLE
OCPBUGS-15063: Removed wrong sentence that may break the procedure etcd recovery procedure

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -305,8 +305,6 @@ Perform the following step only if you are using `OVNKubernetes` network plugin.
 $ oc delete node <non-recovery-controlplane-host-1> <non-recovery-controlplane-host-2>
 ----
 
-. Optional: For any remaining non-recovery control plane nodes, delete and recreate each non-recovery control plane node.
-
 . Verify that the Cluster Network Operator (CNO) redeploys the OVN-Kubernetes control plane and that it no longer references the wrong controller IP addresses. To verify this result, regularly check the output of the following command. Wait until it returns an empty result before you proceed with the next step.
 +
 [source,terminal]


### PR DESCRIPTION
Fixes: OCPBUGS-15063 by removing wrong sentence that may break the procedure for some OVN-Kubernetes clusters.

Version(s):
4.10-latest

Issue: https://issues.redhat.com/browse/OCPBUGS-15063

Link to docs preview:

https://61340--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html

QE review:
- [ ] QE has approved this change.

Additional information:
This PR fixes a fatal error introduced by [OSDOCS-5020](https://issues.redhat.com/browse/OSDOCS-5020)