### PR TITLE
ROX-18086: Clarify FIPS readiness

### DIFF
--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -35,6 +35,8 @@ Distros: openshift-acs
 Topics:
 - Name: Red Hat Advanced Cluster Security for Kubernetes 4.1
   File: 41-release-notes
+- Name: Red Hat Advanced Cluster Security for Kubernetes 4.0
+  File: 40-release-notes
 ---
 Name: RHACS Cloud Service
 Dir: cloud_service

--- a/release_notes/40-release-notes.adoc
+++ b/release_notes/40-release-notes.adoc
@@ -29,7 +29,7 @@ toc::[]
 * xref:../release_notes/40-release-notes.adoc#rhcos-node-scan-rn40[{op-system-first} node host scanning for security vulnerabilities]
 * xref:../release_notes/40-release-notes.adoc#process-listening-endpoints-rn40[Processes listening on endpoints API]
 * xref:../release_notes/40-release-notes.adoc#network-graph-rn40[Network graph 2.0 (Technology Preview) updates]
-* xref:../release_notes/40-release-notes.adoc#fips-compliance-rn40[FIPS compliance]
+* xref:../release_notes/40-release-notes.adoc#fips-ready-rn40[FIPS ready]
 * xref:../release_notes/40-release-notes.adoc#token-expiry-alert-rn40[Alert messages sent to Central logs for expiring tokens]
 * xref:../release_notes/40-release-notes.adoc#sensor-resync-rn40[Improvements for Sensor resync (Technology Preview)]
 * xref:../release_notes/40-release-notes.adoc#doc-additions-rn40[Documentation additions]
@@ -167,10 +167,10 @@ The Network Graph (2.0 preview) has been updated to address user feedback and ad
 
 For more information, see xref:../operating/manage-network-policies.adoc#network-graph-20-docs[Network graph (2.0 preview)].
 
-[id="fips-compliance-rn40"]
-=== FIPS compliance
+[id="fips-ready-rn40"]
+=== FIPS ready
 
-{product-title-short} functionality has been validated on {osp} 4.12 running in Federal Information Processing Standards (FIPS) mode.
+{product-title-short} functionality has been validated on {ocp} 4.12 clusters running in Federal Information Processing Standards (FIPS) mode.
 
 [id="token-expiry-alert-rn40"]
 === Alert messages sent to Central logs for expiring tokens


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherrypick to `rhacs-docs-4.0`

[Issue](https://issues.redhat.com/browse/ROX-18086)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview
](https://61783--docspreview.netlify.app/openshift-acs/latest/release_notes/40-release-notes.html#fips-ready-rn40)

QE review: (**ACS has no QE, approved by SME**) 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- ACS doesn't have a formal "change management" process like OpenShift.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
