### PR TITLE
ROX-17292: Update policy criteria table to reflect new in-app naming

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -13,8 +13,9 @@ You can configure the policy based on the attributes listed in the following tab
 In this table:
 
 * The *Regular expressions*, *AND, OR*, and *NOT* columns indicate whether you can use regular expressions and other logical operators along with the specific attribute.
-** `!` in the *Regular expressions* column indicates that you can only use regular expressions for the listed fields.
-** `!` in the *AND, OR* column indicates that you can only use the mentioned logical operator for the attribute.
+** `!` for *Regex* (Regular expressions) indicates that you can only use regular expressions for the listed fields.
+** `!` for *AND*, or *OR* indicates that you can only use the mentioned logical operator for the attribute.
+** ✕ in the *Regex* / *NOT* / *AND, OR* column indicates that the attribute does not support any of those (regex, negation, logical operators).
 * The *RHACS version* column indicates the version of {product-title} that you must have to use the attribute.
 * You cannot use logical combination operators `AND` and `OR` for attributes that have:
 ** Boolean values `true` and `false`
@@ -29,524 +30,831 @@ In this table:
 *** *Environment Variable*, which consists of both name and value.
 ** Other meanings, including *Add Capabilities*, *Drop Capabilities*, *Days since image was created*, and *Days since image was last scanned*.
 
-[NOTE]
-====
-To use logical operators `AND`, `OR`, and `NOT` for creating security policies, you need {product-title} version 3.0.45 or newer.
-However, on earlier versions you can still use regular expressions for the fields listed in the *Regular expressions* column.
-====
-
-[cols="<,<,<,^,^,^,<"]
+[cols="<,<,<,<,^,<"]
 |===
-| *Attribute* | *Description* | *RHACS version* | *Regular expressions* | *NOT* | *AND, OR* | *Phase*
+| *Attribute* | *Description* | *JSON Attribute* | *Allowed Values* | *Regex*, *NOT*, *AND, OR* | *Phase*
 
-| Namespace
-| The name of the namespace.
-| 3.0.51 and newer
-| ✓
-| ✓
-| ✓
-| Deploy
+6+| *Section: Image registry*
 
 | Image Registry
 | The name of the image registry.
-| All
-| ✓
-| ✓
-| ✓
-| Deploy
+| Image Registry
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Image Remote
+| Image Name
 | The full name of the image in registry, for example `library/nginx`.
-| All
-| ✓
-| ✓
-| ✓
-| Deploy
+| Image Remote
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
 | Image Tag
 | Identifier for an image.
-| All
-| ✓
-| ✓
-| ✓
-| Deploy
+| Image Tag
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Days since image was created
-| The number of days from image creation date.
-| All
-| ✕
-| ✕
-| ✕
-| Build
+| Image Signature
+| The list of signature integrations you can use to verify an image's signature. Create alerts on images that either do not have a signature or their signature is not verifiable by at least one of the provided signature integrations.
+| Image Signature Verified By
+| A valid ID of an already configured image signature integration
+| ! `OR` only
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Days since image was last scanned
-| The number of days since the last image scan.
-| All
+
+6+| *Section: Image contents*
+
+| Image age
+| The minimum number of days from image creation date.
+| Image Age
+| Integer
 | ✕
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Image scan age
+| The minimum number of days since the image was last scanned.
+| Image Scan Age
+| Integer
 | ✕
-| ✕
-| Build
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Image User
+| Matches the USER directive in the Dockerfile. See https://docs.docker.com/engine/reference/builder/#user for details
+.
+| Image User
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
 | Dockerfile Line
 | A specific line in the Dockerfile, including both instructions and arguments.
-| All
-| ! only for values
-| ✕
-| ✓
-| Build
+| Dockerfile Line
+| One of: LABEL, RUN, CMD, EXPOSE, ENV, ADD, COPY, ENTRYPOINT, VOLUME, USER, WORKDIR, ONBUILD
+| ! Regex only for values, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Image is NOT Scanned
-| No scan data is available for the image.
-| All
+| Image scan status
+| Check if an image was scanned.
+| Unscanned Image
+| Boolean
 | ✕
