### PR TITLE
OSSM-3252: Service Mesh 2.4 Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -138,8 +138,8 @@ endif::[]
 :product-dedicated: Red Hat OpenShift Dedicated
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.3.3
-:MaistraVersion: 2.3
+:SMProductVersion: 2.4
+:MaistraVersion: 2.4
 //Service Mesh v1
 :SMProductVersion1x: 1.1.18.2
 //Windows containers

--- a/modules/ossm-rn-deprecated-features.adoc
+++ b/modules/ossm-rn-deprecated-features.adoc
@@ -15,7 +15,26 @@ Deprecated functionality is still included in {product-title} and continues to b
 
 Removed functionality no longer exists in the product.
 
-== Deprecated and removed features {SMProductName} 2.3
+== Deprecated and removed features in {SMProductName} 2.4
+
+The v2.1 `ServiceMeshControlPlane` resource is no longer supported. Customers should upgrade their mesh deployments to use a later version of the `ServiceMeshControlPlane` resource.
+
+Support for Istio OpenShift Routing (IOR) is deprecated and will be removed in a future release.
+
+Support for Grafana is deprecated and will be removed in a future release. 
+
+Support for the following cipher suites, which were deprecated in {SMProductName} 2.3, has been removed from the default list of ciphers used in TLS negotiations on both the client and server sides. Applications that require access to services requiring one of these cipher suites will fail to connect when a TLS connection is initiated from the proxy.
+
+* ECDHE-ECDSA-AES128-SHA
+* ECDHE-RSA-AES128-SHA
+* AES128-GCM-SHA256
+* AES128-SHA
+* ECDHE-ECDSA-AES256-SHA
+* ECDHE-RSA-AES256-SHA
+* AES256-GCM-SHA384
+* AES256-SHA
+
+== Deprecated and removed features in {SMProductName} 2.3
 
 Support for the following cipher suites has been deprecated. In a future release, they will be removed from the default list of ciphers used in TLS negotiations on both the client and server sides.
 
@@ -30,21 +49,21 @@ Support for the following cipher suites has been deprecated. In a future release
 
 The `ServiceMeshExtension` API, which was deprecated in {SMProductName} version 2.2, was removed in {SMProductName} version 2.3. If you are using the `ServiceMeshExtension` API, you must migrate to the `WasmPlugin` API to continue using your WebAssembly extensions.
 
-== Deprecated features {SMProductName} 2.2
+== Deprecated features in {SMProductName} 2.2
 
 The `ServiceMeshExtension` API is deprecated as of release 2.2 and will be removed in a future release.  While `ServiceMeshExtension` API is still supported in release 2.2, customers should start moving to the new `WasmPlugin` API.
 
-== Removed features {SMProductName} 2.2
+== Removed features in {SMProductName} 2.2
 
 This release marks the end of support for {SMProductShortName} control planes based on Service Mesh 1.1 for all platforms.
 
-== Removed features {SMProductName} 2.1
+== Removed features in {SMProductName} 2.1
 
 In Service Mesh 2.1, the Mixer component is removed. Bug fixes and support is provided through the end of the Service Mesh 2.0 life cycle.
 
 Upgrading from a Service Mesh 2.0.x release to 2.1 will not proceed if Mixer plugins are enabled. Mixer plugins must be ported to WebAssembly Extensions.
 
-== Deprecated features {SMProductName} 2.0
+== Deprecated features in {SMProductName} 2.0
 
 The Mixer component was deprecated in release 2.0 and will be removed in release 2.1. While using Mixer for implementing extensions was still supported in release 2.0, extensions should have been migrated to the new link:https://istio.io/latest/blog/2020/wasm-announce/[WebAssembly] mechanism.
 

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -19,9 +19,13 @@ The following issues been resolved in the current release:
 [id="ossm-rn-fixed-issues-ossm_{context}"]
 == {SMProductShortName} fixed issues
 
