### PR TITLE
OBSDOCS-333 - Logging 5.6.8 - Release Notes

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -17,6 +17,8 @@ include::modules/logging-rn-5.7.1.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-rn-5.7.0.adoc[leveloffset=+1]
 
+include::modules/logging-rn-5.6.8.adoc[leveloffset=+1]
+
 include::modules/cluster-logging-rn-5.6.5.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-rn-5.6.4.adoc[leveloffset=+1]

--- a/logging/v5_6/logging-5-6-release-notes.adoc
+++ b/logging/v5_6/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-rn-5.6.8.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.6.5.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.4.adoc[leveloffset=+1]

--- a/modules/logging-rn-5.6.8.adoc
+++ b/modules/logging-rn-5.6.8.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+// cluster-logging-release-notes.adoc
+// logging-5-6-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-6-8_{context}"]
+= Logging 5.6.8
+This release includes link:https://access.redhat.com/errata/RHBA-2023:3996[OpenShift Logging Bug Fix Release 5.6.8].
+
+[id="openshift-logging-5-6-8-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, the vector collector terminated unexpectedly when input match label values contained a `/` character within the `ClusterLogForwarder`. This update resolves the issue by quoting the match label, enabling the collector to start and collect logs. (link:https://issues.redhat.com/browse/LOG-4091[LOG-4091])
+
+* Before this update, when viewing logs within the {product-title} web console, clicking the *more data available* option loaded more log entries only the first time it was clicked. With this update, more entries are loaded with each click. (link:https://issues.redhat.com/browse/OU-187[OU-187])
+
+* Before this update, when viewing logs within the {product-title} web console, clicking the *streaming* option would only display the *streaming logs* message without showing the actual logs. With this update, both the message and the log stream are displayed correctly. (link:https://issues.redhat.com/browse/OU-189[OU-189])
+
+* Before this update, the Loki Operator reset errors in a way that made identifying configuration problems difficult to troubleshoot. With this update, errors persist until the configuration error is resolved. (link:https://issues.redhat.com/browse/LOG-4158[LOG-4158])
+
+* Before this update, clusters with more than 8,000 namespaces caused Elasticsearch to reject queries because the list of namespaces was larger than the `http.max_header_size` setting. With this update, the default value for header size has been increased, resolving the issue. (link:https://issues.redhat.com/browse/LOG-4278[LOG-4278])
+
+[id="openshift-logging-5-6-8-CVEs_{context}"]
+== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2020-24736[CVE-2020-24736]
+* link:https://access.redhat.com/security/cve/CVE-2022-48281[CVE-2022-48281]
+* link:https://access.redhat.com/security/cve/CVE-2023-1667[CVE-2023-1667]
+* link:https://access.redhat.com/security/cve/CVE-2023-2283[CVE-2023-2283]
+* link:https://access.redhat.com/security/cve/CVE-2023-24329[CVE-2023-24329]
+* link:https://access.redhat.com/security/cve/CVE-2023-26604[CVE-2023-26604]
+* link:https://access.redhat.com/security/cve/CVE-2023-28466[CVE-2023-28466]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10, 4.11, 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OBSDOCS-333](https://issues.redhat.com//browse/OBSDOCS-333)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62326--docspreview.netlify.app/openshift-enterprise/latest/logging/v5_6/logging-5-6-release-notes.html#cluster-logging-release-notes-5-6-8_logging-5.6-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
