### PR TITLE
TELCODOCS-609: D/S Docs & RN: TELCODOCS-579 Remote worker node updates

### DIFF
--- a/installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
+++ b/installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
@@ -1,8 +1,8 @@
 :_content-type: ASSEMBLY
-[id="expanding-a-cluster-with-on-premise-bare-metal-nodes"]
+[id="aws-expanding-a-cluster-with-on-premise-bare-metal-nodes"]
 = Expanding a cluster with on-premise bare metal nodes
 include::_attributes/common-attributes.adoc[]
-:context: expanding-a-cluster-with-on-premise-bare-metal-nodes
+:context: aws-expanding-a-cluster-with-on-premise-bare-metal-nodes
 
 toc::[]
 

--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -12,6 +12,8 @@ include::modules/ipi-install-preparing-the-provisioner-node-for-openshift-instal
 
 include::modules/ipi-install-configuring-networking.adoc[leveloffset=+1]
 
+include::modules/ipi-install-establishing-communication-between-subnets.adoc[leveloffset=+1]
+
 include::modules/ipi-install-retrieving-the-openshift-installer.adoc[leveloffset=+1]
 
 include::modules/ipi-install-extracting-the-openshift-installer.adoc[leveloffset=+1]
@@ -43,6 +45,8 @@ include::modules/ipi-install-modifying-install-config-for-no-provisioning-networ
 include::modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc[leveloffset=+2]
 
 include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
+
+include::modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc[leveloffset=+2]
 
 include::modules/ipi-install-configuring-host-dual-network-interfaces-in-the-install-config.yaml-file.adoc[leveloffset=+2]
 

--- a/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
@@ -1,0 +1,59 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="ipi-install-configuring-host-network-interfaces-for-subnets_{context}"]
+= Configuring host network interfaces for subnets
+
+For edge computing scenarios, it can be beneficial to locate worker nodes closer to the edge. Locating remote worker nodes in subnets often involves using different network segments or subnets for the remote worker nodes than the subnet used by the control plane and local worker nodes. Setting up subnets for edge computing scenarios can reduce latency for the edge and allow for enhanced scalability.
+
+If you have established different network segments or subnets for remote worker nodes as described in the section on "Establishing communication between subnets", you must specify the subnets in the `machineNetwork` configuration setting if the workers are using static IP addresses, bonds or other advanced networking. When setting the node IP address in the `networkConfig` paramter for each remote worker node, you must also specify the gateway and the DNS server for the subnet containing the control plane nodes when using static IP addresses. This ensures the remote worker nodes can reach the subnet containing the control plane nodes and that they can receive network traffic from the control plane.
+
+[IMPORTANT]
+====
+All control plane nodes must run in the same subnet. When using more than one subnet, you can also configure the Ingress VIP to run on the control plane nodes by using a manifest. See "Configuring network components to run on the control plane" for details. 
+
+Deploying a cluster with multiple subnets requires using virtual media.
+====
+
+.Procedure
+
+. Add the subnets to the `machineNetwork` in the `install-config.yaml` file when using static IP addresses:
++
+[source,yaml]
+----
+networking:
+  machineNetwork:
+  - cidr: 10.0.0.0/24
+  - cidr: 192.168.0.0/24
+  networkType: OVNKubernetes
+----
+
+. Add the gateway and DNS configuration to the `networkConfig` parameter of each edge worker node using NMState syntax when using a static IP address or advanced networking such as bonds:
++
+[source,yaml]
+----
+networkConfig:
+  nmstate:
+    interfaces:
+    - name: <interface_name> <1>
+      type: ethernet
+      state: up
+      ipv4:
+        enabled: true
+        dhcp: false
+        address:
+        - ip: <node_ip> <2>
+          prefix-length: 24
+        gateway: <gateway_ip> <3>
+        dns-resolver:
+          config:
+            server:
+            - <dns_ip> <4>
+----
++
+<1> Replace `<interface_name>` with the interface name.
+<2> Replace `<node_ip>` with the IP address of the node.
+<3> Replace `<gateway_ip>` with the IP address of the gateway.
+<4> Replace `<dns_ip>` with the IP address of the DNS server.

--- a/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
@@ -14,7 +14,7 @@ If you have established different network segments or subnets for remote worker 
 ====
 All control plane nodes must run in the same subnet. When using more than one subnet, you can also configure the Ingress VIP to run on the control plane nodes by using a manifest. See "Configuring network components to run on the control plane" for details. 
 
-Deploying a cluster with multiple subnets requires using virtual media.
+Deploying a cluster with multiple subnets requires using virtual media, such as `redfish-virtualmedia` and `idrac-virtualmedia`.
 ====
 
 .Procedure

--- a/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc
@@ -6,7 +6,7 @@
 [id="ipi-install-configuring-host-network-interfaces-for-subnets_{context}"]
 = Configuring host network interfaces for subnets
 
