### PR TITLE
[enterprise-4.11] Adding FIPS admonition to install doc

### DIFF
--- a/installing/installing-fips.adoc
+++ b/installing/installing-fips.adoc
@@ -6,16 +6,21 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can install an {product-title} cluster that uses FIPS Validated / Modules in Process cryptographic libraries on the `x86_64` architecture.
+You can install an {product-title} cluster that uses FIPS validated or Modules In Process cryptographic libraries on the `x86_64` architecture.
 
-For the {op-system-first} machines in your cluster, this change is applied when the machines are deployed based on the status of an option in the `install-config.yaml` file, which governs the cluster options that a user can change during cluster deployment. With {op-system-base-full} machines, you must enable FIPS mode when you install the operating system on the machines that you plan to use as worker machines. These configuration methods ensure that your cluster meet the requirements of a FIPS compliance audit: only FIPS Validated / Modules in Process cryptography packages are enabled before the initial system boot.
+[IMPORTANT]
+====
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
+====
+
+For the {op-system-first} machines in your cluster, this change is applied when the machines are deployed based on the status of an option in the `install-config.yaml` file, which governs the cluster options that a user can change during cluster deployment. With {op-system-base-full} machines, you must enable FIPS mode when you install the operating system on the machines that you plan to use as worker machines. These configuration methods ensure that your cluster meet the requirements of a FIPS compliance audit: only FIPS validated or Modules In Process cryptography packages are enabled before the initial system boot.
 
 Because FIPS must be enabled before the operating system that your cluster uses boots for the first time, you cannot enable FIPS after you deploy a cluster.
 
 [id="installation-about-fips-validation_{context}"]
 == FIPS validation in {product-title}
 
-{product-title} uses certain FIPS Validated / Modules in Process modules within {op-system-base} and {op-system} for the operating system components that it uses. See link:https://access.redhat.com/articles/3655361[RHEL8 core crypto components]. For example, when users SSH into {product-title} clusters and containers, those connections are properly encrypted.
+{product-title} uses certain FIPS validated or Modules In Process modules within {op-system-base} and {op-system} for the operating system components that it uses. See link:https://access.redhat.com/articles/3655361[RHEL8 core crypto components]. For example, when users use SSH to connect to {product-title} clusters and containers, those connections are properly encrypted.
 
 {product-title} components are written in Go and built with Red Hat's golang compiler. When you enable FIPS mode for your cluster, all {product-title} components that require cryptographic signing call {op-system-base} and {op-system} cryptographic libraries.
 
@@ -32,7 +37,7 @@ Because FIPS must be enabled before the operating system that your cluster uses 
 |FIPS support in CRI-O runtimes.
 |FIPS support in {product-title} services.
 
-|FIPS Validated / Modules in Process cryptographic module and algorithms that are obtained from {op-system-base} 8 and {op-system} binaries and images.
+|FIPS validated or Modules In Process cryptographic module and algorithms that are obtained from {op-system-base} 8 and {op-system} binaries and images.
 |
 
 |Use of FIPS compatible golang compiler.
@@ -46,24 +51,24 @@ Because FIPS must be enabled before the operating system that your cluster uses 
 [id="installation-about-fips-components_{context}"]
 ==  FIPS support in components that the cluster uses
 
-Although the {product-title} cluster itself uses FIPS Validated / Modules in Process modules, ensure that the systems that support your {product-title} cluster use FIPS Validated / Modules in Process modules for cryptography.
+Although the {product-title} cluster itself uses FIPS validated or Modules In Process modules, ensure that the systems that support your {product-title} cluster use FIPS validated or Modules In Process modules for cryptography.
 
 [id="installation-about-fips-components-etcd_{context}"]
 === etcd
 
-To ensure that the secrets that are stored in etcd use FIPS Validated / Modules in Process encryption, boot the node in FIPS mode. After you install the cluster in FIPS mode, you can xref:../security/encrypting-etcd.adoc#encrypting-etcd[encrypt the etcd data] by using the FIPS-approved `aes cbc` cryptographic algorithm.
+To ensure that the secrets that are stored in etcd use FIPS validated or Modules In Process encryption, boot the node in FIPS mode. After you install the cluster in FIPS mode, you can xref:../security/encrypting-etcd.adoc#encrypting-etcd[encrypt the etcd data] by using the FIPS-approved `aes cbc` cryptographic algorithm.
 
 [id="installation-about-fips-components-storage_{context}"]
 === Storage
 
