### PR TITLE
[RHACS] Fix dropdown version for ACS

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -155,7 +155,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
-              <option value="4.1">4.0</option>
+              <option value="4.1">4.1</option>
               <option value="4.0">4.0</option>
               <option value="3.74">3.74</option>
               <option value="3.73">3.73</option>


### PR DESCRIPTION
Version(s): N/A

Issue: N/A

Link to docs preview: N/A

QE review: N/A (fixes error)
- [ ] QE has approved this change.

Additional information:

Fixes error in https://github.com/openshift/openshift-docs/pull/61073 that causes 4.1 dropdown selector on docs.openshift.com to appear as "4.0"

Based on [what was done for 4.0](https://github.com/openshift/openshift-docs/pull/59503), I think this change will fix the error.