+* https://issues.redhat.com/browse/OSSM-3993[OSSM-3993] Previously, Kiali only supported OpenShift OAuth via a proxy on the standard HTTPS port of `443`. Now, Kiali supports OpenShift OAuth over a non-standard HTTPS port. To enable the port, you must set the `spec.server.web_port` field to the proxy's non-standard HTTPS port in the Kiali CR.
+
 * https://issues.redhat.com/browse/OSSM-3644[OSSM-3644] Previously, the federation egress-gateway received the wrong update of network gateway endpoints, causing extra endpoint entries. Now, the federation-egress gateway has been updated on the server side so it receives the correct network gateway endpoints.
 
 * https://issues.redhat.com/browse/OSSM-3595[OSSM-3595] Previously, the `istio-cni` plugin sometimes failed on {op-system-base} because SELinux did not allow the utility `iptables-restore` to open files in the `/tmp` directory. Now, SELinux passes `iptables-restore` via `stdin` input stream instead of via a file.
+
+* https://issues.redhat.com/browse/OSSM-3586[OSSM-3586] Previously, Istio proxies were slow to start when Google Cloud Platform (GCP) metadata servers were not available. When you upgrade to Istio 1.14.6, Istio proxies start as expected on GCP, even if metadata servers are not available.
 
 * https://issues.redhat.com/browse/OSSM-3025[OSSM-3025] Istiod sometimes fails to become ready. Sometimes, when a mesh contained many member namespaces, the Istiod pod did not become ready due to a deadlock within Istiod. The deadlock is now resolved and the pod now starts as expected.
 
@@ -40,6 +44,19 @@ This is fixed by using the Kiali SA to fetch the cluster version. This also allo
 * https://issues.redhat.com/browse/OSSM-2344[OSSM-2344] Restarting Istiod causes Kiali to flood CRI-O with port-forward requests. This issue occurred when Kiali could not connect to Istiod and Kiali simultaneously issued a large number of requests to istiod. Kiali now limits the number of requests it sends to istiod.
 
 * https://issues.redhat.com/browse/OSSM-2335[OSSM-2335] Dragging the mouse pointer over the Traces scatterchart plot sometimes caused the Kiali console to stop responding due to concurrent backend requests.
+
+* https://issues.redhat.com/browse/OSSM-2221[OSSM-2221] Previously, gateway injection in the `ServiceMeshControlPlane` namespace was not possible because the `ignore-namespace` label was applied to the namespace by default. 
++
+When creating a v2.4 control plane, the namespace no longer has the `ignore-namespace` label applied, and gateway injection is possible.
++
+In the following example, the `oc label` command removes the `ignore-namespace` label from a namespace in an existing deployment:
++
+[source,terminal]
+----
+$ oc label namespace <istio_system> maistra.io/ignore-namespace-
+----
++
+In the example above, <istio_system> represents the name of the `ServiceMeshControlPlane` namespace.
 
 * https://issues.redhat.com/browse/OSSM-2053[OSSM-2053] Using {SMProductName} Operator 2.2 or 2.3, during SMCP reconciliation, the SMMR controller removed the member namespaces from `SMMR.status.configuredMembers`. This caused the services in the member namespaces to become unavailable for a few moments.
 +

--- a/modules/ossm-rn-known-issues.adoc
+++ b/modules/ossm-rn-known-issues.adoc
@@ -15,30 +15,47 @@ Module included in the following assemblies:
 
 These limitations exist in {SMProductName}:
 
-* {SMProductName} does not yet support link:https://issues.redhat.com/browse/MAISTRA-1314[IPv6], as it is not yet fully supported by the upstream Istio project.  As a result, {SMProductName} does not support dual-stack clusters.
+* {SMProductName} does not yet fully support link:https://issues.redhat.com/browse/MAISTRA-1314[IPv6]. As a result, {SMProductName} does not support dual-stack clusters.
 
 * Graph layout - The layout for the Kiali graph can render differently, depending on your application architecture and the data to display (number of graph nodes and their interactions). Because it is difficult if not impossible to create a single layout that renders nicely for every situation, Kiali offers a choice of several different layouts. To choose a different layout, you can choose a different *Layout Schema* from the *Graph Settings* menu.
 
 * The first time you access related services such as {JaegerShortName} and Grafana, from the Kiali console, you must accept the certificate and re-authenticate using your {product-title} login credentials. This happens due to an issue with how the framework displays embedded pages in the console.
 
 ifndef::openshift-rosa[]
