### PR TITLE
WINC Adding a link to addition refs that didn't have one

### DIFF
--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
@@ -28,4 +28,4 @@ include::modules/machineset-creating.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on managing machine sets, see the _Machine management_ section.
+* xref:../../machine_management/index.adoc#overview-of-machine-management[Overview of machine management]

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
@@ -21,5 +21,5 @@ include::modules/machineset-creating.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on managing machine sets, see the _Machine management_ section.
-//Should be an xref some day
+* xref:../../machine_management/index.adoc#overview-of-machine-management[Overview of machine management]
+//Should be an xref some day --- and today is the day!

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
@@ -22,4 +22,4 @@ include::modules/machineset-creating.adoc[leveloffset=+1]
 [id="creating-windows-machineset-gcp-additional"]
 == Additional resources
 
-* For more information on managing machine sets, see xref:../../machine_management/index.adoc#overview-of-machine-management[Overview of machine management].
+* xref:../../machine_management/index.adoc#overview-of-machine-management[Overview of machine management]

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
@@ -38,4 +38,4 @@ include::modules/machineset-creating.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For more information on managing machine sets, see the _Machine management_ section.
+* xref:../../machine_management/index.adoc#overview-of-machine-management[Overview of machine management]


### PR DESCRIPTION
The links in the _Additional references_ section of two assemblies under **Windows containers -> Creating Windows MachineSet objects** didn't have a link, only a "see the _Machine management_ section" wording. Added a link to _Overview of machine management _. 
Also, make the Additional reference consistent in the four assemblies in that directory.

No Dev or QE review needed.

Previews
[Creating a Windows MachineSet object on AWS](https://61680--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html#additional-resources)
[Creating a Windows MachineSet object on Azure](https://61680--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html#additional-resources)
[Creating a Windows MachineSet object on vSphere](https://61680--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html#additional-resources)
[Creating a Windows MachineSet object on GCP](https://61680--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html#creating-windows-machineset-gcp-additional)