### PR TITLE
OCPBUGS#15423: Fixed link pointing to RHV-H for vSphere docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -60,6 +60,8 @@ endif::openshift-origin[]
 :secondary-scheduler-operator: Secondary Scheduler Operator
 :rh-virtualization-first: Red Hat Virtualization (RHV)
 :rh-virtualization: RHV
+:rh-virtualization-hyper-first: Red Hat Virtualization Hypervisor (RHV-H)
+:rh-virtualization-hyper: RHV-H
 :rh-virtualization-engine-name: Manager
 ifdef::openshift-origin[]
 :rh-virtualization-first: oVirt

--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -35,7 +35,7 @@ You can host the VMware vSphere infrastructure on-premise or on a link:https://c
 
 |Hypervisor
 |vSphere 7.0 Update 2 and later with virtual hardware version 15
-|This version is the minimum version that {op-system-first} supports. See the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux?sort=sortTitle%20asc&vendors=VMware&category=Server[Red Hat Enterprise Linux 8 supported hypervisors list].
+|This version is the minimum version that {op-system-first} supports. For more information about supported hardware on the latest version of {op-system-base-full} that is compatible with {op-system}, see link:https://catalog.redhat.com/hardware/search[Hardware] on the Red Hat Customer Portal.
 
 |Storage with in-tree drivers
 |vSphere 7.0 Update 2 and later


### PR DESCRIPTION
[OCPBUGS-15423](https://issues.redhat.com/browse/OCPBUGS-15423)

Version(s):
4.14 through to 4.10

Link to docs preview:
[VMware vSphere CSI Driver Operator requirements](https://61947--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/preparing-to-install-on-vsphere.html#vsphere-csi-driver-reqs_preparing-to-install-on-vsphere)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Request to RHEL writers in Slack](https://redhat-internal.slack.com/archives/C059QKXFLTS/p1688134715743949)
