### PR TITLE
Nodes docs fixes during ROSA review

### DIFF
--- a/modules/nodes-pods-configmap-overview.adoc
+++ b/modules/nodes-pods-configmap-overview.adoc
@@ -6,11 +6,11 @@
 [id="nodes-pods-configmap-overview_{context}"]
 = Understanding config maps
 
-Many applications require configuration using some combination of configuration files, command line arguments, and environment variables. In {product-title}, these configuration artifacts are decoupled from image content to keep containerized applications portable.
+Many applications require configuration by using some combination of configuration files, command line arguments, and environment variables. In {product-title}, these configuration artifacts are decoupled from image content to keep containerized applications portable.
 
 The `ConfigMap` object provides mechanisms to inject containers with configuration data while keeping containers agnostic of {product-title}. A config map can be used to store fine-grained information like individual properties or coarse-grained information like entire configuration files or JSON blobs.
 
-The `ConfigMap` API object holds key-value pairs of configuration data that can be consumed in pods or used to store configuration data for system components such as controllers. For example:
+The `ConfigMap` object holds key-value pairs of configuration data that can be consumed in pods or used to store configuration data for system components such as controllers. For example:
 
 .`ConfigMap` Object Definition
 [source,yaml]
@@ -20,7 +20,7 @@ apiVersion: v1
 metadata:
   creationTimestamp: 2016-02-18T19:14:38Z
   name: example-config
-  namespace: default
+  namespace: my-namespace
 data: <1>
   example.property.1: hello
   example.property.2: world

--- a/modules/nodes-pods-configmaps-use-case-consuming-in-env-vars.adoc
+++ b/modules/nodes-pods-configmaps-use-case-consuming-in-env-vars.adoc
@@ -6,7 +6,7 @@
 [id="nodes-pods-configmaps-use-case-consuming-in-env-vars_{context}"]
 = Populating environment variables in containers by using config maps
 
-Config maps can be used to populate individual environment variables in containers or to populate environment variables in containers from all keys that form valid environment variable names.
+You can use config maps to populate individual environment variables in containers or to populate environment variables in containers from all keys that form valid environment variable names.
 
 As an example, consider the following config map:
 

--- a/modules/nodes-pods-configmaps-use-case-consuming-in-volumes.adoc
+++ b/modules/nodes-pods-configmaps-use-case-consuming-in-volumes.adoc
@@ -37,7 +37,7 @@ spec:
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
-      command: [ "/bin/sh", "cat", "/etc/config/special.how" ]
+      command: [ "/bin/sh", "-c", "cat", "/etc/config/special.how" ]
       volumeMounts:
       - name: config-volume
         mountPath: /etc/config
@@ -67,7 +67,7 @@ spec:
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
-      command: [ "/bin/sh", "cat", "/etc/config/path/to/special-key" ]
+      command: [ "/bin/sh", "-c", "cat", "/etc/config/path/to/special-key" ]
       volumeMounts:
       - name: config-volume
         mountPath: /etc/config

--- a/modules/nodes-pods-configmaps-use-case-setting-command-line-arguments.adoc
+++ b/modules/nodes-pods-configmaps-use-case-setting-command-line-arguments.adoc
@@ -7,7 +7,9 @@
 [id="nodes-pods-configmaps-use-case-setting-command-line-arguments_{context}"]
 = Setting command-line arguments for container commands with config maps
 
-A config map can also be used to set the value of the commands or arguments in a container. This is accomplished by using the Kubernetes substitution syntax `$(VAR_NAME)`. Consider the following config map:
+You can use a config map to set the value of the commands or arguments in a container by using the Kubernetes substitution syntax `$(VAR_NAME)`.
+
+As an example, consider the following config map:
 
 [source,yaml]
 ----
@@ -23,9 +25,9 @@ data:
 
 .Procedure
 
-* To inject values into a command in a container, you must consume the keys you want to use as environment variables, as in the consuming ConfigMaps in environment variables use case. Then you can refer to them in a container's command using the `$(VAR_NAME)` syntax.
+* To inject values into a command in a container, you must consume the keys you want to use as environment variables. Then you can refer to them in a container's command using the `$(VAR_NAME)` syntax.
 +
-.Sample `Pod` specification configured to inject specific environment variables
+.Sample pod specification configured to inject specific environment variables
 [source,yaml]
 ----
 apiVersion: v1

--- a/modules/nodes-pods-configuring-pod-critical.adoc
+++ b/modules/nodes-pods-configuring-pod-critical.adoc
@@ -20,6 +20,10 @@ To make a pod critical:
 +
 [source,yaml]
 ----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-pdb
 spec:
   template:
     metadata:

--- a/modules/nodes-pods-pod-disruption-about.adoc
+++ b/modules/nodes-pods-pod-disruption-about.adoc
@@ -47,9 +47,15 @@ $ oc get poddisruptionbudget --all-namespaces
 .Example output
 [source,terminal]
 ----
