### PR TITLE
OSDOCS-6804: Used the wrong syntax for the SNO variable, fixing

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3849,7 +3849,7 @@ This update adds the following features:
 
 [NOTE]
 ====
-NUMA-aware scheduling with the NUMA Resources Operator is not yet available on :sno:.
+NUMA-aware scheduling with the NUMA Resources Operator is not yet available on {sno}.
 ====
 
 For more information, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-about-numa-aware-scheduling_numa-aware[Scheduling NUMA-aware workloads].


### PR DESCRIPTION
[OSDOCS-6804](https://issues.redhat.com//browse/OSDOCS-6804): Fixing typo for incorrect variable usage 

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-6804

Link to docs preview:
https://62299--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-24-NUMA-scheduler-ga

QE not required