### PR TITLE
OSDOCS-6530: Added a warning about Static IP

### DIFF
--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -79,6 +79,13 @@ endif::rosa-hcp[]
 * Service CIDR: 172.30.0.0/16
 * Pod CIDR: 10.128.0.0/16
 * Host prefix: /23
++
+ifdef::rosa-hcp[]
+[NOTE]
+====
+When using {hcp-title}, the static IP address `172.20.0.1` is reserved for the internal Kubernetes API address. The machine, pod, and service CIDRs ranges must not conflict with this IP address.
+====
+endif::rosa-hcp[]
 
 |Cluster roles and policies
 |* Mode used to create the Operator roles and the OpenID Connect (OIDC) provider: `auto`

--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 [id="cidr-range-definitions"]
 = CIDR range definitions
-include::_attributes/common-attributes.adoc[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: cidr-range-definitions
 
 toc::[]
@@ -25,6 +25,11 @@ OVN-Kubernetes, the default network provider in {product-title} 4.11 and later, 
 [id="machine-cidr-description"]
 == Machine CIDR
 In the Machine CIDR field, you must specify the IP address range for machines or cluster nodes. This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. The default is `10.0.0.0/16`. This range must not conflict with any connected networks.
+
+[NOTE]
+====
+When using {hcp-title}, the static IP address `172.20.0.1` is reserved for the internal Kubernetes API address. The machine, pod, and service CIDRs ranges must not conflict with this IP address.
+====
 
 [id="service-cidr-description"]
 == Service CIDR


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-6530](https://issues.redhat.com/browse/OSDOCS-6530)

Link to docs preview:
* [CIDR Range](https://61400--docspreview.netlify.app/openshift-rosa/latest/networking/cidr-range-definitions.html)
* [ROSA with HCP](https://61400--docspreview.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.html#rosa-sts-overview-of-the-default-cluster-specifications_rosa-hcp-sts-creating-a-cluster-quickly) table
   ![image](https://github.com/openshift/openshift-docs/assets/16167833/064e3e33-35bf-4423-a1f2-56990071b8fe)
* [ROSA table](https://61400--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html#rosa-sts-overview-of-the-default-cluster-specifications_rosa-sts-creating-a-cluster-quickly) (for comparison that the note does not show here)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a warning to not use the `172.20.0.1` IP address since it is used already.