### PR TITLE
OSSM-4355: [DOC] Fix the typo "global.ouathproxy"

### DIFF
--- a/modules/ossm-migrating-to-20.adoc
+++ b/modules/ossm-migrating-to-20.adoc
@@ -463,7 +463,7 @@ Resources are configured under `spec.runtime.<component>`. The following compone
 |istio-telemetry container
 |v2.0
 
-|`global.ouathproxy`
+|`global.oauthproxy`
 |oauth-proxy container used with various addons
 |v1.0/1.1/2.0
 


### PR DESCRIPTION
[OSSM-4355](https://issues.redhat.com//browse/OSSM-4355): [DOC] Fix the typo "global.ouathproxy"

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSSM-4355

Link to docs preview:
https://62209--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/upgrading-ossm.html#resource-utilization-and-scheduling

QE review:
QE not required.
Fixing a typo.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
