### PR TITLE
OBSDOCS-338: typo fix in cluster labels config topic in monitoring docs

### DIFF
--- a/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
+++ b/modules/monitoring-creating-cluster-id-labels-for-metrics.adoc
@@ -8,11 +8,11 @@
 
 You can create cluster ID labels for metrics for default platform monitoring and for user workload monitoring.
 
-For default platform monitoring, you add cluster ID labels for metrics in the `write_relabel` settings for remote write storage in the `cluster-monitoring-config` config map in the `openshift-monitoring` namespace. 
+For default platform monitoring, you add cluster ID labels for metrics in the `write_relabel` settings for remote write storage in the `cluster-monitoring-config` config map in the `openshift-monitoring` namespace.
 
 For user workload monitoring, you edit the settings in the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
 
-.Prerequsites
+.Prerequisites
 
 * You have installed the OpenShift CLI (`oc`).
 * You have configured remote write storage.
@@ -34,8 +34,8 @@ $ oc -n openshift-monitoring edit configmap cluster-monitoring-config
 +
 [NOTE]
 ====
-If you configure cluster ID labels for metrics for the Prometheus instance that monitors user-defined projects, edit the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace. 
-Note that the Prometheus component is called `prometheus` in this config map and not `prometheusK8s`, which is the name used in the `cluster-monitoring-config` config map. 
+If you configure cluster ID labels for metrics for the Prometheus instance that monitors user-defined projects, edit the `user-workload-monitoring-config` config map in the `openshift-user-workload-monitoring` namespace.
+Note that the Prometheus component is called `prometheus` in this config map and not `prometheusK8s`, which is the name used in the `cluster-monitoring-config` config map.
 ====
 
 . In the `writeRelabelConfigs:` section under `data/config.yaml/prometheusK8s/remoteWrite`, add cluster ID relabel configuration values:
@@ -80,10 +80,10 @@ data:
           action: replace <3>
 ----
 <1> The system initially applies a temporary cluster ID source label named `+++__tmp_openshift_cluster_id__+++`. This temporary label gets replaced by the cluster ID label name that you specify.
-<2> Specify the name of the cluster ID label for metrics sent to remote write storage. 
+<2> Specify the name of the cluster ID label for metrics sent to remote write storage.
 If you use a label name that already exists for a metric, that value is overwritten with the name of this cluster ID label.
 For the label name, do not use `+++__tmp_openshift_cluster_id__+++`. The final relabeling step removes labels that use this name.
-<3> The `replace` write relabel action replaces the temporary label with the target label for outgoing metrics. 
+<3> The `replace` write relabel action replaces the temporary label with the target label for outgoing metrics.
 This action is the default and is applied if no action is specified.
 
 . Save the file to apply the changes to the `ConfigMap` object.


### PR DESCRIPTION
Summary: This PR fixes a typo in a `Prerequisites` heading in the monitoring docs (also removes some trailing spaces from line endings in the affected file).

No QE review required.

- Aligned team: DevTools
- For branches: 4.11+
- Jira: https://issues.redhat.com/browse/OBSDOCS-338
- Direct link to doc preview: https://62310--docspreview.netlify.app/openshift-enterprise/latest/monitoring/configuring-the-monitoring-stack.html#creating-cluster-id-labels-for-metrics_configuring-the-monitoring-stack
- SME review: n/a
- QE review: n/a
- Peer review: @ tbd