### PR TITLE
OADP - 1073 Velero CPU and memory requirements

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -53,3 +53,5 @@ include::modules/about-installing-oadp-on-multiple-namespaces.adoc[leveloffset=+
 .Additional resources
 
 * xref:../../../operators/understanding/olm/olm-understanding-olm.adoc#olm-csv_olm-understanding-olm[Cluster service version]
+
+include::modules/oadp-velero-cpu-memory-requirements.adoc[leveloffset=+1]

--- a/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
+++ b/backup_and_restore/application_backup_and_restore/troubleshooting.adoc
@@ -32,6 +32,9 @@ include::modules/migration-debugging-velero-resources.adoc[leveloffset=+1]
 == Pods crash or restart due to lack of memory or CPU
 
 If a Velero or Restic pod crashes due to a lack of memory or CPU, you can set specific resource requests for either of those resources.
+[role="_additional-resources"]
+.Additional resources
+* xref:../../backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc#oadp-velero-cpu-memory-requirements_about-installing-oadp[CPU and memory requirements]
 
 include::modules/oadp-pod-crash-set-resource-request-velero.adoc[leveloffset=+2]
 include::modules/oadp-pod-crash-set-resource-request-restic.adoc[leveloffset=+2]

--- a/modules/oadp-pod-crash-set-resource-request-restic.adoc
+++ b/modules/oadp-pod-crash-set-resource-request-restic.adoc
@@ -22,8 +22,9 @@ kind: DataProtectionApplication
 configuration:
   restic:
     podConfig:
-      resourceAllocations:
+      resourceAllocations: <1>
         requests:
-          cpu: 500m
-          memory: 256Mi
+          cpu: 1000m
+          memory: 16Gi
 ----
+<1> The `resourceAllocations` listed are for average usage.

--- a/modules/oadp-pod-crash-set-resource-request-velero.adoc
+++ b/modules/oadp-pod-crash-set-resource-request-velero.adoc
@@ -22,8 +22,9 @@ kind: DataProtectionApplication
 configuration:
   velero:
     podConfig:
-      resourceAllocations:
+      resourceAllocations: <1>
         requests:
-          cpu: 500m
+          cpu: 200m
           memory: 256Mi
 ----
+<1> The `resourceAllocations` listed are for average usage.

--- a/modules/oadp-setting-resource-limits-and-requests.adoc
+++ b/modules/oadp-setting-resource-limits-and-requests.adoc
@@ -29,12 +29,13 @@ spec:
     velero:
       podConfig:
         nodeSelector: <node selector> <1>
-        resourceAllocations:
+        resourceAllocations: <2>
           limits:
             cpu: "1"
-            memory: 512Mi
+            memory: 1024Mi
           requests:
-            cpu: 500m
+            cpu: 200m
             memory: 256Mi
 ----
 <1> Specify the node selector to be supplied to Velero podSpec.
+<2> The `resourceAllocations` listed are for average usage.

--- a/modules/oadp-velero-cpu-memory-requirements.adoc
+++ b/modules/oadp-velero-cpu-memory-requirements.adoc
@@ -1,0 +1,78 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs.adoc
+
+:_content-type: CONCEPT
+[id="oadp-velero-cpu-memory-requirements_{context}"]
+= Velero CPU and memory requirements based on collected data
+
+The following recommendations are based on observations of performance made in the scale and performance lab. The backup and restore resources can be impacted by the type of plugin, the amount of resources required by that backup or restore, and the respective data contained in the persistent volumes (PVs) related to those resources.
+
+
+== CPU and memory requirement for configurations
+|===
+|Configuration types | ^[1]^ Average usage |^[2]^ Large usage |resourceTimeouts
+
+|CSI
+|Velero:
+
+CPU- Request 200m, Limits 1000m
+
+Memory - Request 256Mi, Limits 1024Mi
+
+|Velero:
+
+CPU- Request 200m, Limits 2000m
+
+
+Memory- Request  256Mi, Limits 2048Mi
+
+|N/A
+
+|Restic
+|^[3]^ Restic:
+
+CPU- Request 1000m, Limits 2000m
+
+Memory - Request 16Gi, Limits 32Gi
+
+
+|^[4]^ Restic:
+
+CPU - Request 2000m, Limits 8000m
+
+
+Memory - Request 16Gi, Limits 40Gi
+
+
+|900m
+
+
+
+|^[5]^ DataMover
+|N/A
+|N/A
+|10m - average usage
+
+60m - large usage
+|===
+
+[.small]
+--
+1. Average usage - use these settings for most usage situations.
+
+2. Large usage - use these settings for large usage situations, such as a large PV (500GB Usage), multiple namespaces (100+), or many pods within a single namespace (2000 pods+), and for optimal performance for backup and restore involving large datasets.
+
+3. Restic resource usage corresponds to the amount of data, and type of data. For example, many small files or large amounts of data can cause Restic to utilize large amounts of resources. The https://velero.io/docs/v1.11/customize-installation/#customize-resource-requests-and-limits/[Velero] documentation references 500m as a supplied default, for most of our testing we found 200m request suitable with 1000m limit.  As cited in the Velero documentation, exact CPU and memory usage is dependent on the scale of files and directories, in addition to environmental limitations.
+
+4. Increasing the CPU has a significant impact on improving backup and restore times.
+
+5. DataMover - DataMover default resourceTimeout is 10m. Our tests show that for restoring a large PV (500GB usage), it is required to increase the resourceTimeout to 60m.
+--
+
+[NOTE]
+====
+The resource requirements listed throughout the guide are for average usage only. For large usage, adjust the settings as described in the table above.
+====
+
+


### PR DESCRIPTION
OADP - 1.2.1

OCP - 4.11+

Resolves - https://issues.redhat.com/browse/OADP-1073

Preview - https://62084--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.html#oadp-Velero-cpu-memory-requirements_about-installing-oadp

https://62084--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.html#oadp-setting-resource-limits-and-requests_installing-oadp-azure

https://62084--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting.html#oadp-pod-crash-resource-request-velero_oadp-troubleshooting


