### PR TITLE
Fixing update wording in conceptual assemblies

### DIFF
--- a/modules/determining-upgrade-viability-conditiontype.adoc
+++ b/modules/determining-upgrade-viability-conditiontype.adoc
@@ -6,7 +6,7 @@
 [id="understanding_clusteroperator_conditiontypes_{context}"]
 = Understanding cluster Operator condition types
 
-The status of cluster Operators includes their condition type, which informs you of the current state of your Operator's health. The following definitions cover a list of some common ClusterOperator condition types. Operators that have additional condition types and use Operator-specific language have been omitted. 
+The status of cluster Operators includes their condition type, which informs you of the current state of your Operator's health. The following definitions cover a list of some common ClusterOperator condition types. Operators that have additional condition types and use Operator-specific language have been omitted.
 
 The Cluster Version Operator (CVO) is responsible for collecting the status conditions from cluster Operators so that cluster administrators can better understand the state of the {product-title} cluster.
 
@@ -18,19 +18,19 @@ The Cluster Version Operator (CVO) is responsible for collecting the status cond
 //----
 
 
-* Available: 
+* Available:
 The condition type `Available` indicates that an Operator is functional and available in the cluster. If the status is `False`, at least one part of the operand is non-functional and the condition requires an administrator to intervene.
 
 * Progressing:
-The condition type `Progressing` indicates that an Operator is actively rolling out new code, propagating configuration changes, or otherwise moving from one steady state to another. 
+The condition type `Progressing` indicates that an Operator is actively rolling out new code, propagating configuration changes, or otherwise moving from one steady state to another.
 +
 Operators do not report the condition type `Progressing` as `True` when they are reconciling a previous known state. If the observed cluster state has changed and the Operator is reacting to it, then the status reports back as `True`, since it is moving from one steady state to another.
 +
 * Degraded:
-The condition type `Degraded` indicates that an Operator has a current state that does not match its required state over a period of time. The period of time can vary by component, but a `Degraded` status represents persistent observation of an Operator's condition.  As a result, an Operator does not fluctuate in and out of the `Degraded` state.  
+The condition type `Degraded` indicates that an Operator has a current state that does not match its required state over a period of time. The period of time can vary by component, but a `Degraded` status represents persistent observation of an Operator's condition.  As a result, an Operator does not fluctuate in and out of the `Degraded` state.
 +
-There might be a different condition type if the transition from one state to another does not persist over a long enough period to report `Degraded`.  
-An Operator does not report `Degraded` during the course of a normal upgrade.  An Operator may report `Degraded` in response to a persistent infrastructure failure that requires eventual administrator intervention.
+There might be a different condition type if the transition from one state to another does not persist over a long enough period to report `Degraded`.
+An Operator does not report `Degraded` during the course of a normal update.  An Operator may report `Degraded` in response to a persistent infrastructure failure that requires eventual administrator intervention.
 +
 [NOTE]
 ====
@@ -38,6 +38,6 @@ This condition type is only an indication that something may need investigation 
 ====
 +
 * Upgradeable:
-The condition type `Upgradeable` indicates whether the Operator is safe to upgrade based on the current cluster state. The message field contains a human-readable description of what the administrator needs to do for the cluster to successfully update. The CVO allows updates when this condition is `True`, `Unknown` or missing. 
+The condition type `Upgradeable` indicates whether the Operator is safe to update based on the current cluster state. The message field contains a human-readable description of what the administrator needs to do for the cluster to successfully update. The CVO allows updates when this condition is `True`, `Unknown` or missing.
 +
 When the `Upgradeable` status is `False`, only minor updates are impacted, and the CVO prevents the cluster from performing impacted updates unless forced.

--- a/modules/understanding-upgrade-channels.adoc
+++ b/modules/understanding-upgrade-channels.adoc
@@ -85,11 +85,11 @@ ifndef::openshift-origin[]
 
 Choosing the appropriate channel involves two decisions.
 
-First, select the minor version you want for your cluster upgrade. Selecting a channel which matches your current version ensures that you only apply z-stream updates and do not receive feature updates. Selecting an available channel which has a version greater than your current version will ensure that after one or more updates your cluster will have updated to that version. Your cluster will only be offered channels which match its current version, the next version, or the next EUS version.
+First, select the minor version you want for your cluster update. Selecting a channel which matches your current version ensures that you only apply z-stream updates and do not receive feature updates. Selecting an available channel which has a version greater than your current version will ensure that after one or more updates your cluster will have updated to that version. Your cluster will only be offered channels which match its current version, the next version, or the next EUS version.
 
 [NOTE]
 ====
