### PR TITLE
OSDOCS-6269: Updates intro. listing all resources and  listing nbdb/sbdb with OVN-K  i/c

### DIFF
--- a/modules/nw-ovn-kubernetes-list-database-contents.adoc
+++ b/modules/nw-ovn-kubernetes-list-database-contents.adoc
@@ -6,8 +6,7 @@
 [id="nw-ovn-kubernetes-list-database-contents_{context}"]
 = Listing the OVN-Kubernetes northbound database contents
 
-To understand logic flow rules you need to examine the northbound database and understand what objects are there to see how they are translated into logic flow rules.
-The up to date information is present on the OVN Raft leader and this procedure describes how to find the Raft leader and subsequently query it to list the OVN northbound database contents.
+Each node is controlled by the `ovnkube-controller` container running in the `ovnkube-node` pod on that node. To understand the OVN logical networking entities you need to examine the northbound database that is running as a container inside the `ovnkube-node` pod on that node to see what objects are in the node you wish to see.
 
 .Prerequisites
 
@@ -16,14 +15,12 @@ The up to date information is present on the OVN Raft leader and this procedure 
 
 .Procedure
 
-. Find the OVN Raft leader for the northbound database.
-+
 [NOTE]
 ====
-The Raft leader stores the most up to date information.
+To run ovn `nbctl` or `sbctl` commands in a cluster you must open a remote shell into the `nbdb` or `sbdb` containers on the relevant node
 ====
 
-.. List the pods by running the following command:
+. List pods by running the following command:
 +
 [source,terminal]
 ----
@@ -33,109 +30,71 @@ $ oc get po -n openshift-ovn-kubernetes
 .Example output
 [source,terminal]
 ----
-NAME                   READY   STATUS    RESTARTS       AGE
-ovnkube-master-7j97q   6/6     Running   2 (148m ago)   149m
-ovnkube-master-gt4ms   6/6     Running   1 (140m ago)   147m
-ovnkube-master-mk6p6   6/6     Running   0              148m
-ovnkube-node-8qvtr     5/5     Running   0              149m
-ovnkube-node-fqdc9     5/5     Running   0              149m
-ovnkube-node-tlfwv     5/5     Running   0              149m
-ovnkube-node-wlwkn     5/5     Running   0              142m
+NAME                                     READY   STATUS    RESTARTS      AGE
+ovnkube-control-plane-8444dff7f9-4lh9k   2/2     Running   0             27m
+ovnkube-control-plane-8444dff7f9-5rjh9   2/2     Running   0             27m
+ovnkube-control-plane-8444dff7f9-k64b7   2/2     Running   2 (11m ago)   27m
+ovnkube-node-55xs2                       8/8     Running   0             26m
+ovnkube-node-7r84r                       8/8     Running   0             16m
+ovnkube-node-bqq8p                       8/8     Running   0             17m
+ovnkube-node-mkj4f                       8/8     Running   0             26m
+ovnkube-node-mlr8k                       8/8     Running   0             26m
+ovnkube-node-wqn2m                       8/8     Running   0             16m
 ----
 
-.. Choose one of the master pods at random and run the following command:
+. Optional: To list the pods with node information, run the following command:
 +
 [source,terminal]
 ----
-$ oc exec -n openshift-ovn-kubernetes ovnkube-master-7j97q \
--- /usr/bin/ovn-appctl -t /var/run/ovn/ovnnb_db.ctl \
---timeout=3 cluster/status OVN_Northbound
+$ oc get pods -n openshift-ovn-kubernetes -owide
 ----
 +
 .Example output
 [source,terminal]
 ----
-Defaulted container "northd" out of: northd, nbdb, kube-rbac-proxy, sbdb, ovnkube-master, ovn-dbchecker
-1c57
-Name: OVN_Northbound
-Cluster ID: c48a (c48aa5c0-a704-4c77-a066-24fe99d9b338)
-Server ID: 1c57 (1c57b6fc-2849-49b7-8679-fbf18bafe339)
-Address: ssl:10.0.147.219:9643
-Status: cluster member
-Role: follower <1>
-Term: 5
-Leader: 2b4f <2>
-Vote: unknown
-
-Election timer: 10000
-Log: [2, 3018]
-Entries not yet committed: 0
-Entries not yet applied: 0
-Connections: ->0000 ->0000 <-8844 <-2b4f
-Disconnections: 0
-Servers:
-    1c57 (1c57 at ssl:10.0.147.219:9643) (self)
-    8844 (8844 at ssl:10.0.163.212:9643) last msg 8928047 ms ago
-    2b4f (2b4f at ssl:10.0.242.240:9643) last msg 620 ms ago <3>
+NAME                                     READY   STATUS    RESTARTS      AGE   IP           NODE                                       NOMINATED NODE   READINESS GATES
+ovnkube-control-plane-8444dff7f9-4lh9k   2/2     Running   0             27m   10.0.0.3     ci-ln-t487nnb-72292-mdcnq-master-1         <none>           <none>
+ovnkube-control-plane-8444dff7f9-5rjh9   2/2     Running   0             27m   10.0.0.4     ci-ln-t487nnb-72292-mdcnq-master-2         <none>           <none>
+ovnkube-control-plane-8444dff7f9-k64b7   2/2     Running   2 (12m ago)   27m   10.0.0.5     ci-ln-t487nnb-72292-mdcnq-master-0         <none>           <none>
+ovnkube-node-55xs2                       8/8     Running   0             26m   10.0.0.4     ci-ln-t487nnb-72292-mdcnq-master-2         <none>           <none>
+ovnkube-node-7r84r                       8/8     Running   0             17m   10.0.128.3   ci-ln-t487nnb-72292-mdcnq-worker-b-wbz7z   <none>           <none>
+ovnkube-node-bqq8p                       8/8     Running   0             17m   10.0.128.2   ci-ln-t487nnb-72292-mdcnq-worker-a-lh7ms   <none>           <none>
+ovnkube-node-mkj4f                       8/8     Running   0             27m   10.0.0.5     ci-ln-t487nnb-72292-mdcnq-master-0         <none>           <none>
+ovnkube-node-mlr8k                       8/8     Running   0             27m   10.0.0.3     ci-ln-t487nnb-72292-mdcnq-master-1         <none>           <none>
+ovnkube-node-wqn2m                       8/8     Running   0             17m   10.0.128.4   ci-ln-t487nnb-72292-mdcnq-worker-c-przlm   <none>           <none>
 ----
-+
-<1> This pod is identified as a follower
-<2> The leader is identified as `2b4f`
-<3> The `2b4f` is on IP address `10.0.242.240`
 
-.. Find the `ovnkube-master` pod running on IP Address `10.0.242.240` using the following command:
+. Navigate into a pod to look at the northbound database by running the following command:
 +
 [source,terminal]
 ----
