### PR TITLE
CMA Adding 2.10.1-267 Release Notes

### DIFF
--- a/nodes/cma/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-rn.adoc
@@ -30,22 +30,43 @@ The following table defines the Custom Metrics Autoscaler Operator versions for 
 |{product-title} version
 |General availability
 
-|2.10.1
+|2.10.1-267
 |4.13
 |General availability
 
-|2.10.1
+|2.10.1-267
 |4.12
 |General availability
 
-|2.10.1
+|2.10.1-267
 |4.11
 |General availability
 
-|2.10.1
+|2.10.1-267
 |4.10
 |General availability
 |===
+
+[id="nodes-pods-autoscaling-custom-rn-210-267_{context}"]
+== Custom Metrics Autoscaler Operator 2.10.1-267 release notes
+
+This release of the Custom Metrics Autoscaler Operator 2.10.1-267 provides new features and bug fixes for running the Operator in an {product-title} cluster. The components of the Custom Metrics Autoscaler Operator 2.10.1-267 were released in link:https://access.redhat.com/errata/RHBA-2023:4089[RHBA-2023:4089].
+
+[IMPORTANT]
+====
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of KEDA.
+====
+
+[id="nodes-pods-autoscaling-custom-rn-210-267-bugs_{context}"]
+=== Bug fixes
+
+* Previously, the `custom-metrics-autoscaler` and `custom-metrics-autoscaler-adapter` images did not contain time zone information. Because of this, scaled objects with cron triggers failed to work because the controllers were unable to find time zone information. With this fix, the image builds now include time zone information. As a result, scaled objects containing cron triggers now function properly. (link:https://issues.redhat.com/browse/OCPBUGS-15264[*OCPBUGS-15264*])
+
+* Previously, the Custom Metrics Autoscaler Operator would attempt to take ownership of all managed objects, including objects in other namespaces and cluster-scoped objects. Because of this, the Custom Metrics Autoscaler Operator was unable to create the role binding for reading the credentials necessary to be an API server. This caused errors in the `kube-system` namespace. With this fix, the Custom Metrics Autoscaler Operator skips adding the `ownerReference` field to any object in another namespace or any cluster-scoped object. As a result, the role binding is now created without any errors. (link:https://issues.redhat.com/browse/OCPBUGS-15038[*OCPBUGS-15038*])
+
+* Previously, the Custom Metrics Autoscaler Operator added an `ownerReferences` field to the `openshift-keda` namespace. While this did not cause functionality problems, the presence of this field could have caused confusion for cluster administrators. With this fix, the Custom Metrics Autoscaler Operator does not add the `ownerReference` field to the `openshift-keda` namespace. As a result, the `openshift-keda` namespace no longer has a superfluous `ownerReference` field. (link:https://issues.redhat.com/browse/OCPBUGS-15293[*OCPBUGS-15293*])
+
+* Previously, if you used a Prometheus trigger configured with authentication method other than pod identity, and the `podIdentity` parameter was set to `none`, the trigger would fail to scale. With this fix, the Custom Metrics Autoscaler for OpenShift now properly handles the `none` pod identity provider type. As a result, a Prometheus trigger configured with authentication method other than pod identity, and the `podIdentity` parameter sset to `none` now properly scales. (link:https://issues.redhat.com/browse/OCPBUGS-15274[*OCPBUGS-15274*])
 
 [id="nodes-pods-autoscaling-custom-rn-210_{context}"]
 == Custom Metrics Autoscaler Operator 2.10.1 release notes
@@ -54,7 +75,7 @@ This release of the Custom Metrics Autoscaler Operator 2.10.1 provides new featu
 
 [IMPORTANT]
 ====
-Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously-installed Technology Preview versions or the community-supported version of KEDA.
+Before installing this version of the Custom Metrics Autoscaler Operator, remove any previously installed Technology Preview versions or the community-supported version of KEDA.
 ====
 
 [id="nodes-pods-autoscaling-custom-rn-210-new_{context}"]


### PR DESCRIPTION
As of 6/28, bug fixes only.

Errata: https://errata.devel.redhat.com/advisory/116492

**_The [link to the errata](https://access.redhat.com/errata/RHBA-2023:4089) will not work until the product GAs (planned 7/17)._**

Preview:
[Custom Metrics Autoscaler Operator 2.10.1-267 release notes](https://61855--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-rn.html#nodes-pods-autoscaling-custom-rn-210-267_nodes-cma-autoscaling-custom-removing)