### PR TITLE
RHDEVDOCS-5435: Clean up Web Terminal Operator uninstall documentation

### DIFF
--- a/modules/removing-devworkspace-operator.adoc
+++ b/modules/removing-devworkspace-operator.adoc
@@ -107,11 +107,6 @@ $ oc delete serviceaccounts devworkspace-webhook-server -n openshift-operators
 +
 [source,terminal]
 ----
-$ oc delete configmap devworkspace-controller -n openshift-operators
-----
-+
-[source,terminal]
-----
 $ oc delete clusterrole devworkspace-webhook-server
 ----
 +


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-5435

Link to docs preview:
https://61733--docspreview.netlify.app/openshift-enterprise/latest/web_console/web_terminal/uninstalling-web-terminal.html#removing-devworkspace-operator_uninstalling-web-terminal

QE review:
- Not required, ACK'd by dev console team
