### PR TITLE
Adds import mode to new app docs

### DIFF
--- a/modules/applications-create-using-cli-modify.adoc
+++ b/modules/applications-create-using-cli-modify.adoc
@@ -30,6 +30,7 @@ The second one represents the output image. If a container image was specified a
 
 |===
 
+[id="specifying-environment-variables"]
 == Specifying environment variables
 
 When generating applications from a template, source, or an image, you can use the `-e|--env` argument to pass environment variables to the application container at run time:
@@ -70,6 +71,7 @@ $ cat postgresql.env | oc new-app openshift/postgresql-92-centos7 --env-file=-
 Any `BuildConfig` objects created as part of `new-app` processing are not updated with environment variables passed with the `-e|--env` or `--env-file` argument.
 ====
 
+[id="specifying-build-environment-variables"]
 == Specifying build environment variables
 
 When generating applications from a template, source, or an image, you can use the `--build-env` argument to pass environment variables to the build container at run time:
@@ -103,6 +105,7 @@ Additionally, environment variables can be given on standard input by using `--b
 $ cat ruby.env | oc new-app openshift/ruby-23-centos7 --build-env-file=-
 ----
 
+[id="specifying-labels"]
 == Specifying labels
 
 When generating applications from source, images, or templates, you can use the `-l|--label` argument to add labels to the created objects. Labels make it easy to collectively select, configure, and delete objects associated with the application.
@@ -112,6 +115,7 @@ When generating applications from source, images, or templates, you can use the 
 $ oc new-app https://github.com/openshift/ruby-hello-world -l name=hello-world
 ----
 
+[id="viewing-output-without-creation"]
 == Viewing the output without creation
 
 To see a dry-run of running the `new-app` command, you can use the `-o|--output` argument with a `yaml` or `json` value. You can then use the output to preview the objects that are created or redirect it to a file that you can edit. After you are satisfied, you can use `oc create` to create the {product-title} objects.
@@ -138,6 +142,7 @@ Create a new application by referencing the file:
 $ oc create -f myapp.yaml
 ----
 
+[id="creating-objects-different-names"]
 == Creating objects with different names
 
 Objects created by `new-app` are normally named after the source repository, or the image used to generate them. You can set the name of the objects produced by adding a `--name` flag to the command:
@@ -147,6 +152,7 @@ Objects created by `new-app` are normally named after the source repository, or 
 $ oc new-app https://github.com/openshift/ruby-hello-world --name=myapp
 ----
 
+[id="creating-objects-different-project"]
 == Creating objects in a different project
 
 Normally, `new-app` creates objects in the current project. However, you can create objects in a different project by using the `-n|--namespace` argument:
@@ -156,6 +162,7 @@ Normally, `new-app` creates objects in the current project. However, you can cre
 $ oc new-app https://github.com/openshift/ruby-hello-world -n myproject
 ----
 
+[id="creating-multiple-objects"]
 == Creating multiple objects
 
 The `new-app` command allows creating multiple applications specifying multiple parameters to `new-app`. Labels specified in the command line apply to all objects created by the single command. Environment variables apply to all components created from source or images.
@@ -172,6 +179,7 @@ $ oc new-app https://github.com/openshift/ruby-hello-world mysql
 If a source code repository and a builder image are specified as separate arguments, `new-app` uses the builder image as the builder for the source code repository. If this is not the intent, specify the required builder image for the source using the `~` separator.
 ====
 
+[id="grouping-images-source-single-pod"]
 == Grouping images and source in a single pod
 
 The `new-app` command allows deploying multiple images together in a single pod. To specify which images to group together, use the `+` separator. The `--group` command line argument can also be used to specify the images that should be grouped together. To group the image built from a source repository with other images, specify its builder image in the group:
@@ -191,6 +199,7 @@ $ oc new-app \
     --group=ruby+mysql
 ----
 
+[id="searching-for-images-templates-other-inputs"]
 == Searching for images, templates, and other inputs
 
 To search for images, templates, and other inputs for the `oc new-app` command, add the `--search` and `--list` flags. For example, to find all of the images or templates that include PHP:
@@ -198,4 +207,19 @@ To search for images, templates, and other inputs for the `oc new-app` command, 
 [source,terminal]
 ----
 $ oc new-app --search php
+----
+
+[id="setting-the-import-mode"]
+== Setting the import mode 
+
+To set the import mode when using `oc new-app`, add the `--import-mode` flag. This flag can be appended with `Legacy` or `PreserveOriginal`, which provides users the option to create image streams using a single sub-manifest, or all manifests, respectively. 
+
+[souce,terminal]
+----
+$ oc new-app --image=registry.redhat.io/ubi8/httpd-24:latest  --import-mode=Legacy --name=test
+----
+
+[source,terminal]
+----
+$ oc new-app --image=registry.redhat.io/ubi8/httpd-24:latest  --import-mode=PreserveOriginal --name=test
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6535

Link to docs preview:
https://61522--docspreview.netlify.app/openshift-enterprise/latest/applications/creating_applications/creating-applications-using-cli.html#setting-the-import-mode

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
