### PR TITLE
Add me-central1 GCP region as supported region

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -32,6 +32,7 @@ regions:
 * `europe-west8` (Milan, Italy)
 * `europe-west9` (Paris, France)
 * `europe-west12` (Turin, Italy)
+* `me-central1` (Doha, Qatar, Middle East)
 * `me-west1` (Tel Aviv, Israel)
 * `northamerica-northeast1` (Montréal, Québec, Canada)
 * `northamerica-northeast2` (Toronto, Ontario, Canada)


### PR DESCRIPTION
Version(s):
CP to 4.13+

Issue:
This PR address [OSDOCS-6664](https://issues.redhat.com/browse/OSDOCS-6664)/[CORS-2699](https://issues.redhat.com/browse/CORS-2699)

Link to doc preview:
https://61810--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#installation-gcp-regions_installing-gcp-account

QE review:
- [x] QE has tested the new region from 4.12.z+