### PR TITLE
OBSDOCS-215: how-to-enable-dedicated-service-monitor

### DIFF
--- a/modules/monitoring-configuring-dedicated-service-monitors.adoc
+++ b/modules/monitoring-configuring-dedicated-service-monitors.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: CONCEPT
+[id="configuring-a-dedicated-service-monitor_{context}"]
+= Configuring a dedicated service monitor
+
+You can configure {product-title} core platform monitoring to use dedicated service monitors to collect metrics for the resource metrics pipeline.
+
+When enabled, a dedicated service monitor exposes two additional metrics from the kubelet endpoint and sets the value of the `honorTimestamps` field to true.
+
+By enabling a dedicated service monitor, you can improve the consistency of Prometheus Adapter-based CPU usage measurements used by, for example, the `oc adm top pod` command or the Horizontal Pod Autoscaler.

--- a/modules/monitoring-enabling-a-dedicated-service-monitor.adoc
+++ b/modules/monitoring-enabling-a-dedicated-service-monitor.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: PROCEDURE
+[id="enabling-a-dedicated-service-monitor_{context}"]
+= Enabling a dedicated service monitor
+
+You can configure core platform monitoring to use a dedicated service monitor by configuring the `dedicatedServiceMonitors` key in the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` namespace.
+
+.Prerequisites
+
+* You have installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
+* You have created the `cluster-monitoring-config` `ConfigMap` object.
+
+.Procedure
+
+. Edit the `cluster-monitoring-config` `ConfigMap` object in the `openshift-monitoring` namespace:
++
+[source,terminal]
+----
+$ oc -n openshift-monitoring edit configmap cluster-monitoring-config
+----
+
+. Add an `enabled: true` key-value pair as shown in the following sample:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    k8sPrometheusAdapter:
+      dedicatedServiceMonitors:
+        enabled: true <1>
+----
+<1> Set the value of the `enabled` field to `true` to deploy a dedicated service monitor that exposes the kubelet `/metrics/resource` endpoint.
+
+. Save the file to apply the changes automatically.
++
+[WARNING]
+====
+When you save changes to a `cluster-monitoring-config` config map, the pods and other resources in the `openshift-monitoring` project might be redeployed.
+The running monitoring processes in that project might also restart.
+====
+

--- a/monitoring/configuring-the-monitoring-stack.adoc
+++ b/monitoring/configuring-the-monitoring-stack.adoc
@@ -85,6 +85,10 @@ include::modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.ado
 
 * link:https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config[Prometheus scrape configuration documentation]
 
+// Enabling a dedicated service monitor
+include::modules/monitoring-configuring-dedicated-service-monitors.adoc[leveloffset=+1]
+include::modules/monitoring-enabling-a-dedicated-service-monitor.adoc[leveloffset=+2]
+
 // Configuring persistent storage
 include::modules/monitoring-configuring-persistent-storage.adoc[leveloffset=+1]
 include::modules/monitoring-configuring-a-local-persistent-volume-claim.adoc[leveloffset=+2]


### PR DESCRIPTION
Summary: Adds content about dedicated service monitor config

- Aligned team: DevTools
- For branches: OCP 4.10+
- Jira: https://issues.redhat.com/browse/OBSDOCS-215
- Direct link to doc preview: https://61893--docspreview.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#configuring-a-dedicated-service-monitor_configuring-the-monitoring-stack
- SME review: @jan--f 
- QE review: @juzhao 
- Peer review: @shipsing 