### PR TITLE
RHDEVDOCS-2877: Managed kafka source integration docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -157,3 +157,6 @@
 :dedicated-product-title: OpenShift Dedicated
 :aro-product-title: Azure Red Hat OpenShift
 :rosa-product-title: Red Hat OpenShift Service on AWS
+
+// Managed Kafka
+:RHOSAK: Red Hat OpenShift Streams for Apache Kafka

--- a/eventing/event-sources/serverless-kafka-developer-source.adoc
+++ b/eventing/event-sources/serverless-kafka-developer-source.adoc
@@ -23,3 +23,6 @@ include::modules/specifying-sink-flag-kn.adoc[leveloffset=+2]
 include::modules/serverless-kafka-source-yaml.adoc[leveloffset=+1]
 
 include::modules/serverless-kafka-sasl-source.adoc[leveloffset=+1]
+
+// Managed Kafka integration
+include::modules/serverless-managed-kafka-source.adoc[leveloffset=+1]

--- a/modules/serverless-managed-kafka-source.adoc
+++ b/modules/serverless-managed-kafka-source.adoc
@@ -1,0 +1,50 @@
+// Module included in the following assemblies:
+//
+// * eventing/event-sources/serverless-kafka-developer-source.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-managed-kafka-source_{context}"]
+= Integrating {RHOSAK} with an Apache Kafka event source
+
+You can integrate your {RHOSAK} with {ServerlessProductName} by using an Apache Kafka event source.
+
+.Prerequisites
+
+* You have credentials from the {RHOSAK} instance you want to integrate, including the bootstrap server, names of your Apache Kafka topics, client ID, and client password.
+* The {ServerlessOperatorName}, Knative Eventing, and Knative Kafka are installed on your {product-title} cluster.
+* You have enabled Apache Kafka sources on your cluster in the Knative Kafka custom resource (CR) settings.
+* You are logged into the {product-title} web console.
+* You have access to or have created an event sink.
+
+.Procedure
+
+. In the *Developer* perspective of the {product-title} web console, navigate to *Secrets*.
+
+. Select *Key/value secret* from the *Create* drop-down to go to the *Create Key/Value Secret* page.
+
+. Enter a *Secret Name*.
+
+. Add two keys.
+.. For the first key:
+... In the *Key* field, enter `user`.
+... Add the client ID from your {RHOSAK} cluster credentials as the *Value*.
+.. Click *Add Key/Value* to add the next key.
+.. For the second key:
+... In the *Key* field, enter `password`.
+... Add the client password from your {RHOSAK} cluster credentials as the *Value*.
+.. Click *Create*.
+
+. Navigate to the *+Add* page. Click the *Event Source* tile.
+. In the *Event Sources* page, click the *Kafka Source* tile, then click *Create Event Source*.
+. Enter the bootstrap server value from your {RHOSAK} cluster credentials in the *Bootstrap servers* field.
+. In the *Topics* field, enter the names of your Apache Kafka topics.
+. Enter a name for the *Consumer group*.
+. In the *SASL* section, select the *Enable* checkbox.
+.. A *User* section appears, where you can select the secret that you created earlier from a list of resources. For the key, select *user* from the list.
+.. A *Password* section appears, where you can select the secret that you created earlier from a list of resources. For the key, select *password* from the list.
+. Connect a *Target*, or event sink, as either a *Resource* or *URI*.
+. Click *Create*.
+
+.Verfification
+
+* You can view the Apache Kafka source that you have created by navigating to the *Topology* view in the *Developer* perspective.


### PR DESCRIPTION
Version(s):
All serverless versions (OCP 4.8+)

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-2877

Link to docs preview:
https://61928--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-kafka-developer-source.html#serverless-managed-kafka-source_serverless-kafka-developer-source

QE review:
- [ ] QE has approved this change.