### PR TITLE
[SRVKS-1088] Add the "Configuring burst and QPS for net-kourier" docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -128,6 +128,8 @@ Topics:
     File: serverless-ossm-v1x-jwt
 - Name: Configuring kube-rbac-proxy resources for Serving
   File: kube-rbac-proxy-serving
+- Name: Configuring burst and QPS for net-kourier
+  File: kube-burst-qps-net-kourier
 - Name: Configuring custom domains for Knative services
   Dir: config-custom-domains
   Topics:

--- a/knative-serving/kube-burst-qps-net-kourier.adoc
+++ b/knative-serving/kube-burst-qps-net-kourier.adoc
@@ -1,0 +1,11 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="kube-burst-qps-net-kourier"]
+= Configuring burst and QPS for net-kourier
+:context: kube-burst-qps-net-kourier
+
+toc::[]
+
+The queries per second (QPS) and burst values determine the frequency of requests or API calls to the API server.
+
+include::modules/serverless-configuring-burst-qps-for-net-kourier.adoc[leveloffset=+1]

--- a/modules/serverless-configuring-burst-qps-for-net-kourier.adoc
+++ b/modules/serverless-configuring-burst-qps-for-net-kourier.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * knative-serving/kube-burst-qps-net-kourier.adoc
+
+:_content-type: REFERENCE
+[id="serverless-configuring-burst-qps-for-net-kourier_{context}"]
+= Configuring burst and QPS values for net-kourier
+
+The queries per second (QPS) value determines the number of client requests or API calls that are sent to the API server.
+
+The burst value determines how many requests from the client can be stored for processing. Requests exceeding this buffer will be dropped. This is helpful for controllers that are bursty and do not spread their requests uniformly in time.
+
+When the `net-kourier-controller` restarts, it parses all `ingress` resources deployed on the cluster, which leads to a significant number of API calls. Due to this, the `net-kourier-controller` can take a long time to start.
+
+You can adjust the QPS and burst values for the `net-kourier-controller` in the KnativeServing CR:
+
+.KnativeServing CR example
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeServing
+metadata:
+  name: knative-serving
+  namespace: knative-serving
+spec:
+  workloads:
+  - name: net-kourier-controller
+    env:
+    - container: controller
+      envVars:
+      - name: KUBE_API_BURST
+        value: "200" <1>
+      - name: KUBE_API_QPS
+        value: "200" <2>
+----
+<1> The QPS rate of communication between controller and the API Server. The default value is 200.
+<2> The burst capacity of communication between Kubelet and the API Server. The default value is 200.


### PR DESCRIPTION
Version(s):
Serverless 1.29+ (CP to branches `serverless-docs-1.29` and `serverless-docs-1.30`)

Issue:
https://issues.redhat.com/browse/SRVKS-1088

Link to docs preview:
https://62138--docspreview.netlify.app/openshift-serverless/latest/knative-serving/kube-burst-qps-net-kourier.html

QE review:
- [ ] QE has approved this change.