### PR TITLE
ROX-18161: update network graph 2.0 info

### DIFF
--- a/modules/generate-network-policies-ng20.adoc
+++ b/modules/generate-network-policies-ng20.adoc
@@ -10,17 +10,12 @@
 
 You can generate network policies from the network graph.
 
-The generated policies apply to the deployments shown in the network graph and they allow all network traffic observed during the selected time.
+The generated policies apply to all deployments that exist in the currently selected cluster. They also allow all network traffic observed during the baseline discovery period.
 
 .Procedure
 . In the {product-title-short} portal, navigate to *Network Graph (2.0 preview)*.
 . Select a cluster, and then select one or more namespaces.
-. In the network graph header, select *Simulate network policy*.
-. Optional: If you want to generate policies for only some deployments, use the *Filter deployments* field to add criteria by which to filter deployments.
-If you do not add a filter, {product-title-short} generates policies for all deployments that you have selected in the cluster.
-. Select an appropriate time from the drop-down list next to *Active traffic*.
-If the selected time is too short, it leaves out periodic or infrequent network communications.
-. Select *Simulate network policy*.
+. In the network graph header, select *Simulate network policy*. {product-title-short} generates policies for all deployments that exist in the selected cluster.
 . Optional: In the information panel that opens, select *Exclude ports & protocols* if you do not want ports and protocols to be scoped in {product-title-short} generated policies.
 . Select *Generate and simulate network policies*.
 The generated network policy configuration YAML file opens in the same panel, and the network graph shows the effects of the policies.


### PR DESCRIPTION
Version(s):

`rhacs-docs-4.0` only

[Issue](https://issues.redhat.com/browse/ROX-18161)

[Link to docs preview
](https://file.rdu.redhat.com/kcarmich/ROX-18161-network-graph/operating/manage-network-policies.html#generate-network-policies-ng20_manage-network-policies)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Making changes that also apply to 4.0 to resolve problems that were discovered in the 4.1 review of https://github.com/openshift/openshift-docs/pull/61772

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
