### PR TITLE
OSDOCS-6614: add 4.14 release notes build file

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -35,8 +35,8 @@ Name: Release notes
 Dir: microshift_release_notes
 Distros: microshift
 Topics:
-- Name: MicroShift 4.13 release notes
-  File: microshift-4-13-release-notes
+- Name: MicroShift 4.14 release notes
+  File: microshift-4-14-release-notes
 ---
 Name: Getting started
 Dir: microshift_getting_started

--- a/microshift_networking/microshift-networking.adoc
+++ b/microshift_networking/microshift-networking.adoc
@@ -45,4 +45,4 @@ include::modules/microshift-mDNS.adoc[leveloffset=+1]
 [id="additional-resources_microshift-understanding-networking-settings"]
 .Additional resources
 
-* xref:../microshift_release_notes/microshift-4-13-release-notes.adoc#microshift-4-13-known-issues[{product-title} {product-version} release notes --> Known issues]
+* xref:../microshift_release_notes/microshift-4-14-release-notes.adoc#microshift-4-14-known-issues[{product-title} {product-version} release notes --> Known issues]

--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -1,0 +1,11 @@
+[id="microshift-4-14-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/attributes-microshift.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+Release note changes should be added/edited in their own PR.
+
+This file is here to allow builds to work.

--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -53,7 +53,7 @@ ifdef::microshift[]
 To navigate the {product-title} documentation, use the navigation bars and links.
 
 Start with xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}] and xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing].
-Next, view the xref:../microshift_release_notes/microshift-4-13-release-notes.adoc#microshift-4-13-release-notes[release notes].
+Next, view the xref:../microshift_release_notes/microshift-4-14-release-notes.adoc#microshift-4-14-release-notes[release notes].
 
 * For information about Red Hat Device Edge, read the link:https://access.redhat.com/documentation/en-us/red_hat_device_edge/4/html/overview/device-edge-overview[Red Hat Device Edge overview].
 * For information about Red Hat Enterprise Linux for Edge, read link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images/index[RHEL for Edge documentation].


### PR DESCRIPTION
Version(s):
main
(not 4.14, my bad--this is just the build file, not the release notes file)

Issue:
https://issues.redhat.com/browse/OSDOCS-6614

Link to docs preview:
N/A, docs plumbing

QE review:
N/A, docs plumbing; https://61628--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes.html

Reference also https://github.com/openshift/openshift-docs/pull/61623