### PR TITLE
[OSDOCS-3991]: OCP content port to ROSA and OSD: Operators

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -309,6 +309,175 @@ Topics:
 # - Name: Exposing the registry
 #   File: securing-exposing-registry
 ---
+Name: Operators
+Dir: operators
+Distros: openshift-dedicated
+Topics:
+- Name: Operators overview
+  File: index
+- Name: Understanding Operators
+  Dir: understanding
+  Topics:
+  - Name: What are Operators?
+    File: olm-what-operators-are
+  - Name: Packaging format
+    File: olm-packaging-format
+  - Name: Common terms
+    File: olm-common-terms
+  - Name: Operator Lifecycle Manager (OLM)
+    Dir: olm
+    Topics:
+    - Name: Concepts and resources
+      File: olm-understanding-olm
+    - Name: Architecture
+      File: olm-arch
+    - Name: Workflow
+      File: olm-workflow
+    - Name: Dependency resolution
+      File: olm-understanding-dependency-resolution
+    - Name: Operator groups
+      File: olm-understanding-operatorgroups
+    - Name: Multitenancy and Operator colocation
+      File: olm-colocation
+    - Name: Operator conditions
+      File: olm-operatorconditions
+    - Name: Metrics
+      File: olm-understanding-metrics
+    - Name: Webhooks
+      File: olm-webhooks
+  - Name: OperatorHub
+    File: olm-understanding-operatorhub
+  - Name: Red Hat-provided Operator catalogs
+    File: olm-rh-catalogs
+  - Name: Operators in multitenant clusters
+    File: olm-multitenancy
+  - Name: CRDs
+    Dir: crds
+    Topics:
+    - Name: Managing resources from CRDs
+      File: crd-managing-resources-from-crds
+- Name: User tasks
+  Dir: user
+  Topics:
+  - Name: Creating applications from installed Operators
+    File: olm-creating-apps-from-installed-operators
+- Name: Administrator tasks
+  Dir: admin
+  Topics:
+  - Name: Adding Operators to a cluster
+    File: olm-adding-operators-to-cluster
+  - Name: Updating installed Operators
+    File: olm-upgrading-operators
+  - Name: Deleting Operators from a cluster
+    File: olm-deleting-operators-from-cluster
+  - Name: Configuring proxy support
+    File: olm-configuring-proxy-support
+  - Name: Viewing Operator status
+    File: olm-status
+  - Name: Managing Operator conditions
+    File: olm-managing-operatorconditions
+  - Name: Managing custom catalogs
+    File: olm-managing-custom-catalogs
+  - Name: Catalog source pod scheduling
+    File: olm-cs-podsched
+# - Name: Managing platform Operators  <= Tech Preview
+#   File: olm-managing-po
+- Name: Developing Operators
+  Dir: operator_sdk
+  Topics:
+  - Name: About the Operator SDK
+    File: osdk-about
+  - Name: Installing the Operator SDK CLI
+    File: osdk-installing-cli
+  - Name: Go-based Operators
+    Dir: golang
+    Topics:
+# Quick start excluded, because it requires cluster-admin permissions.
+#   - Name: Getting started
+#     File: osdk-golang-quickstart
+    - Name: Tutorial
+      File: osdk-golang-tutorial
+    - Name: Project layout
+      File: osdk-golang-project-layout
+    - Name: Updating Go-based projects
+      File: osdk-golang-updating-projects
+  - Name: Ansible-based Operators
+    Dir: ansible
+    Topics:
+# Quick start excluded, because it requires cluster-admin permissions.
+#   - Name: Getting started
+#     File: osdk-ansible-quickstart
+    - Name: Tutorial
+      File: osdk-ansible-tutorial
+    - Name: Project layout
+      File: osdk-ansible-project-layout
+    - Name: Updating Ansible-based projects
+      File: osdk-ansible-updating-projects
+    - Name: Ansible support
+      File: osdk-ansible-support
+    - Name: Kubernetes Collection for Ansible
+      File: osdk-ansible-k8s-collection
+    - Name: Using Ansible inside an Operator
+      File: osdk-ansible-inside-operator
+    - Name: Custom resource status management
+      File: osdk-ansible-cr-status
+  - Name: Helm-based Operators
+    Dir: helm
+    Topics:
+# Quick start excluded, because it requires cluster-admin permissions.
+#   - Name: Getting started
+#     File: osdk-helm-quickstart
+    - Name: Tutorial
+      File: osdk-helm-tutorial
+    - Name: Project layout
+      File: osdk-helm-project-layout
+    - Name: Updating Helm-based projects
+      File: osdk-helm-updating-projects
+    - Name: Helm support
+      File: osdk-helm-support
+#   - Name: Hybrid Helm Operator  <= Tech Preview
+#     File: osdk-hybrid-helm
+#   - Name: Updating Hybrid Helm-based projects  <= Tech Preview
+#     File: osdk-hybrid-helm-updating-projects
+# - Name: Java-based Operators  <= Tech Preview
+#   Dir: java
+#   Topics:
+#   - Name: Getting started
+#     File: osdk-java-quickstart
+#   - Name: Tutorial
+#     File: osdk-java-tutorial
+#   - Name: Project layout
+#     File: osdk-java-project-layout
+#   - Name: Updating Java-based projects
+#     File: osdk-java-updating-projects
+  - Name: Defining cluster service versions (CSVs)
+    File: osdk-generating-csvs
+  - Name: Working with bundle images
+    File: osdk-working-bundle-images
+  - Name: Complying with pod security admission
+    File: osdk-complying-with-psa
+  - Name: Validating Operators using the scorecard
+    File: osdk-scorecard
+  - Name: Validating Operator bundles
+    File: osdk-bundle-validate
+  - Name: High-availability or single-node cluster detection and support
+    File: osdk-ha-sno
+  - Name: Configuring built-in monitoring with Prometheus
+    File: osdk-monitoring-prometheus
+  - Name: Configuring leader election
+    File: osdk-leader-election
+  - Name: Object pruning utility
+    File: osdk-pruning-utility
+  - Name: Migrating package manifest projects to bundle format
+    File: osdk-pkgman-to-bundle
+  - Name: Operator SDK CLI reference
+    File: osdk-cli-ref
+  - Name: Migrating to Operator SDK v0.1.0
+    File: osdk-migrating-to-v0-1-0
+# ROSA customers can't configure/edit the cluster Operators
+# - Name: Cluster Operators reference
+#   File: operator-reference
+---
 Name: Networking
 Dir: networking
 Distros: openshift-dedicated

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -433,6 +433,175 @@ Topics:
 # - Name: Exposing the registry
 #   File: securing-exposing-registry
 ---
+Name: Operators
+Dir: operators
+Distros: openshift-rosa
+Topics:
+- Name: Operators overview
+  File: index
+- Name: Understanding Operators
+  Dir: understanding
+  Topics:
+  - Name: What are Operators?
+    File: olm-what-operators-are
+  - Name: Packaging format
+    File: olm-packaging-format
+  - Name: Common terms
+    File: olm-common-terms
+  - Name: Operator Lifecycle Manager (OLM)
+    Dir: olm
+    Topics:
+    - Name: Concepts and resources
+      File: olm-understanding-olm
+    - Name: Architecture
+      File: olm-arch
+    - Name: Workflow
+      File: olm-workflow
+    - Name: Dependency resolution
+      File: olm-understanding-dependency-resolution
+    - Name: Operator groups
+      File: olm-understanding-operatorgroups
+    - Name: Multitenancy and Operator colocation
+      File: olm-colocation
+    - Name: Operator conditions
+      File: olm-operatorconditions
+    - Name: Metrics
+      File: olm-understanding-metrics
+    - Name: Webhooks
+      File: olm-webhooks
+  - Name: OperatorHub
+    File: olm-understanding-operatorhub
+  - Name: Red Hat-provided Operator catalogs
+    File: olm-rh-catalogs
+  - Name: Operators in multitenant clusters
+    File: olm-multitenancy
+  - Name: CRDs
+    Dir: crds
+    Topics:
+    - Name: Managing resources from CRDs
+      File: crd-managing-resources-from-crds
+- Name: User tasks
+  Dir: user
+  Topics:
+  - Name: Creating applications from installed Operators
+    File: olm-creating-apps-from-installed-operators
+- Name: Administrator tasks
+  Dir: admin
+  Topics:
+  - Name: Adding Operators to a cluster
+    File: olm-adding-operators-to-cluster
+  - Name: Updating installed Operators
+    File: olm-upgrading-operators
+  - Name: Deleting Operators from a cluster
+    File: olm-deleting-operators-from-cluster
+  - Name: Configuring proxy support
+    File: olm-configuring-proxy-support
+  - Name: Viewing Operator status
+    File: olm-status
+  - Name: Managing Operator conditions
+    File: olm-managing-operatorconditions
+  - Name: Managing custom catalogs
+    File: olm-managing-custom-catalogs
+  - Name: Catalog source pod scheduling
+    File: olm-cs-podsched
+# - Name: Managing platform Operators  <= Tech Preview
+#   File: olm-managing-po
+- Name: Developing Operators
+  Dir: operator_sdk
+  Topics:
+  - Name: About the Operator SDK
+    File: osdk-about
+  - Name: Installing the Operator SDK CLI
+    File: osdk-installing-cli
+  - Name: Go-based Operators
+    Dir: golang
+    Topics:
+# Quick start excluded, because it requires cluster-admin permissions.
+#   - Name: Getting started
+#     File: osdk-golang-quickstart
+    - Name: Tutorial
+      File: osdk-golang-tutorial
+    - Name: Project layout
+      File: osdk-golang-project-layout
+    - Name: Updating Go-based projects
+      File: osdk-golang-updating-projects
+  - Name: Ansible-based Operators
+    Dir: ansible
+    Topics:
+# Quick start excluded, because it requires cluster-admin permissions.
+#   - Name: Getting started
+#     File: osdk-ansible-quickstart
+    - Name: Tutorial
+      File: osdk-ansible-tutorial
+    - Name: Project layout
+      File: osdk-ansible-project-layout
+    - Name: Updating Ansible-based projects
+      File: osdk-ansible-updating-projects
+    - Name: Ansible support
+      File: osdk-ansible-support
+    - Name: Kubernetes Collection for Ansible
+      File: osdk-ansible-k8s-collection
+    - Name: Using Ansible inside an Operator
+      File: osdk-ansible-inside-operator
+    - Name: Custom resource status management
+      File: osdk-ansible-cr-status
+  - Name: Helm-based Operators
+    Dir: helm
+    Topics:
+# Quick start excluded, because it requires cluster-admin permissions.
+#   - Name: Getting started
+#     File: osdk-helm-quickstart
+    - Name: Tutorial
+      File: osdk-helm-tutorial
+    - Name: Project layout
+      File: osdk-helm-project-layout
+    - Name: Updating Helm-based projects
+      File: osdk-helm-updating-projects
+    - Name: Helm support
+      File: osdk-helm-support
+#   - Name: Hybrid Helm Operator  <= Tech Preview
+#     File: osdk-hybrid-helm
+#   - Name: Updating Hybrid Helm-based projects  <= Tech Preview
+#     File: osdk-hybrid-helm-updating-projects
+# - Name: Java-based Operators  <= Tech Preview
+#   Dir: java
+#   Topics:
+#   - Name: Getting started
+#     File: osdk-java-quickstart
+#   - Name: Tutorial
+#     File: osdk-java-tutorial
+#   - Name: Project layout
+#     File: osdk-java-project-layout
+#   - Name: Updating Java-based projects
+#     File: osdk-java-updating-projects
+  - Name: Defining cluster service versions (CSVs)
+    File: osdk-generating-csvs
+  - Name: Working with bundle images
+    File: osdk-working-bundle-images
+  - Name: Complying with pod security admission
+    File: osdk-complying-with-psa
+  - Name: Validating Operators using the scorecard
+    File: osdk-scorecard
+  - Name: Validating Operator bundles
+    File: osdk-bundle-validate
+  - Name: High-availability or single-node cluster detection and support
+    File: osdk-ha-sno
+  - Name: Configuring built-in monitoring with Prometheus
+    File: osdk-monitoring-prometheus
+  - Name: Configuring leader election
+    File: osdk-leader-election
+  - Name: Object pruning utility
+    File: osdk-pruning-utility
+  - Name: Migrating package manifest projects to bundle format
+    File: osdk-pkgman-to-bundle
+  - Name: Operator SDK CLI reference
+    File: osdk-cli-ref
+  - Name: Migrating to Operator SDK v0.1.0
+    File: osdk-migrating-to-v0-1-0
+# ROSA customers can't configure/edit the cluster Operators
+# - Name: Cluster Operators reference
+#   File: operator-reference
+---
 Name: Networking
 Dir: networking
 Distros: openshift-rosa

--- a/modules/arch-cluster-operators.adoc
+++ b/modules/arch-cluster-operators.adoc
@@ -7,4 +7,11 @@
 
 In {product-title}, all cluster functions are divided into a series of default _cluster Operators_. Cluster Operators manage a particular area of cluster functionality, such as cluster-wide application logging, management of the Kubernetes control plane, or the machine provisioning system.
 
-Cluster Operators are represented by a `ClusterOperator` object, which cluster administrators can view in the {product-title} web console from the *Administration* -> *Cluster Settings* page. Each cluster Operator provides a simple API for determining cluster functionality. The Operator hides the details of managing the lifecycle of that component. Operators can manage a single component or tens of components, but the end goal is always to reduce operational burden by automating common actions.
+Cluster Operators are represented by a `ClusterOperator` object, which
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+can view in the {product-title} web console from the *Administration* -> *Cluster Settings* page. Each cluster Operator provides a simple API for determining cluster functionality. The Operator hides the details of managing the lifecycle of that component. Operators can manage a single component or tens of components, but the end goal is always to reduce operational burden by automating common actions.

--- a/modules/arch-olm-operators.adoc
+++ b/modules/arch-olm-operators.adoc
@@ -7,9 +7,30 @@
 
 Operator Lifecycle Manager (OLM) and OperatorHub are default components in {product-title} that help manage Kubernetes-native applications as Operators. Together they provide the system for discovering, installing, and managing the optional add-on Operators available on the cluster.
 
-Using OperatorHub in the {product-title} web console, cluster administrators and authorized users can select Operators to install from catalogs of Operators. After installing an Operator from OperatorHub, it can be made available globally or in specific namespaces to run in user applications.
+Using OperatorHub in the {product-title} web console,
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+and authorized users can select Operators to install from catalogs of Operators. After installing an Operator from OperatorHub, it can be made available globally or in specific namespaces to run in user applications.
 
-Default catalog sources are available that include Red Hat Operators, certified Operators, and community Operators. Cluster administrators can also add their own custom catalog sources, which can contain a custom set of Operators.
+Default catalog sources are available that include Red Hat Operators, certified Operators, and community Operators.
+ifndef::openshift-dedicated,openshift-rosa[]
+Cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+Administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+can also add their own custom catalog sources, which can contain a custom set of Operators.
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[NOTE]
+====
+All Operators listed in the Operator Hub marketplace should be available for installation. These Operators are considered customer workloads, and are not monitored by Red Hat Site Reliability Engineering (SRE).
+====
+endif::openshift-dedicated,openshift-rosa[]
 
 Developers can use the Operator SDK to help author custom Operators that take advantage of OLM features, as well. Their Operator can then be bundled and added to a custom catalog source, which can be added to a cluster and made available to users.
 

