### PR TITLE
WMCO 6.0.1 release notes

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -8,9 +8,9 @@
 The following information details the supported platform versions, Windows Server versions, and networking configurations for the Windows Machine Config Operator. See the vSphere documentation for any information that is relevant to only that platform.
 
 [id="wmco-prerequisites-supported-6.0.0_{context}"]
-== WMCO 6.0.0 supported platforms and Windows Server versions
+== WMCO 6 supported platforms and Windows Server versions
 
-The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 6.0.0, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 6.0.0 and WMCO 6.0.1, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
 
 [cols="3,7",options="header"]
 |===

--- a/windows_containers/windows-containers-release-notes-6-x.adoc
+++ b/windows_containers/windows-containers-release-notes-6-x.adoc
@@ -11,7 +11,7 @@ toc::[]
 
 Windows Container Support for Red Hat OpenShift enables running Windows compute nodes in an {product-title} cluster. Running Windows workloads is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With Windows nodes available, you can run Windows container workloads in {product-title}.
 
-The release notes for Red Hat OpenShift for Windows Containers tracks the development of the WMCO, which provides all Windows container workload capabilities in {product-title}.
+These release notes track the development of the WMCO, which provides all Windows container workload capabilities in {product-title}.
 
 ifndef::openshift-origin[]
 [id="getting-support"]
@@ -27,6 +27,25 @@ For more information, see the Red Hat OpenShift Container Platform Life Cycle Po
 
 If you do not have this additional Red Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support.
 endif::openshift-origin[]
+
+[id="wmco-6-0-1"]
+== Release notes for Red Hat Windows Machine Config Operator 6.0.1
+
+This release of the WMCO provides bug fixes for running Windows compute nodes in an {product-title} cluster. The components of the WMCO 6.0.0 were released in link:https: //access.redhat.com/errata/RHBA-2022:NEED[RHBA-2022:NEED].
+
+[NOTE]
+====
+Windows Server 2019 is not supported in vSphere. 
+====
+
+[id="wmco-6-0-1-bug-fixes"]
+=== Bug fixes
+
+* Previously, the test to determine if the Windows Defender antivirus service is running was incorrectly checking for any process whose name started with Windows Defender, regardless of state. This resulted in an error when creating firewall exclusions for containerd on instances without Windows Defender installed. This fix now checks for the presence of the specific running process associated with the Windows Defender antivirus service. As a result, the WMCO can properly configure Windows instances as nodes regardless of whether Windows Defender is installed or not. (https://issues.redhat.com/browse/OCPBUGS-3572[**OCPBUGS-3572**])
+
+* Previously, an endpoint object missing required information caused the WMCO pod to crash during start up. With this fix, WMCO verifies the endpoint object is present with the required fields. As a result, WMCO is able to start and reconcile an invalid or misconfigured endpoint object. (https://issues.redhat.com/browse/OCPBUGS-4336[**OCPBUGS-4336**]) 
+
+* Previously, the `containerd` container runtime reported an incorrect version on each Windows node because repository tags were not propagated to the build system. This configuration caused `containerd` to report its Go build version as the version for each Windows node. With this update, the correct version is injected into the binary during build time, so that `containerd` reports the correct version for each Windows node. (link:https://issues.redhat.com/browse/OCPBUGS-8055[*OCPBUGS-8055*])
 
 [id="wmco-6-0-0"]
 == Release notes for Red Hat Windows Machine Config Operator 6.0.0


### PR DESCRIPTION
[OSDOCS-6621](https://issues.redhat.com/browse/OSDOCS-6621)

Add bug fixes, link to errata (link doesn't work until the errata is released)

Preview:
[Release notes for Red Hat Windows Machine Config Operator 6.0.1](https://file.rdu.redhat.com/mburke/winc-601-release-notes/windows_containers/windows-containers-release-notes-6-x.html#wmco-6-0-1)

[WMCO 6 supported platforms and Windows Server versions](https://file.rdu.redhat.com/mburke/winc-601-release-notes/windows_containers/windows-containers-release-notes-6-x.html#wmco-prerequisites-supported-6.0.0_windows-containers-release-notes)