### PR TITLE
CNV-26876: Document golden images

### DIFF
--- a/modules/virt-golden-images.adoc
+++ b/modules/virt-golden-images.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
+
+:_content-type: CONCEPT
+[id="virt-about-golden-images_{context}"]
+= About golden images
+
+A golden image is a pre-configured snapshot of a virtual machine (VM) that you can use as a resource to deploy new VMs. For example, you can use golden images to provision the same system environment consistently and deploy systems more quickly and efficiently.
+
+[id="virt-how-golden-images-work_{context}"]
+== How do golden images work?
+
+Golden images are created by installing and configuring an operating system and software applications on a reference machine or virtual machine. This includes setting up the system, installing required drivers, applying patches and updates, and configuring specific options and preferences.
+
+After the golden image is created, it is saved as a template or image file that can be replicated and deployed across multiple clusters. The golden image can be updated by its maintainer periodically to incorporate necessary software updates and patches, ensuring that the image remains up to date and secure, and newly created VMs are based on this updated image.
+
+[id="virt-golden-images-implementation_{context}"]
+== Red Hat implementation of golden images
+
+Red Hat publishes golden images as container disks in the registry for versions of :op-system-base:. Container disks are virtual machine images that are stored as a container image in a container image registry. Any published image will automatically be made available in connected clusters after the installation of OpenShift Virtualization. After the images are available in a cluster, they are ready to use to create VMs.

--- a/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can build a virtual machine image into a container disk and store it in your container registry. You can then import the container disk into persistent storage for a virtual machine or attach it directly to the virtual machine for ephemeral storage.
+You can build a virtual machine image into a container disk, commonly known as a golden image, and store it in your container registry. You can then import the container disk into persistent storage for a virtual machine or attach it directly to the virtual machine for ephemeral storage.
 
 [IMPORTANT]
 ====
@@ -16,6 +16,7 @@ If you use large container disks, I/O traffic might increase, impacting worker n
 * xref:../../../nodes/nodes/nodes-nodes-garbage-collection.adoc#nodes-nodes-garbage-collection-configuring_nodes-nodes-configuring[Configuring garbage collection]
 ====
 
+include::modules/virt-golden-images.adoc[leveloffset=+1]
 include::modules/virt-about-container-disks.adoc[leveloffset=+1]
 include::modules/virt-preparing-container-disk-for-vms.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**Version(s):**
4.14

**Issue:**
https://issues.redhat.com/browse/CNV-26876

**Link to docs preview:**
https://61715--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.html#virt-about-golden-images_virt-using-container-disks-with-vms

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->