-$ oc get po -o wide -n openshift-ovn-kubernetes | grep 10.0.242.240 | grep -v ovnkube-node
+$ oc rsh -c nbdb -n openshift-ovn-kubernetes ovnkube-node-55xs2
 ----
-+
-.Example output
-[source,terminal]
-----
-ovnkube-master-gt4ms   6/6     Running             1 (143m ago)   150m   10.0.242.240   ip-10-0-242-240.ec2.internal   <none>           <none>
-----
-+
-The `ovnkube-master-gt4ms` pod runs on IP Address 10.0.242.240.
 
 . Run the following command to show all the objects in the northbound database:
 +
 [source,terminal]
 ----
-$ oc exec -n openshift-ovn-kubernetes -it ovnkube-master-gt4ms \
--c northd -- ovn-nbctl show
+$ ovn-nbctl show
 ----
 +
 The output is too long to list here. The list includes the NAT rules, logical switches, load balancers and so on.
 +
-Run the following command to display the options available with the command `ovn-nbctl`:
-+
-[source,terminal]
-----
-$ oc exec -n openshift-ovn-kubernetes -it ovnkube-master-mk6p6 \
--c northd ovn-nbctl --help
-----
-+
-You can narrow down and focus on specific components by using some of the following commands:
+You can narrow down and focus on specific components by using some of the following optional commands:
 
-. Run the following command to show the list of logical routers:
+.. Run the following command to show the list of logical routers:
 +
 [source,terminal]
 ----
-$ oc exec -n openshift-ovn-kubernetes -it ovnkube-master-gt4ms \
+$ oc exec -n openshift-ovn-kubernetes -it ovnkube-node-55xs2 \
 -c northd -- ovn-nbctl lr-list
 ----
 +
 .Example output
 [source,terminal]
 ----
-f971f1f3-5112-402f-9d1e-48f1d091ff04 (GR_ip-10-0-145-205.ec2.internal)
-69c992d8-a4cf-429e-81a3-5361209ffe44 (GR_ip-10-0-147-219.ec2.internal)
-7d164271-af9e-4283-b84a-48f2a44851cd (GR_ip-10-0-163-212.ec2.internal)
-111052e3-c395-408b-97b2-8dd0a20a29a5 (GR_ip-10-0-165-9.ec2.internal)
-ed50ce33-df5d-48e8-8862-2df6a59169a0 (GR_ip-10-0-209-170.ec2.internal)
-f44e2a96-8d1e-4a4d-abae-ed8728ac6851 (GR_ip-10-0-242-240.ec2.internal)
-ef3d0057-e557-4b1a-b3c6-fcc3463790b0 (ovn_cluster_router)
+45339f4f-7d0b-41d0-b5f9-9fca9ce40ce6 (GR_ci-ln-t487nnb-72292-mdcnq-master-2)
+96a0a0f0-e7ed-4fec-8393-3195563de1b8 (ovn_cluster_router)
 ----
 +
 [NOTE]
@@ -143,30 +102,21 @@ ef3d0057-e557-4b1a-b3c6-fcc3463790b0 (ovn_cluster_router)
 From this output you can see there is router on each node plus an `ovn_cluster_router`.
 ====
 
-. Run the following command to show the list of logical switches:
+.. Run the following command to show the list of logical switches:
 +
 [source,terminal]
 ----
-$ oc exec -n openshift-ovn-kubernetes -it ovnkube-master-gt4ms \
--c northd -- ovn-nbctl ls-list
+$ oc exec -n openshift-ovn-kubernetes -it ovnkube-node-55xs2 \
+-c nbdb -- ovn-nbctl ls-list
 ----
 +
 .Example output
 [source,terminal]
 ----
-82808c5c-b3bc-414a-bb59-8fec4b07eb14 (ext_ip-10-0-145-205.ec2.internal)
-3d22444f-0272-4c51-afc6-de9e03db3291 (ext_ip-10-0-147-219.ec2.internal)
-bf73b9df-59ab-4c58-a456-ce8205b34ac5 (ext_ip-10-0-163-212.ec2.internal)
-bee1e8d0-ec87-45eb-b98b-63f9ec213e5e (ext_ip-10-0-165-9.ec2.internal)
-812f08f2-6476-4abf-9a78-635f8516f95e (ext_ip-10-0-209-170.ec2.internal)
-f65e710b-32f9-482b-8eab-8d96a44799c1 (ext_ip-10-0-242-240.ec2.internal)
-84dad700-afb8-4129-86f9-923a1ddeace9 (ip-10-0-145-205.ec2.internal)
-1b7b448b-e36c-4ca3-9f38-4a2cf6814bfd (ip-10-0-147-219.ec2.internal)
-d92d1f56-2606-4f23-8b6a-4396a78951de (ip-10-0-163-212.ec2.internal)
-6864a6b2-de15-4de3-92d8-f95014b6f28f (ip-10-0-165-9.ec2.internal)
-c26bf618-4d7e-4afd-804f-1a2cbc96ec6d (ip-10-0-209-170.ec2.internal)
-ab9a4526-44ed-4f82-ae1c-e20da04947d9 (ip-10-0-242-240.ec2.internal)
-a8588aba-21da-4276-ba0f-9d68e88911f0 (join)
+bdd7dc3d-d848-4a74-b293-cc15128ea614 (ci-ln-t487nnb-72292-mdcnq-master-2)
+b349292d-ee03-4914-935f-1940b6cb91e5 (ext_ci-ln-t487nnb-72292-mdcnq-master-2)
+0aac0754-ea32-4e33-b086-35eeabf0a140 (join)
+992509d7-2c3f-4432-88db-c179e43592e5 (transit_switch)
 ----
 +
 [NOTE]
@@ -174,55 +124,53 @@ a8588aba-21da-4276-ba0f-9d68e88911f0 (join)
 From this output you can see there is an ext switch for each node plus switches with the node name itself and a join switch.
 ====
 
-. Run the following command to show the list of load balancers:
+.. Run the following command to show the list of load balancers:
 +
 [source,terminal]
 ----
-$ oc exec -n openshift-ovn-kubernetes -it ovnkube-master-gt4ms \
--c northd -- ovn-nbctl lb-list
+$ oc exec -n openshift-ovn-kubernetes -it ovnkube-node-55xs2 \
+-c nbdb -- ovn-nbctl lb-list
 ----
 +
 .Example output
 [source,terminal]
 ----
 UUID                                    LB                  PROTO      VIP                     IPs
