### PR TITLE
TELCODOCS-1238: RN for excluding SR-IOV from Topology Manager

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -103,11 +103,11 @@ A new oc command line interface (CLI) flag, `--import-mode`, has been added to t
 === Networking
 
 [id="ocp-4-14-ingress-node-firewall-operator-ga"]
-== Ingress Node Firewall Operator is generally available
+==== Ingress Node Firewall Operator is generally available
 Ingress Node Firewall Operator was made a technology preview in {product-title} 4.12. With this release, Ingress Node Firewall Operator is generally available. You can now configure firewall rules at the node level. For more information, see xref:../networking/networking-operators-overview.adoc#networking-operators-overview[Ingress Node Firewall Operator].
 
 [id="ocp-4-14-networking-kernal-network-pinning"]
-== Dynamic use of non-reserved CPUs for OVS
+==== Dynamic use of non-reserved CPUs for OVS
 
 With this release, the Open vSwitch (OVS) networking stack can dynamically use non-reserved CPUs.
 This dynamic use of non-reserved CPUs occurs by default in performance-tuned clusters with a CPU manager policy set to `static`.
@@ -118,6 +118,15 @@ OVS remains unable to dynamically use isolated CPUs assigned to containers in `G
 ====
 When the Node Tuning Operator recognizes the performance conditions to activate the use of non-reserved CPUs, there is a several second delay while OVN-Kubernetes configures the CPU affinity alignment of OVS daemons running on the CPUs. During this window, if a `Guaranteed` QoS pod starts, it can experience a latency spike.
 ====
+
+[id="ocp-4-14-networking-sriov-exclude-topology"]
+==== Exclude SR-IOV network topology for NUMA-aware scheduling
+
+With this release, you can exclude advertising the Non-Uniform Memory Access (NUMA) node for the SR-IOV network to the Topology Manager. By not advertising the NUMA node for the SR-IOV network, you can permit more flexible SR-IOV network deployments during NUMA-aware pod scheduling. 
+
+For example, in some scenarios, it is a priority to maximize CPU and memory resources for a pod on a single NUMA node. By not providing a hint to the Topology Manager about the NUMA node for the pod’s SR-IOV network resource, the Topology Manager can deploy the SR-IOV network resource and the pod CPU and memory resources to different NUMA nodes. In earlier {product-title} releases, the Topology Manager attempted to place all resources on the same NUMA node only.
+
+For more information about this more flexible SR-IOV network deployment during NUMA-aware pod scheduling, see xref:../networking/hardware_networks/configuring-sriov-device.adoc#nw-sriov-exclude-topology-manager_configuring-sriov-device[Exclude the SR-IOV network topology for NUMA-aware scheduling].
 
 [id="ocp-4-14-storage"]
 === Storage


### PR DESCRIPTION
[TELCODOCS-1238](https://issues.redhat.com//browse/TELCODOCS-1238): A new specification allows you to exclude advertising the NUMA node that the SR-IOV network resource deploys on. During NUMA-aware scheduling, this allows the SR-IOV network resource to deploy on a separate NUMA node to CPU and memory resources. Previously this was not possible.

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-1238

Link to docs preview:
https://62134--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-sriov-exclude-topology 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
