### PR TITLE
OSDOCS-6772-413: fix broken links welcome page 4.13

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -50,15 +50,19 @@ For documentation that is not specific to {product-title}, see the link:https://
 endif::[]
 
 ifdef::microshift[]
-To navigate the {product-title} documentation, use the navigation bars and links.
+To get started with {product-title}, use the following links:
 
-Start with xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}] and xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing].
-Next, view the xref:../microshift_release_notes/microshift-4-13-release-notes.adoc#microshift-4-13-release-notes[release notes].
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.13/html/getting_started/con-microshift-understanding[Understanding {product-title}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.13/html/installing/index[Installing {product-title}]
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.13/html/release_notes/microshift-4-13-release-notes[{product-title} release notes]
 
-* For information about Red Hat Device Edge, read the link:https://access.redhat.com/documentation/en-us/red_hat_device_edge/4/html/overview/device-edge-overview[Red Hat Device Edge overview].
-* For information about Red Hat Enterprise Linux for Edge, read link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_installing_and_managing_rhel_for_edge_images/index[RHEL for Edge documentation].
-* For container platform documentation that is not specific to {product-title}, read link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation].
+For related information, see the following links:
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_device_edge/4/html/overview/device-edge-overview[Red Hat Device Edge overview]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[RHEL for Edge documentation]
+* link:https://docs.openshift.com/container-platform/latest/welcome/index.html[OpenShift Container Platform documentation]
 endif::[]
+
 
 ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 Start with xref:../architecture/architecture.adoc#architecture-overview-architecture[Architecture] and


### PR DESCRIPTION
Version(s):
4.13 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-15836

Link to docs preview:
https://62233--docspreview.netlify.app/microshift/latest/welcome/index.html

QE review:
- N/A docs plumbing

Additional information:
MicroShift has a different topic map, so xrefs do not work. Each version is being converted to links.

Replacing Welcome page to minimize link updates:https://github.com/openshift/openshift-docs/pull/62235

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
