### PR TITLE
OSDOCS-5631: Greenboot app health check script tutorial

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -146,6 +146,8 @@ Topics:
   File: microshift-applications
 - Name: Operators
   File: microshift-operators
+- Name: Greenboot workload health check scripts
+  File: microshift-greenboot-workload-scripts
 ---
 Name: Troubleshooting
 Dir: microshift_troubleshooting

--- a/microshift_running_apps/microshift-greenboot-workload-scripts.adoc
+++ b/microshift_running_apps/microshift-greenboot-workload-scripts.adoc
@@ -1,0 +1,25 @@
+:_content-type: ASSEMBLY
+[id="microshift-greenboot-workload-scripts"]
+= Greenboot workload health check scripts
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-greenboot-workload-scripts
+
+toc::[]
+
+Greenboot health check scripts are helpful on edge devices where direct serviceability is either limited or non-existent. If you installed the `microshift-greenboot` RPM package, you can also create health check scripts assess the health of your workloads and applications. These additional health check scripts are useful components of software problem checks and automatic system rollbacks.
+
+A {product-title} health check script is included in the `microshift-greenboot` RPM. You can also create your own health check scripts based on the workloads you are running. For example, you can write one that verifies that a service has started.
+
+include::modules/microshift-greenboot-how-workload-health-check-scripts-work.adoc[leveloffset=+1]
+
+include::modules/microshift-greenboot-included-health-checks.adoc[leveloffset=+1]
+
+include::modules/microshift-greenboot-create-health-check-script.adoc[leveloffset=+1]
+
+include::modules/microshift-greenboot-testing-workload-script.adoc[leveloffset=+1]
+
+[id="additional-resources_microshift-greenboot-workload-scripts"]
+[role="_additional-resources"]
+.Additional resources
+* xref:../microshift_install/microshift-greenboot.adoc#microshift-greenboot[The greenboot health check]
+* xref:../microshift_running_apps/microshift-applications.adoc#microshift-manifests-example_applications-microshift[Auto applying manifests]

--- a/modules/microshift-greenboot-create-health-check-script.adoc
+++ b/modules/microshift-greenboot-create-health-check-script.adoc
@@ -1,57 +1,114 @@
-// Module included in the following assemblies:
+//Updated title and ID:
+//Module included in the following assemblies:
 //
-// * microshift_running applications/microshift-greenboot.adoc
+//* microshift_running_apps/microshift-greenboot-workload-scripts.adoc
 
-:_content-type: PROCEDURE
-[id="microshift-greenboot-create-health-check-script_{context}"]
-= Creating a health check script
+:_content-type: CONCEPT
+[id="microshift-greenboot-app-health-check-script_{context}"]
+= How to create a health check script for your application
 
-You can create a health check script for installed workloads by placing them in the `/etc/greenboot/check/required.d` directory. The following procedure provides an example of installing the busybox application and creating a health check script for busybox. You can use this example as a general guide for creating health check scripts for your applications.
+You can create workload or application health check scripts in the text editor of your choice using the example in this documentation. Save the scripts in the `/etc/greenboot/check/required.d` directory. When a script in the `/etc/greenboot/check/required.d` directory exits with an error, greenboot triggers a reboot in an attempt to heal the system.
 
-.Prerequisite
-
-* You have installed a workload. For this example, the busybox application is used as a workload. The "Additional resources" section that follows this procedure has a link to instructions on deploying workloads using manifests.
-
-.Procedure
-
-. To create a health check script, run the following command:
-+
-[source, terminal]
-----
-$ SCRIPT_FILE=/etc/greenboot/check/required.d/50_busybox_running_check.sh
-sudo curl -s https://raw.githubusercontent.com/openshift/microshift/3b7f6025cd77bd1bf827416fd026783ead82b7c8/docs/config/busybox_running_check.sh \
-  -o ${SCRIPT_FILE} && echo SUCCESS || echo ERROR
-sudo chmod 755 ${SCRIPT_FILE}
-----
-+
-In this example, the script verifies that busybox is running as expected. You can replace `/etc/greenboot/check/required.d/50_busybox_running_check.sh` with your own workload details.
-+
 [NOTE]
 ====
-In this example, the {product-title} core service health checks run before the user workload health checks.
+Any script in the `/etc/greenboot/check/required.d` directory triggers a reboot if it exits with an error.
 ====
 
-. To test that your script is running as expected:
+If your health check logic requires any post-check steps, you can also create additional scripts and save them in the relevant greenboot directories. For example:
 
-.. Restart the system.
+* You can also place shell scripts you want to run after a boot has been declared successful in `/etc/greenboot/green.d`.
+* You can place shell scripts you want to run after a boot has been declared failed in `/etc/greenboot/red.d`. For example, if you have steps to heal the system before restarting, you can create scripts for your use case and place them in the `/etc/greenboot/red.d` directory.
 
