### PR TITLE
Aligning page name for "Update channels" assembly

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -542,7 +542,7 @@ Topics:
   File: bare-metal-configuration
 - Name: Configuring multi-architecture compute machines on an OpenShift cluster
   Distros: openshift-enterprise
-  File: multi-architecture-configuration 
+  File: multi-architecture-configuration
 - Name: Enabling encryption on a vSphere cluster
   File: vsphere-post-installation-encryption
 - Name: Machine configuration tasks
@@ -584,7 +584,7 @@ Topics:
 - Name: Understanding OpenShift updates
   File: understanding-openshift-updates
   Distros: openshift-enterprise
-- Name: Understanding upgrade channels
+- Name: Understanding update channels and releases
   File: understanding-upgrade-channels-release
   Distros: openshift-enterprise
 - Name: Understanding OpenShift update duration
@@ -2290,7 +2290,7 @@ Topics:
     File: nodes-cma-autoscaling-custom-trigger
   - Name: Understanding the custom metrics autoscaler trigger authentications
     File: nodes-cma-autoscaling-custom-trigger-auth
-  - Name: Pausing the custom metrics autoscaler 
+  - Name: Pausing the custom metrics autoscaler
     File: nodes-cma-autoscaling-custom-pausing
   - Name: Gathering audit logs
     File: nodes-cma-autoscaling-custom-audit-log

--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -114,4 +114,4 @@ include::modules/ipi-preparing-reinstall-cluster-bare-metal.adoc[leveloffset=+1]
 [id="additional-resources_creating_manifest_ignition"]
 == Additional resources
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-generate-k8s-manifest-ignition_installing-bare-metal[{product-title} Creating the Kubernetes manifest and Ignition config files]
-* xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[{product-title} upgrade channels and releases]
+* xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding update channels and releases]

--- a/installing/validating-an-installation.adoc
+++ b/installing/validating-an-installation.adoc
@@ -26,7 +26,7 @@ include::modules/getting-cluster-version-status-and-update-details.adoc[leveloff
 
 * See xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster between minor versions] for more information on updating your cluster.
 
-* See xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[OpenShift Container Platform upgrade channels and releases] for an overview about upgrade release channels.
+* See xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding update channels and releases] for an overview about update release channels.
 
 //Querying the status of the cluster nodes by using the CLI
 include::modules/querying-the-status-of-cluster-nodes-using-the-cli.adoc[leveloffset=+1]

--- a/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
@@ -28,7 +28,7 @@ include::modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
 
 * For more information about how to prepare the disconnected environment and mirroring the desired image repository, see xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-hub-cluster[Preparing the disconnected environment].
 
-* For more information about update channels and releases, see xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding upgrade channels and releases].
+* For more information about update channels and releases, see xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding update channels and releases].
 
 include::modules/cnf-topology-aware-lifecycle-manager-platform-update.adoc[leveloffset=+2]
 

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -15,9 +15,9 @@ xref:../updating/understanding-openshift-updates.adoc#update-service-about_under
 endif::openshift-origin[]
 
 [id="updating-clusters-overview-upgrade-channels-and-releases"]
-== Understanding upgrade channels and releases
+== Understanding update channels and releases
 ifndef::openshift-origin[]
-xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Upgrade channels and releases]: With upgrade channels, you can choose an upgrade strategy. Upgrade channels are specific to a minor version of {product-title}. Upgrade channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version. For more information, see the following:
+xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Update channels and releases]: With upgrade channels, you can choose an upgrade strategy. Upgrade channels are specific to a minor version of {product-title}. Upgrade channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version. For more information, see the following:
 
 * xref:../updating/understanding-upgrade-channels-release.adoc#upgrade-version-paths_understanding-upgrade-channels-releases[Upgrading version paths]
 * xref:../updating/understanding-upgrade-channels-release.adoc#fast-stable-channel-strategies_understanding-upgrade-channels-releases[Understanding fast and stable channel use and strategies]

