### PR TITLE
PR for SRVKE-1386: [DOC] Create listed 2 times in Knative Eventing installation

### DIFF
--- a/modules/serverless-install-eventing-web-console.adoc
+++ b/modules/serverless-install-eventing-web-console.adoc
@@ -25,19 +25,13 @@ After you install the {ServerlessOperatorName}, install Knative Eventing by usin
 
 . Click *Create Knative Eventing*.
 
-. In the *Create Knative Eventing* page, you can choose to configure the `KnativeEventing` object by using either the default form provided, or by editing the YAML.
+. In the *Create Knative Eventing* page, you can configure the `KnativeEventing` object by using either the form provided, or by editing the YAML file.
 
-* Using the form is recommended for simpler configurations that do not require full control of `KnativeEventing` object creation.
-+
-Optional. If you are configuring the `KnativeEventing` object using the form, make any changes that you want to implement for your Knative Eventing deployment.
+* Use the form for simpler configurations that do not require full control of `KnativeEventing` object creation.
 
 . Click *Create*.
 +
-* Editing the YAML is recommended for more complex configurations that require full control of `KnativeEventing` object creation. You can access the YAML by clicking the *edit YAML* link in the top right of the *Create Knative Eventing* page.
-+
-Optional. If you are configuring the `KnativeEventing` object by editing the YAML, make any changes to the YAML that you want to implement for your Knative Eventing deployment.
-
-. Click *Create*.
+* Edit the YAML file for more complex configurations that require full control of `KnativeEventing` object creation. To access the YAML editor, click *edit YAML* on the *Create Knative Eventing* page.
 
 . After you have installed Knative Eventing, the `KnativeEventing` object is created, and you are automatically directed to the *Knative Eventing* tab. You will see the `knative-eventing` custom resource in the list of resources.
 


### PR DESCRIPTION
**Affected versions for cherry-picking:**

serverless-docs 1.28+


**Dedicated JIRA:**  https://issues.redhat.com/browse/SRVKE-1386

**Description:** 
In the **Installing Knative Eventing by using the web console**,  removed the duplicated `Click Create` step and updated the content. 

**Doc preview:** [Installing Knative Eventing by using the web console](https://62288--docspreview.netlify.app/openshift-serverless/latest/install/installing-knative-eventing.html#serverless-install-eventing-web-console_installing-knative-eventing)
Check steps no. 5 and 6

**Reviews:** 
- SME: Pierangelo
- QE: not required (Change is small)
- Peer: shreyasiddhartha