### PR TITLE
OSDOCS#5961: Add info on repo name when mirroring catalog img

### DIFF
--- a/installing/disconnected_install/installing-mirroring-installation-images.adoc
+++ b/installing/disconnected_install/installing-mirroring-installation-images.adoc
@@ -104,7 +104,7 @@ $ podman login registry.redhat.io
 endif::[]
 * Access to a mirror registry that supports
 link:https://docs.docker.com/registry/spec/manifest-v2-2/[Docker v2-2].
-* On your mirror registry, decide which namespace to use for storing mirrored Operator content. For example, you might create an `olm-mirror` namespace.
+* On your mirror registry, decide which repository, or namespace, to use for storing mirrored Operator content. For example, you might create an `olm-mirror` repository.
 * If your mirror registry does not have internet access, connect removable media to your workstation with unrestricted network access.
 * If you are working with private registries, including `registry.redhat.io`, set the `REG_CREDS` environment variable to the file path of your registry credentials for use in later steps. For example, for the `podman` CLI:
 +

--- a/modules/olm-mirroring-catalog-airgapped.adoc
+++ b/modules/olm-mirroring-catalog-airgapped.adoc
@@ -66,14 +66,14 @@ $ podman login <mirror_registry>
 [source,terminal]
 ----
 $ oc adm catalog mirror \
-    file://local/index/<repo>/<index_image>:<tag> \ <1>
-    <mirror_registry>:<port>/<namespace> \ <2>
+    file://local/index/<repository>/<index_image>:<tag> \ <1>
+    <mirror_registry>:<port>[/<repository>] \ <2>
     -a ${REG_CREDS} \ <3>
     --insecure \ <4>
     --index-filter-by-os='<platform>/<arch>' <5>
 ----
 <1> Specify the `file://` path from the previous command output.
-<2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+<2> Specify the fully qualified domain name (FQDN) for the target registry to mirror the Operator contents to. The mirror registry `<repository>` can be any existing repository, or namespace, on the registry, for example `olm-mirror` as outlined in the prerequisites. If there is an existing repository found during mirroring, the repository name is added to the resulting image name. If you do not want the image name to include the repository name, omit the `<repository>` value from this line, for example `<mirror_registry>:<port>`.
 <3> Optional: If required, specify the location of your registry credentials file.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.
 <5> Optional: Specify which platform and architecture of the index image to select when multiple variants are available. Images are specified as `'<platform>/<arch>[/<variant>]'`. This does not apply to images referenced by the index. Valid values are `linux/amd64`, `linux/ppc64le`, `linux/s390x`, `linux/arm64`, and `.*`
@@ -83,13 +83,13 @@ $ oc adm catalog mirror \
 Red Hat Quay does not support nested repositories. As a result, running the `oc adm catalog mirror` command will fail with a `401` unauthorized error. As a workaround, you can use the `--max-components=2` option when running the `oc adm catalog mirror` command to disable the creation of nested repositories. For more information on this workaround, see the link:https://access.redhat.com/solutions/5440741[Unauthorized error thrown while using catalog mirror command with Quay registry] Knowledgebase Solution.
 ====
 
-. Run the `oc adm catalog mirror` command again. Use the newly mirrored index image as the source and the same mirror registry namespace used in the previous step as the target:
+. Run the `oc adm catalog mirror` command again. Use the newly mirrored index image as the source and the same mirror registry target used in the previous step:
 +
 [source,terminal]
 ----
 $ oc adm catalog mirror \
     <mirror_registry>:<port>/<index_image> \
-    <mirror_registry>:<port>/<namespace> \
+    <mirror_registry>:<port>[/<repository>] \
     --manifests-only \//<1>
     [-a ${REG_CREDS}] \
     [--insecure]

--- a/modules/olm-mirroring-catalog-colocated.adoc
+++ b/modules/olm-mirroring-catalog-colocated.adoc
@@ -32,14 +32,14 @@ $ podman login <mirror_registry>
 ----
 $ oc adm catalog mirror \
     <index_image> \ <1>
-    <mirror_registry>:<port>/<namespace> \ <2>
+    <mirror_registry>:<port>[/<repository>] \ <2>
     [-a ${REG_CREDS}] \ <3>
     [--insecure] \ <4>
     [--index-filter-by-os='<platform>/<arch>'] \ <5>
     [--manifests-only] <6>
 ----
 <1> Specify the index image for the catalog that you want to mirror.
-<2> Specify the fully qualified domain name (FQDN) for the target registry and namespace to mirror the Operator contents to, where `<namespace>` is any existing namespace on the registry. For example, you might create an `olm-mirror` namespace to push all mirrored content to.
+<2> Specify the fully qualified domain name (FQDN) for the target registry to mirror the Operator contents to. The mirror registry `<repository>` can be any existing repository, or namespace, on the registry, for example `olm-mirror` as outlined in the prerequisites. If there is an existing repository found during mirroring, the repository name is added to the resulting image name. If you do not want the image name to include the repository name, omit the `<repository>` value from this line, for example `<mirror_registry>:<port>`.
 <3> Optional: If required, specify the location of your registry credentials file.
 `{REG_CREDS}` is required for `registry.redhat.io`.
 <4> Optional: If you do not want to configure trust for the target registry, add the `--insecure` flag.

--- a/modules/olm-mirroring-catalog-manifests.adoc
+++ b/modules/olm-mirroring-catalog-manifests.adoc
@@ -18,7 +18,7 @@ If you mirrored content to a registry on a disconnected host in the previous sec
 
 [source,text]
 ----
-manifests-index/<namespace>/<index_image_name>-<random_number>
+manifests-index/<repository>/<index_image_name>-<random_number>
 ----
 
 [NOTE]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-5961

4.10+

* Adds info on `oc adm catalog mirror` image name generation behavior when including/excluding repo name
* Adds `[]` around `/<repository>` to indicate optional syntax
* Switches use of "namespace" throughout to instead favor "repository", which seems more natural for the context (and avoids confusion with Kubernetes namespaces)

Preview:

* [Mirroring catalog contents to registries on the same network](https://61978--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirror-catalog-colocated_installing-mirroring-installation-images) (mostly step 2, callout 2)
* [Mirroring catalog contents to airgapped registries](https://61978--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirror-catalog-airgapped_installing-mirroring-installation-images) (mostly step 5, callout 2)