### PR TITLE
Updated infra documentation to indicate worker being a necessary label for infrastructure nodes

### DIFF
--- a/modules/creating-an-infra-node.adoc
+++ b/modules/creating-an-infra-node.adoc
@@ -29,6 +29,11 @@ $ oc label node <node-name> node-role.kubernetes.io/app=""
 $ oc label node <node-name> node-role.kubernetes.io/infra=""
 ----
 
+[IMPORTANT]
+====
+Infrastructure nodes must maintain both infra and worker node labels to be in compliance.
+====
+
 . Check to see if applicable nodes now have the `infra` role and `app` roles:
 +
 [source,terminal]


### PR DESCRIPTION
…es containing both infra and worker node labels. Without the worker node label, infrastructure nodes are not detected properly and will lead to over charging customers for usage on infrastructure nodes

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