-Due to the complexity involved in planning upgrades between versions many minors apart, channels that assist in planning upgrades beyond a single EUS-to-EUS update are not offered.
+Due to the complexity involved in planning updates between versions many minors apart, channels that assist in planning updates beyond a single EUS-to-EUS update are not offered.
 ====
 
 Second, you should choose your desired rollout strategy. You may choose to update as soon as Red Hat declares a release GA by selecting from fast channels or you may want to wait for Red Hat to promote releases to the stable channel. Update recommendations offered in the `fast-{product-version}` and `stable-{product-version}` are both fully supported and benefit equally from ongoing data analysis. The promotion delay before promoting a release to the stable channel represents the only difference between the two channels. Updates to the latest z-streams are generally promoted to the stable channel within a week or two, however the delay when initially rolling out updates to the latest minor is much longer, generally 45-90 days. Please consider the promotion delay when choosing your desired channel, as waiting for promotion to the stable channel may affect your scheduling plans.

--- a/modules/update-service-overview.adoc
+++ b/modules/update-service-overview.adoc
@@ -9,7 +9,7 @@
 
 The OpenShift Update Service (OSUS) provides update recommendations to {product-title}, including {op-system-first}. It provides a graph, or diagram, that contains the _vertices_ of component Operators and the _edges_ that connect them. The edges in the graph show which versions you can safely update to. The vertices are update payloads that specify the intended state of the managed cluster components.
 
-The Cluster Version Operator (CVO) in your cluster checks with the OpenShift Update Service to see the valid updates and update paths based on current component versions and information in the graph. When you request an update, the CVO uses the release image for that update to upgrade your cluster. The release artifacts are hosted in Quay as container images.
+The Cluster Version Operator (CVO) in your cluster checks with the OpenShift Update Service to see the valid updates and update paths based on current component versions and information in the graph. When you request an update, the CVO uses the corresponding release image to update your cluster. The release artifacts are hosted in Quay as container images.
 ////
 By accepting automatic updates, you can automatically
 keep your cluster up to date with the most recent compatible components.
@@ -30,10 +30,10 @@ Two controllers run during continuous update mode. The first controller continuo
 
 [IMPORTANT]
 ====
-Only upgrading to a newer version is supported. Reverting or rolling back your cluster to a previous version is not supported. If your update fails, contact Red Hat support.
+Only updating to a newer version is supported. Reverting or rolling back your cluster to a previous version is not supported. If your update fails, contact Red Hat support.
 ====
 
-During the update process, the Machine Config Operator (MCO) applies the new configuration to your cluster machines. The MCO cordons the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool and marks them as unavailable. By default, this value is set to `1`. The MCO updates the affected nodes alphabetically by zone, based on the `topology.kubernetes.io/zone` label. If a zone has more than one node, the oldest nodes are updated first. For nodes that do not use zones, such as in bare metal deployments, the nodes are upgraded by age, with the oldest nodes updated first. The MCO updates the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool at a time. The MCO then applies the new configuration and reboots the machine.
+During the update process, the Machine Config Operator (MCO) applies the new configuration to your cluster machines. The MCO cordons the number of nodes specified by the `maxUnavailable` field on the machine configuration pool and marks them unavailable. By default, this value is set to `1`. The MCO updates the affected nodes alphabetically by zone, based on the `topology.kubernetes.io/zone` label. If a zone has more than one node, the oldest nodes are updated first. For nodes that do not use zones, such as in bare metal deployments, the nodes are updated by age, with the oldest nodes updated first. The MCO updates the number of nodes as specified by the `maxUnavailable` field on the machine configuration pool at a time. The MCO then applies the new configuration and reboots the machine.
 
 If you use {op-system-base-full} machines as workers, the MCO does not update the kubelet because you must update the OpenShift API on the machines first.
 

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -17,7 +17,7 @@ endif::openshift-origin[]
 [id="updating-clusters-overview-upgrade-channels-and-releases"]
 == Understanding update channels and releases
 ifndef::openshift-origin[]
-xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Update channels and releases]: With upgrade channels, you can choose an upgrade strategy. Upgrade channels are specific to a minor version of {product-title}. Upgrade channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version. For more information, see the following:
+xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Update channels and releases]: With update channels, you can choose an update strategy. Update channels are specific to a minor version of {product-title}. Update channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version. For more information, see the following:
 
 * xref:../updating/understanding-upgrade-channels-release.adoc#upgrade-version-paths_understanding-upgrade-channels-releases[Upgrading version paths]
 * xref:../updating/understanding-upgrade-channels-release.adoc#fast-stable-channel-strategies_understanding-upgrade-channels-releases[Understanding fast and stable channel use and strategies]
@@ -26,7 +26,7 @@ xref:../updating/understanding-upgrade-channels-release.adoc#understanding-upgra
 * xref:../updating/understanding-upgrade-channels-release.adoc#conditional-updates-overview_understanding-upgrade-channels-releases[Understanding conditional updates]
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-With upgrade channels, you can choose an upgrade strategy. Upgrade channels are specific to a minor version of {product-title}. Upgrade channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version.
+With update channels, you can choose an update strategy. Update channels are specific to a minor version of {product-title}. Update channels only control release selection and do not impact the version of the cluster that you install. The `openshift-install` binary file for a specific version of the {product-title} always installs that minor version.
 
 {product-title} {product-version} offers the following update channel:
 
@@ -116,7 +116,7 @@ Using hardware version 13 for your cluster nodes running on vSphere is now depre
 [id="updating-clusters-overview-hosted-control-planes"]
 == Updating hosted control planes
 
-xref:../updating/updating_a_cluster/updating-hosted-control-planes.adoc#updating-hosted-control-planes[Updating hosted control planes]: On hosted control planes for {product-title}, updates are decoupled between the control plane and the nodes. Your service cluster provider, which is the user that hosts the cluster control planes, can manage the updates as needed. The hosted cluster handles control plane updates, and node pools handle node upgrades. For more information, see the following information:
+xref:../updating/updating_a_cluster/updating-hosted-control-planes.adoc#updating-hosted-control-planes[Updating hosted control planes]: On hosted control planes for {product-title}, updates are decoupled between the control plane and the nodes. Your service cluster provider, which is the user that hosts the cluster control planes, can manage the updates as needed. The hosted cluster handles control plane updates, and node pools handle node updates. For more information, see the following information:
 
 * xref:../updating/updating_a_cluster/updating-hosted-control-planes.adoc#updates-for-hosted-control-planes_updating-hosted-control-planes[Updates for hosted control planes]
 * xref:../updating/updating_a_cluster/updating-hosted-control-planes.adoc#updating-node-pools-for-hcp_updating-hosted-control-planes[Updating node pools for hosted control planes]

--- a/updating/understanding-upgrade-channels-release.adoc
+++ b/updating/understanding-upgrade-channels-release.adoc
@@ -26,7 +26,7 @@ ifndef::openshift-origin[]
 {product-title} {product-version} offers the following update channels:
 
 * `stable-{product-version}`
-* `eus-4.y` (only offered for EUS versions and meant to facilitate upgrades between EUS versions)
+* `eus-4.y` (only offered for EUS versions and meant to facilitate updates between EUS versions)
 * `fast-{product-version}`
 * `candidate-{product-version}`
 
@@ -34,7 +34,7 @@ If you do not want the Cluster Version Operator to fetch available updates from 
 
 [WARNING]
 ====
-Red Hat recommends upgrading to versions suggested by OpenShift Update Service only. For a minor version update, versions must be contiguous. Red Hat does not test updates to noncontiguous versions and cannot guarantee compatibility with earlier versions.
+Red Hat recommends updating to versions suggested by OpenShift Update Service only. For a minor version update, versions must be contiguous. Red Hat does not test updates to noncontiguous versions and cannot guarantee compatibility with earlier versions.
 ====
 
 endif::openshift-origin[]


### PR DESCRIPTION
Versions: 4.10+

This PR changes instances of "upgrade" to "update" (the preferred term per our [glossary](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/term_glossary.adoc#update)) in assemblies of the update docs that primarily contain conceptual information. This is limited to visible content and excludes instances of "upgrade" in metadata, filenames, commands, and other places where it cannot be easily changed.

No information is being changed and thus QE is not required.

Preview: 
- [Updating clusters overview](https://62071--docspreview.netlify.app/openshift-enterprise/latest/updating/index.html)
- [Understanding update channels and releases](https://62071--docspreview.netlify.app/openshift-enterprise/latest/updating/understanding-upgrade-channels-release.html)
- [Introduction to OpenShift updates](https://62071--docspreview.netlify.app/openshift-enterprise/latest/updating/understanding_updates/intro-to-updates.html)