### PR TITLE
OBSDOCS-316: distinguish between role vs cluster role in monitoring docs

### DIFF
--- a/modules/monitoring-accessing-alerting-rules-for-your-project.adoc
+++ b/modules/monitoring-accessing-alerting-rules-for-your-project.adoc
@@ -6,12 +6,12 @@
 [id="accessing-alerting-rules-for-your-project_{context}"]
 = Accessing alerting rules for user-defined projects
 
-To list alerting rules for a user-defined project, you must have been assigned the `monitoring-rules-view` role for the project.
+To list alerting rules for a user-defined project, you must have been assigned the `monitoring-rules-view` cluster role for the project.
 
 .Prerequisites
 
 * You have enabled monitoring for user-defined projects.
-* You are logged in as a user that has the `monitoring-rules-view` role for your project.
+* You are logged in as a user that has the `monitoring-rules-view` cluster role for your project.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
+++ b/modules/monitoring-adding-a-secret-to-the-alertmanager-configuration.adoc
@@ -19,12 +19,12 @@ After you add a secret to the config map, the secret is mounted as a volume at `
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring core {product-title} monitoring components in the `openshift-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` config map.
 ** You have created the secret to be configured in Alertmanager in the `openshift-monitoring` project.
 * *If you are configuring components that monitor user-defined projects*:
 ** A cluster administrator has enabled monitoring for user-defined projects.
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the secret to be configured in Alertmanager in the `openshift-user-workload-monitoring` project.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-user-defined-alert-routing.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="applying-a-custom-configuration-to-alertmanager-for-user-defined-alert-routing_{context}"]
-= Applying a custom configuration to Alertmanager for user-defined alert routing 
+= Applying a custom configuration to Alertmanager for user-defined alert routing
 
 If you have enabled a separate instance of Alertmanager dedicated to user-defined alert routing, you can overwrite the configuration for this instance of Alertmanager by editing the `alertmanager-user-workload` secret in the `openshift-user-workload-monitoring` namespace.
 
@@ -14,7 +14,7 @@ ifdef::openshift-rosa,openshift-dedicated[]
 * You have access to the cluster as a user with the `dedicated-admin` role.
 endif::[]
 ifndef::openshift-rosa,openshift-dedicated[]
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 endif::[]
 * You have installed the OpenShift CLI (`oc`).
 
@@ -36,7 +36,7 @@ route:
   group_by:
   - name: Default
   routes:
-  - matchers: 
+  - matchers:
     - "service = prometheus-example-monitor" <1>
     receiver: <receiver> <2>
 receivers:

--- a/modules/monitoring-applying-custom-alertmanager-configuration.adoc
+++ b/modules/monitoring-applying-custom-alertmanager-configuration.adoc
@@ -10,7 +10,7 @@ You can overwrite the default Alertmanager configuration by editing the `alertma
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 
 .Procedure
 

--- a/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
+++ b/modules/monitoring-assigning-tolerations-to-monitoring-components.adoc
@@ -18,10 +18,10 @@ endif::openshift-dedicated,openshift-rosa[]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
+++ b/modules/monitoring-attaching-additional-labels-to-your-time-series-and-alerts.adoc
@@ -12,10 +12,10 @@ Using the external labels feature of Prometheus, you can attach custom labels to
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-choosing-a-metrics-collection-profile.adoc
+++ b/modules/monitoring-choosing-a-metrics-collection-profile.adoc
@@ -13,7 +13,7 @@ To choose a metrics collection profile for core {product-title} monitoring compo
 * You have installed the OpenShift CLI (`oc`).
 * You have enabled Technology Preview features by using the `FeatureGate` custom resource (CR).
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 
 [WARNING]
 ====
@@ -46,7 +46,7 @@ data:
 ----
 +
 <1> The name of the metrics collection profile.
-The available values are `full` or `minimal`. 
+The available values are `full` or `minimal`.
 If you do not specify a value or if the `collectionProfile` key name does not exist in the config map, the default setting of `full` is used.
 +
 The following example sets the metrics collection profile to `minimal` for the core platform instance of Prometheus:

--- a/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
+++ b/modules/monitoring-configuring-a-local-persistent-volume-claim.adoc
@@ -17,10 +17,10 @@ For monitoring components to use a persistent volume (PV), you must configure a 
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-configuring-alert-receivers.adoc
+++ b/modules/monitoring-configuring-alert-receivers.adoc
@@ -11,7 +11,7 @@ You can configure alert receivers to ensure that you learn about important issue
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 
 .Procedure
 

