### PR TITLE
TELCODOCS-1378: Fixing RHACM version

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -49,7 +49,7 @@ endif::openshift-origin[]
 :rh-storage: OpenShift Data Foundation
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
 :rh-rhacm: RHACM
-:rh-rhacm-version: 2.5
+:rh-rhacm-version: 2.8
 :sandboxed-containers-first: OpenShift sandboxed containers
 :sandboxed-containers-operator: OpenShift sandboxed containers Operator
 :sandboxed-containers-version: 1.3


### PR DESCRIPTION
TELCDOCS-1378: RHACM 2.8 released with OCP 4.13 but variable was not updated.

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1378

Link to docs preview:
N/A

**Question to reviewers:** If the attribute gets updated, will all the instances that use this variable get updated after the merge? For example https://docs.openshift.com/container-platform/4.13/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-preparing-the-hub-cluster 

Only hits for `rh-rhacm-version` in the repo (the link above is the only instance within content, the rest are within links):

````
./_attributes/common-attributes.adoc:50::rh-rhacm-version: 2.5
./modules/cnf-topology-aware-lifecycle-manager-policies-concept.adoc:21:For more information about {rh-rhacm} policies, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html-single/governance/index#policy-overview[Policy overview].
./modules/ztp-acm-installing-disconnected-rhacm.adoc:26:* Install {rh-rhacm} in the hub cluster. See link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html/install/installing#install-on-disconnected-networks[Installing {rh-rhacm} in a disconnected environment].
./modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc:13:* You have a disconnected hub cluster installation with {rh-rhacm-first} {rh-rhacm-version} installed.
./modules/cnf-about-topology-aware-lifecycle-manager-policies.adoc:19:For more information about managed policies, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html-single/governance/index#policy-overview[Policy Overview] in the {rh-rhacm} documentation.
./scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc:125:* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/{rh-rhacm-version}/html-single/governance/index#hub-templates[{rh-rhacm} support for hub cluster templates in configuration policies]

````
