### PR TITLE
OSDOCS-6442 Secure token usage with oc client while doing oc login

### DIFF
--- a/cli_reference/openshift_cli/getting-started-cli.adoc
+++ b/cli_reference/openshift_cli/getting-started-cli.adoc
@@ -40,6 +40,9 @@ include::modules/cli-installing-cli-brew.adoc[leveloffset=+2]
 // Logging in to the CLI
 include::modules/cli-logging-in.adoc[leveloffset=+1]
 
+// Logging in to the CLI by using the web
+include::modules/cli-logging-in-web.adoc[leveloffset=+1]
+
 // Using the CLI
 include::modules/cli-using-cli.adoc[leveloffset=+1]
 

--- a/modules/cli-logging-in-web.adoc
+++ b/modules/cli-logging-in-web.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * cli_reference/openshift_cli/getting-started.adoc
+
+:_content-type: PROCEDURE
+[id="cli-logging-in-web_{context}"]
+= Logging in to the OpenShift CLI using a web browser
+
+You can log in to the OpenShift CLI (`oc`) with the help of a web browser to access and manage your cluster. This allows users to avoid inserting their access token into the command line.
+
+[WARNING]
+====
+Logging in to the CLI through the web browser runs a server on localhost with HTTP, not HTTPS; use with caution on multi-user workstations.
+====
+
+.Prerequisites
+
+* You must have access to an {product-title} cluster.
+* You must have installed the OpenShift CLI (`oc`).
+* You must have a browser installed.
+
+.Procedure
+
+. Enter the `oc login` command with the `--web` flag:
++
+[source,terminal]
+----
+$ oc login <cluster_url> --web <1>
+----
+<1> If needed, you can specify the callback port and server URL.
+
+. The web browser opens automatically. If it does not, click the link in the command output. If you do not specify the {product-title} server `oc` tries to open the web console of the cluster specified in the current `oc` configuration file. If no `oc` configuration exists, `oc` prompts interactively for the server URL.
++
+.Example output
+
+[source,terminal]
+----
+Opening login URL in the default browser: https://openshift.example.com
+Opening in existing browser session.
+----
++
+.Example 
+
+[source,terminal]
+----
+$ oc login <https://api.your-openshift-server.com> --web --callback-port 8280 localhost:8443
+----
+. If more than one identity provider is available, select your choice from the options provided. 
+
+. Enter your username and password into the corresponding browser fields. After you are logged in, the browser displays the text `access token received successfully; please return to your terminal`. 
+
+. Check the CLI for a login confirmation.
++
+.Example output
+
+[source,terminal]
+----
+Login successful.
+
+You don't have any projects. You can try to create a new project, by running
+
+    oc new-project <projectname>
+
+----
+
+[NOTE]
+====
+The web console defaults to the profile used in the previous session. To switch between Administrator and Developer profiles, log out of the {product-title} web console and clear the cache.
+====
+
+You can now create a project or issue other commands for managing your cluster.

--- a/modules/getting-started-cli-login.adoc
+++ b/modules/getting-started-cli-login.adoc
@@ -15,7 +15,7 @@ You can log in to the OpenShift CLI (`oc`) to access and manage your cluster.
 
 .Procedure
 
-* Log into {product-title} from the CLI using your username and password or with an OAuth token:
+* Log into {product-title} from the CLI using your username and password, with an OAuth token, or with a web browser:
 ** With username and password:
 +
 [source,terminal]
@@ -27,6 +27,12 @@ $ oc login -u=<username> -p=<password> --server=<your-openshift-server> --insecu
 [source,terminal]
 ----
 $ oc login <https://api.your-openshift-server.com> --token=<tokenID>
+----
+** With a web browser:
++
+[source,terminal]
+----
+$ oc login <cluster_url> --web 
 ----
 
 You can now create a project or issue other commands for managing your cluster.

--- a/modules/oauth-default-clients.adoc
+++ b/modules/oauth-default-clients.adoc
@@ -18,6 +18,9 @@ The following OAuth clients are automatically created when starting the {product
 |`openshift-challenging-client`
 |Requests tokens with a user-agent that can handle `WWW-Authenticate` challenges.
 
+|`openshift-cli-client`
+| Requests tokens by using a local HTTP server fetching an authorization code grant.
+
 |===
 [.small]
 --


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6442](https://issues.redhat.com/browse/OSDOCS-6442)

Link to docs preview:
[getting_started/modules/getting-started-cli-login.html](https://61984--docspreview.netlify.app/openshift-enterprise/latest/getting_started/openshift-cli.html#getting-started-cli-login_openshift-cli)
[cli_reference/openshift_cli/modules/cli-logging-in.html](https://61984--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli.html#logging-in-through-a-web-browser-with-the-cli)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