-NAMESPACE         NAME          MIN-AVAILABLE   SELECTOR
-another-project   another-pdb   4               bar=foo
-test-project      my-pdb        2               foo=bar
+NAMESPACE                              NAME                                    MIN AVAILABLE   MAX UNAVAILABLE   ALLOWED DISRUPTIONS   AGE
+openshift-apiserver                    openshift-apiserver-pdb                 N/A             1                 1                     121m
+openshift-cloud-controller-manager     aws-cloud-controller-manager            1               N/A               1                     125m
+openshift-cloud-credential-operator    pod-identity-webhook                    1               N/A               1                     117m
+openshift-cluster-csi-drivers          aws-ebs-csi-driver-controller-pdb       N/A             1                 1                     121m
+openshift-cluster-storage-operator     csi-snapshot-controller-pdb             N/A             1                 1                     122m
+openshift-cluster-storage-operator     csi-snapshot-webhook-pdb                N/A             1                 1                     122m
+openshift-console                      console                                 N/A             1                 1                     116m
+#...
 ----
 
 The `PodDisruptionBudget` is considered healthy when there are at least

--- a/modules/nodes-pods-pod-disruption-configuring.adoc
+++ b/modules/nodes-pods-pod-disruption-configuring.adoc
@@ -27,7 +27,7 @@ spec:
   minAvailable: 2  <2>
   selector:  <3>
     matchLabels:
-      foo: bar
+      name: my-pod
 ----
 <1> `PodDisruptionBudget` is part of the `policy/v1` API group.
 <2> The minimum number of pods that must be available simultaneously. This can
@@ -47,7 +47,7 @@ spec:
   maxUnavailable: 25% <2>
   selector: <3>
     matchLabels:
-      foo: bar
+      name: my-pod
 ----
 <1> `PodDisruptionBudget` is part of the `policy/v1` API group.
 <2> The maximum number of pods that can be unavailable simultaneously. This can

--- a/modules/nodes-pods-secrets-certificates-creating.adoc
+++ b/modules/nodes-pods-secrets-certificates-creating.adoc
@@ -100,10 +100,10 @@ spec:
   - name: mypod
     image: redis
     volumeMounts:
-    - name: foo
-      mountPath: "/etc/foo"
+    - name: my-container
+      mountPath: "/etc/my-path"
   volumes:
-  - name: foo
+  - name: my-volume
     secret:
       secretName: my-cert
       items:

--- a/modules/nodes-pods-secrets-creating.adoc
+++ b/modules/nodes-pods-secrets-creating.adoc
@@ -120,6 +120,10 @@ spec:
           secretKeyRef: <1>
             name: test-secret
             key: username
+      from:
+        kind: ImageStreamTag
+        namespace: openshift
+        name: 'cli:latest'
 ----
 <1> Specifies the environment variable that consumes the secret key.
 

--- a/modules/nodes-pods-viewing-project.adoc
+++ b/modules/nodes-pods-viewing-project.adoc
@@ -30,7 +30,7 @@ For example:
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-console
+$ oc get pods
 ----
 +
 .Example output

--- a/modules/nodes-pods-viewing-usage.adoc
+++ b/modules/nodes-pods-viewing-usage.adoc
@@ -52,3 +52,10 @@ $ oc adm top pod --selector=''
 ----
 +
 You must choose the selector (label query) to filter on. Supports `=`, `==`, and `!=`.
++
+For example:
++
+[source,terminal]
+----
+$ oc adm top pod --selector='name=my-pod'
+----

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -11,7 +11,7 @@ You can use node selectors on pods and labels on nodes to control where the pod 
 You add labels to a node, a compute machine set, or a machine config. Adding the label to the compute machine set ensures that if the node or machine goes down, new nodes have the label. Labels added to a node or machine config do not persist if the node or machine goes down.
 
 To add node selectors to an existing pod, add a node selector to the controlling object for that pod, such as a `ReplicaSet` object, `DaemonSet` object, `StatefulSet` object, `Deployment` object, or `DeploymentConfig` object.
-Any existing pods under that controlling object are recreated on a node with a matching label. If you are creating a new pod, you can add the node selector directly to the `Pod` spec.
+Any existing pods under that controlling object are recreated on a node with a matching label. If you are creating a new pod, you can add the node selector directly to the pod spec. If the pod does not have a controlling object, you must delete the pod, edit the pod spec, and recreate the pod.
 
 [NOTE]
 ====
@@ -24,27 +24,22 @@ To add a node selector to existing pods, determine the controlling object for th
 For example, the `router-default-66d5cf9464-m2g75` pod is controlled by the `router-default-66d5cf9464`
 replica set:
 
-[source,terminal]
 ----
 $ oc describe pod router-default-66d5cf9464-7pwkc
-----
 