-f0fb50f9-4968-4b55-908c-616bae4db0a2    Service_default/    tcp        172.30.0.1:443          10.0.147.219:6443,10.0.163.212:6443,169.254.169.2:6443
-0dc42012-4f5b-432e-ae01-2cc4bfe81b00    Service_default/    tcp        172.30.0.1:443          10.0.147.219:6443,169.254.169.2:6443,10.0.242.240:6443
-f7fff5d5-5eff-4a40-98b1-3a4ba8f7f69c    Service_default/    tcp        172.30.0.1:443          169.254.169.2:6443,10.0.163.212:6443,10.0.242.240:6443
-12fe57a0-50a4-4a1b-ac10-5f288badee07    Service_default/    tcp        172.30.0.1:443          10.0.147.219:6443,10.0.163.212:6443,10.0.242.240:6443
-3f137fbf-0b78-4875-ba44-fbf89f254cf7    Service_openshif    tcp        172.30.23.153:443       10.130.0.14:8443
-174199fe-0562-4141-b410-12094db922a7    Service_openshif    tcp        172.30.69.51:50051      10.130.0.84:50051
-5ee2d4bd-c9e2-4d16-a6df-f54cd17c9ac3    Service_openshif    tcp        172.30.143.87:9001      10.0.145.205:9001,10.0.147.219:9001,10.0.163.212:9001,10.0.165.9:9001,10.0.209.170:9001,10.0.242.240:9001
-a056ae3d-83f8-45bc-9c80-ef89bce7b162    Service_openshif    tcp        172.30.164.74:443       10.0.147.219:6443,10.0.163.212:6443,10.0.242.240:6443
-bac51f3d-9a6f-4f5e-ac02-28fd343a332a    Service_openshif    tcp        172.30.0.10:53          10.131.0.6:5353
-                                                            tcp        172.30.0.10:9154        10.131.0.6:9154
-48105bbc-51d7-4178-b975-417433f9c20a    Service_openshif    tcp        172.30.26.159:2379      10.0.147.219:2379,169.254.169.2:2379,10.0.242.240:2379
-                                                            tcp        172.30.26.159:9979      10.0.147.219:9979,169.254.169.2:9979,10.0.242.240:9979
-7de2b8fc-342a-415f-ac13-1a493f4e39c0    Service_openshif    tcp        172.30.53.219:443       10.128.0.7:8443
-                                                            tcp        172.30.53.219:9192      10.128.0.7:9192
-2cef36bc-d720-4afb-8d95-9350eff1d27a    Service_openshif    tcp        172.30.81.66:443        10.128.0.23:8443
-365cb6fb-e15e-45a4-a55b-21868b3cf513    Service_openshif    tcp        172.30.96.51:50051      10.130.0.19:50051
-41691cbb-ec55-4cdb-8431-afce679c5e8d    Service_openshif    tcp        172.30.98.218:9099      169.254.169.2:9099
-82df10ba-8143-400b-977a-8f5f416a4541    Service_openshif    tcp        172.30.26.159:2379      10.0.147.219:2379,10.0.163.212:2379,169.254.169.2:2379
-                                                            tcp        172.30.26.159:9979      10.0.147.219:9979,10.0.163.212:9979,169.254.169.2:9979
-debe7f3a-39a8-490e-bc0a-ebbfafdffb16    Service_openshif    tcp        172.30.23.244:443       10.128.0.48:8443,10.129.0.27:8443,10.130.0.45:8443
-8a749239-02d9-4dc2-8737-716528e0da7b    Service_openshif    tcp        172.30.124.255:8443     10.128.0.14:8443
-880c7c78-c790-403d-a3cb-9f06592717a3    Service_openshif    tcp        172.30.0.10:53          10.130.0.20:5353
-                                                            tcp        172.30.0.10:9154        10.130.0.20:9154
-d2f39078-6751-4311-a161-815bbaf7f9c7    Service_openshif    tcp        172.30.26.159:2379      169.254.169.2:2379,10.0.163.212:2379,10.0.242.240:2379
-                                                            tcp        172.30.26.159:9979      169.254.169.2:9979,10.0.163.212:9979,10.0.242.240:9979
-30948278-602b-455c-934a-28e64c46de12    Service_openshif    tcp        172.30.157.35:9443      10.130.0.43:9443
-2cc7e376-7c02-4a82-89e8-dfa1e23fb003    Service_openshif    tcp        172.30.159.212:17698    10.128.0.48:17698,10.129.0.27:17698,10.130.0.45:17698
-e7d22d35-61c2-40c2-bc30-265cff8ed18d    Service_openshif    tcp        172.30.143.87:9001      10.0.145.205:9001,10.0.147.219:9001,10.0.163.212:9001,10.0.165.9:9001,10.0.209.170:9001,169.254.169.2:9001
-75164e75-e0c5-40fb-9636-bfdbf4223a02    Service_openshif    tcp        172.30.150.68:1936      10.129.4.8:1936,10.131.0.10:1936
-                                                            tcp        172.30.150.68:443       10.129.4.8:443,10.131.0.10:443
-                                                            tcp        172.30.150.68:80        10.129.4.8:80,10.131.0.10:80
-7bc4ee74-dccf-47e9-9149-b011f09aff39    Service_openshif    tcp        172.30.164.74:443       10.0.147.219:6443,10.0.163.212:6443,169.254.169.2:6443
-0db59e74-1cc6-470c-bf44-57c520e0aa8f    Service_openshif    tcp        10.0.163.212:31460
-                                                            tcp        10.0.163.212:32361
-c300e134-018c-49af-9f84-9deb1d0715f8    Service_openshif    tcp        172.30.42.244:50051     10.130.0.47:50051
-5e352773-429b-4881-afb3-a13b7ba8b081    Service_openshif    tcp        172.30.244.66:443       10.129.0.8:8443,10.130.0.8:8443
-54b82d32-1939-4465-a87d-f26321442a7a    Service_openshif    tcp        172.30.12.9:8443        10.128.0.35:8443
+7c84c673-ed2a-4436-9a1f-9bc5dd181eea    Service_default/    tcp        172.30.0.1:443          10.0.0.3:6443,169.254.169.2:6443,10.0.0.5:6443
+4d663fd9-ddc8-4271-b333-4c0e279e20bb    Service_default/    tcp        172.30.0.1:443          10.0.0.3:6443,10.0.0.4:6443,10.0.0.5:6443
+292eb07f-b82f-4962-868a-4f541d250bca    Service_openshif    tcp        172.30.105.247:443      10.129.0.12:8443
+034b5a7f-bb6a-45e9-8e6d-573a82dc5ee3    Service_openshif    tcp        172.30.192.38:443       10.0.0.3:10259,10.0.0.4:10259,10.0.0.5:10259
+a68bb53e-be84-48df-bd38-bdd82fcd4026    Service_openshif    tcp        172.30.161.125:8443     10.129.0.32:8443
+6cc21b3d-2c54-4c94-8ff5-d8e017269c2e    Service_openshif    tcp        172.30.3.144:443        10.129.0.22:8443
+37996ffd-7268-4862-a27f-61cd62e09c32    Service_openshif    tcp        172.30.181.107:443      10.129.0.18:8443
+81d4da3c-f811-411f-ae0c-bc6713d0861d    Service_openshif    tcp        172.30.228.23:443       10.129.0.29:8443
+ac5a4f3b-b6ba-4ceb-82d0-d84f2c41306e    Service_openshif    tcp        172.30.14.240:9443      10.129.0.36:9443
+c88979fb-1ef5-414b-90ac-43b579351ac9    Service_openshif    tcp        172.30.231.192:9001     10.128.0.5:9001,10.128.2.5:9001,10.129.0.5:9001,10.129.2.4:9001,10.130.0.3:9001,10.131.0.3:9001
+fcb0a3fb-4a77-4230-a84a-be45dce757e8    Service_openshif    tcp        172.30.189.92:443       10.130.0.17:8440
+67ef3e7b-ceb9-4bf0-8d96-b43bde4c9151    Service_openshif    tcp        172.30.67.218:443       10.129.0.9:8443
+d0032fba-7d5e-424a-af25-4ab9b5d46e81    Service_openshif    tcp        172.30.102.137:2379     10.0.0.3:2379,10.0.0.4:2379,10.0.0.5:2379
+                                                            tcp        172.30.102.137:9979     10.0.0.3:9979,10.0.0.4:9979,10.0.0.5:9979
+7361c537-3eec-4e6c-bc0c-0522d182abd4    Service_openshif    tcp        172.30.198.215:9001     10.0.0.3:9001,10.0.0.4:9001,10.0.0.5:9001,10.0.128.2:9001,10.0.128.3:9001,10.0.128.4:9001
+0296c437-1259-410b-a6fd-81c310ad0af5    Service_openshif    tcp        172.30.198.215:9001     10.0.0.3:9001,169.254.169.2:9001,10.0.0.5:9001,10.0.128.2:9001,10.0.128.3:9001,10.0.128.4:9001
+5d5679f5-45b8-479d-9f7c-08b123c688b8    Service_openshif    tcp        172.30.38.253:17698     10.128.0.52:17698,10.129.0.84:17698,10.130.0.60:17698
+2adcbab4-d1c9-447d-9573-b5dc9f2efbfa    Service_openshif    tcp        172.30.148.52:443       10.0.0.4:9202,10.0.0.5:9202
+                                                            tcp        172.30.148.52:444       10.0.0.4:9203,10.0.0.5:9203
+                                                            tcp        172.30.148.52:445       10.0.0.4:9204,10.0.0.5:9204
+                                                            tcp        172.30.148.52:446       10.0.0.4:9205,10.0.0.5:9205
+2a33a6d7-af1b-4892-87cc-326a380b809b    Service_openshif    tcp        172.30.67.219:9091      10.129.2.16:9091,10.131.0.16:9091
+                                                            tcp        172.30.67.219:9092      10.129.2.16:9092,10.131.0.16:9092
+                                                            tcp        172.30.67.219:9093      10.129.2.16:9093,10.131.0.16:9093
+                                                            tcp        172.30.67.219:9094      10.129.2.16:9094,10.131.0.16:9094
+f56f59d7-231a-4974-99b3-792e2741ec8d    Service_openshif    tcp        172.30.89.212:443       10.128.0.41:8443,10.129.0.68:8443,10.130.0.44:8443
+08c2c6d7-d217-4b96-b5d8-c80c4e258116    Service_openshif    tcp        172.30.102.137:2379     10.0.0.3:2379,169.254.169.2:2379,10.0.0.5:2379
+                                                            tcp        172.30.102.137:9979     10.0.0.3:9979,169.254.169.2:9979,10.0.0.5:9979
+60a69c56-fc6a-4de6-bd88-3f2af5ba5665    Service_openshif    tcp        172.30.10.193:443       10.129.0.25:8443
+ab1ef694-0826-4671-a22c-565fc2d282ec    Service_openshif    tcp        172.30.196.123:443      10.128.0.33:8443,10.129.0.64:8443,10.130.0.37:8443
+b1fb34d3-0944-4770-9ee3-2683e7a630e2    Service_openshif    tcp        172.30.158.93:8443      10.129.0.13:8443
+95811c11-56e2-4877-be1e-c78ccb3a82a9    Service_openshif    tcp        172.30.46.85:9001       10.130.0.16:9001
+4baba1d1-b873-4535-884c-3f6fc07a50fd    Service_openshif    tcp        172.30.28.87:443        10.129.0.26:8443
+6c2e1c90-f0ca-484e-8a8e-40e71442110a    Service_openshif    udp        172.30.0.10:53          10.128.0.13:5353,10.128.2.6:5353,10.129.0.39:5353,10.129.2.6:5353,10.130.0.11:5353,10.131.0.9:5353
+
 ----
 +
 [NOTE]
