### PR TITLE
OSDOCS-6523: adds 4.10.62 to RNs

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -4054,3 +4054,22 @@ $ oc adm release info 4.10.61 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-10-62"]
+=== RHSA-2023:3626 - {product-title} 4.10.62 bug fix and security update
+
+Issued: 2023-06-23
+
+{product-title} release 4.10.62, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:3626[RHBA-2023:3626] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3625[RHSA-2023:3625] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.62 --pullspecs
+----
+
+[id="ocp-4-10-62-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
OSDOCS#6523 adds 4.10.62 to RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-6523
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://joealdinger.github.io/openshift-docs/OSDOCS-6523/release_notes/ocp-4-10-release-notes.html#ocp-4-10-62
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
