### PR TITLE
OCPBUGS#12000: Updated line in Networking requirements in vSphere

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -431,7 +431,7 @@ Available resources vary between clusters. The number of possible clusters withi
 [id="installation-vsphere-installer-infra-requirements-networking_{context}"]
 == Networking requirements
 
-You must use DHCP for the network and ensure that the DHCP server is configured to provide persistent IP addresses to the cluster machines. You must configure the default gateway to use the DHCP server. All nodes must be in the same VLAN. You cannot scale the cluster using a second VLAN as a Day 2 operation.
+You must use the Dynamic Host Configuration Protocol (DHCP) for the network and ensure that the DHCP server is configured to provide persistent IP addresses to the cluster machines. In the DHCP lease, you must configure the DHCP to use the default gateway. All nodes must be in the same VLAN. You cannot scale the cluster using a second VLAN as a Day 2 operation.
 ifdef::restricted[]
 The VM in your restricted network must have access to vCenter so that it can provision and manage nodes, persistent volume claims (PVCs), and other resources.
 endif::restricted[]


### PR DESCRIPTION
[OCPBUGS-12000](https://issues.redhat.com/browse/OCPBUGS-12000)

Version(s):
4.14 through 4.10

Link to docs preview:
[Network requirements](https://61960--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-vsphere-installer-infra-requirements_installing-vsphere-installer-provisioned-network-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [DHCP Lease Time VMware docs](https://docs.vmware.com/en/VMware-Cloud-Director/10.4/VMware-Cloud-Director-Tenant-Portal-Guide/GUID-037776A6-AA66-49FB-A888-DAB5A1F966AB.html)