-For local storage, use {op-system-base}-provided disk encryption or Container Native Storage that uses {op-system-base}-provided disk encryption. By storing all data in volumes that use {op-system-base}-provided disk encryption and enabling FIPS mode for your cluster, both data at rest and data in motion, or network data, are protected by FIPS Validated / Modules in Process encryption.
+For local storage, use {op-system-base}-provided disk encryption or Container Native Storage that uses {op-system-base}-provided disk encryption. By storing all data in volumes that use {op-system-base}-provided disk encryption and enabling FIPS mode for your cluster, both data at rest and data in motion, or network data, are protected by FIPS validated or Modules In Process encryption.
 You can configure your cluster to encrypt the root filesystem of each node, as described
 in xref:../installing/install_config/installing-customizing.adoc#installing-customizing[Customizing nodes].
 
 [id="installation-about-fips-components-runtimes_{context}"]
 === Runtimes
 
-To ensure that containers know that they are running on a host that is using FIPS Validated / Modules in Process cryptography modules, use CRI-O to manage your runtimes. CRI-O supports FIPS mode, in that it configures the containers to know that they are running in FIPS mode.
+To ensure that containers know that they are running on a host that is using FIPS validated or Modules In Process cryptography modules, use CRI-O to manage your runtimes. CRI-O supports FIPS mode, in that it configures the containers to know that they are running in FIPS mode.
 
 [id="installing-fips-mode_{context}"]
 ==  Installing a cluster in FIPS mode

--- a/modules/distr-tracing-product-overview.adoc
+++ b/modules/distr-tracing-product-overview.adoc
@@ -26,3 +26,8 @@ With {DTShortName} you can perform the following functions:
 * *{JaegerName}* - This component is based on the open source link:https://www.jaegertracing.io/[Jaeger project].
 
 * *{OTELNAME}* - This component is based on the open source link:https://opentelemetry.io/[OpenTelemetry project].
+
+[IMPORTANT]
+====
+Jaeger does not use FIPS validated cryptographic modules.
+====

--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -322,7 +322,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <13> You can optionally provide the `sshKey` value that you use to access the
 machines in your cluster.
@@ -343,7 +343,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <11> You can optionally provide the `sshKey` value that you use to access the
 machines in your cluster.

--- a/modules/installation-azure-config-yaml.adoc
+++ b/modules/installation-azure-config-yaml.adoc
@@ -217,7 +217,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
@@ -231,7 +231,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <15> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
@@ -245,7 +245,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <16> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
@@ -259,7 +259,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]

--- a/modules/installation-azure-stack-hub-config-yaml.adoc
+++ b/modules/installation-azure-stack-hub-config-yaml.adoc
@@ -99,7 +99,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <11> If your Azure Stack Hub environment uses an internal certificate authority (CA), add the necessary certificate bundle in `.pem` format.
 <12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
@@ -196,7 +196,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]

--- a/modules/installation-bare-metal-config-yaml.adoc
+++ b/modules/installation-bare-metal-config-yaml.adoc
@@ -266,7 +266,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 endif::openshift-origin[]
 ifndef::restricted[]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -666,7 +666,7 @@ ifndef::openshift-origin[]
 |Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 [NOTE]
 ====

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -199,7 +199,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
@@ -213,7 +213,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
@@ -227,7 +227,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]

--- a/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
+++ b/modules/installation-gcp-user-infra-shared-vpc-config-yaml.adoc
@@ -83,7 +83,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <8> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]

--- a/modules/installation-ibm-cloud-config-yaml.adoc
+++ b/modules/installation-ibm-cloud-config-yaml.adoc
@@ -86,7 +86,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS Validated or Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 <6> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]

--- a/modules/installation-special-config-storage.adoc
+++ b/modules/installation-special-config-storage.adoc
@@ -211,10 +211,10 @@ openshift:
 +
 [IMPORTANT]
 ====
-If you are configuring nodes to use both disk encryption and mirroring, both features must be configured in the same Butane config.  In addition, if you are configuring disk encryption on a node with FIPS mode enabled, you must include the `fips` directive in the same Butane config, even if FIPS mode is also enabled in a separate manifest.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. If you are configuring nodes to use both disk encryption and mirroring, both features must be configured in the same Butane configuration file.  In addition, if you are configuring disk encryption on a node with FIPS mode enabled, you must include the `fips` directive in the same Butane configuration file, even if FIPS mode is also enabled in a separate manifest.
 ====
 
