### PR TITLE
Update prerequisites for Network Observability operator to include OVN-Kubernetes

### DIFF
--- a/modules/network-observability-operator-install.adoc
+++ b/modules/network-observability-operator-install.adoc
@@ -10,6 +10,7 @@ You can install the Network Observability Operator using the {product-title} web
 .Prerequisites
 
 * Installed Loki. It is recommended to install Loki using the link:https://catalog.redhat.com/software/containers/openshift-logging/loki-rhel8-operator/622b46bcae289285d6fcda39[Loki Operator version 5.6].
+* Use OVN-Kubernetes as the CNI provider
 
 [NOTE]
 ====


### PR DESCRIPTION
A prerequisite is missing in the documentation of Network Observability to use OVN-Kubernetes as CNI provider in RHOCP cluster

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10, 4.11, 4.12, 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6606
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.10/networking/network_observability/installing-operators.html#network-observability-operator-installation_network_observability

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
