### PR TITLE
Not to use openshift.io/cluster-monitoring label for user-defined projects

### DIFF
--- a/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
@@ -15,6 +15,11 @@ In {product-title} {product-version} you must remove any custom Prometheus insta
 
 [NOTE]
 ====
+The `openshift.io/cluster-monitoring` label is reserved for platform-specific projects. Do not use the label `openshift.io/cluster-monitoring` on any user-defined projects.
+====
+
+[NOTE]
+====
 You must have access to the cluster as a user with the `cluster-admin` role to enable monitoring for user-defined projects in {product-title}. Cluster administrators can then optionally grant users permission to configure the components that are responsible for monitoring user-defined projects.
 ====
 


### PR DESCRIPTION


<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
openshift.io/cluster-monitoring is reserved for platform projects and should not be configured on any user-defined projects. A note has been appended for the same.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10, 4.11, 4.12, 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://docs.openshift.com/container-platform/4.12/monitoring/enabling-monitoring-for-user-defined-projects.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
