### PR TITLE
OCPBUGS-1378: fixing RHACM variable for OCP 4.11

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -48,7 +48,7 @@ endif::openshift-origin[]
 :rh-storage: OpenShift Data Foundation
 :rh-rhacm-first: Red Hat Advanced Cluster Management (RHACM)
 :rh-rhacm: RHACM
-:rh-rhacm-version: 2.5
+:rh-rhacm-version: 2.6
 :sandboxed-containers-first: OpenShift sandboxed containers
 :sandboxed-containers-operator: OpenShift sandboxed containers Operator
 :sandboxed-containers-version: 1.3


### PR DESCRIPTION
OCPBUGS#1378: Similar to #62013 , updating RHACM variable for 4.11 as it should be version 2.6 for OCP 4.11. (RHACM 2.6 GA'd Sept 2022. As did OCP 4.11)

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/TELCODOCS-1378

Link to docs preview:
https://file.emea.redhat.com/rohennes/OCPBUGS-1378-rhacm-variable-4-11/welcome/index.html 

No QE required