### PR TITLE
Replacing source,terminal markup

### DIFF
--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -24,9 +24,14 @@ To add a node selector to existing pods, determine the controlling object for th
 For example, the `router-default-66d5cf9464-m2g75` pod is controlled by the `router-default-66d5cf9464`
 replica set:
 
+[source,terminal]
 ----
 $ oc describe pod router-default-66d5cf9464-7pwkc
+----
 
+.Example output
+[source,terminal]
+----
 Name:               router-default-66d5cf9464-7pwkc
 Namespace:          openshift-ingress
 
@@ -38,6 +43,7 @@ Controlled By:      ReplicaSet/router-default-66d5cf9464
 
 The web console lists the controlling object under `ownerReferences` in the pod YAML:
 
+[source,terminal]
 ----
 # ...
   ownerReferences:
@@ -58,12 +64,14 @@ The web console lists the controlling object under `ownerReferences` in the pod 
 
 .. Run the following command to add labels to a `MachineSet` object:
 +
+[source,terminal]
 ----
 $ oc patch MachineSet <name> --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"<key>"="<value>","<key>"="<value>"}}]'  -n openshift-machine-api
 ----
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc patch MachineSet abc612-msrtw-worker-us-east-1c  --type='json' -p='[{"op":"add","path":"/spec/template/spec/metadata/labels", "value":{"type":"user-node","region":"east"}}]'  -n openshift-machine-api
 ----
@@ -93,13 +101,14 @@ spec:
 +
 For example:
 +
+[source,terminal]
 ----
 $ oc edit MachineSet abc612-msrtw-worker-us-east-1c -n openshift-machine-api
 ----
 +
 .Example `MachineSet` object
-[source,yaml]
 +
+[source,yaml]
 ----
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet


### PR DESCRIPTION
Follow up to  https://github.com/openshift/openshift-docs/pull/62205. Some [source,terminal] mark up was somehow accidentally removed. This PR replaces them.

Preview: [Using node selectors to control pod placement](https://62284--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-node-selectors.html#nodes-scheduler-node-selectors-pod_nodes-pods-node-selectors)