--- a/modules/monitoring-configuring-external-alertmanagers.adoc
+++ b/modules/monitoring-configuring-external-alertmanagers.adoc
@@ -20,10 +20,10 @@ If you add the same external Alertmanager configuration for multiple clusters an
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring core {product-title} monitoring components in the `openshift-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` config map.
 * *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` config map.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
@@ -63,7 +63,7 @@ data:
 ----
 +
 For `<alertmanager_specification>`, substitute authentication and other configuration details for additional Alertmanager instances.
-Currently supported authentication methods are bearer token (`bearerToken`) and client TLS (`tlsConfig`). 
+Currently supported authentication methods are bearer token (`bearerToken`) and client TLS (`tlsConfig`).
 The following sample config map configures an additional Alertmanager using a bearer token with client TLS authentication:
 +
 [source,yaml]
@@ -85,13 +85,13 @@ data:
           name: alertmanager-bearer-token
           key: token
         tlsConfig:
-          key: 
+          key:
             name: alertmanager-tls
             key: tls.key
-          cert: 
+          cert:
             name: alertmanager-tls
             key: tls.crt
-          ca: 
+          ca:
             name: alertmanager-tls
             key: tls.ca
         staticConfigs:
@@ -150,13 +150,13 @@ data:
           name: alertmanager-bearer-token
           key: token
         tlsConfig:
-          key: 
+          key:
             name: alertmanager-tls
             key: tls.key
-          cert: 
+          cert:
             name: alertmanager-tls
             key: tls.crt
-          ca: 
+          ca:
             name: alertmanager-tls
             key: tls.ca
         staticConfigs:
@@ -172,3 +172,7 @@ ifndef::openshift-dedicated,openshift-rosa[]
 Configurations applied to the `user-workload-monitoring-config` `ConfigMap` object are not activated unless a cluster administrator has enabled monitoring for user-defined projects.
 ====
 endif::openshift-dedicated,openshift-rosa[]
+
+. Save the file to apply the changes to the `ConfigMap` object. The new component placement configuration is applied automatically.
+
+

--- a/modules/monitoring-configuring-remote-write-storage.adoc
+++ b/modules/monitoring-configuring-remote-write-storage.adoc
@@ -13,10 +13,10 @@ You can configure remote write storage to enable Prometheus to send ingested met
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring core {product-title} monitoring components:*
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects:*
-** You have access to the cluster as a user with the `cluster-admin` role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-configuring-the-monitoring-stack.adoc
+++ b/modules/monitoring-configuring-the-monitoring-stack.adoc
@@ -17,10 +17,10 @@ endif::openshift-dedicated,openshift-rosa[]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-creating-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-creating-alert-routing-for-user-defined-projects.adoc
@@ -7,7 +7,7 @@
 = Creating alert routing for user-defined projects
 
 [role="_abstract"]
-If you are a non-administrator user who has been given the `alert-routing-edit` role, you can create or edit alert routing for user-defined projects. 
+If you are a non-administrator user who has been given the `alert-routing-edit` cluster role, you can create or edit alert routing for user-defined projects.
 
 .Prerequisites
 
@@ -18,7 +18,7 @@ endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * Alert routing has been enabled for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
-* You are logged in as a user that has the `alert-routing-edit` role for the project for which you want to create alert routing.
+* You are logged in as a user that has the `alert-routing-edit` cluster role for the project for which you want to create alert routing.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-creating-alerting-rules-for-user-defined-projects.adoc
@@ -11,7 +11,7 @@ You can create alerting rules for user-defined projects. Those alerting rules wi
 .Prerequisites
 
 * You have enabled monitoring for user-defined projects.
-* You are logged in as a user that has the `monitoring-rules-edit` role for the project where you want to create an alerting rule.
+* You are logged in as a user that has the `monitoring-rules-edit` cluster role for the project where you want to create an alerting rule.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/monitoring-creating-alerting-rules.adoc
+++ b/modules/monitoring-creating-alerting-rules.adoc
@@ -10,7 +10,7 @@ For user-defined projects you can create alerting rules. Those alerting rules wi
 .Prerequisites
 
 * You have enabled monitoring for user-defined projects.
-* You are logged in as a user that has the `monitoring-rules-edit` role for the project where you want to create an alerting rule.
+* You are logged in as a user that has the `monitoring-rules-edit` cluster role for the project where you want to create an alerting rule.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
+++ b/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
@@ -22,10 +22,10 @@ endif::openshift-dedicated,openshift-rosa[]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring default platform monitoring components:*
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects:*
-** You have access to the cluster as a user with the `cluster-admin` role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-creating-cluster-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-cluster-monitoring-configmap.adoc
@@ -15,7 +15,7 @@ When you save your changes to the `cluster-monitoring-config` `ConfigMap` object
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/monitoring-creating-new-alerting-rules.adoc
+++ b/modules/monitoring-creating-new-alerting-rules.adoc
@@ -16,7 +16,7 @@ If you create a customized `AlertingRule` resource based on an existing platform
 
 .Prerequisites
 
-* You have access to the cluster as a user that has the `cluster-admin` role.
+* You have access to the cluster as a user that has the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
 * You have enabled Technology Preview features, and all nodes in the cluster are ready.
 

--- a/modules/monitoring-creating-scrape-sample-alerts.adoc
+++ b/modules/monitoring-creating-scrape-sample-alerts.adoc
@@ -13,7 +13,7 @@ You can create alerts that notify you when:
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * You have enabled monitoring for user-defined projects.
 * You have created the `user-workload-monitoring-config` `ConfigMap` object.
 * You have limited the number of samples that can be accepted per target scrape in user-defined projects, by using `enforcedSampleLimit`.

--- a/modules/monitoring-creating-user-defined-workload-monitoring-configmap.adoc
+++ b/modules/monitoring-creating-user-defined-workload-monitoring-configmap.adoc
@@ -15,7 +15,7 @@ When you save your changes to the `user-workload-monitoring-config` `ConfigMap` 
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
+++ b/modules/monitoring-determining-why-prometheus-is-consuming-disk-space.adoc
@@ -29,7 +29,7 @@ Using attributes that are bound to a limited set of possible values reduces the 
 .Prerequisites
 
 ifndef::openshift-dedicated,openshift-rosa[]
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.

--- a/modules/monitoring-disabling-the-local-alertmanager.adoc
+++ b/modules/monitoring-disabling-the-local-alertmanager.adoc
@@ -12,7 +12,7 @@ If you do not need the local Alertmanager, you can disable it by configuring the
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have created the `cluster-monitoring-config` config map.
 * You have installed the OpenShift CLI (`oc`).
 

--- a/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-a-separate-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -21,7 +21,7 @@ ifdef::openshift-rosa,openshift-dedicated[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::[]
 ifndef::openshift-rosa,openshift-dedicated[]
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have enabled monitoring for user-defined projects in the `cluster-monitoring-config` config map for the `openshift-monitoring` namespace.
 endif::[]
 * You have installed the OpenShift CLI (`oc`).
@@ -46,11 +46,11 @@ metadata:
   namespace: openshift-user-workload-monitoring
 data:
   config.yaml: |
-    alertmanager: 
+    alertmanager:
       enabled: true <1>
       enableAlertmanagerConfig: true <2>
 ----
-<1> Set the `enabled` value to `true` to enable a dedicated instance of the Alertmanager for user-defined projects in a cluster. Set the value to `false` or omit the key entirely to disable the Alertmanager for user-defined projects. 
+<1> Set the `enabled` value to `true` to enable a dedicated instance of the Alertmanager for user-defined projects in a cluster. Set the value to `false` or omit the key entirely to disable the Alertmanager for user-defined projects.
 If you set this value to `false` or if the key is omitted, user-defined alerts are routed to the default platform Alertmanager instance.
 <2> Set the `enableAlertmanagerConfig` value to `true` to enable users to define their own alert routing configurations with `AlertmanagerConfig` objects.
 +

--- a/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-enabling-monitoring-for-user-defined-projects.adoc
@@ -15,12 +15,12 @@ In {product-title} {product-version} you must remove any custom Prometheus insta
 
 [NOTE]
 ====
-You must have access to the cluster as a user with the `cluster-admin` role to enable monitoring for user-defined projects in {product-title}. Cluster administrators can then optionally grant users permission to configure the components that are responsible for monitoring user-defined projects.
+You must have access to the cluster as a user with the `cluster-admin` cluster role to enable monitoring for user-defined projects in {product-title}. Cluster administrators can then optionally grant users permission to configure the components that are responsible for monitoring user-defined projects.
 ====
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 * You have optionally created and configured the `user-workload-monitoring-config` `ConfigMap` object in the `openshift-user-workload-monitoring` project. You can add configuration options to this `ConfigMap` object for the components that monitor user-defined projects.

--- a/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
+++ b/modules/monitoring-enabling-query-logging-for-thanos-querier.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="enabling-query-logging-for-thanos-querier_{context}"]
-= Enabling query logging for Thanos Querier 
+= Enabling query logging for Thanos Querier
 
 [role="_abstract"]
 For default platform monitoring in the `openshift-monitoring` project, you can enable the Cluster Monitoring Operator to log all queries run by Thanos Querier.
@@ -17,7 +17,7 @@ Because log rotation is not supported, only enable this feature temporarily when
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 
 .Procedure
@@ -45,7 +45,7 @@ data:
     thanosQuerier:
       enableRequestLogging: <value> <1>
       logLevel: <value> <2>
-      
+
 
 ----
 <1> Set the value to `true` to enable logging and `false` to disable logging. The default value is `false`.

--- a/modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc
+++ b/modules/monitoring-enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing.adoc
@@ -6,11 +6,11 @@
 [id="enabling-the-platform-alertmanager-instance-for-user-defined-alert-routing_{context}"]
 = Enabling the platform Alertmanager instance for user-defined alert routing
 
-You can allow users to create user-defined alert routing configurations that use the main platform instance of Alertmanager. 
+You can allow users to create user-defined alert routing configurations that use the main platform instance of Alertmanager.
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
@@ -33,7 +33,7 @@ metadata:
   namespace: openshift-monitoring
 data:
   config.yaml: |
-    alertmanagerMain: 
+    alertmanagerMain:
       enableUserAlertmanagerConfig: true <1>
 ----
 <1> Set the `enableUserAlertmanagerConfig` value to `true` to allow users to create user-defined alert routing configurations that use the main platform instance of Alertmanager.

--- a/modules/monitoring-granting-user-permissions-using-the-cli.adoc
+++ b/modules/monitoring-granting-user-permissions-using-the-cli.adoc
@@ -10,7 +10,7 @@ You can grant users permissions to monitor their own projects, by using the Open
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * The user account that you are assigning the role to already exists.
 * You have installed the OpenShift CLI (`oc`).
 

--- a/modules/monitoring-granting-user-permissions-using-the-web-console.adoc
+++ b/modules/monitoring-granting-user-permissions-using-the-web-console.adoc
@@ -10,7 +10,7 @@ You can grant users permissions to monitor their own projects, by using the {pro
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * The user account that you are assigning the role to already exists.
 
 .Procedure

--- a/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-alert-routing-for-user-defined-projects.adoc
@@ -16,7 +16,7 @@ ifdef::openshift-rosa,openshift-dedicated[]
 * The `user-workload-monitoring-config` `ConfigMap` object exists. This object is created by default when the cluster is created.
 endif::[]
 ifndef::openshift-rosa,openshift-dedicated[]
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have enabled monitoring for user-defined projects in the `cluster-monitoring-config` config map for the `openshift-monitoring` namespace.
 endif::[]
 * The user account that you are assigning the role to already exists.
@@ -24,7 +24,7 @@ endif::[]
 
 .Procedure
 
-* Assign the `alert-routing-edit` role to a user in the user-defined project:
+* Assign the `alert-routing-edit` cluster role to a user in the user-defined project:
 +
 [source,terminal]
 ----

--- a/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-configure-monitoring-for-user-defined-projects.adoc
@@ -10,7 +10,7 @@ You can grant users permission to configure monitoring for user-defined projects
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * The user account that you are assigning the role to already exists.
 * You have installed the OpenShift CLI (`oc`).
 

--- a/modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc
+++ b/modules/monitoring-granting-users-permission-to-monitor-user-defined-projects.adoc
@@ -9,11 +9,11 @@ Cluster administrators can monitor all core {product-title} and user-defined pro
 
 Cluster administrators can grant developers and other users permission to monitor their own projects. Privileges are granted by assigning one of the following monitoring roles:
 
-* The *monitoring-rules-view* role provides read access to `PrometheusRule` custom resources for a project.
+* The *monitoring-rules-view* cluster role provides read access to `PrometheusRule` custom resources for a project.
 
-* The *monitoring-rules-edit* role grants a user permission to create, modify, and deleting `PrometheusRule` custom resources for a project.
+* The *monitoring-rules-edit* cluster role grants a user permission to create, modify, and deleting `PrometheusRule` custom resources for a project.
 
-* The *monitoring-edit* role grants the same privileges as the `monitoring-rules-edit` role. Additionally, it enables a user to create new scrape targets for services or pods. With this role, you can also create, modify, and delete `ServiceMonitor` and `PodMonitor` resources.
+* The *monitoring-edit* cluster role grants the same privileges as the `monitoring-rules-edit` cluster role. Additionally, it enables a user to create new scrape targets for services or pods. With this role, you can also create, modify, and delete `ServiceMonitor` and `PodMonitor` resources.
 
 You can also grant users permission to configure the components that are responsible for monitoring user-defined projects:
 
@@ -21,6 +21,6 @@ You can also grant users permission to configure the components that are respons
 
 You can also grant users permission to configure alert routing for user-defined projects:
 
-* The **alert-routing-edit** role grants a user permission to create, update, and delete `AlertmanagerConfig` custom resources for a project.
+* The **alert-routing-edit** cluster role grants a user permission to create, update, and delete `AlertmanagerConfig` custom resources for a project.
 
 This section provides details on how to assign these roles by using the {product-title} web console or the CLI.

--- a/modules/monitoring-installation-progress.adoc
+++ b/modules/monitoring-installation-progress.adoc
@@ -10,7 +10,7 @@ You can monitor high-level installation, bootstrap, and control plane logs as an
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
 * You have SSH access to your hosts.
 * You have the fully qualified domain names of the bootstrap and control plane nodes.

--- a/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
+++ b/modules/monitoring-investigating-why-user-defined-metrics-are-unavailable.adoc
@@ -11,7 +11,7 @@
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
 * You have enabled and configured monitoring for user-defined workloads.
 * You have created the `user-workload-monitoring-config` `ConfigMap` object.

--- a/modules/monitoring-modifying-core-platform-alerting-rules.adoc
+++ b/modules/monitoring-modifying-core-platform-alerting-rules.adoc
@@ -11,7 +11,7 @@ For example, you can change the severity label of an alert, add a custom label, 
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
 * You have enabled Technology Preview features, and all nodes in the cluster are ready.
 

--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -6,7 +6,7 @@
 [id="modifying-retention-time-and-size-for-prometheus-metrics-data_{context}"]
 = Modifying the retention time and size for Prometheus metrics data
 
-By default, Prometheus automatically retains metrics data for 15 days. You can modify the retention time for 
+By default, Prometheus automatically retains metrics data for 15 days. You can modify the retention time for
 ifndef::openshift-dedicated,openshift-rosa[]
 Prometheus
 endif::openshift-dedicated,openshift-rosa[]
@@ -17,8 +17,8 @@ to change how soon the data is deleted. You can also set the maximum amount of d
 
 Note the following behaviors of these data retention settings:
 
-* The size-based retention policy applies to all data block directories in the `/prometheus` directory, including persistent blocks, write-ahead log (WAL) data, and m-mapped chunks. 
-* Data in the `/wal` and `/head_chunks` directories counts toward the retention size limit, but Prometheus never purges data from these directories based on size- or time-based retention policies. 
+* The size-based retention policy applies to all data block directories in the `/prometheus` directory, including persistent blocks, write-ahead log (WAL) data, and m-mapped chunks.
+* Data in the `/wal` and `/head_chunks` directories counts toward the retention size limit, but Prometheus never purges data from these directories based on size- or time-based retention policies.
 Thus, if you set a retention size limit lower than the maximum size set for the `/wal` and `/head_chunks` directories, you have configured the system not to retain any data blocks in the `/prometheus` data directories.
 * The size-based retention policy is applied only when Prometheus cuts a new data block, which occurs every two hours after the WAL contains at least three hours of data.
 * If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 15 days, and retention size is not set.
@@ -31,11 +31,11 @@ If any data blocks exceed the defined retention time or the defined size limit, 
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
 ** A cluster administrator has enabled monitoring for user-defined projects.
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
+++ b/modules/monitoring-modifying-the-retention-time-for-thanos-ruler-metrics-data.adoc
@@ -11,7 +11,7 @@ By default, for user-defined projects, Thanos Ruler automatically retains metric
 .Prerequisites
 
 ifndef::openshift-dedicated,openshift-rosa[]
-* You have access to the cluster as a user with the `cluster-admin` role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * A cluster administrator has enabled monitoring for user-defined projects.
 * You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
+++ b/modules/monitoring-moving-monitoring-components-to-different-nodes.adoc
@@ -22,10 +22,10 @@ endif::openshift-dedicated,openshift-rosa[]
 .Prerequisites
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
+++ b/modules/monitoring-querying-metrics-by-using-the-federation-endpoint-for-prometheus.adoc
@@ -7,21 +7,21 @@
 = Querying metrics by using the federation endpoint for Prometheus
 
 You can use the federation endpoint to scrape platform and user-defined metrics from a network location outside the cluster.
-To do so, access the Prometheus `/federate` endpoint for the cluster via an {product-title} route. 
+To do so, access the Prometheus `/federate` endpoint for the cluster via an {product-title} route.
 
 [WARNING]
 ====
-A delay in retrieving metrics data occurs when you use federation. 
+A delay in retrieving metrics data occurs when you use federation.
 This delay can affect the accuracy and timeliness of the scraped metrics.
 
 Using the federation endpoint can also degrade the performance and scalability of your cluster, especially if you use the federation endpoint to retrieve large amounts of metrics data.
 To avoid these issues, follow these recommendations:
 
 * Do not try to retrieve all metrics data via the federation endpoint.
-Query it only when you want to retrieve a limited, aggregated data set. 
-For example, retrieving fewer than 1,000 samples for each request helps minimize the risk of performance degradation. 
+Query it only when you want to retrieve a limited, aggregated data set.
+For example, retrieving fewer than 1,000 samples for each request helps minimize the risk of performance degradation.
 
-* Avoid querying the federation endpoint frequently. 
+* Avoid querying the federation endpoint frequently.
 Limit queries to a maximum of one every 30 seconds.
 
 If you need to forward large amounts of data outside the cluster, use remote write instead. For more information, see the _Configuring remote write storage_ section.
@@ -31,7 +31,7 @@ If you need to forward large amounts of data outside the cluster, use remote wri
 
 * You have installed the OpenShift CLI (`oc`).
 * You have obtained the host URL for the {product-title} route.
-* You have access to the cluster as a user with the `cluster-monitoring-view` role or have obtained a bearer token with `get` permission on the `namespaces` resource.
+* You have access to the cluster as a user with the `cluster-monitoring-view` cluster role or have obtained a bearer token with `get` permission on the `namespaces` resource.
 +
 [NOTE]
 ====
@@ -47,7 +47,7 @@ You can only use bearer token authentication to access the federation endpoint.
 $ token=`oc whoami -t`
 ----
 
-. Query metrics from the `/federate` route. 
+. Query metrics from the `/federate` route.
 The following example queries `up` metrics:
 +
 [source,terminal]

--- a/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
+++ b/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
@@ -26,7 +26,7 @@ endif::openshift-dedicated,openshift-rosa[]
 .Prerequisites
 
 ifndef::openshift-dedicated,openshift-rosa[]
-* You have access to the cluster as a user with the `cluster-admin` role or with view permissions for all projects.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or with view permissions for all projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role or with view permissions for all projects.
@@ -42,7 +42,7 @@ endif::openshift-dedicated,openshift-rosa[]
 |===
 |Option |Description
 
-|Create a custom query. 
+|Create a custom query.
 |Add your Prometheus Query Language (PromQL) query to the *Expression* field.
 
 As you type a PromQL expression, autocomplete suggestions appear in a drop-down list. These suggestions include functions, metrics, labels, and time tokens.
@@ -78,7 +78,7 @@ By default, the query table shows an expanded view that lists every metric and i
 
 |Hide a specific metric. |Go to the query table and click the colored square near the metric name.
 
-|Zoom into the plot and change the time range. 
+|Zoom into the plot and change the time range.
 a|Either:
 
 * Visually select the time range by clicking and dragging on the plot horizontally.

--- a/modules/monitoring-reducing-latency-for-alerting-rules-that-do-not-query-platform-metrics.adoc
+++ b/modules/monitoring-reducing-latency-for-alerting-rules-that-do-not-query-platform-metrics.adoc
@@ -16,7 +16,7 @@ Default {product-title} metrics for user-defined projects provide information ab
 .Prerequisites
 
 * You have enabled monitoring for user-defined projects.
-* You are logged in as a user that has the `monitoring-rules-edit` role for the project where you want to create an alerting rule.
+* You are logged in as a user that has the `monitoring-rules-edit` cluster role for the project where you want to create an alerting rule.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/monitoring-removing-alerting-rules-for-user-defined-projects.adoc
+++ b/modules/monitoring-removing-alerting-rules-for-user-defined-projects.adoc
@@ -11,7 +11,7 @@ You can remove alerting rules for user-defined projects.
 .Prerequisites
 
 * You have enabled monitoring for user-defined projects.
-* You are logged in as a user that has the `monitoring-rules-edit` role for the project where you want to create an alerting rule.
+* You are logged in as a user that has the `monitoring-rules-edit` cluster role for the project where you want to create an alerting rule.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure

--- a/modules/monitoring-resizing-a-persistent-storage-volume.adoc
+++ b/modules/monitoring-resizing-a-persistent-storage-volume.adoc
@@ -11,17 +11,17 @@ Therefore, even if you update the `storage` field for an existing persistent vol
 
 However, resizing a PV is still possible by using a manual process. If you want to resize a PV for a monitoring component such as Prometheus, Thanos Ruler, or Alertmanager, you can update the appropriate config map in which the component is configured. Then, patch the PVC, and delete and orphan the pods.
 Orphaning the pods recreates the `StatefulSet` resource immediately and automatically updates the size of the volumes mounted in the pods with the new PVC settings.
-No service disruption occurs during this process. 
+No service disruption occurs during this process.
 
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
 * *If you are configuring core {product-title} monitoring components*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 ** You have configured at least one PVC for core {product-title} monitoring components.
 * *If you are configuring components that monitor user-defined projects*:
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 ** You have configured at least one PVC for components that monitor user-defined projects.
 

--- a/modules/monitoring-reviewing-monitoring-dashboards-admin.adoc
+++ b/modules/monitoring-reviewing-monitoring-dashboards-admin.adoc
@@ -11,7 +11,7 @@ In the *Administrator* perspective, you can view dashboards relating to core {pr
 .Prerequisites
 
 ifndef::openshift-dedicated,openshift-rosa[]
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `dedicated-admin` role.

--- a/modules/monitoring-setting-audit-log-levels-for-the-prometheus-adapter.adoc
+++ b/modules/monitoring-setting-audit-log-levels-for-the-prometheus-adapter.adoc
@@ -12,7 +12,7 @@ In default platform monitoring, you can configure the audit log level for the Pr
 .Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 
 .Procedure
@@ -41,7 +41,7 @@ data:
       audit:
         profile: <audit_log_level> <1>
 ----
-<1> The audit log level to apply to the Prometheus Adapter. 
+<1> The audit log level to apply to the Prometheus Adapter.
 
 . Set the audit log level by using one of the following values for the `profile:` parameter:
 +

--- a/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
+++ b/modules/monitoring-setting-log-levels-for-monitoring-components.adoc
@@ -31,10 +31,10 @@ The default log level is `info`.
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are setting a log level for Alertmanager, Prometheus Operator, Prometheus, or Thanos Querier in the `openshift-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are setting a log level for Prometheus Operator, Prometheus, or Thanos Ruler in the `openshift-user-workload-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
@@ -72,7 +72,7 @@ data:
 <1> The monitoring stack component for which you are setting a log level.
 For default platform monitoring, available component values are `prometheusK8s`, `alertmanagerMain`, `prometheusOperator`, and `thanosQuerier`.
 <2> The log level to set for the component.
-The available values are `error`, `warn`, `info`, and `debug`. 
+The available values are `error`, `warn`, `info`, and `debug`.
 The default value is `info`.
 
 ** *To set a log level for a component in the `openshift-user-workload-monitoring` project*:

--- a/modules/monitoring-setting-query-log-file-for-prometheus.adoc
+++ b/modules/monitoring-setting-query-log-file-for-prometheus.adoc
@@ -21,10 +21,10 @@ Because log rotation is not supported, only enable this feature temporarily when
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * *If you are enabling the query log file feature for Prometheus in the `openshift-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` role.
+** You have access to the cluster as a user with the `cluster-admin` cluster role.
 ** You have created the `cluster-monitoring-config` `ConfigMap` object.
 * *If you are enabling the query log file feature for Prometheus in the `openshift-user-workload-monitoring` project*:
-** You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+** You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 ** You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]

--- a/modules/monitoring-setting-scrape-sample-and-label-limits-for-user-defined-projects.adoc
+++ b/modules/monitoring-setting-scrape-sample-and-label-limits-for-user-defined-projects.adoc
@@ -16,7 +16,7 @@ If you set sample or label limits, no further sample data is ingested for that t
 .Prerequisites
 
 ifndef::openshift-dedicated,openshift-rosa[]
-* You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * You have enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
@@ -66,7 +66,7 @@ data:
       enforcedLabelNameLengthLimit: 50 <2>
       enforcedLabelValueLengthLimit: 600 <3>
 ----
-<1> Specifies the maximum number of labels per scrape. 
+<1> Specifies the maximum number of labels per scrape.
 The default value is `0`, which specifies no limit.
 <2> Specifies the maximum length in characters of a label name.
 The default value is `0`, which specifies no limit.

--- a/modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.adoc
+++ b/modules/monitoring-setting-the-body-size-limit-for-metrics-scraping.adoc
@@ -20,7 +20,7 @@ Prometheus then considers this target to be down and sets its `up` metric value 
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
 
 .Procedure
@@ -56,6 +56,6 @@ You can also set the value to `automatic` to calculate the limit automatically b
 +
 [WARNING]
 ====
-When you save changes to a `cluster-monitoring-config` config map, the pods and other resources in the `openshift-monitoring` project might be redeployed. 
+When you save changes to a `cluster-monitoring-config` config map, the pods and other resources in the `openshift-monitoring` project might be redeployed.
 The running monitoring processes in that project might also restart.
 ====

--- a/modules/monitoring-setting-up-pod-topology-spread-constraints-for-alertmanager.adoc
+++ b/modules/monitoring-setting-up-pod-topology-spread-constraints-for-alertmanager.adoc
@@ -6,14 +6,14 @@
 [id="setting-up-pod-topology-spread-constraints-for-alertmanager_{context}"]
 = Setting up pod topology spread constraints for Alertmanager
 
-For core {product-title} platform monitoring, you can set up pod topology spread constraints for Alertmanager to fine tune how pod replicas are scheduled to nodes across zones. 
+For core {product-title} platform monitoring, you can set up pod topology spread constraints for Alertmanager to fine tune how pod replicas are scheduled to nodes across zones.
 Doing so helps ensure that Alertmanager pods are highly available and run more efficiently, because workloads are spread across nodes in different data centers or hierarchical infrastructure zones.
 
 You configure pod topology spread constraints for Alertmanager in the `cluster-monitoring-config` config map.
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 * You have installed the OpenShift CLI (`oc`).
 
@@ -42,12 +42,12 @@ data:
       - maxSkew: 1 <1>
         topologyKey: monitoring <2>
         whenUnsatisfiable: DoNotSchedule <3>
-        labelSelector: 
+        labelSelector:
           matchLabels: <4>
             app.kubernetes.io/name: alertmanager
 ----
-<1> Specify a numeric value for `maxSkew`, which defines the degree to which pods are allowed to be unevenly distributed. 
-This field is required, and the value must be greater than zero. 
+<1> Specify a numeric value for `maxSkew`, which defines the degree to which pods are allowed to be unevenly distributed.
+This field is required, and the value must be greater than zero.
 The value specified has a different effect depending on what value you specify for `whenUnsatisfiable`.
 <2> Specify a key of node labels for `topologyKey`.
 This field is required.
@@ -56,7 +56,7 @@ The scheduler will try to put a balanced number of pods into each domain.
 <3> Specify a value for `whenUnsatisfiable`.
 This field is required.
 Available options are `DoNotSchedule` and `ScheduleAnyway`.
-Specify `DoNotSchedule` if you want the `maxSkew` value to define the maximum difference allowed between the number of matching pods in the target topology and the global minimum. 
+Specify `DoNotSchedule` if you want the `maxSkew` value to define the maximum difference allowed between the number of matching pods in the target topology and the global minimum.
 Specify `ScheduleAnyway` if you want the scheduler to still schedule the pod but to give higher priority to nodes that might reduce the skew.
 <4> Specify a value for `matchLabels`. This value is used to identify the set of matching pods to which to apply the constraints.
 
@@ -64,6 +64,6 @@ Specify `ScheduleAnyway` if you want the scheduler to still schedule the pod but
 +
 [WARNING]
 ====
-When you save changes to the `cluster-monitoring-config` config map, the pods and other resources in the `openshift-monitoring` project might be redeployed. 
+When you save changes to the `cluster-monitoring-config` config map, the pods and other resources in the `openshift-monitoring` project might be redeployed.
 The running monitoring processes in that project might also restart.
 ====

--- a/modules/monitoring-setting-up-pod-topology-spread-constraints-for-prometheus.adoc
+++ b/modules/monitoring-setting-up-pod-topology-spread-constraints-for-prometheus.adoc
@@ -13,7 +13,7 @@ You configure pod topology spread constraints for Prometheus in the `cluster-mon
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have created the `cluster-monitoring-config` `ConfigMap` object.
 * You have installed the OpenShift CLI (`oc`).
 
