### PR TITLE
CMA remove Kafka TP note

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-trigger-kafka.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-kafka.adoc
@@ -8,9 +8,6 @@
 
 You can scale pods based on an Apache Kafka topic or other services that support the Kafka protocol. The custom metrics autoscaler does not scale higher than the number of Kafka partitions, unless you set the `allowIdleConsumers` parameter to `true` in the scaled object or scaled job.
 
-:FeatureName: Autoscaling based on Apache Kafka metrics
-include::snippets/technology-preview.adoc[leveloffset=+0]
-
 [NOTE]
 ====
 If the number of consumer groups exceeds the number of partitions in a topic, the extra consumer groups remain idle. To avoid this, by default the number of replicas does not exceed:

--- a/nodes/cma/nodes-cma-autoscaling-custom-rn.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-rn.adoc
@@ -68,9 +68,6 @@ The Custom Metrics Autoscaler Operator is now generally available as of Custom M
 :FeatureName: Scaling by using a scaled job
 include::snippets/technology-preview.adoc[]
 
-:FeatureName: Autoscaling based on Apache Kafka metrics
-include::snippets/technology-preview.adoc[leveloffset=+0]
-
 [id="nodes-pods-autoscaling-custom-rn-210-metrics_{context}"]
 ==== Performance metrics
 


### PR DESCRIPTION
Per @gauravsingh85 the [Apache Kafka trigger was promoted to GA](https://redhat-internal.slack.com/archives/C02F1J9UJJD/p1688411051299279). This PR removes the note that was erroneously left in. 

No QE needed