### PR TITLE
 OSDOCS-5280: Add secondary external gateway support for ovn-k8s

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1332,6 +1332,8 @@ Topics:
     File: logging-network-policy
   - Name: Configuring IPsec encryption
     File: configuring-ipsec-ovn
+  - Name: Configure an external gateway through a secondary network interface
+    File: configuring-secondary-external-gateway
   - Name: Configuring an egress firewall for a project
     File: configuring-egress-firewall-ovn
   - Name: Viewing an egress firewall for a project

--- a/modules/nw-secondary-ext-gw-about.adoc
+++ b/modules/nw-secondary-ext-gw-about.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.adoc
+
+:_content-type: PROCEDURE
+[id="nw-secondary-ext-gw-about_{context}"]
+= How {product-title} determines the external gateway IP address
+
+You configure a secondary external gateway with the `AdminPolicyBasedExternalRoute` custom resource from the the `k8s.ovn.org` API group. The custom resource (CR) supports static and dynamic approaches to specifying an external gateway's IP address. Each namespace that a `AdminPolicyBasedExternalRoute` CR targets cannot be selected by any other `AdminPolicyBasedExternalRoute` CR. A namespace cannot have concurrent secondary external gateways.
+
+Static assignment:: You specify an IP address directly.
+Dynamic assignment:: You specify an IP address indirectly, with namespace and pod selectors, and an optional network attachment definition.
++
+--
+- If the name of a network attachment definition is provided, the external gateway IP address of the network attachment is used.
+- If the name of a network attachment definition is not provided, the external gateway IP address for the pod itself is used. However, this approach works only if the pod is configured with `hostNetwork` set to `true`.
+--

--- a/modules/nw-secondary-ext-gw-configure.adoc
+++ b/modules/nw-secondary-ext-gw-configure.adoc
@@ -1,0 +1,143 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.adoc
+
+:_content-type: PROCEDURE
+[id="nw-secondary-ext-gw-configure_{context}"]
+= Configure a secondary external gateway
+
+You can configure a secondary external gateway for a namespace in your cluster.
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You are logged in to the cluster with a user with `cluster-admin` privileges.
+
+.Procedure
+
+. Create a YAML file that contains an `AdminPolicyBasedExternalRoute` object.
+. To create an admin policy based external route, enter the following command:
++
+[source,terminal]
+----
+$ oc create -f <file>.yaml
+----
++
+--
+where:
+
+`<file>`:: Specifies the name of the YAML file that you created in the previous step.
+--
++
+.Example output
+[source,text]
+----
+adminpolicybasedexternalroute.k8s.ovn.org/default-route-policy created
+----
+
+. To confirm that the admin policy based external route was created, enter the following command:
++
+[source,terminal]
+----
+$ oc describe apbexternalroute <name> | tail -n 6
+----
++
+--
+where:
+
+`<name>`:: Specifies the name of the `AdminPolicyBasedExternalRoute` object.
+--
++
+.Example output
+[source,text]
+----
+Status:
+  Last Transition Time:  2023-04-24T15:09:01Z
+  Messages:
+  Configured external gateway IPs: 172.18.0.8
+  Status:  Success
+Events:  <none>
+----
+
+////
+.Verification
+
+If you created an `AdminPolicyBasedExternalRoute` object that selects a host-network pod IP address as the secondary external gateway, you can confirm that the next hop is correct for a pod with the following steps:
+
+. To get the IP address of the pod, enter the following command:
++
+[source,terminal]
+----
+oc get pods/<pod_name> -n <namespace> -o wide
+----
++
+--
+where:
+
+`<pod_name>`:: Specifies the name of the pod.
+`<namespace>`:: Specifies the namespace of the pod.
+--
++
+.Example output
+[source,text]
+----
+NAMESPACE  NAME   READY   STATUS      RESTARTS      AGE   IP            NODE      NOMINATED NODE   READINESS GATES
+ns1        pod1   1/1     Running     1 (37m ago)   41m   10.130.0.8    node1     <none>           <none>
+----
+
+. Confirm that the IP address from the previous step is available as an external gateway.
+
+.. To find the the OVN-Kubernetes control plane pod that manages the next hop for the pod, enter the following command:
++
+[source,terminal]
+----
+$ oc get pod -n openshift-ovn-kubernetes \
+  --field-selector spec.nodeName=<node_name> \
+  -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' | \
+    grep ovnkube-node-
+----
++
+--
+where:
+
+`<node_name>`:: Specifies the name of the node from the `NODE` column that the pod from the previous step is running on.
+--
++
+.Example output
+[source,text]
+----
+ovnkube-node-rpt55
+----
+
+.. To confirm that the OVN-Kubernetes node pod includes the correct next hop, enter the following command:
++
+[source,terminal]
+----
+$ oc exec -t <pod_name> -n openshift-ovn-kubernetes  -c nbdb \
+    -- ovn-nbctl lr-route-list GR_ovn-work | grep <pod_ip> -A 6 -B 4
+
+oc exec -ti <pod_name> -n openshift-ovn-kubernetes -c nbdb -- ovn-nbctl lr-route-list GR_<node_name> | grep <pod_id> -A6 -B4
+----
++
+--
+where:
+
+`<pod_name>`:: Specifies the name of the OVN-Kubernetes node pod from the previous step.
+`<node_name>`:: Specifies the name of the cluster node that the OVN-Kubernetes node pod is running on.
+`<pod_ip>`:: Specifies the name of the pod IP address.
+--
++
+.Example output
+[source,text]
+----
+IPv4 Routes
+Route Table
+
+:
+10.128.2.206 172.18.0.10 src-ip rtoe-GR_worker-0-1 ecmp-symmetric-reply bfd
+10.128.3.229 172.18.0.10 src-ip rtoe-GR_worker-0-1 ecmp-symmetric-reply bfd
+169.254.169.0/29 169.254.169.4 dst-ip rtoe-GR_worker-0-1
+10.128.0.0/14 100.64.0.1 dst-ip
+0.0.0.0/0 192.168.123.1 dst-ip rtoe-GR_worker-0-1
+----
+////

