### PR TITLE
RHDEVDOCS-5236: Add docs for creating a function via ODC

### DIFF
--- a/functions/serverless-functions-getting-started.adoc
+++ b/functions/serverless-functions-getting-started.adoc
@@ -13,7 +13,14 @@ Function lifecycle management includes creating, building, and deploying a funct
 
 Before you can complete the following procedures, you must ensure that you have completed all of the prerequisite tasks in xref:../functions/serverless-functions-setup.adoc#serverless-functions-setup[Setting up {FunctionsProductName}].
 
-include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
+[id="serverless-functions-getting-started-creating-functions"]
+== Creating functions
+
+Before you can build and deploy a function, you must create it by using the Knative (`kn`) CLI or the {ocp-product-title} web console.
+
+include::modules/serverless-create-func-kn.adoc[leveloffset=+2]
+include::modules/odc-creating-functions.adoc[leveloffset=+2]
+
 include::modules/serverless-kn-func-run.adoc[leveloffset=+1]
 include::modules/serverless-build-func-kn.adoc[leveloffset=+1]
 include::modules/serverless-deploy-func-kn.adoc[leveloffset=+1]

--- a/modules/odc-creating-functions.adoc
+++ b/modules/odc-creating-functions.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * serverless/functions/serverless-functions-getting-started.adoc
+
+:_content-type: PROCEDURE
+[id="odc-creating-functions_{context}"]
+= Creating a function in the web console
+
+You can create a function from a Git repository by using the *Developer* perspective of the {product-title} web console.
+
+.Prerequisites
+
+* Before you can create a function by using the web console, a cluster administrator must complete the following steps:
+** Install the {ServerlessOperatorName} and Knative Serving on the cluster.
+** Install the {pipelines-shortname} Operator on the cluster.
+** Create the following pipeline tasks so that they are available for all namespaces on the cluster:
++
+.func-s2i task
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.30/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+----
++
+.func-deploy task
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.30/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+----
++
+.Node.js function
+[source,terminal]
+----
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.30/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+----
+
+* You must log into the {product-title} web console.
+* You must create a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You must create or have access to a Git repository that contains the code for your function. The repository must contain a `func.yaml` file and use the `s2i` build strategy.
+ 
+
+.Procedure
+
+. In the *Developer* perspective, navigate to *+Add* → *Create Serverless function*. The *Create Serverless function* page is displayed.
+. Enter a *Git Repo URL* that points to the Git repository that contains the code for your function.
+. In the *Pipelines* section:
+.. Select the *Build, deploy and configure a Pipeline Repository* radio button to create a new pipeline for your function.
+.. Select the *Use Pipeline from this cluster* radio button to connect your function to an existing pipeline in the cluster.
+. Click *Create*.
+
+.Verification
+
+* After you have created a function, you can view it in the *Topology* view of the *Developer* perspective.

--- a/modules/serverless-create-func-kn.adoc
+++ b/modules/serverless-create-func-kn.adoc
@@ -5,9 +5,9 @@
 
 :_content-type: PROCEDURE
 [id="serverless-create-func-kn_{context}"]
-= Creating functions
+= Creating a function by using the Knative CLI
 
-Before you can build and deploy a function, you must create it by using the Knative (`kn`) CLI. You can specify the path, runtime, template, and image registry as flags on the command line, or use the `-c` flag to start the interactive experience in the terminal.
+You can specify the path, runtime, template, and image registry for a function as flags on the command line, or use the `-c` flag to start the interactive experience in the terminal.
 
 .Prerequisites
 


### PR DESCRIPTION
Version(s):
1.29+ (4.13+)

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-5236

Link to docs preview:
https://62059--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-getting-started.html#odc-creating-functions_serverless-functions-getting-started

QE review:
- [x] QE has approved this change.

Additional information:
- Replaces https://github.com/openshift/openshift-docs/pull/59549
- Requires manual cherrypicks to 1.29 branch to replace `serverless-1.30` with correct version `serverless-1.29` per QE comments on previous PR
