### PR TITLE
OSDOCS#6386: Remove mention of ccoctl in the cloudwatch log forwarding and efs csi driver rosa procedures

### DIFF
--- a/logging/cluster-logging-external.adoc
+++ b/logging/cluster-logging-external.adoc
@@ -52,6 +52,11 @@ include::modules/cluster-logging-collector-log-forward-syslog.adoc[leveloffset=+
 
 include::modules/cluster-logging-collector-log-forward-cloudwatch.adoc[leveloffset=+1]
 
+ifdef::openshift-rosa[]
+include::modules/rosa-cluster-logging-collector-log-forward-sts-cloudwatch.adoc[leveloffset=+2]
+endif::[]
+
+ifdef::openshift-enterprise,openshift-origin,openshift-dedicated[]
 [id="cluster-logging-collector-log-forward-sts-cloudwatch_{context}"]
 === Forwarding logs to Amazon CloudWatch from STS enabled clusters
 
@@ -59,7 +64,7 @@ For clusters with AWS Security Token Service (STS) enabled, you can create an AW
 ifdef::openshift-enterprise,openshift-origin[]
 xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc[Cloud Credential Operator(CCO)]
 endif::[]
-ifdef::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-dedicated[]
 link:https://docs.openshift.com/container-platform/latest/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.html[Cloud Credential Operator(CCO)]
 endif::[]
  utility `ccoctl`.
@@ -173,7 +178,9 @@ spec:
 .Additional resources
 * link:https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html[AWS STS API Reference]
 
+
 include::modules/cluster-logging-collector-log-forward-secret-cloudwatch.adoc[leveloffset=+2]
+endif::[]
 
 include::modules/cluster-logging-collector-log-forward-loki.adoc[leveloffset=+1]
 

--- a/modules/osd-persistent-storage-csi-efs-sts.adoc
+++ b/modules/osd-persistent-storage-csi-efs-sts.adoc
@@ -10,7 +10,7 @@
 
 This procedure explains how to configure the AWS EFS CSI Driver Operator with {product-title} on AWS Secure Token Service (STS).
 
-Perform this procedure before you have installed the AWS EFS CSI Operator, but not yet installed the AWS EFS CSI driver as part of the _Installing the AWS EFS CSI Driver Operator_ procedure. 
+Perform this procedure before you have installed the AWS EFS CSI Operator, but not yet installed the AWS EFS CSI driver as part of the _Installing the AWS EFS CSI Driver Operator_ procedure.
 
 [IMPORTANT]
 ====
@@ -23,125 +23,152 @@ If you perform this procedure after installing the driver and creating volumes, 
 * AWS account credentials
 * You have installed the AWS EFS CSI Operator.
 
+
 .Procedure
 
-To configure the AWS EFS CSI Driver Operator with STS:
+. Prepare the AWS account:
+.. Create an IAM policy JSON file with the following content:
++
+[source,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticfilesystem:DescribeAccessPoints",
+        "elasticfilesystem:DescribeFileSystems",
+        "elasticfilesystem:DescribeMountTargets",
+        "ec2:DescribeAvailabilityZones"
+      ],
+      "Resource": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Action": [
+        "elasticfilesystem:CreateAccessPoint"
+      ],
+      "Resource": "*",
+      "Condition": {
+        "StringLike": {
+          "aws:RequestTag/efs.csi.aws.com/cluster": "true"
+        }
+      }
+    },
+    {
+      "Effect": "Allow",
+      "Action": "elasticfilesystem:DeleteAccessPoint",
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "aws:ResourceTag/efs.csi.aws.com/cluster": "true"
+        }
+      }
+    }
+  ]
+}
+----
 
-// The on-prem version of this step is documented in the cco-ccoctl-configuring procedure.
-. Extract the CCO utility (`ccoctl`) binary from the Cloud Credential Operator.
-
-.. Find the pod on which the Cloud Credential Operator is running.
+.. Create an IAM trust JSON file with the following content:
 +
 --
+[source,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<your_aws_account_ID>:oidc-provider/<openshift_oidc_provider>"  <1>
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "<openshift_oidc_provider>:sub": [  <2>
+            "system:serviceaccount:openshift-cluster-csi-drivers:aws-efs-csi-driver-operator",
+            "system:serviceaccount:openshift-cluster-csi-drivers:aws-efs-csi-driver-controller-sa"
+          ]
+        }
+      }
+    }
+  ]
+}
+----
+<1> Specify your AWS account ID and the OpenShift OIDC provider endpoint. Obtain the endpoint by running the the following command:
++
 [source,terminal]
 ----
