### PR TITLE
CMP-2030: CO 1.1.0 release notes

### DIFF
--- a/modules/compliance-operator-hcp-install.adoc
+++ b/modules/compliance-operator-hcp-install.adoc
@@ -1,0 +1,109 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/compliance-operator-installation.adoc
+
+:_content-type: PROCEDURE
+[id="installing-compliance-operator-hcp_{context}"]
+= Installing the Compliance Operator on Hosted control planes
+
+The Compliance Operator can be installed in Hosted control planes using the OperatorHub by creating a `Subscription` file.
+
+:FeatureName: Hosted control planes
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+
+* You must have `admin` privileges.
+
+.Procedure
+
+. Define a `Namespace` object similar to the following:
++
+.Example `namespace-object.yaml`
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  labels:
+    openshift.io/cluster-monitoring: "true"
+    pod-security.kubernetes.io/enforce: privileged <1>
+  name: openshift-compliance
+----
+<1> In {product-title} {product-version}, the pod security label must be set to `privileged` at the namespace level.
+
+. Create the `Namespace` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f namespace-object.yaml
+----
+
+. Define an `OperatorGroup` object:
++
+.Example `operator-group-object.yaml`
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: compliance-operator
+  namespace: openshift-compliance
+spec:
+  targetNamespaces:
+  - openshift-compliance
+----
+
+. Create the `OperatorGroup` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f operator-group-object.yaml
+----
+
+. Define a `Subscription` object:
++
+.Example `subscription-object.yaml`
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: compliance-operator-sub
+  namespace: openshift-compliance
+spec:
+  channel: "stable"
+  installPlanApproval: Automatic
+  name: compliance-operator
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  config:
+  nodeSelector:
+    node-role.kubernetes.io/worker: ""
+  env:
+  - name: PLATFORM
+    value: "HyperShift"
+----
+
+. Create the `Subscription` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f subscription-object.yaml
+----
+
+.Verification
+
+. Verify the installation succeeded by inspecting the CSV file by running the following command:
++
+[source,terminal]
+----
+$ oc get csv -n openshift-compliance
+----
+
+. Verify that the Compliance Operator is up and running by running the following command:
++
+[source,terminal]
+----
+$ oc get deploy -n openshift-compliance
+----

--- a/security/compliance_operator/compliance-operator-installation.adoc
+++ b/security/compliance_operator/compliance-operator-installation.adoc
@@ -31,6 +31,18 @@ If the `restricted` Security Context Constraints (SCC) have been modified to con
 You can create a custom SCC for the Compliance Operator scanner pod service account. For more information, see xref:../../security/compliance_operator/compliance-operator-advanced.adoc#compliance-custom-scc_compliance-advanced[Creating a custom SCC for the Compliance Operator].
 ====
 
+// only applies to 4.11+
+include::modules/compliance-operator-hcp-install.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+// 4.13+
+* xref:../../hosted_control_planes/index.adoc#hcp-overview[Hosted control planes overview]
+//
+// 4.11-4.12, commenting out of 4.13-main
+//* xref:../../architecture/control-plane.adoc#hosted-control-planes-overview_control-plane[Overview of hosted control planes (Technology Preview)]
+
 [id="additional-resources-installing-the-compliance-operator"]
 [role="_additional-resources"]
 == Additional resources

--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -15,6 +15,52 @@ For an overview of the Compliance Operator, see xref:../../security/compliance_o
 
 To access the latest release, see xref:../../security/compliance_operator/compliance-operator-updating.adoc#olm-preparing-upgrade_compliance-operator-updating[Updating the Compliance Operator].
 
