### PR TITLE
OSDOCS3361: Enhancing OC-mirror documentation

### DIFF
--- a/openshift_images/managing_images/using-image-pull-secrets.adoc
+++ b/openshift_images/managing_images/using-image-pull-secrets.adoc
@@ -21,3 +21,7 @@ include::modules/images-allow-pods-to-reference-images-from-secure-registries.ad
 include::modules/images-pulling-from-private-registries.adoc[leveloffset=+2]
 
 include::modules/images-update-global-pull-secret.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* For more information on configuring credentials that allow images to be mirrored, see xref:https://docs.openshift.com/container-platform/4.10/installing/disconnected_install/installing-mirroring-disconnected.html#installation-adding-registry-pull-secret_installing-mirroring-disconnected[Configuring credentials that allow images to be mirrored].


### PR DESCRIPTION
Version(s): 4.10+

Issue:
[OSDOCS 3361](https://issues.redhat.com/browse/OSDOCS-3361)

Link to docs preview: [Docs Preview](https://62076--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets.html)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Examples](https://github.com/openshift/oc-mirror/tree/main/docs/examples)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
