### PR TITLE
CNV-29747: Update runtimeClass configuration API

### DIFF
--- a/modules/virt-configuring-cluster-dpdk.adoc
+++ b/modules/virt-configuring-cluster-dpdk.adoc
@@ -89,18 +89,17 @@ The compute nodes automatically restart after you apply the `MachineConfigPool` 
 $ oc get performanceprofiles.performance.openshift.io profile-1 -o=jsonpath='{.status.runtimeClass}{"\n"}'
 ----
 
-. Set the previously obtained `RuntimeClass` name as the default container runtime class for the `virt-launcher` pods by adding the following annotation to the `HyperConverged` custom resource (CR):
+. Set the previously obtained `RuntimeClass` name as the default container runtime class for the `virt-launcher` pods by editing the `HyperConverged` custom resource (CR):
 +
 [source,terminal]
 ----
-$ oc annotate --overwrite -n openshift-cnv hco kubevirt-hyperconverged \
-    kubevirt.kubevirt.io/jsonpatch='[{"op": "add", "path": "/spec/configuration/defaultRuntimeClass", "value": <runtimeclass_name>}]'
+$ oc patch -n openshift-cnv hco kubevirt-hyperconverged \
+    --type='json' -p='[{"op": "add", "path": "/spec/defaultRuntimeClass", "value":"<runtimeclass-name>"}]'
 ----
 +
 [NOTE]
 ====
-Adding the annotation to the `HyperConverged` CR changes a global setting that affects all VMs that are created after the annotation is applied.
-Setting this annotation breaches support of the {VirtProductName} instance and must be used only on test clusters. For best performance, apply for a support exception.
+Editing the `HyperConverged` CR changes a global setting that affects all VMs that are created after the change is applied.
 ====
 
 . Create an `SriovNetworkNodePolicy` object with the `spec.deviceType` field set to `vfio-pci`:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Following a [change](https://github.com/kubevirt/hyperconverged-cluster-operator/pull/2370) in HCO that exposes the defaultRuntimeClass API to the user, it is now possible to configure the defaultRuntimeClass on the cluster by editing the HCO CR. 
This PR updates this API change, thus avoiding forcing the user to use the json-patch annotation workaround.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/CNV-29747

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://61497--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.html#virt-configuring-cluster-dpdk_virt-attaching-vm-to-sriov-network

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
