### PR TITLE
TELCODOCS-1342: NUMA scheduling GA for 4.12.24

### DIFF
--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -8,8 +8,13 @@ toc::[]
 
 Learn about NUMA-aware scheduling and how you can use it to deploy high performance workloads in an {product-title} cluster.
 
-:FeatureName: NUMA-aware scheduling
-include::snippets/technology-preview.adoc[leveloffset=+1]
+[IMPORTANT]
+====
+[subs="attributes+"]
+NUMA-aware scheduling is a Technology Preview feature in {product-title} versions 4.12.0 to 4.12.23 only. It is generally available in {product-title} version 4.12.24 and later. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
 
 The NUMA Resources Operator allows you to schedule high-performance workloads in the same NUMA zone. It deploys a node resources exporting agent that reports on available cluster node NUMA resources, and a secondary scheduler that manages the workloads.
 


### PR DESCRIPTION
[TELCODOCS-1342](https://issues.redhat.com//browse/TELCODOCS-1342): NUMA-aware pod scheduling is GA from 4.12.24 and later. It remains Technology Preview in earlier OCP versions.

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/TELCODOCS-1342

Link to docs preview:
https://62149--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
