### PR TITLE
Fix HW offload supported devices table format

### DIFF
--- a/modules/nw-sriov-hwol-supported-devices.adoc
+++ b/modules/nw-sriov-hwol-supported-devices.adoc
@@ -22,12 +22,12 @@ Hardware offloading is supported on the following network interface controllers:
 |MT28880 Family [ConnectX&#8209;5{nbsp}Ex]
 |15b3
 |1019
-|===
 
 |Mellanox 
 |MT2892 Family [ConnectX&#8209;6 Dx]
 |15b3
 |101d
+|===
 
 .Technology Preview network interface controllers
 [cols="1,2,1,1"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Format issue introduced in main (https://github.com/openshift/openshift-docs/pull/57126) as part of 4.13 development cycle. 

Version(s): main, 4.14, 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://62167--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-hardware-offloading.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
