### PR TITLE
OSDOCS#4495: Updated VPA recommendations note

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-using-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-using-about.adoc
@@ -97,11 +97,11 @@ The VPA uses the `lowerBound` and `upperBound` values to determine if a pod need
 
 By default, workload objects must specify a minimum of two replicas in order for the VPA to automatically delete and update their pods. As a result, workload objects that specify fewer than two replicas are not automatically acted upon by the VPA. The VPA does update new pods from these workload objects if the pods are restarted by some process external to the VPA.  You can change this cluster-wide minimum value by modifying the `minReplicas` parameter in the `VerticalPodAutoscalerController` custom resource (CR).
 
-For example, if you set `minReplicas` to `3`, the VPA does not delete and update pods for workload objects that specify fewer than three replicas.  
+For example, if you set `minReplicas` to `3`, the VPA does not delete and update pods for workload objects that specify fewer than three replicas.
 
 [NOTE]
 ====
-If you set `minReplicas` to `1`, the VPA can delete the only pod for a workload object that specifies only one replica. You should use this setting with one-replica objects only if your workload can tolerate downtime whenever the VPA deletes a pod to adjust its resources. To avoid unwanted downtime with one-replica objects, configure the VPA CRs with the `podUpdatePolicy` set to `Initial`, which automatically updates the pod only when it is restarted by some process external to the VPA, or `Off`, which allows you to update the pod manually at an appropriate time for your application. 
+If you set `minReplicas` to `1`, the VPA can delete the only pod for a workload object that specifies only one replica. You should use this setting with one-replica objects only if your workload can tolerate downtime whenever the VPA deletes a pod to adjust its resources. To avoid unwanted downtime with one-replica objects, configure the VPA CRs with the `podUpdatePolicy` set to `Initial`, which automatically updates the pod only when it is restarted by some process external to the VPA, or `Off`, which allows you to update the pod manually at an appropriate time for your application.
 ====
 
 .Example `VerticalPodAutoscalerController` object
@@ -160,7 +160,9 @@ spec:
 
 [NOTE]
 ====
-There must be operating pods in the project before the VPA can determine recommended resources and apply the recommendations to new pods.
+Before a VPA can determine recommendations for resources and apply the recommended resources to new pods, operating pods must exist and be running in the project.
+
+To obtain the most accurate recommendations from the VPA, assess the workload volume deployed on your infrastructure and the activity level of the workload. For example, if a workload consumes a large amount of resources, remains close to its original storage size, and continues to actively manage pods, the VPA might stabilize after a few minutes. Consider that an idle workload could extend the time needed for the VPA to stabilize.
 ====
 
 [id="nodes-pods-vertical-autoscaler-using-pod_{context}"]
@@ -190,7 +192,11 @@ spec:
 
 [NOTE]
 ====
-There must be operating pods in the project before a VPA can determine recommended resources and apply the recommendations to new pods.
+For the VPA to provide you with a more accurate recommendation, the VPA must observe pod metrics on a running workload that uses typical resources.
+
+For workloads with cyclical resource usage patterns, the VPA provides a more accurate recommendation after it observes a workload's entire cycle.
+
+At a minimum, the VPA needs to observe a workload for a few minutes before the VPA can make a useful recommendation.
 ====
 
 [id="nodes-pods-vertical-autoscaler-using-manual_{context}"]
@@ -230,7 +236,9 @@ With the recommendations, you can edit the workload object to add CPU and memory
 
 [NOTE]
 ====
-There must be operating pods in the project before a VPA can determine recommended resources.
+Before a VPA can determine recommended resources and apply the recommendations to new pods, operating pods must exist and be running in the project.
+
+To obtain the most accurate recommendations from the VPA, wait at least 8 days for the pods to run and for the VPA to stabilize.
 ====
 
 [id="nodes-pods-vertical-autoscaler-using-exempt_{context}"]


### PR DESCRIPTION
[OSDOCS-4495](https://issues.redhat.com/browse/OSDOCS-4495)

Issue:
4.11 to 4.14

Link to docs preview:
* [Automatically applying VPA recommendations](https://61643--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-auto_nodes-pods-vertical-autoscaler)
* [Automatically applying VPA recommendations on pod creation](https://61643--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-pod_nodes-pods-vertical-autoscaler)
* [Manually applying VPA recommendations](https://61643--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-manual_nodes-pods-vertical-autoscaler)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Add info:

[Slack comment](https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1687532460227129) . Reach out to Joel Smith.
