### PR TITLE
OSDOCS-4561: Removed Latency Sensitivity references from vSphere UPI …

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -130,6 +130,7 @@ It is recommended that you update the hardware version of the VM template to ver
 
 . After the template deploys, deploy a VM for a machine in the cluster.
 .. Right-click the template name and click *Clone* -> *Clone to Virtual Machine*.
+
 .. On the *Select a name and folder* tab, specify a name for the VM. You might include the machine type in the name, such as `control-plane-0` or `compute-1`.
 +
 [NOTE]
@@ -137,15 +138,22 @@ It is recommended that you update the hardware version of the VM template to ver
 Ensure that all virtual machine names across a vSphere installation are unique.
 ====
 .. On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
+
 .. On the *Select a compute resource* tab, select the name of a host in your datacenter.
 +
-.. Optional: On the *Select storage* tab, customize the storage options.
 .. On the *Select clone options*, select
 *Customize this virtual machine's hardware*.
-.. On the *Customize hardware* tab, click *VM Options* -> *Advanced*.
-*** Optional: Override default DHCP networking in vSphere. To enable static IP networking:
+
+.. Optional: On the *Customize hardware* tab, click *VM Options* -> *Advanced*.
 +
-... Set your static IP configuration:
+[IMPORTANT]
+====
+The following configuration suggestions are for example purposes only. As a cluster administrator, you must configure resources according to the resource demands placed on your cluster. To best manage cluster resources, consider creating a resource pool from the cluster's root resource pool.
+====
++
+*** Override default DHCP networking in vSphere. To enable static IP networking:
++
+**** Set your static IP configuration:
 +
 [source,terminal]
 ----
@@ -157,26 +165,18 @@ $ export IPCFG="ip=<ip>::<gateway>:<netmask>:<hostname>:<iface>:none nameserver=
 ----
 $ export IPCFG="ip=192.168.100.101::192.168.100.254:255.255.255.0:::none nameserver=8.8.8.8"
 ----
-
-... Set the `guestinfo.afterburn.initrd.network-kargs` property before booting a VM from an OVA in vSphere:
 +
-[source,terminal]
-----
-$ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${IPCFG}"
-----
-+
-*** Optional: In the event of cluster performance issues, from the *Latency Sensitivity* list, select *High*. Ensure that your VM's CPU and memory reservation have the following values:
-**** Memory reservation value must be equal to its configured memory size.
-**** CPU reservation value must be at least the number of low latency virtual CPUs multiplied by the measured physical CPU speed.
-*** Click *Edit Configuration*, and on the *Configuration Parameters* window, search the list of available parameters for steal clock accounting (`stealclock.enable`). If it is available, set its value to `TRUE`. Enabling steal clock accounting can help with troubleshooting cluster issues.
+*** Click *Edit Configuration*, and on the *Configuration Parameters* window, search the list of available parameters for steal clock accounting (`stealclock.enable`). Set the parameter to the value of `TRUE`. Enabling steal clock accounting can help with troubleshooting cluster issues.
 *** Click *Add Configuration Params*. Define the following parameter names and values:
-**** `guestinfo.ignition.config.data`: Locate the base-64 encoded files that you created previously in this procedure, and paste the contents of the base64-encoded Ignition config file for this machine type.
-**** `guestinfo.ignition.config.data.encoding`: Specify `base64`.
 **** `disk.EnableUUID`: Specify `TRUE`.
 **** `stealclock.enable`: If this parameter was not defined, add it and specify `TRUE`.
+**** Create a child resource pool from the cluster's root resource pool. Perform resource allocation in this child resource pool.
+
 .. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the
 machine type.
+
 .. Complete the configuration and power on the VM.
+
 .. Check the console output to verify that Ignition ran.
 +
 .Example command

--- a/modules/machine-vsphere-machines.adoc
+++ b/modules/machine-vsphere-machines.adoc
@@ -39,10 +39,8 @@ Ensure that all virtual machine names across a vSphere installation are unique.
 ====
 .. On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
 .. On the *Select a compute resource* tab, select the name of a host in your datacenter.
-.. Optional: On the *Select storage* tab, customize the storage options.
 .. On the *Select clone options*, select *Customize this virtual machine's hardware*.
 .. On the *Customize hardware* tab, click *VM Options* -> *Advanced*.
-*** From the *Latency Sensitivity* list, select *High*.
 *** Click *Edit Configuration*, and on the *Configuration Parameters* window, click *Add Configuration Params*. Define the following parameter names and values:
 **** `guestinfo.ignition.config.data`: Paste the contents of the base64-encoded compute Ignition config file for this machine type.
 **** `guestinfo.ignition.config.data.encoding`: Specify `base64`.


### PR DESCRIPTION
[OSDOCS-4561](https://issues.redhat.com/browse/OSDOCS-4561)

Version(s):
4.14 to 4.10

Link to docs preview:
* [Installing RHCOS and starting the OpenShift Container Platform bootstrap process](https://61358--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-machines_installing-vsphere)
* [Addng more compute machines to a cluster in vSphere](https://61358--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#machine-vsphere-machines_installing-vsphere)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
