### PR TITLE
OCPBUGS-15307: Clarity around MetalLB address resolution for L2

### DIFF
--- a/modules/nw-metallb-layer2.adoc
+++ b/modules/nw-metallb-layer2.adoc
@@ -9,9 +9,10 @@
 
 In layer 2 mode, the `speaker` pod on one node announces the external IP address for a service to the host network. 
 From a network perspective, the node appears to have multiple IP addresses assigned to a network interface. 
+
 [NOTE]
 ====
-Since layer 2 mode relies on ARP and NDP, the client must be on the same subnet of the nodes announcing the service in order for MetalLB to work. Additionally, the IP address assigned to the service must be on the same subnet of the network used by the client to reach the service. 
+In layer 2 mode, MetalLB relies on ARP and NDP. These protocols implement local address resolution within a specific subnet. In this context, the client must be able to reach the VIP assigned by MetalLB that exists on the same subnet as the nodes announcing the service in order for MetalLB to work. 
 ====
 
 The `speaker` pod responds to ARP requests for IPv4 services and NDP requests for IPv6.


### PR DESCRIPTION
OCPBUGS-15307: Clarity about local address resolution aspect of MetalLB L2.

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-15307

Link to docs preview:
https://file.emea.redhat.com/rohennes/OCPBUGS-15307-metalb-L2/networking/metallb/about-metallb.html#nw-metallb-layer2_about-metallb-and-metallb-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
