### PR TITLE
PR for SRVKS-1004: [DOC] networking.knative.dev/http-option is wrong

### DIFF
--- a/modules/serverless-https-redirect-service.adoc
+++ b/modules/serverless-https-redirect-service.adoc
@@ -17,7 +17,7 @@ metadata:
   name: example
   namespace: default
   annotations:
-    networking.knative.dev/http-option: "redirected"
+    networking.knative.dev/http-protocol: "redirected"
 spec:
   ...
 ----


### PR DESCRIPTION
**Affected versions for cherry-picking:**

serverless-docs 1.28+


**Dedicated JIRA:** https://issues.redhat.com/browse/SRVKS-1004

**Description:** 
In the **HTTPS redirection per service section**, replaced `networking.knative.dev/http-option` with `networking.knative.dev/http-protocol`. 

**Doc preview:** [HTTPS redirection per service](https://62005--docspreview.netlify.app/openshift-serverless/latest/knative-serving/external-ingress-routing/https-redirect-per-service.html)

**Reviews:** 
- SME: Kenjiro Nakayama 
- QE: not required (Change is small) 
- Peer review: Ashleigh Brennan