### PR TITLE
OCPBUGS#15206: Specify `ref` option as mandatory if branch is not "master"

### DIFF
--- a/modules/builds-source-code.adoc
+++ b/modules/builds-source-code.adoc
@@ -23,7 +23,7 @@ ifndef::openshift-online[]
   dockerfile: "FROM openshift/ruby-22-centos7\nUSER example" <3>
 endif::[]
 ----
-<1> The `git` field contains the URI to the remote Git repository of the source code. Optionally, specify the `ref` field to check out a specific Git reference. A valid `ref` can be a SHA1 tag or a branch name.
+<1> The `git` field contains the Uniform Resource Identifier (URI) to the remote Git repository of the source code. You must specify the value of the `ref` field to check out a specific Git reference. A valid `ref` can be a SHA1 tag or a branch name. The default value of the `ref` field is `master`.
 <2> The `contextDir` field allows you to override the default location inside the source code repository where the build looks for the application source code. If your application exists inside a sub-directory, you can override the default location (the root folder) using this field.
 ifndef::openshift-online[]
 <3> If the optional `dockerfile` field is provided, it should be a string containing a Dockerfile that overwrites any Dockerfile that may exist in the source repository.
@@ -31,7 +31,7 @@ endif::[]
 
 If the `ref` field denotes a pull request, the system uses a `git fetch` operation and then checkout `FETCH_HEAD`.
 
-When no `ref` value is provided, {product-title} performs a shallow clone (`--depth=1`). In this case, only the files associated with the most recent commit on the default branch (typically `master`) are downloaded. This results in repositories downloading faster, but without the full commit history. To perform a full `git clone` of the default branch of a specified repository, set `ref` to the name of the default branch (for example `master`).
+When no `ref` value is provided, {product-title} performs a shallow clone (`--depth=1`). In this case, only the files associated with the most recent commit on the default branch (typically `master`) are downloaded. This results in repositories downloading faster, but without the full commit history. To perform a full `git clone` of the default branch of a specified repository, set `ref` to the name of the default branch (for example `main`).
 
 
 [WARNING]

--- a/modules/builds-using-github-webhooks.adoc
+++ b/modules/builds-using-github-webhooks.adoc
@@ -84,6 +84,11 @@ $ curl -H "X-GitHub-Event: push" -H "Content-Type: application/json" -k -X POST 
 The `-k` argument is only necessary if your API server does not have a properly
 signed certificate.
 
+[NOTE]
+====
+The build will only be triggered if the `ref` value from GitHub webhook event matches the `ref` value specified in the `source.git` field of the `BuildConfig` resource.
+====
+
 [role="_additional-resources"]
 .Additional resources
 


### PR DESCRIPTION
Version(s): 4.10+

Issue: [OCPBUGS-15206](https://issues.redhat.com/browse/OCPBUGS-15206)

Link to docs preview:
https://61527--docspreview.netlify.app/openshift-enterprise/latest/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs
https://61527--docspreview.netlify.app/openshift-enterprise/latest/cicd/builds/triggering-builds-build-hooks.html#builds-using-github-webhooks_triggering-builds-build-hooks

QE review:

Additional information: 
[1] https://docs.openshift.com/container-platform/4.13/cicd/builds/creating-build-inputs.html#builds-source-code_creating-build-inputs
[2] https://docs.openshift.com/container-platform/4.13/cicd/builds/triggering-builds-build-hooks.html#builds-using-github-webhooks_triggering-builds-build-hooks