### PR TITLE
[enterprise-4.12] CNV-22631: HCO Bump 4.12.5

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -108,7 +108,7 @@ endif::[]
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.12
 :KubeVirtVersion: v0.58.0
-:HCOVersion: 4.12.4
+:HCOVersion: 4.12.5
 :delete: image:delete.png[title="Delete"]
 ifdef::openshift-origin[]
 :VirtProductName: OKD Virtualization


### PR DESCRIPTION
**Version(s):**
4.12

**Issue:**
https://issues.redhat.com/browse/CNV-22631

**Preview:**
* See "Installed Version"
  * https://61725--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-web-console-overview.html#ui-virtualization-settings-general_virt-web-console-overview

**Additional information:**
Do not merge the PR until after the errata is shipped live