### PR TITLE
Update installation-azure-preparing-diskencryptionsets.adoc

### DIFF
--- a/modules/installation-azure-preparing-diskencryptionsets.adoc
+++ b/modules/installation-azure-preparing-diskencryptionsets.adoc
@@ -68,7 +68,7 @@ $ az group create --name $RESOURCEGROUP --location $LOCATION
 [source,terminal]
 ----
 $ az keyvault create -n $KEYVAULT_NAME -g $RESOURCEGROUP -l $LOCATION \
-    --enable-purge-protection true --enable-soft-delete true
+    --enable-purge-protection true
 ----
 +
 . Create an encryption key in the key vault by running the following command:


### PR DESCRIPTION
Removed --enable-soft-delete true from az keyvault create command

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
All versions
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
Starting with the [az cli release 2.41.0 released on October 11, 2022](https://learn.microsoft.com/en-us/cli/azure/release-notes-azure-cli#key-vault-6), the --enable-soft-delete flag has been removed. Trying to run this will give you "unrecognized arguments". This is also [enabled by default according to Microsoft's documentation](https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview#soft-delete-behavior)

```
az keyvault create -n $KEYVAULT_NAME -g $RESOURCEGROUP -l $LOCATION --enable-purge-protection true --enable-soft-delete true
unrecognized arguments: --enable-soft-delete true
```

Link to docs preview:
https://61645--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/enabling-user-managed-encryption-azure.html#preparing-disk-encryption-sets
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
