### PR TITLE
OSDOCS-6522: Documented the 4.12.22 z-stream

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3763,3 +3763,29 @@ If these conditions are not met, the pod can fail at admission with `UnexpectedA
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-12-22"]
+=== RHSA-2023:3615 - {product-title} 4.12.22 bug fix update and security update
+
+Issued: 2023-06-26
+
+{product-title} release 4.12.22, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:3615[RHSA-2023:3615] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3613[RHSA-2023:3613] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.22 --pullspecs
+----
+
+[id="ocp-4-12-22-bug-fixes"]
+==== Bug fixes
+
+* Previously, client TLS (mTLS) was configured on an Ingress Controller, and the certificate authority (CA) in the client CA bundle required more than 1MB of certificate revocation list (CRLs) to be downloaded. The CRL `ConfigMap` object size limitations prevented updates from occurring. As a result of the missing CRLs, connections with valid client certificates may have been rejected with the error `unknown ca`. With this update, the CRL `ConfigMap` for each Ingress Controller no longer exists; instead, each router pod directly downloads CRLs, ensuring connections with valid client certificates are no longer rejected. (link:https://issues.redhat.com/browse/OCPBUGS-14454[*OCPBUGS-14454*])
+
+* Previously, because client TLS (mTLS) was configured on an Ingress Controller, mismatches between the distributing certificate authority (CA) and the issuing CA caused the incorrect certificate revocation list (CRL) to be downloaded. As a result, the incorrect CRL was downloaded instead of the correct CRL, causing connections with valid client certificates to be rejected with the error message `unknown ca`. With this update, downloaded CRLs are now tracked by the CA that distributes them. This ensures that valid client certificates are no longer rejected. (link:https://issues.redhat.com/browse/OCPBUGS-14455[*OCPBUGS-14455*])
+
+[id="ocp-4-12-22-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-6522](https://issues.redhat.com/browse/OSDOCS-6522)

Version(s):
4.12

Link to docs preview:
[4.12.22](https://61474--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-22)

QE review:
- [ ] Not required.

Additional information:
* https://issues.redhat.com/browse/OCPBUGS-14454

**Note:** Bug fixes need to match those on https://github.com/openshift/openshift-docs/pull/61383, which were verified by engineering. 
