### PR TITLE
OCPBUGS-9347RE: Removed block statement for 3rd party vSphere CSI Driver

### DIFF
--- a/modules/persistent-storage-csi-vsphere-install-issues.adoc
+++ b/modules/persistent-storage-csi-vsphere-install-issues.adoc
@@ -2,23 +2,37 @@
 //
 // persistent-storage-csi-vsphere.adoc
 //
-
+:_content-type: PROCEDURE
 [id="persistent-storage-csi-vsphere-install-issues_{context}"]
 = Removing a third-party vSphere CSI Operator Driver
 
-{product-title} 4.10 includes a built-in version of the vSphere Container Storage Interface (CSI) Operator Driver that is supported by Red Hat. If you have installed a vSphere CSI driver provided by the community or another vendor, upgrades will be prevented in a future release of {product-title}.
+{product-title} {product-version} includes a built-in version of the vSphere Container Storage Interface (CSI) Operator Driver that is supported by Red Hat.
 
-If you remove the third-party vSphere CSI driver, you do not need to delete associated persistent volume (PV) objects, and no data loss should occur.
+If you have installed a vSphere CSI driver provided by the community or another vendor, which is considered a third-party vSphere CSI driver, and you continue with upgrading to the next major version of {product-title}, the `oc` CLI prompts you with the following message:
 
-[NOTE]
+[source,terminal]
+----
+VSphereCSIDriverOperatorCRUpgradeable: VMwareVSphereControllerUpgradeable:
+found existing unsupported csi.vsphere.vmware.com driver
+----
+
+The previous message informs you that Red Hat does not support the third-party vSphere CSI driver during an {product-title} upgrade operation. You can choose to ignore this message and continue with the upgrade operation.
+
+The instructions outlined in the procedure show how to uninstall a third-party vSphere CSI Driver. Consult the vendor's or community provider's uninstall guide for more detailed instructions on removing the driver and its components.
+
+[IMPORTANT]
 ====
-These instructions may not be complete, so consult the vendor or community provider uninstall guide to ensure removal of the driver and components.
+When removing a third-party vSphere CSI driver, you do not need to delete the associated persistent volume (PV) objects. Data loss typically does not occur, but Red Hat does not take any responsibility if data loss does occur.
 ====
 
-To uninstall the third-party vSphere CSI Driver:
+After you have removed the third-party vSphere CSI Driver from the {product-title} cluster, installation of Red Hat's vSphere CSI Operator Driver automatically resumes. If you had existing vSphere CSI PV objects, their lifecycle is now managed by Red Hat's vSphere CSI Operator Driver.
+
+.Procedure
 
 . Delete the third-party vSphere CSI Driver (VMware vSphere Container Storage Plugin) Deployment and Daemonset objects.
+
 . Delete the configmap and secret objects that were installed previously with the third-party vSphere CSI Driver.
+
 . Delete the third-party vSphere CSI driver `CSIDriver` object:
 +
 [source,terminal]

--- a/modules/vmware-csi-driver-reqs.adoc
+++ b/modules/vmware-csi-driver-reqs.adoc
@@ -28,9 +28,13 @@ To install the vSphere CSI Driver Operator, the following requirements must be m
 * Virtual machines of hardware version 15 or later
 * No third-party vSphere CSI driver already installed in the cluster
 
-If a third-party vSphere CSI driver is present in the cluster, {product-title} does not overwrite it. The presence of a third-party vSphere CSI driver prevents {product-title} from updating to {product-title} 4.13 or later.
-
-[NOTE]
+[IMPORTANT]
 ====
-The VMware vSphere CSI Driver Operator is supported only on clusters deployed with `platform: vsphere` in the installation manifest.
+If a third-party vSphere CSI driver is present in the cluster, {product-title} does not overwrite it. If you continue with the third-party vSphere CSI driver when upgrading to the next major version of {product-title}, the `oc` CLI prompts you with the following message: 
+[source,terminal]
+----
+VSphereCSIDriverOperatorCRUpgradeable: VMwareVSphereControllerUpgradeable:
+found existing unsupported csi.vsphere.vmware.com driver
+----
+The previous message informs you that Red Hat does not support the third-party vSphere CSI driver during an {product-title} upgrade operation. You can choose to ignore this message and continue with the upgrade operation.
 ====


### PR DESCRIPTION
[OCPBUGS-9347](https://issues.redhat.com/browse/OCPBUGS-9347)

Version(s):
4.11 and 4.10

Link to docs preview:
* [VMware vSphere CSI Driver Operator requirements](https://dfitzmau.github.io/previews/installing-vsphere-installer-provisioned-customizations.html#vsphere-csi-driver-reqs_installing-vsphere-installer-provisioned-customizations)
* [Removing a third-party vSphere CSI Operator Driver](https://dfitzmau.github.io/previews/persistent-storage-csi-vsphere.html#persistent-storage-csi-vsphere-install-issues_persistent-storage-csi-vsphere)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Slack](https://redhat-internal.slack.com/archives/CBQHQFU0N/p1686324089585079) - contact Hemant
