### PR TITLE
log-4129: fix oc CLI command to validate if user has rights to view infra/audit logs

### DIFF
--- a/modules/cluster-logging-visualizer-indices.adoc
+++ b/modules/cluster-logging-visualizer-indices.adoc
@@ -16,7 +16,7 @@ If you can view the pods and logs in the `default`, `kube-` and `openshift-` pro
 +
 [source,terminal]
 ----
-$ oc auth can-i get pods/log -n <project>
+$ oc auth can-i get pods --subresource log -n <project>
 ----
 +
 .Example output

--- a/modules/cluster-logging-visualizer-kibana.adoc
+++ b/modules/cluster-logging-visualizer-kibana.adoc
@@ -20,7 +20,7 @@ If you can view the pods and logs in the `default`, `kube-` and `openshift-` pro
 +
 [source,terminal]
 ----
-$ oc auth can-i get pods/log -n <project>
+$ oc auth can-i get pods --subresource log -n <project>
 ----
 +
 .Example output

--- a/modules/cluster-logging-visualizer-launch.adoc
+++ b/modules/cluster-logging-visualizer-launch.adoc
@@ -16,7 +16,7 @@ If you can view the pods and logs in the `default`, `kube-*` and `openshift-*` p
 +
 [source,terminal]
 ----
-$ oc auth can-i get pods/log -n <project>
+$ oc auth can-i get pods --subresource log -n <project>
 ----
 +
 .Example output


### PR DESCRIPTION
Version(s): 4.14 but this should probably be backported

Issue: https://issues.redhat.com/browse/LOG-4129

Link to docs preview:
https://62115--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-visualizer

QE review:
- [x] QE has approved this change.
