### PR TITLE
[enterprise-4.11]: OSSM-3488: Installation and upgrade tasks for OSSM 2.4 release

### DIFF
--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -15,7 +15,7 @@ The following configurations are supported for the current release of {SMProduct
 
 The {SMProductName} Operator supports multiple versions of the `ServiceMeshControlPlane` resource. Version {MaistraVersion} {SMProductShortName} control planes are supported on the following platform versions:
 
-* Red Hat {product-title} version 4.9 or later.
+* Red Hat {product-title} version 4.10 or later.
 * {product-dedicated} version 4.
 * Azure Red Hat OpenShift (ARO) version 4.
 * Red Hat OpenShift Service on AWS (ROSA).
@@ -34,15 +34,20 @@ Explicitly unsupported cases include:
 {SMProductName} supports the following network configurations.
 
 * OpenShift-SDN
-* OVN-Kubernetes is supported on {product-title} 4.7.32+, {product-title} 4.8.12+, and {product-title} 4.9+.
+* OVN-Kubernetes is available on all supported versions of {product-title}.
 * Third-Party Container Network Interface (CNI) plugins that have been certified on {product-title} and passed {SMProductShortName} conformance testing. See link:https://access.redhat.com/articles/5436171[Certified OpenShift CNI Plug-ins] for more information.
 
 [id="ossm-supported-configurations-sm_{context}"]
-== Supported configurations for Service Mesh
+== Supported configurations for {SMProductShortName}
 
-* This release of {SMProductName} is only available on {product-title} x86_64, IBM Z, and IBM Power Systems.
-** IBM Z is only supported on {product-title} 4.6 and later.
-** IBM Power Systems is only supported on {product-title} 4.6 and later.
+ifndef::openshift-rosa[]
+* This release of {SMProductName} is only available on {product-title} x86_64, {ibmzProductName}, and {ibmpowerProductName}.
+** {ibmzProductName} is only supported on {product-title} 4.10 and later.
+** {ibmpowerProductName} is only supported on {product-title} 4.10 and later.
+endif::openshift-rosa[]
+ifdef::openshift-rosa[]
+* This release of {SMProductName} is only available on {product-title} x86_64.
+endif::openshift-rosa[]
 * Configurations where all {SMProductShortName} components are contained within a single {product-title} cluster.
 * Configurations that do not integrate external services such as virtual machines.
 * {SMProductName} does not support `EnvoyFilter` configuration except where explicitly documented.

--- a/modules/ossm-upgrade-23-24-changes.adoc
+++ b/modules/ossm-upgrade-23-24-changes.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+// * service_mesh/v2x/upgrading-ossm.adoc
+
+:_content-type: CONCEPT
+[id="ossm-upgrade-23-24-changes_{context}"]
+= Upgrade changes from version 2.3 to version 2.4
+
+Upgrading the {SMProductShortName} control plane from version 2.3 to 2.4 introduces the following behavioral changes:
+
+* Support for Istio OpenShift Routing (IOR) has been deprecated. IOR functionality is still enabled, but it will be removed in a future release.
+
+* The following cipher suites are no longer supported, and were removed from the list of ciphers used in client and server side TLS negotiations. 
+
+** ECDHE-ECDSA-AES128-SHA
+** ECDHE-RSA-AES128-SHA
+** AES128-GCM-SHA256
+** AES128-SHA
+** ECDHE-ECDSA-AES256-SHA
+** ECDHE-RSA-AES256-SHA
+** AES256-GCM-SHA384
+** AES256-SHA
++
+Applications that require access to services that use one of these cipher suites will fail to connect when the proxy initiates a TLS connection.

--- a/service_mesh/v2x/upgrading-ossm.adoc
+++ b/service_mesh/v2x/upgrading-ossm.adoc
@@ -36,6 +36,8 @@ Although you can deploy multiple versions of the control plane in the same clust
 
 For more information about migrating your extensions, refer to xref:../../service_mesh/v2x/ossm-extensions.adoc#ossm-extensions-migration-overview_ossm-extensions[Migrating from ServiceMeshExtension to WasmPlugin resources].
 
+include::modules/ossm-upgrade-23-24-changes.adoc[leveloffset=+2]
+
 include::modules/ossm-upgrade-22-23-changes.adoc[leveloffset=+2]
 
 include::modules/ossm-upgrade-21-22-changes.adoc[leveloffset=+2]


### PR DESCRIPTION
This is a manual CP from #60137 to Enterprise 4.11

(Gabriel helped me walk through this process)
