### PR TITLE
OSDOCS-6370: Added selinux file content relabeling content

### DIFF
--- a/modules/storage-selinux-file-context-relabeling.adoc
+++ b/modules/storage-selinux-file-context-relabeling.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * storage/understanding-persistent-storage.adoc
+
+:_content-type: CONCEPT
+[id="selinux-file-context-relabeling_{context}"]
+= SELinux File Context Relabeling
+
+When a pod is created and requires a volume to be mounted, the CRI-O container runtime is instructed by the node's kubelet process upon pod creation to relabel the entire volume with proper SELinux contexts.
+
+There are three methods for skipping the SELinux relabeling for a volume:
+
+* Skip SELinux Relabeling using the `spc_t` SELinux context
+* Automating SELinux Relabeling using the Cluster Resource Override Operator
+* Skip SELinux Relabeling with a custom `RuntimeClass`
+
+By default, volume SELinux context relabeling happens for every volume on container startup and can cause significant delays when the volume has many files and directories as the procedure has to occur asynchronously, recursively through the entire volume. However, if a pod is configured to have the SELinux `spc_t` type, or is configured to have `io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel` and the volume is already correctly labeled, then the relabel process will be skipped.

--- a/modules/storage-skip-selinux-relabeling-runtimeclass.adoc
+++ b/modules/storage-skip-selinux-relabeling-runtimeclass.adoc
@@ -1,0 +1,80 @@
+// Module included in the following assemblies:
+//
+// * storage/understanding-persistent-storage.adoc
+
+:_content-type: PROCEDURE
+[id="storage-skip-selinux-relabeling-runtimeclass_{context}"]
+= Skip SELinux Relabeling with a custom RuntimeClass
+
+Add a custom `RuntimeClass` to skip the SELinux relabel process if the top level of the volume is found to have the correct label.
+
+[IMPORTANT]
+====
+The volume will have to be labeled at least once and will be performed automatically by CRI-O. A container creation timeout might occur.
+====
+
+.Procedure
+
+. Edit the CRI-O configuration file to include the following:
++
+[source,text]
+----
+[crio.runtime.runtimes.selinux]
+runtime_path = "/usr/bin/runc"
+runtime_root = "/run/runc"
+runtime_type = "oci"
+allowed_annotations = ["io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel"]
+----
+
+. Create a `MachineConfig` object to allow CRI-O to have a customized runtime class:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: worker
+  name: 99-worker-selinux-configuration
+spec:
+  config:
+    ignition:
+      version: 3.2.0
+    storage:
+      files:
+      - contents:
+          source: data:text/plain;charset=utf-8;base64...
+        mode: 0640
+        overwrite: true
+        path: /etc/crio/crio.conf.d/01-selinux.conf
+  osImageURL: ""
+----
+
+. Create the `RuntimeClass` object. The name must match as described in the CRI-O configuration file:
++
+[source,yaml]
+----
+apiVersion: node.k8s.io/v1
+kind: RuntimeClass
+metadata:
+  name: selinux
+handler: selinux
+----
+
+. Configure the Pod to have `annotations:io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"` in the `metadata` attribute, as well as the `runtimeClassName: selinux` set in the `spec` attribute:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: sandbox
+  annotations:
+    io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"
+...
+spec:
+  runtimeClassName: selinux
+...
+----
++
+When a pod is created, CRI-O operates the pod with the `runtimeClassName: selinux`, which is configured to process the annotation `io.kubernetes.cri-o.TrySkipVolumeSELinuxLabel: "true"`. The SELinux relabel process is skipped if the volume is already labeled correctly.