-| ✕
-| ✕
-| Build
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
 | CVSS
 | Common Vulnerability Scoring System, use it to match images with vulnerabilities whose scores are greater than `>`, less than `<`, or equal to `=` the specified CVSS.
-| All
-| ✕
-| ✕
-| ✓
-| Build
+| CVSS
+| <, >, \<=, >= or nothing (which implies equal to) +
+
+-- and --
+ +
+a decimal (a number with an optional fractional value). +
+
+Examples: +
+>=5, or +
+9.5
+| AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Severity
+| The severity of the vulnerability based on the CVSS or the vendor. Can be one of Low, Moderate, Important or Critical.
+| Severity
+| <, >, <=, >= or nothing (which implies equal to) +
+
+-- and --
+ +
+One of: +
+UNKNOWN +
+LOW +
+MODERATE +
+IMPORTANT +
+CRITICAL +
+
+Examples: +
+>=IMPORTANT, or +
+CRITICAL
+| AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
 | Fixed By
-| The version string of a package that fixes a flagged vulnerability in an image.
-| All
-| ✓
-| ✓
-| ✓
-| Build
+| The version string of a package that fixes a flagged vulnerability in an image. This criterion may be used in addition to other criteria that identify a vulnerability, for example using the CVE criterion.
+| Fixed By
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
 | CVE
 | Common Vulnerabilities and Exposures, use it with specific CVE numbers.
-| All
-| ✓
-| ✓
-| ✓
-| Build
+| CVE
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
 | Image Component
 | Name and version number of a specific software component present in an image.
-| All
-| ✓
-| ✕
-| ✓
-| Build
+| Image Component
+| key=value +
+
+Value is optional. +
+
+If value is missing, it must be in format "key=".
+| Regex, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
 | Image OS
-| Name and version number of the base operating system of the image.
-| 3.0.47 and newer
-| ✓
-| ✓
-| ✓
-| Build
+| Name and version number of the base operating system of the image. For example, `alpine:3.17.3`
+| Image OS
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Require image label
+| Ensure the presence of a Docker image label. The policy triggers if any image in the deployment does not have the specified label. You can use regular expressions for both key and value fields to match labels. The `Require Image Label` policy criteria only works when you integrate with a Docker registry. For details about Docker labels see Docker documentation, https://docs.docker.com/config/labels-custom-metadata/.
+| Required Image Label
+| key=value +
+
+Value is optional. +
+
+If value is missing, it must be in format "key=".
+| Regex, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Disallow image label
+| Ensure that a particular Docker image label is NOT used. The policy triggers if any image in the deployment has the specified label. You can use regular expressions for both key and value fields to match labels. The 'Disallow Image Label policy' criteria only works when you integrate with a Docker registry. For details about Docker labels see Docker documentation, https://docs.docker.com/config/labels-custom-metadata/.
+| Disallowed Image Label
+| key=value +
+
+Value is optional. +
+
+If value is missing, it must be in format "key=".
+| Regex, +
+AND, OR
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+6+| *Section: Container configuration*
 
 | Environment Variable
 | Check environment variables by name or value.
-| All
-| ! only for key and value
-| ✕
-| ✓
-| Deploy
+| Environment Variable
+| RAW=key=value to match an environment variable as directly specified in the deployment configuration with a specific key and value. `value` can be omitted to match on only the key. +
 