--- a/modules/cluster-openshift-controller-manager-operators.adoc
+++ b/modules/cluster-openshift-controller-manager-operators.adoc
@@ -15,7 +15,7 @@ The OpenShift Controller Manager Operator installs and maintains the `OpenShiftC
 $ oc get clusteroperator openshift-controller-manager -o yaml
 ----
 
-The custom resource definitino (CRD) `openshiftcontrollermanagers.operator.openshift.io` can be viewed in a cluster with:
+The custom resource definition (CRD) `openshiftcontrollermanagers.operator.openshift.io` can be viewed in a cluster with:
 
 [source,terminal]
 ----

--- a/modules/crd-creating-custom-resources-from-file.adoc
+++ b/modules/crd-creating-custom-resources-from-file.adoc
@@ -9,7 +9,7 @@
 [id="crd-creating-custom-resources-from-file_{context}"]
 = Creating custom resources from a file
 
-After a custom resource definitions (CRD) has been added to the cluster, custom resources (CRs) can be created with the CLI from a file using the CR specification.
+After a custom resource definition (CRD) has been added to the cluster, custom resources (CRs) can be created with the CLI from a file using the CR specification.
 
 .Prerequisites
 

--- a/modules/creating-new-osdk-v0-1-0-project.adoc
+++ b/modules/creating-new-osdk-v0-1-0-project.adoc
@@ -19,6 +19,7 @@ Operator SDK
 
 . Ensure the SDK version is v0.1.0:
 +
+[source,terminal]
 ----
 $ operator-sdk --version
 operator-sdk version 0.1.0
@@ -26,6 +27,7 @@ operator-sdk version 0.1.0
 
 . Create a new project:
 +
+[source,terminal]
 ----
 $ mkdir -p $GOPATH/src/github.com/example-inc/
 $ cd $GOPATH/src/github.com/example-inc/
@@ -35,8 +37,9 @@ $ ls
 memcached-operator old-memcached-operator
 ----
 
-. Copy over `.git` from old project:
+. Copy `.git` from the old project:
 +
+[source,terminal]
 ----
 $ cp -rf old-memcached-operator/.git memcached-operator/.git
 ----

--- a/modules/migrating-custom-types-pkg-apis.adoc
+++ b/modules/migrating-custom-types-pkg-apis.adoc
@@ -22,6 +22,7 @@ Operator SDK
 .. Create the API for your custom resource (CR) in the new project with
 `operator-sdk add api --api-version=<apiversion> --kind=<kind>`:
 +
+[source,terminal]
 ----
 $ cd memcached-operator
 $ operator-sdk add api --api-version=cache.example.com/v1alpha1 --kind=Memcached
@@ -51,6 +52,7 @@ project's `pkg/apis/<group>/<version>/<kind>_types.go` file.
 .. Each `<kind>_types.go` file has an `init()` function. Be sure not to remove that
 since that registers the type with the Manager's scheme:
 +
+[source,golang]
 ----
 func init() {
 	SchemeBuilder.Register(&Memcached{}, &MemcachedList{})

--- a/modules/migrating-reconcile-code.adoc
+++ b/modules/migrating-reconcile-code.adoc
@@ -22,6 +22,7 @@ Operator SDK
 In v0.0.x projects, resources to be watched were previously defined in
 `cmd/<operator-name>/main.go`:
 +
+[source,golang]
 ----
 sdk.Watch("cache.example.com/v1alpha1", "Memcached", "default", time.Duration(5)*time.Second)
 ----
@@ -32,6 +33,7 @@ to watch resources:
 
 .. Add a controller to watch your CR type with `operator-sdk add controller --api-version=<apiversion> --kind=<kind>`.
 +
+[source,terminal]
 ----
 $ operator-sdk add controller --api-version=cache.example.com/v1alpha1 --kind=Memcached
 
@@ -45,6 +47,7 @@ pkg/controller/
 
 .. Inspect the `add()` function in your `pkg/controller/<kind>/<kind>_controller.go` file:
 +
+[source,golang]
 ----
 import (
     cachev1alpha1 "github.com/example-inc/memcached-operator/pkg/apis/cache/v1alpha1"
@@ -75,13 +78,14 @@ documentation and the Kubernetes
 link:https://github.com/kubernetes/community/blob/master/contributors/devel/sig-api-machinery/controllers.md[controller conventions]
 documentation for more details.
 +
-If your operator is watching more than one CR type, you can do one of the
+If your Operator is watching more than one CR type, you can do one of the
 following depending on your application:
 +
 --
 ** If the CR is owned by your primary CR, watch it as a secondary resource in
 the same controller to trigger the reconcile loop for the primary resource.
 +
+[source,golang]
 ----
 // Watch for changes to the primary resource Memcached
     err = c.Watch(&source.Kind{Type: &cachev1alpha1.Memcached{}}, &handler.EnqueueRequestForObject{})
@@ -95,10 +99,12 @@ the same controller to trigger the reconcile loop for the primary resource.
 
 ** Add a new controller to watch and reconcile the CR independently of the other CR.
 +
+[source,terminal]
 ----
 $ operator-sdk add controller --api-version=app.example.com/v1alpha1 --kind=AppService
 ----
 +
+[source,golang]
 ----
   // Watch for changes to the primary resource AppService
     err = c.Watch(&source.Kind{Type: &appv1alpha1.AppService{}}, &handler.EnqueueRequestForObject{})
@@ -116,12 +122,14 @@ difference in the arguments and return values:
 --
 - Reconcile:
 +
+[source,golang]
 ----
     func (r *ReconcileMemcached) Reconcile(request reconcile.Request) (reconcile.Result, error)
 ----
 
 - Handle:
 +
+[source,golang]
 ----
     func (h *Handler) Handle(ctx context.Context, event sdk.Event) error
 ----
@@ -130,7 +138,7 @@ difference in the arguments and return values:
 Instead of receiving an `sdk.Event` (with the object), the `Reconcile()`
 function receives a
 link:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconcile#Request[Request]
-(`Name`/`Namespace` key) to lookup the object.
+(`Name`/`Namespace` key) to look up the object.
 +
 If the `Reconcile()` function returns an error, the controller will requeue and
 retry the `Request`. If no error is returned, then depending on the
@@ -138,11 +146,12 @@ link:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/reconci
 the controller will either not retry the `Request`, immediately retry, or retry
 after a specified duration.
 
-.. Copy the code from the old project's `Handle()` function over the existing code
+.. Copy the code from the old project's `Handle()` function to the existing code
 in your controller's `Reconcile()` function. Be sure to keep the initial section
 in the `Reconcile()` code that looks up the object for the `Request` and checks
 to see if it is deleted.
 +
+[source,golang]
 ----
 import (
     apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -182,6 +191,7 @@ field for `reconcile.Result`. This will cause the controller to requeue the
 `Request` and trigger the reconcile after the desired duration. Note that the
 default value of `0` means no requeue.
 +
+[source,golang]
 ----
 reconcilePeriod := 30 * time.Second
 reconcileResult := reconcile.Result{RequeueAfter: reconcilePeriod}
@@ -203,6 +213,7 @@ See the examples below and the `controller-runtime`
 link:https://sdk.operatorframework.io/docs/building-operators/golang/references/client/[client API documentation]
 in the `operator-sdk` project for more details:
 +
+[source,golang]
 ----
 // Create
 dep := &appsv1.Deployment{...}
@@ -237,9 +248,9 @@ dep := &appsv1.Deployment{}
 err = r.client.Get(context.TODO(), types.NamespacedName{Name: name, Namespace: namespace}, dep)
 ----
 
-.. Copy and initialize any other fields that you may have had in your `Handler`
-struct into the `Reconcile<Kind>` struct:
+.. Copy and initialize any other fields from your `Handler` struct into the `Reconcile<Kind>` struct:
 +
+[source,golang]
 ----
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
@@ -257,31 +268,29 @@ type ReconcileMemcached struct {
 
 . *Copy changes from `main.go`.*
 +
-The main function for a v0.1.0 operator in `cmd/manager/main.go` sets up the
+The main function for a v0.1.0 Operator in `cmd/manager/main.go` sets up the
 link:https://godoc.org/github.com/kubernetes-sigs/controller-runtime/pkg/manager[Manager],
-which registers the custom resources and starts all the controllers.
+which registers the custom resources and starts all of the controllers.
 +
-There is no requirement to migrate the SDK functions `sdk.Watch()`,`sdk.Handle()`, and
-`sdk.Run()` from the old `main.go` since that logic is now defined in a
+There is no requirement to migrate the SDK functions `sdk.Watch()`,`sdk.Handle()`, and `sdk.Run()` from the old `main.go` since that logic is now defined in a
 controller.
 +
 However, if there are any Operator-specific flags or settings defined in the old
-`main.go` file, copy those over.
+`main.go` file, copy them over.
 +
 If you have any third party resource types registered with the SDK's scheme, see
 link:https://sdk.operatorframework.io/docs/building-operators/golang/advanced-topics/#adding-3rd-party-resources-to-your-operator[Advanced Topics]
-in the `operator-sdk` project for how to register those with the Manager's
+in the `operator-sdk` project for how to register them with the Manager's
 scheme in the new project.
 
-. *Copy user defined files.*
+. *Copy user-defined files.*
 +
-If there are any user defined `pkgs`, scripts, or documentation in the older
-project, copy these files into the new project.
+If there are any user-defined `pkgs`, scripts, or documentation in the older
+project, copy those files into the new project.
 
 . *Copy changes to deployment manifests.*
 +
-For any updates made to the following manifests in the old project, copy over
-the changes to their corresponding files in the new project. Be careful not to
+For any updates made to the following manifests in the old project, copy the changes to their corresponding files in the new project. Be careful not to
 directly overwrite the files, but inspect and make any changes necessary:
 +
 --
@@ -293,13 +302,12 @@ directly overwrite the files, but inspect and make any changes necessary:
 * `deploy/crd.yaml` to `deploy/crds/<group>_<version>_<kind>_crd.yaml`
 --
 
-. *Copy user defined dependencies.*
+. *Copy user-defined dependencies.*
 +
-For any user defined dependencies added to the old project's `Gopkg.toml`, copy
+For any user-defined dependencies added to the old project's `Gopkg.toml`, copy
 and append them to the new project's `Gopkg.toml`. Run `dep ensure` to update
 the vendor in the new project.
 
 . *Confirm your changes.*
 +
-At this point, you should be able to build and run your Operator to verify that
-it works.
+Build and run your Operator to verify that it works.

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -44,7 +44,9 @@ The Operator manages the containerized TuneD daemon for {product-title} as a Kub
 
 Node-level settings applied by the containerized TuneD daemon are rolled back on an event that triggers a profile change or when the containerized TuneD daemon is terminated gracefully by receiving and handling a termination signal.
 
-The Node Tuning Operator uses the Performance Profile controller to implement automatic tuning to achieve low latency performance for {product-title} applications. The cluster administrator configures a performance profile to define node-level settings such as the following:
+The Node Tuning Operator uses the Performance Profile controller to implement automatic tuning to achieve low latency performance for {product-title} applications.
+
+The cluster administrator configures a performance profile to define node-level settings such as the following:
 
 * Updating the kernel to kernel-rt.
 * Choosing CPUs for housekeeping.

--- a/modules/olm-accessing-images-private-registries.adoc
+++ b/modules/olm-accessing-images-private-registries.adoc
@@ -22,10 +22,11 @@ Instead, the authentication details can be added to the global cluster pull secr
 
 .Prerequisites
 
-* At least one of the following hosted in a private registry:
+* You have at least one of the following hosted in a private registry:
 ** An index image or catalog image.
 ** An Operator bundle image.
 ** An Operator or Operand image.
+* You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
 

--- a/modules/olm-approving-pending-upgrade.adoc
+++ b/modules/olm-approving-pending-upgrade.adoc
@@ -19,7 +19,7 @@ If an installed Operator has the approval strategy in its subscription set to *M
 
 . Operators that have a pending update display a status with *Upgrade available*. Click the name of the Operator you want to update.
 
-. Click the *Subscription* tab. Any update requiring approval are displayed next to *Upgrade Status*. For example, it might display *1 requires approval*.
+. Click the *Subscription* tab. Any updates requiring approval are displayed next to *Upgrade status*. For example, it might display *1 requires approval*.
 
 . Click *1 requires approval*, then click *Preview Install Plan*.
 

--- a/modules/olm-changing-update-channel.adoc
+++ b/modules/olm-changing-update-channel.adoc
@@ -25,7 +25,7 @@ If the approval strategy in the subscription is set to *Automatic*, the update p
 
 . Click the *Subscription* tab.
 
-. Click the name of the update channel under *Channel*.
+. Click the name of the update channel under *Update channel*.
 
 . Click the newer update channel that you want to change to, then click *Save*.
 

--- a/modules/olm-colocation-namespaces.adoc
+++ b/modules/olm-colocation-namespaces.adoc
@@ -20,9 +20,21 @@ These scenarios can lead to the following issues:
 
 These issues usually surface because, when installing Operators with the {product-title} web console, the default behavior installs Operators that support the *All namespaces* install mode into the default `openshift-operators` global namespace.
 
-As a cluster administrator, you can bypass this default behavior manually by using the following workflow:
+ifndef::openshift-dedicated,openshift-rosa[]
+As a cluster administrator,
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+As an administrator with the `dedicated-admin` role,
+endif::openshift-dedicated,openshift-rosa[]
+you can bypass this default behavior manually by using the following workflow:
 
+ifndef::openshift-dedicated,openshift-rosa[]
 . Create a namespace for the installation of the Operator.
+endif::openshift-dedicated,openshift-rosa[]
+// In OSD/ROSA, dedicated-admins can create projects, but not namespaces.
+ifdef::openshift-dedicated,openshift-rosa[]
+. Create a project for the installation of the Operator.
+endif::openshift-dedicated,openshift-rosa[]
 . Create a custom _global Operator group_, which is an Operator group that watches all namespaces. By associating this Operator group with the namespace you just created, it makes the installation namespace a global namespace, which makes Operators installed there available in all namespaces.
 . Install the desired Operator in the installation namespace.
 

--- a/modules/olm-creating-catalog-from-index.adoc
+++ b/modules/olm-creating-catalog-from-index.adoc
@@ -25,16 +25,40 @@ endif::[]
 [id="olm-creating-catalog-from-index_{context}"]
 = Adding a catalog source to a cluster
 
-Adding a catalog source to an {product-title} cluster enables the discovery and installation of Operators for users. Cluster administrators can create a `CatalogSource` object that references an index image. OperatorHub uses catalog sources to populate the user interface.
+Adding a catalog source to an {product-title} cluster enables the discovery and installation of Operators for users.
+ifndef::openshift-dedicated,openshift-rosa[]
+Cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+Administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+can create a `CatalogSource` object that references an index image. OperatorHub uses catalog sources to populate the user interface.
 
+// In OSD/ROSA, a dedicated-admin can see catalog sources here, but can't add, edit, or delete them.
+ifndef::openshift-dedicated,openshift-rosa[]
 [TIP]
 ====
 Alternatively, you can use the web console to manage catalog sources. From the *Administration* -> *Cluster Settings* -> *Configuration* -> *OperatorHub* page, click the *Sources* tab, where you can create, update, delete, disable, and enable individual sources.
 ====
+endif::openshift-dedicated,openshift-rosa[]
+
+// In OSD/ROSA, a dedicated-admin can update catalog sources in the console by searching for them. 
+ifdef::openshift-dedicated,openshift-rosa[]
+[TIP]
+====
+Alternatively, you can use the web console to manage catalog sources. From the *Home* -> *Search* page, select a project, click the *Resources* drop-down and search for `CatalogSource`. You can create, update, delete, disable, and enable individual sources.
+====
+endif::openshift-dedicated,openshift-rosa[]
 
 .Prerequisites
 
-* An index image built and pushed to a registry.
+* You built and pushed an index image to a registry.
+ifndef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 

--- a/modules/olm-creating-etcd-cluster-from-operator.adoc
+++ b/modules/olm-creating-etcd-cluster-from-operator.adoc
@@ -6,14 +6,26 @@ This procedure walks through creating a new etcd cluster using the etcd Operator
 
 .Prerequisites
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * Access to an {product-title} {product-version} cluster.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* Access to an {product-title} cluster.
+endif::openshift-dedicated,openshift-rosa[]
 * The etcd Operator already installed cluster-wide by an administrator.
 
 .Procedure
 
 . Create a new project in the {product-title} web console for this procedure. This example uses a project called `my-etcd`.
 
-. Navigate to the *Operators -> Installed Operators* page. The Operators that have been installed to the cluster by the cluster administrator and are available for use are shown here as a list of cluster service versions (CSVs). CSVs are used to launch and manage the software provided by the Operator.
+. Navigate to the *Operators -> Installed Operators* page. The Operators that have been installed to the cluster by the
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrator
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+dedicated-admin
+endif::openshift-dedicated,openshift-rosa[]
+and are available for use are shown here as a list of cluster service versions (CSVs). CSVs are used to launch and manage the software provided by the Operator.
 +
 [TIP]
 ====
@@ -33,9 +45,9 @@ As shown under *Provided APIs*, this Operator makes available three new resource
 
 .. In the *etcd Cluster* API box, click *Create instance*.
 
-.. The next screen allows you to make any modifications to the minimal starting template of an `EtcdCluster` object, such as the size of the cluster. For now, click *Create* to finalize. This triggers the Operator to start up the pods, services, and other components of the new etcd cluster.
+.. The next page allows you to make any modifications to the minimal starting template of an `EtcdCluster` object, such as the size of the cluster. For now, click *Create* to finalize. This triggers the Operator to start up the pods, services, and other components of the new etcd cluster.
 
-. Click on the *example* etcd cluster, then click the *Resources* tab to see that your project now contains a number of resources created and configured automatically by the Operator.
+. Click the *example* etcd cluster, then click the *Resources* tab to see that your project now contains a number of resources created and configured automatically by the Operator.
 +
 Verify that a Kubernetes service has been created that allows you to access the database from other pods in your project.
 
@@ -46,4 +58,11 @@ Verify that a Kubernetes service has been created that allows you to access the 
 $ oc policy add-role-to-user edit <user> -n <target_project>
 ----
 
-You now have an etcd cluster that will react to failures and rebalance data as pods become unhealthy or are migrated between nodes in the cluster. Most importantly, cluster administrators or developers with proper access can now easily use the database with their applications.
+You now have an etcd cluster that will react to failures and rebalance data as pods become unhealthy or are migrated between nodes in the cluster. Most importantly,
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+dedicated-admins
+endif::openshift-dedicated,openshift-rosa[]
+or developers with proper access can now easily use the database with their applications.

--- a/modules/olm-creating-fb-catalog-image.adoc
+++ b/modules/olm-creating-fb-catalog-image.adoc
@@ -17,9 +17,9 @@ You can use the `opm` CLI to create a catalog image that uses the plain text _fi
 
 .Prerequisites
 
-* `opm`
-* `podman` version 1.9.3+
-* A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+* You have installed the `opm` CLI.
+* You have `podman` version 1.9.3+.
+* A bundle image is built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2].
 
 .Procedure
 

--- a/modules/olm-creating-index-image.adoc
+++ b/modules/olm-creating-index-image.adoc
@@ -10,9 +10,9 @@ You can create an index image based on the SQLite database format by using the `
 
 .Prerequisites
 
