### PR TITLE
OSDOCS#6464: Added bug fix for parse image reference for oc-mirror in the release note

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -496,6 +496,14 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-14-openshift-cli-bug-fixes"]
 ==== OpenShift CLI (oc)
 
+Previously, container image references that have both tag and digest were not correctly interpreted by the oc-mirror plug-in and resulted in the following error:
+
+[source,yaml]
+----
+"localhost:6000/cp/cpd/postgresql:13.7@sha256" is not a valid image reference: invalid reference format
+----
+
+This behavior has been fixed, and the references are now accepted and correctly mirrored. 
 
 [discrete]
 [id="ocp-4-14-olm-bug-fixes"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s): 4.14

Issue: [OSDOCS-6464](https://issues.redhat.com/browse/OSDOCS-6464)

Link to docs preview:
[Doc Preview](https://61802--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-bug-fixes) OpenShift CLI (oc) section in bug fixes.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
