### PR TITLE
OCPBUGS#8693: Deleted hyperVGeneration entry

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -213,7 +213,7 @@ endif::ibm-power[]
 ifdef::azure[]
 [IMPORTANT]
 ====
-You are required to use Azure virtual machines with `premiumIO` set to `true`. The machines must also have the `hyperVGeneration` property contain `V1`.
+You are required to use Azure virtual machines that have the `premiumIO` parameter set to `true`.
 ====
 endif::azure[]
 


### PR DESCRIPTION
[OCPBUGS-8693](https://issues.redhat.com/browse/OCPBUGS-8693)

Version(s):
4.14 through to 4.11

Link to docs preview:
[Minimum resource requirements for cluster installation](https://61909--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations.html#installation-minimum-resource-requirements_installing-azure-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [Requested review on Slack](https://redhat-internal.slack.com/archives/CHFF1LCUR/p1688053729114299)