-* `opm`
-* `podman` version 1.9.3+
-* A bundle image built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+* You have installed the `opm` CLI.
+* You have `podman` version 1.9.3+.
+* A bundle image is built and pushed to a registry that supports link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2].
 
 .Procedure
 

--- a/modules/olm-cs-status-cli.adoc
+++ b/modules/olm-cs-status-cli.adoc
@@ -18,7 +18,12 @@ You can view the status of an Operator catalog source by using the CLI.
 
 .Prerequisites
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
@@ -11,11 +11,14 @@ Cluster administrators can delete installed Operators from a selected namespace 
 
 .Prerequisites
 
-- Access to an {product-title} cluster using an account with
+- You have access to an {product-title} cluster using an account with
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-- `oc` command installed on workstation.
+ifdef::openshift-dedicated,openshift-rosa[]
+`dedicated-admin` permissions.
+endif::openshift-dedicated,openshift-rosa[]
+- The OpenShift CLI (`oc`) is installed on your workstation.
 
 .Procedure
 

--- a/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc
@@ -17,6 +17,9 @@ Cluster administrators can delete installed Operators from a selected namespace 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+`dedicated-admin` permissions.
+endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 

--- a/modules/olm-filtering-fbc.adoc
+++ b/modules/olm-filtering-fbc.adoc
@@ -15,19 +15,22 @@ endif::[]
 
 You can use the `opm` CLI to update or filter (also known as prune) a catalog image that uses the file-based catalog format. By extracting and modifying the contents of an existing catalog image, you can update, add, or remove one or more Operator package entries from the catalog. You can then rebuild the image as an updated version of the catalog.
 
+// This note points to a topic that's excluded from OSD and ROSA.
+ifndef::openshift-dedicated,openshift-rosa[]
 [NOTE]
 ====
 Alternatively, if you already have a catalog image on a mirror registry, you can use the oc-mirror CLI plugin to automatically prune any removed images from an updated source version of that catalog image while mirroring it to the target registry.
 
 For more information about the oc-mirror plugin and this use case, see the "Keeping your mirror registry content updated" section, and specifically the "Pruning images" subsection, of "Mirroring images for a disconnected installation using the oc-mirror plugin".
 ====
+endif::openshift-dedicated,openshift-rosa[]
 
 .Prerequisites
-
-* `opm` CLI.
-* `podman` version 1.9.3+.
-* A file-based catalog image.
-* A catalog directory structure recently initialized on your workstation related to this catalog.
+* You have the following on your workstation:
+** The `opm` CLI.
+** `podman` version 1.9.3+.
+** A file-based catalog image.
+** A catalog directory structure recently initialized on your workstation related to this catalog.
 +
 If you do not have an initialized catalog directory, create the directory and generate the Dockerfile. For more information, see the "Initialize the catalog" step from the "Creating a file-based catalog image" procedure.
 

--- a/modules/olm-injecting-custom-ca.adoc
+++ b/modules/olm-injecting-custom-ca.adoc
@@ -6,16 +6,27 @@
 [id="olm-inject-custom-ca_{context}"]
 = Injecting a custom CA certificate
 
-When a cluster administrator adds a custom CA certificate to a cluster using a config map, the Cluster Network Operator merges the user-provided certificates and system CA certificates into a single bundle. You can inject this merged bundle into your Operator running on Operator Lifecycle Manager (OLM), which is useful if you have a man-in-the-middle HTTPS proxy.
+ifndef::openshift-dedicated,openshift-rosa[]
+When a cluster administrator
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+When an administrator with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+adds a custom CA certificate to a cluster using a config map, the Cluster Network Operator merges the user-provided certificates and system CA certificates into a single bundle. You can inject this merged bundle into your Operator running on Operator Lifecycle Manager (OLM), which is useful if you have a man-in-the-middle HTTPS proxy.
 
 .Prerequisites
 
-- Access to an {product-title} cluster using an account with
+ifndef::openshift-dedicated,openshift-rosa[]
+* Access to an {product-title} cluster using an account with
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
-- Custom CA certificate added to the cluster using a config map.
-- Desired Operator installed and running on OLM.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* Access to a {product-title} cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+* Custom CA certificate added to the cluster using a config map.
+* Desired Operator installed and running on OLM.
 
 .Procedure
 
@@ -35,7 +46,7 @@ metadata:
 +
 After creating this config map, it is immediately populated with the certificate contents of the merged bundle.
 
-. Update your the `Subscription` object to include a `spec.config` section that mounts the `trusted-ca` config map as a volume to each container within a pod that requires a custom CA:
+. Update the `Subscription` object to include a `spec.config` section that mounts the `trusted-ca` config map as a volume to each container within a pod that requires a custom CA:
 +
 [source,yaml]
 ----

