### PR TITLE
OSDOCS-6864: Adjust pods per node to reflect OVN-Kubernetes limits

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -23,18 +23,18 @@ Red Hat does not provide direct guidance on sizing your {product-title} cluster.
 | 150,000
 
 | Number of pods per node
-| 500 ^[3]^
+| 2,500 ^[3][4]^
 
 | Number of pods per core
 | There is no default value.
 
-| Number of namespaces ^[4]^
+| Number of namespaces ^[5]^
 | 10,000
 
 | Number of builds
 | 10,000 (Default pod RAM 512 Mi) - Source-to-Image (S2I) build strategy
 
-| Number of pods per namespace ^[5]^
+| Number of pods per namespace ^[6]^
 | 25,000
 
 | Number of routes and back ends per Ingress Controller
@@ -46,7 +46,7 @@ Red Hat does not provide direct guidance on sizing your {product-title} cluster.
 | Number of config maps
 | 90,000
 
-| Number of services ^[6]^
+| Number of services ^[7]^
 | 10,000
 
 | Number of services per namespace
@@ -55,25 +55,26 @@ Red Hat does not provide direct guidance on sizing your {product-title} cluster.
 | Number of back-ends per service
 | 5,000
 
-| Number of deployments per namespace ^[5]^
+| Number of deployments per namespace ^[6]^
 | 2,000
 
 | Number of build configs
 | 12,000
 
 | Number of custom resource definitions (CRD)
-| 512 ^[7]^
+| 512 ^[8]^
 
 |===
 [.small]
 --
 1. Pause pods were deployed to stress the control plane components of {product-title} at 2000 node scale. The ability to scale to similar numbers will vary depending upon specific deployment and workload parameters.
 2. The pod count displayed here is the number of test pods. The actual number of pods depends on the application's memory, CPU, and storage requirements.
-3. This was tested on a cluster with 100 worker nodes with 500 pods per worker node. The default `maxPods` is still 250. To get to 500 `maxPods`, the cluster must be created with a `maxPods` set to `500` using a custom kubelet config. If you need 500 user pods, you need a `hostPrefix` of `22` because there are 10-15 system pods already running on the node. The maximum number of pods with attached persistent volume claims (PVC) depends on storage backend from where PVC are allocated. In our tests, only {rh-storage} v4 (OCS v4) was able to satisfy the number of pods per node discussed in this document.
-4. When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentation, is highly recommended to free etcd storage.
-5. There are a number of control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
-6. Each service port and each service back-end has a corresponding entry in iptables. The number of back-ends of a given service impact the size of the endpoints objects, which impacts the size of data that is being sent all over the system.
-7. {product-title} has a limit of 512 total custom resource definitions (CRD), including those installed by {product-title}, products integrating with {product-title} and user created CRDs. If there are more than 512 CRDs created, then there is a possibility that `oc` commands requests may be throttled.
+3. This was tested on a cluster with 31 servers: 3 control planes, 2 infrastructure nodes, and 26 worker nodes. The default `maxPods` is still 250. To get to 2,500 pods per node, the cluster must be created with `maxPods` set to `2500` using a custom kubelet config. If you need 2,500 user pods, you need a `hostPrefix` of `20` because there are 10-15 system pods already running on the node. The maximum number of pods with attached persistent volume claims (PVC) depends on the storage backend from where PVC are allocated. In our tests, only {rh-storage} v4 (OCS v4) was able to satisfy 2,500 of pods per node.
+4. The maximum tested pods per node is 2,500 for clusters using the `OVNKubernetes` network plugin. The maximum tested pods per node for the `OpenShiftSDN` network plugin is 500 pods.
+5. When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentation, is highly recommended to free etcd storage.
+6. There are several control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
+7. Each service port and each service back-end has a corresponding entry in `iptables`. The number of back-ends of a given service impact the size of the `Endpoints` objects, which impacts the size of data that is being sent all over the system.
+8. {product-title} has a limit of 512 total custom resource definitions (CRD), including those installed by {product-title}, products integrating with {product-title} and user-created CRDs. If there are more than 512 CRDs created, then there is a possibility that `oc` command requests might be throttled.
 --
 
 [id="cluster-maximums-major-releases-example-scenario_{context}"]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-6864

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

[OpenShift Container Platform tested cluster maximums for major releases](https://62307--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums.html#cluster-maximums-major-releases_object-limits)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