--- a/modules/nw-secondary-ext-gw-object.adoc
+++ b/modules/nw-secondary-ext-gw-object.adoc
@@ -1,0 +1,180 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.adoc
+
+:_content-type: CONCEPT
+[id="nw-secondary-ext-gw-object_{context}"]
+= AdminPolicyBasedExternalRoute object configuration
+
+You can define an `AdminPolicyBasedExternalRoute` object, which is cluster scoped, with the following properties. A namespace can be selected by only one `AdminPolicyBasedExternalRoute` CR at a time.
+
+.`AdminPolicyBasedExternalRoute` object
+[cols=".^3,.^2,.^5a",options="header"]
+
+|====
+|Field|Type|Description
+
+|`metadata.name`
+|`string`
+|
+Specifies the name of the  `AdminPolicyBasedExternalRoute` object.
+
+|`spec.from`
+|`string`
+|
+Specifies a namespace selector that the routing polices apply to. Only `namespaceSelector` is supported for external traffic. For example:
+
+[source,yaml]
+----
+from:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: novxlan-externalgw-ecmp-4059
+----
+
+A namespace can be targeted by only one `AdminPolicyBasedExternalRoute` CR. If a namespace is selected by more than one `AdminPolicyBasedExternalRoute` CR, a `failed` error status occurs on the second and subsequent CRs targeting the same namespace.
+
+|`spec.nextHops`
+|`object`
+|
+Specifies the destinations where the packets are forwarded to. Must be either or both of `static` and `dynamic`. You must have at least one next hop defined.
+
+|====
+
+
+.`nextHops` object
+[cols=".^3,.^2,.^5a",options="header"]
+|====
+|Field|Type|Description
+
+|`static`
+|`array`
+| Specifies an array of static IP addresses.
+
+|`dynamic`
+|`array`
+| Specifies an array of pod selectors corresponding to pods configured with a network attachment definition to use as the external gateway target.
+
+|====
+
+
+.`nextHops.static` object
+[cols=".^3,.^2,.^5a",options="header"]
+|====
+|Field|Type|Description
+
+|`ip`
+|`string`
+| Specifies either an IPv4 or IPv6 address of the next destination hop.
+
+|`bfdEnabled`
+|`boolean`
+|Optional: Specifies whether Bi-Directional Forwarding Detection (BFD) is supported by the network. The default value is `false`.
+
+|====
+
+.`nextHops.dynamic` object
+[cols=".^3,.^2,.^5a",options="header"]
+|====
+|Field|Type|Description
+
+|`podSelector`
+|`string`
+|
+Specifies a [set-based](https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/#set-based-requirement) label selector to filter the pods in the namespace that match this network configuration.
+
+|`namespaceSelector`
+|`string`
+| Specifies a `set-based` selector to filter the namespaces that the `podSelector` applies to. You must specify a value for this field.
+
+
+|`bfdEnabled`
+|`boolean`
+|Optional: Specifies whether Bi-Directional Forwarding Detection (BFD) is supported by the network. The default value is `false`.
+
+|`networkAttachmentName`
+|`string`
+|
+Optional: Specifies the name of a network attachment definition. The name must match the list of logical networks associated with the pod. If this field is not specified, the host network of the pod is used. However, the pod must be configure as a host network pod to use the host network.
+
+|====
+
+[id="example-secondary-external-gateway-configurations_{context}"]
+== Example secondary external gateway configurations
+
+In the following example, the `AdminPolicyBasedExternalRoute` object configures two static IP addresses as external gateways for pods in namespaces with the `kubernetes.io/metadata.name: novxlan-externalgw-ecmp-4059` label.
+
+[source,yaml]
+----
+apiVersion: k8s.ovn.org/v1
+kind: AdminPolicyBasedExternalRoute
+metadata:
+  name: default-route-policy
+spec:
+  from:
+    namespaceSelector:
+      matchLabels:
+        kubernetes.io/metadata.name: novxlan-externalgw-ecmp-4059
+  nextHops:
+    static:
+    - ip: "172.18.0.8"
+    - ip: "172.18.0.9"
+----
+
+In the following example, the `AdminPolicyBasedExternalRoute` object configures a dynamic external gateway. The IP addresses used for the external gateway are derived from the additional network attachments associated with each of the selected pods.
+
+[source,yaml]
+----
+apiVersion: k8s.ovn.org/v1
+kind: AdminPolicyBasedExternalRoute
+metadata:
+  name: shadow-traffic-policy
+spec:
+  from:
+    namespaceSelector:
+      matchLabels:
+        externalTraffic: ""
+  nextHops:
+    dynamic:
+    - podSelector:
+        matchLabels:
+          gatewayPod: ""
+      namespaceSelector:
+        matchLabels:
+          shadowTraffic: ""
+      networkAttachmentName: shadow-gateway
+    - podSelector:
+        matchLabels:
+          gigabyteGW: ""
+      namespaceSelector:
+        matchLabels:
+          gatewayNamespace: ""
+      networkAttachmentName: gateway
+----
+
+In the following example, the `AdminPolicyBasedExternalRoute` object configures both static and dynamic external gateways.
+
+[source,yaml]
+----
+apiVersion: k8s.ovn.org/v1
+kind: AdminPolicyBasedExternalRoute
+metadata:
+  name: multi-hop-policy
+spec:
+  from:
+    namespaceSelector:
+      matchLabels:
+        trafficType: "egress"
+  nextHops:
+    static:
+    - ip: "172.18.0.8"
+    - ip: "172.18.0.9"
+    dynamic:
+    - podSelector:
+        matchLabels:
+          gatewayPod: ""
+      namespaceSelector:
+        matchLabels:
+          egressTraffic: ""
+      networkAttachmentName: gigabyte
+----

--- a/modules/nw-secondary-ext-gw-status.adoc
+++ b/modules/nw-secondary-ext-gw-status.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.adoc
+
+:_content-type: PROCEDURE
+[id="nw-secondary-ext-gw-status_{context}"]
+= View the status of a secondary external gateway
+
+You can view the status of a secondary external gateway that is configured for your cluster. The `status` field for the `AdminPolicyBasedExternalRoute` custom resource reports recent status messages whenever you update the resource, subject to a few limitations:
+
+- Namespaces impacted are not reported in status messages
+- Pods selected as part of a dynamic next hop configuration do not trigger status updates as a result of pod lifecycle events, such as pod termination
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You are logged in to the cluster with a user with `cluster-admin` privileges.
+
+.Procedure
+
+* To access the status logs for a secondary external gateway, enter the following command:
++
+[source,terminal]
+----
+$ oc get adminpolicybasedexternalroutes <name> -o yaml
+----
++
+--
+where:
+
+`<name>`:: Specifies the name of an `AdminPolicyBasedExternalRoute` object.
+--
++
+.Example output
+[source,text]
+----
+...
+Status:
+  Last Transition Time:  2023-04-24T14:49:45Z
+  Messages:
+    Configured external gateway IPs: 172.18.0.8,172.18.0.9
+    Configured external gateway IPs: 172.18.0.8
+  Status:  Success
+Events: <none>
+----

--- a/networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.adoc
@@ -1,0 +1,34 @@
+:_content-type: ASSEMBLY
+[id="configuring-secondary-external-gateway"]
+= Configure an external gateway through a secondary network interface
+include::_attributes/common-attributes.adoc[]
+:context: configuring-secondary-external-gateway
+
+toc::[]
+
+As a cluster administrator, you can configure an external gateway on a secondary network.
+
+This feature offers the following benefits:
+
+- Granular control over egress traffic on a per-namespace basis
+- Flexible configuration of static and dynamic external gateway IP addresses
+- Support for both IPv4 and IPv6 address families
+
+[id="{context}_prerequisites"]
+== Prerequisites
+
+* Your cluster uses the OVN-Kubernetes network plugin.
+* Your infrastructure is configured to route traffic from the secondary external gateway.
+
+include::modules/nw-secondary-ext-gw-about.adoc[leveloffset=+1]
+
+include::modules/nw-secondary-ext-gw-object.adoc[leveloffset=+1]
+
+include::modules/nw-secondary-ext-gw-configure.adoc[leveloffset=+1]
+
+// TODO - Resolve this after OCP 4.14 is released
+//include::modules/nw-secondary-ext-gw-status.adoc[leveloffset=+1]
+
+[id="{context}_additional-resources"]
+== Additional resources
+* For more information about additional network attachments, see xref:../../networking/multiple_networks/understanding-multiple-networks.adoc#understanding-multiple-networks[Understanding multiple networks]


### PR DESCRIPTION
   
- https://issues.redhat.com/browse/OSDOCS-5280

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62157--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-secondary-external-gateway.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
