### PR TITLE
OCPBUGS#9440: Update FBC filtering proc to encompass general updates

### DIFF
--- a/installing/disconnected_install/installing-mirroring-installation-images.adoc
+++ b/installing/disconnected_install/installing-mirroring-installation-images.adoc
@@ -94,6 +94,9 @@ Mirroring Operator catalogs for use with disconnected clusters has the following
 
 * Workstation with unrestricted network access.
 * `podman` version 1.9.3 or later.
+* If you want to filter, or _prune_, an existing catalog and selectively mirror only a subset of Operators, see the following sections:
+** xref:../../cli_reference/opm/cli-opm-install.adoc#cli-opm-install[Installing the opm CLI]
+** xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-filtering-fbc_olm-managing-custom-catalogs[Updating or filtering a file-based catalog image]
 ifndef::openshift-origin[]
 * If you want to mirror a Red Hat-provided catalog, run the following command on your workstation with unrestricted network access to authenticate with `registry.redhat.io`:
 +
@@ -133,6 +136,7 @@ include::modules/olm-mirroring-catalog-post.adoc[leveloffset=+2]
 .Additional resources
 
 * xref:../../post_installation_configuration/preparing-for-users.adoc#post-install-mirrored-catalogs[Populating OperatorHub from mirrored Operator catalogs]
+* xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-filtering-fbc_olm-managing-custom-catalogs[Updating or filtering a file-based catalog image]
 
 [id="next-steps_installing-mirroring-installation-images"]
 == Next steps

--- a/modules/olm-filtering-fbc.adoc
+++ b/modules/olm-filtering-fbc.adoc
@@ -11,9 +11,9 @@ endif::[]
 
 :_content-type: PROCEDURE
 [id="olm-filtering-fbc_{context}"]
-= Filtering a file-based catalog image
+= Updating or filtering a file-based catalog image
 
-You can use the `opm` CLI to filter, or prune, a catalog image that uses the file-based catalog format. By extracting and updating the contents of an existing catalog image, you can remove one or more Operator packages from the catalog, and then rebuild the image as an updated version.
+You can use the `opm` CLI to update or filter (also known as prune) a catalog image that uses the file-based catalog format. By extracting and modifying the contents of an existing catalog image, you can update, add, or remove one or more Operator package entries from the catalog. You can then rebuild the image as an updated version of the catalog.
 
 [NOTE]
 ====
@@ -46,14 +46,14 @@ $ opm render <registry>/<namespace>/<catalog_image_name>:<tag> \
 Alternatively, you can use the `-o json` flag to output in JSON format.
 ====
 
-. Modify the contents of the resulting `index.yaml` file to remove one or more Operator packages.
+. Modify the contents of the resulting `index.yaml` file to your specifications by updating, adding, or removing one or more Operator package entries.
 +
 [IMPORTANT]
 ====
 After a bundle has been published in a catalog, assume that one of your users has installed it. Ensure that all previously published bundles in a catalog have an update path to the current or newer channel head to avoid stranding users that have that version installed.
 ====
 +
-The following example lists a set of `olm.package`, `olm.channel`, and `olm.bundle` blobs which must be deleted to remove an Operator package from the catalog:
+For example, if you wanted to remove an Operator package, the following example lists a set of `olm.package`, `olm.channel`, and `olm.bundle` blobs which must be deleted to remove the package from the catalog:
 +
 .Example removed entries
 [%collapsible]
@@ -152,4 +152,4 @@ $ podman push <registry>/<namespace>/<catalog_image_name>:<tag>
 +
 For more information, see "Adding a catalog source to a cluster" in the "Additional resources" of this section.
 
-. After the catalog source is in a *READY* state, navigate to the *Operators* -> *OperatorHub* page and check that the Operator package that you removed no longer appears.
+. After the catalog source is in a *READY* state, navigate to the *Operators* -> *OperatorHub* page and check that the changes you made are reflected in the list of Operators.

--- a/modules/olm-updating-index-image.adoc
+++ b/modules/olm-updating-index-image.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
 // * operators/admin/olm-managing-custom-catalogs.adoc
