### PR TITLE
OCPBUGS#14986: fixes TP table and moves CSI to storage

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -72,13 +72,6 @@ Installer-provisioned Infrastructure (IPI) provides a full-stack installation an
 
 For more information, see xref:../installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.adoc#preparing-to-install-on-ibm-power-vs[Preparing to install on {ibmpowerProductName} Virtual Server].
 
-[id="ocp-4-13-powervs-csi-driver-operator"]
-==== {ibmpowerProductName} Virtual Server Block CSI Driver Operator (Technology Preview)
-
-{product-title} is capable of provisioning persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for {ibmpowerProductName} Virtual Server Block Storage.
-
-For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block.adoc#persistent-storage-csi-ibm-powervs-block[{ibmpowerProductName} Virtual Server Block CSI Driver Operator].
-
 [id="ocp-4-13-secure-execution-z-linux-one"]
 ==== IBM Secure Execution on {ibmzProductName} and {linuxoneProductName}
 
@@ -970,6 +963,13 @@ Previously, if there was no default storage class, persistent volumes claims (PV
 This feature is supported with Technology Preview status.
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#absent-default-storage-class[Absent default storage class].
+
+[id="ocp-4-13-powervs-csi-driver-operator"]
+==== {ibmpowerProductName} Virtual Server Block CSI Driver Operator (Technology Preview)
+
+{product-title} is capable of provisioning persistent volumes (PVs) by using the Container Storage Interface (CSI) driver for {ibmpowerProductName} Virtual Server Block Storage.
+
+For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-ibm-powervs-block.adoc#persistent-storage-csi-ibm-powervs-block[{ibmpowerProductName} Virtual Server Block CSI Driver Operator].
 
 [id="ocp-4-13-storage-csi-inline-ephemeral-vols-GA"]
 ==== CSI inline ephemeral volumes is generally available
@@ -2232,6 +2232,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 
+|{ibmpowerProductName} Virtual Server Block CSI Driver Operator
+|Not Available
+|Not Available
+|Technology Preview
+
 |Automatic device discovery and provisioning with Local Storage Operator
 |Technology Preview
 |Technology Preview
@@ -2252,9 +2257,9 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|IBM Cloud VPC clusters
+|IBM Cloud VPC clusters (x86_64)
 |Technology Preview
-|Technology Preview
+|General Availability
 |General Availability
 
 |Selectable Cluster Inventory
@@ -2357,10 +2362,6 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 
-|{ibmpowerProductName} Virtual Server Block CSI Driver Operator
-|Not Available
-|Not Available
-|Technology Preview
 |====
 
 [discrete]


### PR DESCRIPTION
OCPBUGS#14986 moves CSI driver Operator to Storage component and aligns the TP for IBM Cloud VPC with 4.12's release notes
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
Table bug https://issues.redhat.com/browse/OCPBUGS-14986
Storage bug https://issues.redhat.com/browse/OCPBUGS-15357
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
CSI drive moved to [storage](https://61605--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-powervs-csi-driver-operator)
TP [tables](https://61605--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-technology-preview)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