--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -24,13 +24,16 @@ ifndef::olm-user[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+the `dedicated-admin` role.
+endif::[]
 endif::[]
 
 ifdef::olm-user[]
 - Access to an {product-title} cluster using an account with Operator installation permissions.
 endif::[]
 
-- Install the `oc` command to your local system.
+- You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/olm-installing-from-operatorhub-using-web-console.adoc
+++ b/modules/olm-installing-from-operatorhub-using-web-console.adoc
@@ -37,14 +37,17 @@ You can install and subscribe to an Operator from OperatorHub by using the {prod
 .Prerequisites
 
 ifdef::olm-admin[]
-- Access to an {product-title} cluster using an account with
+* Access to an {product-title} cluster using an account with
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 endif::[]
 
 ifdef::olm-user[]
-- Access to an {product-title} cluster using an account with Operator installation permissions.
+* Access to an {product-title} cluster using an account with Operator installation permissions.
 endif::[]
 
 .Procedure
@@ -75,7 +78,7 @@ ifdef::olm-user[]
 .. Choose a specific, single namespace in which to install the Operator. The Operator will only watch and be made available for use in this single namespace.
 endif::[]
 
-.. Select an *Update Channel* (if more than one is available).
+.. Select an *Update channel* (if more than one is available).
 
 .. Select *Automatic* or *Manual* approval strategy, as described earlier.
 

--- a/modules/olm-installing-global-namespaces.adoc
+++ b/modules/olm-installing-global-namespaces.adoc
@@ -8,10 +8,27 @@
 
 When installing Operators with the {product-title} web console, the default behavior installs Operators that support the *All namespaces* install mode into the default `openshift-operators` global namespace. This can cause issues related to shared install plans and update policies between all Operators in the namespace. For more details on these limitations, see "Multitenancy and Operator colocation".
 
-As a cluster administrator, you can bypass this default behavior manually by creating a custom global namespace and using that namespace to install your individual or scoped set of Operators and their dependencies.
+ifndef::openshift-dedicated,openshift-rosa[]
+As a cluster administrator,
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+As an administrator with the `dedicated-admin` role,
+endif::[]
+you can bypass this default behavior manually by creating a custom global namespace and using that namespace to install your individual or scoped set of Operators and their dependencies.
+
+.Prerequisites
+
+ifndef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 
+// In OSD/ROSA, dedicated-admins can't create namespaces directly but can create projects.
+ifndef::openshift-dedicated,openshift-rosa[]
 . Before installing the Operator, create a namespace for the installation of your desired Operator. This installation namespace will become the custom global namespace:
 
 .. Define a `Namespace` resource and save the YAML file, for example, `global-operators.yaml`:
@@ -30,6 +47,16 @@ metadata:
 ----
 $ oc create -f global-operators.yaml
 ----
+endif::openshift-dedicated,openshift-rosa[]
+// Slightly different step for OSD/ROSA since dedicated-admins can't create namespaces directly.
+ifdef::openshift-dedicated,openshift-rosa[]
+. Before installing the Operator, create a namespace for the installation of your desired Operator. You can do this by creating a project. The namespace for this project will become the custom global namespace:
++
+[source,terminal]
+----
+$ oc new-project global-operators
+----
+endif::openshift-dedicated,openshift-rosa[]
 
 . Create a custom _global Operator group_, which is an Operator group that watches all namespaces:
 

--- a/modules/olm-installing-operators-from-operatorhub.adoc
+++ b/modules/olm-installing-operators-from-operatorhub.adoc
@@ -17,12 +17,16 @@ endif::[]
 
 OperatorHub is a user interface for discovering Operators; it works in conjunction with Operator Lifecycle Manager (OLM), which installs and manages Operators on a cluster.
 
-ifndef::olm-user[]
+ifndef::olm-user,openshift-dedicated,openshift-rosa[]
 As a cluster administrator, you can install an Operator from OperatorHub by using the {product-title}
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 web console or CLI. Subscribing an Operator to one or more namespaces makes the Operator available to developers on your cluster.
 endif::[]
 endif::[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+As a `dedicated-admin`, you can install an Operator from OperatorHub by using the {product-title} web console or CLI. Subscribing an Operator to one or more namespaces makes the Operator available to developers on your cluster.
+endif::openshift-dedicated,openshift-rosa[]
 
 ifdef::olm-user[]
 As a user with the proper permissions, you can install an Operator from OperatorHub by using the {product-title} web console or CLI.
@@ -31,7 +35,7 @@ endif::[]
 During installation, you must determine the following initial settings for the Operator:
 
 ifndef::olm-user[]
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-rosa,openshift-dedicated[]
 Installation Mode:: Choose *All namespaces on the cluster (default)* to have the Operator installed on all namespaces or choose individual namespaces, if available, to only install the Operator on selected namespaces. This example chooses *All namespaces...* to make the Operator available to all users and projects.
 endif::[]
 endif::[]
@@ -45,4 +49,11 @@ Approval Strategy:: You can choose automatic or manual updates.
 +
 If you choose automatic updates for an installed Operator, when a new version of that Operator is available in the selected channel, Operator Lifecycle Manager (OLM) automatically upgrades the running instance of your Operator without human intervention.
 +
-If you select manual updates, when a newer version of an Operator is available, OLM creates an update request. As a cluster administrator, you must then manually approve that update request to have the Operator updated to the new version.
+If you select manual updates, when a newer version of an Operator is available, OLM creates an update request. As a 
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrator,
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+`dedicated-admin`,
+endif::openshift-dedicated,openshift-rosa[]
+you must then manually approve that update request to have the Operator updated to the new version.

--- a/modules/olm-installing-specific-version-cli.adoc
+++ b/modules/olm-installing-specific-version-cli.adoc
@@ -20,13 +20,16 @@ ifndef::olm-user[]
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions
 endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+the `dedicated-admin` role.
+endif::[]
 endif::[]
 
 ifdef::olm-user[]
-- Access to an {product-title} cluster using an account with Operator installation permissions
+- Access to an {product-title} cluster using an account with Operator installation permissions.
 endif::[]
 
-- OpenShift CLI (`oc`) installed
+- You have installed the OpenShift CLI (`oc`).
 
 .Procedure
 

--- a/modules/olm-migrating-sqlite-catalog-to-fbc.adoc
+++ b/modules/olm-migrating-sqlite-catalog-to-fbc.adoc
@@ -10,9 +10,14 @@ You can update your deprecated SQLite database format catalogs to the file-based
 
 .Prerequisites
 
-* SQLite database catalog source
-* Cluster administrator permissions
-* Latest version of the `opm` CLI tool released with {product-title} {product-version} on workstation
+* You have a SQLite database catalog source.
+ifndef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+* You have the latest version of the `opm` CLI tool released with {product-title} {product-version} on your workstation.
 
 .Procedure
 

--- a/modules/olm-multitenancy-solution.adoc
+++ b/modules/olm-multitenancy-solution.adoc
@@ -8,7 +8,14 @@
 
 While a *Multinamespace* install mode does exist, it is supported by very few Operators. As a middle ground solution between the standard *All namespaces* and *Single namespace* install modes, you can install multiple instances of the same Operator, one for each tenant, by using the following workflow:
 
+// In OSD/ROSA, dedicated-admins can create projects, but not namespaces.
+ifndef::openshift-dedicated,openshift-rosa[]
 . Create a namespace for the tenant Operator that is separate from the tenant's namespace.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+. Create a namespace for the tenant Operator that is separate from the tenant's namespace. You can do this by creating a project.
+endif::openshift-dedicated,openshift-rosa[]
+
 . Create an Operator group for the tenant Operator scoped only to the tenant's namespace.
 . Install the Operator in the tenant Operator namespace.
 
@@ -32,7 +39,10 @@ You cannot use different versions of the same Operator on the same cluster. Even
 * The instance ships an older revision of the CRDs that lack information or versions that newer revisions have that are already in use on the cluster.
 ====
 
+// In OSD/ROSA, tenants shouldn't be able to install Operators. Dedicated-admins can, but they can't grant non-admin users the ability to install their own Operators.
+ifndef::openshift-dedicated,openshift-rosa[]
 [WARNING]
 ====
 As an administrator, use caution when allowing non-cluster administrators to install Operators self-sufficiently, as explained in "Allowing non-cluster administrators to install Operators". These tenants should only have access to a curated catalog of Operators that are known to not have dependencies. These tenants must also be forced to use the same version line of an Operator, to ensure the CRDs do not change. This requires the use of namespace-scoped catalogs and likely disabling the global default catalogs.
 ====
+endif::openshift-dedicated,openshift-rosa[]

--- a/modules/olm-node-selector.adoc
+++ b/modules/olm-node-selector.adoc
@@ -6,9 +6,12 @@
 [id="olm-node-selector_{context}"]
 = Overriding the node selector for catalog source pods
 
-.Prequisites
+.Prerequisites
 
-* `CatalogSource` object of source type `grpc` with `spec.image` defined
+* A `CatalogSource` object of source type `grpc` with `spec.image` is defined.
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 

--- a/modules/olm-operator-framework.adoc
+++ b/modules/olm-operator-framework.adoc
@@ -11,7 +11,7 @@ Operator SDK::
 The Operator SDK assists Operator authors in bootstrapping, building, testing, and packaging their own Operator based on their expertise without requiring knowledge of Kubernetes API complexities.
 
 Operator Lifecycle Manager::
-Operator Lifecycle Manager (OLM) controls the installation, upgrade, and role-based access control (RBAC) of Operators in a cluster. Deployed by default in {product-title} {product-version}.
+Operator Lifecycle Manager (OLM) controls the installation, upgrade, and role-based access control (RBAC) of Operators in a cluster. It is deployed by default in {product-title} {product-version}.
 
 Operator Registry::
 The Operator Registry stores cluster service versions (CSVs) and custom resource definitions (CRDs) for creation in a cluster and stores Operator metadata about packages and channels. It runs in a Kubernetes or OpenShift cluster to provide this Operator catalog data to OLM.

--- a/modules/olm-operator-maturity-model.adoc
+++ b/modules/olm-operator-maturity-model.adoc
@@ -7,7 +7,7 @@
 
 The level of sophistication of the management logic encapsulated within an Operator can vary. This logic is also in general highly dependent on the type of the service represented by the Operator.
 
-One can however generalize the scale of the maturity of the encapsulated operations of an Operator for certain set of capabilities that most Operators can include. To this end, the following Operator maturity model defines five phases of maturity for generic day two operations of an Operator:
+One can however generalize the scale of the maturity of the encapsulated operations of an Operator for certain set of capabilities that most Operators can include. To this end, the following Operator maturity model defines five phases of maturity for generic Day 2 operations of an Operator:
 
 .Operator maturity model
 image::operator-maturity-model.png[]

--- a/modules/olm-operatorhub-architecture.adoc
+++ b/modules/olm-operatorhub-architecture.adoc
@@ -10,7 +10,9 @@ The OperatorHub UI component is driven by the Marketplace Operator by default on
 [id="olm-operatorhub-arch-operatorhub_crd_{context}"]
 == OperatorHub custom resource
 
-The Marketplace Operator manages an `OperatorHub` custom resource (CR) named `cluster` that manages the default `CatalogSource` objects provided with OperatorHub. You can modify this resource to enable or disable the default catalogs, which is useful when configuring {product-title} in restricted network environments.
+The Marketplace Operator manages an `OperatorHub` custom resource (CR) named `cluster` that manages the default `CatalogSource` objects provided with OperatorHub.
+ifndef::openshift-dedicated,openshift-rosa[]
+You can modify this resource to enable or disable the default catalogs, which is useful when configuring {product-title} in restricted network environments.
 
 .Example `OperatorHub` custom resource
 [source,yaml]
@@ -30,3 +32,4 @@ spec:
 ----
 <1> `disableAllDefaultSources` is an override that controls availability of all default catalogs that are configured by default during an {product-title} installation.
 <2> Disable default catalogs individually by changing the `disabled` parameter value per source.
+endif::openshift-dedicated,openshift-rosa[]

--- a/modules/olm-overriding-operator-pod-affinity.adoc
+++ b/modules/olm-overriding-operator-pod-affinity.adoc
@@ -33,8 +33,10 @@ By default, when you install an Operator, {product-title} installs the Operator 
 
 The following examples describe situations where you might want to schedule an Operator pod to a specific node or set of nodes:
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * If an Operator requires a particular platform, such as `amd64` or `arm64`
 * If an Operator requires a particular operating system, such as Linux or Windows
+endif::openshift-dedicated,openshift-rosa[]
 * If you want Operators that work together scheduled on the same host or on hosts located on the same rack
 * If you want Operators dispersed throughout the infrastructure to avoid downtime due to network or hardware issues
 

--- a/modules/olm-overriding-operatorconditions.adoc
+++ b/modules/olm-overriding-operatorconditions.adoc
@@ -6,17 +6,43 @@
 [id="olm-supported-operatorconditions_{context}"]
 = Overriding Operator conditions
 
-As a cluster administrator, you might want to ignore a supported Operator condition reported by an Operator. When present, Operator conditions in the `Spec.Overrides` array override the conditions in the `Spec.Conditions` array, allowing cluster administrators to deal with situations where an Operator is incorrectly reporting a state to Operator Lifecycle Manager (OLM).
+ifndef::openshift-dedicated,openshift-rosa[]
+As a cluster administrator,
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+As an administrator with the `dedicated-admin` role,
+endif::openshift-dedicated,openshift-rosa[]
+you might want to ignore a supported Operator condition reported by an Operator. When present, Operator conditions in the `Spec.Overrides` array override the conditions in the `Spec.Conditions` array, allowing
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrators 
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+`dedicated-admin` administrators
+endif::openshift-dedicated,openshift-rosa[]
+to deal with situations where an Operator is incorrectly reporting a state to Operator Lifecycle Manager (OLM).
 
 [NOTE]
 ====
-By default, the `Spec.Overrides` array is not present in an `OperatorCondition` object until it is added by a cluster administrator. The `Spec.Conditions` array is also not present until it is either added by a user or as a result of custom Operator logic.
+By default, the `Spec.Overrides` array is not present in an `OperatorCondition` object until it is added by
+ifndef::openshift-dedicated,openshift-rosa[]
+a cluster administrator
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+an administrator with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+. The `Spec.Conditions` array is also not present until it is either added by a user or as a result of custom Operator logic.
 ====
 
 For example, consider a known version of an Operator that always communicates that it is not upgradeable. In this instance, you might want to upgrade the Operator despite the Operator communicating that it is not upgradeable. This could be accomplished by overriding the Operator condition by adding the condition `type` and `status` to the `Spec.Overrides` array in the `OperatorCondition` object.
 
 .Prerequisites
 
+ifndef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 * An Operator with an `OperatorCondition` object, installed using OLM.
 
 .Procedure
@@ -51,4 +77,9 @@ spec:
     message: "The operator is performing a migration."
     lastTransitionTime: "2020-08-24T23:15:55Z"
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 <1> Allows the cluster administrator to change the upgrade readiness to `True`.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+<1> Allows the `dedicated-admin` user to change the upgrade readiness to `True`.
+endif::openshift-dedicated,openshift-rosa[]

--- a/modules/olm-overriding-proxy-settings.adoc
+++ b/modules/olm-overriding-proxy-settings.adoc
@@ -6,7 +6,14 @@
 [id="olm-overriding-proxy-settings_{context}"]
 = Overriding proxy settings of an Operator
 
-If a cluster-wide egress proxy is configured, Operators running with Operator Lifecycle Manager (OLM) inherit the cluster-wide proxy settings on their deployments. Cluster administrators can also override these proxy settings by configuring the subscription of an Operator.
+If a cluster-wide egress proxy is configured, Operators running with Operator Lifecycle Manager (OLM) inherit the cluster-wide proxy settings on their deployments.
+ifndef::openshift-dedicated,openshift-rosa[]
+Cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+Administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+can also override these proxy settings by configuring the subscription of an Operator.
 
 [IMPORTANT]
 ====
@@ -15,10 +22,15 @@ Operators must handle setting environment variables for proxy settings in the po
 
 .Prerequisites
 
-- Access to an {product-title} cluster using an account with
+ifndef::openshift-dedicated,openshift-rosa[]
+* Access to an {product-title} cluster using an account with
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 `cluster-admin` permissions.
 endif::[]
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* Access to a {product-title} cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 

--- a/modules/olm-overview.adoc
+++ b/modules/olm-overview.adoc
@@ -16,6 +16,20 @@ _Operator Lifecycle Manager_ (OLM) helps users install, update, and manage the l
 .Operator Lifecycle Manager workflow
 image::olm-workflow.png[]
 
-OLM runs by default in {product-title} {product-version}, which aids cluster administrators in installing, upgrading, and granting access to Operators running on their cluster. The {product-title} web console provides management screens for cluster administrators to install Operators, as well as grant specific projects access to use the catalog of Operators available on the cluster.
+OLM runs by default in {product-title} {product-version}, which aids
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+in installing, upgrading, and granting access to Operators running on their cluster. The {product-title} web console provides management screens for 
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+`dedicated-admin` administrators
+endif::openshift-dedicated,openshift-rosa[]
+to install Operators, as well as grant specific projects access to use the catalog of Operators available on the cluster.
 
 For developers, a self-service experience allows provisioning and configuring instances of databases, monitoring, and big data services without having to be subject matter experts, because the Operator has that knowledge baked into it.

--- a/modules/olm-policy-scoping-operator-install.adoc
+++ b/modules/olm-policy-scoping-operator-install.adoc
@@ -10,6 +10,11 @@ To provide scoping rules to Operator installations and upgrades on Operator Life
 
 Using this example, a cluster administrator can confine a set of Operators to a designated namespace.
 
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have installed the OpenShift CLI (`oc`).
+
 .Procedure
 
 . Create a new namespace:

--- a/modules/olm-preparing-multitenant-operators.adoc
+++ b/modules/olm-preparing-multitenant-operators.adoc
@@ -6,12 +6,21 @@
 [id="olm-preparing-operators-multitenant_{context}"]
 = Preparing for multiple instances of an Operator for multitenant clusters
 
-As a cluster administrator, you can add multiple instances of an Operator for use in multitenant clusters. This is an alternative solution to either using the standard *All namespaces* install mode, which can be considered to violate the principle of least privilege, or the *Multinamespace* mode, which is not widely adopted. For more information, see "Operators in multitenant clusters".
+ifndef::openshift-dedicated,openshift-rosa[]
+As a cluster administrator,
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+As an administrator with the `dedicated-admin` role,
+endif::openshift-dedicated,openshift-rosa[]
+you can add multiple instances of an Operator for use in multitenant clusters. This is an alternative solution to either using the standard *All namespaces* install mode, which can be considered to violate the principle of least privilege, or the *Multinamespace* mode, which is not widely adopted. For more information, see "Operators in multitenant clusters".
 
 In the following procedure, the _tenant_ is a user or group of users that share common access and privileges for a set of deployed workloads. The _tenant Operator_ is the instance of an Operator that is intended for use by only that tenant.
 
 .Prerequisites
 
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 * All instances of the Operator you want to install must be the same version across a given cluster.
 +
 [IMPORTANT]
@@ -21,6 +30,8 @@ For more information on this and other limitations, see "Operators in multitenan
 
 .Procedure
 
+// In OSD/ROSA, dedicated-admins can't create namespaces directly but can create projects.
+ifndef::openshift-dedicated,openshift-rosa[]
 . Before installing the Operator, create a namespace for the tenant Operator that is separate from the tenant's namespace. For example, if the tenant's namespace is `team1`, you might create a `team1-operator` namespace:
 
 .. Define a `Namespace` resource and save the YAML file, for example, `team1-operator.yaml`:
@@ -39,6 +50,16 @@ metadata:
 ----
 $ oc create -f team1-operator.yaml
 ----
+endif::openshift-dedicated,openshift-rosa[]
+// Slightly different step for OSD/ROSA since dedicated-admins can't create namespaces directly.
+ifdef::openshift-dedicated,openshift-rosa[]
+. Before installing the Operator, create a namespace for the tenant Operator that is separate from the tenant's namespace. You can do this by creating a project. For example, if the tenant's namespace is `team1`, you might create a `team1-operator` project:
++
+[source,terminal]
+----
+$ oc new-project team1-operator
+----
+endif::openshift-dedicated,openshift-rosa[]
 
 . Create an Operator group for the tenant Operator scoped to the tenant's namespace, with only that one namespace entry in the `spec.targetNamespaces` list:
 

--- a/modules/olm-priority-class-name.adoc
+++ b/modules/olm-priority-class-name.adoc
@@ -13,9 +13,12 @@ endif::[]
 [id="olm-priority-class-name_{context}"]
 = Overriding the priority class name for catalog source pods
 
-.Prequisites
+.Prerequisites
 
-* `CatalogSource` object of source type `grpc` with `spec.image` defined
+* A `CatalogSource` object of source type `grpc` with `spec.image` is defined.
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 

--- a/modules/olm-pruning-index-image.adoc
+++ b/modules/olm-pruning-index-image.adoc
@@ -37,13 +37,13 @@ endif::[]
 .Prerequisites
 
 ifeval::["{context}" != "olm-managing-custom-catalogs"]
-* Workstation with unrestricted network access
+* A workstation with unrestricted network access.
 endif::[]
-* `podman` version 1.9.3+
-* link:https://github.com/fullstorydev/grpcurl[`grpcurl`] (third-party command-line tool)
-* `opm`
-* Access to a registry that supports
-link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2]
+* You have `podman` version 1.9.3+.
+* You have link:https://github.com/fullstorydev/grpcurl[`grpcurl`] (third-party command-line tool).
+* You have installed the `opm` CLI.
+* You have access to a registry that supports
+link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2].
 
 .Procedure
 

--- a/modules/olm-removing-catalogs.adoc
+++ b/modules/olm-removing-catalogs.adoc
@@ -2,11 +2,16 @@
 //
 // * operators/admin/olm-managing-custom-catalogs.adoc
 
+// The OSD/ROSA version of this procedure is sd-olm-removing-catalogs.adoc.
+
 :_content-type: PROCEDURE
 [id="olm-removing-catalogs_{context}"]
 = Removing custom catalogs
 
 As a cluster administrator, you can remove custom Operator catalogs that have been previously added to your cluster by deleting the related catalog source.
+
+.Prerequisites
+* You have access to the cluster as a user with the `cluster-admin` role.
 
 .Procedure
 

--- a/modules/olm-sqlite-catalog-configuring-elevated-permissions.adoc
+++ b/modules/olm-sqlite-catalog-configuring-elevated-permissions.adoc
@@ -18,9 +18,14 @@ The SQLite database catalog format is deprecated, but still supported by Red Hat
 
 .Prerequisites
 
-* SQLite database catalog source
-* Cluster administrator permissions
-* Target namespace that supports running pods with the elevated pod security admission standard of `baseline` or `privileged`
+* You have a SQLite database catalog source.
+ifndef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+* You have a target namespace that supports running pods with the elevated pod security admission standard of `baseline` or `privileged`.
 
 .Procedure
 

--- a/modules/olm-status-viewing-cli.adoc
+++ b/modules/olm-status-viewing-cli.adoc
@@ -11,7 +11,12 @@ You can view Operator subscription status by using the CLI.
 
 .Prerequisites
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/olm-tolerations.adoc
+++ b/modules/olm-tolerations.adoc
@@ -6,9 +6,12 @@
 [id="olm-tolerations_{context}"]
 = Overriding tolerations for catalog source pods
 
-.Prequisites
+.Prerequisites
 
-* `CatalogSource` object of source type `grpc` with `spec.image` defined
+* A `CatalogSource` object of source type `grpc` with `spec.image` is defined.
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -13,16 +13,23 @@ endif::[]
 [id="olm-updating-index-image_{context}"]
 = Updating a SQLite-based index image
 
-After configuring OperatorHub to use a catalog source that references a custom index image, cluster administrators can keep the available Operators on their cluster up to date by adding bundle images to the index image.
+After configuring OperatorHub to use a catalog source that references a custom index image,
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+can keep the available Operators on their cluster up-to-date by adding bundle images to the index image.
 
 You can update an existing index image using the `opm index add` command.
 
 .Prerequisites
 
-* `opm`
-* `podman` version 1.9.3+
-* An index image built and pushed to a registry.
-* An existing catalog source referencing the index image.
+* You have installed the `opm` CLI.
+* You have `podman` version 1.9.3+.
+* An index image is built and pushed to a registry.
+* You have an existing catalog source referencing the index image.
 
 .Procedure
 

--- a/modules/olm-updating-sqlite-catalog-to-a-new-opm-version.adoc
+++ b/modules/olm-updating-sqlite-catalog-to-a-new-opm-version.adoc
@@ -10,9 +10,14 @@ You can rebuild your SQLite database catalog image with the latest version of th
 
 .Prerequisites
 
-* SQLite database catalog source
-* Cluster administrator permissions
-* Latest version of the `opm` CLI tool released with {product-title} {product-version} on workstation
+* You have a SQLite database catalog source.
+ifndef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+* You have the latest version of the `opm` CLI tool released with {product-title} {product-version} on your workstation.
 
 .Procedure
 

--- a/modules/osdk-common-prereqs.adoc
+++ b/modules/osdk-common-prereqs.adoc
@@ -49,7 +49,12 @@ ifdef::java[]
 * link:https://java.com/en/download/help/download_options.html[Java] v11+
 * link:https://maven.apache.org/install.html[Maven] v3.6.3+
 endif::[]
+ifndef::openshift-dedicated,openshift-rosa[]
 * Logged into an {product-title} {product-version} cluster with `oc` with an account that has `cluster-admin` permissions
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* Logged into an {product-title} cluster with `oc` with an account that has `dedicated-admin` permissions
+endif::openshift-dedicated,openshift-rosa[]
 * To allow the cluster to pull the image, the repository where you push your image must be set as public, or you must configure an image pull secret
 
 ifeval::["{context}" == "osdk-ansible-quickstart"]

--- a/modules/osdk-control-compat.adoc
+++ b/modules/osdk-control-compat.adoc
@@ -47,8 +47,7 @@ Operators that use deprecated APIs can adversely impact critical workloads when 
 +
 [IMPORTANT]
 ====
-You must use `olm.maxOpenShiftVersion` annotation only if your Operator bundle version cannot work in later versions. Be aware that cluster admins cannot upgrade their clusters with your solution installed. If you do not provide later version and a valid upgrade path,
-cluster admins may uninstall your Operator and can upgrade the cluster version.
+You must use `olm.maxOpenShiftVersion` annotation only if your Operator bundle version cannot work in later versions. Be aware that cluster admins cannot upgrade their clusters with your solution installed. If you do not provide later version and a valid upgrade path, administrators may uninstall your Operator and can upgrade the cluster version.
 ====
 +
 .Example CSV with `olm.maxOpenShiftVersion` annotation

--- a/modules/osdk-deploy-olm.adoc
+++ b/modules/osdk-deploy-olm.adoc
@@ -28,14 +28,19 @@ The Operator bundle format is the default packaging method for Operator SDK and 
 - Operator SDK CLI installed on a development workstation
 - Operator bundle image built and pushed to a registry
 - OLM installed on a Kubernetes-based cluster (v1.16.0 or later if you use `apiextensions.k8s.io/v1` CRDs, for example {product-title} {product-version})
+ifndef::openshift-dedicated,openshift-rosa[]
 - Logged in to the cluster with `oc` using an account with `cluster-admin` permissions
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+- Logged in to the cluster with `oc` using an account with `dedicated-admin` permissions
+endif::openshift-dedicated,openshift-rosa[]
 ifdef::golang[]
 - If your Operator is Go-based, your project must be updated to use supported images for running on {product-title}
 endif::[]
 
 .Procedure
 
-. Enter the following command to run the Operator on the cluster: 
+* Enter the following command to run the Operator on the cluster: 
 +
 [source,terminal]
 ----

--- a/modules/osdk-init-resource.adoc
+++ b/modules/osdk-init-resource.adoc
@@ -8,7 +8,7 @@
 
 An Operator might require the user to instantiate a custom resource before the Operator can be fully functional. However, it can be challenging for a user to determine what is required or how to define the resource.
 
-As an Operator developer, you can specify a single required custom resource by adding `operatorframework.io/initialization-resource` to the cluster service version (CSV) during Operator installation. You are then prompted  prompted to create the custom resource through a template that is provided in the CSV.
+As an Operator developer, you can specify a single required custom resource by adding `operatorframework.io/initialization-resource` to the cluster service version (CSV) during Operator installation. You are then prompted to create the custom resource through a template that is provided in the CSV.
 The annotation must include a template that contains a complete YAML definition that is required to initialize the resource during installation.
 
 If this annotation is defined, after installing the Operator from the {product-title} web console, the user is prompted to create the resource using the template provided in the CSV.

--- a/modules/osdk-manually-defined-csv-fields.adoc
+++ b/modules/osdk-manually-defined-csv-fields.adoc
@@ -11,7 +11,7 @@ Operator authors must directly modify their cluster service version (CSV) YAML f
 
 The following tables detail which manually-defined CSV fields are required and which are optional.
 
-.Required
+.Required CSV fields
 [cols="2a,8a",options="header"]
 |===
 |Field |Description
@@ -52,7 +52,7 @@ The following tables detail which manually-defined CSV fields are required and w
 |===
 
 
-.Optional
+.Optional CSV fields
 [cols="2a,8a",options="header"]
 |===
 |Field |Description

--- a/modules/osdk-monitoring-custom-metrics.adoc
+++ b/modules/osdk-monitoring-custom-metrics.adoc
@@ -105,7 +105,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
   name: prometheus-k8s-role
-  namespace: <operator_namespace>
+  namespace: memcached-operator-system
 rules:
   - apiGroups:
       - ""

--- a/modules/osdk-pruning-utility-about.adoc
+++ b/modules/osdk-pruning-utility-about.adoc
@@ -6,7 +6,14 @@
 [id="osdk-about-pruning-utility_{context}"]
 = About the operator-lib pruning utility
 
-Objects, such as jobs or pods, are created as a normal part of the Operator life cycle. If the cluster administrator or the Operator does not remove these object, they can stay in the cluster and consume resources.
+Objects, such as jobs or pods, are created as a normal part of the Operator life cycle. If
+ifndef::openshift-dedicated,openshift-rosa[]
+the cluster administrator
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+an administrator with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+or the Operator does not remove these object, they can stay in the cluster and consume resources.
 
 Previously, the following options were available for pruning unnecessary objects:
 

--- a/modules/osdk-pruning-utility-config.adoc
+++ b/modules/osdk-pruning-utility-config.adoc
@@ -59,7 +59,7 @@ The pruning utility configuration file defines pruning actions by using the foll
 |`MaxCountStrategy`, `MaxAgeStrategy`, or `CustomStrategy` are currently supported.
 
 |`Strategy.MaxCountSetting`
-|Integer value for `MaxCountStrategy` that specifies how many resources should remain after the pruning utility run.
+|Integer value for `MaxCountStrategy` that specifies how many resources should remain after the pruning utility runs.
 
 |`Strategy.MaxAgeSetting`
 |Go `time.Duration` string value, such as `48h`, that specifies the age of resources to prune.
@@ -71,7 +71,7 @@ The pruning utility configuration file defines pruning actions by using the foll
 |Optional: Go function to call before pruning a resource.
 
 |`CustomStrategy`
-|Optional: Go function that implements a custom pruning strategy
+|Optional: Go function that implements a custom pruning strategy.
 |===
 
 .Pruning execution

--- a/modules/osdk-publish-catalog.adoc
+++ b/modules/osdk-publish-catalog.adoc
@@ -18,7 +18,12 @@ The Operator SDK uses the `opm` CLI to facilitate index image creation. Experien
 - Operator SDK CLI installed on a development workstation
 - Operator bundle image built and pushed to a registry
 - OLM installed on a Kubernetes-based cluster (v1.16.0 or later if you use `apiextensions.k8s.io/v1` CRDs, for example {product-title} {product-version})
+ifndef::openshift-dedicated,openshift-rosa[]
 - Logged in to the cluster with `oc` using an account with `cluster-admin` permissions
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+- Logged in to the cluster with `oc` using an account with `dedicated-admin` permissions
+endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 

--- a/modules/osdk-quickstart.adoc
+++ b/modules/osdk-quickstart.adoc
@@ -215,7 +215,7 @@ I0205 17:48:45.881666       7 leaderelection.go:253] successfully acquired lease
 ----
 endif::[]
 
