### PR TITLE
OCPBUGS-7621-main: Updated vsphere docs with pre-configuring external…

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -278,6 +278,13 @@ cluster.
 
 * Verify the cloud provider account on your host has the correct permissions to deploy the cluster. An account with incorrect permissions causes the installation process to fail with an error message that displays the missing permissions.
 
+* Optional: Before you create the cluster, configure an external load balancer in place of the default load balancer. 
++
+[IMPORTANT]
+====
+You do not need to specify API and Ingress static addresses for your installation program. If you choose this configuration, you must take additional actions to define network targets that accept an IP address from each referenced vSphere subnet. See the section "Configuring an external load balancer".
+====
+
 .Procedure
 
 ifdef::gcp[]


### PR DESCRIPTION
[OCPBUGS-7621](https://issues.redhat.com/browse/OCPBUGS-7621)

Version(s):
4.14 and 4.13

Link to docs preview:
* [Deploying the cluster](https://62343--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-launching-installer_installing-vsphere-installer-provisioned-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
