### PR TITLE
[OSDOCS-6554]: Adds CloudFront perms for AWS STS with private bucket

### DIFF
--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -80,8 +80,9 @@ ifdef::aws-sts[]
 .Required AWS permissions
 [cols="a,a"]
 |====
-|`iam` permissions |`s3` permissions
+|Permission type |Required permissions
 
+|`iam` permissions
 |* `iam:CreateOpenIDConnectProvider`
 * `iam:CreateRole`
 * `iam:DeleteOpenIDConnectProvider`
@@ -96,6 +97,8 @@ ifdef::aws-sts[]
 * `iam:PutRolePolicy`
 * `iam:TagOpenIDConnectProvider`
 * `iam:TagRole`
+
+|`s3` permissions
 |* `s3:CreateBucket`
 * `s3:DeleteBucket`
 * `s3:DeleteObject`
@@ -106,12 +109,38 @@ ifdef::aws-sts[]
 * `s3:GetObjectTagging`
 * `s3:ListBucket`
 * `s3:PutBucketAcl`
+* `s3:PutBucketPolicy`
+* `s3:PutBucketPublicAccessBlock`
 * `s3:PutBucketTagging`
 * `s3:PutObject`
 * `s3:PutObjectAcl`
 * `s3:PutObjectTagging`
 
+|`cloudfront` permissions
+|* `cloudfront:ListCloudFrontOriginAccessIdentities`
+* `cloudfront:ListDistributions`
+* `cloudfront:ListTagsForResource`
+
 |====
++
+If you plan to store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL, the AWS account that runs the `ccoctl` utility requires the following additional permissions:
++
+--
+* `cloudfront:CreateCloudFrontOriginAccessIdentity`
+* `cloudfront:CreateDistribution`
+* `cloudfront:DeleteCloudFrontOriginAccessIdentity`
+* `cloudfront:DeleteDistribution`
+* `cloudfront:GetCloudFrontOriginAccessIdentity`
+* `cloudfront:GetCloudFrontOriginAccessIdentityConfig`
+* `cloudfront:GetDistribution`
+* `cloudfront:TagResource`
+* `cloudfront:UpdateDistribution`
+--
++
+[NOTE]
+====
+These additional permissions support the use of the `--create-private-s3-bucket` option when processing credentials requests with the `ccoctl aws create-all` command.
+====
 endif::aws-sts[]
 
 .Procedure
@@ -158,8 +187,7 @@ $ chmod 775 ccoctl
 $ ccoctl --help
 ----
 +
-.Output of `ccoctl --help`:
-+
+.Output of `ccoctl --help`
 [source,terminal]
 ----
 OpenShift credentials provisioning tool


### PR DESCRIPTION
Version(s):
4.10+

Issue:
[OSDOCS-6554](https://issues.redhat.com//browse/OSDOCS-6554)

Link to docs preview:
[Configuring the Cloud Credential Operator utility](https://61520--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-sts.html#cco-ccoctl-configuring_cco-mode-sts) (Table 2 in Prerequisites)

QE review:
- [x] QE has approved this change.

Additional information: