### PR TITLE
RHDEVDOCS-2831: Improvements for deployment docs

### DIFF
--- a/applications/deployments/deployment-strategies.adoc
+++ b/applications/deployments/deployment-strategies.adoc
@@ -6,24 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-A _deployment strategy_ is a way to change or upgrade an application. The aim is to make the change without downtime in a way that the user barely notices the improvements.
+_Deployment strategies_ are used to change or upgrade applications without downtime so that users barely notice a change.
 
-Because the end user usually accesses the application through a route handled by a router, the deployment strategy can focus on `DeploymentConfig` object features or routing features. Strategies that focus on the deployment impact all routes that use the application. Strategies that use router features target individual routes.
+Because users generally access applications through a route handled by a router, deployment strategies can focus on `DeploymentConfig` object features or routing features. Strategies that focus on `DeploymentConfig` object features impact all routes that use the application. Strategies that use router features target individual routes.
 
-Many deployment strategies are supported through the `DeploymentConfig` object, and some additional strategies are supported through router features. Deployment strategies are discussed in this section.
+Most deployment strategies are supported through the `DeploymentConfig` object, and some additional strategies are supported through router features.
 
-
-////
-This link keeps breaking Travis for some reason.
-
-[NOTE]
-====
-See
-xref:../../applications/deployments/route-based-deployment-strategies.adoc#route-based-deployment-strategies[Using route-based deployment strategies] for more on these additional strategies.
-====
-////
-
-*Choosing a deployment strategy*
+[id="choosing-deployment-strategies"]
+== Choosing a deployment strategy
 
 Consider the following when choosing a deployment strategy:
 
@@ -35,6 +25,7 @@ Consider the following when choosing a deployment strategy:
 
 A deployment strategy uses readiness checks to determine if a new pod is ready for use. If a readiness check fails, the `DeploymentConfig` object retries to run the pod until it times out. The default timeout is `10m`, a value set in `TimeoutSeconds` in `dc.spec.strategy.*params`.
 
+// Rolling strategies
 include::modules/deployments-rolling-strategy.adoc[leveloffset=+1]
 include::modules/deployments-canary-deployments.adoc[leveloffset=+2]
 include::modules/deployments-creating-rolling-deployment.adoc[leveloffset=+2]
@@ -45,13 +36,15 @@ include::modules/odc-starting-rolling-deployment.adoc[leveloffset=+2]
 * xref:../../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating and deploying applications on {product-title} using the *Developer* perspective]
 * xref:../../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]
 
+// Recreate strategies
 include::modules/deployments-recreate-strategy.adoc[leveloffset=+1]
-include::modules/odc-starting-recreate-deployment.adoc[leveloffset=+1]
+include::modules/odc-starting-recreate-deployment.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../../applications/creating_applications/odc-creating-applications-using-developer-perspective.adoc#odc-creating-applications-using-developer-perspective[Creating and deploying applications on {product-title} using the *Developer* perspective]
 * xref:../../applications/odc-viewing-application-composition-using-topology-view.adoc#odc-viewing-application-composition-using-topology-view[Viewing the applications in your project, verifying their deployment status, and interacting with them in the *Topology* view]
 
+// Custom strategies
 include::modules/deployments-custom-strategy.adoc[leveloffset=+1]
 include::modules/deployments-lifecycle-hooks.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.10+

Issue:
Prep work for https://issues.redhat.com/browse/RHDEVDOCS-2831

Link to docs preview:
https://61662--docspreview.netlify.app/openshift-enterprise/latest/applications/deployments/deployment-strategies.html

QE review:
Not required - just editing / docs changes, doesn't change the meaning of the content