### PR TITLE
OCPBUGS#16038: Replace fake passwords with standard replace values

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -1511,6 +1511,14 @@ Nest admonitions when using the `collapsible` option.
 |password
 |===
 
+[IMPORTANT]
+====
+Do not use a password format that matches the format of a real password. Documenting such a password format can cause the following issues:
+
+* Indicates that Red Hat publicly exposes sensitive data in their documentation.
+* Leads to additional security incidents that the Information Security, InfoSec, team must investigate. Such security incidents, although minor, can impact the InfoSec team's resources and potentially delay them from focusing on actual security incidents.   
+====
+
 .Projects and applications
 [option="header"]
 |===

--- a/modules/builds-creating-secrets.adoc
+++ b/modules/builds-creating-secrets.adoc
@@ -43,8 +43,8 @@ metadata:
   name: mysecret
 type: Opaque <1>
 data:
-  username: dXNlci1uYW1l
-  password: cGFzc3dvcmQ=
+  username: <username>
+  password: <password>
 ----
 +
 <1> Specifies an _opaque_ secret.

--- a/modules/builds-secrets-overview.adoc
+++ b/modules/builds-secrets-overview.adoc
@@ -17,8 +17,8 @@ metadata:
   namespace: my-namespace
 type: Opaque <1>
 data: <2>
-  username: dmFsdWUtMQ0K <3>
-  password: dmFsdWUtMg0KDQo=
+  username: <username> <3>
+  password: <password>
 stringData: <4>
   hostname: myapp.mydomain.com <5>
 ----

--- a/modules/builds-using-secrets.adoc
+++ b/modules/builds-using-secrets.adoc
@@ -44,8 +44,8 @@ kind: Secret
 metadata:
   name: test-secret
 data:
-  username: dmFsdWUtMQ0K     <1>
-  password: dmFsdWUtMQ0KDQo= <2>
+  username: <username> <1>
+  password: <password> <2>
 stringData:
   hostname: myapp.mydomain.com <3>
   secret.properties: |-     <4>

--- a/modules/cluster-logging-collector-log-forward-es.adoc
+++ b/modules/cluster-logging-collector-log-forward-es.adoc
@@ -98,8 +98,8 @@ kind: Secret
 metadata:
   name: openshift-test-secret
 data:
-  username: dGVzdHVzZXJuYW1lCg==
-  password: dGVzdHBhc3N3b3JkCg==
+  username: <username>
+  password: <password>
 ----
 
 . Create the secret:

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -42,8 +42,8 @@ $ podman login registry.redhat.io
 +
 [source,bash]
 ----
-Username: myrhusername
-Password: ************
+Username: <username>
+Password: <password>
 ----
 
 . Optional: Display help for the PPC tool:

--- a/modules/completing-installation.adoc
+++ b/modules/completing-installation.adoc
@@ -12,14 +12,14 @@ INFO Install complete!                                
 
 INFO Run 'export KUBECONFIG=/home/joe/ocp/auth/kubeconfig' to manage the cluster with 'oc', the {product-title} CLI.
 
-INFO The cluster is ready when 'oc login -u kubeadmin -p 39RPg-y4c7V-n4bbn-vAF3M' succeeds (wait a few minutes).
+INFO The cluster is ready when 'oc login -u kubeadmin -p <password>' succeeds (wait a few minutes).
 
 INFO Access the {product-title} web-console here: https://console-openshift-console.apps.mycluster.devel.example.com
 
-INFO Login to the console with user: kubeadmin, password: 39RPg-y4c7V-n4bbn-vAF3M
+INFO Login to the console with user: kubeadmin, password: "password"
 ----
 
-To access the {product-title} cluster from your web browser, log in as kubeadmin with the password (for example, 39RPg-y4c7V-n4bbn-vAF3M), using the URL shown:
+To access the {product-title} cluster from your web browser, log in as kubeadmin with the password, using the URL shown:
 
      https://console-openshift-console.apps.mycluster.devel.example.com
 
@@ -27,7 +27,7 @@ To access the {product-title} cluster from the command line, identify the locati
 ----
 $ export KUBECONFIG=/home/joe/ocp/auth/kubeconfig
 
