### PR TITLE
[OSDOCS-4158]: New `ccoctl` steps for cluster capabilities

### DIFF
--- a/installing/installing_azure/uninstalling-cluster-azure.adoc
+++ b/installing/installing_azure/uninstalling-cluster-azure.adoc
@@ -9,3 +9,5 @@ toc::[]
 You can remove a cluster that you deployed to Microsoft Azure.
 
 include::modules/installation-uninstall-clouds.adoc[leveloffset=+1]
+
+include::modules/cco-ccoctl-deleting-sts-resources.adoc[leveloffset=+1]

--- a/modules/about-manually-maintained-credentials-upgrade.adoc
+++ b/modules/about-manually-maintained-credentials-upgrade.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * updating/preparing_for_updates/preparing-manual-creds-update.adoc
-// * authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
 
 :_content-type: CONCEPT
 
@@ -39,8 +38,8 @@ Clusters installed on these platforms are configured using the `ccoctl` utility.
 +
 Administrators of clusters on these platforms must take the following actions:
 +
-. Configure the `ccoctl` utility for the new release.
-. Use the `ccoctl` utility to update the cloud provider resources.
+. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
+. Configure the `ccoctl` utility for the new release and use it to update the cloud provider resources.
 . Indicate that the cluster is ready to update with the `upgradeable-to` annotation.
 
 Microsoft Azure Stack Hub::
@@ -48,6 +47,7 @@ These clusters use manual mode with long-term credentials and do not use the `cc
 +
 Administrators of clusters on these platforms must take the following actions:
 +
+. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
 . Manually update the cloud provider resources for the new release.
 . Indicate that the cluster is ready to update with the `upgradeable-to` annotation.
 

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -137,6 +137,8 @@ The `ccoctl` utility is a Linux binary that must run in a Linux environment.
 //Upgrade prereqs
 ifdef::update[]
 * Your cluster was configured using the `ccoctl` utility to create and manage cloud credentials from outside of the cluster.
+
+* You have extracted the `CredentialsRequest` custom resources (CRs) from the {product-title} release image and ensured that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster.
 endif::update[]
 
 //AWS permissions needed when running ccoctl during install (I think we can omit from upgrade, since they already have an appropriate AWS account if they are upgrading).
@@ -213,12 +215,14 @@ endif::aws-sts[]
 
 .Procedure
 
+ifndef::update[]
 . Obtain the {product-title} release image by running the following command:
 +
 [source,terminal]
 ----
 $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
 ----
+endif::update[]
 
 . Obtain the CCO container image from the {product-title} release image by running the following command:
 +

--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -24,6 +24,13 @@
 // * installing/installing_gcp/installing-gcp-vpc.adoc
 // * installing/installing_gcp/installing-gcp-shared-vpc.adoc
 // * installing/installing_gcp/installing-gcp-private.adoc
+//
+// Azure assemblies
+// * installing/installing_azure/installing-azure-customizations.adoc
+// * installing/installing_azure/installing-azure-government-region.adoc
+// * installing/installing_azure/installing-azure-network-customizations.adoc
+// * installing/installing_azure/installing-azure-private.adoc
+// * installing/installing_azure/installing-azure-vnet.adoc
 
 //Platforms that must use `ccoctl`
 ifeval::["{context}" == "installing-alibaba-default"]
@@ -88,6 +95,23 @@ ifeval::["{context}" == "installing-gcp-private"]
 :google-cloud-platform:
 endif::[]
 
+//global Azure install assemblies
+ifeval::["{context}" == "installing-azure-customizations"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-government-region"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-network-customizations"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-private"]
+:azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-vnet"]
+:azure-workload-id:
+endif::[]
+
 :_content-type: PROCEDURE
 [id="cco-ccoctl-creating-at-once_{context}"]
 ifdef::aws-sts[]
@@ -103,6 +127,11 @@ ifdef::google-cloud-platform[]
 
 You can use the `ccoctl gcp create-all` command to automate the creation of GCP resources.
 endif::google-cloud-platform[]
+ifdef::azure-workload-id[]
+= Creating Azure resources with the Cloud Credential Operator utility
+
+You can use the `ccoctl azure create-all` command to automate the creation of Azure resources.
+endif::azure-workload-id[]
 ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 [id="cco-ccoctl-creating-at-once_{context}"]
 = Creating credentials for {product-title} components with the ccoctl tool
@@ -127,129 +156,44 @@ endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 
 .Procedure
 
-ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
-. Set the `$RELEASE_IMAGE` variable by running the following command:
+. Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
 +
 [source,terminal]
 ----
 $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
 ----
-endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 
 . Extract the list of `CredentialsRequest` objects from the {product-title} release image by running the following command:
 +
 [source,terminal]
-ifdef::aws-sts[]
 ----
 $ oc adm release extract \
+  --from=$RELEASE_IMAGE \
   --credentials-requests \
-  --cloud=aws \
-  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
-  --from=quay.io/<path_to>/ocp-release:<version>
+  --included \// <1>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
+  --to=<path_to_directory_for_credentials_requests> <3>
 ----
-endif::aws-sts[]
-ifdef::google-cloud-platform[]
-----
-$ oc adm release extract \
-  --credentials-requests \
-  --cloud=gcp \
-  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
-  quay.io/<path_to>/ocp-release:<version>
-----
-endif::google-cloud-platform[]
-ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
-----
-$ oc adm release extract \
-  --credentials-requests \
-  --cloud=alibabacloud \
-  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
-  $RELEASE_IMAGE
-----
-endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
-+
-<1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
+<1> The `--included` parameter includes only the manifests that your specific cluster configuration requries.
+<2> Specify the location of the `install-config.yaml` file.
+<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 [NOTE]
 ====
 This command can take a few moments to run.
 ====
 
-ifdef::aws-sts[]
-. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
+ifdef::aws-sts,google-cloud-platform,azure-workload-id[]
+. Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the following command:
 +
-.Example `credrequests` directory contents for {product-title} 4.12 on AWS
-+
-[source,terminal]
-----
-0000_30_machine-api-operator_00_credentials-request.yaml <1>
-0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <2>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <3>
-0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
-0000_50_cluster-network-operator_02-cncc-credentials.yaml <5>
-0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <6>
-----
-+
-<1> The Machine API Operator CR is required.
-<2> The Cloud Credential Operator CR is required.
-<3> The Image Registry Operator CR is required.
-<4> The Ingress Operator CR is required.
-<5> The Network Operator CR is required.
-<6> The Storage Operator CR is an optional component and might be disabled in your cluster.
-endif::aws-sts[]
-ifdef::google-cloud-platform[]
-. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
-+
-.Example `credrequests` directory contents for {product-title} 4.12 on GCP
-+
-[source,terminal]
-----
-0000_26_cloud-controller-manager-operator_16_credentialsrequest-gcp.yaml <1>
-0000_30_machine-api-operator_00_credentials-request.yaml <2>
-0000_50_cloud-credential-operator_05-gcp-ro-credentialsrequest.yaml <3>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request-gcs.yaml <4>
-0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <5>
-0000_50_cluster-network-operator_02-cncc-credentials.yaml <6>
-0000_50_cluster-storage-operator_03_credentials_request_gcp.yaml <7>
-----
-+
-<1> The Cloud Controller Manager Operator CR is required.
-<2> The Machine API Operator CR is required.
-<3> The Cloud Credential Operator CR is required.
-<4> The Image Registry Operator CR is required.
-<5> The Ingress Operator CR is required.
-<6> The Network Operator CR is required.
-<7> The Storage Operator CR is an optional component and might be disabled in your cluster.
-endif::google-cloud-platform[]
-ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
-. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
-+
-.Example `credrequests` directory contents for {product-title} 4.12 on Alibaba Cloud
-+
-[source,terminal]
-----
-0000_30_machine-api-operator_00_credentials-request.yaml <1>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request-alibaba.yaml <2>
-0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <3>
-0000_50_cluster-storage-operator_03_credentials_request_alibaba.yaml <4>
-----
-+
-<1> The Machine API Operator CR is required.
-<2> The Image Registry Operator CR is required.
-<3> The Ingress Operator CR is required.
-<4> The Storage Operator CR is an optional component and might be disabled in your cluster.
-endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
-
-ifdef::aws-sts,google-cloud-platform[]
-. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
-+
-endif::aws-sts,google-cloud-platform[]
+endif::aws-sts,google-cloud-platform,azure-workload-id[]
 ifdef::aws-sts[]
 [source,terminal]
 ----
 $ ccoctl aws create-all \
   --name=<name> \// <1>
   --region=<aws_region> \// <2>
-  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <3>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <3>
   --output-dir=<path_to_ccoctl_output_dir> \// <4>
   --create-private-s3-bucket <5>
 ----
@@ -271,7 +215,7 @@ $ ccoctl gcp create-all \
   --name=<name> \// <1>
   --region=<gcp_region> \// <2>
   --project=<gcp_project_id> \// <3>
-  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests <4>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> <4>
 ----
 <1> Specify the user-defined name for all created GCP resources used for tracking.
 <2> Specify the GCP region in which cloud resources will be created.
@@ -283,9 +227,34 @@ $ ccoctl gcp create-all \
 If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
 ====
 endif::google-cloud-platform[]
+ifdef::azure-workload-id[]
+[source,terminal]
+----
+$ ccoctl azure create-all \
+  --name=<azure_infra_name> \// <1>
+  --output-dir=<ccoctl_output_dir> \// <2>
+  --region=<azure_region> \// <3>
+  --subscription-id=<azure_subscription_id> \// <4>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <5>
+  --dnszone-resource-group-name=<azure_dns_zone_resource_group_name> \// <6>
+  --tenant-id=<azure_tenant_id> <7>
+----
+<1> Specify the user-defined name for all created Azure resources used for tracking.
+<2> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<3> Specify the Azure region in which cloud resources will be created.
+<4> Specify the Azure subscription ID to use.
+<5> Specify the directory containing the files for the component `CredentialsRequest` objects.
+<6> Specify the name of the resource group containing the cluster's base domain Azure DNS zone.
+<7> Specify the Azure tenant ID to use.
++
+[NOTE]
+====
+If your cluster uses Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set, you must include the `--enable-tech-preview` parameter.
+====
+endif::azure-workload-id[]
 
 ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
-. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
+. Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the following command:
 
 .. Run the following command to use the tool:
 +
@@ -294,7 +263,7 @@ ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 $ ccoctl alibabacloud create-ram-users \
   --name <name> \// <1>
   --region=<alibaba_region> \// <2>
-  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <3>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <3>
   --output-dir=<path_to_ccoctl_output_dir> <4>
 ----
 <1> Specify the name used to tag any cloud resources that are created for tracking.
@@ -308,8 +277,7 @@ If your cluster uses Technology Preview features that are enabled by the `TechPr
 ====
 +
 .Example output
