### PR TITLE
[OSDOCS-6601]: Updating DR docs to reflect specificity to non-STS clusters

### DIFF
--- a/modules/rosa-policy-shared-responsibility.adoc
+++ b/modules/rosa-policy-shared-responsibility.adoc
@@ -461,9 +461,9 @@ Disaster recovery includes data and configuration backup, replicating data and c
 |Virtual Storage management
 |**Red Hat**
 
-- Back up all Kubernetes objects on the cluster through hourly, daily, and weekly volume snapshots.
+- For ROSA clusters created with IAM user credentials, back up all Kubernetes objects on the cluster through hourly, daily, and weekly volume snapshots.
 
-- Back up persistent volumes on the cluster through daily and weekly volume snapshots.
+- For ROSA clusters created with IAM user credentials, back up persistent volumes on the cluster through daily and weekly volume snapshots.
 
 |- Back up customer applications and application data.
 

--- a/modules/rosa-sdpolicy-platform.adoc
+++ b/modules/rosa-sdpolicy-platform.adoc
@@ -15,7 +15,7 @@ This section provides information about the service definition for the {product-
 
 [IMPORTANT]
 ====
-It is critical that customers have a backup plan for their applications and application data.
+It is critical that customers have a backup plan for their applications and application data. The table below only applies to clusters created with IAM user credentials.
 ====
 
 Application and application data backups are not a part of the {product-title} service.
@@ -110,8 +110,8 @@ Red Hat workloads typically refer to Red Hat-provided Operators made available t
 * {rhq-short}
 * Red Hat Advanced Cluster Management
 * Red Hat Advanced Cluster Security
-* {SMProductName} 
-* {ServerlessProductName} 
+* {SMProductName}
+* {ServerlessProductName}
 * {logging-sd}
 * {pipelines-title}
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-6601
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://61620--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-backup-policy_rosa-service-definition
![image](https://github.com/openshift/openshift-docs/assets/122639474/8444b83a-9277-48c0-8037-3951fbfe3862)

https://61620--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.html#rosa-policy-disaster-recovery_rosa-policy-responsibility-matrix

![image](https://github.com/openshift/openshift-docs/assets/122639474/e4aa6a15-5725-46b9-b1c9-325b892511bb)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
