### PR TITLE
[SRVCOM-2491and SRVKE-1467] Backport release notes additions to Serverless 1.28

### DIFF
--- a/modules/serverless-rn-1-28-0.adoc
+++ b/modules/serverless-rn-1-28-0.adoc
@@ -8,6 +8,11 @@
 
 {ServerlessProductName} 1.28 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
 
+[IMPORTANT]
+====
+{ocp-product-title} 4.13 is based on {op-system-base-full} 9.2.  {op-system-base} 9.2 is yet to be submitted for Federal Information Processing Standards (FIPS) validation. Although Red Hat cannot commit to a specific timeframe, we expect to obtain FIPS validation for {op-system-base} 9.0 and {op-system-base} 9.2 modules, and later even minor releases of {op-system-base} 9.x. Information on updates will be available in the link:https://access.redhat.com/articles/2918071[Compliance Activities and Government Standards Knowledgebase article].
+====
+
 [id="new-features-1-28-0_{context}"]
 == New features
 
@@ -52,3 +57,5 @@ Node.js, TypeScript, and Quarkus functions are supported on these architectures.
 * On the Windows platform, Python functions cannot be locally built, run, or deployed using the Source-to-Image builder due to the `app.sh` file permissions.
 +
 To work around this problem, use the Windows Subsystem for Linux.
+
+* `KafkaSource` resources created before {product-title} 1.27 get stuck when being deleted. To work around the issue, after starting to delete a `KafkaSource`, remove the finalizer from the resource.


### PR DESCRIPTION
Version(s):
Serverless 1.28

Issue:
https://issues.redhat.com/browse/SRVCOM-2491
https://issues.redhat.com/browse/SRVKE-1467

Link to docs preview:
1. IMPORTANT note https://61373--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-28-0_serverless-release-notes
2. Last known issues entry https://61373--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#known-issues-1-28-0_serverless-release-notes

QE review:
- [X] QE has approved this change. (The approvals are in the original https://github.com/openshift/openshift-docs/pull/60890 and https://github.com/openshift/openshift-docs/pull/60876)