### PR TITLE
OSDOCS#6319: ARM support for GCP

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -25,7 +25,8 @@ endif::openshift-origin[]
 * Microsoft Azure on 64-bit x86 instances
 * Microsoft Azure on 64-bit ARM instances
 * Microsoft Azure Stack Hub
-* Google Cloud Platform (GCP)
+* Google Cloud Platform (GCP) on 64-bit x86 instances 
+* Google Cloud Platform (GCP) on 64-bit ARM instances 
 * {rh-openstack-first}
 * IBM Cloud VPC
 * {ibmzProductName} or {linuxoneProductName}
@@ -132,7 +133,7 @@ Not all installation options are supported for all platforms, as shown in the fo
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS (x86_64) |AWS (arm64) |Azure (x86_64) |Azure (arm64)|Azure Stack Hub |GCP |Nutanix |{rh-openstack} |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |{ibmzProductName} |{ibmpowerProductName} |{ibmpowerProductName} Virtual Server
+||Alibaba |AWS (64-bit x86) |AWS (64-bit ARM) |Azure (64-bit x86) |Azure (64-bit ARM)|Azure Stack Hub |GCP (64-bit x86) |GCP (64-bit ARM) |Nutanix |{rh-openstack} |Bare metal (64-bit x86) |Bare metal (64-bit ARM) |vSphere |IBM Cloud VPC |{ibmzProductName} |{ibmpowerProductName} |{ibmpowerProductName} Virtual Server
 
 |Default
 |xref:../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[&#10003;]
@@ -141,6 +142,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[&#10003;]
 |xref:../installing/installing_azure/installing-azure-default.adoc#installing-azure-default[&#10003;]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[&#10003;]
 |xref:../installing/installing_gcp/installing-gcp-default.adoc#installing-gcp-default[&#10003;]
 |xref:../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installing-nutanix-installer-provisioned[&#10003;]
 |
@@ -159,6 +161,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[&#10003;]
 |xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-customizations[&#10003;]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-default.adoc#installing-azure-stack-hub-default[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[&#10003;]
 |xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-customizations[&#10003;]
 |xref:../installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc#installing-nutanix-installer-provisioned[&#10003;]
 |xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#installing-openstack-installer-custom[&#10003;]
@@ -179,6 +182,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_azure/installing-azure-network-customizations.adoc#installing-azure-network-customizations[&#10003;]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc#installing-azure-stack-hub-network-customizations[&#10003;]
 |xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-network-customizations[&#10003;]
 |
 |xref:../installing/installing_openstack/installing-openstack-installer-kuryr.adoc#installing-openstack-installer-kuryr[&#10003;]
 |
@@ -196,6 +200,7 @@ ifndef::openshift-origin[]
 |
 |
 |
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[&#10003;]
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[&#10003;]
 |xref:../installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc#installing-restricted-networks-nutanix-installer-provisioned[&#10003;]
 |xref:../installing/installing_openstack/installing-openstack-installer-restricted.adoc#installing-openstack-installer-restricted[&#10003;]
@@ -215,7 +220,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_azure/installing-azure-private.adoc#installing-azure-private[&#10003;]
 |
 |xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[&#10003;]
-|
+|xref:../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-private[&#10003;]
 |
 |
 |
@@ -234,7 +239,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_azure/installing-azure-vnet.adoc#installing-azure-vnet[&#10003;]
 |
 |xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[&#10003;]
-|
+|xref:../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-vpc[&#10003;]
 |
 |
 |
@@ -447,7 +452,7 @@ endif::openshift-origin[]
 //This table is for all flavors of OpenShift, except OKD. A separate table is required because OKD does not support multiple AWS architecture types. Trying to maintain one table using conditions, while convenient, is very fragile and prone to publishing errors.
 ifndef::openshift-origin[]
 |===
-||Alibaba |AWS (x86_64) |AWS (arm64) |Azure (x86_64) |Azure (arm64) |Azure Stack Hub |GCP |Nutanix |{rh-openstack} |Bare metal (x86_64) |Bare metal (arm64) |vSphere |VMC |IBM Cloud VPC |{ibmzProductName} |{ibmzProductName} with {op-system-base} KVM |{ibmpowerProductName} |Platform agnostic
+||Alibaba |AWS (64-bit x86) |AWS (64-bit ARM) |Azure (64-bit x86) |Azure (64-bit ARM) |Azure Stack Hub |GCP (64-bit x86) |GCP (64-bit ARM) |Nutanix |{rh-openstack} |Bare metal (64-bit x86) |Bare metal (64-bit ARM) |vSphere |IBM Cloud VPC |{ibmzProductName} |{ibmzProductName} with {op-system-base} KVM |{ibmpowerProductName} |Platform agnostic
 
 
 |Custom
@@ -457,6 +462,7 @@ ifndef::openshift-origin[]
 |xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[&#10003;]
 |xref:../installing/installing_azure/installing-azure-user-infra.adoc#installing-azure-user-infra[&#10003;]
 |xref:../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installing-azure-stack-hub-user-infra[&#10003;]
+|xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[&#10003;]
 |xref:../installing/installing_gcp/installing-gcp-user-infra.adoc#installing-gcp-user-infra[&#10003;]
 |
 |xref:../installing/installing_openstack/installing-openstack-user.adoc#installing-openstack-user[&#10003;]
@@ -471,6 +477,7 @@ ifndef::openshift-origin[]
 
 
 |Network customization
+|
 |
 |
 |
@@ -497,6 +504,7 @@ ifndef::openshift-origin[]
 |
 |
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[&#10003;]
+|xref:../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installing-restricted-networks-gcp[&#10003;]
 |
 |
 |xref:../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installing-restricted-networks-bare-metal[&#10003;]
@@ -515,6 +523,7 @@ ifndef::openshift-origin[]
 |
 |
 |
+|xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[&#10003;]
 |xref:../installing/installing_gcp/installing-gcp-user-infra-vpc.adoc#installing-gcp-user-infra-vpc[&#10003;]
 |
 |

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -50,6 +50,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types-arm.adoc[leveloffset=+2]
+
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -56,6 +56,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types-arm.adoc[leveloffset=+2]
+
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -53,6 +53,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types-arm.adoc[leveloffset=+2]
+
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -49,6 +49,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types-arm.adoc[leveloffset=+2]
+
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -61,6 +61,8 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-gcp-tested-machine-types-arm.adoc[leveloffset=+2]
+
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-gcp-enabling-shielded-vms.adoc[leveloffset=+2]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -513,17 +513,17 @@ Optional installation configuration parameters are described in the following ta
 
 ifndef::openshift-origin[]
 
-ifndef::aws,bare,ibm-power,ibm-z,azure,ibm-power-vs[]
+ifndef::aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 |`compute.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
 |String
-endif::aws,bare,ibm-power,ibm-z,azure,ibm-power-vs[]
+endif::aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 
-ifdef::aws,bare,azure[]
+ifdef::aws,bare,azure,gcp[]
 |`compute.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
 |String
-endif::aws,bare,azure[]
+endif::aws,bare,azure,gcp[]
 
 ifdef::ibm-z[]
 |`compute.architecture`
@@ -577,17 +577,17 @@ accounts for the dramatically decreased machine performance.
 |Array of `MachinePool` objects.
 
 ifndef::openshift-origin[]
-ifndef::aws,bare,ibm-z,ibm-power,azure,ibm-power-vs[]
+ifndef::aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 |`controlPlane.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
 |String
-endif::aws,bare,ibm-z,ibm-power,azure,ibm-power-vs[]
+endif::aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 
-ifdef::aws,bare,azure[]
+ifdef::aws,bare,azure,gcp[]
 |`controlPlane.architecture`
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
 |String
-endif::aws,bare,azure[]
+endif::aws,bare,azure,gcp[]
 
 ifdef::ibm-z[]
 |`controlPlane.architecture`
@@ -1282,6 +1282,10 @@ The `licenses` parameter is a deprecated field and nested virtualization is enab
 |The availability zones where the installation program creates machines.
 |A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+[IMPORTANT]
+====
+When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use a zone where Ampere Altra Arm CPU's are available. You can find which zones are compatible with 64-bit ARM processors in the "GCP availability zones" link.
+====
 
 |`platform.gcp.defaultMachinePlatform.osDisk.diskSizeGB`
 |The size of the disk in gigabytes (GB).
@@ -1379,6 +1383,10 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |The availability zones where the installation program creates control plane machines.
 |A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+[IMPORTANT]
+====
+When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use a zone where Ampere Altra Arm CPU's are available. You can find which zones are compatible with 64-bit ARM processors in the "GCP availability zones" link.
+====
 
 |`controlPlane.platform.gcp.secureBoot`
 |Whether to enable Shielded VM secure boot for control plane machines. Shielded VMs have additional security protocols such as secure boot, firmware and integrity monitoring, and rootkit protection. For more information on Shielded VMs, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
@@ -1432,6 +1440,10 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |The availability zones where the installation program creates compute machines.
 |A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
+[IMPORTANT]
+====
+When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use a zone where Ampere Altra Arm CPU's are available. You can find which zones are compatible with 64-bit ARM processors in the "GCP availability zones" link.
+====
 
 |`compute.platform.gcp.secureBoot`
 |Whether to enable Shielded VM secure boot for compute machines. Shielded VMs have additional security protocols such as secure boot, firmware and integrity monitoring, and rootkit protection. For more information on Shielded VMs, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].

--- a/modules/installation-gcp-enabling-shielded-vms.adoc
+++ b/modules/installation-gcp-enabling-shielded-vms.adoc
@@ -14,6 +14,11 @@
 = Enabling Shielded VMs
 You can use Shielded VMs when installing your cluster. Shielded VMs have extra security features including secure boot, firmware and integrity monitoring, and rootkit detection. For more information, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
 
+[NOTE]
+====
+Shielded VMs are currently not supported on clusters with 64-bit ARM infrastructures. 
+====
+
 .Prerequisites
 * You have created an `install-config.yaml` file.
 

--- a/modules/installation-gcp-tested-machine-types-arm.adoc
+++ b/modules/installation-gcp-tested-machine-types-arm.adoc
@@ -1,0 +1,21 @@
+// module included in the following assemblies 
+//
+// installing/installing_gcp/installing-gcp-customizations.adoc
+// installing/installing_gcp/installing-gcp-network-customizations.adoc
+// installing/installing_gcp/installing-gcp-private.adoc
+// installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+// installing/installing_gcp/installing-gcp-user-infra.adoc
+// installing/installing_gcp/installing-gcp-vpc.adoc
+// installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+// installing/installing_gcp/installing-restricted-networks-gcp.adoc
+
+[id="installation-gcp-tested-machine-types-arm_{context}"]
+= Tested instance types for GCP on 64-bit ARM infrastructures 
+
+The following Google Cloud Platform (GCP) 64-bit ARM instance types have been tested with {product-title}.
+
+.Machine series for 64-bit ARM machines 
+[%collapsible]
+====
+include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/gcp/tested_instance_types_arm.md[]
+====


### PR DESCRIPTION
**For Version:** 4.14+
**Issue:** [OSDOCS-6319](https://issues.redhat.com//browse/OSDOCS-6319)

**Previews:**  

[Selecting a cluster installation method and preparing it for users -> Supported installation methods for different platforms ](https://62253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-preparing.html)

Installing 
- [Installing a cluster on GCP with customizations -> Tested instance types for GCP on 64-bit ARM infrastructures](https://62253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations.html)
- [Installing a cluster on GCP with Network customizations -> Tested instance types for GCP on 64-bit ARM infrastructures](https://62253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations.html#installation-gcp-tested-machine-types-arm_installing-gcp-network-customizations)
- [Installing a cluster on GCP with Network customizations -> Enabling Shielded VMs](https://62253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations#installation-gcp-enabling-shielded-vms_installing-gcp-network-customizations)
- [Installing a cluster on GCP in a restricted network -> Tested instance types for GCP on 64-bit ARM infrastructures ](https://62253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#installation-gcp-tested-machine-types-arm_installing-restricted-networks-gcp-installer-provisioned)
- [Installing a cluster on GCP into an existing VPC -> Tested instance types for GCP on 64-bit ARM infrastructures ](https://62253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-vpc.html#installation-gcp-tested-machine-types-arm_installing-gcp-vpc)
- [Installing a private cluster on GCP -> Tested instance types for GCP in 64-bit ARM infrastructures ](https://62253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-private.html#installation-gcp-tested-machine-types-arm_installing-gcp-private)

[Installing on GCP -> Installation configuration parameters for GCP](https://62253--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-optional_installation-config-parameters-gcp)
Updates made in these parameter sections in _Optional Parameters_

-  _Optional Parameters_
            - `compute.architecture`
            - `controlPlane.architecture`
-  _Additional Google Cloud Platform (GCP) configuration parameters_
            - `platform.gcp.defaultMachinePlatform.zones`
            - `controlPlane.platform.gcp.zones`
            - `compute.platform.gcp.zones`


 
**QE review:** 
- [x] QE approval
