### PR TITLE
OCPBUGS-13226: Clarifying release notes for change in behavior for se…

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -1163,17 +1163,21 @@ The `haproxy.router.openshift.io/balance` variable, which sets the router load-b
 [id="ocp-4-11-legacy-service-account"]
 ==== LegacyServiceAccountTokenNoAutoGeneration is on by default
 
-To align with upstream link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.24.md#urgent-upgrade-notes-1[Kubernetes having moved] the `LegacyServiceAccountTokenNoAutoGeneration` feature gate to beta and enabling it by default, {product-title} now also follows this security feature and releases with the feature enabled. As a result, when creating new service accounts (SA), a service account token secret is no longer automatically generated. Previously, {product-title} automatically added a service account token to a secret for each new SA.
+In previous releases, two service account token secrets were generated when a service account was created:
 
-If you need a service account token secret, you must manually use the TokenRequest API to request bound service account tokens or create a service account token secret.
+* A service account token secret for authenticating to the internal {product-title} registry
+* A service account token secret for accessing the Kubernetes API
 
-After updating to {product-version}, existing service account token secrets are not deleted and continue to function as expected.
+Starting with {product-title} 4.11, this second service account token secret for accessing the Kubernetes API is no longer created. This is because the `LegacyServiceAccountTokenNoAutoGeneration` upstream Kubernetes feature gate was enabled in Kubernetes 1.24, which stops the automatic generation of secret-based service account tokens for accessing the Kubernetes API. After upgrading to {product-title} 4.11, any existing service account token secrets are not deleted and continue to function.
 
-Service Account token secrets still appear as auto-generated in {product-title} 4.11. However, instead of two secrets per Service Account, there will now be only one, which will be further reduced to zero in a future release. These tokens do not work. For now, dockercfg secrets are still being generated as secrets and no secrets will be deleted during upgrades.
+[NOTE]
+====
+Do not rely on these automatically generated secrets for your own use; they might be removed in a future {product-title} release.
+====
 
-* For information about using the TokenRequest API, see xref:../authentication/bound-service-account-tokens.html#bound-sa-tokens-configuring_bound-service-account-tokens[Using bound service account tokens]
+Workloads are automatically injected with a projected volume to obtain a bound service account token. If your workload needs an additional service account token, add an additional projected volume in your workload manifest. For more information, see xref:../authentication/bound-service-account-tokens.html#bound-sa-tokens-configuring_bound-service-account-tokens[Using bound service account tokens].
 
-* For information about creating a service account token secret, see xref:../nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-creating-sa_nodes-pods-secrets[Creating a service account token secret].
+You can also manually create a service account token secret to obtain a token, if the security exposure of a non-expiring token in a readable API object is acceptable to you. For more information, see xref:../nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-creating-sa_nodes-pods-secrets[Creating a service account token secret].
 
 [discrete]
 [id="ocp-4-11-operator-sdk-1-22-0"]


### PR DESCRIPTION
…rvice account token secrets

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-13226

Link to docs preview:
https://file.rdu.redhat.com/~ahoffer/2023/OCPBUGS-13226-411/release_notes/ocp-4-11-release-notes.html#ocp-4-11-legacy-service-account

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
**This will require change management**