-. *Delete a CR*
+. *Delete a CR.*
 +
 Delete a CR by running the following command:
 +

--- a/modules/osdk-run-operator.adoc
+++ b/modules/osdk-run-operator.adoc
@@ -21,6 +21,10 @@ endif::[]
 [id="osdk-run-operator_{context}"]
 = Running the Operator
 
+// The "run locally" and "run as a deployment" options require cluster-admin. Therefore, these options are not available for OSD/ROSA.
+
+// Deployment options for OCP
+ifndef::openshift-dedicated,openshift-rosa[]
 There are three ways you can use the Operator SDK CLI to build and run your Operator:
 
 * Run locally outside the cluster as a Go program.
@@ -33,6 +37,27 @@ ifdef::golang[]
 Before running your Go-based Operator as either a deployment on {product-title} or as a bundle that uses OLM, ensure that your project has been updated to use supported images.
 ====
 endif::[]
+endif::openshift-dedicated,openshift-rosa[]
+
+// Deployment options for OSD/ROSA
+ifdef::openshift-dedicated,openshift-rosa[]
+To build and run your Operator, use the Operator SDK CLI to bundle your Operator, and then use Operator Lifecycle Manager (OLM) to deploy on the cluster.
+
+[NOTE]
+====
+If you wish to deploy your Operator on an OpenShift Container Platform cluster instead of a {product-title} cluster, two additional deployment options are available:
+
+* Run locally outside the cluster as a Go program.
+* Run as a deployment on the cluster.
+====
+
+ifdef::golang[]
+[NOTE]
+====
+Before running your Go-based Operator as a bundle that uses OLM, ensure that your project has been updated to use supported images.
+====
+endif::[]
+endif::openshift-dedicated,openshift-rosa[]
 
 ifeval::["{context}" == "osdk-golang-tutorial"]
 :!golang:

--- a/modules/osdk-run-proxy.adoc
+++ b/modules/osdk-run-proxy.adoc
@@ -18,7 +18,14 @@ endif::[]
 [id="osdk-run-proxy_{context}"]
 = Enabling proxy support
 
-Operator authors can develop Operators that support network proxies. Cluster administrators configure proxy support for the environment variables that are handled by Operator Lifecycle Manager (OLM). To support proxied clusters, your Operator must inspect the environment for the following standard proxy variables and pass the values to Operands:
+Operator authors can develop Operators that support network proxies.
+ifndef::openshift-dedicated,openshift-rosa[]
+Cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+Administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+configure proxy support for the environment variables that are handled by Operator Lifecycle Manager (OLM). To support proxied clusters, your Operator must inspect the environment for the following standard proxy variables and pass the values to Operands:
 
 * `HTTP_PROXY`
 * `HTTPS_PROXY`

--- a/modules/osdk-scorecard-select-tests.adoc
+++ b/modules/osdk-scorecard-select-tests.adoc
@@ -6,7 +6,7 @@
 [id="osdk-scorecard-select-tests_{context}"]
 = Selecting tests
 
-Scorecard tests are selected by setting the `--selector` CLI flag to a set of label strings. If a selector flag is not supplied, then all the tests within the scorecard configuration file are run.
+Scorecard tests are selected by setting the `--selector` CLI flag to a set of label strings. If a selector flag is not supplied, then all of the tests within the scorecard configuration file are run.
 
 Tests are run serially with test results being aggregated by the scorecard and written to standard output, or _stdout_.
 

--- a/modules/osdk-suggested-namespace-node-selector.adoc
+++ b/modules/osdk-suggested-namespace-node-selector.adoc
@@ -10,7 +10,14 @@ Some Operators expect to run only on control plane nodes, which can be done by s
 
 To avoid getting duplicated and potentially conflicting cluster-wide default `nodeSelector`, you can set a default node selector on the namespace where the Operator runs. The default node selector will take precedence over the cluster default so the cluster default will not be applied to the pods in the Operators namespace.
 
-When adding the Operator to a cluster using OperatorHub, the web console auto-populates the suggested namespace for the cluster administrator during the installation process. The suggested namespace is created using the namespace manifest in YAML which is included in the cluster service version (CSV).
+When adding the Operator to a cluster using OperatorHub, the web console auto-populates the suggested namespace for the
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrator
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+installer
+endif::openshift-dedicated,openshift-rosa[]
+during the installation process. The suggested namespace is created using the namespace manifest in YAML which is included in the cluster service version (CSV).
 
 .Procedure
 

--- a/modules/osdk-suggested-namespace.adoc
+++ b/modules/osdk-suggested-namespace.adoc
@@ -8,7 +8,14 @@
 
 Some Operators must be deployed in a specific namespace, or with ancillary resources in specific namespaces, to work properly. If resolved from a subscription, Operator Lifecycle Manager (OLM) defaults the namespaced resources of an Operator to the namespace of its subscription.
 
-As an Operator author, you can instead express a desired target namespace as part of your cluster service version (CSV) to maintain control over the final namespaces of the resources installed for their Operators. When adding the Operator to a cluster using OperatorHub, this enables the web console to autopopulate the suggested namespace for the cluster administrator during the installation process.
+As an Operator author, you can instead express a desired target namespace as part of your cluster service version (CSV) to maintain control over the final namespaces of the resources installed for their Operators. When adding the Operator to a cluster using OperatorHub, this enables the web console to autopopulate the suggested namespace for the
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrator
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+installer
+endif::openshift-dedicated,openshift-rosa[]
+during the installation process.
 
 .Procedure
 

--- a/modules/sd-olm-removing-catalogs.adoc
+++ b/modules/sd-olm-removing-catalogs.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * operators/admin/olm-managing-custom-catalogs.adoc
+
+// The OCP version of this procedure is olm-removing-catalogs.adoc.
+
+:_content-type: PROCEDURE
+[id="sd-olm-removing-catalogs_{context}"]
+= Removing custom catalogs
+
+As an administrator with the `dedicated-admin` role, you can remove custom Operator catalogs that have been previously added to your cluster by deleting the related catalog source.
+
+.Prerequisites
+* You have access to the cluster as a user with the `dedicated-admin` role.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, navigate to *Home* -> *Search*.
+
+. Select a project from the *Project:* list.
+
+. Select *CatalogSource* from the *Resources* list.
+
+. Select the *Options* menu {kebab} for the catalog that you want to remove, and then click *Delete CatalogSource*.

--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -9,7 +9,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Using Operator Lifecycle Manager (OLM), cluster administrators can install OLM-based Operators to an {product-title} cluster.
+Using Operator Lifecycle Manager (OLM),
+ifndef::openshift-dedicated,openshift-rosa[]
+cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+can install OLM-based Operators to an {product-title} cluster.
 
 [NOTE]
 ====
@@ -32,7 +39,7 @@ include::modules/olm-installing-operators-from-operatorhub.adoc[leveloffset=+1]
 * xref:../../operators/understanding/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[Understanding OperatorHub]
 
 include::modules/olm-installing-from-operatorhub-using-web-console.adoc[leveloffset=+1]
-ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
+ifdef::openshift-enterprise,openshift-webscale,openshift-origin,openshift-dedicated,openshift-rosa[]
 include::modules/olm-installing-from-operatorhub-using-cli.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -80,20 +87,28 @@ When you initiate the Operator installation, if the Operator has dependencies, t
 
 include::modules/olm-pod-placement.adoc[leveloffset=+1]
 
+// TODO: Uncondition these xrefs when the Nodes content is ported to OSD/ROSA.
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * Adding taints and tolerations xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-adding_nodes-scheduler-taints-tolerations[manually to nodes] or xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-adding-machineset_nodes-scheduler-taints-tolerations[with compute machine sets]
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors-project_nodes-scheduler-node-selectors[Creating project-wide node selectors]
 * xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-projects_nodes-scheduler-taints-tolerations[Creating a project with a node selector and toleration]
+endif::openshift-dedicated,openshift-rosa[]
 endif::[]
 
 include::modules/olm-overriding-operator-pod-affinity.adoc[leveloffset=+1]
 
+// TODO: Uncondition these xrefs when the Nodes content is ported to OSD/ROSA.
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity-about_nodes-scheduler-pod-affinity[Understanding pod affinity]
 * xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-about_nodes-scheduler-node-affinity[Understanding node affinity]
-* xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes].
-
+endif::openshift-dedicated,openshift-rosa[]
+// This xref points to a topic not currently included in the OSD and ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/admin/olm-configuring-proxy-support.adoc
+++ b/operators/admin/olm-configuring-proxy-support.adoc
@@ -11,8 +11,19 @@ If a global proxy is configured on the {product-title} cluster, Operator Lifecyc
 [role="_additional-resources"]
 .Additional resources
 
