### PR TITLE
OSDOCS 6789: HPA with custom metrics operator install method and authenticationRef indentation level typo

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2268,7 +2268,7 @@ Topics:
     File: nodes-cma-autoscaling-custom-install
   - Name: Understanding the custom metrics autoscaler triggers
     File: nodes-cma-autoscaling-custom-trigger
-  - Name: Understanding the custom metrics autoscaler trigger authentications
+  - Name: Understanding custom metrics autoscaler trigger authentications
     File: nodes-cma-autoscaling-custom-trigger-auth
   - Name: Pausing the custom metrics autoscaler
     File: nodes-cma-autoscaling-custom-pausing

--- a/modules/nodes-cma-autoscaling-custom-creating-job.adoc
+++ b/modules/nodes-cma-autoscaling-custom-creating-job.adoc
@@ -65,16 +65,8 @@ spec:
       threshold: '5'
       query: sum(rate(http_requests_total{job="test-app"}[1m]))
       authModes: "bearer"
-  - authenticationRef: <14>
-      name: prom-triggerauthentication
-    metadata:
-      name: prom-triggerauthentication
-     type: object
-  - authenticationRef: <15>
+    authenticationRef: <14>
       name: prom-cluster-triggerauthentication
-    metadata:
-      name: prom-cluster-triggerauthentication
-    type: object
 ----
 <1> Specifies the maximum duration the job can run.
 <2> Specifies the number of retries for a job. The default is `6`.
@@ -99,19 +91,15 @@ spec:
 +
 <12> Optional: Specifies a scaling strategy: `default`, `custom`, or `accurate`. The default is `default`. For more information, see the link in the "Additional resources" section that follows.
 <13> Specifies the trigger to use as the basis for scaling, as described in the "Understanding the custom metrics autoscaler triggers" section.
-<14> Optional: Specifies a trigger authentication, as described in the "Creating a custom metrics autoscaler trigger authentication" section.
-<15> Optional: Specifies a cluster trigger authentication, as described in the "Creating a custom metrics autoscaler trigger authentication" section.
-+
-[NOTE]
-====
-It is not necessary to specify both a namespace trigger authentication and a cluster trigger authentication.
-====
+<14> Optional: Specifies a trigger authentication or a cluster trigger authentication. For more information, see _Understanding the custom metrics autoscaler trigger authentication_ in the _Additional resources_ section.
+* Enter `TriggerAuthentication` to use a trigger authentication. This is the default.
+* Enter `ClusterTriggerAuthentication` to use a cluster trigger authentication.
 
-. Create the custom metrics autoscaler:
+. Create the custom metrics autoscaler by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc create -f <filename>.yaml
 ----
 
 .Verification

--- a/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
+++ b/modules/nodes-cma-autoscaling-custom-creating-workload.adoc
@@ -125,16 +125,9 @@ spec:
       threshold: '5'
       query: sum(rate(http_requests_total{job="test-app"}[1m]))
       authModes: basic
-  - authenticationRef: <17>
+    authenticationRef: <17>
       name: prom-triggerauthentication
-    metadata:
-      name: prom-triggerauthentication
-    type: object
-  - authenticationRef: <18>
-      name: prom-cluster-triggerauthentication
-    metadata:
-      name: prom-cluster-triggerauthentication
-    type: object
+      kind: TriggerAuthentication
 ----
 <1> Optional: Specifies that the Custom Metrics Autoscaler Operator is to scale the replicas to the specified value and stop autoscaling, as described in the "Pausing the custom metrics autoscaler for a workload" section.
 <2> Specifies a name for this custom metrics autoscaler. 
@@ -152,19 +145,15 @@ spec:
 <14> Optional: Specifies a name for the horizontal pod autoscaler. The default is `keda-hpa-{scaled-object-name}`.
 <15> Optional: Specifies a scaling policy to use to control the rate to scale pods up or down, as described in the "Scaling policies" section.
 <16> Specifies the trigger to use as the basis for scaling, as described in the "Understanding the custom metrics autoscaler triggers" section. This example uses {product-title} monitoring.
-<17> Optional: Specifies a trigger authentication, as described in the "Creating a custom metrics autoscaler trigger authentication" section.
-<18> Optional: Specifies a cluster trigger authentication, as described in the "Creating a custom metrics autoscaler trigger authentication" section.
-+
-[NOTE]
-====
-It is not necessary to specify both a namespace trigger authentication and a cluster trigger authentication.
-====
+<17> Optional: Specifies a trigger authentication or a cluster trigger authentication. For more information, see _Understanding the custom metrics autoscaler trigger authentication_ in the _Additional resources_ section.
+* Enter `TriggerAuthentication` to use a trigger authentication. This is the default.
+* Enter `ClusterTriggerAuthentication` to use a cluster trigger authentication.
 
-. Create the custom metrics autoscaler:
+. Create the custom metrics autoscaler by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc create -f <filename>.yaml
 ----
 
 .Verification

--- a/modules/nodes-cma-autoscaling-custom-trigger-auth-using.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-auth-using.adoc
@@ -54,12 +54,14 @@ spec:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc create -f <filename>.yaml
 ----
 