-| Disallowed Annotation
-| An annotation which is not allowed to be present on Kubernetes resources in a specified environment.
-| All
-| ✓
-| ✕
-| ✓
-| Deploy
+If the environment variable is not directly defined in the configuration, then the format SOURCE=KEY can be used, where SOURCE is one of SECRET_KEY, CONFIG_MAP_KEY, FIELD or RESOURCE_FIELD. In this case, criteria can only match the key and not the value.
+| ! Regex only for key and value (if using RAW) +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Disallowed Image Label
-| Check for the presence of a Docker image label that should not be in use.
-The policy triggers if any image in the deployment has the specified label.
-You can use regular expressions for both `key` and `value` fields to match labels.
-The `Disallowed Image Label` policy criteria only works when you integrate with a Docker registry.
-| 3.0.40 and newer
-| ✓
-| ✕
-| ✓
-| Deploy
 
-| Required Image Label
-| Check for the presence of a required Docker image label.
-The policy triggers if any image in the deployment does not have the specified label.
-You can use regular expressions for both `key` and `value` fields to match labels.
-The `Required Image Label` policy criteria only works when you integrate with a Docker registry.
-| 3.0.40 and newer
-| ✓
-| ✕
-| ✓
-| Deploy
+| Container CPU Request
+| Check for the number of cores reserved for a given resource.
+| Container CPU Request
+| <, >, <=, >= or nothing (which implies equal to) +
 
-| Required Label
-| Check for the presence of a required label in Kubernetes.
-| All
-| ✓
-| ✕
-| ✓
-| Deploy
+-- and --
+ +
+A decimal (a number with an optional fractional value) +
 
-| Required Annotation
-| Check for the presence of a required annotation in Kubernetes.
-| All
-| ✓
-| ✕
-| ✓
-| Deploy
+Examples: +
+  >=5, or +
+  9.5
+| AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Volume Name
-| Name of the storage.
-| All
-| ✓
-| ✓
-| ✓
-| Deploy
 
-| Volume Source
-| Indicates the form in which the volume is provisioned. For example, `persistentVolumeClaim` or `hostPath`.
-| All
-| ✓
-| ✓
-| ✓
-| Deploy
+| Container CPU Limit
+| Check for the maximum number of cores a resource is allowed to use.
+| Container CPU Limit
+| (Same as Container CPU Request)
+| AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Volume Destination
-| The path where the volume is mounted.
-| All
-| ✓
-| ✓
-| ✓
-| Deploy
 
-| Volume Type
-| The type of volume.
-| All
-| ✓
-| ✓
-| ✓
-| Deploy
+| Container Memory Request
+| Check for the amount of memory reserved for a given resource.
+| Container Memory Request
+| (Same as Container CPU Request)
+| AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Writable Volume
-| Volumes that are mounted as writable.
-| All
-| ✕
-| ✕
-| ✕
-| Deploy
 
-| Protocol
-| Protocol, such as, TCP or UDP, that is used by the exposed port.
-| All
-| ✓
-| ✓
-| ✓
-| Deploy
+| Container Memory Limit
+| Check for the maximum amount of memory a resource is allowed to use.
+| Container Memory Limit
+| (Same as Container CPU Request)
+| AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Port
-| Port numbers exposed by a deployment.
-| All
-| ✕
-| ✓
-| ✓
-| Deploy
 
-| Privileged
+| Privileged container
 | Privileged running deployments.
-| All
+| Privileged Container
+| Boolean
 | ✕
-| ✕
-| ✕
-| Deploy
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Read-Only Root Filesystem
+
+| Root filesystem writeability
 | Containers running with the root file system configured as read only.
-| All
+| Read-Only Root Filesystem
+| Boolean
 | ✕
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+
+| Seccomp Profile Type
+| The type of seccomp profile allowed for the container.
+| Seccomp Profile Type
+| One of: +
+
+UNCONFINED +
+RUNTIME_DEFAULT +
+LOCALHOST
 | ✕
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+
+| Privilege escalation
+| Provides alerts when a development is configured to allow a container process to gain more privileges than its parent process.
+| Allow Privilege Escalation
+| Boolean
 | ✕
-| Deploy
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
 
 | Drop Capabilities
 | Linux capabilities that must be dropped from the container.
 For example `CAP_SETUID` or `CAP_NET_RAW`.