+// Configuring the cluster-wide proxy is a different topic in OSD/ROSA.
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[Configuring the cluster-wide proxy]
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* xref:../../networking/configuring-cluster-wide-proxy.adoc[Configuring a cluster-wide proxy]
+endif::openshift-dedicated,openshift-rosa[]
+
+// This xref points to a topic that is not currently included in the OSD and ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../networking/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI] (custom CA certificate)
+endif::openshift-dedicated,openshift-rosa[]
+
 * Developing Operators that support proxy settings for xref:../../operators/operator_sdk/golang/osdk-golang-tutorial.adoc#osdk-run-proxy_osdk-golang-tutorial[Go], xref:../../operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc#osdk-run-proxy_osdk-ansible-tutorial[Ansible], and xref:../../operators/operator_sdk/helm/osdk-helm-tutorial.adoc#osdk-run-proxy_osdk-helm-tutorial[Helm]
 
 

--- a/operators/admin/olm-cs-podsched.adoc
+++ b/operators/admin/olm-cs-podsched.adoc
@@ -33,26 +33,36 @@ include::modules/disabling-catalogsource-objects.adoc[leveloffset=+1]
 
 * xref:../../operators/understanding/olm-understanding-operatorhub.adoc#olm-operatorhub-arch-operatorhub_crd_olm-understanding-operatorhub[OperatorHub custom resource]
 
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks-operatorhub_olm-restricted-networks[Disabling the default OperatorHub catalog sources]
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../operators/admin/olm-restricted-networks.html#olm-restricted-networks-operatorhub_olm-restricted-networks[Disabling the default OperatorHub catalog sources]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-node-selector.adoc[leveloffset=+1]
 
+// TODO: Uncondition this xref when the Nodes content is ported to OSD/ROSA.
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-priority-class-name.adoc[leveloffset=+1]
 
+// TODO: Uncondition this xref when the Nodes content is ported to OSD/ROSA.
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/pods/nodes-pods-priority.adoc#admin-guide-priority-preemption-priority-class_nodes-pods-priority[Pod priority classes]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-tolerations.adoc[leveloffset=+1]
 
+// TODO: Uncondition this xref with the Nodes content is ported to OSD/ROSA.
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
-
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/admin/olm-deleting-operators-from-cluster.adoc
+++ b/operators/admin/olm-deleting-operators-from-cluster.adoc
@@ -10,7 +10,11 @@ The following describes how to delete, or uninstall, Operators that were previou
 
 [IMPORTANT]
 ====
-You must successfully and completely uninstall an Operator prior to attempting to reinstall the same Operator. Failure to fully uninstall the Operator properly can leave resources, such as a project or namespace, stuck in a "Terminating" state and cause "error resolving resource" messages to be observed when trying to reinstall the Operator. For more information, see xref:../../support/troubleshooting/troubleshooting-operator-issues.adoc#olm-reinstall_troubleshooting-operator-issues[Reinstalling Operators after failed uninstallation].
+You must successfully and completely uninstall an Operator prior to attempting to reinstall the same Operator. Failure to fully uninstall the Operator properly can leave resources, such as a project or namespace, stuck in a "Terminating" state and cause "error resolving resource" messages to be observed when trying to reinstall the Operator.
+// TODO: Uncondition this xref when the Support content is ported to OSD/ROSA.
+ifndef::openshift-dedicated,openshift-rosa[]
+For more information, see xref:../../support/troubleshooting/troubleshooting-operator-issues.adoc#olm-reinstall_troubleshooting-operator-issues[Reinstalling Operators after failed uninstallation].
+endif::openshift-dedicated,openshift-rosa[]
 ====
 
 include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]

--- a/operators/admin/olm-managing-custom-catalogs.adoc
+++ b/operators/admin/olm-managing-custom-catalogs.adoc
@@ -6,7 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Cluster administrators and Operator catalog maintainers can create and manage custom catalogs packaged using the xref:../../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[bundle format] on Operator Lifecycle Manager (OLM) in {product-title}.
+ifndef::openshift-dedicated,openshift-rosa[]
+Cluster administrators
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+Administrators with the `dedicated-admin` role
+endif::openshift-dedicated,openshift-rosa[]
+and Operator catalog maintainers can create and manage custom catalogs packaged using the xref:../../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[bundle format] on Operator Lifecycle Manager (OLM) in {product-title}.
 
 [IMPORTANT]
 ====
@@ -23,7 +29,7 @@ If your cluster is using custom catalogs, see xref:../../operators/operator_sdk/
 [id="olm-managing-custom-catalogs-bundle-format-prereqs"]
 == Prerequisites
 
-* Install the xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[`opm` CLI].
+* You have installed the xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[`opm` CLI].
 
 [id="olm-managing-custom-catalogs-fb"]
 == File-based catalogs
@@ -36,7 +42,13 @@ As of {product-title} 4.11, the default Red Hat-provided Operator catalog releas
 
 The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
 
-Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format] and xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format.
+ifndef::openshift-dedicated,openshift-rosa[]
+For more information about working with file-based catalogs, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format] and xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+For more information about working with file-based catalogs, see xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format].
+endif::openshift-dedicated,openshift-rosa[]
 ====
 
 include::modules/olm-creating-fb-catalog-image.adoc[leveloffset=+2]
@@ -46,11 +58,13 @@ include::modules/olm-creating-fb-catalog-image.adoc[leveloffset=+2]
 * xref:../../cli_reference/opm/cli-opm-ref.adoc#cli-opm-ref[`opm` CLI reference]
 
 include::modules/olm-filtering-fbc.adoc[leveloffset=+2]
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#updating-mirror-registry-content[Mirroring images for a disconnected installation using the oc-mirror plugin -> Keeping your mirror registry content updated]
 * xref:../../operators/admin/olm-restricted-networks.adoc#olm-creating-catalog-from-index_olm-restricted-networks[Adding a catalog source to a cluster]
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="olm-managing-custom-catalogs-sqlite"]
 == SQLite-based catalogs
@@ -64,10 +78,13 @@ include::modules/olm-pruning-index-image.adoc[leveloffset=+2]
 
 include::modules/olm-catalog-source-and-psa.adoc[leveloffset=+1]
 
+// This xref points to a topic that is not currently included in the OSD and ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-migrating-sqlite-catalog-to-fbc.adoc[leveloffset=+2]
 
@@ -85,9 +102,14 @@ include::modules/olm-creating-catalog-from-index.adoc[leveloffset=+1]
 .Additional resources
 
 * xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource_olm-understanding-olm[Operator Lifecycle Manager concepts and resources -> Catalog source]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries]
+// This xref may be relevant to OSD/ROSA, but the topic is not currently included in the OSD and ROSA docs.
 * xref:../../openshift_images/managing_images/image-pull-policy.adoc#image-pull-policy[Image pull policy]
+endif::openshift-dedicated,openshift-rosa[]
 
+// Exclude from OSD/ROSA - dedicated-admins can't create the necessary secrets to do this procedure.
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/olm-accessing-images-private-registries.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -96,6 +118,17 @@ include::modules/olm-accessing-images-private-registries.adoc[leveloffset=+1]
 * See xref:../../cicd/builds/creating-build-inputs.adoc#builds-secrets-overview_creating-build-inputs[What is a secret?] for more information on the types of secrets, including those used for registry credentials.
 * See xref:../../openshift_images/managing_images/using-image-pull-secrets.adoc#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret] for more details on the impact of changing this secret.
 * See xref:../../openshift_images/managing_images/using-image-pull-secrets.adoc#images-allow-pods-to-reference-images-from-secure-registries_using-image-pull-secrets[Allowing pods to reference images from other secured registries] for more details on linking pull secrets to service accounts per namespace.
+endif::openshift-dedicated,openshift-rosa[]
 
+// Exclude from OSD/ROSA - dedicated-admins can't do this procedure.
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/olm-restricted-networks-configuring-operatorhub.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
+
+// Removing custom catalogs can be done as a dedicated-admin, but the steps are different.
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/olm-removing-catalogs.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+include::modules/sd-olm-removing-catalogs.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/admin/olm-managing-operatorconditions.adoc
+++ b/operators/admin/olm-managing-operatorconditions.adoc
@@ -6,7 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 As a cluster administrator, you can manage Operator conditions by using Operator Lifecycle Manager (OLM).
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+As an administrator with the `dedicated-admin` role, you can manage Operator conditions by using Operator Lifecycle Manager (OLM).
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-overriding-operatorconditions.adoc[leveloffset=+1]
 include::modules/olm-updating-use-operatorconditions.adoc[leveloffset=+1]

--- a/operators/admin/olm-status.adoc
+++ b/operators/admin/olm-status.adoc
@@ -23,4 +23,6 @@ include::modules/olm-cs-status-cli.adoc[leveloffset=+1]
 
 * xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource_olm-understanding-olm[Operator Lifecycle Manager concepts and resources -> Catalog source]
 * gRPC documentation: link:https://grpc.github.io/grpc/core/md_doc_connectivity-semantics-and-api.html[States of Connectivity]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries]
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/admin/olm-upgrading-operators.adoc
+++ b/operators/admin/olm-upgrading-operators.adoc
@@ -6,7 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-As a cluster administrator, you can update Operators that have been previously installed using Operator Lifecycle Manager (OLM) on your {product-title} cluster.
+As
+ifndef::openshift-dedicated,openshift-rosa[]
+a cluster administrator,
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+an administrator with the `dedicated-admin` role,
+endif::[]
+you can update Operators that have been previously installed using Operator Lifecycle Manager (OLM) on your {product-title} cluster.
 
 [NOTE]
 ====

--- a/operators/index.adoc
+++ b/operators/index.adoc
@@ -8,9 +8,21 @@ toc::[]
 
 include::modules/operators-overview.adoc[leveloffset=+1]
 
-With Operators, you can create applications to monitor the running services in the cluster.
-Operators are designed specifically for your applications. Operators implement and automate the common Day 1 operations such as installation and configuration as well as Day 2 operations such as autoscaling up and down and creating backups. All these activities are in a piece of software running inside your cluster.
+With Operators, you can create applications to monitor the running services in the cluster. Operators are designed specifically for your applications. Operators implement and automate the common Day 1 operations such as installation and configuration as well as Day 2 operations such as autoscaling up and down and creating backups. All these activities are in a piece of software running inside your cluster.
 
+// Include Cluster Operators and Add-on Operators for OSD/ROSA. These modules are in architecture/control-place.adoc, but this assembly is not currently included in the OSD/ROSA docs.
+ifdef::openshift-dedicated,openshift-rosa[]
+
+== Operators in {product-title}
+include::modules/arch-cluster-operators.adoc[leveloffset=+2]
+
+include::modules/arch-olm-operators.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* For more details on running add-on Operators in {product-title}, see the _Operators_ guide sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[Operator Lifecycle Manager (OLM)] and xref:../operators/understanding/olm-understanding-operatorhub.adoc#olm-understanding-operatorhub[OperatorHub].
+* For more details on the Operator SDK, see xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Developing Operators].
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="operators-overview-developer-tasks"]
 == For developers
@@ -18,31 +30,58 @@ Operators are designed specifically for your applications. Operators implement a
 As a developer, you can perform the following Operator tasks:
 
 ** xref:../operators/operator_sdk/osdk-installing-cli.adoc#osdk-installing-cli[Install Operator SDK CLI].
+// The Operator quickstarts aren't published for OSD/ROSA, so for OSD/ROSA, these xrefs point to the tutorials instead.
+ifndef::openshift-dedicated,openshift-rosa[]
 ** Create xref:../operators/operator_sdk/golang/osdk-golang-quickstart.adoc#osdk-golang-quickstart[Go-based Operators], xref:../operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc#osdk-ansible-quickstart[Ansible-based Operators], xref:../operators/operator_sdk/java/osdk-java-quickstart.adoc#osdk-java-quickstart[Java-based Operators], and xref:../operators/operator_sdk/helm/osdk-helm-quickstart.adoc#osdk-helm-quickstart[Helm-based Operators].
-** xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Use Operator SDK to build,test, and deploy an Operator].
+endif::openshift-dedicated,openshift-rosa[]
+// TODO: When the Java-based Operators is GA, it can be added to the list below for OSD/ROSA.
+ifdef::openshift-dedicated,openshift-rosa[]
+** Create xref:../operators/operator_sdk/golang/osdk-golang-tutorial.adoc#osdk-golang-tutorial[Go-based Operators], xref:../operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc#osdk-ansible-tutorial[Ansible-based Operators], and xref:../operators/operator_sdk/helm/osdk-helm-tutorial.adoc#osdk-helm-tutorial[Helm-based Operators].
+endif::openshift-dedicated,openshift-rosa[]
+** xref:../operators/operator_sdk/osdk-about.adoc#osdk-about[Use Operator SDK to build, test, and deploy an Operator].
+ifndef::openshift-dedicated,openshift-rosa[]
 ** xref:../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-operators-in-namespace[Install and subscribe an Operator to your namespace].
+endif::openshift-dedicated,openshift-rosa[]
 ** xref:../operators/user/olm-creating-apps-from-installed-operators.adoc#olm-creating-apps-from-installed-operators[Create an application from an installed Operator through the web console].
 
+// This xref could be relevant for OSD/ROSA, but the target doesn't currently exist in the OSD/ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../machine_management/deleting-machine.adoc#machine-lifecycle-hook-deletion-uses_deleting-machine[Machine deletion lifecycle hook examples for Operator developers]
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="operators-overview-administrator-tasks"]
 == For administrators
 
+ifndef::openshift-dedicated,openshift-rosa[]
 As a cluster administrator, you can perform the following Operator tasks:
+endif::openshift-dedicated,openshift-rosa[]
 
-** xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Manage custom catalogs]
-** xref:../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allow non-cluster administrators to install Operators]
-** xref:../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-operators-in-namespace[Install an Operator from OperatorHub]
+ifdef::openshift-dedicated,openshift-rosa[]
+As an administrator with the `dedicated-admin` role, you can perform the following Operator tasks:
+endif::openshift-dedicated,openshift-rosa[]
+
+** xref:../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Manage custom catalogs].
+ifndef::openshift-dedicated,openshift-rosa[]
+** xref:../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allow non-cluster administrators to install Operators].
+endif::openshift-dedicated,openshift-rosa[]
+ifndef::openshift-dedicated,openshift-rosa[]
+** xref:../operators/user/olm-installing-operators-in-namespace.adoc#olm-installing-operators-in-namespace[Install an Operator from OperatorHub].
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+** xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-operators-from-operatorhub_olm-adding-operators-to-a-cluster[Install an Operator from OperatorHub].
+endif::openshift-dedicated,openshift-rosa[]
 ** xref:../operators/admin/olm-status.adoc#olm-status[View Operator status].
-** xref:../operators/admin/olm-managing-operatorconditions.adoc#olm-managing-operatorconditions[Manage Operator conditions]
-** xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrade installed Operators]
-** xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Delete installed Operators]
-** xref:../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configure proxy support]
-** xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Use Operator Lifecycle Manager on restricted networks]
+** xref:../operators/admin/olm-managing-operatorconditions.adoc#olm-managing-operatorconditions[Manage Operator conditions].
+** xref:../operators/admin/olm-upgrading-operators.adoc#olm-upgrading-operators[Upgrade installed Operators].
+** xref:../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Delete installed Operators].
+** xref:../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[Configure proxy support].
+ifndef::openshift-dedicated,openshift-rosa[]
+** xref:../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Use Operator Lifecycle Manager on restricted networks].
 
 To know all about the cluster Operators that Red Hat provides, see xref:../operators/operator-reference.adoc#cluster-operators-ref[Cluster Operators reference].
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="operators-overview-next-steps"]
 == Next steps

--- a/operators/operator-reference.adoc
+++ b/operators/operator-reference.adoc
@@ -24,20 +24,24 @@ include::modules/cluster-bare-metal-operator.adoc[leveloffset=+1]
 * xref:../installing/cluster-capabilities.adoc#cluster-bare-metal-operator_cluster-capabilities[Bare-metal capability]
 
 include::modules/baremetal-event-relay.adoc[leveloffset=+1]
+
 include::modules/cloud-credential-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 [discrete]
 [id="additional-resources_cluster-op-ref-cco"]
 === Additional resources
-
 * xref:../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
 * xref:../rest_api/security_apis/credentialsrequest-cloudcredential-openshift-io-v1.adoc#credentialsrequest-cloudcredential-openshift-io-v1[`CredentialsRequest` custom resource]
 
 include::modules/cluster-authentication-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-autoscaler-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-cloud-controller-manager-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-capi-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-config-operator.adoc[leveloffset=+1]
 
 include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+1]
