### PR TITLE
ROX-15826: Add GUI method for using init bundle

### DIFF
--- a/modules/compliance-operator-configure-scanning.adoc
+++ b/modules/compliance-operator-configure-scanning.adoc
@@ -6,7 +6,7 @@
 = Configuring the ScanSettingBinding object
 
 [role="_abstract"]
-Create a `ScanSettingBinding` object in the `openshift-compliance` namespace to scan the cluster using the `cis` and `cis-node` profiles. 
+Create a `ScanSettingBinding` object in the `openshift-compliance` namespace to scan the cluster by using the `cis` and `cis-node` profiles.
 
 [NOTE]
 ====
@@ -55,7 +55,7 @@ $ scansettingbinding.compliance.openshift.io/cis-compliance created
 * Use the web console to create the object by performing the following steps:
 
 .. Change the active project to `openshift-compliance`.
-.. Click *+* to open the *Import YAML* window.
+.. Click *+* to open the *Import YAML* page.
 .. Paste the YAML from the previous example and then click *Create*.
 
 .Additional resources

--- a/modules/create-resource-init-bundle.adoc
+++ b/modules/create-resource-init-bundle.adoc
@@ -58,6 +58,10 @@ If you are installing by using Helm charts, do not perform this step.
 
 .Procedure
 ifdef::openshift[]
+To create resources, perform one of the following steps:
+
+* In the {ocp} web console, in the top menu, click *+* to open the *Import YAML* page. You can drag the init bundle file or copy and paste its contents into the editor, and then click *Create*.
+
 * Using the {osp} CLI, run the following command to create the resources:
 +
 [source,terminal]


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.1`
- Cherry pick to `rhacs-docs-4.0`
- Cherry pick to `rhacs-docs-3.74`

[Issue](https://issues.redhat.com/browse/ROX-15826)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview
](https://62320--docspreview.netlify.app/openshift-acs/latest/cloud_service/installing_cloud_ocp/init-bundle-cloud-ocp-apply.html#init-bundle-cloud-ocp-apply)

QE review:
- [x] QE has approved this change. (**ACS has no QE; approved by SME**)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Checked with UI team to make sure language for item was correct (`+` icon, page name)
- Changed previous mention of **Import YAML** from "window" to "page" per IBM Style guidelines.

