### PR TITLE
OSDOCS-6497 Upgrade to Kubernetes 1.27 release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -14,7 +14,7 @@ Built on {op-system-base-full} and Kubernetes, {product-title} provides a more s
 == About this release
 
 // TODO: Update with the relevant information closer to release.
-{product-title} (link:https://access.redhat.com/errata/RHSA-2023:1326[RHSA-2023:1326]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.26.md[Kubernetes 1.26] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2023:1326[RHSA-2023:1326]) is now available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md[Kubernetes 1.27] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
 {product-title} {product-version} clusters are available at https://console.redhat.com/openshift. With the {cluster-manager-first} application for {product-title}, you can deploy {product-title} clusters to either on-premises or cloud environments.
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6497](https://issues.redhat.com/browse/OSDOCS-6497)

Link to docs preview:
[Preview](https://61364--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-about-this-release)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Seems like QE approval isn't needed for this but if a peer or merge reviewer disagrees let me know and I can get that.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