@@ -47,9 +51,13 @@ include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+1]
 * xref:../installing/cluster-capabilities.adoc#cluster-csi-snapshot-controller-operator_cluster-capabilities[CSI snapshot controller capability]
 
 include::modules/cluster-image-registry-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-machine-approver-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-monitoring-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-network-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-samples-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -64,6 +72,7 @@ include::modules/cluster-storage-operator.adoc[leveloffset=+1]
 * xref:../installing/cluster-capabilities.adoc#cluster-storage-operator_cluster-capabilities[Storage capability]
 
 include::modules/cluster-version-operator.adoc[leveloffset=+1]
+
 include::modules/console-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -81,27 +90,34 @@ include::modules/control-plane-machine-set-operator.adoc[leveloffset=+1]
 * xref:../rest_api/machine_apis/controlplanemachineset-machine-openshift-io-v1.adoc#controlplanemachineset-machine-openshift-io-v1[`ControlPlaneMachineSet` custom resource]
 
 include::modules/cluster-dns-operator.adoc[leveloffset=+1]
+
 include::modules/etcd-operator.adoc[leveloffset=+1]
+
 include::modules/ingress-operator.adoc[leveloffset=+1]
+
 include::modules/insights-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../installing/cluster-capabilities.adoc#insights-operator_cluster-capabilities[Insights capability]
 * See xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for details about Insights Operator and Telemetry.
 
 include::modules/kube-apiserver-operator.adoc[leveloffset=+1]
+
 include::modules/kube-controller-manager-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-kube-scheduler-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-kube-storage-version-migrator-operator.adoc[leveloffset=+1]
+
 include::modules/machine-api-operator.adoc[leveloffset=+1]
+
 include::modules/machine-config-operator.adoc[leveloffset=+1]
+
 include::modules/operator-marketplace.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * xref:../installing/cluster-capabilities.adoc#marketplace-operator_cluster-capabilities[Marketplace capability]
 
 include::modules/node-tuning-operator.adoc[leveloffset=+1]
@@ -110,10 +126,10 @@ include::modules/node-tuning-operator.adoc[leveloffset=+1]
 [role="_additional-resources"]
 [id="cluster-operators-ref-nto-addtl-resources"]
 === Additional resources
-
 * xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-understanding-low-latency_cnf-master[Low latency tuning of OCP nodes]
 
 include::modules/openshift-apiserver-operator.adoc[leveloffset=+1]
+
 include::modules/cluster-openshift-controller-manager-operators.adoc[leveloffset=+1]
 
 [id="cluster-operators-ref-olm"]
@@ -133,13 +149,12 @@ include::modules/olm-arch-catalog-registry.adoc[leveloffset=+2]
 [discrete]
 [id="cluster-operators-ref-olm-addtl-resources"]
 === Additional resources
-
 * For more information, see the sections on xref:../operators/understanding/olm/olm-understanding-olm.adoc#olm-understanding-olm[understanding Operator Lifecycle Manager (OLM)].
 
 include::modules/openshift-service-ca-operator.adoc[leveloffset=+1]
+
 include::modules/vsphere-problem-detector-operator.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
-
 * For more details, see xref:../installing/installing_vsphere/using-vsphere-problem-detector-operator.adoc#using-vsphere-problem-detector-operator[Using the vSphere Problem Detector Operator].

--- a/operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+// This assembly is currently excluded from the OSD and ROSA docs, because it requires cluster-admin permissions.
+
 The Operator SDK includes options for generating an Operator project that leverages existing Ansible playbooks and modules to deploy Kubernetes resources as a unified application, without having to write any Go code.
 
 To demonstrate the basics of setting up and running an link:https://docs.ansible.com/ansible/latest/index.html[Ansible]-based Operator using tools and libraries provided by the Operator SDK, Operator developers can build an example Ansible-based Operator for Memcached, a distributed key-value store, and deploy it to a cluster.

--- a/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
+++ b/operators/operator_sdk/ansible/osdk-ansible-tutorial.adoc
@@ -18,10 +18,20 @@ Operator SDK:: The `operator-sdk` CLI tool and `controller-runtime` library API
 
 Operator Lifecycle Manager (OLM):: Installation, upgrade, and role-based access control (RBAC) of Operators on a cluster
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [NOTE]
 ====
 This tutorial goes into greater detail than xref:../../../operators/operator_sdk/ansible/osdk-ansible-quickstart.adoc#osdk-ansible-quickstart[Getting started with Operator SDK for Ansible-based Operators].
 ====
+endif::openshift-dedicated,openshift-rosa[]
+
+// The "Getting started" quickstarts require cluster-admin and are therefore only available in OCP.
+ifdef::openshift-dedicated,openshift-rosa[]
+[NOTE]
+====
+This tutorial goes into greater detail than link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-ansible-quickstart[Getting started with Operator SDK for Ansible-based Operators] in the OpenShift Container Platform documentation.
+====
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
 
@@ -37,9 +47,21 @@ include::modules/osdk-ansible-create-api.adoc[leveloffset=+1]
 include::modules/osdk-ansible-modify-manager.adoc[leveloffset=+1]
 
 include::modules/osdk-run-proxy.adoc[leveloffset=+1]
+
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-run-locally_osdk-ansible-tutorial[Running locally outside the cluster] (OpenShift Container Platform documentation)
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-run-deployment_osdk-ansible-tutorial[Running as a deployment on the cluster] (OpenShift Container Platform documentation)
+endif::openshift-dedicated,openshift-rosa[]
+
+// In OSD/ROSA, the only applicable option for running the Operator is to bundle and deploy with OLM.
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="osdk-bundle-deploy-olm_{context}"]
 === Bundling an Operator and deploying with Operator Lifecycle Manager
@@ -54,4 +76,9 @@ include::modules/osdk-create-cr.adoc[leveloffset=+1]
 == Additional resources
 
 * See xref:../../../operators/operator_sdk/ansible/osdk-ansible-project-layout.adoc#osdk-ansible-project-layout[Project layout for Ansible-based Operators] to learn about the directory structures created by the Operator SDK.
+ifndef::openshift-dedicated,openshift-rosa[]
 * If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* If a xref:../../../networking/configuring-cluster-wide-proxy.adoc#configuring-a-cluster-wide-proxy[cluster-wide egress proxy is configured], administrators with the `dedicated-admin` role can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/operator_sdk/golang/osdk-golang-quickstart.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-quickstart.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+// This assembly is currently excluded from the OSD and ROSA docs, because it requires cluster-admin permissions.
+
 To demonstrate the basics of setting up and running a Go-based Operator using tools and libraries provided by the Operator SDK, Operator developers can build an example Go-based Operator for Memcached, a distributed key-value store, and deploy it to a cluster.
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]

--- a/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
+++ b/operators/operator_sdk/golang/osdk-golang-tutorial.adoc
@@ -14,10 +14,20 @@ Operator SDK:: The `operator-sdk` CLI tool and `controller-runtime` library API
 
 Operator Lifecycle Manager (OLM):: Installation, upgrade, and role-based access control (RBAC) of Operators on a cluster
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [NOTE]
 ====
 This tutorial goes into greater detail than xref:../../../operators/operator_sdk/golang/osdk-golang-quickstart.adoc#osdk-golang-quickstart[Getting started with Operator SDK for Go-based Operators].
 ====
+endif::openshift-dedicated,openshift-rosa[]
+
+// The "Getting started" quickstarts require cluster-admin and are therefore only available in OCP.
+ifdef::openshift-dedicated,openshift-rosa[]
+[NOTE]
+====
+This tutorial goes into greater detail than link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-golang-quickstart[Getting started with Operator SDK for Go-based Operators] in the OpenShift Container Platform documentation.
+====
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
 
@@ -46,9 +56,20 @@ include::modules/osdk-golang-controller-reconcile-loop.adoc[leveloffset=+2]
 include::modules/osdk-golang-controller-rbac-markers.adoc[leveloffset=+2]
 
 include::modules/osdk-run-proxy.adoc[leveloffset=+1]
+
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
+ifdef::openshift-dedicated,openshift-rosa[]
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-run-locally_osdk-golang-tutorial[Running locally outside the cluster] (OpenShift Container Platform documentation)
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-run-deployment_osdk-golang-tutorial[Running as a deployment on the cluster] (OpenShift Container Platform documentation)
+endif::openshift-dedicated,openshift-rosa[]
+
+// In OSD/ROSA, the only applicable option for running the Operator is to bundle and deploy with OLM.
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="osdk-bundle-deploy-olm_{context}"]
 === Bundling an Operator and deploying with Operator Lifecycle Manager
@@ -63,4 +84,9 @@ include::modules/osdk-create-cr.adoc[leveloffset=+1]
 == Additional resources
 
 * See xref:../../../operators/operator_sdk/golang/osdk-golang-project-layout.adoc#osdk-golang-project-layout[Project layout for Go-based Operators] to learn about the directory structures created by the Operator SDK.
+ifndef::openshift-dedicated,openshift-rosa[]
 * If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* If a xref:../../../networking/configuring-cluster-wide-proxy.adoc#configuring-a-cluster-wide-proxy[cluster-wide egress proxy is configured], administrators with the `dedicated-admin` role can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/operator_sdk/helm/osdk-helm-quickstart.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-quickstart.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+// This assembly is currently excluded from the OSD and ROSA docs, because it requires cluster-admin permissions.
+
 The Operator SDK includes options for generating an Operator project that leverages existing link:https://helm.sh/docs/[Helm] charts to deploy Kubernetes resources as a unified application, without having to write any Go code.
 
 To demonstrate the basics of setting up and running an link:https://helm.sh/docs/[Helm]-based Operator using tools and libraries provided by the Operator SDK, Operator developers can build an example Helm-based Operator for Nginx and deploy it to a cluster.

--- a/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
+++ b/operators/operator_sdk/helm/osdk-helm-tutorial.adoc
@@ -18,10 +18,20 @@ Operator SDK:: The `operator-sdk` CLI tool and `controller-runtime` library API
 
 Operator Lifecycle Manager (OLM):: Installation, upgrade, and role-based access control (RBAC) of Operators on a cluster
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [NOTE]
 ====
 This tutorial goes into greater detail than xref:../../../operators/operator_sdk/helm/osdk-helm-quickstart.adoc#osdk-helm-quickstart[Getting started with Operator SDK for Helm-based Operators].
 ====
+endif::openshift-dedicated,openshift-rosa[]
+
+// The "Getting started" quickstarts require cluster-admin and are therefore only available in OCP.
+ifdef::openshift-dedicated,openshift-rosa[]
+[NOTE]
+====
+This tutorial goes into greater detail than link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-helm-quickstart[Getting started with Operator SDK for Helm-based Operators] in the OpenShift Container Platform documentation.
+====
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
 
@@ -39,9 +49,22 @@ include::modules/osdk-helm-sample-chart.adoc[leveloffset=+2]
 include::modules/osdk-helm-modify-cr.adoc[leveloffset=+2]
 
 include::modules/osdk-run-proxy.adoc[leveloffset=+1]
+
+
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-run-locally_osdk-helm-tutorial[Running locally outside the cluster] (OpenShift Container Platform documentation)
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-run-deployment_osdk-helm-tutorial[Running as a deployment on the cluster] (OpenShift Container Platform documentation)
+endif::openshift-dedicated,openshift-rosa[]
+
+// In OSD/ROSA, the only applicable option for running the Operator is to bundle and deploy with OLM.
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="osdk-bundle-deploy-olm_{context}"]
 === Bundling an Operator and deploying with Operator Lifecycle Manager
@@ -56,4 +79,9 @@ include::modules/osdk-create-cr.adoc[leveloffset=+1]
 == Additional resources
 
 * See xref:../../../operators/operator_sdk/helm/osdk-helm-project-layout.adoc#osdk-helm-project-layout[Project layout for Helm-based Operators] to learn about the directory structures created by the Operator SDK.
+ifndef::openshift-dedicated,openshift-rosa[]
 * If a xref:../../../networking/enable-cluster-wide-proxy.adoc#enable-cluster-wide-proxy[cluster-wide egress proxy is configured], cluster administrators can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* If a xref:../../../networking/configuring-cluster-wide-proxy.adoc#configuring-a-cluster-wide-proxy[cluster-wide egress proxy is configured], administrators with the `dedicated-admin` role can xref:../../../operators/admin/olm-configuring-proxy-support.adoc#olm-configuring-proxy-support[override the proxy settings or inject a custom CA certificate] for specific Operators running on Operator Lifecycle Manager (OLM).
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/operator_sdk/java/osdk-java-quickstart.adoc
+++ b/operators/operator_sdk/java/osdk-java-quickstart.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 :FeatureName: Java-based Operator SDK
 include::snippets/technology-preview.adoc[]
 
+// This assembly is not included in the OSD and ROSA docs, because it is Tech Preview. However, once Java-based Operator SDK is GA, this assembly will still need to be excluded from OSD and ROSA if it continues to require cluster-admin permissions.
+
 toc::[]
 
 To demonstrate the basics of setting up and running a Java-based Operator using tools and libraries provided by the Operator SDK, Operator developers can build an example Java-based Operator for Memcached, a distributed key-value store, and deploy it to a cluster.

--- a/operators/operator_sdk/java/osdk-java-tutorial.adoc
+++ b/operators/operator_sdk/java/osdk-java-tutorial.adoc
@@ -6,6 +6,8 @@ include::_attributes/common-attributes.adoc[]
 :FeatureName: Java-based Operator SDK
 include::snippets/technology-preview.adoc[]
 
+// This assembly is not currrently included in the OSD and ROSA distros, because it is Tech Preview. However, some conditionalization has been added for OSD and ROSA so that the content will be applicable to those distros once this feature is GA and included in the OSD and ROSA docs.
+
 toc::[]
 
 Operator developers can take advantage of Java programming language support in the Operator SDK to build an example Java-based Operator for Memcached, a distributed key-value store, and manage its lifecycle.
@@ -16,10 +18,20 @@ Operator SDK:: The `operator-sdk` CLI tool and `java-operator-sdk` library API
 
 Operator Lifecycle Manager (OLM):: Installation, upgrade, and role-based access control (RBAC) of Operators on a cluster
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [NOTE]
 ====
 This tutorial goes into greater detail than xref:../../../operators/operator_sdk/java/osdk-java-quickstart.adoc#osdk-java-quickstart[Getting started with Operator SDK for Java-based Operators].
 ====
+endif::openshift-dedicated,openshift-rosa[]
+
+// The "Getting started" quickstarts require cluster-admin and are therefore only available in OCP.
+ifdef::openshift-dedicated,openshift-rosa[]
+[NOTE]
+====
+This tutorial goes into greater detail than link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-java-quickstart[Getting started with Operator SDK for Java-based Operators] in the OpenShift Container Platform documentation.
+====
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/osdk-common-prereqs.adoc[leveloffset=+1]
 
@@ -45,8 +57,19 @@ include::modules/osdk-java-controller-labels-memcached.adoc[leveloffset=+2]
 include::modules/osdk-java-controller-memcached-deployment.adoc[leveloffset=+2]
 
 include::modules/osdk-run-operator.adoc[leveloffset=+1]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-run-locally_osdk-java-tutorial[Running locally outside the cluster] (OpenShift Container Platform documentation)
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-run-deployment_osdk-java-tutorial[Running as a deployment on the cluster] (OpenShift Container Platform documentation)
+endif::openshift-dedicated,openshift-rosa[]
+
+// In OSD/ROSA, the only applicable option for running the Operator is to bundle and deploy with OLM.
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/osdk-run-locally.adoc[leveloffset=+2]
 include::modules/osdk-run-deployment.adoc[leveloffset=+2]
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="osdk-bundle-deploy-olm_{context}"]
 === Bundling an Operator and deploying with Operator Lifecycle Manager

--- a/operators/operator_sdk/osdk-about.adoc
+++ b/operators/operator_sdk/osdk-about.adoc
@@ -24,7 +24,13 @@ The Operator SDK is a framework that uses the link:https://github.com/kubernetes
 - Extensions to cover common Operator use cases
 - Metrics set up automatically in any generated Go-based Operator for use on clusters where the Prometheus Operator is deployed
 
