### PR TITLE
RHDEVDOCS-5389: Correct the formatting of sample commands in Pipeline…

### DIFF
--- a/modules/op-using-pipelines-as-code-with-a-github-app.adoc
+++ b/modules/op-using-pipelines-as-code-with-a-github-app.adoc
@@ -39,8 +39,19 @@ To create and configure a GitHub App manually for {pac}, perform the following s
 
 * **GitHub Application Name**: `{pipelines-shortname}`
 * **Homepage URL**: OpenShift Console URL 
-* **Webhook URL**: The {pac} route or ingress URL. You can find it by running the command `echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controller -o jsonpath='{.spec.host}')`.
-* **Webhook secret**: An arbitrary secret. You can generate a secret by executing the command `openssl rand -hex 20`.
+* **Webhook URL**: The {pac} route or ingress URL. You can find it by running the following command:
++
+[source,terminal]
+----
+$ echo https://$(oc get route -n openshift-pipelines pipelines-as-code-controller -o jsonpath='{.spec.host}')
+----
+
+* **Webhook secret**: An arbitrary secret. You can generate a secret by running the following command:
++
+[source,terminal]
+----
+$ openssl rand -hex 20
+----
 
 . Select the following **Repository permissions**:
 


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: enterprise-4.11 and later
• **JIRA issue**: [RHDEVDOCS-5389](https://issues.redhat.com/browse/RHDEVDOCS-5389)
• **Preview page**: [Using Pipelines as Code with a GitHub App](https://61415--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-pipelines-as-code.html#using-pipelines-as-code-with-a-github-app_using-pipelines-as-code)
• **SME Review**: **Not needed**
• **QE review**: **Not needed**
• **Peer-review**: Completed by @Srivaralakshmi 