### PR TITLE
[RHACS] ROX-13807: Removing reference to telemetry from Helm chart documentation

### DIFF
--- a/modules/central-services-public-config.adoc
+++ b/modules/central-services-public-config.adoc
@@ -96,10 +96,6 @@ include::snippets/technology-preview.adoc[]
 |`Central.declarativeConfiguration.mounts.secrets`
 | Mounts secrets used for declarative configurations.
 
-| `central.disableTelemetry`
-| Use `true` to disable online telemetry data collection.
-//TODO: Add link to telemetry
-
 | `central.endpointsConfig`
 | The endpoint configuration options for Central.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
3.74+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/ROX-13807
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://62177--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/install-central-other.html#central-services-public-configuration-file-central_install-central-other
- https://62177--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html#central-services-public-configuration-file-central_install-central-ocp
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Merge into `rhacs-docs` and cherry-pick into:
- `rhacs-docs-4.1`
- `rhacs-docs-4.0`
- `rhacs-docs-3.74`
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