-$ oc get pod -n openshift-cloud-credential-operator -l app=cloud-credential-operator
+$ rosa describe cluster \
+  -c $(oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}') \
+  -o yaml | awk '/oidc_endpoint_url/ {print $2}' | cut -d '/' -f 3,4
 ----
-
-.Example output
-[source,terminal]
-----
-NAME                                        READY   STATUS    RESTARTS   AGE
-cloud-credential-operator-78c9c575b-r6mmr   2/2     Running   0          6h33m
-----
++
+<2> Specify the OpenShift OIDC endpoint again.
 --
 
-.. Copy the `ccoctl` binary from the pod to a local directory.
+.. Create the IAM role:
 +
 [source,terminal]
 ----
-$ oc cp -c cloud-credential-operator openshift-cloud-credential-operator/<CCO-pod-name>:/usr/bin/ccoctl ./ccoctl 
+$ aws iam create-role \
+  --role-name "<your_cluster_name>-aws-efs-csi-operator" \
+  --assume-role-policy-document file://<your_trust_file_name>.json \
+  --query "Role.Arn" --output text
 ----
++
+Save the output. You will use it in the next steps.
 
-.. Change the permissions to make `ccoctl` executable.
+.. Create the IAM policy:
 +
 [source,terminal]
 ----
-$ chmod 775 ./ccoctl
+$ aws iam create-policy \
+  --policy-name "<your_rosa_cluster_name>-rosa-efs-csi" \
+  --policy-document file://<your_policy_file_name>.json \
+  --query 'Policy.Arn' --output text) || \
+  POLICY=$(aws iam list-policies \
+  --query 'Policies[?PolicyName==`rosa-efs-csi`].Arn' \
+  --output text
 ----
++
+Save the output. You will use it in the next steps.
 
-.. To verify that `ccoctl` is ready to use, display the help file:
+.. Attach the IAM policy to the IAM role:
 +
 [source,terminal]
 ----
-$ ./ccoctl --help
+$ aws iam attach-role-policy \
+     --role-name "<your_rosa_cluster_name>-aws-efs-csi-operator" \
+     --policy-arn <policy_ARN> <1>
 ----
-
-. Create and save an EFS `CredentialsRequest` YAML file, such as shown in the following example:
 +
-.Example
+<1> Replace `policy_ARN` with the output you saved while creating the policy.
+
+. Create a `Secret` YAML file for the driver operator:
++
 [source,yaml]
 ----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
+apiVersion: v1
+kind: Secret
 metadata:
-  name: openshift-aws-efs-csi-driver
-  namespace: openshift-cloud-credential-operator
-spec:
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
-    kind: AWSProviderSpec
-    statementEntries:
-    - action:
-      - elasticfilesystem:*
-      effect: Allow
-      resource: '*'
-  secretRef:
-    name: aws-efs-cloud-credentials
-    namespace: openshift-cluster-csi-drivers
-  serviceAccountNames:
-  - aws-efs-csi-driver-operator
-  - aws-efs-csi-driver-controller-sa
+ name: aws-efs-cloud-credentials
+ namespace: openshift-cluster-csi-drivers
+stringData:
+  credentials: |-
+    [default]
+    sts_regional_endpoints = regional
+    role_arn = <role_ARN> <1>
+    web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 ----
+<1> Replace `role_ARN` with the output you saved while creating the role.
 
-. Run the `ccoctl` tool to generate a new IAM role in AWS, and create a YAML file for it in the local file system (`<path_to_ccoctl_output_dir>/manifests/openshift-cluster-csi-drivers-aws-efs-cloud-credentials-credentials.yaml`).
+. Create the secret:
 +
---
 [source,terminal]
 ----
-$ ccoctl aws create-iam-roles --name=<name> --region=<aws_region> --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests --identity-provider-arn=<oidc_provider_arn>
+$ oc apply -f aws-efs-cloud-credentials.yaml
 ----
-
-* `name=<name>` is the name used to tag any cloud resources that are created for tracking.
-
-* `region=<aws_region>` is the AWS region where cloud resources are created.
-
-* `dir=<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the EFS CredentialsRequest file in previous step.
-
-* `<oidc_provider_arn>` is the ARN for the OIDC provider that associates with your cluster.
-
-.Example
-[source,terminal]
-----
-$ ccoctl aws create-iam-roles --name=my-aws-efs --credentials-requests-dir= credrequests --identity-provider-arn=arn:aws:iam::123456789012:oidc-provider/example.cloudfront.net/<cluster-ID>
-----
-
-.Example output
-[source,terminal]
-----
-2022/03/21 06:24:44 Role arn:aws:iam::123456789012:role/my-aws-efs -openshift-cluster-csi-drivers-aws-efs-cloud- created
-2022/03/21 06:24:44 Saved credentials configuration to: /manifests/openshift-cluster-csi-drivers-aws-efs-cloud-credentials-credentials.yaml
-2022/03/21 06:24:45 Updated Role policy for Role my-aws-efs-openshift-cluster-csi-drivers-aws-efs-cloud-credentials
-----
---
-
-. Create the AWS EFS cloud credentials and secret:
 +
---
-[source,terminal]
-----
-$ oc create -f <path_to_ccoctl_output_dir>/manifests/openshift-cluster-csi-drivers-aws-efs-cloud-credentials-credentials.yaml
-----
-
-.Example
-[source,terminal]
-----
-$ oc create -f /manifests/openshift-cluster-csi-drivers-aws-efs-cloud-credentials-credentials.yaml
-----
-
-.Example output
-[source,terminal]
-----
-secret/aws-efs-cloud-credentials created
-----
---
+You are now ready to install the AWS EFS CSI driver.

--- a/modules/rosa-cluster-logging-collector-log-forward-sts-cloudwatch.adoc
+++ b/modules/rosa-cluster-logging-collector-log-forward-sts-cloudwatch.adoc
@@ -1,0 +1,195 @@
+// Module included in the following assemblies:
+//
+// * logging/cluster-logging-external.adoc
+
+:_content-type: PROCEDURE
+
+[id="cluster-logging-collector-log-forward-sts-cloudwatch_{context}"]
+= Forwarding logs to Amazon CloudWatch from STS enabled clusters
+
+For clusters with AWS Security Token Service (STS) enabled, create the AWS IAM roles and policies that will allow the log forwarding, and a `ClusterLogForwarder` custom resource (CR) with an output for CloudWatch.
+
+[NOTE]
+====
+This feature is not supported by the vector collector.
+====
+
+.Prerequisites
+
+* {logging-title-uc}: 5.5 and later
+
+.Procedure
+. Prepare the AWS account:
+.. Create an IAM policy JSON file with the following content:
++
+[source,json]
+----
+{
+"Version": "2012-10-17",
+"Statement": [
+    {
+    "Effect": "Allow",
+    "Action": [
+      "logs:CreateLogGroup",
+      "logs:CreateLogStream",
+      "logs:DescribeLogGroups",
+      "logs:DescribeLogStreams",
+      "logs:PutLogEvents",
+      "logs:PutRetentionPolicy"
+    ],
+    "Resource": "arn:aws:logs:*:*:*"
+    }
+  ]
+}
+----
++
+.. Create an IAM trust JSON file with the following content:
++
+[source,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::<you_aws_account_id>:oidc-provider/<openshift_oidc_provider>" <1>
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "<openshift_oidc_provider>:sub": "system:serviceaccount:openshift-logging:logcollector" <2>
+        }
+      }
+    }
+  ]
+}
+----
++
+--
+<1> Specify your AWS account ID and the OpenShift OIDC provider endpoint. Obtain the endpoint by running the the following command:
++
+[source,terminal]
+----
+$ rosa describe cluster \
+  -c $(oc get clusterversion -o jsonpath='{.items[].spec.clusterID}{"\n"}') \
+  -o yaml | awk '/oidc_endpoint_url/ {print $2}' | cut -d '/' -f 3,4
+----
++
+<2> Specify the OpenShift OIDC endpoint again.
+--
+
+.. Create the IAM role:
++
+[source,terminal]
+----
+$ aws iam create-role
+  --role-name “<your_rosa_cluster_name>-RosaCloudWatch” \
+  --assume-role-policy-document file://<your_trust_file_name>.json \
+  --query Role.Arn \
+  --output text
+----
++
+Save the output. You will use it in the next steps.
++
+.. Create the IAM policy:
++
+[source,terminal]
+----
+$ aws iam create-policy \
+--policy-name "RosaCloudWatch" \
+--policy-document file:///<your_policy_file_name>.json \
+--query Policy.Arn \
+--output text
+----
++
+Save the output. You will use it in the next steps.
+
+.. Attach the IAM policy to the IAM role:
++
+[source,terminal]
+----
+$ aws iam attach-role-policy \
+ --role-name “<your_rosa_cluster_name>-RosaCloudWatch” \
+ --policy-arn <policy_ARN> <1>
+----
++
+<1> Replace `policy_ARN` with the output you saved while creating the policy.
+
+. Create a `Secret` YAML file for the logging operator:
++
+--
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: cloudwatch-credentials
+  namespace: openshift-logging
+stringData:
+  credentials: |-
+    [default]
+    sts_regional_endpoints = regional
+    role_arn: <role_ARN>  <1>
+    web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+----
+<1> Replace `role_ARN` with the output you saved while creating the role.
+--
+
+. Create the secret:
++
+[source,terminal]
+----
+$ oc apply -f cloudwatch-credentials.yaml
+----
+
+. Create or edit a `ClusterLogForwarder` custom resource:
++
+[source,yaml]
+----
+apiVersion: "logging.openshift.io/v1"
+kind: ClusterLogForwarder
+metadata:
+  name: instance <1>
+  namespace: openshift-logging <2>
+spec:
+  outputs:
+   - name: cw <3>
+     type: cloudwatch <4>
+     cloudwatch:
+       groupBy: logType <5>
+       groupPrefix: <group prefix> <6>
+       region: us-east-2 <7>
+     secret:
+        name: <your_secret_name> <8>
+  pipelines:
+    - name: to-cloudwatch <9>
+      inputRefs: <10>
+        - infrastructure
+        - audit
+        - application
+      outputRefs:
+        - cw <11>
+----
+<1> The name of the `ClusterLogForwarder` CR must be `instance`.
+<2> The namespace for the `ClusterLogForwarder` CR must be `openshift-logging`.
+<3> Specify a name for the output.
+<4> Specify the `cloudwatch` type.
+<5> Optional: Specify how to group the logs:
++
+* `logType` creates log groups for each log type
+* `namespaceName` creates a log group for each application name space. Infrastructure and audit logs are unaffected, remaining grouped by `logType`.
+* `namespaceUUID` creates a new log groups for each application namespace UUID. It also creates separate log groups for infrastructure and audit logs.
+<6> Optional: Specify a string to replace the default `infrastructureName` prefix in the names of the log groups.
+<7> Specify the AWS region.
+<8> Specify the name of the secret you created previously.
+<9> Optional: Specify a name for the pipeline.
+<10> Specify which log types to forward by using the pipeline: `application,` `infrastructure`, or `audit`.
+<11> Specify the name of the output to use when forwarding logs with this pipeline.
+
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.aws.amazon.com/STS/latest/APIReference/welcome.html[AWS STS API Reference]
+
+include::modules/cluster-logging-collector-log-forward-secret-cloudwatch.adoc[leveloffset=+2]


### PR DESCRIPTION
IMPORTANT This PR is being replaced by https://github.com/openshift/openshift-docs/pull/63277 to add a few small edits from peer review.

Versions: main, 4.13, 4.14

Issue: https://issues.redhat.com/browse/OSDOCS-6386

Link to docs preview:
**Forwarding logs to Amazon CloudWatch from STS enabled clusters:** https://61744--docspreview.netlify.app/openshift-rosa/latest/logging/cluster-logging-external.html#cluster-logging-collector-log-forward-sts-cloudwatch_cluster-logging-external
**Configuring AWS EFS CSI Driver Operator with Secure Token Service:** https://61744--docspreview.netlify.app/openshift-rosa/latest/storage/container_storage_interface/osd-persistent-storage-aws-efs-csi.html#efs-sts_osd-persistent-storage-aws-efs-csi


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Change is for ROSA only.  No SMEs, QE work only on the procedures.  Still waiting for some comments from QE, some reviews still pending.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
