### PR TITLE
[RHACS] ROX-18160: Release notes and errata update for patch 3.74.5

### DIFF
--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -17,6 +17,7 @@ toc::[]
 |`3.74.2` | 13 April 2023
 |`3.74.3` | 2 May 2023
 |`3.74.4` | 5 June 2023
+|`3.74.5` | 13 July 2023
 |====
 
 [id="about-this-release-374"]
@@ -389,6 +390,17 @@ Release date: 5 June 2023
 ** link:https://access.redhat.com/security/cve/cve-2023-24540[CVE-2023-24540]
 ** link:https://nvd.nist.gov/vuln/detail/cve-2023-24539[CVE-2023-24539]
 ** link:https://nvd.nist.gov/vuln/detail/cve-2023-29400[CVE-2023-29400]
+
+[id="resolved-in-version-3745"]
+=== Resolved in version 3.74.5
+
+Release date: 13 July 2023
+
+* Fixed an issue with Sensor upgrade errors caused by PodSecurityPolicies (PSPs) that are not supported in Kubernetes version 1.25 and later.
+
+* Fixed an issue with upgrades failing because {product-title-short} applied PSPs, even when not enabled.
+
+* Provides a Python3 security update. (link:https://access.redhat.com/errata/RHSA-2023:3591[RHSA-2023:3591])
 
 [id="known-issues-374"]
 === Known issues


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
3.74
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-18160
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://62168--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes.html#resolved-in-version-3745
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [ ] SME has approved this change.
<!--- SME approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Merge into `rhacs-docs-3.74`.
- No cherry-picking required.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
