### PR TITLE
OCPBUGS-10830: Adding bare metal restricted UPI for 64-bit ARM support to chart

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -518,7 +518,7 @@ ifndef::openshift-origin[]
 |
 |xref:../installing/installing_rhv/installing-rhv-restricted-network.adoc#installing-rhv-restricted-network[&#10003;]
 |xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[&#10003;]
-|
+|xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[&#10003;]
 |xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc#installing-restricted-networks-vsphere[&#10003;]
 |
 |xref:../installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc#installing-restricted-networks-ibm-z[&#10003;]


### PR DESCRIPTION
**For Versions:** 4.12+ 
**Issue:** [OCPBUGS-10830](https://issues.redhat.com/browse/OCPBUGS-10830)

**Description:** Showing that installs on restricted networks are supported on Bare metal UPI 

**Preview:** 
[Selecting an installations methods and preparing a cluster -> Supported installation methods for different platforms ](https://62070--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html#installing-preparing-selecting-cluster-type)

**QE review:**
- [x]  QE approved