### PR TITLE
ROX-18157: Add missing image to 4.1 Release Notes

### DIFF
--- a/release_notes/41-release-notes.adoc
+++ b/release_notes/41-release-notes.adoc
@@ -409,18 +409,22 @@ This can lead to inaccuracies or inconsistencies in the reported GID. This issue
 
 | Main
 | Includes Central, Sensor, Admission controller, and Compliance. Also includes `roxctl` for use in continuous integration (CI) systems.
-a| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:4.1`
+a| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:4.1.0`
 
 | Scanner
 | Scans images and nodes.
-a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:4.1`
+a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:4.1.0`
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:4.1`
+a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:4.1.0`
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-a| * `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:4.1`
-* `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:4.1`
+a| * `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:4.1.0`
+* `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:4.1.0`
+
+| Central DB
+| Postgres instance that provides the database storage for Central.
+a| `registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8:4.1.0`
 |===


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.1`

[Issue](https://issues.redhat.com/browse/ROX-18157)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview
](https://61976--docspreview.netlify.app/openshift-acs/latest/release_notes/41-release-notes.html#image-versions_release-notes-41)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