-. Create a control plane or compute node manifest from the corresponding Butane config and save it to the `<installation_directory>/openshift` directory. For example, to create a manifest for the compute nodes, run the following command:
+. Create a control plane or compute node manifest from the corresponding Butane configuration file and save it to the `<installation_directory>/openshift` directory. For example, to create a manifest for the compute nodes, run the following command:
 +
 [source,terminal]
 ----
@@ -223,7 +223,7 @@ $ butane $HOME/clusterconfig/worker-storage.bu -o <installation_directory>/opens
 +
 Repeat this step for each node type that requires disk encryption or mirroring.
 
-. Save the Butane configs in case you need to update the manifests in the future.
+. Save the Butane configuration file in case you need to update the manifests in the future.
 
 . Continue with the remainder of the {product-title} installation.
 +

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -127,7 +127,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 endif::openshift-origin[]
 ifndef::restricted[]

--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -60,7 +60,7 @@ ifndef::openshift-origin[]
 
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 endif::openshift-origin[]
 * **extensions**: Extend {op-system} features by adding selected pre-packaged software. For this feature, available extensions include link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/security_hardening/index#protecting-systems-against-intrusive-usb-devices_security-hardening[usbguard] and kernel modules.

--- a/modules/osdk-csv-manual-annotations.adoc
+++ b/modules/osdk-csv-manual-annotations.adoc
@@ -34,7 +34,7 @@ The following table lists Operator metadata annotations that can be manually def
 
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 - `proxy-aware`: Operator supports running on a cluster behind a proxy. Operator accepts the standard proxy environment variables  `HTTP_PROXY` and `HTTPS_PROXY`, which Operator Lifecycle Manager (OLM) provides to the Operator automatically when the cluster is configured to use a proxy. Required environment variables are passed down to Operands for managed workloads.
 

--- a/modules/rhel-compute-requirements.adoc
+++ b/modules/rhel-compute-requirements.adoc
@@ -33,7 +33,7 @@ For the most recent list of major functionality that has been deprecated or remo
 
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 endif::[]
 ** NetworkManager 1.0 or later.

--- a/modules/security-compliance-nist.adoc
+++ b/modules/security-compliance-nist.adoc
@@ -20,7 +20,7 @@ technologies are allowed on nodes.
 
 [IMPORTANT]
 ====
-The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
 endif::openshift-origin[]
 

--- a/modules/ssh-agent-using.adoc
+++ b/modules/ssh-agent-using.adoc
@@ -177,7 +177,7 @@ $ ssh-keygen -t ed25519 -N '' -f <path>/<file_name> <1>
 +
 [NOTE]
 ====
-If you plan to install an {product-title} cluster that uses FIPS Validated / Modules in Process cryptographic libraries on the `x86_64` architecture, do not create a key that uses the `ed25519` algorithm. Instead, create a key that uses the `rsa` or `ecdsa` algorithm.
+If you plan to install an {product-title} cluster that uses FIPS validated or Modules In Process cryptographic libraries on the `x86_64` architecture, do not create a key that uses the `ed25519` algorithm. Instead, create a key that uses the `rsa` or `ecdsa` algorithm.
 ====
 
 . View the public SSH key:

--- a/service_mesh/v2x/ossm-reference-jaeger.adoc
+++ b/service_mesh/v2x/ossm-reference-jaeger.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 When the {SMProductShortName} Operator deploys the `ServiceMeshControlPlane` resource, it can also create the resources for distributed tracing. {SMProductShortName} uses Jaeger for distributed tracing.
 
+[IMPORTANT]
+====
+Jaeger does not use FIPS validated cryptographic modules.
+====
+
 include::modules/ossm-enabling-jaeger.adoc[leveloffset=+1]
 
 include::modules/ossm-config-smcp-jaeger.adoc[leveloffset=+1]


### PR DESCRIPTION
Adding FIPS admonition to install doc for 4.11

https://bscott-rh.github.io/openshift-docs/cve-4.11/installing/installing-fips.html
https://bscott-rh.github.io/openshift-docs/cve-4.11/installing/installing_gcp/installing-gcp-customizations.html#installation-configuration-parameters-optional_installing-gcp-customizations (fips mode parameter in the table)
^-- same content applies to AWS, alibaba, Azure, vsphere, OSP, bare metal
https://bscott-rh.github.io/openshift-docs/cve-4.11/service_mesh/v2x/ossm-architecture.html#distr-tracing-product-overview_ossm-architecture
https://bscott-rh.github.io/openshift-docs/cve-4.11/service_mesh/v2x/ossm-reference-jaeger.html