### PR TITLE
RHDEVDOCS-5105: Add test / invoke docs for functions in ODC

### DIFF
--- a/functions/serverless-functions-getting-started.adoc
+++ b/functions/serverless-functions-getting-started.adoc
@@ -17,7 +17,10 @@ include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-run.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
+// invoking functions
 include::modules/serverless-kn-func-invoke.adoc[leveloffset=+1]
+include::modules/odc-invoke-serverless-function.adoc[leveloffset=+1]
+// deleting functions
 include::modules/serverless-kn-func-delete.adoc[leveloffset=+1]
 
 

--- a/functions/serverless-functions-getting-started.adoc
+++ b/functions/serverless-functions-getting-started.adoc
@@ -17,9 +17,17 @@ include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-kn-func-run.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]
+
+[id="serverless-functions-getting-started-invoking-functions"]
+== Invoking functions
+
+You can invoke a function to test that it is working and able to receive events correctly.
+Invoking a function locally is useful for a quick test during function development. Invoking a function on the cluster is useful for testing that is closer to the production environment.
+
 // invoking functions
-include::modules/serverless-kn-func-invoke.adoc[leveloffset=+1]
-include::modules/odc-invoke-serverless-function.adoc[leveloffset=+1]
+include::modules/serverless-kn-func-invoke.adoc[leveloffset=+2]
+include::modules/odc-invoke-serverless-function.adoc[leveloffset=+2]
+
 // deleting functions
 include::modules/serverless-kn-func-delete.adoc[leveloffset=+1]
 

--- a/modules/odc-invoke-serverless-function.adoc
+++ b/modules/odc-invoke-serverless-function.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
+:_content-type: PROCEDURE
+[id="odc-invoke-serverless-function_{context}"]
+= Testing a function in the web console
+
+You can test a deployed serverless function by invoking it in the *Developer* perspective of the {product-title} web console.
+
+.Prerequisites
+
+* The {ServerlessOperatorName} and Knative Serving are installed on your {product-title} cluster.
+* You have logged in to the web console and are in the *Developer* perspective.
+* You have created and deployed a function.
+
+.Procedure
+
+. In the *Developer* perspective, navigate to *Topology*.
+
+. Click a function.
+. Select *Test Serverless Function* from the *Actions* drop-down list in the *Details* panel. This action opens the *Test Serverless Function* dialog box.
+. In the dialog box, modify the settings for your test as required:
+
+.. Choose the *Format* type for your test. The format type can be either *CloudEvent* or *HTTP*.
+.. The *Content-Type* defaults to the `Content-Type` HTTP header value.
+.. You can use the *Advanced Settings* to modify the *Type* or *Source* for CloudEvent tests, or to add optional headers.
+.. You can modify the input data for the test.
+
+. Click *Test* to run your test. After the test is complete, the dialog box displays a status code and a message that informs you whether your test was succesful.
+. Click *Back* to perform another test, or *Close* to close the dialog box.

--- a/modules/serverless-kn-func-invoke.adoc
+++ b/modules/serverless-kn-func-invoke.adoc
@@ -7,7 +7,7 @@
 [id="serverless-kn-func-invoke_{context}"]
 = Invoking a deployed function with a test event
 
-You can use the `kn func invoke` CLI command to send a test request to invoke a function either locally or on your {ocp-product-title} cluster. You can use this command to test that a function is working and able to receive events correctly. Invoking a function locally is useful for a quick test during function development. Invoking a function on the cluster is useful for testing that is closer to the production environment.
+You can use the `kn func invoke` CLI command to send a test request to invoke a function either locally or on your {ocp-product-title} cluster.
 
 .Prerequisites
 


### PR DESCRIPTION
Version(s):
OCP 4.14 - need to map serverless versions

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-5105

Link to docs preview:
https://62038--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-getting-started.html#serverless-functions-getting-started-invoking-functions

QE review:
- [x] QE has approved this change.

Additional information:
Replaces https://github.com/openshift/openshift-docs/pull/59750
Peer review completed on previous PR by @shipsing 