-.. Once the system has restarted, run the following command:
-+
-[source, terminal]
+[id="microshift-greenboot-about-workload-health-check-script-example_{context}"]
+== About the workload health check script example
+
+The following example uses the {product-title} health check script as a template. You can use this example with the provided libraries as a guide for creating basic health check scripts for your applications.
+
+[id="microshift-greenboot-app-health-check-basic-prereqs_{context}"]
+=== Basic prerequisites for creating a health check script
+
+* The workload must be installed.
+* You must have root access.
+
+[id="microshift-greenboot-app-health-check-ex-reqs_{context}"]
+=== Example and functional requirements
+
+You can start with the following example health check script. Modify it for your use case. In your workload health check script, you must complete the following minimum steps:
+
+* Set the environment variables.
+* Define the user workload namespaces.
+* List the expected pod count.
+
+[IMPORTANT]
+====
+Choose a name prefix for your application that ensures it runs after the `40_microshift_running_check.sh` script, which implements the {product-title} health check procedure for its core services.
+====
+
+.Example workload health check script
+
+[source, bash]
 ----
-$ sudo journalctl -o cat -u greenboot-healthcheck.service
-----
-+
-.Example output for the busybox health check script
-+
-[source, terminal]
-----
-...
-...
-STARTED
-Waiting 300s for pod image(s) from the 'busybox' namespace to be downloaded
-Waiting 300s for 1 pod(s) from the 'busybox' namespace to be in 'Ready' state
-Checking pod restart count in the 'busybox' namespace
-FINISHED
-Script '50_busybox_running_check.sh' SUCCESS
+# #!/bin/bash
+set -e
+
+SCRIPT_NAME=$(basename $0)
+PODS_NS_LIST=(<user_workload_namespace1> <user_workload_namespace2>)
+PODS_CT_LIST=(<user_workload_namespace1_pod_count> <user_workload_namespace2_pod_count>)
+# Update these two lines with at least one namespace and the pod counts that are specific to your workloads. Use the kubernetes <namespace> where your workload is deployed.
+
+# Set greenboot to read and execute the workload health check functions library.
+source /usr/share/microshift/functions/greenboot.sh
+
+# Set the exit handler to log the exit status.
+trap 'script_exit' EXIT
+
+# Set the script exit handler to log a `FAILURE` or `FINISHED` message depending on the exit status of the last command.
+# args: None
+# return: None
+function script_exit() {
+    [ "$?" -ne 0 ] && status=FAILURE || status=FINISHED
+    echo $status
+}
+
+# Set the system to automatically stop the script if the user running it is not 'root'.
+if [ $(id -u) -ne 0 ] ; then
+    echo "The '${SCRIPT_NAME}' script must be run with the 'root' user privileges"
+    exit 1
+fi
+
+echo "STARTED"
+
+# Set the script to stop without reporting an error if the MicroShift service is not running.
+if [ $(systemctl is-enabled microshift.service 2>/dev/null) != "enabled" ] ; then
+    echo "MicroShift service is not enabled. Exiting..."
+    exit 0
+fi
+
+# Set the wait timeout for the current check based on the boot counter.
+WAIT_TIMEOUT_SECS=$(get_wait_timeout)
+
+# Set the script to wait for the pod images to be downloaded.
+for i in ${!PODS_NS_LIST[@]}; do
+    CHECK_PODS_NS=${PODS_NS_LIST[$i]}
+
+    echo "Waiting ${WAIT_TIMEOUT_SECS}s for pod image(s) from the ${CHECK_PODS_NS} namespace to be downloaded"
+    wait_for ${WAIT_TIMEOUT_SECS} namespace_images_downloaded
+done
+
+# Set the script to wait for pods to enter ready state.
+for i in ${!PODS_NS_LIST[@]}; do
+    CHECK_PODS_NS=${PODS_NS_LIST[$i]}
+    CHECK_PODS_CT=${PODS_CT_LIST[$i]}
+
+    echo "Waiting ${WAIT_TIMEOUT_SECS}s for ${CHECK_PODS_CT} pod(s) from the ${CHECK_PODS_NS} namespace to be in 'Ready' state"
+    wait_for ${WAIT_TIMEOUT_SECS} namespace_pods_ready
+done
+
+# Verify that pods are not restarting by running, which could indicate a crash loop.
+for i in ${!PODS_NS_LIST[@]}; do
+    CHECK_PODS_NS=${PODS_NS_LIST[$i]}
+
+    echo "Checking pod restart count in the ${CHECK_PODS_NS} namespace"
+    namespace_pods_not_restarting ${CHECK_PODS_NS}
+done
 ----

