### PR TITLE
OCPBUGS#14292: reformat operators section to avoid confusion

### DIFF
--- a/microshift_running_apps/microshift-operators.adoc
+++ b/microshift_running_apps/microshift-operators.adoc
@@ -12,7 +12,11 @@ Operators offer a more localized configuration experience and integrate with Kub
 
 {product-title} applications are generally expected to be deployed in static environments. However, Operators are available if helpful in your use case. To determine an Operator's compatibility with {product-title}, check the Operator's documentation.
 
+[id="how-to-install-operators_{context}"]
+== How to install Operators in {product-title}
+
 To minimize the footprint of {product-title}, Operators are installed directly with manifests instead of using the Operator Lifecycle Manager (OLM). The following examples provide instructions on how you can use the `kustomize` configuration management tool with {product-title} to deploy an application. Use the same steps to install Operators with manifests.
 
-include::modules/microshift-manifests-overview.adoc[leveloffset=+1]
-include::modules/microshift-applying-manifests-example.adoc[leveloffset=+1]
+include::modules/microshift-manifests-overview.adoc[leveloffset=+2]
+
+include::modules/microshift-applying-manifests-example.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.13, 4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-14292

Link to docs preview:
https://61656--docspreview.netlify.app/microshift/latest/microshift_running_apps/microshift-operators.html

In the Customer Portal, this creates a header and drops the modules down one so they aren't completely the same as the Application deployment section; they will bump down to 2.1.1 and 2.2.1. (https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.13/html/running_applications/operators-with-microshift)

QE review:
N/A, docs plumbing


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
