### PR TITLE
RHDEVDOCS-5409: Adding a note specifying the OCP version to work with…

### DIFF
--- a/modules/op-release-notes-1-11.adoc
+++ b/modules/op-release-notes-1-11.adoc
@@ -14,11 +14,13 @@ In addition to fixes and stability improvements, the following sections highligh
 
 [NOTE]
 ====
-You can use {pipelines-title} on the {product-title} cluster that runs on ARM hardware. This update includes support for the `ClusterTask` resources where images are available and the Tekton CLI tool on ARM hardware.
+Before upgrading to the {pipelines-title} Operator 1.11, ensure that you have at least installed the {product-title} 4.12.19 or 4.13.1 version on your cluster.
 ====
 
 [id="pipelines-new-features-1-11_{context}"]
 === Pipelines
+
+* With this update, you can use {pipelines-title} on the {product-title} cluster that runs on ARM hardware. You have support for the `ClusterTask` resources where images are available and the Tekton CLI tool on ARM hardware.
 
 * This update adds support for results, object parameters, array results, and indexing into an array when you set the `enable-api-fields` feature flag to `beta` value in the `TektonConfig` CR.
 


### PR DESCRIPTION
Aligned team: Dev Tools

Purpose: To resolve the following issues:
https://issues.redhat.com/browse/RHDEVDOCS-5409

OCP version this PR applies to: enterprise 4.12 and later

Link to docs preview: https://61437--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#op-release-notes-1-11_op-release-notes

Need an ACK from Eng: @piyush-garg @vdemeester 
Need an ACK from PM: @koustavsaha
Need an ACK from QE: @VeereshAradhya @ppitonak
Need an ACK from CS and DPM: @Preeticp
Need an ack from PX: @RickJWagner 

Peer review: @Dhruv-Soni11 