-+
-[source,terminal]
+[source,text]
 ----
 2022/02/11 16:18:26 Created RAM User: user1-alicloud-openshift-machine-api-alibabacloud-credentials
 2022/02/11 16:18:27 Ready for creating new ram policy user1-alicloud-openshift-machine-api-alibabacloud-credentials-policy-policy
@@ -332,9 +300,8 @@ A RAM user can have up to two AccessKeys at the same time. If you run `ccoctl al
 $ ls <path_to_ccoctl_output_dir>/manifests
 ----
 +
-.Example output:
-+
-[source,terminal]
+.Example output
+[source,text]
 ----
 openshift-cluster-csi-drivers-alibaba-disk-credentials-credentials.yaml
 openshift-image-registry-installer-cloud-credentials-credentials.yaml
@@ -357,8 +324,9 @@ where:
 `<path_to_installation_dir>`:: Specifies the directory in which the installation program creates files.
 endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 
-ifdef::aws-sts,google-cloud-platform[]
+ifdef::aws-sts,google-cloud-platform,azure-workload-id[]
 .Verification
+
 
 * To verify that the {product-title} secrets are created, list the files in the `<path_to_ccoctl_output_dir>/manifests` directory:
 +
@@ -366,12 +334,11 @@ ifdef::aws-sts,google-cloud-platform[]
 ----
 $ ls <path_to_ccoctl_output_dir>/manifests
 ----
-endif::aws-sts,google-cloud-platform[]
+endif::aws-sts,google-cloud-platform,azure-workload-id[]
 ifdef::aws-sts[]
 +
-.Example output:
-+
-[source,terminal]
+.Example output
+[source,text]
 ----
 cluster-authentication-02-config.yaml
 openshift-cloud-credential-operator-cloud-credential-operator-iam-ro-creds-credentials.yaml
@@ -380,13 +347,32 @@ openshift-image-registry-installer-cloud-credentials-credentials.yaml
 openshift-ingress-operator-cloud-credentials-credentials.yaml
 openshift-machine-api-aws-cloud-credentials-credentials.yaml
 ----
-//Would love a GCP version of the above output.
-
++
 You can verify that the IAM roles are created by querying AWS. For more information, refer to AWS documentation on listing IAM roles.
 endif::aws-sts[]
 ifdef::google-cloud-platform[]
 You can verify that the IAM service accounts are created by querying GCP. For more information, refer to GCP documentation on listing IAM service accounts.
+//to-do: include sample output for GCP when available.
 endif::google-cloud-platform[]
+ifdef::azure-workload-id[]
++
+.Example output
+[source,text]
+----
+azure-ad-pod-identity-webhook-config.yaml
+cluster-authentication-02-config.yaml
+openshift-cloud-controller-manager-azure-cloud-credentials-credentials.yaml
+openshift-cloud-network-config-controller-cloud-credentials-credentials.yaml
+openshift-cluster-api-capz-manager-bootstrap-credentials-credentials.yaml
+openshift-cluster-csi-drivers-azure-disk-credentials-credentials.yaml
+openshift-cluster-csi-drivers-azure-file-credentials-credentials.yaml
+openshift-image-registry-installer-cloud-credentials-credentials.yaml
+openshift-ingress-operator-cloud-credentials-credentials.yaml
+openshift-machine-api-azure-cloud-credentials-credentials.yaml
+----
++
+You can verify that the Azure AD service accounts are created by querying Azure. For more information, refer to Azure documentation on listing AD service accounts.
+endif::azure-workload-id[]
 
 //Platforms that must use `ccoctl`
 ifeval::["{context}" == "installing-alibaba-default"]
@@ -449,4 +435,21 @@ ifeval::["{context}" == "installing-gcp-shared-vpc"]
 endif::[]
 ifeval::["{context}" == "installing-gcp-private"]
 :!google-cloud-platform:
+endif::[]
+
+//global Azure install assemblies
+ifeval::["{context}" == "installing-azure-customizations"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-government-region"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-network-customizations"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-private"]
+:!azure-workload-id:
+endif::[]
+ifeval::["{context}" == "installing-azure-vnet"]
+:!azure-workload-id:
 endif::[]

--- a/modules/cco-ccoctl-creating-individually.adoc
+++ b/modules/cco-ccoctl-creating-individually.adoc
@@ -40,9 +40,8 @@ Some `ccoctl` commands make AWS API calls to create or modify AWS resources. You
 $ ccoctl aws create-key-pair
 ----
 +
-.Example output:
-+
-[source,terminal]
+.Example output
+[source,text]
 ----
 2021/04/13 11:01:02 Generating RSA keypair
 2021/04/13 11:01:03 Writing private key to /<path_to_ccoctl_output_dir>/serviceaccount-signer.private
@@ -59,22 +58,16 @@ This command also creates a private key that the cluster requires during install
 [source,terminal]
 ----
 $ ccoctl aws create-identity-provider \
---name=<name> \
---region=<aws_region> \
---public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public
+  --name=<name> \// <1>
+  --region=<aws_region> \// <2>
+  --public-key-file=<path_to_ccoctl_output_dir>/serviceaccount-signer.public <3>
 ----
+<1> `<name>` is the name used to tag any cloud resources that are created for tracking.
+<2> `<aws-region>` is the AWS region in which cloud resources will be created.
+<3> `<path_to_ccoctl_output_dir>` is the path to the public key file that the `ccoctl aws create-key-pair` command generated.
 +
-where:
-+
---
-** `<name>` is the name used to tag any cloud resources that are created for tracking.
-** `<aws-region>` is the AWS region in which cloud resources will be created.
-** `<path_to_ccoctl_output_dir>` is the path to the public key file that the `ccoctl aws create-key-pair` command generated.
---
-+
-.Example output:
-+
-[source,terminal]
+.Example output
+[source,text]
 ----
 2021/04/13 11:16:09 Bucket <name>-oidc created
 2021/04/13 11:16:10 OpenID Connect discovery document in the S3 bucket <name>-oidc at .well-known/openid-configuration updated
@@ -87,50 +80,39 @@ where `openid-configuration` is a discovery document and `keys.json` is a JSON w
 +
 This command also creates a YAML configuration file in `/<path_to_ccoctl_output_dir>/manifests/cluster-authentication-02-config.yaml`. This file sets the issuer URL field for the service account tokens that the cluster generates, so that the AWS IAM identity provider trusts the tokens.
 
-. Create IAM roles for each component in the cluster.
+. Create IAM roles for each component in the cluster:
+
+.. Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
++
+[source,terminal]
+----
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
+----
 
 .. Extract the list of `CredentialsRequest` objects from the {product-title} release image:
 +
 [source,terminal]
 ----
-$ oc adm release extract --credentials-requests \
---cloud=aws \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests <1>
---from=quay.io/<path_to>/ocp-release:<version>
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --included \// <1>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
+  --to=<path_to_directory_for_credentials_requests> <3>
 ----
-+
-<1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
+<1> The `--included` parameter includes only the manifests that your specific cluster configuration requries.
+<2> Specify the location of the `install-config.yaml` file.
+<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 
-.. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
-+
-.Example `credrequests` directory contents for {product-title} 4.12 on AWS
-+
-[source,terminal]
-----
-0000_30_machine-api-operator_00_credentials-request.yaml <1>
-0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <2>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <3>
-0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
-0000_50_cluster-network-operator_02-cncc-credentials.yaml <5>
-0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <6>
-----
-+
-<1> The Machine API Operator CR is required.
-<2> The Cloud Credential Operator CR is required.
-<3> The Image Registry Operator CR is required.
-<4> The Ingress Operator CR is required.
-<5> The Network Operator CR is required.
-<6> The Storage Operator CR is an optional component and might be disabled in your cluster.
-
-.. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory:
+.. Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the following command:
 +
 [source,terminal]
 ----
 $ ccoctl aws create-iam-roles \
---name=<name> \
---region=<aws_region> \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
---identity-provider-arn=arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
+  --name=<name> \
+  --region=<aws_region> \
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \
+  --identity-provider-arn=arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com
 ----
 +
 [NOTE]
@@ -151,9 +133,8 @@ For each `CredentialsRequest` object, `ccoctl` creates an IAM role with a trust 
 $ ll <path_to_ccoctl_output_dir>/manifests
 ----
 +
-.Example output:
-+
-[source,terminal]
+.Example output
+[source,text]
 ----
 total 24
 -rw-------. 1 <user> <user> 161 Apr 13 11:42 cluster-authentication-02-config.yaml

--- a/modules/cco-ccoctl-deleting-sts-resources.adoc
+++ b/modules/cco-ccoctl-deleting-sts-resources.adoc
@@ -4,54 +4,82 @@
 // * installing/installing_gcp/uninstalling-cluster-gcp.adoc
 
 ifeval::["{context}" == "uninstall-cluster-aws"]
+:cp-first: Amazon Web Services
+:cp: AWS
+:cp-name: aws
 :aws-sts:
 endif::[]
 ifeval::["{context}" == "uninstalling-cluster-gcp"]
-:google-cloud-platform:
+:cp-first: Google Cloud Platform
+:cp: GCP
+:cp-name: gcp
+:gcp-workload-id:
+endif::[]
+ifeval::["{context}" == "uninstall-cluster-azure"]
+:cp-first: Microsoft Azure
+:cp: Azure
+:cp-name: azure
+:azure-workload-id:
 endif::[]
 
 :_content-type: PROCEDURE
 [id="cco-ccoctl-deleting-sts-resources_{context}"]
-ifdef::aws-sts[]
-= Deleting AWS resources with the Cloud Credential Operator utility
+= Deleting {cp-first} resources with the Cloud Credential Operator utility
 
-To clean up resources after uninstalling an {product-title} cluster with the Cloud Credential Operator (CCO) in manual mode with STS, you can use the CCO utility (`ccoctl`) to remove the AWS resources that `ccoctl` created during installation.
-endif::aws-sts[]
-
-ifdef::google-cloud-platform[]
-= Deleting GCP resources with the Cloud Credential Operator utility
-
-To clean up resources after uninstalling an {product-title} cluster with the Cloud Credential Operator (CCO) in manual mode with GCP Workload Identity, you can use the CCO utility (`ccoctl`) to remove the GCP resources that `ccoctl` created during installation.
-endif::google-cloud-platform[]
+After uninstalling an {product-title} cluster that uses short-term credentials managed outside the cluster, you can use the CCO utility (`ccoctl`) to remove the {cp-first} ({cp}) resources that `ccoctl` created during installation.
 
 .Prerequisites
 
 * Extract and prepare the `ccoctl` binary.
-ifdef::aws-sts[]
-* Install an {product-title} cluster with the CCO in manual mode with STS.
-endif::aws-sts[]
-ifdef::google-cloud-platform[]
-* Install an {product-title} cluster with the CCO in manual mode with GCP Workload Identity.
-endif::google-cloud-platform[]
+* Uninstall an {product-title} cluster on {cp} that uses short-term credentials.
 
 .Procedure
-
-ifdef::aws-sts[]
-* Delete the AWS resources that `ccoctl` created:
+//GCP has extra prep steps
+ifdef::gcp-workload-id[]
+. Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
 +
 [source,terminal]
 ----
-$ ccoctl aws delete \
-  --name=<name> \ <1>
-  --region=<aws_region> <2>
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
+----
+
+. Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --included \// <1>
+  --to=<path_to_directory_for_credentials_requests> <2>
+----
+<1> The `--included` parameter includes only the manifests that your specific cluster configuration requries.
+<2> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
+
+. Delete the {cp} resources that `ccoctl` created by running the following command:
+endif::gcp-workload-id[]
+ifdef::aws-sts,azure-workload-id[]
+* Delete the {cp} resources that `ccoctl` created by running the following command:
+endif::aws-sts,azure-workload-id[]
++
+[source,terminal,subs="attributes+"]
+----
+$ ccoctl {cp-name} delete \
+  --name=<name> \// <1>
+ifdef::aws-sts,azure-workload-id[  --region=<{cp-name}_region> <2>]
+ifdef::gcp-workload-id[]
+  --project=<{cp-name}_project_id> \// <2>
+  --credentials-requests-dir=<path_to_credentials_requests_directory>
+endif::gcp-workload-id[]
 ----
 +
 <1> `<name>` matches the name that was originally used to create and tag the cloud resources.
-<2> `<aws_region>` is the AWS region in which to delete cloud resources.
+ifdef::aws-sts,azure-workload-id[<2> `<{cp-name}_region>` is the {cp} region in which to delete cloud resources.]
+ifdef::gcp-workload-id[<2> `<{cp-name}_project_id>` is the {cp} project ID in which to delete cloud resources.]
+ifdef::aws-sts[]
 +
-.Example output:
-+
-[source,terminal]
+.Example output
+[source,text]
 ----
 2021/04/08 17:50:41 Identity Provider object .well-known/openid-configuration deleted from the bucket <name>-oidc
 2021/04/08 17:50:42 Identity Provider object keys.json deleted from the bucket <name>-oidc
@@ -68,55 +96,25 @@ $ ccoctl aws delete \
 2021/04/08 17:51:11 IAM Role <name>-openshift-machine-api-aws-cloud-credentials deleted
 2021/04/08 17:51:39 Identity Provider with ARN arn:aws:iam::<aws_account_id>:oidc-provider/<name>-oidc.s3.<aws_region>.amazonaws.com deleted
 ----
-//Would love a GCP version of the above output.
+//Would love a GCP and Azure version of the above output.
 endif::aws-sts[]
-ifdef::google-cloud-platform[]
-. Obtain the {product-title} release image by running the following command:
-+
-[source,terminal]
-----
-$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
-----
-
-. Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
-+
-[source,terminal]
-----
-$ oc adm release extract --credentials-requests \
-  --cloud=gcp \
-  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
-  $RELEASE_IMAGE
-----
-+
-<1> `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
-
-. Delete the GCP resources that `ccoctl` created:
-+
-[source,terminal]
-----
-$ ccoctl gcp delete \
-  --name=<name> \ <1>
-  --project=<gcp_project_id> \ <2>
-  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
-----
-+
-<1> `<name>` matches the name that was originally used to create and tag the cloud resources.
-<2> `<gcp_project_id>` is the GCP project ID in which to delete cloud resources.
-endif::google-cloud-platform[]
 
 .Verification
 
