### PR TITLE
TELCODOCS-1359: Fix documentation for workflow to expand cluster on AWS with bare metal nodes

### DIFF
--- a/installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
+++ b/installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
@@ -21,4 +21,10 @@ include::modules/installation-aws_con_connecting-the-vpc-to-the-on-premise-netwo
 
 include::modules/installation-aws_proc_creating-firewall-rules-for-port-6183.adoc[leveloffset=+1]
 
-After you have the networking configured, you can proceed with xref:../installing_bare_metal_ipi/ipi-install-expanding-the-cluster.adoc#ipi-install-expanding-the-cluster[expanding the cluster].
+After you have the networking configured, you can proceed with expanding the cluster.
+
+include::modules/configuring-a-provisioning-resource-to-scale-the-cluster.adoc[leveloffset=+1]
+include::modules/adding-new-hosts-in-the-cluster-with-the-bmo.adoc[leveloffset=+1]
+
+
+

--- a/modules/adding-new-hosts-in-the-cluster-with-the-bmo.adoc
+++ b/modules/adding-new-hosts-in-the-cluster-with-the-bmo.adoc
@@ -1,0 +1,135 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
+:_content-type: PROCEDURE
+[id="adding-new-hosts-in-the-cluster-with-the-bmo_{context}"]
+= Provisioning new hosts in the cluster by using the BMO
+
+You can use the Bare Metal Operator (BMO) to provision bare-metal hosts in the cluster by creating a `BareMetalHost` custom resource (CR).
+
+[NOTE]
+====
+To provision bare-metal hosts to the cluster by using the BMO, you must set the `spec.externallyProvisioned` specification in the `BareMetalHost` custom resource to `false`.
+====
+
+.Prerequisites
+
+* You have baseboard management controller (BMC) access to the hosts.
+* You deployed a provisioning service in the cluster by creating a `Provisioning` CR.
+
+.Procedure
+
+. Create the `Secret` CR and the `BareMetalHost` CR.
+
+.. Save the following YAML in the `bmh.yaml` file:
++
+[source,yaml]
+----
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: worker1-bmc
+  namespace: openshift-machine-api
+type: Opaque
+data:
+  username: <base64_of_uid>
+  password: <base64_of_pwd>
+---
+apiVersion: metal3.io/v1alpha1
+kind: BareMetalHost
+metadata:
+  name: worker1
+  namespace: openshift-machine-api
+spec:
+  bmc:
+    address: <protocol>://<bmc_url> <1>
+    credentialsName: "worker1-bmc"
+  bootMACAddress: <nic1_mac_address>
+  externallyProvisioned: false <2>
+  customDeploy:
+    method: install_coreos
+  online: true 
+  userData:
+    name: worker-user-data-managed
+    namespace: openshift-machine-api
+----
+<1> You can only use bare-metal host drivers that support virtual media networking booting, for example `redfish-virtualmedia` and `idrac-virtualmedia`.
+<2> You must set the `spec.externallyProvisioned` specification in the `BareMetalHost` custom resource to `false`. The default value is `false`.
+
+. Create the bare-metal host object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f bmh.yaml
+----
++
+.Example output
+[source,terminal]
+----
+secret/worker1-bmc created                    
+baremetalhost.metal3.io/worker1 created
+----
+
+. Approve all certificate signing requests (CSRs).
+
+.. Verify that the provisioning state of the host is `provisioned` by running the following command:
++
+[source,terminal]
+----
+$ oc get bmh -A
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE               NAME          STATE                    CONSUMER   ONLINE   ERROR   AGE                      
+openshift-machine-api   controller1   externally provisioned              true             5m25s                    
+openshift-machine-api   worker1       provisioned                         true             4m45s                    
+----
+
+.. Get the list of pending CSRs by running the following command:
++
+[source,terminal]
+----
+$ oc get csr
+----
++
+.Example output
+[source,terminal]
+----
+NAME        AGE   SIGNERNAME                                    REQUESTOR                                         REQUESTEDDURATION CONDITION                                                       
+csr-gfm9f   33s   kubernetes.io/kube-apiserver-client-kubelet   system:serviceaccount:openshift-machine-config-o
+perator:node-bootstrapper   <none>              Pending                                                         
+----
+
+.. Approve the CSR by running the following command:
++
+[source,terminal]
+----
+$ oc adm certificate approve <csr_name>
+----
++
+.Example output
+[source,terminal]
+----
+certificatesigningrequest.certificates.k8s.io/<csr_name> approved
+----
+
+.Verification
+
+* Verify that the node is ready by running the following command:
++
+[source,terminal]
+----
+$ oc get nodes
+----
++
+.Example output
+[source,terminal]
+----
+NAME        STATUS   ROLES           AGE     VERSION                                                              
+app1        Ready    worker          47s     v1.24.0+dc5a2fd                                                      
+controller1 Ready    master,worker   2d22h   v1.24.0+dc5a2fd                                                      
+----
+