-. Create or edit a `ScaledObject` YAML file:
+. Create or edit a `ScaledObject` YAML file that uses the trigger authentication:
+
+.. Create a YAML file that defines the object by running the following command:
 +
-.Example scaled object
+.Example scaled object with a trigger authentication
 [source,yaml,options="nowrap"]
 ----
 apiVersion: keda.sh/v1alpha1
@@ -74,8 +76,7 @@ spec:
   minReplicaCount: 0
   pollingInterval: 30
   triggers:
-  - authenticationRef:  
-    type: prometheus
+  - type: prometheus
     metadata:
       serverAddress: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092
       namespace: kedatest # replace <NAMESPACE>
@@ -83,29 +84,46 @@ spec:
       threshold: '5'
       query: sum(rate(http_requests_total{job="test-app"}[1m]))
       authModes: "basic"
-    - authenticationRef: <1>
-        name: prom-triggerauthentication
-      metadata:
-        name: prom-triggerauthentication
-      type: object
-    - authenticationRef: <2>
-        name: prom-cluster-triggerauthentication
-        kind: ClusterTriggerAuthentication
-      metadata:
-        name: prom-cluster-triggerauthentication
-      type: object
+    authenticationRef:
+      name: prom-triggerauthentication <1>
+      kind: TriggerAuthentication <2>
 ----
-<1> Optional: Specify a trigger authentication.
-<2> Optional: Specify a cluster trigger authentication. You must include the `kind: ClusterTriggerAuthentication` parameter.
+<1> Specify the name of your trigger authentication object.
+<2> Specify `TriggerAuthentication`. `TriggerAuthentication` is the default.
 +
-[NOTE]
-====
-It is not necessary to specify both a namespace trigger authentication and a cluster trigger authentication.
-====
+.Example scaled object with a cluster trigger authentication
+[source,yaml,options="nowrap"]
+----
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: scaledobject
+  namespace: my-namespace
+spec:
+  scaleTargetRef:
+    name: example-deployment
+  maxReplicaCount: 100
+  minReplicaCount: 0
+  pollingInterval: 30
+  triggers:
+  - type: prometheus
+    metadata:
+      serverAddress: https://thanos-querier.openshift-monitoring.svc.cluster.local:9092
+      namespace: kedatest # replace <NAMESPACE>
+      metricName: http_requests_total
+      threshold: '5'
+      query: sum(rate(http_requests_total{job="test-app"}[1m]))
+      authModes: "basic"
+    authenticationRef:
+      name: prom-cluster-triggerauthentication <1>
+      kind: ClusterTriggerAuthentication <2>
+----
+<1> Specify the name of your trigger authentication object.
+<2> Specify `ClusterTriggerAuthentication`.
 
-. Create the object. For example:
+.. Create the scaled object by running the following command:
 +
 [source,terminal]
 ----
-$ oc apply -f <file-name>
+$ oc apply -f <filename>
 ----

--- a/nodes/cma/nodes-cma-autoscaling-custom-adding.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-adding.adoc
@@ -19,3 +19,10 @@ include::modules/nodes-cma-autoscaling-custom-creating-workload.adoc[leveloffset
 ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/nodes-cma-autoscaling-custom-creating-job.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated[]
+
+[role="_additional-resources"]
+[id="nodes-cma-autoscaling-custom-adding-additional-resources"]
+== Additional resources
+
+* xref:../../nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc#nodes-cma-autoscaling-custom-trigger-auth[Understanding custom metrics autoscaler trigger authentications]
+

--- a/nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-trigger.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 :context: nodes-cma-autoscaling-custom-trigger
 [id="nodes-cma-autoscaling-custom-overview-trigger"]
-= Understanding the custom metrics autoscaler triggers
+= Understanding custom metrics autoscaler triggers
 include::_attributes/common-attributes.adoc[]
 
 toc::[]


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-6789

Previews:
[Adding a custom metrics autoscaler to a job](https://62301--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-adding.html#nodes-cma-autoscaling-custom-creating-job_nodes-cma-autoscaling-custom-adding) -- Step 1 code block example, fixed spacing as indicated in OSDOC-6789. Changed call out <14> per [comment below](https://github.com/openshift/openshift-docs/pull/62301#issuecomment-1634740493). 

[Adding a custom metrics autoscaler to a workload](https://62301--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-adding.html#nodes-cma-autoscaling-custom-creating-workload_nodes-cma-autoscaling-custom-adding) -- Step 1 code block example, fixed spacing as indicated in OSDOC-6789. Changed call out <17> per [comment below](https://github.com/openshift/openshift-docs/pull/62301#issuecomment-1634740493). 

[Using trigger authentications](https://62301--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.html#nodes-cma-autoscaling-custom-trigger-auth-using_nodes-cma-autoscaling-custom-trigger-auth) -- Step 2 code block example, created separate example trigger authentication YAMLs, per [comment below](https://github.com/openshift/openshift-docs/pull/62301#issuecomment-1634740493). 

QE review:
- [x] QE has approved this change.

