### PR TITLE
OCPBUGS#15063: Removed sentences in Restoring to a previous cluster s…

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -291,8 +291,6 @@ etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          
 +
 If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
 +
-.. Optional: For each lost control plane host, repeat the steps for verifying that the single member control plane has started successfully.
-+
 [NOTE]
 ====
 Perform the following step only if you are using `OVNKubernetes` network plugin.
@@ -304,8 +302,6 @@ Perform the following step only if you are using `OVNKubernetes` network plugin.
 ----
 $ oc delete node <non-recovery-controlplane-host-1> <non-recovery-controlplane-host-2>
 ----
-
-. Optional: For any remaining non-recovery control plane nodes, delete and recreate each non-recovery control plane node.
 
 . Verify that the Cluster Network Operator (CNO) redeploys the OVN-Kubernetes control plane and that it no longer references the wrong controller IP addresses. To verify this result, regularly check the output of the following command. Wait until it returns an empty result before you proceed with the next step.
 +


### PR DESCRIPTION
[OCPBUGS-15063](https://issues.redhat.com/browse/OCPBUGS-15063)

Version(s):
4.14. to 4.10

Link to docs preview: [Restoring to a previous cluster state](https://61352--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
