### PR TITLE
OSDOCS-6772: fix broken links welcome page 4-14

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -50,12 +50,17 @@ For documentation that is not specific to {product-title}, see the link:https://
 endif::[]
 
 ifdef::microshift[]
-Start with xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}] and xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing].
-Next, view the xref:../microshift_release_notes/microshift-4-14-release-notes.adoc#microshift-4-14-release-notes[release notes].
+To get started with {product-title}, use the following links:
 
-* For information about Red Hat Device Edge, read the link:https://access.redhat.com/documentation/en-us/red_hat_device_edge/4/html/overview/device-edge-overview[Red Hat Device Edge overview].
-* For information about Red Hat Enterprise Linux for Edge, read the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[RHEL for Edge documentation].
-* For container platform documentation that is not specific to {product-title}, read the link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14/html/getting_started/con-microshift-understanding[Understanding {product-title}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14/html/installing/index[Installing {product-title}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14/html/release_notes/microshift-4-14-release-notes[{product-title} release notes]
+
+For related information, see the following links:
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_device_edge/4/html/overview/device-edge-overview[Red Hat Device Edge overview]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[RHEL for Edge documentation]
+* link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation]
 endif::[]
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-15836

Link to docs preview:
https://62231--docspreview.netlify.app/microshift/latest/welcome/index.html
Note these will still 404 because the 4.14 docs are not live.

QE review:
- N/A docs plumbing

Additional information:
MicroShift has a different topic map, so xrefs do not work. Each version is being converted to links.

Replacing Welcome page to minimize link updates:https://github.com/openshift/openshift-docs/pull/62235

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
