### PR TITLE
[main] WINC removing backticks from headings

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2472,7 +2472,7 @@ Topics:
   File: understanding-windows-container-workloads
 - Name: Enabling Windows container workloads
   File: enabling-windows-container-workloads
-- Name: Creating Windows MachineSet objects
+- Name: Creating Windows machine sets
   Dir: creating_windows_machinesets
   Topics:
   - Name: Creating a Windows machine set on AWS


### PR DESCRIPTION
When cherrypicking https://github.com/openshift/openshift-docs/pull/61726 to remove backticks from the WINC creating a MachineSet topic, I noticed that I missed the title of the subsection in the title map. Since I needed to manually CP for 4.10 and 4.11, I manually CP'd all the branches and made the change there. This PR updates `main` only.