### PR TITLE
OBSDOCS-185: changes-to-sample-code-for-repeat-interval-settings

### DIFF
--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -37,7 +37,7 @@ route:
   routes:
   - matchers:
     - "alertname=Watchdog"
-    repeat_interval: 5m
+    repeat_interval: 2m
     receiver: watchdog
   - matchers:
     - "service=<your_service>" <4>
@@ -53,11 +53,8 @@ receivers:
 ----
 <1> The `group_wait` value specifies how long Alertmanager waits before sending an initial notification for a group of alerts.
 This value controls how long Alertmanager waits while collecting initial alerts for the same group before sending a notification.
-The default value is 30 seconds (`30s`).
 <2> The `group_interval` value specifies how much time must elapse before Alertmanager sends a notification about new alerts added to a group of alerts for which an initial notification was already sent.
-The default is five minutes (`5m`).
 <3> The `repeat_interval` value specifies the minimum amount of time that must pass before an alert notification is repeated.
-The default is four hours (`4h`).
 If you want a notification to repeat at each group interval, set the `repeat_interval` value to less than the `group_interval` value.
 However, the repeated notification can still be delayed, for example, when certain Alertmanager pods are restarted or rescheduled.
 <4> The `service` value specifies the service that fires the alerts.
@@ -75,7 +72,7 @@ Do not use the `target_match`, `target_match_re`, `source_match`, or `source_mat
 +
 The following Alertmanager configuration example configures PagerDuty as an alert receiver:
 +
-[source,yaml,subs=quotes]
+[source,yaml]
 ----
 global:
   resolve_timeout: 5m
@@ -87,9 +84,9 @@ route:
   routes:
   - matchers:
     - "alertname=Watchdog"
-    repeat_interval: 5m
+    repeat_interval: 2m
     receiver: watchdog
-  *- matchers:
+  - matchers:
     - "service=example-app"
     routes:
     - matchers:
@@ -98,9 +95,9 @@ route:
 receivers:
 - name: default
 - name: watchdog
-*- name: team-frontend-page
+- name: team-frontend-page
   pagerduty_configs:
-  - service_key: "_your-key_"*
+  - service_key: "_your-key_"
 ----
 +
 With this configuration, alerts of `critical` severity that are fired by the `example-app` service are sent using the `team-frontend-page` receiver. Typically these types of alerts would be paged to an individual or a critical response team.


### PR DESCRIPTION
Summary: This PR adjusts the description of the `group_interval` setting and to the sample code for the `repeat_interval` settings.

- Aligned team: DevTools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/OBSDOCS-185
- Direct link to doc preview: https://61754--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts.html#applying-custom-alertmanager-configuration_managing-alerts
- SME review: @simonpasquier (done) 
- QE review: @juzhao (done)
- Peer review: @gwynnemonahan (done)