### PR TITLE
CMA add specific parameters for OCP Prometheus

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
+++ b/modules/nodes-cma-autoscaling-custom-prometheus-config.adoc
@@ -173,5 +173,11 @@ subjects:
 $ oc create -f <file-name>.yaml
 ----
 
-You can now deploy a scaled object or scaled job to enable autoscaling for your application, as described in the following sections. To use {product-title} monitoring as the source, in the trigger, or scaler, specify the `prometheus` type and use `\https://thanos-querier.openshift-monitoring.svc.cluster.local:9092` as the `serverAddress`.
+You can now deploy a scaled object or scaled job to enable autoscaling for your application, as described in "Understanding how to add custom metrics autoscalers". To use {product-title} monitoring as the source, in the trigger, or scaler, you must include the following parameters:
+
+* `triggers.type` must be `prometheus`
+* `triggers.metadata.serverAddress` must be `\https://thanos-querier.openshift-monitoring.svc.cluster.local:9092`
+* `triggers.metadata.authModes` must be `bearer`
+* `triggers.metadata.namespace` must be set to the namespace of the object to scale
+* `triggers.authenticationRef` must point to the trigger authentication resource specified in the previous step
 


### PR DESCRIPTION
Per [Slack](https://redhat-internal.slack.com/archives/C02F1J9UJJD/p1687329664428689?thread_ts=1687289719.175849&cid=C02F1J9UJJD), add the following:

```
You can now deploy a scaled object or scaled job to enable autoscaling for your application, as described in the following sections. 
To use OpenShift Container Platform monitoring as the source, in the trigger you need to specify:
 - `prometheus` trigger type
 -  `https://thanos-querier.openshift-monitoring.svc.cluster.local:9092` as the `serverAddress`
 - `authModes` needs to be set to `bearer`
 - `namespace` needs to be set to the namespace of the object you want to scale
 - `authenticationRef` needs to point to the trigger authentication resource specified in step 4
```