### PR TITLE
[OCPBUGS-14626]: Removing references to oc login from etcd restore doc

### DIFF
--- a/modules/dr-restoring-cluster-state.adoc
+++ b/modules/dr-restoring-cluster-state.adoc
@@ -22,7 +22,7 @@ When you restore your cluster, you must use an etcd backup that was taken from t
 
 .Prerequisites
 
-* Access to the cluster as a user with the `cluster-admin` role.
+* Access to the cluster as a user with the `cluster-admin` role through a certificate-based `kubeconfig` file, like the one that was used during installation.
 * A healthy control plane host to use as the recovery host.
 * SSH access to control plane hosts.
 * A backup directory containing both the etcd snapshot and the resources for the static pods, which were from the same backup. The file names in the directory must be in the following formats: `snapshot_<datetimestamp>.db` and `static_kuberesources_<datetimestamp>.tar.gz`.
@@ -271,16 +271,6 @@ $ sudo crictl ps | grep etcd | egrep -v "operator|etcd-guard"
 ----
 $ oc -n openshift-etcd get pods -l k8s-app=etcd
 ----
-+
-[NOTE]
-====
-If you attempt to run `oc login` prior to running this command and receive the following error, wait a few moments for the authentication controllers to start and try again.
-
-[source,terminal]
-----
-Unable to connect to the server: EOF
-----
-====
 +
 .Example output
 [source,terminal]
@@ -558,17 +548,16 @@ $ oc patch etcd/cluster --type=merge -p '{"spec": {"unsupportedConfigOverrides":
 +
 This command ensures that you can successfully re-create secrets and roll out the static pods.
 
-. In a separate terminal window, log in to the cluster as a user with the `cluster-admin` role by entering the following command:
+. In a separate terminal window within the recovery host, export the recovery `kubeconfig` file by running the following command:
 +
 [source,terminal]
 ----
-$ oc login -u <cluster_admin> <1>
+$ export KUBECONFIG=/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost-recovery.kubeconfig
 ----
-<1> For `<cluster_admin>`, specify a user name with the `cluster-admin` role.
 
 . Force etcd redeployment.
 +
-In a terminal that has access to the cluster as a `cluster-admin` user, run the following command:
+In the same terminal window where you exported the recovery `kubeconfig` file, run the following command:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-14626
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62131--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.html#dr-scenario-2-restoring-cluster-state_dr-restoring-cluster-state
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