-$ oc login -u kubeadmin -p 39RPg-y4c7V-n4bbn-vAF3M
+$ oc login -u kubeadmin -p <password>
 ----
 
 At this point, you can begin using the {product-title} cluster. To understand the management of your {product-title} cluster going forward, you should explore the {product-title} control plane.

--- a/modules/developer-cli-odo-creating-a-database-with-odo.adoc
+++ b/modules/developer-cli-odo-creating-a-database-with-odo.adoc
@@ -48,9 +48,9 @@ This configuration ensures that when a database service is started, appropriate 
 +
 [source,yaml]
 ----
-  databaseName: "sampledb"
-  databasePassword: "samplepwd"
-  databaseUser: "sampleuser"
+  databaseName: "<database_name>"
+  databasePassword: "<password>"
+  databaseUser: "<username>"
 ----
 
 . Create a database from the YAML file:

--- a/modules/gitops-logging-into-keycloak.adoc
+++ b/modules/gitops-logging-into-keycloak.adoc
@@ -35,7 +35,7 @@ keycloak-1-2sjcl           1/1    Running            0        45m
 ----
 $ oc -n argocd exec keycloak-1-2sjcl -- "env" | grep SSO_ADMIN_USERNAME
 
-SSO_ADMIN_USERNAME=Cqid54Ih
+SSO_ADMIN_USERNAME=<username>
 ----
 .. Get the Keycloak password:
 +
@@ -43,7 +43,7 @@ SSO_ADMIN_USERNAME=Cqid54Ih
 ----
 $ oc -n argocd exec keycloak-1-2sjcl -- "env" | grep SSO_ADMIN_PASSWORD
 
-SSO_ADMIN_PASSWORD=GVXxHifH
+SSO_ADMIN_PASSWORD=<password>
 ----
 . On the login page, click *LOG IN VIA KEYCLOAK*.
 +
@@ -66,6 +66,3 @@ Login using `kubeadmin` is not supported.
 policy.csv:
 <name>, <email>, role:admin
 ----
-
-
-

--- a/modules/identity-provider-creating-htpasswd-file-linux.adoc
+++ b/modules/identity-provider-creating-htpasswd-file-linux.adoc
@@ -21,7 +21,7 @@ this is available by installing the `httpd-tools` package.
 +
 [source,terminal]
 ----
-$ htpasswd -c -B -b </path/to/users.htpasswd> <user_name> <password>
+$ htpasswd -c -B -b </path/to/users.htpasswd> <username> <password>
 ----
 +
 The command generates a hashed version of the password.
@@ -30,7 +30,7 @@ For example:
 +
 [source,terminal]
 ----
-$ htpasswd -c -B -b users.htpasswd user1 MyPassword!
+$ htpasswd -c -B -b users.htpasswd <username> <password>
 ----
 +
 .Example output

--- a/modules/identity-provider-creating-htpasswd-file-windows.adoc
+++ b/modules/identity-provider-creating-htpasswd-file-windows.adoc
@@ -21,7 +21,7 @@ directory of many Apache httpd distributions.
 +
 [source,terminal]
 ----
-> htpasswd.exe -c -B -b <\path\to\users.htpasswd> <user_name> <password>
+> htpasswd.exe -c -B -b <\path\to\users.htpasswd> <username> <password>
 ----
 +
 The command generates a hashed version of the password.
@@ -30,7 +30,7 @@ For example:
 +
 [source,terminal]
 ----
-> htpasswd.exe -c -B -b users.htpasswd user1 MyPassword!
+> htpasswd.exe -c -B -b users.htpasswd <username> <password>
 ----
 +
 .Example output
@@ -43,5 +43,5 @@ Adding password for user user1
 +
 [source,terminal]
 ----
-> htpasswd.exe -b <\path\to\users.htpasswd> <user_name> <password>
+> htpasswd.exe -b <\path\to\users.htpasswd> <username> <password>
 ----

--- a/modules/installation-aws-user-infra-installation.adoc
+++ b/modules/installation-aws-user-infra-installation.adoc
@@ -47,7 +47,7 @@ INFO Waiting up to 10m0s for the openshift-console route to be created...
 INFO Install complete!
 INFO To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/myuser/install_dir/auth/kubeconfig'
 INFO Access the OpenShift web-console here: https://console-openshift-console.apps.mycluster.example.com