-For edge computing scenarios, it can be beneficial to locate worker nodes closer to the edge. Locating remote worker nodes in subnets often involves using different network segments or subnets for the remote worker nodes than the subnet used by the control plane and local worker nodes. Setting up subnets for edge computing scenarios can reduce latency for the edge and allow for enhanced scalability.
+For edge computing scenarios, it can be beneficial to locate worker nodes closer to the edge. To locate remote worker nodes in subnets, you might use different network segments or subnets for the remote worker nodes than you used for the control plane subnet and local worker nodes. You can reduce latency for the edge and allow for enhanced scalability by setting up subnets for edge computing scenarios.
 
 If you have established different network segments or subnets for remote worker nodes as described in the section on "Establishing communication between subnets", you must specify the subnets in the `machineNetwork` configuration setting if the workers are using static IP addresses, bonds or other advanced networking. When setting the node IP address in the `networkConfig` paramter for each remote worker node, you must also specify the gateway and the DNS server for the subnet containing the control plane nodes when using static IP addresses. This ensures the remote worker nodes can reach the subnet containing the control plane nodes and that they can receive network traffic from the control plane.
 

--- a/modules/ipi-install-establishing-communication-between-subnets.adoc
+++ b/modules/ipi-install-establishing-communication-between-subnets.adoc
@@ -1,0 +1,155 @@
+// This module is included in the following assemblies: 
+//
+// installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="ipi-install-establishing-communication-between-subnets_{context}"]
+= Establishing communication between subnets
+
+In a typical {product-title} cluster setup, all nodes, including the control plane and worker nodes, reside in the same network. However, for edge computing scenarios, it can be beneficial to locate worker nodes closer to the edge. This often involves using different network segments or subnets for the remote worker nodes than the subnet used by the control plane and local worker nodes. Such a setup can reduce latency for the edge and allow for enhanced scalability. However, the network must be configured properly before installing {product-title} to ensure that the edge subnets containing the remote worker nodes can reach the subnet containing the control plane nodes and receive traffic from the control plane too. 
+
+[IMPORTANT]
+====
+All control plane nodes must run in the same subnet. When using more than one subnet, you can also configure the Ingress VIP to run on the control plane nodes by using a manifest. See "Configuring network components to run on the control plane" for details. 
+
+Deploying a cluster with multiple subnets requires using virtual media.
+====
+
+This procedure details the network configuration required to allow the remote worker nodes in the second subnet to communicate effectively with the control plane nodes in the first subnet and to allow the control plane nodes in the first subnet to communicate effectively with the remote worker nodes in the second subnet.
+
+In this procedure, the cluster spans two subnets:
+
+- The first subnet (`10.0.0.0`) contains the control plane and local worker nodes.
+- The second subnet (`192.168.0.0`) contains the edge worker nodes.
+
+.Procedure
+
+. Configure the first subnet to communicate with the second subnet:
+
+.. Log in as `root` to a control plane node by running the following command:
++
+[source,terminal]
+----
+$ sudo su -
+----
+
+.. Get the name of the network interface:
++
+[source,terminal]
+----
+# nmcli dev status
+----
+
+.. Add a route to the second subnet (`192.168.0.0`) via the gateway:
+s+
+[source,terminal]
+----
+# nmcli connection modify <interface_name> +ipv4.routes "192.168.0.0/24 via <gateway>"
+----
++
+Replace `<interface_name>` with the interface name. Replace `<gateway>` with the IP address of the actual gateway.
++
+.Example
++
+[source,terminal]
+----
+# nmcli connection modify eth0 +ipv4.routes "192.168.0.0/24 via 192.168.0.1"
+----
+
+.. Apply the changes:
++
+[source,terminal]
+----
+# nmcli connection up <interface_name>
+----
++
+Replace `<interface_name>` with the interface name.
+
+.. Verify the routing table to ensure the route has been added successfully:
++
+[source,terminal]
+----
+# ip route
+----
+
+.. Repeat the previous steps for each control plane node in the first subnet.
++
+[NOTE]
+====
+Adjust the commands to match your actual interface names and gateway.
+====
+
+. Configure the second subnet to communicate with the first subnet:
+
+.. Log in as `root` to a remote worker node:
++
+[source,terminal]
+----
+$ sudo su -
+----
+
+.. Get the name of the network interface:
++
+[source,terminal]
+----
+# nmcli dev status
+----
+
+.. Add a route to the first subnet (`10.0.0.0`) via the gateway:
++
+[source,terminal]
+----
+# nmcli connection modify <interface_name> +ipv4.routes "10.0.0.0/24 via <gateway>"
+----
++
+Replace `<interface_name>` with the interface name. Replace `<gateway>` with the IP address of the actual gateway.
++
+.Example
++
+[source,terminal]
+----
+# nmcli connection modify eth0 +ipv4.routes "10.0.0.0/24 via 10.0.0.1"
+----
+
+.. Apply the changes:
++
+[source,terminal]
+----
+# nmcli connection up <interface_name>
+----
++
+Replace `<interface_name>` with the interface name.
+
+.. Verify the routing table to ensure the route has been added successfully:
++
+[source,terminal]
+----
+# ip route
+----
+
+.. Repeat the previous steps for each worker node in the second subnet.
++
+[NOTE]
+====
+Adjust the commands to match your actual interface names and gateway.
+====
+
+. Once you have configured the networks, test the connectivity to ensure the remote worker nodes can reach the control plane nodes and the control plane nodes can reach the remote worker nodes. 
+
+.. From the control plane nodes in the first subnet, ping a remote worker node in the second subnet:
++
+[source,terminal]
+----
+$ ping <remote_worker_node_ip_address>
+----
++
+If the ping is successful, it means the control plane nodes in the first subnet can reach the remote worker nodes in the second subnet. If you don't receive a response, review the network configurations and repeat the procedure for the node.
+
+.. From the remote worker nodes in the second subnet, ping a control plane node in the first subnet:
++
+[source,terminal]
+----
+$ ping <control_plane_node_ip_address>
+----
++
+If the ping is successful, it means the remote worker nodes in the second subnet can reach the control plane in the first subnet. If you don't receive a response, review the network configurations and repeat the procedure for the node.

