### PR TITLE
OCPBUGS-11991: Updating RHACM variable

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -49,7 +49,7 @@ endif::openshift-origin[]
 :rh-storage: OpenShift Data Foundation
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
 :rh-rhacm: RHACM
-:rh-rhacm-version: 2.5
+:rh-rhacm-version: 2.7
 :sandboxed-containers-first: OpenShift sandboxed containers
 :sandboxed-containers-operator: OpenShift sandboxed containers Operator
 :sandboxed-containers-version: 1.3


### PR DESCRIPTION
OCPBUGS#11991: Similar to #61551, updating RHACM variable for 4.12 as it should be version 2.7 for OCP 4.12

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-11991

Link to docs preview:
For example, link fixed in Additional resources section here: https://file.emea.redhat.com/rohennes/OCPBUGS-11991-variable/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html#ztp-using-hub-cluster-templates_ztp-advanced-policy-config

No QE required.