-| All
-| ✕
-| ✕
-| ✓
-| Deploy
+| Drop Capabilities +
+
+| One of: +
+
+AUDIT_CONTROL +
+AUDIT_READ +
+AUDIT_WRITE +
+BLOCK_SUSPEND +
+CHOWN +
+DAC_OVERRIDE +
+DAC_READ_SEARCH +
+FOWNER +
+FSETID +
+IPC_LOCK +
+IPC_OWNER +
+KILL +
+LEASE +
+LINUX_IMMUTABLE +
+MAC_ADMIN +
+MAC_OVERRIDE +
+MKNOD +
+NET_ADMIN +
+NET_BIND_SERVICE +
+NET_BROADCAST +
+NET_RAW +
+SETGID +
+SETFCAP +
+SETPCAP +
+SETUID +
+SYS_ADMIN +
+SYS_BOOT +
+SYS_CHROOT +
+SYS_MODULE +
+SYS_NICE +
+SYS_PACCT +
+SYS_PTRACE +
+SYS_RAWIO +
+SYS_RESOURCE +
+SYS_TIME +
+SYS_TTY_CONFIG +
+SYSLOG +
+WAKE_ALARM +
+| AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
 
 | Add Capabilities
 | Linux capabilities that must not be added to the container, for instance the ability to send raw packets or override file permissions.
-| All
-| ✕
-| ✕
-| ✓
-| Deploy
+| Add Capabilities
+| (same as Drop Capabilities)
+| AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Process Name
-| Name of the process executed in a deployment.
-| All
-| ✓
-| ✓
-| ✓
-| Runtime
-
-| Process Ancestor
-| Name of any parent process for a process executed in a deployment.
-| All
-| ✓
-| ✓
-| ✓
-| Runtime
-
-| Process Arguments
-| Command arguments for a process executed in a deployment.
-| All
-| ✓
-| ✓
-| ✓
-| Runtime
-
-| Process UID
-| Unix user ID for a process executed in a deployment.
-| All
-| ✕
-| ✓
-| ✓
-| Runtime
-
-| Port Exposure
-| Exposure method of the service, for example, load balancer or node port.
-| All
-| ✕
-| ✓
-| ✓
-| Deploy
-
-| Service Account
-| The name of the service account.
-| All
-| ✓
-| ✓
-| ✓
-| Deploy
-
-| Writable Host Mount
-| Resource has mounted a path on the host with write permissions.
-| All
-| ✕
-| ✕
-| ✕
-| Deploy
-
-| Unexpected Process Executed
-| Check deployments for which process executions are not listed in the deployment's locked process baseline.
-| All
-| ✕
-| ✕
-| ✕
-| Runtime
-
-| Minimum RBAC Permissions
-| Match if the deployment's Kubernetes service account has Kubernetes RBAC permission level equal to `=` or greater than `>` the specified level.
-| All
-| ✕
-| ✓
-| ✕
-| Deploy
 
 | Container Name
 | The name of the container.
-| 3.0.52 and newer
-| ✓
-| ✓
-| ✓
-| Deploy
+| Container Name
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Container CPU Request
-| Check for the number of cores reserved for a given resource.
-| All
-| ✕
-| ✕
-| ✓
-| Deploy
 
-| Container CPU Limit
-| Check for the maximum number of cores a resource is allowed to use.
-| All
-| ✕
-| ✕
-| ✓
-| Deploy
+| AppArmor Profile
+| The Application Armor ("AppArmor") profile used in the container.
+| AppArmor Profile
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
 
-| Container Memory Request
-| Check for the amount of memory reserved for a given resource.
-| All
-| ✕
-| ✕
-| ✓
-| Deploy
 
-| Container Memory Limit
-| Check for the maximum amount of memory a resource is allowed to use.
-| All
+| Liveness Probe
+| Whether the container defines a liveness probe.
+| Liveness Probe
+| Boolean
 | ✕
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+
+| Readiness Probe
+| Whether the container defines a readiness probe.
+| Readiness Probe
+| Boolean
 | ✕