@@ -230,4 +178,10 @@ c300e134-018c-49af-9f84-9deb1d0715f8    Service_openshif    tcp        172.30.42
 From this truncated output you can see there are many OVN-Kubernetes load balancers. Load balancers in OVN-Kubernetes are representations of services.
 ====
 
-
+. Run the following command to display the options available with the command `ovn-nbctl`:
++
+[source,terminal]
+----
+$ oc exec -n openshift-ovn-kubernetes -it ovnkube-node-55xs2 \
+-c nbdb ovn-nbctl --help
+----

--- a/modules/nw-ovn-kubernetes-list-resources.adoc
+++ b/modules/nw-ovn-kubernetes-list-resources.adoc
@@ -25,75 +25,74 @@ $ oc get all,ep,cm -n openshift-ovn-kubernetes
 .Example output
 [source,terminal]
 ----
-NAME                       READY   STATUS    RESTARTS      AGE
-pod/ovnkube-master-9g7zt   6/6     Running   1 (48m ago)   57m
-pod/ovnkube-master-lqs4v   6/6     Running   0             57m
-pod/ovnkube-master-vxhtq   6/6     Running   0             57m
-pod/ovnkube-node-9k9kc     5/5     Running   0             57m
-pod/ovnkube-node-jg52r     5/5     Running   0             51m
-pod/ovnkube-node-k8wf7     5/5     Running   0             57m
-pod/ovnkube-node-tlwk6     5/5     Running   0             47m
-pod/ovnkube-node-xsvnk     5/5     Running   0             57m
+Warning: apps.openshift.io/v1 DeploymentConfig is deprecated in v4.14+, unavailable in v4.10000+
+NAME                                         READY   STATUS    RESTARTS       AGE
+pod/ovnkube-control-plane-65c6f55656-6d55h   2/2     Running   0              114m
+pod/ovnkube-control-plane-65c6f55656-fd7vw   2/2     Running   2 (104m ago)   114m
+pod/ovnkube-control-plane-65c6f55656-vtqtm   2/2     Running   0              114m
+pod/ovnkube-node-bcvts                       8/8     Running   0              113m
+pod/ovnkube-node-drgvv                       8/8     Running   0              113m
+pod/ovnkube-node-f2pxt                       8/8     Running   0              113m
+pod/ovnkube-node-frqsb                       8/8     Running   0              105m
+pod/ovnkube-node-lbxkk                       8/8     Running   0              105m
+pod/ovnkube-node-tt7bx                       8/8     Running   1 (102m ago)   105m
 