-INFO Login to the console with user: "kubeadmin", and password: "4vYBz-Fe5en-ymBEc-Wt6NL"
+INFO Login to the console with user: "kubeadmin", and password: "password"
 INFO Time elapsed: 1s
 ----
 +

--- a/modules/installation-osp-describing-cloud-parameters.adoc
+++ b/modules/installation-osp-describing-cloud-parameters.adoc
@@ -31,15 +31,15 @@ clouds:
     auth:
       auth_url: http://10.10.14.42:5000/v3
       project_name: shiftstack
-      username: shiftstack_user
-      password: XXX
+      username: <username>
+      password: <password>
       user_domain_name: Default
       project_domain_name: Default
   dev-env:
     region_name: RegionOne
     auth:
-      username: 'devuser'
-      password: XXX
+      username: <username>
+      password: <password>
       project_name: 'devonly'
       auth_url: 'https://10.10.14.22:5001/v2.0'
 ----

--- a/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc
@@ -16,7 +16,7 @@ hosts:
     role: master
     bmc:
       address: redfish://<out_of_band_ip> <1>
-      username: <user>
+      username: <username>
       password: <password>
     bootMACAddress: <NIC1_mac_address>
     rootDeviceHints:

--- a/modules/ldap-syncing-about.adoc
+++ b/modules/ldap-syncing-about.adoc
@@ -28,7 +28,7 @@ The LDAP client configuration section of the configuration defines the connectio
 ----
 url: ldap://10.0.0.0:389 <1>
 bindDN: cn=admin,dc=example,dc=com <2>
-bindPassword: password <3>
+bindPassword: <password> <3>
 insecure: false <4>
 ca: my-ldap-ca-bundle.crt <5>
 ----

--- a/modules/metering-use-mysql-or-postgresql-for-hive.adoc
+++ b/modules/metering-use-mysql-or-postgresql-for-hive.adoc
@@ -19,7 +19,7 @@ Create your MySQL or Postgres instance with a user name and password. Then creat
 +
 [source,terminal]
 ----
-$ oc --namespace openshift-metering create secret generic <YOUR_SECRETNAME> --from-literal=username=<YOUR_DATABASE_USERNAME> --from-literal=password=<YOUR_DATABASE_PASSWORD>
+$ oc --namespace openshift-metering create secret generic <YOUR_SECRETNAME> --from-literal=username=<database_username> --from-literal=password=<database_password>
 ----
 +
 * Create a secret by using a YAML file. For example:
@@ -29,10 +29,10 @@ $ oc --namespace openshift-metering create secret generic <YOUR_SECRETNAME> --fr
 apiVersion: v1
 kind: Secret
 metadata:
-  name: <YOUR_SECRETNAME> <1>
+  name: <secret_name> <1>
 data:
-  username: <BASE64_ENCODED_DATABASE_USERNAME> <2>
-  password: <BASE64_ENCODED_DATABASE_PASSWORD> <3>
+  username: <base64_encoded_database_username> <2>
+  password: <base64_encoded_database_password> <3>
 ----
 <1> The name of the secret.
 <2> Base64 encoded database user name.
@@ -81,8 +81,8 @@ spec:
         db:
           url: "jdbc:postgresql://postgresql.example.com:5432/hive_metastore"
           driver: "org.postgresql.Driver"
-          username: "REPLACEME"
-          password: "REPLACEME"
+          username: "<username>"
+          password: "<password>"
 ----
 +
 You can pass additional JDBC parameters using the `spec.hive.config.url`. For more details, see the link:https://jdbc.postgresql.org/documentation/head/connect.html#connection-parameters[PostgreSQL JDBC driver documentation].

--- a/modules/nodes-containers-downward-api-container-secrets.adoc
+++ b/modules/nodes-containers-downward-api-container-secrets.adoc
@@ -21,8 +21,8 @@ kind: Secret
 metadata:
   name: mysecret
 data:
-  password: cGFzc3dvcmQ=
-  username: ZGV2ZWxvcGVy
+  password: <password>
+  username: <username>
 type: kubernetes.io/basic-auth
 ----
 

--- a/modules/nodes-pods-secrets-about.adoc
+++ b/modules/nodes-pods-secrets-about.adoc
@@ -29,8 +29,8 @@ metadata:
   namespace: my-namespace
 type: Opaque <1>
 data: <2>
