### PR TITLE
ROX-18157: Add missing image to 4.0 RNs

### DIFF
--- a/release_notes/40-release-notes.adoc
+++ b/release_notes/40-release-notes.adoc
@@ -488,18 +488,22 @@ Release date: 31 May 2023
 
 | Main
 | Includes Central, Sensor, Admission controller, and Compliance. Also includes `roxctl` for use in continuous integration (CI) systems.
-a| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:4.0`
+a| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:4.0.2`
 
 | Scanner
 | Scans images and nodes.
-a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:4.0`
+a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:4.0.2`
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:4.0`
+a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:4.0.2`
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-a| * `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:4.0`
-* `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:4.0`
+a| * `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:4.0.2`
+* `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:4.0.2`
+
+| Central DB
+| Postgres instance that provides the database storage for Central.
+a| `registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8:4.0.2`
 |===


### PR DESCRIPTION
Version(s):
`rhacs-docs-4.0` only

[Issue](https://issues.redhat.com/browse/ROX-18157)

Link to docs preview: Cannot get rsync command to work with file.rdu, and bot doesn't do previews for this branch. See screenshot at end for local asciibinder preview. Or see https://github.com/openshift/openshift-docs/pull/61976 for 4.1 version.
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