--- a/modules/nodes-rwn_con_adding-remote-worker-nodes.adoc
+++ b/modules/nodes-rwn_con_adding-remote-worker-nodes.adoc
@@ -1,0 +1,19 @@
+// This module is included in the following assemblies: 
+//
+// nodes/edge/nodes-edge-remote-workers.adoc
+
+:_content-type: CONCEPT
+[id="nodes-rwn_con_adding-remote-worker-nodes_{context}"]
+= Adding remote worker nodes
+
+Adding remote worker nodes to a cluster involves some additional considerations. 
+
+* You must ensure that a route or a default gateway is in place to route traffic between the control plane and every remote worker node.
+
+* You must place the Ingress VIP on the control plane. 
+
+* Adding remote worker nodes with user-provisioned infrastructure is identical to adding other worker nodes.
+
+* To add remote worker nodes to an installer-provisioned cluster at install time, specify the subnet for each worker node in the `install-config.yaml` file before installation. There are no additional settings required for the DHCP server. You must use virtual media, because the remote worker nodes will not have access to the local provisioning network.
+
+* To add remote worker nodes to an installer-provisioned cluster deployed with a provisioning network, ensure that `virtualMediaViaExternalNetwork` flag is set to `true` in the `install-config.yaml` file so that it will add the nodes using virtual media. Remote worker nodes will not have access to the local provisioning network. They must be deployed with virtual media rather than PXE. Additionally, specify each subnet for each group of remote worker nodes and the control plane nodes in the DHCP server.

--- a/nodes/edge/nodes-edge-remote-workers.adoc
+++ b/nodes/edge/nodes-edge-remote-workers.adoc
@@ -29,6 +29,17 @@ Note the following limitations when planning a cluster with remote worker nodes:
 
 * You are responsible for configuring and maintaining L2/L3-level network connectivity between the control plane and the network-edge nodes.
 
+include::modules/nodes-rwn_con_adding-remote-worker-nodes.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-establishing-communication-between-subnets_ipi-install-installation-workflow[Establishing communications between subnets]
+
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#ipi-install-configuring-host-network-interfaces-for-subnets_ipi-install-installation-workflow[Configuring host network interfaces for subnets]
+
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configure-network-components-to-run-on-the-control-plane_ipi-install-installation-workflow[Configuring network components to run on the control plane]
+
+
 include::modules/nodes-edge-remote-workers-network.adoc[leveloffset=+1]
 
 For more information on using these objects in a cluster with remote worker nodes, see xref:../../nodes/edge/nodes-edge-remote-workers.html#nodes-edge-remote-workers-strategies_nodes-edge-remote-workers[About remote worker node strategies].
@@ -64,3 +75,4 @@ include::modules/nodes-edge-remote-workers-strategies.adoc[leveloffset=+1]
 * For more information on replication controllers, see xref:../../applications/deployments/what-deployments-are.html#deployments-replicationcontrollers_what-deployments-are[Replication controllers].
 
 * For more information on the controller manager, see xref:../../operators/operator-reference.adoc#kube-controller-manager-operator_cluster-operators-ref[Kubernetes Controller Manager Operator].
+


### PR DESCRIPTION
Added modules to establish edge subnets for remote worker nodes.

Fixes: [TELCODOCS-609](https://issues.redhat.com//browse/TELCODOCS-609)

See https://issues.redhat.com/browse/TELCODOCS-609 for additional details.

Preview URL: http://jowilkin.com:8080/TELCODOCS-609/nodes/edge/nodes-edge-remote-workers.html#adding-remote-worker-nodes_nodes-edge-remote-workers

http://jowilkin.com:8080/TELCODOCS-609/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#establishing-communication-between-subnets_ipi-install-installation-workflow

http://jowilkin.com:8080/TELCODOCS-609/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-host-network-interfaces-for-subnets_ipi-install-installation-workflow

For release(s): 4.14, 4.13-4.10
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
