### PR TITLE
OADP2132: Remove note line 64 for OADP 1.2.0

### DIFF
--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -60,8 +60,6 @@ In {product-title} version 4.12 or later, verify that this is the only default `
 [NOTE]
 ====
 In OADP 1.1 the above setting is mandatory.
-
-In OADP 1.2 the `privileged-movers` setting is not required in most scenarios. The restoring container permissions should be adequate for the Volsync copy. In some user scenarios, there may be permission errors that the `privileged-mover`= `true` setting should resolve.
 ====
 
 * You have installed the VolSync Operator by using the Operator Lifecycle Manager (OLM).


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->[OADP-2132](https://issues.redhat.com/browse/OADP-2132): Remove: Text from Note for OADP 1.2.0

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Enterprise 4.10 → branch/enterprise-4.10
Enterprise 4.11 → branch/enterprise-4.11
Enterprise 4.12 → branch/enterprise-4.12
Enterprise 4.13 → branch/enterprise-4.13
Enterprise 4.14 → branch/enterprise-4.14
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OADP-2132
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[oadp-using-data-mover-for-csi-snapshots_backing-up-applications](https://61627--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-using-data-mover-for-csi-snapshots_backing-up-applications)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Reviewed by Prasad from QE
Reviewed by Wes from Dev

Both gave LGTM approval

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
