### PR TITLE
OCPBUGS-15034 manual port back to 411

### DIFF
--- a/modules/nw-multus-bridge-object.adoc
+++ b/modules/nw-multus-bridge-object.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-additional-network.adoc
-
+:_content-type: REFERENCE
 [id="nw-multus-bridge-object_{context}"]
 = Configuration for a bridge additional network
 
@@ -23,49 +23,81 @@ plugin:
 
 |`type`
 |`string`
-|
-
-|`bridge`
-|`string`
-|Specify the name of the virtual bridge to use. If the bridge interface does not exist on the host, it is created. The default value is `cni0`.
+|The name of the CNI plugin to configure: `bridge`.
 
 |`ipam`
 |`object`
 |The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition.
 
+|`bridge`
+|`string`
+|Optional: Specify the name of the virtual bridge to use. If the bridge interface does not exist on the host, it is created. The default value is `cni0`.
+
 |`ipMasq`
 |`boolean`
-|Set to `true` to enable IP masquerading for traffic that leaves the virtual network. The source IP address for all traffic is rewritten to the bridge's IP address. If the bridge does not have an IP address, this setting has no effect. The default value is `false`.
+|Optional: Set to `true` to enable IP masquerading for traffic that leaves the virtual network. The source IP address for all traffic is rewritten to the bridge's IP address. If the bridge does not have an IP address, this setting has no effect. The default value is `false`.
 
 |`isGateway`
 |`boolean`
-|Set to `true` to assign an IP address to the bridge. The default value is `false`.
+|Optional: Set to `true` to assign an IP address to the bridge. The default value is `false`.
 
 |`isDefaultGateway`
 |`boolean`
-|Set to `true` to configure the bridge as the default gateway for the virtual network. The default value is `false`. If `isDefaultGateway` is set to `true`, then `isGateway` is also set to `true` automatically.
+|Optional: Set to `true` to configure the bridge as the default gateway for the virtual network. The default value is `false`. If `isDefaultGateway` is set to `true`, then `isGateway` is also set to `true` automatically.
 
 |`forceAddress`
 |`boolean`
-|Set to `true` to allow assignment of a previously assigned IP address to the virtual bridge. When set to `false`, if an IPv4 address or an IPv6 address from overlapping subsets is assigned to the virtual bridge, an error occurs. The default value is `false`.
+|Optional: Set to `true` to allow assignment of a previously assigned IP address to the virtual bridge. When set to `false`, if an IPv4 address or an IPv6 address from overlapping subsets is assigned to the virtual bridge, an error occurs. The default value is `false`.
 
 |`hairpinMode`
 |`boolean`
-|Set to `true` to allow the virtual bridge to send an Ethernet frame back through the virtual port it was received on. This mode is also known as _reflective relay_. The default value is `false`.
+|Optional: Set to `true` to allow the virtual bridge to send an Ethernet frame back through the virtual port it was received on. This mode is also known as _reflective relay_. The default value is `false`.
 
 |`promiscMode`
 |`boolean`
-|Set to `true` to enable promiscuous mode on the bridge. The default value is `false`.
+|Optional: Set to `true` to enable promiscuous mode on the bridge. The default value is `false`.
 
 |`vlan`
 |`string`
-|Specify a virtual LAN (VLAN) tag as an integer value. By default, no VLAN tag is assigned.
+|Optional: Specify a virtual LAN (VLAN) tag as an integer value. By default, no VLAN tag is assigned.
+
+|`preserveDefaultVlan`
+|`string`
+|Optional: Indicates whether the default vlan must be preserved on the `veth` end connected to the bridge. Defaults to true.
+
+|`vlanTrunk`
+|`list`
+|Optional: Assign a VLAN trunk tag. The default value is `none`.
 
 |`mtu`
 |`string`
-|Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
+|Optional: Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
+|`enabledad`
+|`boolean`
+|Optional: Enables duplicate address detection for the container side `veth`. The default value is `false`.
+
+|`macspoofchk`
+|`boolean`
+|Optional: Enables mac spoof check, limiting the traffic originating from the container to the mac address of the interface. The default value is `false`.
 |====
+
+[NOTE]
+====
+The VLAN parameter configures the VLAN tag on the host end of the `veth` and also enables the `vlan_filtering` feature on the bridge interface.
+====
+
+[NOTE]
+====
+To configure uplink for a L2 network you need to allow the vlan on the uplink interface by using the following command:
+
+[source,terminal]
+----
+$  bridge vlan add vid VLAN_ID dev DEV
+----
+
+====
+
 
 [id="nw-multus-bridge-config-example_{context}"]
 == bridge configuration example
