### PR TITLE
[RHACS] Fixes broken link in 4.1 release notes

### DIFF
--- a/release_notes/41-release-notes.adoc
+++ b/release_notes/41-release-notes.adoc
@@ -422,7 +422,7 @@ This can lead to inaccuracies or inconsistencies in the reported GID. This issue
 
 * Currently, the Syslog common event format (CEF) sends the name and severity fields in an incorrect order. There is currently no workaround for this issue.
 
-* Currently, an issue exists with {ocp} and Operator upgrades. See xref:../41-release-notes.adoc#kernel-module-collection-method_release-notes-41[Kernel module collection method] for important information and steps you must take before upgrading.
+* Currently, an issue exists with {ocp} and Operator upgrades. See xref:../release_notes/41-release-notes.adoc#kernel-module-collection-method_release-notes-41[Kernel module collection method] for important information and steps you must take before upgrading.
 
 [id="image-versions_{context}"]
 == Image versions


### PR DESCRIPTION
Minor bug fixes broken link in 4.1 release notes.

Cherry-pick in `rhacs-docs-4.1`

Preview: https://62210--docspreview.netlify.app/openshift-acs/latest/release_notes/41-release-notes.html#known-issues_release-notes-41