-ifdef::aws-sts[]
-* To verify that the resources are deleted, query AWS. For more information, refer to AWS documentation.
-endif::aws-sts[]
-
-ifdef::google-cloud-platform[]
-* To verify that the resources are deleted, query GCP. For more information, refer to GCP documentation.
-endif::google-cloud-platform[]
+* To verify that the resources are deleted, query {cp}. For more information, refer to {cp} documentation.
 
 ifeval::["{context}" == "uninstall-cluster-aws"]
+:!cp-first: Amazon Web Services
+:!cp: AWS
 :!aws-sts:
 endif::[]
 ifeval::["{context}" == "uninstalling-cluster-gcp"]
-:!google-cloud-platform:
+:!cp-first: Google Cloud Platform
+:!cp: GCP
+:!gcp-workload-id:
+endif::[]
+ifeval::["{context}" == "uninstall-cluster-azure"]
+:!cp-first: Microsoft Azure
+:!cp: Azure
+:!azure-workload-id:
 endif::[]

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -16,62 +16,13 @@ On AWS clusters, some `ccoctl` commands make AWS API calls to create or modify A
 
 .Prerequisites
 
-* Obtain the {product-title} release image for the version that you are upgrading to.
+* You have extracted the `CredentialsRequest` custom resources (CRs) from the {product-title} release image and ensured that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster.
 
