### PR TITLE
Corrected logTypes from FLOW to FLOWS

### DIFF
--- a/modules/network-observability-flowcollector-view.adoc
+++ b/modules/network-observability-flowcollector-view.adoc
@@ -45,7 +45,7 @@ spec:
       limits:
         memory: 800Mi
     conversationEndTimeout: 10s
-    logTypes: FLOW                            <3>
+    logTypes: FLOWS                            <3>
     conversationHeartbeatInterval: 30s
   loki:                                       <4>
     url: 'http://loki-gateway-http.netobserv.svc:8080/api/logs/v1/network'


### PR DESCRIPTION
The configurable options for logTypes are FLOWS CONVERSATIONS, ENDED_CONVERSATIONS, or ALL. In this config, logTypes is defined as FLOW instead of FLOWS and it needs to be corrected.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10, 4.11, 4.12 and 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6604
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.13/networking/network_observability/configuring-operator.html#network-observability-flowcollector-view_network_observability

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