--- a/updating/migrating-to-multi-payload.adoc
+++ b/updating/migrating-to-multi-payload.adoc
@@ -6,13 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can migrate your current cluster with single-architecture compute machines to a cluster with multi-architecture compute machines by updating to a multi-architecture, manifest-listed payload. This allows you to add mixed architecture compute nodes to your cluster. 
+You can migrate your current cluster with single-architecture compute machines to a cluster with multi-architecture compute machines by updating to a multi-architecture, manifest-listed payload. This allows you to add mixed architecture compute nodes to your cluster.
 
 For information about configuring your multi-architecture compute machines, see _Configuring multi-architecture compute machines on an {product-title} cluster_.
 
 [IMPORTANT]
 ====
-Migration from a multi-architecture payload to a single-architecture payload is not supported. Once a cluster has transitioned to using a multi-architecture payload, it can no longer accept a single-architecture upgrade payload. 
+Migration from a multi-architecture payload to a single-architecture payload is not supported. Once a cluster has transitioned to using a multi-architecture payload, it can no longer accept a single-architecture upgrade payload.
 ====
 
 include::modules/migrating-to-multi-arch-cli.adoc[leveloffset=+1]
@@ -23,6 +23,6 @@ include::modules/migrating-to-multi-arch-cli.adoc[leveloffset=+1]
 * xref:../updating/updating-cluster-within-minor.adoc#updating-cluster-within-minor[Updating a cluster using the web console]
 * xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI]
 * xref:../updating/index.adoc#understanding-clusterversion-conditiontypes_updating-clusters-overview[Understanding cluster version condition types]
-* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding upgrade channels and releases]
+* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding update channels and releases]
 * xref:../installing/installing-preparing.adoc#installing-preparing-install-manage[Selecting a cluster installation type]
 * xref:../machine_management/deploying-machine-health-checks.adoc#machine-health-checks-about_deploying-machine-health-checks[About machine health checks]

--- a/updating/updating-cluster-cli.adoc
+++ b/updating/updating-cluster-cli.adoc
@@ -51,7 +51,7 @@ include::modules/update-upgrading-cli.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../updating/preparing-eus-eus-upgrade.adoc#preparing-eus-eus-upgrade[Preparing to perform an EUS-to-EUS update]
-* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding upgrade channels and releases]
+* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding update channels and releases]
 
 include::modules/update-conditional-updates.adoc[leveloffset=+1]
 
@@ -62,7 +62,7 @@ ifndef::openshift-origin[]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Upgrade channels and release paths]
+* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding update channels and releases]
 
 endif::openshift-origin[]
 

--- a/updating/updating-cluster-within-minor.adoc
+++ b/updating/updating-cluster-within-minor.adoc
@@ -58,4 +58,4 @@ include::modules/update-changing-update-server-web.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Understanding upgrade channels and releases]
+* xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding update channels and releases]

--- a/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+++ b/updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
@@ -27,7 +27,7 @@ include::modules/disconnected-osus-overview.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../../updating/understanding-openshift-updates.adoc#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]
-* xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels_understanding-upgrade-channels-releases[Understanding upgrade channels and releases]
+* xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding update channels and releases]
 
 [id="update-service-prereqs"]
 == Prerequisites


### PR DESCRIPTION
Versions: 4.10+

This PR aligns references to the page title of the current [Understanding update channels and releases](https://docs.openshift.com/container-platform/4.13/updating/understanding-upgrade-channels-release.html) page to use the [preferred term of "update"](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/term_glossary.adoc#update) over "upgrade". 

The alignment only affects the topic map and links that point to the top of this page. This is not a comprehensive sweep of the docs to catch every use of the word "upgrade", nor does this align any anchors or metadata to use "update".

QE not required since no information/meaning is being changed.

Preview: https://61524--docspreview.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html (specifically the updated title in the left TOC)