@@ -42,12 +42,12 @@ data:
       - maxSkew: 1 <1>
         topologyKey: monitoring <2>
         whenUnsatisfiable: DoNotSchedule <3>
-        labelSelector: 
+        labelSelector:
           matchLabels: <4>
             app.kubernetes.io/name: prometheus
 ----
-<1> Specify a numeric value for `maxSkew`, which defines the degree to which pods are allowed to be unevenly distributed. 
-This field is required, and the value must be greater than zero. 
+<1> Specify a numeric value for `maxSkew`, which defines the degree to which pods are allowed to be unevenly distributed.
+This field is required, and the value must be greater than zero.
 The value specified has a different effect depending on what value you specify for `whenUnsatisfiable`.
 <2> Specify a key of node labels for `topologyKey`.
 This field is required.
@@ -56,7 +56,7 @@ The scheduler will try to put a balanced number of pods into each domain.
 <3> Specify a value for `whenUnsatisfiable`.
 This field is required.
 Available options are `DoNotSchedule` and `ScheduleAnyway`.
-Specify `DoNotSchedule` if you want the `maxSkew` value to define the maximum difference allowed between the number of matching pods in the target topology and the global minimum. 
+Specify `DoNotSchedule` if you want the `maxSkew` value to define the maximum difference allowed between the number of matching pods in the target topology and the global minimum.
 Specify `ScheduleAnyway` if you want the scheduler to still schedule the pod but to give higher priority to nodes that might reduce the skew.
 <4> Specify a value for `matchLabels`. This value is used to identify the set of matching pods to which to apply the constraints.
 
