### PR TITLE
OCPBUGS-15797: Removing single deviceClass limitation in LVMCluster CR

### DIFF
--- a/modules/deploying-lvms-on-sno-cluster.adoc
+++ b/modules/deploying-lvms-on-sno-cluster.adoc
@@ -33,7 +33,6 @@ Before you begin deploying {lvms} on {sno} clusters, ensure that the following r
 Before you deploy {lvms} on {sno} clusters, be aware of the following limitations:
 
 * You can only create a single instance of the `LVMCluster` custom resource (CR) on an {product-title} cluster.
-* You can make only a single `deviceClass` entry in the `LVMCluster` CR.
 * When a device becomes part of the `LVMCluster` CR, it cannot be removed.
 
 [id="lvms-deployment-limitations-for-sno-ran_{context}"]

--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -64,7 +64,7 @@ include::modules/lvms-creating-logical-volume-manager-cluster.adoc[leveloffset=+
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../../nodes/nodes/nodes-sno-worker-nodes.adoc[Adding worker nodes to {sno} clusters].
+* xref:../../../nodes/nodes/nodes-sno-worker-nodes.adoc[Adding worker nodes to {sno} clusters]
 
 * xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-reference-file_logical-volume-manager-storage[{lvms} reference YAML file]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-15797
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62339--docspreview.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-preface-sno-ran_logical-volume-manager-storage


<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