-* The Bookinfo sample application cannot be installed on IBM Z and IBM Power.
+* The Bookinfo sample application cannot be installed on {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName}.
 
-* WebAssembly extensions are not supported on IBM Z and IBM Power.
+* WebAssembly extensions are not supported on {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName}.
 
-* LuaJIT is not supported on IBM Power.
+* LuaJIT is not supported on {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName}.
 
+* Single stack IPv6 support is not available on {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName}.
 endif::openshift-rosa[]
+
 [id="ossm-rn-known-issues-ossm_{context}"]
 == {SMProductShortName} known issues
 
 These are the known issues in {SMProductName}:
 
-* https://issues.redhat.com/browse/OSSM-2221[OSSM-2221] Gateway injection does not work in control plane namespace. If you use the Gateway injection feature to create a gateway in the same location as the control plane, the injection fails and OpenShift generates this message:
+* https://issues.redhat.com/browse/OSSM-3890[OSSM-3890] Attempting to use the Gateway API in a multitenant mesh deployment generates an error message similar to the following:
 +
-`Warning  Failed          10s   kubelet, ocp-wide-vh8fd-worker-vhqm9  Failed to pull image "auto": rpc error: code = Unknown desc = reading manifest latest in docker.io/library/auto: errors`
+[source,text]
+----
+2023-05-02T15:20:42.541034Z	error	watch error in cluster Kubernetes: failed to list *v1alpha2.TLSRoute: the server could not find the requested resource (get tlsroutes.gateway.networking.k8s.io)
+2023-05-02T15:20:42.616450Z	info	kube	controller "gateway.networking.k8s.io/v1alpha2/TCPRoute" is syncing...
+----
 +
-To create a gateway in the control plane namespace, use the `gateways` parameter in the SMCP spec to configure ingress and egress gateways for the mesh.
+To support Gateway API in a multitenant mesh deployment, all Gateway API Custom Resource Definition (CRD) files must be present in the cluster. 
++
+In a multitenant mesh deployment, CRD scan is disabled, and Istio has no way to discover which CRDs are present in a cluster. As a result, Istio attempts to watch all supported Gateway API CRDs, but generates errors if some of those CRDs are not present.
++
+{SMProductShortName} 2.3.1 and later versions support both `v1alpha2` and `v1beta1` CRDs. Therefore, both CRD versions must be present for a multitenant mesh deployment to support the Gateway API.
++
+Workaround: In the following example, the `kubectl get` operation installs the `v1alpha2` and `v1beta1` CRDs. Note the URL contains the additional `experimental` segment and updates any of your existing scripts accordingly:
++
+[source,terminal]
+----
+$ kubectl get crd gateways.gateway.networking.k8s.io ||   { kubectl kustomize "github.com/kubernetes-sigs/gateway-api/config/crd/experimental?ref=v0.5.1" | kubectl apply -f -; }
+----
 
 * https://issues.redhat.com/browse/OSSM-2042[OSSM-2042] Deployment of SMCP named `default` fails. If you are creating an SMCP object, and set its version field to v2.3, the name of the object cannot be `default`. If the name is `default`, then the control plane fails to deploy, and OpenShift generates a `Warning` event with the following message:
 +
