### PR TITLE
OSDOCS-6655: Release notes for admin-ack for upgrading 4.13 to 4.14

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -65,6 +65,17 @@ With {product-title} {product-version}, if you deploy a cluster to an existing A
 
 For more information, see xref:../installing/installing_aws/installing-aws-vpc.adoc#installation-aws-vpc-security-groups_installing-aws-vpc[Applying existing AWS security groups to the cluster].
 
+[id="ocp-4-14-admin-ack-updating"]
+==== Required administrator acknowledgment when updating from {product-title} 4.13 to 4.14
+
+{product-title} 4.14 uses Kubernetes 1.27, which removed a xref:../release_notes/ocp-4-14-release-notes.adoc#ocp-4-14-removed-kube-1-27-apis[deprecated API].
+
+A cluster administrator must provide a manual acknowledgment before the cluster can be updated from {product-title} 4.13 to 4.14. This is to help prevent issues after updating to {product-title} 4.14, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this is done, the administrator can provide the administrator acknowledgment.
+
+All {product-title} 4.13 clusters require this administrator acknowledgment before they can be updated to {product-title} 4.14.
+
+For more information, see xref:../updating/preparing_for_updates/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.14].
+
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration
 
@@ -90,7 +101,7 @@ The `ImageSetConfiguration` stores the OCI images. After processing the catalog,
 [id="oc-logging-in-browser"]
 ==== Logging in to the CLI using a web browser
 
-With {product-title} {product-version}, a new `oc` command-line interface (CLI) flag, `--web` is now available for the `oc login` command. 
+With {product-title} {product-version}, a new `oc` command-line interface (CLI) flag, `--web` is now available for the `oc login` command.
 
 With this enhancement, you can log in using a web browser, which allows you to avoid inserting your access token into the command line.
 
@@ -176,7 +187,7 @@ For more information, see xref:../nodes/scheduling/nodes-scheduler-pod-topology-
 [id="ocp-4-14-MaxUnavailableStatefulSet"]
 ==== MaxUnavailableStatefulSet enabled
 
-With this release, the `MaxUnavailableStatefulSet` featureset configuration parameter is enabled by default. This allows users to define the maximum number of `StatefulSet` pods that can be unavailable during updates, and reduces application downtime when upgrading.  
+With this release, the `MaxUnavailableStatefulSet` featureset configuration parameter is enabled by default. This allows users to define the maximum number of `StatefulSet` pods that can be unavailable during updates, and reduces application downtime when upgrading.
 
 [id="ocp-4-14-monitoring"]
 === Monitoring
@@ -472,6 +483,22 @@ In the following tables, features are marked with the following statuses:
 
 [id="ocp-4-14-removed-features"]
 === Removed features
+
+[id="ocp-4-14-removed-kube-1-27-apis"]
+==== Beta APIs removed from Kubernetes 1.27
+
+Kubernetes 1.27 removed the following deprecated API, so you must migrate manifests and API clients to use the appropriate API version. For more information about migrating removed APIs, see the link:https://kubernetes.io/docs/reference/using-api/deprecation-guide/#v1-27[Kubernetes documentation].
+
+.APIs removed from Kubernetes 1.27
+[cols="2,2,2",options="header",]
+|===
+|Resource |Removed API |Migrate to
+
+|`CSIStorageCapacity`
+|`storage.k8s.io/v1beta1`
+|`storage.k8s.io/v1`
+
+|===
 
 [id="ocp-4-14-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OSDOCS-6655

Link to docs preview:
* https://61786--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-admin-ack-updating
* https://61786--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-removed-kube-1-27-apis

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

The link to the preparing to upgrade section will still say 4.13 until #61787 is merged.
