### PR TITLE
Remove outdated tech preview language for postgresql

### DIFF
--- a/modules/create-collection-rules.adoc
+++ b/modules/create-collection-rules.adoc
@@ -5,11 +5,11 @@
 [id="creating-collection-rules_{context}"]
 = Creating collection rules
 
-When creating collections, you must configure at least one rule or attach another collection to the new collection that you are creating. 
+When creating collections, you must configure at least one rule or attach another collection to the new collection that you are creating.
 
 [NOTE]
 ====
-For {product-title-short} release 3.74, collections are available only for deployments.
+Currently, collections are available only for deployments.
 ====
 
 Configure rules to select the resources to include in the collection. Use the preview panel to see the results of the collection rules as you configure them. You can configure rules in any order.
@@ -17,7 +17,7 @@ Configure rules to select the resources to include in the collection. Use the pr
 .Procedure
 
 . In the *Deployments* section, select one of the following options from the drop-down list:
-* *All deployments*: Includes all deployments in the collection. If you select this option, you must filter the collection by using namespaces or clusters or by attaching another collection. 
+* *All deployments*: Includes all deployments in the collection. If you select this option, you must filter the collection by using namespaces or clusters or by attaching another collection.
 * *Deployments with names matching* Click this option to select by name and then click one of the following options:
 ** Select *An exact value of* and enter the exact name of the deployment.
 ** Select *A regex value of* to use regular expression to search for a deployment. This option is useful if you do not know the exact name of the deployment. A regular expression is a string of letters, numbers, and symbols that defines a pattern. {product-title-short} uses this pattern to match characters or groups of characters and return results. For more information about regular expression, see "Regular-Expressions.info" in the "Additional resources" section.

--- a/modules/migrate-scope-collections.adoc
+++ b/modules/migrate-scope-collections.adoc
@@ -5,14 +5,11 @@
 [id="migrate-scope-collections_{context}"]
 = Migration of access scopes to collections
 
-Database changes in {product-title-short} from `rocksdb` to PostgreSQL are provided as a Technology Preview beginning with release 3.74. When the database is migrated from `rocksdb` to PostgreSQL, existing access scopes used in vulnerability reporting are migrated to collections. You can verify that the migration resulted in the correct configuration for your existing reports by navigating to *Vulnerability Management* -> *Reporting* and viewing the report information.
-
-:FeatureName: PostgreSQL support
-include::snippets/technology-preview.adoc[]
+Database changes in {product-title-short} from `rocksdb` to PostgreSQL are provided as a Technology Preview beginning with release 3.74 and are generally available in release 4.0. When the database is migrated from `rocksdb` to PostgreSQL, existing access scopes used in vulnerability reporting are migrated to collections. You can verify that the migration resulted in the correct configuration for your existing reports by navigating to *Vulnerability Management* -> *Reporting* and viewing the report information.
 
 The migration process creates collection objects for access scopes that were used in report configurations. {product-title-short} generates two or more collections for a single access scope, depending on the complexity of the access scope. The generated collections for a given access scope include the following types:
 
-* Embedded collections: To mimic the exact selection logic of the original access scope, {product-title-short} generates one or more collections where matched deployments result in the same selection of clusters and namespaces as the original access scope. The collection name is in the format of `System-generated embedded collection _number_ for the scope` where _number_ is a number starting from 0. 
+* Embedded collections: To mimic the exact selection logic of the original access scope, {product-title-short} generates one or more collections where matched deployments result in the same selection of clusters and namespaces as the original access scope. The collection name is in the format of `System-generated embedded collection _number_ for the scope` where _number_ is a number starting from 0.
 +
 [NOTE]
 ====
@@ -27,7 +24,7 @@ Failed to create collections for scope _scope-name_: Unsupported operator NOT_IN
 The scope is attached to the following report configurations: [list of report configs]; Please manually create an equivalent collection and edit the listed report configurations to use this collection. Note that reports will not function correctly until a collection is attached.
 ----
 
-You can also click the report in *Vulnerability Management* -> *Reporting* to view the report information page. This page contains a message if a report needs a collection attached to it. 
+You can also click the report in *Vulnerability Management* -> *Reporting* to view the report information page. This page contains a message if a report needs a collection attached to it.
 
 [NOTE]
 ====

--- a/modules/object-collections.adoc
+++ b/modules/object-collections.adoc
@@ -5,23 +5,20 @@
 [id="understanding-object-collections_{context}"]
 = Understanding deployment collections
 
