### PR TITLE
OSDOCS-5967 test trailing line continuation - should fail

### DIFF
--- a/modules/troubleshooting-network-observability-must-gather.adoc
+++ b/modules/troubleshooting-network-observability-must-gather.adoc
@@ -13,7 +13,7 @@ You can use the must-gather tool to collect information about the Network Observ
 +
 [source,terminal]
 ----
-$ oc adm must-gather
+$ oc adm must-gather \
  --image-stream=openshift/must-gather \
- --image=quay.io/netobserv/must-gather
+ --image=quay.io/netobserv/must-gather \
 ----


### PR DESCRIPTION
DO NOT MERGE

Version(s):


Issue:
Testing why preview build did not fail - the extra trailing space used to break the build, but looks like it doesn't anymore 


```
[source,terminal]
----
$ oc adm must-gather \
 --image-stream=openshift/must-gather \
 --image=quay.io/netobserv/must-gather \
----
```