-NAME                            TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)             AGE
-service/ovn-kubernetes-master   ClusterIP   None         <none>        9102/TCP            57m
-service/ovn-kubernetes-node     ClusterIP   None         <none>        9103/TCP,9105/TCP   57m
-service/ovnkube-db              ClusterIP   None         <none>        9641/TCP,9642/TCP   57m
+NAME                                   TYPE        CLUSTER-IP   EXTERNAL-IP   PORT(S)             AGE
+service/ovn-kubernetes-control-plane   ClusterIP   None         <none>        9108/TCP            114m
+service/ovn-kubernetes-node            ClusterIP   None         <none>        9103/TCP,9105/TCP   114m
 
-NAME                            DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                                                 AGE
-daemonset.apps/ovnkube-master   3         3         3       3            3           beta.kubernetes.io/os=linux,node-role.kubernetes.io/master=   57m
-daemonset.apps/ovnkube-node     5         5         5       5            5           beta.kubernetes.io/os=linux                                   57m
+NAME                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                 AGE
+daemonset.apps/ovnkube-node   6         6         6       6            6           beta.kubernetes.io/os=linux   114m
 
-NAME                              ENDPOINTS                                                        AGE
-endpoints/ovn-kubernetes-master   10.0.132.11:9102,10.0.151.18:9102,10.0.192.45:9102               57m
-endpoints/ovn-kubernetes-node     10.0.132.11:9105,10.0.143.72:9105,10.0.151.18:9105 + 7 more...   57m
-endpoints/ovnkube-db              10.0.132.11:9642,10.0.151.18:9642,10.0.192.45:9642 + 3 more...   57m
+NAME                                    READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/ovnkube-control-plane   3/3     3            3           114m
+
+NAME                                               DESIRED   CURRENT   READY   AGE
+replicaset.apps/ovnkube-control-plane-65c6f55656   3         3         3       114m
+
+NAME                                     ENDPOINTS                                               AGE
+endpoints/ovn-kubernetes-control-plane   10.0.0.3:9108,10.0.0.4:9108,10.0.0.5:9108               114m
+endpoints/ovn-kubernetes-node            10.0.0.3:9105,10.0.0.4:9105,10.0.0.5:9105 + 9 more...   114m
 
 NAME                                 DATA   AGE
-configmap/control-plane-status       1      55m
-configmap/kube-root-ca.crt           1      57m
-configmap/openshift-service-ca.crt   1      57m
-configmap/ovn-ca                     1      57m
-configmap/ovn-kubernetes-master      0      55m
-configmap/ovnkube-config             1      57m
-configmap/signer-ca                  1      57m
+configmap/control-plane-status       1      113m
+configmap/kube-root-ca.crt           1      114m
+configmap/openshift-service-ca.crt   1      114m
+configmap/ovn-ca                     1      114m
+configmap/ovnkube-config             1      114m
+configmap/signer-ca                  1      114m
+
 ----
 +
-There are three `ovnkube-masters` that run on the control plane nodes, and two daemon sets used to deploy the `ovnkube-master` and `ovnkube-node` pods.
 There is one `ovnkube-node` pod for each node in the cluster.
-In this example, there are 5, and since there is one `ovnkube-node` per node in the cluster, there are five nodes in the cluster.
-The `ovnkube-config` `ConfigMap` has the {product-title} OVN-Kubernetes configurations started by online-master and `ovnkube-node`.
-The `ovn-kubernetes-master` `ConfigMap` has the information of the current online master leader.
+The `ovnkube-config` config map has the {product-title} OVN-Kubernetes configurations.
++
 
-. List all the containers in the `ovnkube-master` pods by running the following command:
+. List all of the containers in the `ovnkube-node` pods by running the following command:
 +
 [source,terminal]
 ----
-$ oc get pods ovnkube-master-9g7zt \
--o jsonpath='{.spec.containers[*].name}' -n openshift-ovn-kubernetes
+$ oc get pods ovnkube-node-bcvts -o jsonpath='{.spec.containers[*].name}' -n openshift-ovn-kubernetes
 ----
 .Expected output
 +
 [source,terminal]
 ----
-northd nbdb kube-rbac-proxy sbdb ovnkube-master ovn-dbchecker
+ovn-controller ovn-acl-logging kube-rbac-proxy-node kube-rbac-proxy-ovn-metrics northd nbdb sbdb ovnkube-controller
 ----
-+
-The `ovnkube-master` pod is made up of several containers.
-It is responsible for hosting the northbound database (`nbdb` container), the southbound database (`sbdb` container), watching for cluster events for pods, egressIP, namespaces, services, endpoints, egress firewall, and network policy and writing them to the northbound database (`ovnkube-master` pod), as well as managing pod subnet allocation to nodes.
+The `ovnkube-node` pod is made up of several containers. It is responsible for hosting the northbound database (`nbdb` container), the southbound database (`sbdb` container), the north daemon (`northd` container), `ovn-controller` and the `ovnkube-controller`container. The `ovnkube-controller` container watches for API objects like pods, egress IPs, namespaces, services, endpoints, egress firewall, and network policies. It is also responsible for allocating pod IP from the available subnet pool for that node.
 
-. List all the containers in the `ovnkube-node` pods by running the following command:
+. List all the containers in the `ovnkube-control-plane` pods by running the following command:
 +
 [source,terminal]
 ----
-$ oc get pods ovnkube-node-jg52r \
--o jsonpath='{.spec.containers[*].name}' -n openshift-ovn-kubernetes
+$ oc get pods ovnkube-control-plane-65c6f55656-6d55h -o jsonpath='{.spec.containers[*].name}' -n openshift-ovn-kubernetes
 ----
 .Expected output
 +
 [source,terminal]
 ----
-ovn-controller ovn-acl-logging kube-rbac-proxy kube-rbac-proxy-ovn-metrics ovnkube-node
+kube-rbac-proxy ovnkube-cluster-manager
 ----
 +
