### PR TITLE
OCPBUGS-15984 - reverting changes regarding BMH

### DIFF
--- a/modules/restore-replace-stopped-etcd-member.adoc
+++ b/modules/restore-replace-stopped-etcd-member.adoc
@@ -266,19 +266,13 @@ metadata:
   providerID: aws:///us-east-1a/i-0fdb85790d76d0c3f
 ----
 
-.. Delete the `BareMetalHost` object by running the following command, replacing `<host_name>` with the name of the bare-metal host for the unhealthy node:
+.. Delete the machine of the unhealthy member:
 +
 [source,terminal]
 ----
-$ oc delete bmh -n openshift-machine-api <host_name>
+$ oc delete machine -n openshift-machine-api clustername-8qw5l-master-0 <1>
 ----
-
-..  Delete the machine of the unhealthy member by running the following command, replacing `<machine_name>` with the name of the control plane machine for the unhealthy node, for example `clustername-8qw5l-master-0`:
-+
-[source,terminal]
-----
-$ oc delete machine -n openshift-machine-api <machine_name>
-----
+<1> Specify the name of the control plane machine for the unhealthy node.
 
 .. Verify that the machine was deleted:
 +


### PR DESCRIPTION
OCPBUGS#15984: The changes in #56878 should have been applied to `modules/restore-replace-stopped-baremetal-etcd-member.adoc` only, and not `modules/restore-replace-stopped-etcd-member.adoc`. The changes applied to bare-metal section only. Reverting the changes to `modules/restore-replace-stopped-etcd-member.adoc`

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-15984

Link to docs preview:
https://62175--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/replacing-unhealthy-etcd-member.html#restore-replace-stopped-etcd-member_replacing-unhealthy-etcd-member

QE not required this is an over-eager find and replace fix. 