### PR TITLE
No sudo for podman login on registry exposure

### DIFF
--- a/modules/registry-exposing-default-registry-manually.adoc
+++ b/modules/registry-exposing-default-registry-manually.adoc
@@ -49,5 +49,5 @@ $ sudo update-ca-trust enable
 +
 [source,terminal]
 ----
-$ sudo podman login -u kubeadmin -p $(oc whoami -t) $HOST
+$ podman login -u kubeadmin -p $(oc whoami -t) $HOST
 ----


### PR DESCRIPTION
The last step in the guide for exposing the internal registry says to run 'podman login' with 'sudo'. This conflicts with the common practice of running 'podman' with the user credentials. Therefore, dropping the 'sudo' part from that step.

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
