### PR TITLE
[enterprise-4.13] CP-OCPBUGS#14422-413: move greenboot

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -55,6 +55,8 @@ Topics:
   File: microshift-install-rpm
 - Name: Embedding in a RHEL for Edge image
   File: microshift-embed-in-rpm-ostree
+- Name: Greenboot health check
+  File: microshift-greenboot
 ---
 Name: Support
 Dir: microshift_support
@@ -144,8 +146,6 @@ Topics:
   File: microshift-applications
 - Name: Operators
   File: microshift-operators
-- Name: Greenboot health check
-  File: microshift-greenboot
 ---
 Name: Troubleshooting
 Dir: microshift_troubleshooting

--- a/microshift_install/microshift-greenboot.adoc
+++ b/microshift_install/microshift-greenboot.adoc
@@ -16,20 +16,29 @@ A {product-title} health check script is included in the `microshift-greenboot` 
 
 [NOTE]
 ====
-Health check scripts might run on a system not using an OSTree file system, but no rollback is possible in the case of an update failure.
+Rollback is not possible in the case of an update failure on a system not using OSTree. This is true even though health checks might run.
 ====
 
 include::modules/microshift-greenboot-dir-structure.adoc[leveloffset=+1]
+
 include::modules/microshift-greenboot-microshift-health-script.adoc[leveloffset=+1]
+
 include::modules/microshift-greenboot-systemd-journal-data.adoc[leveloffset=+1]
-//include::modules/microshift-greenboot-create-health-check-script.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * xref:../microshift_running_apps/microshift-applications.adoc#microshift-manifests-example_applications-microshift[Auto applying manifests]
 
 include::modules/microshift-greenboot-updates-workloads.adoc[leveloffset=+1]
+
 include::modules/microshift-greenboot-workloads-validation.adoc[leveloffset=+1]
+
 include::modules/microshift-greenboot-health-check-log.adoc[leveloffset=+1]
+
 include::modules/microshift-greenboot-prerollback-log.adoc[leveloffset=+1]
+
 include::modules/microshift-greenboot-check-update.adoc[leveloffset=+1]
+
+//[role="_additional-resources_microshift-greenboot"]
+//.Additional resources
+//once the greenboot application health check is merged, an assembly-level xref can go here

--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -46,7 +46,7 @@ This release adds improvements related to the following components and concepts.
 
 [id="microshift-4-13-installation"]
 === Installation
-This release includes integration with the greenboot health check framework. Greenboot assesses system health and automates a rollback to the last healthy state in the event of software trouble. You can add the optional greenboot RPM to your installation. For more information, read the xref:../microshift_running_apps/microshift-greenboot.adoc#microshift-greenboot[Greenboot documentation].
+This release includes integration with the greenboot health check framework. Greenboot assesses system health and automates a rollback to the last healthy state in the event of software trouble. You can add the optional greenboot RPM to your installation. For more information, read the xref:../microshift_install/microshift-greenboot.adoc#microshift-greenboot[Greenboot documentation].
 
 //[id="microshift-4-13-new-feature-for-use-at-installation"]
 //==== New feature for use during installation here


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-14422

Replaces: https://github.com/openshift/openshift-docs/pull/61706

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
Manual CP of #61665