-  username: dmFsdWUtMQ0K <3>
-  password: dmFsdWUtMg0KDQo=
+  username: <username> <3>
+  password: <password>
 stringData: <4>
   hostname: myapp.mydomain.com <5>
 ----

--- a/modules/nodes-pods-secrets-creating-basic.adoc
+++ b/modules/nodes-pods-secrets-creating-basic.adoc
@@ -31,7 +31,7 @@ type: kubernetes.io/basic-auth <1>
 data:
 stringData: <2>
   username: admin
-  password: t0p-Secret
+  password: <password>
 ----
 <1> Specifies a basic authentication secret.
 <2> Specifies the basic authentication values to use.

--- a/modules/nodes-pods-secrets-creating-opaque.adoc
+++ b/modules/nodes-pods-secrets-creating-opaque.adoc
@@ -22,8 +22,8 @@ metadata:
   name: mysecret
 type: Opaque <1>
 data:
-  username: dXNlci1uYW1l
-  password: cGFzc3dvcmQ=
+  username: <username>
+  password: <password>
 ----
 <1> Specifies an opaque secret.
 

--- a/modules/nodes-pods-secrets-creating.adoc
+++ b/modules/nodes-pods-secrets-creating.adoc
@@ -22,8 +22,8 @@ metadata:
   name: test-secret
 type: Opaque <1>
 data: <2>
-  username: dmFsdWUtMQ0K
-  password: dmFsdWUtMQ0KDQo=
+  username: <username>
+  password: <password>
 stringData: <3>
   hostname: myapp.mydomain.com
   secret.properties: |

--- a/modules/op-configuring-basic-authentication-for-git.adoc
+++ b/modules/op-configuring-basic-authentication-for-git.adoc
@@ -30,8 +30,8 @@ metadata:
     tekton.dev/git-0: https://github.com
 type: kubernetes.io/basic-auth
 stringData:
-  username: <2>
-  password: <3>
+  username: <username> <2>
+  password: <password> <3>
 ----
 <1> Name of the secret. In this example, `basic-user-pass`.
 <2> Username for the Git repository.

--- a/modules/op-release-notes-1-8.adoc
+++ b/modules/op-release-notes-1-8.adoc
@@ -186,8 +186,8 @@ type: Opaque
 stringData:
   POSTGRES_HOST: <hostname>
   POSTGRES_DB: <database_name>
-  POSTGRES_USER: <user_name>
-  POSTGRES_PASSWORD: <user_password>
+  POSTGRES_USER: <username>
+  POSTGRES_PASSWORD: <password>
   POSTGRES_PORT: <listening_port_number>
 ----
 // link:https://issues.redhat.com/browse/SRVKP-2309[SRVKP-2309 Pipeline as code: validate repository URL uniqueness])

--- a/modules/op-understanding-credential-selection.adoc
+++ b/modules/op-understanding-credential-selection.adoc
@@ -22,8 +22,8 @@ metadata:
     tekton.dev/git-1: gitlab.com
 type: kubernetes.io/basic-auth
 stringData:
-  username: <1>
-  password: <2>
+  username: <username> <1>
+  password: <password> <2>
 ----
 <1> Username for the repository
 <2> Password or personal access token for the repository

--- a/modules/reviewing-the-installation-log.adoc
+++ b/modules/reviewing-the-installation-log.adoc
@@ -31,7 +31,7 @@ Cluster credentials are included at the end of the log if the installation is su
 time="2020-12-03T09:50:47Z" level=info msg="Install complete!"
 time="2020-12-03T09:50:47Z" level=info msg="To access the cluster as the system:admin user when using 'oc', run 'export KUBECONFIG=/home/myuser/install_dir/auth/kubeconfig'"
 time="2020-12-03T09:50:47Z" level=info msg="Access the OpenShift web-console here: https://console-openshift-console.apps.mycluster.example.com"
-time="2020-12-03T09:50:47Z" level=info msg="Login to the console with user: \"kubeadmin\", and password: \"6zYIx-ckbW3-4d2Ne-IWvDF\""
+time="2020-12-03T09:50:47Z" level=info msg="Login to the console with user: \"kubeadmin\", and password: \"password\""
 time="2020-12-03T09:50:47Z" level=debug msg="Time elapsed per stage:"
 time="2020-12-03T09:50:47Z" level=debug msg="    Infrastructure: 6m45s"
 time="2020-12-03T09:50:47Z" level=debug msg="Bootstrap Complete: 11m30s"

