### PR TITLE
New distro created to deprecate ROSA docs from docs.openshift.com sta…

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -185,6 +185,16 @@ openshift-rosa:
     rosa-preview:
       name: ''
       dir: rosa-preview/
+openshift-rosa-portal:
+  name: Red Hat OpenShift Service on AWS
+  author: OpenShift Documentation Project <openshift-docs@redhat.com>
+  site: commercial
+  site_name: Documentation
+  site_url: https://docs.openshift.com/
+  branches:
+    enterprise-4.13:
+      name: ''
+      dir: rosa-portal/
 partner-roks:
   name: Red Hat OpenShift on IBM Cloud
   author: OpenShift Documentation Project <openshift-docs@redhat.com>

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -314,7 +314,7 @@ Topics:
 ---
 Name: Registry
 Dir: registry
-Distros: openshift-rosa
+Distros: openshift-rosa-portal
 Topics:
 - Name: Registry overview
   File: index

--- a/registry/configuring-registry-operator.adoc
+++ b/registry/configuring-registry-operator.adoc
@@ -51,12 +51,12 @@ endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/registry-operator-distribution-across-availability-zones.adoc[leveloffset=+1]
 
-ifndef::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-portal[]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Configuring pod topology spread constraints]
-endif::openshift-dedicated,openshift-rosa[]
+endif::openshift-dedicated,openshift-rosa,openshift-rosa-portal[]
 
 include::modules/registry-operator-configuration-resource-overview.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[OSDOCS-4908:](https://issues.redhat.com/browse/OSDOCS-4908) Deprecation of ROSA docs from docs.openshift.com
Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OSDOCS-4908](https://issues.redhat.com/browse/OSDOCS-4908)
Preview pages: [Click to see the build preview in your browser]()
Peer review **requested**: @kalexand-rh 