-.Example output
-[source,yaml]
-----
 Name:               router-default-66d5cf9464-7pwkc
 Namespace:          openshift-ingress
 
-....
+# ...
 
 Controlled By:      ReplicaSet/router-default-66d5cf9464
+# ...
 ----
 
 The web console lists the controlling object under `ownerReferences` in the pod YAML:
 
-.Example output
-[source,yaml]
 ----
+# ...
   ownerReferences:
     - apiVersion: apps/v1
       kind: ReplicaSet
@@ -52,6 +47,7 @@ The web console lists the controlling object under `ownerReferences` in the pod 
       uid: d81dd094-da26-11e9-a48a-128e7edf0312
       controller: true
       blockOwnerDeletion: true
+# ...
 ----
 
 .Procedure
@@ -62,14 +58,12 @@ The web console lists the controlling object under `ownerReferences` in the pod 
 
 .. Run the following command to add labels to a `MachineSet` object:
 +
-[source,terminal]
 ----
 $ oc patch MachineSet <name> --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"<key>"="<value>","<key>"="<value>"}}]'  -n openshift-machine-api
 ----
 +
 For example:
 +
-[source,terminal]
 ----
 $ oc patch MachineSet abc612-msrtw-worker-us-east-1c  --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"type":"user-node","region":"east"}}]'  -n openshift-machine-api
 ----
@@ -99,30 +93,30 @@ spec:
 +
 For example:
 +
-[source,terminal]
 ----
 $ oc edit MachineSet abc612-msrtw-worker-us-east-1c -n openshift-machine-api
 ----
 +
 .Example `MachineSet` object
 [source,yaml]
++
 ----
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 
-....
+# ...
 
 spec:
-...
+# ...
   template:
     metadata:
-...
+# ...
     spec:
       metadata:
         labels:
           region: east
           type: user-node
-....
+# ...
 ----
 
 * Add labels directly to a node:
@@ -180,11 +174,11 @@ ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.26.0
 ----
 kind: ReplicaSet
 
-....
+# ...
 
 spec:
 
-....
+# ...
 
   template:
     metadata:
@@ -208,7 +202,7 @@ spec:
 apiVersion: v1
 kind: Pod
 
-....
+# ...
 
 spec:
   nodeSelector:

--- a/modules/pod-disruption-eviction-policy.adoc
+++ b/modules/pod-disruption-eviction-policy.adoc
@@ -41,7 +41,7 @@ spec:
   minAvailable: 2
   selector:
     matchLabels:
-      foo: bar
+      name: my-pod
   unhealthyPodEvictionPolicy: AlwaysAllow <1>
 ----
 <1> Choose either `IfHealthyBudget` or `AlwaysAllow` as the unhealthy pod eviction policy. The default is `IfHealthyBudget` when the `unhealthyPodEvictionPolicy` field is empty.


### PR DESCRIPTION
Fixing various errors in the Nodes docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

Previews
[Understanding config maps](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmap-overview_configmaps) -- Various small edits
[Populating environment variables in containers by using config maps](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmaps-use-case-consuming-in-env-vars_configmaps) -- Correct a passive sentence
[Injecting content into a volume by using config maps](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmaps-use-case-consuming-in-volumes_configmaps) -- Added a required `"-c"` to the command
[Setting command-line arguments for container commands with config maps](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmaps-use-case-setting-command-line-arguments_configmaps) -- Correct a passive sentence and change a sentence for consistency [with a similar sentence](https://docs.openshift.com/container-platform/4.13/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmaps-use-case-consuming-in-env-vars_configmaps)  and other edits
[Preventing pod removal using critical pods](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-critical_nodes-pods-configuring) -- added docs-required lines to object example
[Understanding how to use pod disruption budgets](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring) -- Updated the example list of PDBs
[Specifying the number of pods that must be up with pod disruption budgets](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-pod-disruption-configuring_nodes-pods-configuring) -- Replaced foo-bar references
[Generating signed certificates for use with secrets](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-certificates-creating_nodes-pods-secrets) -- Replaced foo-bar references 
[Understanding how to create secrets](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-creating_nodes-pods-secrets) -- Added required `from` stanza
[Viewing pods in a project](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-viewing.html#nodes-pods-viewing-project_nodes-pods-viewing) -- Removed unneeded `-n -n openshift-console` (procedure puts us in a project)
[Viewing pod usage statistics](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-viewing.html#nodes-pods-viewing-usage_nodes-pods-viewing) -- Added a real example for clarity
[Using node selectors to control pod placement](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-node-selectors.html#nodes-scheduler-node-selectors-pod_nodes-pods-node-selectors) -- s/`Pod` spec/pod spec. Added sentence for clarity and updated examples with `# ...` for clipped code blocks. 
[Specifying the eviction policy for unhealthy pods](https://62205--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#pod-disruption-eviction-policy_nodes-pods-configuring)-- Replaced foo-bar references

No QE needed