### PR TITLE
OCPBUGS#15423: Fixed link pointing to RHV-H for vSphere docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -59,6 +59,8 @@ endif::openshift-origin[]
 :secondary-scheduler-operator: Secondary Scheduler Operator
 :rh-virtualization-first: Red Hat Virtualization (RHV)
 :rh-virtualization: RHV
+:rh-virtualization-hyper-first: Red Hat Virtualization Hypervisor (RHV-H)
+:rh-virtualization-hyper: RHV-H
 :rh-virtualization-engine-name: Manager
 ifdef::openshift-origin[]
 :rh-virtualization-first: oVirt

--- a/modules/installation-vsphere-infrastructure.adoc
+++ b/modules/installation-vsphere-infrastructure.adoc
@@ -76,7 +76,7 @@ If your vSphere nodes are below hardware version 15 or your VMware vSphere versi
 
 |Hypervisor
 |vSphere 7 with HW version 15
-|This version is the minimum version that {op-system-first} supports. See the link:https://access.redhat.com/ecosystem/search/#/ecosystem/Red%20Hat%20Enterprise%20Linux?sort=sortTitle%20asc&vendors=VMware&category=Server[Red Hat Enterprise Linux 8 supported hypervisors list].
+|This version is the minimum version that {op-system-first} supports. For more information about supported hardware on the latest version of {op-system-base-full} that is compatible with {op-system}, see link:https://catalog.redhat.com/hardware/search[Hardware] on the Red Hat Customer Portal.
 
 |Storage with in-tree drivers
 |vSphere 7


### PR DESCRIPTION
Cherry Picked from b93a69a31b95596914bfef0bb8a90bcc13c166dd on [OCPBUGS-15423](https://github.com/openshift/openshift-docs/pull/61947)

Version(s):
4.11

Link to docs preview:
[VMware vSphere CSI Driver Operator requirements](https://dfitzmau.github.io/previews/preparing-to-install-on-vsphere.html#installation-vsphere-infrastructure_preparing-to-install-on-vsphere)

QE review:
- [ ] QE has approved this change.