@@ -115,7 +132,7 @@ endif::openshift-rosa[]
 * link:https://issues.redhat.com/browse/MAISTRA-2692[MAISTRA-2692] With Mixer removed, custom metrics that have been defined in {SMProductShortName} 2.0.x cannot be used in 2.1. Custom metrics can be configured using `EnvoyFilter`. Red Hat is unable to support `EnvoyFilter` configuration except where explicitly documented. This is due to tight coupling with the underlying Envoy APIs, meaning that backward compatibility cannot be maintained.
 ifndef::openshift-rosa[]
 
-* link:https://issues.redhat.com/browse/MAISTRA-2648[MAISTRA-2648] `ServiceMeshExtensions` are currently not compatible with meshes deployed on IBM Z Systems.
+* link:https://issues.redhat.com/browse/MAISTRA-2648[MAISTRA-2648] Service mesh extensions are currently not compatible with meshes deployed on {ibmzProductName}.
 endif::openshift-rosa[]
 
 * link:https://issues.jboss.org/browse/MAISTRA-1959[MAISTRA-1959] _Migration to 2.0_ Prometheus scraping (`spec.addons.prometheus.scrape` set to `true`) does not work when mTLS is enabled. Additionally, Kiali displays extraneous graph data when mTLS is disabled.
@@ -132,9 +149,6 @@ spec:
           excludedPorts:
           - 15020
 ----
-+
-//Keep MAISTRA-1314 in RN until IPv6 is actually supported
-* link:https://issues.redhat.com/browse/MAISTRA-1314[MAISTRA-1314] {SMProductName} does not yet support IPv6.
 
 * link:https://issues.jboss.org/browse/MAISTRA-453[MAISTRA-453] If you create a new project and deploy pods immediately, sidecar injection does not occur. The operator fails to add the `maistra.io/member-of` before the pods are created, therefore the pods must be deleted and recreated for sidecar injection to occur.
 

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -15,9 +15,162 @@ Module included in the following assemblies:
 
 This release adds improvements related to the following components and concepts.
 
