### PR TITLE
OSDOCS-6824: Adds notes for 4.12.24 MS release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -257,3 +257,12 @@ Issued: 2023-07-06
 {product-title} release 4.12.23, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3928[RHBA-2023:3928] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3925[RHSA-2023:3925] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-24-dp"]
+=== RHBA-2023:3677 - {product-title} 4.12.24 bug fix and security update
+
+Issued: 2023-07-12
+
+{product-title} release 4.12.24, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3980[RHBA-2023:3980] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3977[RHSA-2023:3977] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-6824

Link to docs preview:
https://62178--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-24-dp

QE review:
N/A

NOTE: DO NOT MERGE until after 7/12/23 z-stream release.
