### PR TITLE
[No Jira] Remove a redundant note from the release notes

### DIFF
--- a/modules/serverless-rn-1-29-0.adoc
+++ b/modules/serverless-rn-1-29-0.adoc
@@ -45,10 +45,6 @@ Additionally, you can lock the version of the Knative (`kn`) CLI. For details, s
 
 * This release includes the upgraded Developer Preview for {ServerlessProductName} Logic.
 
-* A `PodDistruptionBudget` and a `HorizontalPodAutoscaler` have been added for the `3scale-kourier-gateway` deployment.
-** `PodDistruptionBudget` is used to define the minimum availability requirements for pods in a deployment.
-** `HorizontalPodAutoscaler` is used to automatically scale the number of pods in the deployment based on demand or on your custom metrics.
-
 * API version `v1alpha1` of the Knative Operator Serving and Eventings CRDs has been removed. You need to use the `v1beta1` version instead. This does not affect the existing installations, because CRDs are updated automatically when upgrading the Serverless Operator.
 
 [id="known-issues-1-29-0_{context}"]


### PR DESCRIPTION
Version(s):
Serverless 1.29 (both `serverless-docs` and the 1.29 branch)

Issue:
[feedback from PM]

Link to docs preview:
(just a removed note) https://61382--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-29-0_serverless-release-notes

QE review:
- [x] PM has approved this change. (QE approve not needed here)