+== New features {SMProductName} version 2.4
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.10 and later versions.
+
+=== Component versions included in {SMProductName} version 2.4
+
+|===
+|Component |Version
+
+|Istio
+|1.16.5
+
+|Envoy Proxy
+|1.24.8
+
+|Jaeger
+|1.42.0
+
+|Kiali
+|1.65.6
+|===
+
+=== Cluster-wide deployments
+This enhancement introduces a generally available version of cluster-wide deployments. A cluster-wide deployment contains a service mesh control plane that monitors resources for an entire cluster. The control plane uses a single query across all namespaces to monitor each Istio or Kubernetes resource that affects the mesh configuration. Reducing the number of queries the control plane performs in a cluster-wide deployment improves performance.
+
+=== Support for discovery selectors
+This enhancement introduces a generally available version of the `meshConfig.discoverySelectors` field, which can be used in cluster-wide deployments to limit the services the service mesh control plane can discover.
+
+[source,yaml]
+----
+spec:
+  meshConfig    
+    discoverySelectors:
+    - matchLabels:
+        env: prod
+        region: us-east1
+    - matchExpressions:
+      - key: app
+        operator: In
+        values:
+          - cassandra
+          - spark
+----
+
+=== Integration with cert-manager istio-csr
+With this update, {SMProductName} integrates with the `cert-manager` controller and the `istio-csr` agent. `cert-manager` adds certificates and certificate issuers as resource types in Kubernetes clusters, and simplifies the process of obtaining, renewing, and using those certificates. `cert-manager` provides and rotates an intermediate CA certificate for Istio. Integration with `istio-csr` enables users to delegate signing certificate requests from Istio proxies to `cert-manager`. `ServiceMeshControlPlane` v2.4 accepts CA certificates provided by `cert-manager` as `cacerts` secret.
+
+[NOTE]
+====
+Integration with `cert-manager` and `istio-csr` is not supported on {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName}.
+====
+
+=== Integration with external authorization systems 
+This enhancement introduces a generally available method of integrating {SMProductName} with external authorization systems by using the `action: CUSTOM` field of the `AuthorizationPolicy` resource. Use the `envoyExtAuthzHttp` field to delegate the access control to an external authorization system.
+
+=== Integration with external Prometheus installation
+
+This enhancement introduces a generally available version of the Prometheus extension provider. You can expose metrics to the {product-title} monitoring stack or a custom Prometheus installation by setting the value of the `extensionProviders` field to `prometheus` in the `spec.meshConfig` specification. The telemetry object configures Istio proxies to collect traffic metrics. {SMProductShortName} only supports the Telemetry API for Prometheus metrics. 
+
+[source,yaml]
+----
+spec:
+  meshConfig:
+    extenstionProviders:
+    - name: prometheus
+      prometheus: {}
+---
+apiVersion: telemetry.istio.io/v1alpha1
+kind: Telemetry
+metadata:
+  name: enable-prometheus-metrics
+spec:
+  metrics:
+  - providers:
+    - name: prometheus
+----
+
+=== Single stack IPv6 support
+
+This enhancement introduces generally available support for single stack IPv6 clusters, providing access to a broader range of IP addresses. Dual stack IPv4 or IPv6 cluster is not supported.
+
+[NOTE]
+====
+Single stack IPv6 support is not available on {ibmpowerProductName}, {ibmzProductName}, and {linuxoneProductName}.
+====
+
+=== {product-title} Gateway API support
+
+include::snippets/technology-preview.adoc[]
+
+This enhancement introduces an updated Technology Preview version of the {product-title} Gateway API. By default, the {product-title} Gateway API is disabled.
+
+==== Enabling {product-title} Gateway API
+To enable the {product-title} Gateway API, set the value of the `enabled` field to `true` in the `techPreview.gatewayAPI` specification of the `ServiceMeshControlPlane` resource.
+
+[source,yaml]
+----
+spec:
+  techPreview:
+    gatewayAPI:
+      enabled: true
+----
+
+Previously, environment variables were used to enable the Gateway API.
+
+[source,yaml]
+----
+spec:
+  runtime:
+    components:
+      pilot:
+        container:
+          env:
+            PILOT_ENABLE_GATEWAY_API: "true"
+            PILOT_ENABLE_GATEWAY_API_STATUS: "true"
+            PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: "true"
+----
+
+=== Control plane deployment on infrastructure nodes
+{SMProductShortName} control plane deployment is now supported and documented on OpenShift infrastructure nodes. For more information, see the following documentation:
+
+* Configuring all {SMProductShortName} control plane components to run on infrastructure nodes
+* Configuring individual {SMProductShortName} control plane components to run on infrastructure nodes
+
+=== Istio 1.16 support
+{SMProductShortName} 2.4 is based on Istio 1.16, which brings in new features and product enhancements. While many Istio 1.16 features are supported, the following exceptions should be noted:
+
+* HBONE protocol for sidecars is an experimental feature that is not supported.
+* {SMProductShortName} on ARM64 architecture is not supported.
+* OpenTelemetry API remains a Technology Preview feature.
+
+== New features {SMProductName} version 2.3.4
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.10 and later versions.
+
+=== Component versions included in {SMProductName} version 2.3.4
+
+|===
+|Component |Version
+
+|Istio
+|1.14.6
+
+|Envoy Proxy
+|1.22.9
+
+|Jaeger
+|1.42.0
+
+|Kiali
+|1.57.9
+|===
+
 == New features {SMProductName} version 2.3.3
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 and later versions.
 //only Envoy Proxy changed 04/17/2023
 //kiali and istio changed 04/19/2023
 //Jaeger updated 04/20/2023
@@ -42,7 +195,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} version 2.3.2
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.3.2
 
@@ -64,7 +217,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} version 2.3.1
 
-This release of {SMProductName} introduces new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} introduces new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.3.1
 
@@ -86,7 +239,7 @@ This release of {SMProductName} introduces new features, addresses Common Vulner
 
 == New features {SMProductName} version 2.3
 
-This release of {SMProductName} introduces new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9, 4.10, and 4.11.
+This release of {SMProductName} introduces new features, addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.3
 