-The `ovnkube-node` pod has a container (`ovn-controller`) that resides on each {product-title} node. Each node’s `ovn-controller` connects the OVN northbound to the OVN southbound database to learn about the OVN configuration. The `ovn-controller` connects southbound to `ovs-vswitchd` as an OpenFlow controller, for control over network traffic, and to the local `ovsdb-server` to allow it to monitor and control Open vSwitch configuration.
+The `ovnkube-control-plane` pod has a container (`ovnkube-cluster-manager`) that resides on each {product-title} node. The `ovnkube-cluster-manager` container allocates pod subnet, transit switch subnet IP and join switch subnet IP to each node in the cluster. The `kube-rbac-proxy` container monitors metrics for the `ovnkube-cluster-manager` container.

--- a/modules/nw-ovn-kubernetes-list-southbound-database-contents.adoc
+++ b/modules/nw-ovn-kubernetes-list-southbound-database-contents.adoc
@@ -6,8 +6,7 @@
 [id="nw-ovn-kubernetes-list-southbound-database-contents_{context}"]
 = Listing the OVN-Kubernetes southbound database contents
 
-Logic flow rules are stored in the southbound database that is a representation of your infrastructure.
-The up to date information is present on the OVN Raft leader and this procedure describes how to find the Raft leader and query it to list the OVN southbound database contents.
+Each node is controlled by the `ovnkube-controller` container running in the `ovnkube-node` pod on that node. To understand the OVN logical networking entities you need to examine the northbound database that is running as a container inside the `ovnkube-node` pod on that node to see what objects are in the node you wish to see.
 
 .Prerequisites
 
@@ -16,14 +15,12 @@ The up to date information is present on the OVN Raft leader and this procedure 
 
 .Procedure
 
-. Find the OVN Raft leader for the southbound database.
-+
 [NOTE]
 ====
-The Raft leader stores the most up to date information.
+To run ovn `nbctl` or `sbctl` commands in a cluster you must open a remote shell into the `nbdb` or `sbdb` containers on the relevant node
 ====
 
-.. List the pods by running the following command:
+. List the pods by running the following command:
 +
 [source,terminal]
 ----
@@ -33,105 +30,110 @@ $ oc get po -n openshift-ovn-kubernetes
 .Example output
 [source,terminal]
 ----
-NAME                   READY   STATUS    RESTARTS       AGE
-ovnkube-master-7j97q   6/6     Running   2 (134m ago)   135m
-ovnkube-master-gt4ms   6/6     Running   1 (126m ago)   133m
-ovnkube-master-mk6p6   6/6     Running   0              134m
-ovnkube-node-8qvtr     5/5     Running   0              135m
-ovnkube-node-bqztb     5/5     Running   0              117m
-ovnkube-node-fqdc9     5/5     Running   0              135m
-ovnkube-node-tlfwv     5/5     Running   0              135m
-ovnkube-node-wlwkn     5/5     Running   0              128m
+NAME                                     READY   STATUS    RESTARTS      AGE
+ovnkube-control-plane-8444dff7f9-4lh9k   2/2     Running   0             27m
+ovnkube-control-plane-8444dff7f9-5rjh9   2/2     Running   0             27m
+ovnkube-control-plane-8444dff7f9-k64b7   2/2     Running   2 (11m ago)   27m
+ovnkube-node-55xs2                       8/8     Running   0             26m
+ovnkube-node-7r84r                       8/8     Running   0             16m
+ovnkube-node-bqq8p                       8/8     Running   0             17m
+ovnkube-node-mkj4f                       8/8     Running   0             26m
+ovnkube-node-mlr8k                       8/8     Running   0             26m
+ovnkube-node-wqn2m                       8/8     Running   0             16m
 ----
 
-.. Choose one of the master pods at random and run the following command to find the OVN southbound Raft leader:
+. Optional: To list the pods with node information, run the following command:
 +
 [source,terminal]
 ----
-$ oc exec -n openshift-ovn-kubernetes ovnkube-master-7j97q \
--- /usr/bin/ovn-appctl -t /var/run/ovn/ovnsb_db.ctl \
---timeout=3 cluster/status OVN_Southbound
+$ oc get pods -n openshift-ovn-kubernetes -owide
 ----
 +
 .Example output
 [source,terminal]
 ----
-Defaulted container "northd" out of: northd, nbdb, kube-rbac-proxy, sbdb, ovnkube-master, ovn-dbchecker
-1930
-Name: OVN_Southbound
-Cluster ID: f772 (f77273c0-7986-42dd-bd3c-a9f18e25701f)
-Server ID: 1930 (1930f4b7-314b-406f-9dcb-b81fe2729ae1)
-Address: ssl:10.0.147.219:9644
-Status: cluster member
-Role: follower <1>
-Term: 3
-Leader: 7081 <2>
-Vote: unknown
-
-Election timer: 16000
-Log: [2, 2423]
-Entries not yet committed: 0
-Entries not yet applied: 0
-Connections: ->0000 ->7145 <-7081 <-7145
-Disconnections: 0
-Servers:
-    7081 (7081 at ssl:10.0.163.212:9644) last msg 59 ms ago <3>
-    1930 (1930 at ssl:10.0.147.219:9644) (self)
-    7145 (7145 at ssl:10.0.242.240:9644) last msg 7871735 ms ago
+NAME                                     READY   STATUS    RESTARTS      AGE   IP           NODE                                       NOMINATED NODE   READINESS GATES
+ovnkube-control-plane-8444dff7f9-4lh9k   2/2     Running   0             27m   10.0.0.3     ci-ln-t487nnb-72292-mdcnq-master-1         <none>           <none>
+ovnkube-control-plane-8444dff7f9-5rjh9   2/2     Running   0             27m   10.0.0.4     ci-ln-t487nnb-72292-mdcnq-master-2         <none>           <none>
+ovnkube-control-plane-8444dff7f9-k64b7   2/2     Running   2 (12m ago)   27m   10.0.0.5     ci-ln-t487nnb-72292-mdcnq-master-0         <none>           <none>
+ovnkube-node-55xs2                       8/8     Running   0             26m   10.0.0.4     ci-ln-t487nnb-72292-mdcnq-master-2         <none>           <none>
+ovnkube-node-7r84r                       8/8     Running   0             17m   10.0.128.3   ci-ln-t487nnb-72292-mdcnq-worker-b-wbz7z   <none>           <none>
+ovnkube-node-bqq8p                       8/8     Running   0             17m   10.0.128.2   ci-ln-t487nnb-72292-mdcnq-worker-a-lh7ms   <none>           <none>
+ovnkube-node-mkj4f                       8/8     Running   0             27m   10.0.0.5     ci-ln-t487nnb-72292-mdcnq-master-0         <none>           <none>
+ovnkube-node-mlr8k                       8/8     Running   0             27m   10.0.0.3     ci-ln-t487nnb-72292-mdcnq-master-1         <none>           <none>
+ovnkube-node-wqn2m                       8/8     Running   0             17m   10.0.128.4   ci-ln-t487nnb-72292-mdcnq-worker-c-przlm   <none>           <none>
 ----