-* Extract and prepare the `ccoctl` binary from the release image.
+* You have extracted and configured the `ccoctl` binary from the release image.
 
 .Procedure
 
-. Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
-+
-[source,terminal]
-----
-$ oc adm release extract \
-  --credentials-requests \
-  --cloud=<provider_type> \// <1>
-  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <2>
-  quay.io/<path_to>/ocp-release:<version>
-----
-<1> Specify the value for your cloud provider. Valid values are `alibabacloud`, `aws`, `azure`, `gcp`, `ibmcloud`, and `nutanix`.
-<2> Specify the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
-
-. For each `CredentialsRequest` CR in the release image, ensure that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster. This field is where the generated secrets that hold the credentials configuration are stored.
-+
-.Sample AWS `CredentialsRequest` object
-[source,yaml]
-----
-apiVersion: cloudcredential.openshift.io/v1
-kind: CredentialsRequest
-metadata:
-  name: cloud-credential-operator-iam-ro
-  namespace: openshift-cloud-credential-operator
-spec:
-  providerSpec:
-    apiVersion: cloudcredential.openshift.io/v1
-    kind: AWSProviderSpec
-    statementEntries:
-    - effect: Allow
-      action:
-      - iam:GetUser
-      - iam:GetUserPolicy
-      - iam:ListAccessKeys
-      resource: "*"
-  secretRef:
-    name: cloud-credential-operator-iam-ro-creds
-    namespace: openshift-cloud-credential-operator <1>
-----
-<1> This field indicates the namespace which needs to exist to hold the generated secret.
-+
-The `CredentialsRequest` CRs for other platforms have a similar format with different platform-specific values.
-
-. For any `CredentialsRequest` CR for which the cluster does not already have a namespace with the name specified in `spec.secretRef.namespace`, create the namespace by running the following command:
-+
-[source,terminal]
-----
-$ oc create namespace <component_namespace>
-----
-
-. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory by running the command for your cloud provider. The following commands process `CredentialsRequest` objects:
+. Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the command for your cloud provider. The following commands process `CredentialsRequest` objects:
 +
 .{alibaba}
 [%collapsible]
