### PR TITLE
CNV-30537: Warning about DPDK checkup traffic-gen's high privileges

### DIFF
--- a/modules/virt-checking-cluster-dpdk-readiness.adoc
+++ b/modules/virt-checking-cluster-dpdk-readiness.adoc
@@ -23,6 +23,16 @@ You run a DPDK checkup by performing the following steps:
 * You have installed the OpenShift CLI (`oc`).
 * You have configured the compute nodes to run DPDK applications on VMs with zero packet loss.
 
+[IMPORTANT]
+====
+The traffic generator pod created by the checkup has elevated privileges:
+
+* It runs as root.
+* It has a bind mount to the node's file system.
+
+The container image of the traffic generator is pulled from the upstream Project Quay container registry.
+====
+
 .Procedure
 
 . Create a `ServiceAccount`, `Role`, and `RoleBinding` manifest for the DPDK checkup and the traffic generator pod:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
The traffic generator pod used by the DPDK checkup requires high privileges.

Add a warning to the users.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/CNV-30537

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://61982--docspreview.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups.html#virt-checking-cluster-dpdk-readiness_virt-running-cluster-checkups


QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