--- a/modules/configuring-a-provisioning-resource-to-scale-the-cluster.adoc
+++ b/modules/configuring-a-provisioning-resource-to-scale-the-cluster.adoc
@@ -1,0 +1,70 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.adoc
+:_content-type: PROCEDURE
+
+[id="configuring-a-provisioning-resource-to-scale-the-cluster_{context}"]
+= Configuring a provisioning resource to scale the cluster
+
+Create a `Provisioning` custom resource (CR) to enable Metal platform components on the cluster. 
+
+.Procedure
+
+. Create a `Provisioning` CR.
+
+.. Save the following YAML in the `provisioning.yaml` file:
++
+[source,yaml]
+----
+apiVersion: metal3.io/v1alpha1
+kind: Provisioning
+metadata:
+  name: provisioning-configuration
+spec:
+  provisioningNetwork: "Disabled"
+  watchAllNamespaces: true
+----
++
+[NOTE]
+====
+{product-title} {product-version} does not support enabling a provisioning network when you scale a cluster by using the Bare Metal Operator.
+====
+
+. Create the `Provisioning` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f provisioning.yaml
+----
++
+.Example output
+[source,terminal]
+----
+provisioning.metal3.io/provisioning-configuration created
+----
+
+.Verification
+
+* Verify that the provisioning service is running by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -n openshift-machine-api
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                  READY   STATUS    RESTARTS        AGE
+cluster-autoscaler-operator-678c476f4c-jjdn5          2/2     Running   0               5d21h
+cluster-baremetal-operator-6866f7b976-gmvgh           2/2     Running   0               5d21h
+control-plane-machine-set-operator-7d8566696c-bh4jz   1/1     Running   0               5d21h
+ironic-proxy-64bdw                                    1/1     Running   0               5d21h
+ironic-proxy-rbggf                                    1/1     Running   0               5d21h
+ironic-proxy-vj54c                                    1/1     Running   0               5d21h
+machine-api-controllers-544d6849d5-tgj9l              7/7     Running   1 (5d21h ago)   5d21h
+machine-api-operator-5c4ff4b86d-6fjmq                 2/2     Running   0               5d21h
+metal3-6d98f84cc8-zn2mx                               5/5     Running   0               5d21h
+metal3-image-customization-59d745768d-bhrp7           1/1     Running   0               5d21h
+----
+


### PR DESCRIPTION
Added modified UPI modules for expanding a cloud-based cluster.

Fixes: [TELCODOCS-1359](https://issues.redhat.com//browse/TELCODOCS-1359)

See https://issues.redhat.com/browse/TELCODOCS-1359 for additional details.

Preview URL: http://jowilkin.com:8080/TELCODOCS-1359/welcome/index.html

For release(s): 4.14, 4.13, 4.12, 4.11, 4.10
QE Review: http://184.23.213.161:8080/TELCODOCS-1359/installing/installing_aws/installing-aws-expanding-a-cluster-with-on-premise-bare-metal-nodes.html#connecting-the-vpc-to-the-on-premise-network_expanding-a-cluster-with-on-premise-bare-metal-nodes

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