-| ✓
-| Deploy
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+
+6+| *Section: Deployment metadata*
+
+| Disallowed Annotation
+| An annotation which is not allowed to be present on Kubernetes resources in a specified environment.
+| Disallowed Annotation
+| key=value +
+
+Value is optional. +
+
+If value is missing, it must be in format "key=".
+| Regex, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Required Label
+| Check for the presence of a required label in Kubernetes.
+| Required Label
+| key=value +
+
+Value is optional. +
+
+If value is missing, it must be in format "key=".
+| Regex, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Required Annotation
+| Check for the presence of a required annotation in Kubernetes.
+| Required Annotation
+| key=value +
+
+Value is optional. +
+
+If value is missing, it must be in format "key=".
+| Regex, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Runtime Class
+| The `RuntimeClass` of the deployment.
+| Runtime Class
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Host Network
+| Check if `HostNetwork` is enabled which means that the container is not placed inside a separate network stack (for example, the container's networking is not containerized). This implies that the container has full access to the host's network interfaces.
+| Host Network
+| Boolean
+| ✕
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Host PID
+| Check if the Process ID (PID) namespace is isolated between the containers and the host. This allows for processes in different PID namespaces to have the same PID.
+| Host PID
+| Boolean
+| ✕
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Host IPC
+| Check if the IPC (POSIX/SysV IPC) namespace (which provides separation of named shared memory segments, semaphores and message queues) on the host is shared with containers.
+| Host IPC
+| Boolean
+| ✕
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Namespace
+| The name of the namespace the deployment belongs to.
+| Namespace
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Replicas
+| The number of deployment replicas.
+| Replicas
+| <, >, <=, >= or nothing (which implies equal to) +
+
+-- and --
+ +
+a decimal (a number with an optional fractional value). +
+
+Examples: +
+>=5, or +
+9.5
+| NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+6+| *Section: Storage*
+
+| Volume Name
+| Name of the storage.
+| Volume Name
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Volume Source
+| Indicates the form in which the volume is provisioned. For example, `persistentVolumeClaim` or `hostPath`.
+| Volume Source
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Volume Destination
+| The path where the volume is mounted.
+| Volume Destination
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Volume Type
+| The type of volume.
+| Volume Type
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Mounted volume writability
+| Volumes that are mounted as writable.
+| Writable Mounted Volume
+| Boolean
+| ✕
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Mount Propagation
+| Check if container is mounting volumes in `Bidirectional`, `Host to Container`, or `None` modes.
+| Mount Propagation
+| One of: +
+
+NONE +
+HOSTTOCONTAINER +
+BIDIRECTIONAL +
+| NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Host mount writability
+| Resource has mounted a path on the host with write permissions.
+| Writable Host Mount
+| Boolean
+| ✕
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+6+| *Section: Networking*
+
+| Protocol
+| Protocol, such as, TCP or UDP, that is used by the exposed port.
+| Exposed Port Protocol
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Port
+| Port numbers exposed by a deployment.
+| Exposed Port
+| <, >, <=, >= or nothing (which implies equal to) +
+
+-- and --
+ +
+an integer. +
+
+Examples: +
+>=1024, or +
+22
+| NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Exposed Node Port
+| Port numbers exposed externally by a deployment.
+| Exposed Node Port
+| (Same as Exposed Port)
+| NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Port Exposure
+| Exposure method of the service, for example, load balancer or node port.
+| Port Exposure Method
+| One of: +
+
+UNSET +
+EXTERNAL +
+NODE +
+HOST +
+INTERNAL +
+ROUTE +
+| NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Unexpected Network Flow Detected
+| Check if the detected network traffic is part of the network baseline for the deployment.
+| Unexpected Network Flow Detected
+| Boolean
+| ✕
+| *Runtime* ONLY - Network
+
+| Ingress Network Policy
+| Check the presence or absence of ingress Kubernetes network policies.
+| Has Ingress Network Policy
+| Boolean
+| Regex, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Egress Network Policy
+| Check the presence or absence of egress Kubernetes network policies.
+| Has Egress Network Policy
+| Boolean
+| Regex, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+6+| *Section: Process activity*
+
+| Process Name
+| Name of the process executed in a deployment.
+| Process Name
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Runtime* ONLY - Process
+
+| Process Ancestor
+| Name of any parent process for a process executed in a deployment.
+| Process Ancestor
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Runtime* ONLY - Process
+
+| Process Arguments
+| Command arguments for a process executed in a deployment.
+| Process Arguments
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Runtime* ONLY - Process
+
+| Process UID
+| Unix user ID for a process executed in a deployment.
+| Process UID
+| Integer
+| NOT, +
+AND, OR
+| *Runtime* ONLY - Process
+
+| Unexpected Process Executed
+| Check deployments for which process executions are not listed in the deployment's locked process baseline.
+| Unexpected Process Executed
+| Boolean
+| ✕
+| *Runtime* ONLY - Process
+
+6+| *Section: Kubernetes access*
+
+| Service Account
+| The name of the service account.
+| Service Account
+| String
+| Regex, +
+NOT, +
+AND, OR
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Automount Service Account Token
+| Check if the deployment configuration automatically mounts the service account token.
+| Automount Service Account Token
+| Boolean
+| ✕
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Minimum RBAC Permissions
+| Match if the deployment's Kubernetes service account has Kubernetes RBAC permission level equal to `=` or greater than `>` the specified level.
+| Minimum RBAC Permissions
+| One of: +
+
+DEFAULT +
+ELEVATED_IN_NAMESPACE +
+ELEVATED_CLUSTER_WIDE +
+CLUSTER_ADMIN
+| NOT
+| *Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+6+| *Section: Kubernetes events*
 
 | Kubernetes Action
 | The name of the Kubernetes action, such as `Pod Exec`.
-| 3.0.55 and newer
-| ✕
-| ✕
-| ! `OR` only
-| Runtime
-
 | Kubernetes Resource
-| The name of the accessed Kubernetes resource, such as `configmaps` or `secrets`.
-| 3.63 and newer
-| ✕
-| ✕
-| ! `OR` only
-| Runtime
+| One of: +
 
-| Kubernetes Resource Name
-| The name of the accessed Kubernetes resource.
-| 3.63 and newer
-| ✓
-| ✓
+PODS_EXEC +
+PODS_PORTFORWARD +
 | ! `OR` only
-| Runtime
-
-| Kubernetes API Verb
-| The Kubernetes API verb that is used to access the resource, such as `GET` or `POST`.
-| 3.63 and newer
-| ✕
-| ✕
-| ! `OR` only
-| Runtime
+| *Runtime* ONLY - Kubernetes Events
 
 | Kubernetes User Name
 | The name of the user who accessed the resource.
-| 3.63 and newer
-| ✓
-| ✓
-| ! `OR` only
-| Runtime
+| Kubernetes User Name
+| Alphanumeric with hyphens (-) and colon (:) only
+| Regex, +
+NOT, +
+! `OR` only
+| *Runtime* ONLY - Kubernetes Events
 
 | Kubernetes User Group
 | The name of the group to which the user who accessed the resource belongs to.
-| 3.63 and newer
-| ✓
-| ✕
+| Kubernetes User Groups
+| Alphanumeric with hyphens (-) and colon (:) only
+| Regex, +
+! `OR` only
+| *Runtime* ONLY - Kubernetes Events
+
+| Kubernetes Resource
+| The name of the accessed Kubernetes resource, such as `configmaps` or `secrets`.
+| Kubernetes Resource
+| One of: +
+
+SECRETS +
+CONFIGMAPS +
 | ! `OR` only
-| Runtime
+| *Runtime* ONLY - Audit Log
+
+| Kubernetes API Verb
+| The Kubernetes API verb that is used to access the resource, such as `GET` or `POST`.
+| Kubernetes API Verb
+| One of: +
+
+CREATE +
+DELETE +
+GET +
+PATCH +
+UPDATE +
+| ! `OR` only
+| *Runtime* ONLY - Audit Log
+
+| Kubernetes Resource Name
+| The name of the accessed Kubernetes resource.
+| Kubernetes Resource Name
+| Alphanumeric with hyphens (-) and colon (:) only
+| Regex, +
+NOT, +
+! `OR` only
+| *Runtime* ONLY - Audit Log
 
 | User Agent
 | The user agent that the user used to access the resource.
 For example `oc`, or `kubectl`.
-| 3.63 and newer
-| ✓
-| ✓
-| ! `OR` only
-| Runtime
+| User Agent
+| String
+| Regex, +
+NOT, +
+! `OR` only
+| *Runtime* ONLY - Audit Log
 
 | Source IP Address
 | The IP address from which the user accessed the resource.
-| 3.63 and newer
-| ✓
-| ✓
-| ! `OR` only
-| Runtime
+| Source IP Address
+| IPV4 or IPV6 address
+| Regex, +
+NOT, +
+! `OR` only
+| *Runtime* ONLY - Audit Log
 
 | Is Impersonated User
 | Check if the request was made by a user that is impersonated by a service account or some other account.
-| 3.63 and newer
+| Is Impersonated User
+| Boolean
 | ✕
-| ✕
-| ✕
-| Runtime
-
-| Runtime Class
-| The RuntimeClass of the deployment.
-| 3.67 and newer
-| ✓
-| ✓
-| ✓
-| Deploy
-
-| Automount Service Account Token
-| Check if the deployment configuration automatically mounts the service account token.
-| 3.68 and newer
-| ✕
-| ✕
-| ✕
-| Deploy
-
-| Liveness Probe
-| Whether the container defines a liveness probe.
-| 3.69 and newer
-| ✕
-| ✕
-| ✕
-| Deploy
-
-| Readiness Probe
-| Whether the container defines a readiness probe.
-| 3.69 and newer
-| ✕
-| ✕
-| ✕
-| Deploy
-
-| Replicas
-| The number of deployment replicas.
-| 3.69 and newer
-| ✕
-| ✓
-| ✓
-| Deploy
-
-| Privilege escalation
-| Provides alerts when a development is configured to allow a container process to gain more privileges than its parent process.
-| 3.70 and later
-| ✕
-| ✕
-| ✕
-| Deploy
-
-| Ingress Network Policy
-| Check the presence or absence of ingress Kubernetes network policies.
-| 3.70 and later
-| ✕
-| ✕
-| ✓
-| Deploy
-
-| Egress Network Policy
-| Check the presence or absence of egress Kubernetes network policies.
-| 3.70 and later
-| ✕
-| ✕
-| ✓
-| Deploy
-
-| Not verified by trusted image signers
-| The list of signature integrations you can use to verify an image's signature. Create alerts on images that either do not have a signature or their signature is not verifiable by at least one of the provided signature integrations.
-| 3.70 and later
-| ✕
-| ✕
-| ! `OR` only
-| Deploy
+| *Runtime* ONLY - Audit Log
 
 |===
-
-[NOTE]
-====
-If you are using {product-title} version 3.0.44 or older, the policy criteria you specify in the *Policy criteria* section are "AND"ed.
-It means that the violation only triggers if all the specified policy criteria match.
-====


### PR DESCRIPTION
Version(s):
- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.1`

[Issue](https://issues.redhat.com/browse/ROX-17292)

[Link to docs preview
](https://61461--docspreview.netlify.app/openshift-acs/latest/operating/manage-security-policies.html#policy-criteria_manage-security-policies)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
