### PR TITLE
OSDOCS-6445 Descheduler resource limits RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -123,6 +123,11 @@ When the Node Tuning Operator recognizes the performance conditions to activate 
 [id="ocp-4-14-nodes"]
 === Nodes
 
+[id="ocp-4-14-descheduler-resource-limits"]
+==== Descheduler resource limits for large clusters
+
+With this release, the resource limits for the descheduler operand are removed. This enables the descheduler to be used for large clusters with many nodes and pods without failing due to out-of-memory errors.
+
 [id="ocp-4-14-monitoring"]
 === Monitoring
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6445](https://issues.redhat.com/browse/OSDOCS-6445)

Link to docs preview:
[Preview](https://61877--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-descheduler-resource-limits)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
