### PR TITLE
OSDOCS-5992: Adding configuration and cusomization for dashboard

### DIFF
--- a/modules/network-observability-configuring-netobserv-dashboard.adoc
+++ b/modules/network-observability-configuring-netobserv-dashboard.adoc
@@ -1,0 +1,26 @@
+//
+// network_observability/configuring-operator.adoc
+
+:_content-type: PROCEDURE
+[id="network-observability-netobserv-dashboard_{context}"]
+= Configuring viewable metrics for the Netobserv dashboard
+You can add or remove metrics from the *Netobserv* dashboard by editing the `ignoreTags` list in the `FlowCollector` `spec.processor.metrics` parameter. 
+
+.Procedure
+. In the web console, navigate to *Operators* → *Installed Operators*.
+. Under the *Provided APIs* heading for the *NetObserv Operator*, select *Flow Collector*.
+. Select *cluster* then select the *YAML* tab.
+. Edit the `ignoreTags` list to add or remove metrics from the dashboard, as in the following YAML sample:
+[source,yaml]
+----
+apiVersion: flows.netobserv.io/v1alpha1
+kind: FlowCollector
+metadata:
+  name: cluster
+spec:
+  processor:
+    metrics:
+      ignoreTags: [egress, ingress, flows, bytes, packets, namespaces, nodes, workloads]
+----
+
+For more information about available tags, see the _Flow Collector API Reference_

--- a/modules/network-observability-netobserv-dashboard-custom-alerts.adoc
+++ b/modules/network-observability-netobserv-dashboard-custom-alerts.adoc
@@ -1,0 +1,37 @@
+//
+// network_observability/configuring-operator.adoc
+
+:_content-type: CONCEPT
+[id="network-observability-netobserv-dashboard-custom-alerts_{context}"]
+= Create custom NetObserv dashboard alerts
+You can create custom alerts for the *Netobserv* dashboard. For more information, see _Creating alerting rules for user-defined projects_ in the _Monitoring_ documentation. 
+
+An example of an alerting rule configuration YAML file is as follows:
+[source,yaml]
+----
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: alert-external-traffic
+  namespace: netobserv
+spec:
+  groups:
+  - name: AlertExternalTraffic
+    rules:
+    - alert: MediumTraffic
+      annotations:
+      description: Amount of traffic from/to cluster external workloads is medium.
+      expr: sum(rate(netobserv_workload_ingress_bytes_total{DstK8S_OwnerType=""}[1m])) > 150
+      for: 1m
+      labels:
+        app: netobserv
+        severity: info
+    - alert: HighTraffic
+      annotations:
+      description: Amount of traffic from/to cluster external workloads is high.
+      expr: sum(rate(netobserv_workload_ingress_bytes_total{DstK8S_OwnerType=""}[1m])) > 100000
+      for: 1m
+      labels:
+        app: netobserv
+        severity: critical
+----

--- a/modules/network-observability-viewing-alerts.adoc
+++ b/modules/network-observability-viewing-alerts.adoc
@@ -9,13 +9,13 @@
 You can access metrics about health and resource useage of the Network Observability Operator from the *Dashboards* page in the web console. A health alert banner that directs you to the dashboard can appear on the *Network Traffic* and *Home* pages in the event that an alert is triggered. Alerts are generated in the following cases:
 
 * The *NetObservLokiError* alert occurs if the `flowlogs-pipeline` workload is dropping flows because of Loki errors, such as if the Loki ingestion rate limit has been reached.
-* The *NetObservNoFlows* alert occurs if no flows are ingested for a certain amount of time..Prerequisites
+* The *NetObservNoFlows* alert occurs if no flows are ingested for a certain amount of time.
 
+.Prerequisites
 * You have the Network Observability Operator installed.
 * You have access to the cluster as a user with the `cluster-admin` role or with view permissions for all projects.
 
 .Procedure
-
 . From the *Administrator* perspective in the web console, navigate to *Observe* → *Dashboards*.
 . From the *Dashboards* dropdown, select *Netobserv/Health*. 
 Metrics about the health of the Operator are displayed on the page. 

