### PR TITLE
OSDOCS#5739: Added a note related to minversion and maxversion in ImageSetConfiguration

### DIFF
--- a/modules/oc-mirror-imageset-config-params.adoc
+++ b/modules/oc-mirror-imageset-config-params.adoc
@@ -152,7 +152,7 @@ operators:
 |String. For example: `fast` or `stable-v4.13`.
 
 |`mirror.operators.packages.channels.maxVersion`
-|The highest version of the Operator mirror across all channels in which it exists.
+|The highest version of the Operator mirror across all channels in which it exists. See the following note for further information.
 |String. For example: `5.2.3-31`
 
 |`mirror.operators.packages.channels.minBundle`
@@ -160,15 +160,15 @@ operators:
 |String. For example: `bundleName`
 
 |`mirror.operators.packages.channels.minVersion`
-|The lowest version of the Operator to mirror across all channels in which it exists.
+|The lowest version of the Operator to mirror across all channels in which it exists. See the following note for further information.
 |String. For example: `5.2.3-31`
 
 |`mirror.operators.packages.maxVersion`
-|The highest version of the Operator to mirror across all channels in which it exists.
+|The highest version of the Operator to mirror across all channels in which it exists. See the following note for further information.
 |String. For example: `5.2.3-31`.
 
 |`mirror.operators.packages.minVersion`
-|The lowest version of the Operator to mirror across all channels in which it exists.
+|The lowest version of the Operator to mirror across all channels in which it exists. See the following note for further information.
 |String. For example: `5.2.3-31`.
 
 |`mirror.operators.skipDependencies`
@@ -269,3 +269,12 @@ channels:
 |Boolean. The default value is `false`.
 
 |===
+
+[NOTE]
+====
+Using the the `minVersion` and `maxVersion` properties to filter for a specific Operator version range can result in a multiple channel heads error. The error message will state that there are `multiple channel heads`. This is because when the filter is applied, the update graph of the operator is truncated.
+
+The Operator Lifecycle Manager requires that every operator channel contains versions that form an update graph with exactly one end point, that is , the latest version of the operator. When applying the filter range that graph can turn into two or more separate graphs or a graph that has more than one end point.
+
+To avoid this error, do not filter out the latest version of an operator. If you still run into the error, depending on the operator, either the `maxVersion` property needs to be increased or the `minVersion` property needs to be decreased. Because every operator graph can be different, you might need to adjust these values, according to the procedure, until the error is gone.
+====


### PR DESCRIPTION
Version(s): 4.12+

Issue: [OSDOCS 5739](https://issues.redhat.com/browse/OSDOCS-5739)

Link to docs preview:
[Doc preview](https://61801--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected.html#oc-mirror-imageset-config-params_installing-mirroring-disconnected)

QE review:
- [x] QE has approved this change.

Additional information:

