### PR TITLE
OCPBUGS#14264: Updated the vSphere regions and zones tag info

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1833,11 +1833,11 @@ a|Multiple IP addresses
 |String
 
 |`platform.vsphere.failureDomains.region`
-|You define a region by using a tag from the `openshift-region` tag category. The tag must be attached to the vCenter datacenter.
+|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter datacenter. To define a region, use a tag from the `openshift-region` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `datacenter`, for the parameter.
 |String
 
 |`platform.vsphere.failureDomains.zone`
-|You define a zone by using a tag from the `openshift-zone` tag category. The tag must be attached to the vCenter datacenter.
+|If you define multiple failure domains for your cluster, you must attach the tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
 |`String`
 
 |`platform.vsphere.ingressVIPs`


### PR DESCRIPTION
[OCPBUGS-14264](https://issues.redhat.com/browse/OCPBUGS-14264)

Version(s):
4.13 and 4.14

Link to docs preview:
[Installation configuration parameters](https://61420--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-configuration-parameters_installing-vsphere-installer-provisioned-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
