### PR TITLE
[OSDOCS-6557]:Docs refers wrongly to on-premise storage

### DIFF
--- a/storage/index.adoc
+++ b/storage/index.adoc
@@ -6,7 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+ifndef::openshift-rosa[]
 {product-title} supports multiple types of storage, both for on-premise and cloud providers. You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
+endif::openshift-rosa[]
+
+ifdef::openshift-rosa[]
+{product-title} supports Amazon Elastic Block Store (Amazon EBS) and Amazon Elastic File System (Amazon EFS) storage. You can manage container storage for persistent and non-persistent data in an {product-title} cluster.
+endif::openshift-rosa[]
 
 include::modules/openshift-storage-common-terms.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-6557
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://61674--docspreview.netlify.app/openshift-rosa/latest/storage/index.html
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/7c44698b-5fbd-4502-b331-9b3252a2ba19)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
