### PR TITLE
[enterprise-4.10] OCPBUGS#15063: Removed sentences in Restoring to a previous cluster s…

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -283,8 +283,6 @@ etcd-ip-10-0-143-125.ec2.internal                1/1     Running     1          
 +
 If the status is `Pending`, or the output lists more than one running etcd pod, wait a few minutes and check again.
 +
-.. Optional: For each lost control plane host, repeat the steps for verifying that the single member control plane has started successfully.
-+
 [NOTE]
 ====
 Perform the following step only if you are using `OVNKubernetes` Container Network Interface (CNI) plugin.


### PR DESCRIPTION
Cherry Picked from dc403895869c5db3b880bf6c36eaba33722a621e [OCPBUGS-15063](https://issues.redhat.com/browse/OCPBUGS-15063)

Version(s):
4.10

Link to docs preview: [Restoring to a previous cluster state](https://dfitzmau.github.io/previews/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