--- a/modules/microshift-greenboot-how-workload-health-check-scripts-work.adoc
+++ b/modules/microshift-greenboot-how-workload-health-check-scripts-work.adoc
@@ -1,0 +1,26 @@
+//Module included in the following assemblies:
+//
+//* microshift_running_apps/microshift-greenboot-workload-scripts.adoc
+
+:_content-type: CONCEPT
+[id="microshift-greenboot-how-workload-health-check-scripts-work_{context}"]
+= How workload health check scripts work
+
+The workload or application health check script described in this tutorial uses the {product-title} health check functions that are available in the `/usr/share/microshift/functions/greenboot.sh` file. This enables you to reuse procedures already implemented for the {product-title} core services.
+
+The script starts by running checks that the basic functions of the workload are operating as expected. To run the script successfully:
+
+* Execute the script from a root user account.
+* Enable the {product-title} service.
+
+The health check performs the following actions:
+
+* Gets a wait timeout of the current boot cycle for the `wait_for` function.
+* Calls the `namespace_images_downloaded` function to wait until pod images are available.
+* Calls the `namespace_pods_ready` function to wait until pods are ready.
+* Calls the `namespace_pods_not_restarting` function to verify pods are not restarting.
+
+[NOTE]
+====
+Restarting pods can indicate a crash loop.
+====

--- a/modules/microshift-greenboot-included-health-checks.adoc
+++ b/modules/microshift-greenboot-included-health-checks.adoc
@@ -1,0 +1,25 @@
+//Module included in the following assemblies:
+//
+//* microshift_running_apps/microshift-greenboot-workload-scripts.adoc
+
+:_content-type: CONCEPT
+[id="microshift-greenboot-included-health-checks_{context}"]
+= Included greenboot health checks
+
+Health check scripts are available in `/usr/lib/greenboot/check`, a read-only directory in RPM-OSTree systems. The following health checks are included with the `greenboot-default-health-checks` framework.
+
+* Check if repository URLs are still DNS solvable:
++
+This script is under `/usr/lib/greenboot/check/required.d/01_repository_dns_check.sh` and ensures that DNS queries to repository URLs are still available.
+
+* Check if update platforms are still reachable:
++
+This script is under `/usr/lib/greenboot/check/wanted.d/01_update_platform_check.sh` and tries to connect and get a 2XX or 3XX HTTP code from the update platforms defined in `/etc/ostree/remotes.d`.
+
+* Check if the current boot has been triggered by the hardware watchdog:
++
+This script is under `/usr/lib/greenboot/check/required.d/02_watchdog.sh` and checks whether the current boot has been watchdog-triggered or not.
+
+** If the watchdog-triggered reboot occurs within the grace period, the current boot is marked as red. Greenboot does not trigger a rollback to the previous deployment.
+** If the watchdog-triggered reboot occurs after the grace period, the current boot is not marked as red. Greenboot does not trigger a rollback to the previous deployment.
+** A 24-hour grace period is enabled by default. This grace period can be either disabled by modifying `GREENBOOT_WATCHDOG_CHECK_ENABLED` in `/etc/greenboot/greenboot.conf to false`, or configured by changing the `GREENBOOT_WATCHDOG_GRACE_PERIOD=number_of_hours` variable value in `/etc/greenboot/greenboot.conf`.

--- a/modules/microshift-greenboot-testing-workload-script.adoc
+++ b/modules/microshift-greenboot-testing-workload-script.adoc
@@ -1,0 +1,52 @@
+//Module included in the following assemblies:
+//
+//* microshift_running_apps/microshift-greenboot-workload-scripts.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-greenboot-test-workload-health-check-script_{context}"]
+= Testing a workload health check script
+
+.Prerequisites
+
+* You have root access.
+* You have installed a workload.
+* You have created a health check script for the workload.
+* The {product-title} service is enabled.
+
+.Procedure
+
+. To test that greenboot is running a health check script file, reboot the host by running the following command:
++
+[source, terminal]
+----
+$ sudo reboot
+----
+
+. Examine the output of greenboot health checks by running the following command:
++
+[source, terminal]
+----
+$ sudo journalctl -o cat -u greenboot-healthcheck.service
+----
++
+[NOTE]
+====
+{product-title} core service health checks run before the workload health checks.
+====
++
+.Example output
+
+[source, terminal]
+----
+GRUB boot variables:
+boot_success=0
+boot_indeterminate=0
+Greenboot variables:
+GREENBOOT_WATCHDOG_CHECK_ENABLED=true
+...
+...
+FINISHED
+Script '40_microshift_running_check.sh' SUCCESS
+Running Wanted Health Check Scripts...
+Finished greenboot Health Checks Runner.
+----


### PR DESCRIPTION
Version(s):
4.13, 4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-5631

Link to docs preview:
https://61653--docspreview.netlify.app/microshift/latest/microshift_running_apps/microshift-greenboot-workload-scripts.html

QE review:
- [x] QE has approved this change.


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
