### PR TITLE
OSDOCS-6552: Release note for GA of matchLabelKeys for pod topology s…

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -145,6 +145,13 @@ For more information about this more flexible SR-IOV network deployment during N
 
 With this release, the resource limits for the descheduler operand are removed. This enables the descheduler to be used for large clusters with many nodes and pods without failing due to out-of-memory errors.
 
+[id="ocp-4-14-nodes-pod-topology-constraints-matchlabelkeys"]
+==== Pod topology spread constraints matchLabelKeys parameter is now generally available
+
+The `matchLabelKeys` parameter for configuring pod topology spread constraints is now generally available in {product-title} 4.14. Previously, the parameter was available as a Technology Preview feature by enabling the `TechPreviewNoUpgrade` feature set. The `matchLabelKeys` parameter takes a list of pod label keys to select the pods to calculate spreading over.
+
+For more information, see xref:../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Controlling pod placement by using pod topology spread constraints].
+
 [id="ocp-4-14-monitoring"]
 === Monitoring
 


### PR DESCRIPTION
…pread constraints

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OSDOCS-6552

Link to docs preview:
https://61616--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-nodes-pod-topology-constraints-matchlabelkeys

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
