### PR TITLE
PR for SRVCOM-2478: [DOC] Rephrase misleading documentation

### DIFF
--- a/modules/serverless-enabling-tls-internal-traffic.adoc
+++ b/modules/serverless-enabling-tls-internal-traffic.adoc
@@ -23,7 +23,7 @@ include::snippets/technology-preview.adoc[]
 
 .Procedure
 
-. Create a Knative service that includes the `internal-encryption: "true"` field in the spec:
+. Create or update your `KnativeServing` resource and make sure that it includes the `internal-encryption: "true"` field in the spec:
 +
 [source,yaml]
 ----


### PR DESCRIPTION
**Affected versions for cherry-picking:**
- /cherry-pick serverless-docs-1.29
- /cherry-pick serverless-docs-1.28
- /cherry-pick serverless-docs-1.30

**Dedicated JIRA:** https://issues.redhat.com/browse/SRVCOM-2478

**Description:** 
Updated the misleading information in the **Enabling TLS authentication for internal traffic** section. Changed step no. 1 present in the content. 

**Doc preview:** [Enabling TLS authentication for internal traffic](https://62006--docspreview.netlify.app/openshift-serverless/latest/knative-serving/config-applications/serverless-config-tls.html#serverless-enabling-tls-internal-traffic_serverless-config-tls) (Check step no. 1) 

**Reviews:** 
- SME: Reto Lehmann
- QE: not required
- Peer review: Ashleigh Brennan