### PR TITLE
Reverting the Registry Module to OpenShift-rosa Distro

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -314,7 +314,7 @@ Topics:
 ---
 Name: Registry
 Dir: registry
-Distros: openshift-rosa-portal
+Distros: openshift-rosa
 Topics:
 - Name: Registry overview
   File: index


### PR DESCRIPTION
[OSDOCS-4908:](https://issues.redhat.com/browse/OSDOCS-4908) Deprecation of ROSA docs from docs.openshift.com
Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OSDOCS-4908](https://issues.redhat.com/browse/OSDOCS-4908)
Preview pages: 
Peer review requested: @kalexand-rh