-+
-<1> This pod is identified as a follower
-<2> The leader is identified as `7081`
-<3> The `7081` is on IP address `10.0.163.212`
 
-.. Find the `ovnkube-master` pod running on IP Address `10.0.163.212` using the following command:
+. Navigate into a pod to look at the southbound database:
 +
 [source,terminal]
 ----
-$ oc get po -o wide -n openshift-ovn-kubernetes | grep 10.0.163.212 | grep -v ovnkube-node
+$ oc rsh -c sbdb -n openshift-ovn-kubernetes ovnkube-node-55xs2
 ----
-+
-.Example output
-[source,terminal]
-----
-ovnkube-master-mk6p6   6/6     Running   0              136m   10.0.163.212   ip-10-0-163-212.ec2.internal   <none>           <none>
-----
-+
-The `ovnkube-master-mk6p6` pod runs on IP Address 10.0.163.212.
 
-. Run the following command to show all the information stored in the southbound database:
+. Run the following command to show all the objects in the southbound database:
 +
 [source,terminal]
 ----
-$ oc exec -n openshift-ovn-kubernetes -it ovnkube-master-mk6p6 \
--c northd -- ovn-sbctl show
+$ ovn-sbctl show
 ----
+
 +
 .Example output
 +
 [source,terminal]
 ----
-Chassis "8ca57b28-9834-45f0-99b0-96486c22e1be"
-    hostname: ip-10-0-156-16.ec2.internal
+Chassis "5db31703-35e9-413b-8cdf-69e7eecb41f7"
+    hostname: ci-ln-9gp362t-72292-v2p94-worker-a-8bmwz
     Encap geneve
-        ip: "10.0.156.16"
+        ip: "10.0.128.4"
         options: {csum="true"}
-    Port_Binding k8s-ip-10-0-156-16.ec2.internal
-    Port_Binding etor-GR_ip-10-0-156-16.ec2.internal
-    Port_Binding jtor-GR_ip-10-0-156-16.ec2.internal
-    Port_Binding openshift-ingress-canary_ingress-canary-hsblx
-    Port_Binding rtoj-GR_ip-10-0-156-16.ec2.internal
-    Port_Binding openshift-monitoring_prometheus-adapter-658fc5967-9l46x
-    Port_Binding rtoe-GR_ip-10-0-156-16.ec2.internal
-    Port_Binding openshift-multus_network-metrics-daemon-77nvz
-    Port_Binding openshift-ingress_router-default-64fd8c67c7-df598
-    Port_Binding openshift-dns_dns-default-ttpcq
-    Port_Binding openshift-monitoring_alertmanager-main-0
-    Port_Binding openshift-e2e-loki_loki-promtail-g2pbh
-    Port_Binding openshift-network-diagnostics_network-check-target-m6tn4
-    Port_Binding openshift-monitoring_thanos-querier-75b5cf8dcb-qf8qj
-    Port_Binding cr-rtos-ip-10-0-156-16.ec2.internal
-    Port_Binding openshift-image-registry_image-registry-7b7bc44566-mp9b8
+    Port_Binding tstor-ci-ln-9gp362t-72292-v2p94-worker-a-8bmwz
+Chassis "070debed-99b7-4bce-b17d-17e720b7f8bc"
+    hostname: ci-ln-9gp362t-72292-v2p94-worker-b-svmp6
+    Encap geneve
+        ip: "10.0.128.2"
+        options: {csum="true"}
+    Port_Binding k8s-ci-ln-9gp362t-72292-v2p94-worker-b-svmp6
+    Port_Binding rtoe-GR_ci-ln-9gp362t-72292-v2p94-worker-b-svmp6
+    Port_Binding openshift-monitoring_alertmanager-main-1
+    Port_Binding rtoj-GR_ci-ln-9gp362t-72292-v2p94-worker-b-svmp6
+    Port_Binding etor-GR_ci-ln-9gp362t-72292-v2p94-worker-b-svmp6
+    Port_Binding cr-rtos-ci-ln-9gp362t-72292-v2p94-worker-b-svmp6
+    Port_Binding openshift-e2e-loki_loki-promtail-qcrcz
+    Port_Binding jtor-GR_ci-ln-9gp362t-72292-v2p94-worker-b-svmp6
+    Port_Binding openshift-multus_network-metrics-daemon-mkd4t
+    Port_Binding openshift-ingress-canary_ingress-canary-xtvj4
+    Port_Binding openshift-ingress_router-default-6c76cbc498-pvlqk
+    Port_Binding openshift-dns_dns-default-zz582
+    Port_Binding openshift-monitoring_thanos-querier-57585899f5-lbf4f
+    Port_Binding openshift-network-diagnostics_network-check-target-tn228
+    Port_Binding openshift-monitoring_prometheus-k8s-0
+    Port_Binding openshift-image-registry_image-registry-68899bd877-xqxjj
+Chassis "179ba069-0af1-401c-b044-e5ba90f60fea"
+    hostname: ci-ln-9gp362t-72292-v2p94-master-0
+    Encap geneve
+        ip: "10.0.0.5"
+        options: {csum="true"}
+    Port_Binding tstor-ci-ln-9gp362t-72292-v2p94-master-0
+Chassis "68c954f2-5a76-47be-9e84-1cb13bd9dab9"
+    hostname: ci-ln-9gp362t-72292-v2p94-worker-c-mjf9w
+    Encap geneve
+        ip: "10.0.128.3"
+        options: {csum="true"}
+    Port_Binding tstor-ci-ln-9gp362t-72292-v2p94-worker-c-mjf9w
+Chassis "2de65d9e-9abf-4b6e-a51d-a1e038b4d8af"
+    hostname: ci-ln-9gp362t-72292-v2p94-master-2
+    Encap geneve
+        ip: "10.0.0.4"
+        options: {csum="true"}
+    Port_Binding tstor-ci-ln-9gp362t-72292-v2p94-master-2
+Chassis "1d371cb8-5e21-44fd-9025-c4b162cc4247"
+    hostname: ci-ln-9gp362t-72292-v2p94-master-1
+    Encap geneve
+        ip: "10.0.0.3"
+        options: {csum="true"}
+    Port_Binding tstor-ci-ln-9gp362t-72292-v2p94-master-1
 ----
 +
 This detailed output shows the chassis and the ports that are attached to the chassis which in this case are all of the router ports and anything that runs like host networking.