-Deployment collections are only available to {product-title-short} customers using the PostgreSQL database. {product-title-short} Cloud Service uses the PostgreSQL database by default. Other {product-title-short} customers can migrate to the PostgreSQL database with help from Red Hat. 
-
-:FeatureName: PostgreSQL database option
-include::snippets/technology-preview.adoc[leveloffset=+1]
+Deployment collections are only available to {product-title-short} customers using the PostgreSQL database. By default, {product-title-managed-short} uses the PostgreSQL database, and it is also used by default when installing {product-title-short} release 4.0 and later. {product-title-short} customers using an earlier release than 3.74 can migrate to the PostgreSQL database with help from Red Hat.
 
 An {product-title-short} collection is a user-defined, named reference. It defines a logical grouping by using selection rules. Those rules can match a deployment, namespace, or cluster name or label. You can specify rules by using exact matches or regular expressions. Collections are resolved at run time and can refer to objects that do not exist at the time of the collection definition. Collections can be constructed by using other collections to describe complex hierarchies.
 
 Collections provide you with a language to describe how your dynamic infrastructure is organized, eliminating the need for cloning and repetitive editing of {product-title-short} properties such as inclusion and exclusion scopes.
 
-You can use collections to identify any group of deployments in your system, such as: 
+You can use collections to identify any group of deployments in your system, such as:
 
 * An infrastructure area that is owned by a specific development team
 * An application that requires different policy exceptions when running in a development or in a production cluster
 * A distributed application that spans multiple namespaces, defined with a common deployment label
 * An entire production or test environment
 
-Collections can be created and managed by using the {product-title-short} portal. The collection editor helps you apply selection rules at the deployment, namespace, and cluster level. You can use simple and complex rules, including regular expression. 
+Collections can be created and managed by using the {product-title-short} portal. The collection editor helps you apply selection rules at the deployment, namespace, and cluster level. You can use simple and complex rules, including regular expression.
 
 You can define a collection by selecting one or more deployments, namespaces, or clusters, as shown in the following image. This image shows a collection that contains deployments with the name reporting or that contain `db` in the name. The collection includes deployments matching those names in the namespace with a specific label of `kubernetes.io/metadata.name=medical`, and in clusters named `production`.
 

--- a/operating/create-use-collections.adoc
+++ b/operating/create-use-collections.adoc
@@ -10,19 +10,16 @@ toc::[]
 
 You can use collections in {product-title-short} to define and name a group of resources by using matching patterns. You can then configure system processes to use these collections.
 
-For {product-title-short} release 3.74, collections are available only under the following conditions:
+Currently, collections are available only under the following conditions:
 
 * Collections are available only for deployments.
 * You can only use collections with vulnerability reporting. See "Vulnerability reporting" in the Additional resources section for more information.
-* Collections are available only to {product-title-short} customers using the PostgreSQL database (Technology Preview).
-
-:FeatureName: PostgreSQL database option
-include::snippets/technology-preview.adoc[leveloffset=+1]
-
-{product-title-managed} (Field Trial) uses the PostgreSQL database by default. Other {product-title-short} customers can migrate to the PostgreSQL database with help from Red Hat.
-
-:FeatureName: Red Hat Advanced Cluster Security Cloud Service
-include::snippets/field-trial.adoc[leveloffset=+1]
+* Deployment collections are only available to {product-title-short} customers if they are using the PostgreSQL database.
++
+[NOTE]
+====
+By default, {product-title-managed-short} uses the PostgreSQL database, and it is also used by default when installing {product-title-short} release 4.0 and later. {product-title-short} customers using an earlier release than 3.74 can migrate to the PostgreSQL database with help from Red Hat.
+====
 
 [id="prerequisites_collections"]
 == Prerequisites


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.1`
- Cherry pick to `rhacs-docs-4.0`

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Links to docs previews:
- https://62181--docspreview.netlify.app/openshift-acs/latest/operating/create-use-collections.html
- https://62181--docspreview.netlify.app/openshift-acs/latest/operating/create-use-collections.html#understanding-object-collections_create-use-collections
- https://62181--docspreview.netlify.app/openshift-acs/latest/operating/create-use-collections.html#migrate-scope-collections_create-use-collections

QE review:
- [x] QE has approved this change. (RHACS has no QE; approved by SME)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Remove outdated tech preview language for PostgreSQL (released GA in 4.0)