--- a/modules/sbo-categories-of-exposable-binding-data.adoc
+++ b/modules/sbo-categories-of-exposable-binding-data.adoc
@@ -69,8 +69,8 @@ kind: Secret
 metadata:
   name: hippo-pguser-hippo
 data:
-  password: "MTBz"
-  user: "Z3Vlc3Q="
+  password: "<password>"
+  user: "<username>"
 ----
 
 ////

--- a/modules/sbo-connecting-spring-petclinic-sample-app-to-postgresql-database-service.adoc
+++ b/modules/sbo-connecting-spring-petclinic-sample-app-to-postgresql-database-service.adoc
@@ -74,8 +74,8 @@ $ for i in username password host port type; do oc exec -it deploy/spring-petcli
 .Example output: With all the values from the secret resource
 [source,text]
 ----
-/bindings/spring-petclinic-pgcluster/username: hippo
-/bindings/spring-petclinic-pgcluster/password: KXKF{nAI,I-J6zLt:W+FKnze
+/bindings/spring-petclinic-pgcluster/username: <username>
+/bindings/spring-petclinic-pgcluster/password: <password>
 /bindings/spring-petclinic-pgcluster/host: hippo-primary.my-petclinic.svc
 /bindings/spring-petclinic-pgcluster/port: 5432
 /bindings/spring-petclinic-pgcluster/type: postgresql

--- a/modules/sbo-methods-of-exposing-binding-data.adoc
+++ b/modules/sbo-methods-of-exposing-binding-data.adoc
@@ -56,8 +56,8 @@ kind: Secret
 metadata:
   name: hippo-pguser-hippo
 data:
-  password: "MTBz"
-  user: "Z3Vlc3Q="
+  password: "<password>"
+  user: "<username>"
   ...
 ----
 
@@ -169,8 +169,8 @@ kind: Secret
 metadata:
   name: hippo-pguser-hippo
 data:
-  password: "MTBz"
-  user: "Z3Vlc3Q="
+  password: "<password>"
+  user: "<username>"
 ----
 
 .Example: Exposing binding data from a `ConfigMap` object defined in the CR annotations

--- a/modules/serverless-kafka-sasl-source.adoc
+++ b/modules/serverless-kafka-sasl-source.adoc
@@ -52,7 +52,7 @@ spec:
       password:
         secretKeyRef:
           name: <kafka_auth_secret>
-          key: password
+          key: <password>
       type:
         secretKeyRef:
           name: <kafka_auth_secret>

--- a/modules/templates-exposing-object-fields.adoc
+++ b/modules/templates-exposing-object-fields.adoc
@@ -48,7 +48,7 @@ objects:
     annotations:
       template.openshift.io/base64-expose-password: "{.data['password']}"
   stringData:
-    password: bar
+    password: <password>
 - kind: Service
   apiVersion: v1
   metadata:

--- a/modules/templates-rails-writing-application.adoc
+++ b/modules/templates-rails-writing-application.adoc
@@ -63,7 +63,7 @@ default: &default
   pool: 5
   host: localhost
   username: rails
-  password:
+  password: <password>
 ----
 
 . Create your application's development and test databases:


### PR DESCRIPTION
Cherry Picked from f536b00e03d050784274c4642bb1df79de92bd6c from [OCPBUGS#16038](https://github.com/openshift/openshift-docs/pull/62251)

[OCPBUGS-16038](https://issues.redhat.com/browse/OCPBUGS-16038)

Version(s): 4.10

Link to docs preview:
* Changes touch on a lot of documentation. Here is a preview link to the [OCP Welcome page](https://62251--docspreview.netlify.app/openshift-enterprise/latest/welcome/index.html).
* To access the OCP Docs Guidelines preview, Click *Files changed* > Locate *doc_guidelines.adoc* > Click the three dots > Click *View file*. 

QE review:
- [x] QE approval not required. See Kathryn's comment. Changes are deemed internal to the docs' team. 

Additional information:
Reach out to me for more info. I can show you the InfoSec email and the source of the issue if required. 
