### PR TITLE
WINC removing backticks from headings

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2475,13 +2475,13 @@ Topics:
 - Name: Creating Windows MachineSet objects
   Dir: creating_windows_machinesets
   Topics:
-  - Name: Creating a Windows MachineSet object on AWS
+  - Name: Creating a Windows machine set on AWS
     File: creating-windows-machineset-aws
-  - Name: Creating a Windows MachineSet object on Azure
+  - Name: Creating a Windows machine set on Azure
     File: creating-windows-machineset-azure
-  - Name: Creating a Windows MachineSet object on vSphere
+  - Name: Creating a Windows machine set on vSphere
     File: creating-windows-machineset-vsphere
-  - Name: Creating a Windows MachineSet object on GCP
+  - Name: Creating a Windows machine set on GCP
     File: creating-windows-machineset-gcp
 - Name: Scheduling Windows container workloads
   File: scheduling-windows-workloads

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="creating-windows-machineset-aws"]
-= Creating a Windows `MachineSet` object on AWS
+= Creating a Windows machine set on AWS
 include::_attributes/common-attributes.adoc[]
 :context: creating-windows-machineset-aws
 

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="creating-windows-machineset-azure"]
-= Creating a Windows `MachineSet` object on Azure
+= Creating a Windows machine set on Azure
 include::_attributes/common-attributes.adoc[]
 :context: creating-windows-machineset-azure
 

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="creating-windows-machineset-gcp"]
-= Creating a Windows `MachineSet` object on GCP
+= Creating a Windows machine set on GCP
 include::_attributes/common-attributes.adoc[]
 :context: creating-windows-machineset-gcp
 

--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="creating-windows-machineset-vsphere"]
-= Creating a Windows MachineSet object on vSphere
+= Creating a Windows machine set on vSphere
 include::_attributes/common-attributes.adoc[]
 :context: creating-windows-machineset-vsphere
 


### PR DESCRIPTION
Removing backticks from the WINC creating module headings.

No QE.

Previews
 [Creating a Windows machine set on AWS ](https://61726--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.html)
[ Creating a Windows machine set on Azure](https://61726--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.html)
[Creating a Windows machine set on vSphere](https://61726--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.html)
[Creating a Windows machine set on GCP](https://61726--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.html)