@@ -141,10 +143,11 @@ Their IP address is translated into the IP address of the node that the pod is r
 In addition to the chassis information the southbound database has all the logic flows and those logic flows are then sent to the `ovn-controller` running on each of the nodes.
 The `ovn-controller` translates the logic flows into open flow rules and ultimately programs `OpenvSwitch` so that your pods can then follow open flow rules and make it out of the network.
 +
-Run the following command to display the options available with the command `ovn-sbctl`:
+
+. Run the following command to display the options available with the command `ovn-sbctl`:
 +
 [source,terminal]
 ----
-$ oc exec -n openshift-ovn-kubernetes -it ovnkube-master-mk6p6 \
--c northd -- ovn-sbctl --help
+$ oc exec -n openshift-ovn-kubernetes -it ovnkube-node-55xs2 \
+-c sbdb ovn-sbctl --help
 ----

--- a/modules/ovn-kubernetes-architecture-con.adoc
+++ b/modules/ovn-kubernetes-architecture-con.adoc
@@ -10,18 +10,18 @@ image::299_OpenShift_OVN-Kubernetes_arch_0223_1.png[OVN-Kubernetes architecture]
 The key components are:
 
 * **Cloud Management System (CMS)** - A platform specific client for OVN that provides a CMS specific plugin for OVN integration. The plugin translates the cloud management system's concept of the logical network configuration, stored in the CMS configuration database in a  CMS-specific  format, into an intermediate representation understood by OVN.
-* **OVN Northbound database (`nbdb`)** - Stores the logical network configuration passed by the CMS plugin.
-* **OVN Southbound database (`sbdb`)** - Stores the physical and logical network configuration state for OpenVswitch (OVS) system on each node, including tables that bind them.
-* **ovn-northd** - This is the intermediary client between `nbdb` and `sbdb`. It translates  the logical network configuration in terms of conventional network concepts, taken from the `nbdb`, into  logical data path flows in the `sbdb` below it. The container name is `northd` and it runs in the `ovnkube-master` pods.
-* **ovn-controller** - This is the OVN agent that interacts with OVS and hypervisors, for any information or update that is needed for `sbdb`. The `ovn-controller` reads logical flows from the `sbdb`, translates them into `OpenFlow` flows and sends them to the node’s OVS daemon. The container name is `ovn-controller` and it runs in the `ovnkube-node` pods.
+* **OVN Northbound database (`nbdb`) container** - Stores the logical network configuration passed by the CMS plugin.
+* **OVN Southbound database (`sbdb`) container** - Stores the physical and logical network configuration state for Open vSwitch (OVS) system on each node, including tables that bind them.
+* **OVN north daemon (`ovn-northd`)** - This is the intermediary client between `nbdb` container and `sbdb` container. It translates  the logical network configuration in terms of conventional network concepts, taken from the `nbdb` container, into  logical data path flows in the `sbdb` container. The container name for `ovn-northd` daemon is `northd` and it runs in the `ovnkube-node` pods.
+* **ovn-controller** - This is the OVN agent that interacts with OVS and hypervisors, for any information or update that is needed for `sbdb` container. The `ovn-controller` reads logical flows from the `sbdb` container, translates them into `OpenFlow` flows and sends them to the node’s OVS daemon. The container name is `ovn-controller` and it runs in the `ovnkube-node` pods.
+
+The OVN northd, northbound database, and southbound database run on each node in the cluster and mostly contain and process information that is local to that node.
 
 The OVN northbound database has the logical network configuration passed down to it by the cloud management system (CMS).
-The OVN northbound Database contains the current desired state of the network, presented as a collection of logical ports, logical switches, logical routers, and more.
+The OVN northbound database contains the current desired state of the network, presented as a collection of logical ports, logical switches, logical routers, and more.
 The `ovn-northd` (`northd` container) connects to the OVN northbound database and the OVN southbound database.
-It translates the logical network configuration in terms of conventional network concepts, taken from the OVN northbound Database, into logical data path flows in the OVN southbound database.
+It translates the logical network configuration in terms of conventional network concepts, taken from the OVN northbound database, into logical data path flows in the OVN southbound database.
 
-The OVN southbound database has physical and logical representations of the network and binding tables that link them together. Every node in the cluster is represented in the southbound database, and you can see the ports that are connected to it.
-It also contains all the logic flows, the logic flows are shared with the `ovn-controller` process that runs on each node and the `ovn-controller` turns those into `OpenFlow` rules to program `Open vSwitch`.
+The OVN southbound database has physical and logical representations of the network and binding tables that link them together. It contains the chassis information of the node and other constructs like remote transit switch ports that are required to to connect to the other nodes in the cluster. The OVN southbound database also contains all the logic flows. The logic flows are shared with the `ovn-controller` process that runs on each node and the `ovn-controller` turns those into `OpenFlow` rules to program `Open vSwitch`(OVS).
 
-The Kubernetes control plane nodes each contain an `ovnkube-master` pod which hosts containers for the OVN northbound and southbound databases.
-All OVN northbound databases form a `Raft` cluster and all southbound databases form a separate `Raft` cluster. At any given time a single `ovnkube-master` is the leader and the other `ovnkube-master` pods are followers.
+The Kubernetes control plane nodes each contain an `ovnkube-control-plane` pod which does the central IP address management (IPAM) allocation for each node in the cluster. At any given time a single `ovnkube-control-plane` pod is the leader.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
Updates to the[ Introduction to OVN-K](https://62156--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#ovn-kubernetes-architecture-con:~:text=The%20Kubernetes%20control%20plane%20nodes%20each%20contain%20an%20ovnkube%2Dcontrol%2Dplane%20pod%20which%20does%20the%20central%20IPAM%20allocation%20for%20each%20node%20in%20the%20cluster.%20At%20any%20given%20time%20a%20single%20ovnkube%2Dcontrol%2Dplane%20is%20the%20leader%20and%20the%20other%20ovnkube%2Dcontrol%2Dplane%20pods%20are%20followers.)
Updates to the [Listing all resources in OVN-K project](https://62156--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#nw-ovn-kubernetes-list-resources_ovn-kubernetes-architecture)
Updates to [Listing the OVN-K nbdb](https://62156--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#nw-ovn-kubernetes-list-database-contents_ovn-kubernetes-architecture)
Updates to [Listing the OVN-K sbdb](https://62156--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#nw-ovn-kubernetes-list-southbound-database-contents_ovn-kubernetes-architecture)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @tssurya 
https://github.com/openshift/openshift-docs/pull/64493
https://github.com/openshift/openshift-docs/pull/64418
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