--- a/modules/storage-skip-selinux-relabeling.adoc
+++ b/modules/storage-skip-selinux-relabeling.adoc
@@ -1,0 +1,222 @@
+// Module included in the following assemblies:
+//
+// * storage/understanding-persistent-storage.adoc
+
+:_content-type: PROCEDURE
+[id="storage-skip-selinux-relabeling_{context}"]
+= Skip SELinux Relabeling using the spc_t SELinux context
+
+The SELinux Super Privileged Container type, `spc_t`, defines a container that will not be constrained by SELinux policies.
+
+If a pod `securityContext` has `type: spc_t` set, it will be inherited by containers that have no `type` specified. When this option is configured, CRI-O will skip the SELinux relabel process.
+
+[WARNING]
+====
+If a pod is running with an SCC with the `runAsUser` attribute set to `runAsAny`, an unconstrained container process might be able to overwrite files on the host.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Create a custom SCC called `custom_scc.yaml`:
++
+[source,yaml]
+----
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:authenticated
+kind: SecurityContextConstraints
+metadata:
+  name: custom
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+----
+
+. Assign the custom SCC to the service account and namespace:
++
+[source,terminal]
+----
+$ oc adm policy add-scc-to-user custom -z <service-account> -n <namespace>
+----
+
+. Add the following changes to the `Deployment` object in the `securityContext` attribute:
++
+[source,yaml]
+----
+      securityContext:
+        fsGroupChangePolicy: OnRootMismatch
+        seLinuxOptions:
+          type: spc_t
+----
+
+[id="automating-selinux-cro_{context}"]
+== Automating SELinux Relabeling using the Cluster Resource Override Operator
+
+The Cluster Resource Override Operator (CRO) has been extended to allow for users to automate applying the `spc_t` label. The CRO Operator applies the `spc_t` SELinux context per namespace when the CRO is configured with the `forceSelinuxRelabel` attribute set to `true`.
+
+.Procedure
+
+. Install the CRO Operator:
+
+.. In the {product-title} web console, navigate to *Home* -> *Projects*
+
+... Click *Create Project*.
+
+... Specify `clusterresourceoverride-operator` as the name of the project.
+
+... Click *Create*.
+
+.. Navigate to *Operators* -> *OperatorHub*.
+
+... Choose  *ClusterResourceOverride Operator* from the list of available Operators and click *Install*.
+
+... On the *Install Operator* page, make sure *A specific Namespace on the cluster* is selected for *Installation Mode*.
+
+... Make sure *clusterresourceoverride-operator* is selected for *Installed Namespace*.
+
+... Select an *Update Channel* and *Approval Strategy*.
+
+... Click *Install*.
+
+.. On the *Installed Operators* page, click *ClusterResourceOverride*.
+
+... On the *ClusterResourceOverride Operator* details page, click *Create Instance*.
+
+... On the *Create ClusterResourceOverride* page, edit the YAML template to set the overcommit values as needed:
++
+[source,yaml]
+----
+apiVersion: operator.autoscaling.openshift.io/v1
+kind: ClusterResourceOverride
+metadata:
+  name: cluster <1>
+spec:
+  podResourceOverride:
+    spec:
+      memoryRequestToLimitPercent: 50 <2>
+      cpuRequestToLimitPercent: 25 <3>
+      limitCPUToMemoryPercent: 200 <4>
+      forceSelinuxRelabel: true <5>
+----
+<1> The name must be `cluster`.
+<2> Optional. Specify the percentage to override the container memory limit, if used, between 1-100. The default is 50.
+<3> Optional. Specify the percentage to override the container CPU limit, if used, between 1-100. The default is 25.
+<4> Optional. Specify the percentage to override the container memory limit, if used. Scaling 1Gi of RAM at 100 percent is equal to 1 CPU core. This is processed prior to overriding the CPU request, if configured. The default is 200.
+<5> Forces the SELinux relabeling policy.
+
+... Click *Create*.
++
+The CRO is now installed and configured.
+
+. Configure the Security Context Constraint (SCC):
+
+.. Save the following to the `cro-selinux-context-scc.yaml` file to create the SCC called `custom`:
++
+[source,yaml]
+----
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+apiVersion: security.openshift.io/v1
+defaultAddCapabilities: null
+fsGroup:
+  type: MustRunAs
+groups:
+- system:authenticated
+kind: SecurityContextConstraints
+metadata:
+  name: custom
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+- KILL
+- MKNOD
+- SETUID
+- SETGID
+runAsUser:
+  type: MustRunAsRange
+seLinuxContext:
+  type: RunAsAny
+supplementalGroups:
+  type: RunAsAny
+users: []
+volumes:
+- configMap
+- downwardAPI
+- emptyDir
+- persistentVolumeClaim
+- projected
+- secret
+----
+
+. Create a namespace file called `cro-selinux-context-ns.yaml` with the following contents:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+ name: selinux-relabel
+ labels:
+   clusterresourceoverrides.admission.autoscaling.openshift.io/enabled: "true"
+   forceselinuxrelabel.admission.node.openshift.io/enabled: "true"
+----
+
+. Run the following command to create the namespace:
++
+[source,terminal]
+----
+ $ oc create -f cro-selinux-context-ns.yaml
+----
+
+.. Create the SCC in the global namespace:
++
+[source,terminal]
+----
+ $ oc create -f cro-selinux-context-scc.yaml
+----
+
+.. Apply the SCC to the `selinux-relabel` namespace:
++
+[source,terminal]
+----
+ $ oc adm policy add-scc-to-user custom -z default -n selinux-relabel
+----

--- a/storage/understanding-persistent-storage.adoc
+++ b/storage/understanding-persistent-storage.adoc
@@ -34,3 +34,9 @@ include::modules/storage-persistent-storage-block-volume.adoc[leveloffset=+1]
 include::modules/storage-persistent-storage-block-volume-examples.adoc[leveloffset=+2]
 
 include::modules/storage-persistent-storage-fsGroup.adoc[leveloffset=+1]
+
+include::modules/storage-selinux-file-context-relabeling.adoc[leveloffset=+1]
+
+include::modules/storage-skip-selinux-relabeling.adoc[leveloffset=+2]
+
+include::modules/storage-skip-selinux-relabeling-runtimeclass.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.7+

Issue:
https://issues.redhat.com/browse/OSDOCS-6370

Link to docs preview (VPN required):
[SELinux File Context Relabeling](https://file.rdu.redhat.com/antaylor/OSDOCS-6370/storage/understanding-persistent-storage.html#selinux-file-context-relabeling_understanding-persistent-storage)
[Skip SELinux Relabeling using the spc_t SELinux context](https://file.rdu.redhat.com/antaylor/OSDOCS-6370/storage/understanding-persistent-storage.html#storage-skip-selinux-relabeling_understanding-persistent-storage)
[Automating SELinux Relabeling using the Cluster Resource Override Operator](https://file.rdu.redhat.com/antaylor/OSDOCS-6370/storage/understanding-persistent-storage.html#automating-selinux-cro_understanding-persistent-storage)
[Skip SELinux Relabeling with a custom RuntimeClass](https://file.rdu.redhat.com/antaylor/OSDOCS-6370/storage/understanding-persistent-storage.html#storage-skip-selinux-relabeling-runtimeclass_understanding-persistent-storage)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
https://access.redhat.com/solutions/6221251

This is part of a CAP closed loop improvement initiative:
https://issues.redhat.com/browse/CLIOT-262

