### PR TITLE
Corrections to https://github.com/openshift/openshift-docs/pull/60936

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
@@ -38,7 +38,7 @@ include::modules/oadp-using-data-mover-for-csi-snapshots.adoc[leveloffset=+1]
 
 You can use OADP 1.2 Data Mover to backup and restore application data for clusters that use CephFS, CephRBD, or both.
 
-OADP 1.2 Data Mover leverages Ceph features that support large-scale environments. One of these is the shallow copy method, which is available for {product-title} 4.12 and later. This feature supports backing up and restoring `StorageClass` and `AccessMode` resources other than what is found on the source persistent valune claim (PVC).
+OADP 1.2 Data Mover leverages Ceph features that support large-scale environments. One of these is the shallow copy method, which is available for {product-title} 4.12 and later. This feature supports backing up and restoring `StorageClass` and `AccessMode` resources other than what is found on the source persistent volume claim (PVC).
 
 [IMPORTANT]
 ====

--- a/modules/oadp-ceph-cephfs.adoc
+++ b/modules/oadp-ceph-cephfs.adoc
@@ -10,7 +10,7 @@ You can use OpenShift API for Data Protection (OADP) 1.2 Data Mover to back up a
 
 .Prerequisites
 
-* A stateful application is running in a separate namespace with persistent valune claims (PVCs) using CephFS as the provisioner.
+* A stateful application is running in a separate namespace with persistent volume claims (PVCs) using CephFS as the provisioner.
 * The `StorageClass` and `VolumeSnapshotClass` CRs are defined for CephFS and OADP 1.2 Data Mover.
 * There is a secret `cloud-credentials` in the `openshift-adp` namespace.
 
@@ -133,11 +133,11 @@ $ oc get vsb <vsb-name> -n <app-ns> -ojsonpath="{.status.phase}`
 $ oc delete vsb -n <app_namespace> --all
 ----
 
-.. Delete any `VolumeSnapshotContent` CRs that were created during backup by by running the following command:
+.. Delete any `VolumeSnapshotContent` CRs that were created during backup by running the following command:
 +
 [source,terminal]
 ----
-$ oc oc delete volumesnapshotcontent --all
+$ oc delete volumesnapshotcontent --all
 ----
 
 .. Create a `Restore` CR similar to the following:

--- a/modules/oadp-ceph-preparing-crs.adoc
+++ b/modules/oadp-ceph-preparing-crs.adoc
@@ -122,7 +122,7 @@ allowVolumeExpansion: true
 volumeBindingMode: Immediate
 ----
 
-. To use the shallow copy feature, create a CephFS `StorageClass` CR and set the `backingSnapshot` parameter set to `true` tas in the following example:
+. To use the shallow copy feature, create a CephFS `StorageClass` CR and set the `backingSnapshot` parameter set to `true` as in the following example:
 +
 .Example CephFS `StorageClass` CR with `backingSnapshot` set to `true`
 +

--- a/modules/oadp-ceph-split.adoc
+++ b/modules/oadp-ceph-split.adoc
@@ -118,11 +118,11 @@ $ oc get vsb <vsb-name> -n <app-ns> -ojsonpath="{.status.phase}`
 $ oc delete vsb -n <app_namespace> --all
 ----
 
-.. Delete any `VolumeSnapshotContent` CRs that were created during backup by by running the following command:
+.. Delete any `VolumeSnapshotContent` CRs that were created during backup by running the following command:
 +
 [source,terminal]
 ----
-$ oc oc delete volumesnapshotcontent --all
+$ oc delete volumesnapshotcontent --all
 ----
 
 .. Create a `Restore` CR similar to the following:


### PR DESCRIPTION
OCP 4.12+

Corrects last typos in https://github.com/openshift/openshift-docs/pull/60936

Preview: https://61491--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-12-data-mover-ceph