### PR TITLE
Removes IR alert note IRO docs

### DIFF
--- a/modules/registry-removed.adoc
+++ b/modules/registry-removed.adoc
@@ -18,19 +18,6 @@
 [id="registry-removed_{context}"]
 = Image registry removed during installation
 
-On platforms that do not provide shareable object storage, the OpenShift Image
-Registry Operator bootstraps itself as `Removed`. This allows
-`openshift-installer` to complete installations on these platform types.
+On platforms that do not provide shareable object storage, the OpenShift Image Registry Operator bootstraps itself as `Removed`. This allows `openshift-installer` to complete installations on these platform types.
 
-After installation, you must edit the Image Registry Operator configuration to
-switch the `managementState` from `Removed` to `Managed`.
-
-[NOTE]
-====
-The Prometheus console provides an `ImageRegistryRemoved` alert, for example:
-
-"Image Registry has been removed. `ImageStreamTags`, `BuildConfigs` and
-`DeploymentConfigs` which reference `ImageStreamTags` may not work as
-expected. Please configure storage and update the config to `Managed`
-state by editing configs.imageregistry.operator.openshift.io."
-====
+After installation, you must edit the Image Registry Operator configuration to switch the `managementState` from `Removed` to `Managed`.


### PR DESCRIPTION
Removal of old note/alert.

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-2958

Link to docs preview:
https://62300--docspreview.netlify.app/openshift-enterprise/latest/registry/configuring-registry-operator.html#registry-removed_configuring-registry-operator

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
