### PR TITLE
TELCODOCS-1365 adding missed parameter per-pod-power-management

### DIFF
--- a/modules/cnf-performance-profile-creator-arguments.adoc
+++ b/modules/cnf-performance-profile-creator-arguments.adoc
@@ -74,6 +74,13 @@ Possible values:
 
 Default: `default`.
 
+| `per-pod-power-management`
+a|Enable per-pod power management. You cannot use this argument if you configured `ultra-low-latency` as the power consumption mode.
+
+Possible values: `true` or `false`.
+
+Default: `false`.
+
 | `profile-name`
 | Name of the performance profile to create.
 Default: `performance`.


### PR DESCRIPTION
[TELCODOCS-1365]: Add per-pod-power-management argument to Performance Profile Creator Arguments
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1365
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://61462--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-create-performance-profiles.html#performance-profile-creator-arguments_cnf-create-performance-profiles
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
