### PR TITLE
OSDOCS-6885: Added note for RHCOS, RHEL nodes not supported

### DIFF
--- a/security/security_profiles_operator/spo-enabling.adoc
+++ b/security/security_profiles_operator/spo-enabling.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Before you can use the Security Profiles Operator, you must ensure the Operator is deployed in the cluster.
 
+[IMPORTANT]
+====
+The Security Profiles Operator supports only Red Hat Enterprise Linux CoreOS (RHCOS) worker nodes. Red Hat Enterprise Linux (RHEL) nodes are not supported.
+====
+
 include::modules/spo-installing.adoc[leveloffset=+1]
 
 include::modules/spo-installing-cli.adoc[leveloffset=+1]

--- a/security/security_profiles_operator/spo-seccomp.adoc
+++ b/security/security_profiles_operator/spo-seccomp.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Create and manage seccomp profiles and bind them to workloads.
 
+[IMPORTANT]
+====
+The Security Profiles Operator supports only Red Hat Enterprise Linux CoreOS (RHCOS) worker nodes. Red Hat Enterprise Linux (RHEL) nodes are not supported.
+====
+
 include::modules/spo-creating-profiles.adoc[leveloffset=+1]
 
 include::modules/spo-applying-profiles.adoc[leveloffset=+1]

--- a/security/security_profiles_operator/spo-selinux.adoc
+++ b/security/security_profiles_operator/spo-selinux.adoc
@@ -8,6 +8,11 @@ toc::[]
 
 Create and manage SELinux profiles and bind them to workloads.
 
+[IMPORTANT]
+====
+The Security Profiles Operator supports only Red Hat Enterprise Linux CoreOS (RHCOS) worker nodes. Red Hat Enterprise Linux (RHEL) nodes are not supported.
+====
+
 include::modules/spo-creating-profiles.adoc[leveloffset=+1]
 
 include::modules/spo-applying-profiles.adoc[leveloffset=+1]

--- a/security/security_profiles_operator/spo-understanding.adoc
+++ b/security/security_profiles_operator/spo-understanding.adoc
@@ -8,4 +8,9 @@ toc::[]
 
 {product-title} administrators can use the Security Profiles Operator to define increased security measures in clusters.
 
+[IMPORTANT]
+====
+The Security Profiles Operator supports only Red Hat Enterprise Linux CoreOS (RHCOS) worker nodes. Red Hat Enterprise Linux (RHEL) nodes are not supported.
+====
+
 include::modules/spo-about.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-6885

Link to docs preview:
[Understanding the Security Profiles Operator](https://file.rdu.redhat.com/antaylor/OSDOCS-6885/security/security_profiles_operator/spo-understanding.html)
[Managing seccomp profiles](https://file.rdu.redhat.com/antaylor/OSDOCS-6885/security/security_profiles_operator/spo-seccomp.html)
[Managing SELinux profiles](https://file.rdu.redhat.com/antaylor/OSDOCS-6885/security/security_profiles_operator/spo-selinux.html)
[Enabling the Security Profiles Operator](https://file.rdu.redhat.com/antaylor/OSDOCS-6885/security/security_profiles_operator/spo-enabling.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
(None)