-Operator authors with cluster administrator access to a Kubernetes-based cluster (such as {product-title}) can use the Operator SDK CLI to develop their own Operators based on Go, Ansible, or Helm. link:https://kubebuilder.io/[Kubebuilder] is embedded into the Operator SDK as the scaffolding solution for Go-based Operators, which means existing Kubebuilder projects can be used as is with the Operator SDK and continue to work.
+ifndef::openshift-dedicated,openshift-rosa[]
+Operator authors with cluster administrator access to a Kubernetes-based cluster (such as {product-title})
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+Operator authors with dedicated-admin access to {product-title}
+endif::openshift-dedicated,openshift-rosa[]
+can use the Operator SDK CLI to develop their own Operators based on Go, Ansible, Java, or Helm. link:https://kubebuilder.io/[Kubebuilder] is embedded into the Operator SDK as the scaffolding solution for Go-based Operators, which means existing Kubebuilder projects can be used as is with the Operator SDK and continue to work.
 
 [NOTE]
 ====

--- a/operators/operator_sdk/osdk-complying-with-psa.adoc
+++ b/operators/operator_sdk/osdk-complying-with-psa.adoc
@@ -14,7 +14,10 @@ If your Operator project does not require escalated permissions to run, you can 
 * The allowed pod security admission level for the Operator's namespace
 * The allowed security context constraints (SCC) for the workload's service account
 
+// This xref points to a topic that is not currently included in the OSD/ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
 For more information, see xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission].
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/security-context-constraints-psa-synchronization.adoc[leveloffset=+1]
 include::modules/osdk-ensuring-operator-workloads-run-restricted-psa.adoc[leveloffset=+1]
@@ -26,8 +29,11 @@ include::modules/osdk-ensuring-operator-workloads-run-restricted-psa.adoc[levelo
 
 include::modules/osdk-managing-psa-for-operators-with-escalated-permissions.adoc[leveloffset=+1]
 
+// This xref points to a topic that is not included in the OSD/ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
 [id="osdk-complying-with-psa-additional-resources"]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/operator_sdk/osdk-generating-csvs.adoc
+++ b/operators/operator_sdk/osdk-generating-csvs.adoc
@@ -69,7 +69,10 @@ include::modules/olm-defining-csv-webhooks.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+// This xref points to a topic that is not currently included in the OSD and ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../architecture/admission-plug-ins.adoc#admission-webhook-types_admission-plug-ins[Types of webhook admission plugins]
+endif::openshift-dedicated,openshift-rosa[]
 * Kubernetes documentation:
 ** link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook[Validating admission webhooks]
 ** link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook[Mutating admission webhooks]

--- a/operators/operator_sdk/osdk-ha-sno.adoc
+++ b/operators/operator_sdk/osdk-ha-sno.adoc
@@ -6,7 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-An {product-title} cluster can be configured in high-availability (HA) mode, which uses multiple nodes, or in non-HA mode, which uses a single node. A single-node cluster, also known as {sno}, is likely to have more conservative resource constraints. Therefore, it is important that Operators installed on a single-node cluster can adjust accordingly and still run well.
+// OSD/ROSA don't support single-node clusters, but these Operator authors still need to know how to handle this configuration for their Operators to work correctly in OCP.
+ifdef::openshift-dedicated,openshift-rosa[]
+To ensure that your Operator runs well on both high-availability (HA) and non-HA modes in OpenShift Container Platform clusters, you can use the Operator SDK to detect the cluster's infrastructure topology and set the resource requirements to fit the cluster's topology.
+endif::openshift-dedicated,openshift-rosa[]
+
+// Not using {product-title} here, because HA mode and non-HA mode are specific to OCP and should be spelled out this way in other distros.
+An OpenShift Container Platform cluster can be configured in high-availability (HA) mode, which uses multiple nodes, or in non-HA mode, which uses a single node. A single-node cluster, also known as {sno}, is likely to have more conservative resource constraints. Therefore, it is important that Operators installed on a single-node cluster can adjust accordingly and still run well.
 
 By accessing the cluster high-availability mode API provided in {product-title}, Operator authors can use the Operator SDK to enable their Operator to detect a cluster's infrastructure topology, either HA or non-HA mode. Custom Operator logic can be developed that uses the detected cluster topology to automatically switch the resource requirements, both for the Operator and for any Operands or workloads it manages, to a profile that best fits the topology.
 

--- a/operators/operator_sdk/osdk-installing-cli.adoc
+++ b/operators/operator_sdk/osdk-installing-cli.adoc
@@ -8,7 +8,13 @@ toc::[]
 
 The Operator SDK provides a command-line interface (CLI) tool that Operator developers can use to build, test, and deploy an Operator. You can install the Operator SDK CLI on your workstation so that you are prepared to start authoring your own Operators.
 
-Operator authors with cluster administrator access to a Kubernetes-based cluster, such as {product-title}, can use the Operator SDK CLI to develop their own Operators based on Go, Ansible, java, or Helm. link:https://kubebuilder.io/[Kubebuilder] is embedded into the Operator SDK as the scaffolding solution for Go-based Operators, which means existing Kubebuilder projects can be used as is with the Operator SDK and continue to work.
+ifndef::openshift-dedicated,openshift-rosa[]
+Operator authors with cluster administrator access to a Kubernetes-based cluster, such as {product-title},
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+Operator authors with dedicated-admin access to {product-title}
+endif::openshift-dedicated,openshift-rosa[]
+can use the Operator SDK CLI to develop their own Operators based on Go, Ansible, Java, or Helm. link:https://kubebuilder.io/[Kubebuilder] is embedded into the Operator SDK as the scaffolding solution for Go-based Operators, which means existing Kubebuilder projects can be used as is with the Operator SDK and continue to work.
 
 [NOTE]
 ====

--- a/operators/operator_sdk/osdk-monitoring-prometheus.adoc
+++ b/operators/operator_sdk/osdk-monitoring-prometheus.adoc
@@ -6,9 +6,30 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+// Dedicated-admins in OSD and ROSA don't have the permissions to complete the procedures in this assembly. Also, the procedures use the default Prometheus Operator in the openshift-monitoring project, which OSD/ROSA customers should not use.
+
+ifndef::openshift-dedicated,openshift-rosa[]
 This guide describes the built-in monitoring support provided by the Operator SDK using the Prometheus Operator and details usage for authors of Go-based and Ansible-based Operators.
 
 include::modules/osdk-monitoring-prometheus-operator-support.adoc[leveloffset=+1]
-
 include::modules/osdk-monitoring-custom-metrics.adoc[leveloffset=+1]
 include::modules/osdk-ansible-metrics.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+// Since OSD/ROSA dedicated-admins can't do the procedures in this assembly, point to the OCP docs.
+The Operator SDK provides built-in monitoring support using the Prometheus Operator, which you can use to expose custom metrics for your Operator.
+
+[WARNING]
+====
+By default, {product-title} provides a Prometheus Operator in the `openshift-user-workload-monitoring` project. You should use this Prometheus instance to monitor user workloads in {product-title}.
+
+Do not use the Prometheus Operator in the `openshift-monitoring` project. Red Hat Site Reliability Engineers (SRE) use this Prometheus instance to monitor core cluster components.
+====
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-monitoring-custom-metrics_osdk-monitoring-prometheus[Exposing custom metrics for Go-based Operators] (OpenShift Container Platform documentation)
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/operators/index#osdk-ansible-metrics_osdk-monitoring-prometheus[Exposing custom metrics for Ansible-based Operators] (OpenShift Container Platform documentation) 
+* xref:../../monitoring/monitoring-overview.adoc#understanding-the-monitoring-stack_monitoring-overview[Understanding the monitoring stack] in {product-title}
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/understanding/olm-multitenancy.adoc
+++ b/operators/understanding/olm-multitenancy.adoc
@@ -26,8 +26,10 @@ include::modules/olm-multitenancy-solution.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-preparing-operators-multitenant_olm-adding-operators-to-a-cluster[Preparing for multiple instances of an Operator for multitenant clusters]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allowing non-cluster administrators to install Operators]
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-restricted-networks-operatorhub_olm-managing-custom-catalogs[Disabling the default OperatorHub catalog sources]
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="olm-colocation_{context}"]
 == Operator colocation and Operator groups

--- a/operators/understanding/olm-packaging-format.adoc
+++ b/operators/understanding/olm-packaging-format.adoc
@@ -39,7 +39,13 @@ As of {product-title} 4.11, the default Red Hat-provided Operator catalog releas
 
 The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
 
-Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs] and xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format.
+ifndef::openshift-dedicated,openshift-rosa[]
+For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs] and xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs-fb[Managing custom catalogs].
+endif::openshift-dedicated,openshift-rosa[]
 ====
 
 include::modules/olm-fb-catalogs-structure.adoc[leveloffset=+2]
@@ -57,6 +63,8 @@ For reference documentation about the `opm` CLI commands related to managing fil
 
 include::modules/olm-fb-catalogs-automation.adoc[leveloffset=+2]
 
+// Tech Preview features should not be included in ROSA/OSD.
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/olm-rukpak-about.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
@@ -74,5 +82,6 @@ include::modules/olm-rukpak-registry-bundle.adoc[leveloffset=+3]
 * xref:../../operators/understanding/olm-packaging-format.adoc#olm-bundle-format_olm-packaging-format[Legacy OLM bundle format]
 
 include::modules/olm-rukpak-bd.adoc[leveloffset=+2]
-include::modules/olm-rukpak-provisioner.adoc[leveloffset=+2]
 
+include::modules/olm-rukpak-provisioner.adoc[leveloffset=+2]
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/understanding/olm-rh-catalogs.adoc
+++ b/operators/understanding/olm-rh-catalogs.adoc
@@ -14,8 +14,15 @@ As of {product-title} 4.11, the default Red Hat-provided Operator catalog releas
 
 The `opm` subcommands, flags, and functionality related to the SQLite database format are also deprecated and will be removed in a future release. The features are still supported and must be used for catalogs that use the deprecated SQLite database format.
 
-Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format. For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs], 
+Many of the `opm` subcommands and flags for working with the SQLite database format, such as `opm index prune`, do not work with the file-based catalog format.
+ifndef::openshift-dedicated,openshift-rosa[]
+For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs], 
 xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format], and xref:../../installing/disconnected_install/installing-mirroring-disconnected.adoc#installing-mirroring-disconnected[Mirroring images for a disconnected installation using the oc-mirror plugin].
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+For more information about working with file-based catalogs, see xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs], and  
+xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Operator Framework packaging format].
+endif::openshift-dedicated,openshift-rosa[]
 ====
 
 include::modules/olm-about-catalogs.adoc[leveloffset=+1]
@@ -25,6 +32,8 @@ include::modules/olm-about-catalogs.adoc[leveloffset=+1]
 
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-managing-custom-catalogs[Managing custom catalogs]
 * xref:../../operators/understanding/olm-packaging-format.adoc#olm-file-based-catalogs_olm-packaging-format[Packaging format]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-rh-catalogs.adoc[leveloffset=+1]

--- a/operators/understanding/olm/olm-operatorconditions.adoc
+++ b/operators/understanding/olm/olm-operatorconditions.adoc
@@ -17,5 +17,8 @@ include::modules/olm-supported-operatorconditions.adoc[leveloffset=+1]
 
 * xref:../../../operators/admin/olm-managing-operatorconditions.adoc#olm-operatorconditions[Managing Operator conditions]
 * xref:../../../operators/operator_sdk/osdk-generating-csvs.adoc#osdk-operatorconditions_osdk-generating-csvs[Enabling Operator conditions]
+// The following xrefs point to topics that are not currently included in the OSD/ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../../nodes/pods/nodes-pods-configuring.adoc#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring[Using pod disruption budgets to specify the number of pods that must be up]
 * xref:../../../applications/deployments/route-based-deployment-strategies.adoc#deployments-graceful-termination_route-based-deployment-strategies[Graceful termination]
+endif::openshift-dedicated,openshift-rosa[]

--- a/operators/understanding/olm/olm-understanding-olm.adoc
+++ b/operators/understanding/olm/olm-understanding-olm.adoc
@@ -20,32 +20,41 @@ include::modules/olm-catalogsource.adoc[leveloffset=+2]
 * xref:../../../operators/admin/olm-managing-custom-catalogs.adoc#olm-creating-catalog-from-index_olm-managing-custom-catalogs[Adding a catalog source to a cluster]
 * xref:../../../operators/understanding/olm/olm-understanding-dependency-resolution.adoc#olm-dependency-catalog-priority_olm-understanding-dependency-resolution[Catalog priority]
 * xref:../../../operators/admin/olm-status.adoc#olm-cs-status-cli_olm-status[Viewing Operator catalog source status by using the CLI]
+// This xref points to a topic that is not currently included in the OSD/ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
+endif::openshift-dedicated,openshift-rosa[]
 * xref:../../../operators/admin/olm-cs-podsched.adoc#olm-cs-podsched[Catalog source pod scheduling]
 
 include::modules/olm-catalogsource-image-template.adoc[leveloffset=+3]
 include::modules/olm-cs-health.adoc[leveloffset=+3]
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../../operators/admin/olm-managing-custom-catalogs.adoc#olm-removing-catalogs_olm-managing-custom-catalogs[Removing custom catalogs]
 * xref:../../../operators/admin/olm-managing-custom-catalogs.adoc#olm-restricted-networks-operatorhub_olm-managing-custom-catalogs[Disabling the default OperatorHub catalog sources]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-subscription.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../../operators/understanding/olm/olm-colocation.adoc#olm-colocation[Multitenancy and Operator colocation]
+endif::openshift-dedicated,openshift-rosa[]
 * xref:../../../operators/admin/olm-status.adoc#olm-status-viewing-cli_olm-status[Viewing Operator subscription status by using the CLI]
 
 include::modules/olm-installplan.adoc[leveloffset=+2]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../../operators/understanding/olm/olm-colocation.adoc#olm-colocation[Multitenancy and Operator colocation]
 * xref:../../../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allowing non-cluster administrators to install Operators]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-operatorgroups-about.adoc[leveloffset=+2]
 .Additional resources

--- a/operators/understanding/olm/olm-understanding-operatorgroups.adoc
+++ b/operators/understanding/olm/olm-understanding-operatorgroups.adoc
@@ -20,9 +20,12 @@ include::modules/olm-operatorgroups-intersections.adoc[leveloffset=+1]
 include::modules/olm-operatorgroups-limitations.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../../operators/understanding/olm/olm-colocation.adoc#olm-colocation[Operator Lifecycle Manager (OLM) -> Multitenancy and Operator colocation]
+endif::openshift-dedicated,openshift-rosa[]
 * xref:../../../operators/understanding/olm-multitenancy.adoc#olm-multitenancy[Operators in multitenant clusters]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../../operators/admin/olm-creating-policy.adoc#olm-creating-policy[Allowing non-cluster administrators to install Operators]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-operatorgroups-troubleshooting.adoc[leveloffset=+1]

--- a/operators/understanding/olm/olm-webhooks.adoc
+++ b/operators/understanding/olm/olm-webhooks.adoc
@@ -14,7 +14,9 @@ See xref:../../../operators/operator_sdk/osdk-generating-csvs.adoc#olm-defining-
 [role="_additional-resources"]
 == Additional resources
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../../architecture/admission-plug-ins.adoc#admission-webhook-types_admission-plug-ins[Types of webhook admission plugins]
+endif::openshift-dedicated,openshift-rosa[]
 * Kubernetes documentation:
 ** link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#validatingadmissionwebhook[Validating admission webhooks]
 ** link:https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/#mutatingadmissionwebhook[Mutating admission webhooks]


### PR DESCRIPTION
This PR ports the Operators book from OCP to the OSD and ROSA books using single-sourcing.

Version(s):
* `enterprise-4.13`

Issue:
https://issues.redhat.com/browse/OSDOCS-3991

Link to docs preview:
* OCP: https://61793--docspreview.netlify.app/openshift-enterprise/latest/operators/index.html
* ROSA: https://61793--docspreview.netlify.app/openshift-rosa/latest/operators/index.html
* OSD: https://61793--docspreview.netlify.app/openshift-dedicated/latest/operators/index.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
