### PR TITLE
GH#55028: Updated vSphere and VMware virtual hw version for OpenShift 4.11

### DIFF
--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -16,7 +16,7 @@ Multiple compute nodes can be updated in parallel given workloads are tolerant o
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -11,7 +11,7 @@ To reduce the risk of downtime, it is recommended that control plane nodes be up
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -103,7 +103,7 @@ xref:../updating/updating-restricted-network-cluster/index.adoc#about-restricted
 [id="updating-clusters-overview-vsphere-updating-hardware"]
 == Updating hardware on nodes running in vSphere
 
-xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
+xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
 
 * xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-virtual-hardware-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Updating virtual hardware on vSphere]
 * xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#scheduling-virtual-hardware-update-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Scheduling an update for virtual hardware on vSphere]

--- a/updating/updating-hardware-on-nodes-running-on-vsphere.adoc
+++ b/updating/updating-hardware-on-nodes-running-on-vsphere.adoc
@@ -6,9 +6,14 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster.
+You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster.
 
 You can update your virtual hardware immediately or schedule an update in vCenter.
+
+[IMPORTANT]
+====
+Version 4.11 of {product-title} requires VMware virtual hardware version 15 or later.
+====
 
 [id="updating-virtual-hardware-on-vsphere_{context}"]
 == Updating virtual hardware on vSphere


### PR DESCRIPTION
…for OpenShift 4.11

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 
4.11


Issue: 
https://github.com/openshift/openshift-docs/issues/55028

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

The release notes at https://docs.openshift.com/container-platform/4.11/release_notes/ocp-4-11-release-notes.html#ocp-4-11-removed-features-virt-hw-v13 say that support for virtual hardware version 13 is removed in OCP 4.11 and that version 15 or later is now recommended, along with vSphere version 7.0U2 and later now being supported.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