@@ -81,7 +32,7 @@ $ oc create namespace <component_namespace>
 $ ccoctl alibabacloud create-ram-users \
   --name <name> \// <1>
   --region=<alibaba_region> \// <2>
-  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <3>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <3>
   --output-dir=<path_to_ccoctl_output_dir> <4>
 ----
 <1> Specify the name used to tag any cloud resources that are created for tracking.
@@ -103,7 +54,7 @@ A RAM user can have up to two AccessKeys at the same time. If you run `ccoctl al
 $ ccoctl aws create-all \// <1>
   --name=<name> \// <2>
   --region=<aws_region> \// <3>
-  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <4>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <4>
   --output-dir=<path_to_ccoctl_output_dir> \// <5>
   --create-private-s3-bucket <6>
 ----
@@ -124,7 +75,7 @@ $ ccoctl gcp create-all \
   --name=<name> \// <1>
   --region=<gcp_region> \// <2>
   --project=<gcp_project_id> \// <3>
-  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <4>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <4>
   --output-dir=<path_to_ccoctl_output_dir> <5>
 ----
 <1> Specify the user-defined name for all created GCP resources used for tracking.
@@ -157,7 +108,7 @@ $ ccoctl ibmcloud create-service-id \
 [source,terminal]
 ----
 $ ccoctl nutanix create-shared-secrets \
-  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <1>
   --output-dir=<ccoctl_output_dir> \// <2>
   --credentials-source-filepath=<path_to_credentials_file> <3>
 ----

--- a/modules/cco-determine-mode-cli.adoc
+++ b/modules/cco-determine-mode-cli.adoc
@@ -121,11 +121,15 @@ ifdef::update[]
 
 * If your cluster was configured using the CCO utility (`ccoctl`), you must take the following actions:
 
+.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
+
 .. Configure the `ccoctl` utility for the new release and use it to update the cloud provider resources.
 
 .. Update the `upgradeable-to` annotation to indicate that the cluster is ready to update.
 
 * If your cluster is using the CCO in manual mode but was not configured using the `ccoctl` utility, you must take the following actions:
+
+.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
 
 .. Manually update the cloud provider resources for the new release.
 

--- a/modules/cco-determine-mode-gui.adoc
+++ b/modules/cco-determine-mode-gui.adoc
@@ -144,11 +144,15 @@ ifdef::update[]
 
 * If your cluster was configured using the CCO utility (`ccoctl`), you must take the following actions:
 
+.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
+
 .. Configure the `ccoctl` utility for the new release and use it to update the cloud provider resources.
 
 .. Update the `upgradeable-to` annotation to indicate that the cluster is ready to update.
 
 * If your cluster is using the CCO in manual mode but was not configured using the `ccoctl` utility, you must take the following actions:
+
+.. Extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
 
 .. Manually update the cloud provider resources for the new release.
 

--- a/modules/configuring-albo-on-sts-cluster.adoc
+++ b/modules/configuring-albo-on-sts-cluster.adoc
@@ -20,7 +20,7 @@ $ oc get credentialsrequest -n openshift-cloud-credential-operator  \
 ----
 <1> The `aws-load-balancer-controller-<cr-name>` parameter specifies the credential request name created by the AWS Load Balancer Operator. The `cr-name` specifies the name of the AWS Load Balancer Controller instance.
 
-. Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory by running the following command:
+. Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -359,17 +359,32 @@ $ openshift-install version
 ----
 +
 .Example output
-[source,terminal]
+[source,text]
 ----
 release image quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64
 ----
 
-.. Locate all `CredentialsRequest` objects in this release image that target the cloud you are deploying on:
+.. Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 --credentials-requests --cloud=azure
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
 ----
+
+.. Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
++
+[source,terminal]
+----
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --included \// <1>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
+  --to=<path_to_directory_for_credentials_requests> <3>
+----
+<1> The `--included` parameter includes only the manifests that your specific cluster configuration requries.
+<2> Specify the location of the `install-config.yaml` file.
+<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 This command creates a YAML file for each `CredentialsRequest` object.
 +
@@ -413,37 +428,8 @@ stringData:
   azure_resourcegroup: ${resource_group}
   azure_region: ${azure_region}
 ----
-endif::ash[]
 
-ifdef::aws,ash[]
-. Optional: If you manually created a cloud identity and access management (IAM) role, locate any `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation in the release image by running the following command: 
-+
-[source,terminal]
-----
-$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 --credentials-requests --cloud=<platform_name>
-----
-+
-.Example output
-[source,terminal]
-----
-0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-set: TechPreviewNoUpgrade
-----
-+
-[IMPORTANT]
-====
-The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-set: TechPreviewNoUpgrade` annotation.
-
-* If you are not using any of these features, do not create secrets for these objects. Creating secrets for Technology Preview features that you are not using can cause the installation to fail.
-
-* If you are using any of these features, you must create secrets for the corresponding objects.
-====
-// Right now, only the CAPI Operator is an issue, but it might make sense to update `0000_30_capi-operator_00_credentials-request.yaml` to `<tech_preview_credentials_request>.yaml` for the future.
-+
-.. Delete all `CredentialsRequest` objects that have the `TechPreviewNoUpgrade` annotation.
-endif::aws,ash[]
-
-ifdef::ash[]
-. Create a `cco-configmap.yaml` file in the manifests directory with the Cloud Credential Operator (CCO) disabled:
+.. Create a `cco-configmap.yaml` file in the manifests directory with the Cloud Credential Operator (CCO) disabled:
 +
 .Sample `ConfigMap` object
 [source,yaml]

--- a/modules/manually-configure-iam-nutanix.adoc
+++ b/modules/manually-configure-iam-nutanix.adoc
@@ -37,16 +37,27 @@ credentials:
 <2> Specify the Prism Central credentials.
 <3> Optional: Specify the Prism Element credentials.
 
+. Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
++
+[source,terminal]
+----
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
+----
+
 . Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm release extract --credentials-requests --cloud=nutanix \//
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
-quay.io/<path_to>/ocp-release:<version>
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --included \// <1>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
+  --to=<path_to_directory_for_credentials_requests> <3>
 ----
-+
-<1> Specify the path to the directory that contains the files for the component `CredentialsRequests` objects. If the specified directory does not exist, this command creates it.
+<1> The `--included` parameter includes only the manifests that your specific cluster configuration requries.
+<2> Specify the location of the `install-config.yaml` file.
+<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 .Sample `CredentialsRequest` object
 [source,yaml]
@@ -69,23 +80,12 @@ quay.io/<path_to>/ocp-release:<version>
       namespace: openshift-machine-api
 ----
 
-. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
-+
-.Example `credrequests` directory contents for {product-title} 4.12 on Nutanix
-+
-[source,terminal]
-----
-0000_30_machine-api-operator_00_credentials-request.yaml <1>
-----
-+
-<1> The Machine API Operator CR is required.
-
-. Use the `ccoctl` tool to process all of the `CredentialsRequest` objects in the `credrequests` directory by running the following command:
+. Use the `ccoctl` tool to process all `CredentialsRequest` objects by running the following command:
 +
 [source,terminal]
 ----
 $ ccoctl nutanix create-shared-secrets \
-  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
+  --credentials-requests-dir=<path_to_credentials_requests_directory> \// <1>
   --output-dir=<ccoctl_output_dir> \// <2>
   --credentials-source-filepath=<path_to_credentials_file> <3>
 ----
@@ -131,8 +131,7 @@ $ ls ./<installation_directory>/manifests
 ----
 +
 .Example output
-+
-[source,terminal]
+[source,text]
 ----
 total 64
 -rw-r----- 1 <user> <user> 2335 Jul  8 12:22 cluster-config.yaml

--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -75,22 +75,27 @@ endif::ibm-power-vs[]
 $ openshift-install create manifests --dir <installation_directory>
 ----
 
-. From the directory that contains the installation program, obtain the {product-title} release image that your `openshift-install` binary is built to use:
+. From the directory that contains the installation program, set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
 +
 [source,terminal]
 ----
 $ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
 ----
 
-. Extract the `CredentialsRequest` objects from the {product-title} release image:
+. Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm release extract --cloud=<provider_name> --credentials-requests $RELEASE_IMAGE \ <1>
-    --to=<path_to_credential_requests_directory> <2>
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --included \// <1>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
+  --to=<path_to_directory_for_credentials_requests> <3>
 ----
-<1> The name of the provider. For example: `ibmcloud` or `powervs`.
-<2> The directory where the credential requests will be stored.
+<1> The `--included` parameter includes only the manifests that your specific cluster configuration requries.
+<2> Specify the location of the `install-config.yaml` file.
+<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 This command creates a YAML file for each `CredentialsRequest` object.
 +
@@ -128,26 +133,6 @@ This command creates a YAML file for each `CredentialsRequest` object.
         roles:
         - crn:v1:bluemix:public:iam::::role:Viewer
 ----
-
-ifndef::ibm-power-vs[]
-. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
-+
-.Example `credrequests` directory contents for {product-title} 4.12 on IBM Cloud VPC
-+
-[source,terminal]
-----
-0000_26_cloud-controller-manager-operator_15_credentialsrequest-ibm.yaml <1>
-0000_30_machine-api-operator_00_credentials-request.yaml <2>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request-ibmcos.yaml <3>
-0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
-0000_50_cluster-storage-operator_03_credentials_request_ibm.yaml <5>
-----
-<1> The Cloud Controller Manager Operator CR is required.
-<2> The Machine API Operator CR is required.
-<3> The Image Registry Operator CR is required.
-<4> The Ingress Operator CR is required.
-<5> The Storage Operator CR is an optional component and might be disabled in your cluster.
-endif::ibm-power-vs[]
 
 . Create the service ID for each credential request, assign the policies defined, create an API key, and generate the secret:
 +

--- a/modules/manually-create-identity-access-management.adoc
+++ b/modules/manually-create-identity-access-management.adoc
@@ -153,22 +153,27 @@ endif::cco-multi-mode[]
 $ openshift-install create manifests
 ----
 
-. Locate all `CredentialsRequest` objects in the release image that target the cloud you are deploying on by running the following command:
+. Set a `$RELEASE_IMAGE` variable with the release image from your installation file by running the following command:
 +
 [source,terminal]
 ----
-$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 \
-  --credentials-requests \
-ifdef::aws[]
-  --cloud=aws
-endif::aws[]
-ifdef::azure,ash[]
-  --cloud=azure
-endif::azure,ash[]
-ifdef::google-cloud-platform[]
-  --cloud=gcp
-endif::google-cloud-platform[]
+$ RELEASE_IMAGE=$(./openshift-install version | awk '/release image/ {print $3}')
 ----
+
+. Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
++
+[source,terminal]
+----
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --included \// <1>
+  --install-config=<path_to_directory_with_installation_configuration>/install-config.yaml \// <2>
+  --to=<path_to_directory_for_credentials_requests> <3>
+----
+<1> The `--included` parameter includes only the manifests that your specific cluster configuration requries.
+<2> Specify the location of the `install-config.yaml` file.
+<3> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
 +
 This command creates a YAML file for each `CredentialsRequest` object.
 +
@@ -279,29 +284,6 @@ data:
   service_account.json: <base64_encoded_gcp_service_account_file>
 endif::google-cloud-platform[]
 ----
-+
-[IMPORTANT]
-====
-The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-set: TechPreviewNoUpgrade` annotation.
-
-* If you are not using any of these features, do not create secrets for these objects. Creating secrets for Technology Preview features that you are not using can cause the installation to fail.
-
-* If you are using any of these features, you must create secrets for the corresponding objects.
-====
-
-** To find `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation, run the following command:
-+
-[source,terminal]
-----
-$ grep "release.openshift.io/feature-set" *
-----
-+
-.Example output
-[source,terminal]
-----
-0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-set: TechPreviewNoUpgrade
-----
-// Right now, only the CAPI Operator is an issue, but it might make sense to update `0000_30_capi-operator_00_credentials-request.yaml` to `<tech_preview_credentials_request>.yaml` for the future.
 
 [IMPORTANT]
 ====

--- a/modules/manually-maintained-credentials-upgrade-extract.adoc
+++ b/modules/manually-maintained-credentials-upgrade-extract.adoc
@@ -1,0 +1,108 @@
+// Module included in the following assemblies:
+//
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
+
+
+:_content-type: PROCEDURE
+[id="cco-ccoctl-upgrading-extracting_{context}"]
+= Extracting and preparing credentials request resources
+
+Before updating a cluster that uses the Cloud Credential Operator (CCO) in manual mode, you must extract and prepare the `CredentialsRequest` custom resources (CRs) for the new release.
+
+.Prerequisites
+
+* Install the {oc-first} that matches the version for your updated version.
+* Log in to the cluster as user with `cluster-admin` privileges.
+
+.Procedure
+
+. Obtain the pull spec for the update that you want to apply by running the following command:
++
+[source,terminal]
+----
+$ oc adm upgrade
+----
++
+The output of this command includes pull specs for the available updates similar to the following:
++
+.Partial example output
+[source,text]
+----
+...
+Recommended updates:
+
+VERSION IMAGE
+4.14.0  quay.io/openshift-release-dev/ocp-release@sha256:6a899c54dda6b844bb12a247e324a0f6cde367e880b73ba110c056df6d018032
+...
+----
+
+. Set a `$RELEASE_IMAGE` variable with the release image that you want to use by running the following command:
++
+[source,terminal]
+----
+$ RELEASE_IMAGE=<update_pull_spec>
+----
++
+where `<update_pull_spec>` is the pull spec for the release image that you want to use. For example:
++
+[source,text]
+----
+quay.io/openshift-release-dev/ocp-release@sha256:6a899c54dda6b844bb12a247e324a0f6cde367e880b73ba110c056df6d018032
+----
+
+. Extract the list of `CredentialsRequest` custom resources (CRs) from the {product-title} release image by running the following command:
++
+[source,terminal]
+----
+$ oc adm release extract \
+  --from=$RELEASE_IMAGE \
+  --credentials-requests \
+  --included \// <1>
+  --to=<path_to_directory_for_credentials_requests> <2>
+----
+<1> The `--included` parameter includes only the manifests that your specific cluster configuration requries for the target release.
+<2> Specify the path to the directory where you want to store the `CredentialsRequest` objects. If the specified directory does not exist, this command creates it.
++
+This command creates a YAML file for each `CredentialsRequest` object.
+
+. For each `CredentialsRequest` CR in the release image, ensure that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster. This field is where the generated secrets that hold the credentials configuration are stored.
++
+.Sample AWS `CredentialsRequest` object
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: cloud-credential-operator-iam-ro
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - iam:GetUser
+      - iam:GetUserPolicy
+      - iam:ListAccessKeys
+      resource: "*"
+  secretRef:
+    name: cloud-credential-operator-iam-ro-creds
+    namespace: openshift-cloud-credential-operator <1>
+----
+<1> This field indicates the namespace which must exist to hold the generated secret.
++
+The `CredentialsRequest` CRs for other platforms have a similar format with different platform-specific values.
+
+. For any `CredentialsRequest` CR for which the cluster does not already have a namespace with the name specified in `spec.secretRef.namespace`, create the namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace <component_namespace>
+----
+
+.Next steps
+
+* If the cloud credential management for your cluster was configured using the CCO utility (`ccoctl`), configure the `ccoctl` utility for a cluster update and use it to update your cloud provider resources.
+
+* If your cluster was not configured with the `ccoctl` utility, manually update your cloud provider resources.

--- a/modules/manually-maintained-credentials-upgrade.adoc
+++ b/modules/manually-maintained-credentials-upgrade.adoc
@@ -5,68 +5,150 @@
 :_content-type: PROCEDURE
 
 [id="manually-maintained-credentials-upgrade_{context}"]
-= Updating cloud provider resources with manually maintained credentials
+= Manually updating cloud provider resources
 
-Before upgrading a cluster with manually maintained credentials, you must create any new credentials for the release image that you are upgrading to. You must also review the required permissions for existing credentials and accommodate any new permissions requirements in the new release for those components.
+Before upgrading a cluster with manually maintained credentials, you must create secrets for any new credentials for the release image that you are upgrading to. You must also review the required permissions for existing credentials and accommodate any new permissions requirements in the new release for those components.
+
+.Prerequisites
+
+* You have extracted the `CredentialsRequest` custom resources (CRs) from the {product-title} release image and ensured that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster.
 
 .Procedure
 
-. Extract and examine the `CredentialsRequest` custom resource for the new release.
+. Create YAML files with secrets for any `CredentialsRequest` custom resources that the new release image adds. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object.
 +
-The "Manually creating IAM" section of the installation content for your cloud provider explains how to obtain and use the credentials required for your cloud.
+.Sample AWS YAML files
+[%collapsible]
+====
+.Sample AWS `CredentialsRequest` object with secrets
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: <component_credentials_request>
+  namespace: openshift-cloud-credential-operator
+  ...
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+    statementEntries:
+    - effect: Allow
+      action:
+      - s3:CreateBucket
+      - s3:DeleteBucket
+      resource: "*"
+      ...
+  secretRef:
+    name: <component_secret>
+    namespace: <component_namespace>
+  ...
+----
 
-. Update the manually maintained credentials on your cluster:
+.Sample AWS `Secret` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <component_secret>
+  namespace: <component_namespace>
+data:
+  aws_access_key_id: <base64_encoded_aws_access_key_id>
+  aws_secret_access_key: <base64_encoded_aws_secret_access_key>
+----
+====
 +
---
-* Create new secrets for any `CredentialsRequest` custom resources that are added by the new release image.
-* If the `CredentialsRequest` custom resources for any existing credentials that are stored in secrets have changed permissions requirements, update the permissions as required.
---
+.Sample Azure YAML files
+[%collapsible]
+====
+[NOTE]
+=====
+Global Azure and Azure Stack Hub use the same `CredentialsRequest` object and secret formats.
+=====
+.Sample Azure `CredentialsRequest` object with secrets
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: <component_credentials_request>
+  namespace: openshift-cloud-credential-operator
+  ...
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AzureProviderSpec
+    roleBindings:
+    - role: Contributor
+      ...
+  secretRef:
+    name: <component_secret>
+    namespace: <component_namespace>
+  ...
+----
 
-. If your cluster uses cluster capabilities to disable one or more optional components, delete the `CredentialsRequest` custom resources for any disabled components.
-+
-.Example `credrequests` directory contents for {product-title} 4.12 on AWS
-+
-[source,terminal]
+.Sample Azure `Secret` object
+[source,yaml]
 ----
-0000_30_machine-api-operator_00_credentials-request.yaml <1>
-0000_50_cloud-credential-operator_05-iam-ro-credentialsrequest.yaml <2>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request.yaml <3>
-0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <4>
-0000_50_cluster-network-operator_02-cncc-credentials.yaml <5>
-0000_50_cluster-storage-operator_03_credentials_request_aws.yaml <6>
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <component_secret>
+  namespace: <component_namespace>
+data:
+  azure_subscription_id: <base64_encoded_azure_subscription_id>
+  azure_client_id: <base64_encoded_azure_client_id>
+  azure_client_secret: <base64_encoded_azure_client_secret>
+  azure_tenant_id: <base64_encoded_azure_tenant_id>
+  azure_resource_prefix: <base64_encoded_azure_resource_prefix>
+  azure_resourcegroup: <base64_encoded_azure_resourcegroup>
+  azure_region: <base64_encoded_azure_region>
 ----
+====
 +
---
-<1> The Machine API Operator CR is required.
-<2> The Cloud Credential Operator CR is required.
-<3> The Image Registry Operator CR is required.
-<4> The Ingress Operator CR is required.
-<5> The Network Operator CR is required.
-<6> The Storage Operator CR is an optional component and might be disabled in your cluster.
---
-+
-.Example `credrequests` directory contents for {product-title} 4.12 on GCP
-+
-[source,terminal]
+.Sample GCP YAML files
+[%collapsible]
+====
+.Sample GCP `CredentialsRequest` object with secrets
+[source,yaml]
 ----
-0000_26_cloud-controller-manager-operator_16_credentialsrequest-gcp.yaml <1>
-0000_30_machine-api-operator_00_credentials-request.yaml <2>
-0000_50_cloud-credential-operator_05-gcp-ro-credentialsrequest.yaml <3>
-0000_50_cluster-image-registry-operator_01-registry-credentials-request-gcs.yaml <4>
-0000_50_cluster-ingress-operator_00-ingress-credentials-request.yaml <5>
-0000_50_cluster-network-operator_02-cncc-credentials.yaml <6>
-0000_50_cluster-storage-operator_03_credentials_request_gcp.yaml <7>
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: <component_credentials_request>
+  namespace: openshift-cloud-credential-operator
+  ...
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+      predefinedRoles:
+      - roles/iam.securityReviewer
+      - roles/iam.roleViewer
+      skipServiceCheck: true
+      ...
+  secretRef:
+    name: <component_secret>
+    namespace: <component_namespace>
+  ...
 ----
-+
---
-<1> The Cloud Controller Manager Operator CR is required.
-<2> The Machine API Operator CR is required.
-<3> The Cloud Credential Operator CR is required.
-<4> The Image Registry Operator CR is required.
-<5> The Ingress Operator CR is required.
-<6> The Network Operator CR is required.
-<7> The Storage Operator CR is an optional component and might be disabled in your cluster.
---
+
+.Sample GCP `Secret` object
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: <component_secret>
+  namespace: <component_namespace>
+data:
+  service_account.json: <base64_encoded_gcp_service_account_file>
+----
+====
+
+. If the `CredentialsRequest` custom resources for any existing credentials that are stored in secrets have changed permissions requirements, update the permissions as required.
 
 .Next steps
 * Update the `upgradeable-to` annotation to indicate that the cluster is ready to upgrade.

--- a/updating/preparing_for_updates/preparing-manual-creds-update.adoc
+++ b/updating/preparing_for_updates/preparing-manual-creds-update.adoc
@@ -26,23 +26,27 @@ include::modules/about-manually-maintained-credentials-upgrade.adoc[leveloffset=
 .Additional resources
 * xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-determine-mode-gui_preparing-manual-creds-update[Determining the Cloud Credential Operator mode by using the web console]
 * xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-determine-mode-cli_preparing-manual-creds-update[Determining the Cloud Credential Operator mode by using the CLI]
-* xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-ccoctl-configuring_preparing-manual-creds-update[Configuring the Cloud Credential Operator utility for a cluster update]
-* xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#manually-maintained-credentials-upgrade_preparing-manual-creds-update[Updating cloud provider resources with manually maintained credentials]
+* xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-ccoctl-upgrading-extracting_preparing-manual-creds-update[Extracting and preparing credentials request resources]
 * xref:../../authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc#about-cloud-credential-operator[About the Cloud Credential Operator]
 
 //Determining the Cloud Credential Operator mode by using the web console
 include::modules/cco-determine-mode-gui.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-ccoctl-configuring_preparing-manual-creds-update[Configuring the Cloud Credential Operator utility for a cluster update]
-* xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#manually-maintained-credentials-upgrade_preparing-manual-creds-update[Updating cloud provider resources with manually maintained credentials]
+* xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-ccoctl-upgrading-extracting_preparing-manual-creds-update[Extracting and preparing credentials request resources]
 
 //Determining the Cloud Credential Operator mode by using the CLI
 include::modules/cco-determine-mode-cli.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
+* xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-ccoctl-upgrading-extracting_preparing-manual-creds-update[Extracting and preparing credentials request resources]
+
+//Extracting and preparing credentials request resources
+include::modules/manually-maintained-credentials-upgrade-extract.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
 * xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-ccoctl-configuring_preparing-manual-creds-update[Configuring the Cloud Credential Operator utility for a cluster update]
-* xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#manually-maintained-credentials-upgrade_preparing-manual-creds-update[Updating cloud provider resources with manually maintained credentials]
+* xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#manually-maintained-credentials-upgrade_preparing-manual-creds-update[Manually updating cloud provider resources]
 
 //Configuring the Cloud Credential Operator utility for a cluster update
 include::modules/cco-ccoctl-configuring.adoc[leveloffset=+1]
@@ -51,21 +55,12 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+1]
 include::modules/cco-ccoctl-upgrading.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_alibaba/installing-alibaba-default.adoc#cco-ccoctl-creating-at-once_installing-alibaba-default[Creating {alibaba} credentials for {product-title} components with the `ccoctl` tool]
-* xref:../../installing/installing_aws/installing-aws-customizations.adoc#cco-ccoctl-configuring_installing-aws-customizations[Creating AWS resources with the Cloud Credential Operator utility]
-* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#cco-ccoctl-creating-at-once_installing-gcp-customizations[Creating GCP resources with the Cloud Credential Operator utility]
-* xref:../../installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.adoc#manually-create-iam-ibm-cloud_installing-ibm-cloud-customizations[Manually creating IAM for IBM Cloud VPC]
-* xref:../../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#manually-create-iam-nutanix_installing-nutanix-installer-provisioned[Configuring IAM for Nutanix]
 * xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-manual-upgrade-annotation_preparing-manual-creds-update[Indicating that the cluster is ready to upgrade]
 
-//Updating cloud provider resources with manually maintained credentials
+//Manually updating cloud provider resources
 include::modules/manually-maintained-credentials-upgrade.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-* xref:../../installing/installing_aws/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[Manually creating long-term credentials for AWS]
-* xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-create-iam_manually-creating-iam-azure[Manually creating long-term credentials for Azure]
-* xref:../../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#manually-create-iam_installing-azure-stack-hub-default[Manually creating long-term credentials for Azure Stack Hub]
-* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials for GCP]
 * xref:../../updating/preparing_for_updates/preparing-manual-creds-update.adoc#cco-manual-upgrade-annotation_preparing-manual-creds-update[Indicating that the cluster is ready to upgrade]
 
 //Indicating that the cluster is ready to upgrade


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-4158](https://issues.redhat.com//browse/OSDOCS-4158)

Link to docs preview:
* [Creating credentials for OpenShift Container Platform components with the ccoctl tool](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-default#cco-ccoctl-creating-at-once_installing-alibaba-default) (AliCloud)
* [Manually creating IAM](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.html#manually-create-iam-ibm-cloud_installing-ibm-cloud-customizations) (IBM)
* [Configuring IAM for Nutanix](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#manually-create-iam-nutanix_installing-nutanix-installer-provisioned)
* [Creating AWS resources with a single command](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#cco-ccoctl-creating-at-once_installing-aws-customizations) (topic is reused by [GCP](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#cco-ccoctl-creating-at-once_installing-gcp-customizations); Azure version is in-flight in another PR and will need the `--included` update in this PR when the other merges)
* [Creating AWS resources individually](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#cco-ccoctl-creating-individually_installing-aws-customizations)
* [Creating the Kubernetes manifest and Ignition config files](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.html#installation-user-infra-generate-k8s-manifest-ignition_installing-azure-stack-hub-user-infra) (ASH)
* [Deleting AWS resources with the Cloud Credential Operator utility](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/uninstalling-cluster-aws.html#cco-ccoctl-deleting-sts-resources_uninstall-cluster-aws)
* [Deleting Microsoft Azure resources with the Cloud Credential Operator utility](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/uninstalling-cluster-azure#cco-ccoctl-deleting-sts-resources_uninstall-cluster-azure)
* [Deleting GCP resources with the Cloud Credential Operator utility](https://62148--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/uninstalling-cluster-gcp.html#cco-ccoctl-deleting-sts-resources_uninstalling-cluster-gcp)
* [Preparing to update a cluster with manually maintained credentials](https://62148--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update), throughout, but primarily:
  * [Extracting and preparing credentials request resources](https://62148--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-ccoctl-upgrading-extracting_preparing-manual-creds-update)
  * [Updating cloud provider resources with the Cloud Credential Operator utility](https://62148--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#cco-ccoctl-upgrading_preparing-manual-creds-update)
  * [Manually updating cloud provider resources](https://62148--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update#manually-maintained-credentials-upgrade_preparing-manual-creds-update)

QE review:
- [x] QE has approved this change.

Additional information:
* Also adjusting existing content for consistency/style adherence.
* Locations will change when #60222 merges
* Some of the numbering is off while i have commented lines in here to ask dev about, will resolve before merge.