### PR TITLE
OSDOCS-6482: Update uname command usage

### DIFF
--- a/_unused_topics/microshift-adding-containers-to-blueprint.adoc
+++ b/_unused_topics/microshift-adding-containers-to-blueprint.adoc
@@ -51,7 +51,7 @@ $ rpm2cpio microshift-release-info-${VERSION}.noarch.rpm | cpio -idmv
 +
 [source,terminal]
 ----
-$ jq -r '.images | .[] | ("[[containers]]\nsource = \"" + . + "\"\n")' ./usr/share/microshift/release/release-$(uname -i).json
+$ jq -r '.images | .[] | ("[[containers]]\nsource = \"" + . + "\"\n")' ./usr/share/microshift/release/release-$(uname -m).json
 ----
 +
 .Brief output sample

--- a/modules/microshift-install-rpms.adoc
+++ b/modules/microshift-install-rpms.adoc
@@ -20,8 +20,8 @@ Use the following procedure to install {product-title} from an RPM package.
 [source,terminal,subs="attributes+"]
 ----
 $ sudo subscription-manager repos \
-    --enable rhocp-{ocp-version}-for-{rhel-major}-$(uname -i)-rpms \
-    --enable fast-datapath-for-{rhel-major}-$(uname -i)-rpms
+    --enable rhocp-{ocp-version}-for-{rhel-major}-$(uname -m)-rpms \
+    --enable fast-datapath-for-{rhel-major}-$(uname -m)-rpms
 ----
 
 . Install {product-title} by running the following command:


### PR DESCRIPTION
**For version:** 4.13+
**Issue:** [OSDOCS-6482](https://issues.redhat.com//browse/OSDOCS-6482)

**Preview:** 

Installing 
- [Installing from RPM-> Installing MicroShift from an RPM package](https://62150--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#installing-microshift-from-rpm-package_microshift-install-rpm) 

The `microshift-adding-containers-to-blueprint.adoc` module is no longer currently used but updating the `uname ` tag anyway

**QE review** 

- [x] QE approval