+[id="compliance-operator-release-notes-1-1-0"]
+== OpenShift Compliance Operator 1.1.0
+
+The following advisory is available for the OpenShift Compliance Operator 1.1.0:
+
+* link:https://access.redhat.com/errata/RHBA-2023:3630[RHBA-2023:3630 - OpenShift Compliance Operator bug fix and enhancement update]
+
+[id="compliance-operator-1-1-0-new-features-and-enhancements"]
+=== New features and enhancements
+
+* A start and end timestamp is now available in the `ComplianceScan` custom resource definition (CRD) status.
+
+* The Compliance Operator can now be deployed on Hosted Control Planes using the OperatorHub by creating a `Subscription` file. For more information, see xref:../../security/compliance_operator/compliance-operator-installation.html#installing-compliance-operator-hcp_compliance-operator-installation[Installing the Compliance Operator on Hosted Control Planes].
+
+[id="compliance-operator-1-1-0-bug-fixes"]
+=== Bug fixes
+
+* Before this update, some Compliance Operator rule instructions were not present. After this update, instructions are improved for the following rules:
++
+** `classification_banner`
+** `oauth_login_template_set`
+** `oauth_logout_url_set`
+** `oauth_provider_selection_set`
+** `ocp_allowed_registries`
+** `ocp_allowed_registries_for_import`
++
+(link:https://issues.redhat.com/browse/OCPBUGS-10473[*OCPBUGS-10473*])
+
+* Before this update, check accuracy and rule instructions were unclear. After this update, the check accuracy and instructions are improved for the following `sysctl` rules:
++
+** `kubelet-enable-protect-kernel-sysctl`
+** `kubelet-enable-protect-kernel-sysctl-kernel-keys-root-maxbytes`
+** `kubelet-enable-protect-kernel-sysctl-kernel-keys-root-maxkeys`
+** `kubelet-enable-protect-kernel-sysctl-kernel-panic`
+** `kubelet-enable-protect-kernel-sysctl-kernel-panic-on-oops`
+** `kubelet-enable-protect-kernel-sysctl-vm-overcommit-memory`
+** `kubelet-enable-protect-kernel-sysctl-vm-panic-on-oom`
++
+(link:https://issues.redhat.com/browse/OCPBUGS-11334[*OCPBUGS-11334*])
+
+* Before this update, the `ocp4-alert-receiver-configured` rule did not include instructions. With this update, the `ocp4-alert-receiver-configured` rule now includes improved instructions. (link:https://issues.redhat.com/browse/OCPBUGS-7307[*OCPBUGS-7307*])
+
+* Before this update, the `rhcos4-sshd-set-loglevel-info` rule would fail for the `rhcos4-e8` profile. With this update, the remediation for the `sshd-set-loglevel-info` rule was updated to apply the correct configuration changes, allowing subsequent scans to pass after the remediation is applied. (link:https://issues.redhat.com/browse/OCPBUGS-7816[*OCPBUGS-7816*])
+
+* Before this update, a new installation of {product-title} with the latest Compliance Operator install failed on the `scheduler-no-bind-address` rule. With this update, the `scheduler-no-bind-address` rule has been disabled on newer versions of {product-title} since the parameter was removed. (link:https://issues.redhat.com/browse/OCPBUGS-8347[*OCPBUGS-8347*])
+
 [id="compliance-operator-release-notes-1-0-0"]
 == OpenShift Compliance Operator 1.0.0
 


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/CMP-2030

Link to docs preview (VPN required):
[OpenShift Compliance Operator 1.1.0](https://file.rdu.redhat.com/antaylor/CMP-2030/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-release-notes-1-1-0)
[Installing the Compliance Operator on Hosted Control Planes](https://file.rdu.redhat.com/antaylor/CMP-2030/security/compliance_operator/compliance-operator-installation.html#installing-compliance-operator-hcp_compliance-operator-installation)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This release includes Hypershift support (called Hosted Control Planes). Additional resources (xrefs to other content about hosted control planes) varies from 4.11- 4.12 and 4.13+. I have included all references as comments and will manually cherrypick to ensure that all content is displayed correctly for all supported versions. 

I will also remove Hypershift references for the 4.10 release, as it is unsupported.

**NOTE:** The link to the errata **will not work** until the errata is published and live.