@@ -64,6 +64,6 @@ Specify `ScheduleAnyway` if you want the scheduler to still schedule the pod but
 +
 [WARNING]
 ====
-When you save changes to the `cluster-monitoring-config` config map, the pods and other resources in the `openshift-monitoring` project might be redeployed. 
+When you save changes to the `cluster-monitoring-config` config map, the pods and other resources in the `openshift-monitoring` project might be redeployed.
 The running monitoring processes in that project might also restart.
 ====

--- a/modules/monitoring-setting-up-pod-topology-spread-constraints-for-thanos-ruler.adoc
+++ b/modules/monitoring-setting-up-pod-topology-spread-constraints-for-thanos-ruler.adoc
@@ -6,7 +6,7 @@
 [id="setting-up-pod-topology-spread-constraints-for-thanos-ruler_{context}"]
 = Setting up pod topology spread constraints for Thanos Ruler
 
-For user-defined monitoring, you can set up pod topology spread constraints for Thanos Ruler to fine tune how pod replicas are scheduled to nodes across zones. 
+For user-defined monitoring, you can set up pod topology spread constraints for Thanos Ruler to fine tune how pod replicas are scheduled to nodes across zones.
 Doing so helps ensure that Thanos Ruler pods are highly available and run more efficiently, because workloads are spread across nodes in different data centers or hierarchical infrastructure zones.
 
 You configure pod topology spread constraints for Thanos Ruler in the `user-workload-monitoring-config` config map.