-// * operators/admin/olm-restricted-network.adoc
 
 ifdef::openshift-origin[]
 :index-image: catalog
@@ -17,9 +16,6 @@ endif::[]
 After configuring OperatorHub to use a catalog source that references a custom index image, cluster administrators can keep the available Operators on their cluster up to date by adding bundle images to the index image.
 
 You can update an existing index image using the `opm index add` command.
-ifeval::["{context}" == "olm-restricted-networks"]
-For restricted networks, the updated content must also be mirrored again to the cluster.
-endif::[]
 
 .Prerequisites
 
@@ -73,22 +69,6 @@ $ opm index add \
 ----
 $ podman push <registry>/<namespace>/<existing_index_image>:<updated_tag>
 ----
-
-ifeval::["{context}" == "olm-restricted-networks"]
-. Follow the steps in the _Mirroring an Operator catalog_ procedure again to mirror the updated content. However, when you get to the step about creating the `ImageContentSourcePolicy` (ICSP) object, use the `oc replace` command instead of the `oc create` command. For example:
-+
-[source,terminal,subs="attributes+"]
-----
-$ oc replace -f ./manifests-{index-image}-<random_number>/imageContentSourcePolicy.yaml
-----
-+
-This change is required because the object already exists and must be updated.
-+
-[NOTE]
-====
-Normally, the `oc apply` command can be used to update existing objects that were previously created using `oc apply`. However, due to a known issue regarding the size of the `metadata.annotations` field in ICSP objects, the `oc replace` command must be used for this step currently.
-====
-endif::[]
 
 . After Operator Lifecycle Manager (OLM) automatically polls the index image referenced in the catalog source at its regular interval, verify that the new packages are successfully added:
 +

--- a/operators/admin/olm-restricted-networks.adoc
+++ b/operators/admin/olm-restricted-networks.adoc
@@ -75,10 +75,3 @@ include::modules/olm-creating-catalog-from-index.adoc[leveloffset=+1]
 * xref:../../operators/admin/olm-managing-custom-catalogs.adoc#olm-accessing-images-private-registries_olm-managing-custom-catalogs[Accessing images for Operators from private registries]
 * xref:../../operators/understanding/olm/olm-understanding-olm.adoc#olm-catalogsource-image-template_olm-understanding-olm[Image template for custom catalog sources]
 * xref:../../openshift_images/managing_images/image-pull-policy.adoc#image-pull-policy[Image pull policy]
-
-include::modules/olm-updating-index-image.adoc[leveloffset=+1]
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog]


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-9440

4.11+

* (Follow-up to https://github.com/openshift/openshift-docs/pull/60519) For the deprecated SQLite-based catalog format, the procedures for "filtering" (or pruning, to remove packages) and "updating" are separate modules. However for FBC catalogs, the "filtering" proc is very similar to what a general "updating" proc would be. This PR retitles the existing "Filtering..." proc to encompass both "Updating or filtering...", and makes relevant tweaks to the body text so that it still flows naturally and is not solely "removal" focused.
* Removes the "Updating a SQLite-based index image" module from the [Using OLM on restricted networks](https://62155--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-restricted-networks.html) assembly, which should have been taken out at the same time as the "Filtering..." procedure was (in https://github.com/openshift/openshift-docs/pull/59236/files#diff-7c895cc6bd1d22891367c759addcb0c2cef1c35b2b4c5ddde8b59fc1bed752c5), because the SQLite catalog format is deprecated in 4.11+. Updates the module to also remove the `ifevals` that are no longer relevant now that it does not appear in the "restricted networks" assembly.
* Adds back in "Prerequisites" links to the updating/filtering procedure in [Mirroring Operator catalogs for use with disconnected clusters](https://62155--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-installation-images.html#olm-mirror-catalog-prerequisites_installing-mirroring-installation-images) (previously removed temporarily in https://github.com/openshift/openshift-docs/pull/59236/files#diff-0c89af7d3860efc30204d9b90b9d0da18c22f7096bca7833fbe4b488d70e24c8L99).

Preview: [Updating or filtering a file-based catalog image](https://62155--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-managing-custom-catalogs.html#olm-filtering-fbc_olm-managing-custom-catalogs)