### PR TITLE
OSDOCS-6552: GA for matchLabelKeys for pod topology spread constraints

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -26,7 +26,6 @@ The following Technology Preview features are enabled by this feature set:
 ** Swap memory on nodes. Enables swap memory use for {product-title} workloads on a per-node basis. (`NodeSwap`)
 ** OpenStack Machine API Provider. This gate has no effect and is planned to be removed from this feature set in a future release. (`MachineAPIProviderOpenStack`)
 ** Insights Operator. Enables the Insights Operator, which gathers {product-title} configuration data and sends it to Red Hat. (`InsightsConfigAPI`)
-** Pod topology spread constraints. Enables the `matchLabelKeys` parameter for pod topology constraints. The parameter is list of pod label keys to select the pods over which spreading will be calculated. (`MatchLabelKeysInPodTopologySpread`)
 ** Retroactive Default Storage Class. Enables {product-title} to retroactively assign the default storage class to PVCs if there was no default storage class when the PVC was created.(`RetroactiveDefaultStorageClass`)
 ** Pod disruption budget (PDB) unhealthy pod eviction policy. Enables support for specifying how unhealthy pods are considered for eviction when using PDBs. (`PDBUnhealthyPodEvictionPolicy`)
 ** Dynamic Resource Allocation API. Enables a new API for requesting and sharing resources between pods and containers. This is an internal feature that most users do not need to interact with. (`DynamicResourceAllocation`)

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
@@ -35,6 +35,8 @@ spec:
     labelSelector: <4>
       matchLabels:
         foo: bar <5>
+    matchLabelKeys:
+      - my-pod-label <6>
   containers:
   - image: "docker.io/ocpqe/hello-pod"
     name: hello-pod
@@ -44,6 +46,7 @@ spec:
 <3> How to handle a pod if it does not satisfy the spread constraint. The default is `DoNotSchedule`, which tells the scheduler not to schedule the pod. Set to `ScheduleAnyway` to still schedule the pod, but the scheduler prioritizes honoring the skew to not make the cluster more imbalanced.
 <4> Pods that match this label selector are counted and recognized as a group when spreading to satisfy the constraint. Be sure to specify a label selector, otherwise no pods can be matched.
 <5> Be sure that this `Pod` spec also sets its labels to match this label selector if you want it to be counted properly in the future.
+<6> A list of pod label keys to select which pods to calculate spreading over. 
 
 . Create the pod:
 +

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -18,11 +18,9 @@ For more information about the features activated by the `TechPreviewNoUpgrade` 
 
 ** xref:../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-swap-memory_nodes-nodes-managing[Swap memory on nodes]
 
-** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
-
 ** xref:../../machine_management/capi-machine-management.adoc#capi-machine-management[Managing machines with the Cluster API]
 
-** xref:../../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Controlling pod placement by using pod topology spread constraints]
+** xref:../../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
 
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
 


### PR DESCRIPTION
…iewNoUpgrade list

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6552

Link to docs preview:
* https://61615--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling
* https://61615--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.html#nodes-scheduler-pod-topology-spread-constraints-configuring_nodes-scheduler-pod-topology-spread-constraints

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

- Removed from TPNoUpgrade feature set
- Reordered list of links after that list to be in order
- Added example of matchLabelKeys to pod spec
