### PR TITLE
[SRVKS-1081] Add net-kourier-controller liveness probe error known issue to 1.29

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -32,6 +32,7 @@ include::modules/serverless-rn-1-29-0.adoc[leveloffset=+1]
 // 1.29.0 additional resources
 [role="_additional-resources"]
 .Additional resources
+* link:https://access.redhat.com/solutions/7019323[Knowledgebase solution for the net-kourier-controller liveness probe error]
 * link:https://openshift-knative.github.io/docs/docs/latest/serverless-logic/about.html[Red Hat OpenShift Serverless Logic documentation]
 
 // OCP + OSD + ROSA

--- a/modules/serverless-rn-1-29-0.adoc
+++ b/modules/serverless-rn-1-29-0.adoc
@@ -59,3 +59,5 @@ Additionally, you can lock the version of the Knative (`kn`) CLI. For details, s
 * Webhook Horizontal Pod Autoscaler (HPA) settings are overridden by the {ServerlessOperatorName}. As a result, it fails to scale for higher workloads. To work around this issue, manually set the initial replica value that corresponds to your workload.
 
 * `KafkaSource` resources created before {product-title} 1.27 get stuck when being deleted. To work around the issue, after starting to delete a `KafkaSource`, remove the finalizer from the resource.
+
+* The `net-kourier-controller` might not be able to start due to the liveness probe error. You can work around the problem using the Knowledgebase solution.


### PR DESCRIPTION
Version(s):
Serverless 1.29+

Issue:
https://issues.redhat.com/browse/SRVKS-1081

Link to docs preview:
https://61374--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#known-issues-1-29-0_serverless-release-notes

QE review:
- [ ] QE has approved this change.