### PR TITLE
Correct Release Notes date 

### DIFF
--- a/release_notes/41-release-notes.adoc
+++ b/release_notes/41-release-notes.adoc
@@ -356,7 +356,7 @@ Network graph 1.0 has been removed after the depreciation notice in {product-tit
 [id="resolved-in-version-41_{context}"]
 === Resolved in version 4.1
 
-Release date: 26 Jun 2023
+Release date: 29 Jun 2023
 
 //bugs are not linked because ACS Jira is not public
 


### PR DESCRIPTION
Version(s):
- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.1`

Issue: none
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview
](https://61908--docspreview.netlify.app/openshift-acs/latest/release_notes/41-release-notes.html)

QE review: (**N/A** - missed changing date when release date changed)
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