@@ -76,7 +108,7 @@ The following example configures an additional network named `bridge-net`:
 ----
 {
   "cniVersion": "0.3.1",
-  "name": "work-network",
+  "name": "bridge-net",
   "type": "bridge",
   "isGateway": true,
   "vlan": 2,

--- a/modules/nw-multus-host-device-object.adoc
+++ b/modules/nw-multus-host-device-object.adoc
@@ -1,14 +1,13 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-additional-network.adoc
-
+:_content-type: REFERENCE
 [id="nw-multus-host-device-object_{context}"]
 = Configuration for a host device additional network
 
 [NOTE]
 ====
-Specify your network device by setting only one of the
-following parameters: `device`, `hwaddr`, `kernelpath`, or `pciBusID`.
+Specify your network device by setting only one of the following parameters: `device`,`hwaddr`, `kernelpath`, or `pciBusID`.
 ====
 
 The following object describes the configuration parameters for the host-device CNI plugin:
@@ -57,7 +56,7 @@ The following example configures an additional network named `hostdev-net`:
 ----
 {
   "cniVersion": "0.3.1",
-  "name": "work-network",
+  "name": "hostdev-net",
   "type": "host-device",
   "device": "eth1"
 }

--- a/modules/nw-multus-ipvlan-object.adoc
+++ b/modules/nw-multus-ipvlan-object.adoc
@@ -4,12 +4,12 @@
 
 //37.1. IPVLAN overview
 // https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/getting-started-with-ipvlan_configuring-and-managing-networking#ipvlan-overview_getting-started-with-ipvlan
+:_content-type: REFERENCE
 
 [id="nw-multus-ipvlan-object_{context}"]
 = Configuration for an IPVLAN additional network
 
-The following object describes the configuration parameters for the IPVLAN CNI
-plugin:
+The following object describes the configuration parameters for the IPVLAN CNI plugin:
 
 .IPVLAN CNI plugin JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
@@ -28,25 +28,30 @@ plugin:
 |`string`
 |The name of the CNI plugin to configure: `ipvlan`.
 
+|`ipam`
+|`object`
+|The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition. This is required unless the plugin is chained.
+
 |`mode`
 |`string`
-|The operating mode for the virtual network. The value must be `l2`, `l3`, or `l3s`. The default value is `l2`.
+|Optional: The operating mode for the virtual network. The value must be `l2`, `l3`, or `l3s`. The default value is `l2`.
 
 |`master`
 |`string`
-|The Ethernet interface to associate with the network attachment. If a `master` is not specified, the interface for the default network route is used.
+|Optional: The Ethernet interface to associate with the network attachment. If a `master` is not specified, the interface for the default network route is used.
 
 |`mtu`
 |`integer`
-|Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
-
-|`ipam`
-|`object`
-|The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition.
-
-Do not specify `dhcp`. Configuring IPVLAN with DHCP is not supported because IPVLAN interfaces share the MAC address with the host interface.
+|Optional: Set the maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
 |====
+
+[NOTE]
+====
+* The `ipvlan` object does not allow virtual interfaces to communicate with the `master` interface. Therefore the container will not be able to reach the host by using the `ipvlan` interface. Be sure that the container joins a network that provides connectivity to the host, such as a network supporting the Precision Time Protocol (`PTP`).
+* A single `master` interface cannot simultaneously be configured to use both `macvlan` and `ipvlan`.
+* For IP allocation schemes that cannot be interface agnostic, the `ipvlan` plugin can be chained with an earlier plugin that handles this logic. If the `master` is omitted, then the previous result must contain a single interface name for the `ipvlan` plugin to enslave. If `ipam` is omitted, then the previous result is used to configure the `ipvlan` interface.
+====
 
 [id="nw-multus-ipvlan-config-example_{context}"]
 == ipvlan configuration example
@@ -57,7 +62,7 @@ The following example configures an additional network named `ipvlan-net`:
 ----
 {
   "cniVersion": "0.3.1",
-  "name": "work-network",
+  "name": "ipvlan-net",
   "type": "ipvlan",
   "master": "eth1",
   "mode": "l3",
@@ -71,4 +76,3 @@ The following example configures an additional network named `ipvlan-net`:
   }
 }
 ----
-

--- a/modules/nw-multus-macvlan-object.adoc
+++ b/modules/nw-multus-macvlan-object.adoc
@@ -1,12 +1,11 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-additional-network.adoc
-
+:_content-type: REFERENCE
 [id="nw-multus-macvlan-object_{context}"]
 = Configuration for a MACVLAN additional network
 
-The following object describes the configuration parameters for the macvlan CNI
-plugin:
+The following object describes the configuration parameters for the macvlan CNI plugin:
 
 .MACVLAN CNI plugin JSON configuration object
 [cols=".^2,.^2,.^6",options="header"]
@@ -25,21 +24,21 @@ plugin:
 |`string`
 |The name of the CNI plugin to configure: `macvlan`.
 
-|`mode`
-|`string`
-|Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
-
-|`master`
-|`string`
-|The host network interface to associate with the newly created macvlan interface. If a value is not specified, then the default route interface is used.
-
-|`mtu`
-|`string`
-|The maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
-
 |`ipam`
 |`object`
 |The configuration object for the IPAM CNI plugin. The plugin manages IP address assignment for the attachment definition.
+
+|`mode`
+|`string`
+|Optional: Configures traffic visibility on the virtual network. Must be either `bridge`, `passthru`, `private`, or `vepa`. If a value is not provided, the default value is `bridge`.
+
+|`master`
+|`string`
+|Optional: The host network interface to associate with the newly created macvlan interface. If a value is not specified, then the default route interface is used.
+
+|`mtu`
+|`string`
+|Optional: The maximum transmission unit (MTU) to the specified value. The default value is automatically set by the kernel.
 
 |====
 


### PR DESCRIPTION
[OCPBUGS-15034]: Issues in file networking/multiple_networks/configuring-additional-network.adoc

Version(s): 4.11
Issue: https://issues.redhat.com/browse/OCPBUGS-15034

Link to docs preview:https://file.emea.redhat.com/kquinn/OCPBUGS-15034-411/networking/multiple_networks/configuring-additional-network.html

NOTE: A manual backport of https://github.com/openshift/openshift-docs/pull/61277 failing on merge to 411