@@ -15,7 +15,7 @@ You configure pod topology spread constraints for Thanos Ruler in the `user-work
 
 ifndef::openshift-dedicated,openshift-rosa[]
 * A cluster administrator has enabled monitoring for user-defined projects.
-* You have access to the cluster as a user with the `cluster-admin` role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
+* You have access to the cluster as a user with the `cluster-admin` cluster role, or as a user with the `user-workload-monitoring-config-edit` role in the `openshift-user-workload-monitoring` project.
 * You have created the `user-workload-monitoring-config` `ConfigMap` object.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
@@ -62,6 +62,6 @@ data:
 +
 [WARNING]
 ====
-When you save changes to the `user-workload-monitoring-config` config map, the pods and other resources in the `openshift-user-workload-monitoring` project might be redeployed. 
+When you save changes to the `user-workload-monitoring-config` config map, the pods and other resources in the `openshift-user-workload-monitoring` project might be redeployed.
 The running monitoring processes in that project might also restart.
 ====

--- a/modules/monitoring-silencing-alerts.adoc
+++ b/modules/monitoring-silencing-alerts.adoc
@@ -19,7 +19,7 @@ endif::openshift-dedicated,openshift-rosa[]
 * If you are a non-administrator user, you have access to the cluster as a user with the following user roles:
 ** The `cluster-monitoring-view` cluster role, which allows you to access Alertmanager.
 ** The `monitoring-alertmanager-edit` role, which permits you to create and silence alerts in the *Administrator* perspective in the web console.
-** The `monitoring-rules-edit` role, which permits you to create and silence alerts in the *Developer* perspective in the web console.
+** The `monitoring-rules-edit` cluster role, which permits you to create and silence alerts in the *Developer* perspective in the web console.
 
 .Procedure
 

--- a/modules/monitoring-specifying-how-a-service-is-monitored.adoc
+++ b/modules/monitoring-specifying-how-a-service-is-monitored.adoc
@@ -14,7 +14,7 @@ This procedure shows you how to create a `ServiceMonitor` resource for a service
 .Prerequisites
 
 ifndef::openshift-dedicated,openshift-rosa[]
-* You have access to the cluster as a user with the `cluster-admin` role or the `monitoring-edit` role.
+* You have access to the cluster as a user with the `cluster-admin` cluster role or the `monitoring-edit` cluster role.
 * You have enabled monitoring for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
@@ -53,7 +53,7 @@ spec:
 ----
 +
 This defines a `ServiceMonitor` resource that scrapes the metrics exposed by the `prometheus-example-app` sample service, which includes the `version` metric.
-+ 
++
 [NOTE]
 ====
 A `ServiceMonitor` resource in a user-defined namespace can only discover services in the same namespace. That is, the `namespaceSelector` field of the `ServiceMonitor` resource is always ignored.

--- a/modules/monitoring-understanding-alert-routing-for-user-defined-projects.adoc
+++ b/modules/monitoring-understanding-alert-routing-for-user-defined-projects.adoc
@@ -28,7 +28,7 @@ After a user has defined alert routing for a user-defined project, user-defined 
 
 * To the `alertmanager-main` pods in the `openshift-monitoring` namespace if using the default platform Alertmanager instance.
 
-* To the `alertmanager-user-workload` pods in the `openshift-user-workload-monitoring` namespace if you have enabled a separate instance of Alertmanager for user-defined projects. 
+* To the `alertmanager-user-workload` pods in the `openshift-user-workload-monitoring` namespace if you have enabled a separate instance of Alertmanager for user-defined projects.
 endif::openshift-dedicated,openshift-rosa[]
 ifdef::openshift-dedicated,openshift-rosa[]
 After a user has defined alert routing for a user-defined project, user-defined alert notifications are routed to the `alertmanager-user-workload` pods in the `openshift-user-workload-monitoring` namespace.

--- a/modules/monitoring-viewing-a-list-of-available-metrics.adoc
+++ b/modules/monitoring-viewing-a-list-of-available-metrics.adoc
@@ -9,7 +9,7 @@
 As a cluster administrator or as a user with view permissions for all projects, you can view a list of metrics available in a cluster and output the list in JSON format.
 
 .Prerequisites
-* You are a cluster administrator, or you have access to the cluster as a user with the `cluster-monitoring-view` role.
+* You are a cluster administrator, or you have access to the cluster as a user with the `cluster-monitoring-view` cluster role.
 * You have installed the {product-title} CLI (`oc`).
 * You have obtained the {product-title} API route for Thanos Querier.
 * You are able to get a bearer token by using the `oc whoami -t` command.

--- a/monitoring/managing-alerts.adoc
+++ b/monitoring/managing-alerts.adoc
@@ -16,11 +16,11 @@ In {product-title} {product-version}, the Alerting UI enables you to manage aler
 ====
 The alerts, silences, and alerting rules that are available in the Alerting UI relate to the projects that you have access to. For example, if you are logged in as a user with the `cluster-admin` role, you can access all alerts, silences, and alerting rules.
 
-If you are a non-administrator user, you can create and silence alerts if you are assigned the following user roles: 
+If you are a non-administrator user, you can create and silence alerts if you are assigned the following user roles:
 
-* The `cluster-monitoring-view` role, which allows you to access Alertmanager
+* The `cluster-monitoring-view` cluster role, which allows you to access Alertmanager
 * The `monitoring-alertmanager-edit` role, which permits you to create and silence alerts in the *Administrator* perspective in the web console
-* The `monitoring-rules-edit` role, which permits you to create and silence alerts in the *Developer* perspective in the web console
+* The `monitoring-rules-edit` cluster role, which permits you to create and silence alerts in the *Developer* perspective in the web console
 ====
 
 // Accessing the Alerting UI in the Administrator and Developer perspectives


### PR DESCRIPTION
Summary: This PR adds content to distinguish more clearly which monitoring user roles are cluster roles. It touches many files, but usually only adds one or two words to each file.

Also, as a bonus fix, some files with trailing spaces on certain lines had those spaces automatically removed when I saved the file.

- Aligned team: DevTools
- For branches: 4.10+
- Jira: https://issues.redhat.com/browse/OBSDOCS-316
- Direct link to doc preview:  The PR adds a single word to 56 different files, and so there is no practical way to link to a preview of every change. Here's a general link to the monitoring docs: https://62152--docspreview.netlify.app/openshift-enterprise/latest/monitoring/monitoring-overview.html
- SME review: @machine424 
- QE review: @juzhao
- Peer review: @ tbd