--- a/networking/network_observability/configuring-operator.adoc
+++ b/networking/network_observability/configuring-operator.adoc
@@ -13,14 +13,32 @@ include::modules/network-observability-flowcollector-view.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-For more information about conversation tracking, see xref:../../networking/network_observability/observing-network-traffic.adoc#network-observability-working-with-conversations_nw-observe-network-traffic[Working with conversations].
+* For more information about Flow Collector specifications, see the xref:../network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference]
+* For more information about conversation tracking, see xref:../../networking/network_observability/observing-network-traffic.adoc#network-observability-working-with-conversations_nw-observe-network-traffic[Working with conversations].
 
-include::modules/network-observability-flowcollector-kafka-config.adoc[leveloffset=+1]
-include::modules/network-observability-enriched-flows-kafka.adoc[leveloffset=+1]
+[id="configuring-kafka"]
+== Kafka configurations
+include::modules/network-observability-flowcollector-kafka-config.adoc[leveloffset=+2]
+include::modules/network-observability-enriched-flows-kafka.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources 
 For more information about specifying flow format, see xref:../../networking/network_observability/json-flows-format-reference.adoc#network-observability-flows-format_json_reference[Network flows format reference].
 
-include::modules/network-observability-configuring-FLP-sampling.adoc[leveloffset=+1]
-include::modules/network-observability-configuring-quickfilters-flowcollector.adoc[leveloffset=+1]
+[id="configuring-traffic-flows"]
+== Traffic flows configuration
+include::modules/network-observability-configuring-quickfilters-flowcollector.adoc[leveloffset=+2]
+
+[id="configuring-resources"]
+== Resource management configurations
+include::modules/network-observability-configuring-FLP-sampling.adoc[leveloffset=+2]
+
+[id="configuring-dashboard-monitoring"]
+== Dashboard monitoring configurations
+include::modules/network-observability-disabling-health-alerts.adoc[leveloffset=+2]
+include::modules/network-observability-configuring-netobserv-dashboard.adoc[leveloffset=+2]
+include::modules/network-observability-netobserv-dashboard-custom-alerts.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources 
+For more information about creating custom alerts for the *Netobserv* dashboard, see xref:../../monitoring/managing-alerts.adoc#creating-alerting-rules-for-user-defined-projects_managing-alerts[Creating alerting rules for user-defined projects].

--- a/networking/network_observability/network-observability-operator-monitoring.adoc
+++ b/networking/network_observability/network-observability-operator-monitoring.adoc
@@ -10,4 +10,7 @@ You can use the web console to monitor alerts related to the health of the Netwo
 
 
 include::modules/network-observability-viewing-alerts.adoc[leveloffset=+1]
-include::modules/network-observability-disabling-health-alerts.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+For more information about configuring metrics and alerts for these dashboards, see xref:../network_observability/configuring-operator.adoc#configuring-dashboard-monitoring[Dashboard monitoring configurations].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.10+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-5992

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
New modules:
[Configuring viewable Netobserv dashboard metrics](https://61790--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/configuring-operator.html#network-observability-netobserv-dashboard_network_observability)
[Create custom NetObserv dashboard alerts](https://61790--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/configuring-operator.html#network-observability-netobserv-dashboard-custom-alerts_network_observability)

**Additional changes**
* New Configuration anchored headings to separate different types of Configurations, such as: 
[Configuring dashboard monitoring](https://61790--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/configuring-operator.html#configuring-dashboard-monitoring)
- **Note** the topic _Disabling health alerts_ was relocated from the Monitoring Operator assembly to the Configuring assembly and placed under the Configuring dashboard monitoring heading. 
* Additional Resources added, such as a link to API Reference in the Configuration assembly and a link to the Dashboard configurations in the Monitoring assembly:
[Monitoring the Network Observability Operator](https://61790--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/network-observability-operator-monitoring.html)
* A `.Prerequisite` was rendering incorrectly due to line placement, so I fixed that as well. 
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