@@ -132,9 +285,16 @@ include::snippets/technology-preview.adoc[]
 
 This release introduces a Technology Preview version of the {product-title} Service Mesh Console, which integrates the Kiali interface directly into the OpenShift web console. For additional information, see link:https://cloud.redhat.com/blog/introducing-the-openshift-service-mesh-console-a-developer-preview[Introducing the OpenShift Service Mesh Console (A Technology Preview)]
 
-=== Cluster-Wide deployment
+===  Cluster-wide deployment
+:FeatureName: Cluster-wide deployment
+include::snippets/technology-preview.adoc[]
 
 This release introduces cluster-wide deployment as a Technology Preview feature. A cluster-wide deployment contains a Service Mesh Control Plane that monitors resources for an entire cluster. The control plane uses a single query across all namespaces to monitor each Istio or Kubernetes resource kind that affects the mesh configuration. In contrast, the multitenant approach uses a query per namespace for each resource kind. Reducing the number of queries the control plane performs in a cluster-wide deployment improves performance.
+
+[NOTE]
+====
+This cluster-wide deployment documentation is only applicable for control planes deployed using SMCP v2.3. cluster-wide deployments created using SMCP v2.3 are not compatible with cluster-wide deployments created using SMCP v2.4.
+====
 
 ==== Configuring cluster-wide deployment
 
@@ -172,9 +332,31 @@ Additionally, the SMMR must also be configured for cluster-wide deployment. This
 ----
 <1> Adds all namespaces to the mesh, including any namespaces you subsequently create. The following namespaces are not part of the mesh: kube, openshift, kube-* and openshift-*.
 
+== New features {SMProductName} version 2.2.7
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.10 and later versions.
+
+=== Component versions included in {SMProductName} version 2.2.7
+
+|===
+|Component |Version
+
+|Istio
+|1.12.9
+
+|Envoy Proxy
+|1.20.8
+
+|Jaeger
+|1.42.0
+
+|Kiali
+|1.48.6
+|===
+
 == New features {SMProductName} version 2.2.6
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.2.6
 
@@ -196,7 +378,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} version 2.2.5
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.2.5
 
@@ -218,7 +400,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} version 2.2.4
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.2.4
 
@@ -240,7 +422,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} version 2.2.3
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.2.3
 
@@ -262,7 +444,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} version 2.2.2
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.2.2
 
@@ -288,7 +470,7 @@ With this enhancement, in addition to copying annotations, you can copy specific
 
 == New features {SMProductName} version 2.2.1
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.2.1
 
@@ -310,7 +492,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} 2.2
 
-This release of {SMProductName} adds new features and enhancements, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} adds new features and enhancements, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.2
 
@@ -407,7 +589,7 @@ If the Kubernetes API deployment controller is disabled, you must manually deplo
 
 == New features {SMProductName} 2.1.6
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.1.6
 
@@ -429,7 +611,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} 2.1.5.2
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.1.5.2
 
@@ -451,7 +633,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} 2.1.5.1
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.1.5.1
 
@@ -473,7 +655,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 
 == New features {SMProductName} 2.1.5
 
-This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 or later.
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), bug fixes, and is supported on {product-title} 4.9 and later versions.
 
 === Component versions included in {SMProductName} version 2.1.5
 
@@ -908,7 +1090,6 @@ ifdef::openshift-rosa[]
 
 {SMProductName} is now supported through {product-dedicated}.
 endif::openshift-rosa[]
-
 
 == New features {SMProductName} 2.0.6
 


### PR DESCRIPTION
This PR replaces https://github.com/openshift/openshift-docs/pull/58437

Version(s): 4.10+

Issue: https://issues.redhat.com/browse/OSSM-3252

Link to release notes docs preview: https://58437--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html

Link to deprecated functionality preview build: https://58437--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes.html#deprecated-and-removed-features-red-hat-openshift-service-mesh-2-4

QE review:
QE has approved this change.
