### PR TITLE
[WIP] OSDOCS#3995: ROSA - port 'Security' content from OCP

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -377,14 +377,14 @@ Topics:
   Topics:
     # - Name: CLI and web console
     #   File: rosa-cli-openshift-console
-    - Name: Getting started with the ROSA CLI
-      File: rosa-get-started-cli
-    - Name: Managing objects with the ROSA CLI
-      File: rosa-manage-objects-cli
-    - Name: Checking account and version information with the ROSA CLI
-      File: rosa-checking-acct-version-cli
-    - Name: Checking logs with the ROSA CLI
-      File: rosa-checking-logs-cli
+  - Name: Getting started with the ROSA CLI
+    File: rosa-get-started-cli
+  - Name: Managing objects with the ROSA CLI
+    File: rosa-manage-objects-cli
+  - Name: Checking account and version information with the ROSA CLI
+    File: rosa-checking-acct-version-cli
+  - Name: Checking logs with the ROSA CLI
+    File: rosa-checking-logs-cli
 ---
 Name: Red Hat OpenShift Cluster Manager
 Dir: ocm
@@ -437,18 +437,256 @@ Topics:
   - Name: Configuring cluster memory to meet container memory and risk requirements
     File: nodes-cluster-resource-configure
 ---
+# Ported PR #62384
 Name: Security and compliance
 Dir: security
 Distros: openshift-rosa
 Topics:
-- Name: Audit logs
-  File: audit-log-view
-- Name: Adding additional constraints for IP-based AWS role assumption
-  File: rosa-adding-additional-constraints-for-ip-based-aws-role-assumption
-#- Name: Security
-#  File: rosa-security
-#- Name: Application and cluster compliance
-#  File: rosa-app-security-compliance
+- Name: Security and compliance overview
+  File: index
+- Name: Container security
+  Dir: container_security
+  Topics:
+  - Name: Understanding container security
+    File: security-understanding
+  - Name: Understanding host and VM security
+    File: security-hosts-vms
+  # - Name: Hardening Red Hat Enterprise Linux CoreOS
+  # File: security-hardening
+  #  Distros: openshift-rosa
+  #- Name: Container image signatures
+  #  File: security-container-signature
+  # - Name: Hardening Fedora CoreOS
+  #   File: security-hardening
+  #   Distros: openshift-rosa
+  # - Name: Understanding compliance
+  #   File: security-compliance
+  # - Name: Securing container content
+  #   File: security-container-content
+  # - Name: Using container registries securely
+  #   File: security-registries
+  # - Name: Securing the build process
+  #   File: security-build
+  # - Name: Deploying containers
+  #   File: security-deploy
+  # - Name: Securing the container platform
+  #   File: security-platform
+  # - Name: Securing networks
+  #   File: security-network
+  # - Name: Securing attached storage
+  #  File: security-storage
+  #- Name: Monitoring cluster events and logs
+  #   File: security-monitoring
+- Name: Configuring certificates
+  Dir: certificates
+  Distros: openshift-rosa
+  Topics:
+  - Name: Replacing the default ingress certificate
+    File: replacing-default-ingress-certificate
+  - Name: Adding API server certificates
+    File: api-server
+  - Name: Securing service traffic using service serving certificates
+    File: service-serving-certificate
+  - Name: Updating the CA bundle
+    File: updating-ca-bundle
+# - Name: Certificate types and descriptions
+#   Dir: certificate_types_descriptions
+#   Distros: openshift-rosa
+#   Topics:
+#   - Name: User-provided certificates for the API server
+#     File: user-provided-certificates-for-api-server
+#   - Name: Proxy certificates
+#     File: proxy-certificates
+#   - Name: Service CA certificates
+#     File: service-ca-certificates
+#   - Name: Node certificates
+#     File: node-certificates
+#   - Name: Bootstrap certificates
+#     File: bootstrap-certificates
+#   - Name: etcd certificates
+#     File: etcd-certificates
+#   - Name: OLM certificates
+#     File: olm-certificates
+#   - Name: Aggregated API client certificates
+#     File: aggregated-api-client-certificates
+#   - Name: Machine Config Operator certificates
+#     File: machine-config-operator-certificates
+#   - Name: User-provided certificates for default ingress
+#     File: user-provided-certificates-for-default-ingress
+#   - Name: Ingress certificates
+#     File: ingress-certificates
+#   - Name: Monitoring and cluster logging Operator component certificates
+#     File: monitoring-and-cluster-logging-operator-component-certificates
+#   - Name: Control plane certificates
+#     File: control-plane-certificates
+#  The commented topics in the Compliance Operator section are as a result of a realignment for OCP docs. They are now in subdirectories. (10/2023)
+# - Name: Supported compliance profiles
+#   File: compliance-operator-supported-profiles
+#  - Name: Installing the Compliance Operator
+#    File: compliance-operator-installation
+# - Name: Updating the Compliance Operator
+#   File: compliance-operator-updating
+#  - Name: Compliance Operator scans
+#    File: compliance-scans
+#  - Name: Managing the Compliance Operator
+#    File: compliance-operator-manage
+#   - Name: Compliance Operator scans
+#    File: compliance-scans
+#  - Name: Tailoring the Compliance Operator
+#    File: compliance-operator-tailor
+#  - Name: Retrieving Compliance Operator raw results
+#    File: compliance-operator-raw-results
+#  - Name: Managing Compliance Operator remediation
+#    File: compliance-operator-remediation
+#  - Name: Performing advanced Compliance Operator tasks
+#    File: compliance-operator-advanced
+#  - Name: Troubleshooting the Compliance Operator
+#    File: compliance-operator-troubleshooting
+#  - Name: Uninstalling the Compliance Operator
+#    File: compliance-operator-uninstallation
+#  - Name: Using the oc-compliance plugin
+#    File: oc-compliance-plug-in-using
+#  - Name: Understanding the Custom Resource Definitions
+#    File: compliance-operator-crd
+- Name: Compliance Operator
+  Dir: compliance_operator
+  Distros: openshift-rosa
+  Topics:
+  - Name: Compliance Operator overview
+    File: co-overview
+  - Name: Compliance Operator release notes
+    File: compliance-operator-release-notes
+  - Name: Compliance Operator concepts
+    Dir: co-concepts
+    Topics:
+    - Name: Understanding the Compliance Operator
+      File: compliance-operator-understanding
+    - Name: Understanding the Custom Resource Definitions
+      File: compliance-operator-crd
+  - Name: Compliance Operator management
+    Dir: co-management
+    Distros: openshift-rosa
+    Topics:
+    - Name: Installing the Compliance Operator
+      File: compliance-operator-installation
+    - Name: Updating the Compliance Operator
+      File: compliance-operator-updating
+    - Name: Managing the Compliance Operator
+      File: compliance-operator-manage
+    - Name: Uninstalling the Compliance Operator
+      File: compliance-operator-uninstallation
+  - Name: Compliance Operator scan management
+    Dir: co-scans
+    Distros: openshift-rosa
+    Topics:
+    - Name: Supported compliance profiles
+      File: compliance-operator-supported-profiles
+    - Name: Compliance Operator scans
+      File: compliance-scans
+    - Name: Tailoring the Compliance Operator
+      File: compliance-operator-tailor
+    - Name: Retrieving Compliance Operator raw results
+      File: compliance-operator-raw-results
+    - Name: Managing Compliance Operator remediation
+      File: compliance-operator-remediation
+    - Name: Performing advanced Compliance Operator tasks
+      File: compliance-operator-advanced
+    - Name: Troubleshooting the Compliance Operator
+      File: compliance-operator-troubleshooting
+    - Name: Using the oc-compliance plugin
+      File: oc-compliance-plug-in-using
+- Name: File Integrity Operator
+  Dir: file_integrity_operator
+  Distros: openshift-rosa
+  Topics:
+  - Name: File Integrity Operator release notes
+    File: file-integrity-operator-release-notes
+  - Name: Installing the File Integrity Operator
+    File: file-integrity-operator-installation
+  - Name: Updating the File Integrity Operator
+    File: file-integrity-operator-updating
+  - Name: Understanding the File Integrity Operator
+    File: file-integrity-operator-understanding
+  - Name: Configuring the File Integrity Operator
+    File: file-integrity-operator-configuring
+  - Name: Performing advanced File Integrity Operator tasks
+    File: file-integrity-operator-advanced-usage
+  - Name: Troubleshooting the File Integrity Operator
+    File: file-integrity-operator-troubleshooting
+#- Name: Security Profiles Operator
+#  Dir: security_profiles_operator
+#  Topics:
+#  - Name: Security Profiles Operator overview
+#    File: spo-overview
+#  - Name: Security Profiles Operator release notes
+#    File: spo-release-notes
+#  - Name: Understanding the Security Profiles Operator
+#    File: spo-understanding
+#  - Name: Enabling the Security Profiles Operator
+#    File: spo-enabling
+#  - Name: Managing seccomp profiles
+#    File: spo-seccomp
+#  - Name: Managing SELinux profiles
+#    File: spo-selinux
+#  - Name: Advanced Security Profiles Operator tasks
+#    File: spo-advanced
+#  - Name: Troubleshooting the Security Profiles Operator
+#    File: spo-troubleshooting
+#  - Name: Uninstalling the Security Profiles Operator
+#    File: spo-uninstalling
+# - Name: cert-manager Operator for Red Hat OpenShift
+#   Dir: cert_manager_operator
+#   Distros: openshift-rosa
+#   Topics:
+#  - Name: cert-manager Operator for Red Hat OpenShift overview
+#    File: index
+#  - Name: cert-manager Operator for Red Hat OpenShift release notes
+#    File: cert-manager-operator-release-notes
+#  - Name: Installing the cert-manager Operator for Red Hat OpenShift
+#    File: cert-manager-operator-install
+#  - Name: Enabling monitoring for the cert-manager Operator for Red Hat OpenShift
+#    File: cert-manager-monitoring
+#  - Name: Configuring the egress proxy for the cert-manager Operator for Red Hat OpenShift
+#    File: cert-manager-operator-proxy
+#  - Name: Customizing cert-manager by using the cert-manager Operator API fields
+#    File: cert-manager-customizing-api-fields
+#  - Name: Authenticating the cert-manager Operator with AWS Security Token Service
+#    File: cert-manager-authenticate-aws
+#  - Name: Configuring log levels for cert-manager and the cert-manager Operator for Red Hat OpenShift
+#    File: cert-manager-log-levels
+#  - Name: Authenticating the cert-manager Operator for Red Hat OpenShift on AWS
+#    File: cert-manager-authentication-non-sts
+#  - Name: Uninstalling the cert-manager Operator for Red Hat OpenShift
+#    File: cert-manager-operator-uninstall
+# - Name: Viewing audit logs
+#   File: audit-log-view
+# - Name: Configuring the audit log policy
+#   File: audit-log-policy-config
+# - Name: Configuring TLS security profiles
+#   File: tls-security-profiles
+# - Name: Configuring seccomp profiles
+#   File: seccomp-profiles
+# - Name: Allowing JavaScript-based access to the API server from additional hosts
+#   File: allowing-javascript-access-api-server
+#   Distros: openshift-rosa
+# - Name: Encrypting etcd data
+#   File: encrypting-etcd
+#   Distros: openshift-rosa
+# - Name: Scanning pods for vulnerabilities
+#   File: pod-vulnerability-scan
+#   Distros: openshift-rosa
+# - Name: Network-Bound Disk Encryption (NBDE)
+#   Dir: network_bound_disk_encryption
+#   Topics:
+#  - Name: About disk encryption technology
+#    File: nbde-about-disk-encryption-technology
+#  - Name: Tang server installation considerations
+#    File: nbde-tang-server-installation-considerations
+#  - Name: Tang server encryption key management
+#    File: nbde-managing-encryption-keys
+#  - Name: Disaster recovery considerations
+#    File: nbde-disaster-recovery-considerations
+#    Distros: openshift-rosa
 ---
 Name: Authentication and authorization
 Dir: authentication
@@ -537,15 +775,14 @@ Topics:
     File: using-s21-images
   - Name: Customizing source-to-image images
     File: customizing-s2i-images
----
-  Name: Add-on services
-  Dir: adding_service_cluster
-  Distros: openshift-rosa
-  Topics:
-  - Name: Adding services to a cluster
-    File: adding-service
-  - Name: Available services
-    File: rosa-available-services
+  - Name: Add-on services
+    Dir: adding_service_cluster
+    Distros: openshift-rosa
+    Topics:
+    - Name: Adding services to a cluster
+      File: adding-service
+    - Name: Available services
+      File: rosa-available-services
 ---
 Name: Storage
 Dir: storage
@@ -811,9 +1048,8 @@ Topics:
 - Name: Deployments
   Dir: deployments
   Distros: openshift-rosa
-  Topics:
-    - Name: Custom domains for applications
-      File: osd-config-custom-domains-applications
+- Name: Custom domains for applications
+  File: osd-config-custom-domains-applications
 # - Name: Application GitOps workflows
 #   File: rosa-app-gitops-workflows
 # - Name: Application logging

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1048,6 +1048,7 @@ Topics:
 - Name: Deployments
   Dir: deployments
   Distros: openshift-rosa
+  Topics:
 - Name: Custom domains for applications
   File: osd-config-custom-domains-applications
 # - Name: Application GitOps workflows

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -437,7 +437,7 @@ Topics:
   - Name: Configuring cluster memory to meet container memory and risk requirements
     File: nodes-cluster-resource-configure
 ---
-# Ported PR #62384
+# Ported via PR #62384
 Name: Security and compliance
 Dir: security
 Distros: openshift-rosa
@@ -548,71 +548,72 @@ Topics:
 #    File: oc-compliance-plug-in-using
 #  - Name: Understanding the Custom Resource Definitions
 #    File: compliance-operator-crd
-- Name: Compliance Operator
-  Dir: compliance_operator
-  Distros: openshift-rosa
-  Topics:
-  - Name: Compliance Operator overview
-    File: co-overview
-  - Name: Compliance Operator release notes
-    File: compliance-operator-release-notes
-  - Name: Compliance Operator concepts
-    Dir: co-concepts
-    Topics:
-    - Name: Understanding the Compliance Operator
-      File: compliance-operator-understanding
-    - Name: Understanding the Custom Resource Definitions
-      File: compliance-operator-crd
-  - Name: Compliance Operator management
-    Dir: co-management
-    Distros: openshift-rosa
-    Topics:
-    - Name: Installing the Compliance Operator
-      File: compliance-operator-installation
-    - Name: Updating the Compliance Operator
-      File: compliance-operator-updating
-    - Name: Managing the Compliance Operator
-      File: compliance-operator-manage
-    - Name: Uninstalling the Compliance Operator
-      File: compliance-operator-uninstallation
-  - Name: Compliance Operator scan management
-    Dir: co-scans
-    Distros: openshift-rosa
-    Topics:
-    - Name: Supported compliance profiles
-      File: compliance-operator-supported-profiles
-    - Name: Compliance Operator scans
-      File: compliance-scans
-    - Name: Tailoring the Compliance Operator
-      File: compliance-operator-tailor
-    - Name: Retrieving Compliance Operator raw results
-      File: compliance-operator-raw-results
-    - Name: Managing Compliance Operator remediation
-      File: compliance-operator-remediation
-    - Name: Performing advanced Compliance Operator tasks
-      File: compliance-operator-advanced
-    - Name: Troubleshooting the Compliance Operator
-      File: compliance-operator-troubleshooting
-    - Name: Using the oc-compliance plugin
-      File: oc-compliance-plug-in-using
-- Name: File Integrity Operator
-  Dir: file_integrity_operator
-  Distros: openshift-rosa
-  Topics:
-  - Name: File Integrity Operator release notes
-    File: file-integrity-operator-release-notes
-  - Name: Installing the File Integrity Operator
-    File: file-integrity-operator-installation
-  - Name: Updating the File Integrity Operator
-    File: file-integrity-operator-updating
-  - Name: Understanding the File Integrity Operator
-    File: file-integrity-operator-understanding
-  - Name: Configuring the File Integrity Operator
-    File: file-integrity-operator-configuring
-  - Name: Performing advanced File Integrity Operator tasks
-    File: file-integrity-operator-advanced-usage
-  - Name: Troubleshooting the File Integrity Operator
-    File: file-integrity-operator-troubleshooting
+# Per mtg with Aaren de Jong, Lance Bragstad, and William Dettlebeck, remove  Compliance and File Integrity Operator sections until tested (2/7/2024)
+#- Name: Compliance Operator
+#  Dir: compliance_operator
+#  Distros: openshift-rosa
+#  Topics:
+#  - Name: Compliance Operator overview
+#    File: co-overview
+#  - Name: Compliance Operator release notes
+#    File: compliance-operator-release-notes
+#  - Name: Compliance Operator concepts
+#    Dir: co-concepts
+#    Topics:
+#    - Name: Understanding the Compliance Operator
+#      File: compliance-operator-understanding
+#    - Name: Understanding the Custom Resource Definitions
+#      File: compliance-operator-crd
+#  - Name: Compliance Operator management
+#    Dir: co-management
+#    Distros: openshift-rosa
+#    Topics:
+#    - Name: Installing the Compliance Operator
+#      File: compliance-operator-installation
+#    - Name: Updating the Compliance Operator
+#      File: compliance-operator-updating
+#    - Name: Managing the Compliance Operator
+#      File: compliance-operator-manage
+#    - Name: Uninstalling the Compliance Operator
+#      File: compliance-operator-uninstallation
+#  - Name: Compliance Operator scan management
+#    Dir: co-scans
+#    Distros: openshift-rosa
+#    Topics:
+#    - Name: Supported compliance profiles
+#      File: compliance-operator-supported-profiles
+#    - Name: Compliance Operator scans
+#      File: compliance-scans
+#    - Name: Tailoring the Compliance Operator
+#      File: compliance-operator-tailor
+#    - Name: Retrieving Compliance Operator raw results
+#      File: compliance-operator-raw-results
+#    - Name: Managing Compliance Operator remediation
+#      File: compliance-operator-remediation
+#    - Name: Performing advanced Compliance Operator tasks
+#      File: compliance-operator-advanced
+#    - Name: Troubleshooting the Compliance Operator
+#      File: compliance-operator-troubleshooting
+#    - Name: Using the oc-compliance plugin
+#      File: oc-compliance-plug-in-using
+#- Name: File Integrity Operator
+#  Dir: file_integrity_operator
+#  Distros: openshift-rosa
+#  Topics:
+#  - Name: File Integrity Operator release notes
+#    File: file-integrity-operator-release-notes
+#  - Name: Installing the File Integrity Operator
+#    File: file-integrity-operator-installation
+#  - Name: Updating the File Integrity Operator
+#    File: file-integrity-operator-updating
+#  - Name: Understanding the File Integrity Operator
+#    File: file-integrity-operator-understanding
+#  - Name: Configuring the File Integrity Operator
+#    File: file-integrity-operator-configuring
+#  - Name: Performing advanced File Integrity Operator tasks
+#    File: file-integrity-operator-advanced-usage
+#  - Name: Troubleshooting the File Integrity Operator
+#    File: file-integrity-operator-troubleshooting
 #- Name: Security Profiles Operator
 #  Dir: security_profiles_operator
 #  Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1049,8 +1049,8 @@ Topics:
   Dir: deployments
   Distros: openshift-rosa
   Topics:
-- Name: Custom domains for applications
-  File: osd-config-custom-domains-applications
+  - Name: Custom domains for applications
+    File: osd-config-custom-domains-applications
 # - Name: Application GitOps workflows
 #   File: rosa-app-gitops-workflows
 # - Name: Application logging

--- a/modules/checking-file-intergrity-cr-status.adoc
+++ b/modules/checking-file-intergrity-cr-status.adoc
@@ -12,10 +12,19 @@ The `FileIntegrity` custom resource (CR) reports its status through the .`status
 
 * To query the `FileIntegrity` CR status, run:
 +
+ifndef::openshift-dedicated,openshift-rosa[]
 [source,terminal]
 ----
 $ oc get fileintegrities/worker-fileintegrity  -o jsonpath="{ .status.phase }"
 ----
+endif::[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[source,terminal]
+----
+$ oc get fileintegrities/worker-fileintegrity  -o jsonpath="{ .status.phase }" -n openshift-file-integrity
+----
+endif::[]
 +
 .Example output
 [source,terminal]

--- a/modules/file-integrity-events.adoc
+++ b/modules/file-integrity-events.adoc
@@ -10,7 +10,12 @@ Transitions in the status of the `FileIntegrity` and `FileIntegrityNodeStatus` o
 
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc get events --field-selector reason=FileIntegrityStatus
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc get events --field-selector reason=FileIntegrityStatus -n openshift-file-integrity
+endif::[]
 ----
 
 .Example output
@@ -26,7 +31,12 @@ When a node scan fails, an event is created with the `add/changed/removed` and c
 
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc get events --field-selector reason=NodeIntegrityStatus
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc get events --field-selector reason=NodeIntegrityStatus -n openshift-file-integrity
+endif::[]
 ----
 
 .Example output
@@ -46,7 +56,12 @@ Changes to the number of added, changed, or removed files results in a new event
 
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc get events --field-selector reason=NodeIntegrityStatus
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc get events --field-selector reason=NodeIntegrityStatus -n openshift-file-integrity
+endif::[]
 ----
 
 .Example output

--- a/modules/file-integrity-examine-default-config.adoc
+++ b/modules/file-integrity-examine-default-config.adoc
@@ -15,5 +15,10 @@ the same name as the `FileIntegrity` CR.
 +
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc describe cm/worker-fileintegrity
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc describe cm/worker-fileintegrity -n openshift-file-integrity
+endif::[]
 ----

--- a/modules/file-integrity-node-status-failure.adoc
+++ b/modules/file-integrity-node-status-failure.adoc
@@ -7,10 +7,19 @@
 
 To simulate a failure condition, modify one of the files AIDE tracks. For example, modify `/etc/resolv.conf` on one of the worker nodes:
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [source,terminal]
 ----
 $ oc debug node/ip-10-0-130-192.ec2.internal
 ----
+endif[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[source,terminal]
+----
+$ oc debug node/ip-10-0-130-192.ec2.internal -n openshift-file-integrity
+----
+endif[]
 
 .Example output
 [source,terminal]
@@ -31,15 +40,26 @@ After some time, the `Failed` condition is reported in the results array of the 
 
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc get fileintegritynodestatuses.fileintegrity.openshift.io/worker-fileintegrity-ip-10-0-130-192.ec2.internal -ojsonpath='{.results}' | jq -r
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc get fileintegritynodestatuses.fileintegrity.openshift.io/worker-fileintegrity-ip-10-0-130-192.ec2.internal -ojsonpath='{.results}' | jq -r -n openshift-file-integrity
+endif::[]
 ----
 
 Alternatively, if you are not mentioning the object name, run:
 
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc get fileintegritynodestatuses.fileintegrity.openshift.io -ojsonpath='{.items[*].results}' | jq
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc get fileintegritynodestatuses.fileintegrity.openshift.io -ojsonpath='{.items[*].results}' | jq -n openshift-file-integrity
+endif::[]
 ----
+endif::[]
 
 .Example output
 [source,terminal]
@@ -63,7 +83,12 @@ The `Failed` condition points to a config map that gives more details about what
 
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc describe cm aide-ds-worker-fileintegrity-ip-10-0-130-192.ec2.internal-failed
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc describe cm aide-ds-worker-fileintegrity-ip-10-0-130-192.ec2.internal-failed -n openshift-file-integrity
+endif::[]
 ----
 
 .Example output

--- a/modules/file-integrity-operator-defining-custom-config.adoc
+++ b/modules/file-integrity-operator-defining-custom-config.adoc
@@ -27,7 +27,12 @@ to deploy a custom software running as a daemon set and storing its data under
 +
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc extract cm/worker-fileintegrity --keys=aide.conf
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc extract cm/worker-fileintegrity --keys=aide.conf -n openshift-file-integrity
+endif::[]
 ----
 +
 This creates a file named `aide.conf` that you can edit. To illustrate how the
@@ -68,10 +73,22 @@ Store the other content in `/etc`:
 +
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc create cm master-aide-conf --from-file=aide.conf
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc create cm master-aide-conf --from-file=aide.conf -n openshift-file-integrity
+endif::[]
 ----
 
 . Define a `FileIntegrity` CR manifest that references the config map:
++
+ifdef::openshift-dedicated,openshift-rosa[]
+[source,terminal]
+----
+$ oc create -f master-fileintegrity.yaml -n openshift-file-integrity
+----
+endif::[] 
 +
 [source,yaml]
 ----
@@ -93,7 +110,12 @@ config map with the same name as the `FileIntegrity` object:
 +
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc describe cm/master-fileintegrity | grep /opt/mydaemon
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc describe cm/master-fileintegrity | grep /opt/mydaemon -n openshift-file-integrity
+endif::[]
 ----
 +
 .Example output

--- a/modules/file-integrity-operator-reinitializing-database.adoc
+++ b/modules/file-integrity-operator-reinitializing-database.adoc
@@ -14,7 +14,12 @@ If the File Integrity Operator detects a change that was planned, it might be re
 +
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc annotate fileintegrities/worker-fileintegrity file-integrity.openshift.io/re-init=
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc annotate fileintegrities/worker-fileintegrity file-integrity.openshift.io/re-init= -n openshift-file-integrity
+endif::[]
 ----
 +
 The old database and log files are backed up and a new database is initialized. The old database and logs are retained on the nodes under `/etc/kubernetes`, as

--- a/modules/file-integrity-understanding-file-integrity-node-statuses-object.adoc
+++ b/modules/file-integrity-understanding-file-integrity-node-statuses-object.adoc
@@ -8,10 +8,19 @@
 
 The scan results of the `FileIntegrity` CR are reported in another object called `FileIntegrityNodeStatuses`.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [source,terminal]
 ----
-$ oc get fileintegritynodestatuses
+$ oc get fileintegritynodestatuses 
 ----
+endif::[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[source,terminal]
+----
+$ oc get fileintegritynodestatuses -n openshift-file-integrity
+----
+endif::[]
 
 .Example output
 [source,terminal]

--- a/modules/running-compliance-scans.adoc
+++ b/modules/running-compliance-scans.adoc
@@ -8,10 +8,12 @@
 
 You can run a scan using the Center for Internet Security (CIS) profiles. For convenience, the Compliance Operator creates a `ScanSetting` object with reasonable defaults on startup. This `ScanSetting` object is named `default`.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [NOTE]
 ====
 For all-in-one control plane and worker nodes, the compliance scan runs twice on the worker and control plane nodes. The compliance scan might generate inconsistent scan results. You can avoid inconsistent results by defining only a single role in the `ScanSetting` object.
 ====
+endif::[]
 
 .Procedure
 

--- a/modules/security-hosts-vms-openshift.adoc
+++ b/modules/security-hosts-vms-openshift.adoc
@@ -4,6 +4,7 @@
 
 [id="security-hosts-vms-openshift_{context}"]
 = Securing {product-title}
+ifndef::openshift-dedicated,openshift-rosa[]
 When you deploy {product-title}, you have the choice of an
 installer-provisioned infrastructure (there are several available platforms)
 or your own user-provisioned infrastructure.
@@ -18,15 +19,23 @@ Some low-level security-related configuration, such as adding kernel modules req
 benefit from a user-provisioned infrastructure.
 endif::[]
 Likewise, user-provisioned infrastructure is appropriate for disconnected {product-title} deployments.
+endif::openshift-dedicated,openshift-rosa[]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 Keep in mind that, when it comes to making security enhancements and other
 configuration changes to {product-title}, the goals should include:
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+When it comes to making security enhancements and other
+configuration changes to {product-title}, the goals should include:
+endif::[]
 
 * Keeping the underlying nodes as generic as possible. You want to be able to
 easily throw away and spin up similar nodes quickly and in prescriptive ways.
 * Managing modifications to nodes through {product-title} as much as possible,
 rather than making direct, one-off changes to the nodes.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 In pursuit of those goals, most node changes should be done during installation through Ignition
 or later using MachineConfigs that are applied to sets of nodes by the Machine Config Operator.
 Examples of security-related configuration changes you can do in this way include:
@@ -40,6 +49,13 @@ Examples of security-related configuration changes you can do in this way includ
 * Configuring disk encryption
 
 * Configuring the chrony time service
+endif::[]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 Besides the Machine Config Operator, there are several other Operators available to configure {product-title} infrastructure that are managed by the Cluster Version Operator (CVO). The CVO is able to automate many aspects of
 {product-title} cluster updates.
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+There are several other Operators available to configure {product-title} infrastructure that are managed by the Cluster Version Operator (CVO). The CVO is able to automate many aspects of
+{product-title} cluster updates.
+endif::[]

--- a/modules/security-hosts-vms-rhcos.adoc
+++ b/modules/security-hosts-vms-rhcos.adoc
@@ -9,7 +9,12 @@ Containers simplify the act of deploying many applications to run on the same ho
 
 In Linux, containers are just a special type of process, so securing containers is similar in many ways to securing any other running process. An environment for running containers starts with an operating system that can secure the host kernel from containers and other processes running on the host, as well as secure containers from each other.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 Because {product-title} {product-version} runs on {op-system} hosts, with the option of using {op-system-base-full} as worker nodes, the following concepts apply by default to any deployed {product-title} cluster. These {op-system-base} security features are at the core of what makes running containers in {product-title} more secure:
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+Because {product-title} {product-version} runs on {op-system} hosts, the following concepts apply by default to any deployed {product-title} cluster. These {op-system} security features are at the core of what makes running containers in {product-title} more secure:
+endif::[]
 
 * _Linux namespaces_ enable creating an abstraction of a particular global system resource to make it appear as a separate instance to processes within a namespace. Consequently, several containers can use the same computing resource simultaneously without creating a conflict. Container namespaces that are separate from the host by default include mount table, process table, network interface, user, control group, UTS, and IPC namespaces. Those containers that need direct access to host namespaces need to have elevated permissions to request that access.
 ifdef::openshift-enterprise,openshift-webscale,openshift-aro[]

--- a/security/certificates/replacing-default-ingress-certificate.adoc
+++ b/security/certificates/replacing-default-ingress-certificate.adoc
@@ -15,4 +15,6 @@ include::modules/customize-certificates-replace-default-router.adoc[leveloffset=
 == Additional resources
 
 * xref:../../security/certificates/updating-ca-bundle.adoc#ca-bundle-understanding_updating-ca-bundle[Replacing the CA Bundle certificate]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../security/certificate_types_descriptions/proxy-certificates.adoc#customization[Proxy certificate customization]
+endif::[]

--- a/security/certificates/updating-ca-bundle.adoc
+++ b/security/certificates/updating-ca-bundle.adoc
@@ -20,5 +20,7 @@ include::modules/ca-bundle-replacing.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress_replacing-default-ingress[Replacing the default ingress certificate]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../networking/enable-cluster-wide-proxy.adoc#nw-proxy-configure-object_config-cluster-wide-proxy[Enabling the cluster-wide proxy]
 * xref:../../security/certificate_types_descriptions/proxy-certificates.adoc#customization[Proxy certificate customization]
+endif::[]

--- a/security/compliance_operator/co-management/compliance-operator-installation.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-installation.adoc
@@ -8,10 +8,26 @@ toc::[]
 
 Before you can use the Compliance Operator, you must ensure it is deployed in the cluster.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [IMPORTANT]
 ====
 The Compliance Operator might report incorrect results on managed platforms, such as OpenShift Dedicated, Red Hat OpenShift Service on AWS, and Microsoft Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
 ====
+endif::[]
+
+ifdef::openshift-rosa[]
+[IMPORTANT]
+====
+The Compliance Operator might report incorrect results on managed platforms, such as {product-rosa}. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
+====
+endif::[]
+
+ifdef::openshift-dedicated[]
+[IMPORTANT]
+====
+The Compliance Operator might report incorrect results on managed platforms, such as {product-short-name}. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
+====
+endif::[]
 
 include::modules/compliance-operator-console-installation.adoc[leveloffset=+1]
 
@@ -33,6 +49,7 @@ You can create a custom SCC for the Compliance Operator scanner pod service acco
 
 // only applies to 4.11+
 include::modules/compliance-operator-hcp-install.adoc[leveloffset=+1]
+ifndef::openshift-dedicated,openshift-rosa[]
 
 [role="_additional-resources"]
 .Additional resources
@@ -43,8 +60,10 @@ include::modules/compliance-operator-hcp-install.adoc[leveloffset=+1]
 // 4.11-4.12, commenting out of 4.13-main
 //* xref:../../../architecture/control-plane.adoc#hosted-control-planes-overview_control-plane[Overview of hosted control planes (Technology Preview)]
 
+
 [id="additional-resources-installing-the-compliance-operator"]
 [role="_additional-resources"]
 == Additional resources
 
 * The Compliance Operator is supported in a restricted network environment. For more information, see xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+endif::[]

--- a/security/compliance_operator/co-management/compliance-operator-manage.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-manage.adoc
@@ -12,8 +12,10 @@ include::modules/compliance-profilebundle.adoc[leveloffset=+1]
 
 include::modules/compliance-update.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [id="additional-resources_managing-the-compliance-operator"]
 [role="_additional-resources"]
 == Additional resources
 
 * The Compliance Operator is supported in a restricted network environment. For more information, see xref:../../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+endif::[]

--- a/security/compliance_operator/co-scans/compliance-operator-remediation.adoc
+++ b/security/compliance_operator/co-scans/compliance-operator-remediation.adoc
@@ -6,7 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Each `ComplianceCheckResult` represents a result of one compliance rule check. If the rule can be remediated automatically, a `ComplianceRemediation` object with the same name, owned by the `ComplianceCheckResult` is created. Unless requested, the remediations are not applied automatically, which gives an {product-title} administrator the opportunity to review what the remediation does and only apply a remediation once it has been verified.
+ifndef::openshift-dedicated,openshift-rosa[]
+Each `ComplianceCheckResult` represents a result of one compliance rule check. If the rule can be remediated automatically, a `ComplianceRemediation` object with the same name, owned by the `ComplianceCheckResult` is created. Unless requested, the remediations are not applied automatically, which gives an {product-title} administrator the opportunity to review what the remediation does and only apply a remediation after it has been verified.
+endif::[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+Each `ComplianceCheckResult` represents a result of one compliance rule check. Auto-remediation cannot be applied to managed systems.
+endif::[]
 
 [IMPORTANT]
 ====
@@ -18,17 +24,30 @@ FIPS mode is supported on the following architectures:
 * `ppc64le`
 * `s390x`
 ====
+ifdef::openshift-dedicated,openshift-rosa[]
+[NOTE]
+====
+{product-rosa} does not support auto-remediation.
+====
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/compliance-filtering-results.adoc[leveloffset=+1]
 
 include::modules/compliance-review.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/compliance-apply-remediation-for-customized-mcp.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/compliance-evaluate-kubeletconfig-rules.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/compliance-custom-node-pools.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
 
+// Auto-remediation is not supported in ROSA or any managed service.
+
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/compliance-kubeletconfig-sub-pool-remediation.adoc[leveloffset=+1]
 
 include::modules/compliance-applying.adoc[leveloffset=+1]
@@ -47,3 +66,4 @@ include::modules/compliance-inconsistent.adoc[leveloffset=+1]
 == Additional resources
 
 *  xref:../../../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing-about_nodes-nodes-managing[Modifying nodes].
+endif::openshift-dedicated,openshift-rosa[]

--- a/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
+++ b/security/compliance_operator/co-scans/compliance-operator-supported-profiles.adoc
@@ -7,10 +7,26 @@ include::_attributes/common-attributes.adoc[]
 There are several profiles available as part of the Compliance Operator (CO) installation. While you can use the following profiles to assess gaps in a cluster, usage alone does not infer or guarantee compliance with a particular profile.
 
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [IMPORTANT]
 ====
 The Compliance Operator might report incorrect results on managed platforms, such as OpenShift Dedicated, Red Hat OpenShift Service on AWS, and Azure Red Hat OpenShift. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
 ====
+endif::[]
+
+ifdef::openshift-rosa[]
+[IMPORTANT]
+====
+The Compliance Operator might report incorrect results on managed platforms, such as {product-rosa}. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
+====
+endif::[]
+
+ifdef::openshift-dedicated[]
+[IMPORTANT]
+====
+The Compliance Operator might report incorrect results on managed platforms, such as {product-short-name}. For more information, see the link:https://access.redhat.com/solutions/6983418[Red Hat Knowledgebase Solution #6983418].
+====
+endif::[]
 
 include::modules/compliance-supported-profiles.adoc[leveloffset=+1]
 

--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -129,7 +129,9 @@ The following advisory is available for the OpenShift Compliance Operator 1.1.0:
 
 * A start and end timestamp is now available in the `ComplianceScan` custom resource definition (CRD) status.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * The Compliance Operator can now be deployed on Hosted Control Planes using the OperatorHub by creating a `Subscription` file. For more information, see xref:../../security/compliance_operator/co-management/compliance-operator-installation.adoc#installing-compliance-operator-hcp_compliance-operator-installation[Installing the Compliance Operator on Hosted Control Planes].
+endif::openshift-dedicated,openshift-rosa[]
 
 [id="compliance-operator-1-1-0-bug-fixes"]
 === Bug fixes

--- a/security/container_security/security-hosts-vms.adoc
+++ b/security/container_security/security-hosts-vms.adoc
@@ -18,8 +18,11 @@ include::modules/security-hosts-vms-rhcos.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../nodes/nodes/nodes-nodes-resources-configuring.adoc#allocate-node-enforcement_nodes-nodes-resources-configuring[How nodes enforce resource constraints]
+endif::[]
 * xref:../../authentication/managing-security-context-constraints.adoc#managing-pod-security-policies[Managing security context constraints]
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../architecture/architecture-installation.adoc#supported-platforms-for-openshift-clusters_architecture-installation[Supported platforms for OpenShift clusters]
 * xref:../../installing/installing_bare_metal/installing-bare-metal.adoc#installation-requirements-user-infra_installing-bare-metal[Requirements for a cluster with user-provisioned infrastructure]
 * xref:../../architecture/architecture-rhcos.adoc#rhcos-configured_architecture-rhcos[Choosing how to configure {op-system}]
@@ -29,6 +32,8 @@ include::modules/security-hosts-vms-rhcos.adoc[leveloffset=+1]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-encrypt-disk_installing-customizing[Disk encryption]
 * xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-chrony_installing-customizing[Chrony time service]
 * xref:../../updating/understanding_updates/intro-to-updates.adoc#update-service-about_understanding-openshift-updates[About the OpenShift Update Service]
+endif::[]
+
 ////
 ifndef::openshift-origin[]
 * xref:../../installing/installing-fips.adoc#installing-fips[FIPS cryptography]

--- a/security/container_security/security-understanding.adoc
+++ b/security/container_security/security-understanding.adoc
@@ -11,11 +11,19 @@ Securing a containerized application relies on multiple levels of security:
 * Container security begins with a trusted base container image and continues
 through the container build process as it moves through your CI/CD pipeline.
 +
+ifndef::openshift-dedicated,openshift-rosa[]
 [IMPORTANT]
 ====
 Image streams by default do not automatically update. This default behavior might create a security issue because security updates to images referenced by an image stream do not automatically occur.
 For information about how to override this default behavior, see xref:../../openshift_images/image-streams-manage.adoc#images-imagestreams-import_image-streams-managing[Configuring periodic importing of imagestreamtags].
 ====
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+[IMPORTANT]
+====
+Image streams by default do not automatically update. This default behavior might create a security issue because security updates to images referenced by an image stream do not automatically occur.
+====
+endif::openshift-dedicated,openshift-rosa[]
 * When a container is deployed, its security depends on it running
 on secure operating systems and networks, and
 establishing firm boundaries between the container itself and
@@ -42,8 +50,14 @@ help you achieve those security measures.
 This guide contains the following information:
 
 * Why container security is important and how it compares with existing security standards.
+ifndef::openshift-dedicated,openshift-rosa[]
 * Which container security measures are provided by the host ({op-system} and {op-system-base}) layer and
 which are provided by {product-title}.
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* Which container security measures are provided by the host ({op-system}) layer and
+which are provided by {product-title}.
+endif::[]
 * How to evaluate your container content and sources for vulnerabilities.
 * How to design your build and deployment process to proactively check container content.
 * How to control access to containers through authentication and authorization.
@@ -62,7 +76,15 @@ include::modules/security-understanding-containers.adoc[leveloffset=+1]
 // What is OpenShift?
 include::modules/security-understanding-openshift.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../architecture/architecture.adoc#architecture[{product-title} architecture]
 * link:https://www.redhat.com/en/resources/openshift-security-guide-ebook[OpenShift Security Guide]
+endif::[]
+
+ifdef::openshift-dedicated,openshift-rosa[]
+[role="_additional-resources"]
+.Additional resources
+* link:https://www.redhat.com/en/resources/openshift-security-guide-ebook[OpenShift Security Guide]
+endif::[]

--- a/security/file_integrity_operator/file-integrity-operator-installation.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-installation.adoc
@@ -11,8 +11,10 @@ include::modules/file-integrity-operator-installing-web-console.adoc[leveloffset
 
 include::modules/file-integrity-operator-installing-cli.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [id="additional-resources-installing-the-file-integrity-operator"]
 [role="_additional-resources"]
 == Additional resources
 
 * The File Integrity Operator is supported in a restricted network environment. For more information, see xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[Using Operator Lifecycle Manager on restricted networks].
+endif::[]

--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -60,7 +60,7 @@ The following advisory is available for the OpenShift File Integrity Operator 1.
 [id="file-integrity-operator-1-3-1-new-features-and-enhancements"]
 === New features and enhancements
 
-* FIO now includes kubelet certificates as default files, excluding them from issuing warnings when they're managed by {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-14348[*OCPBUGS-14348*])
+* FIO now includes kubelet certificates as default files, excluding them from issuing warnings when they are managed by {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-14348[*OCPBUGS-14348*])
 
 * FIO now correctly directs email to the address for Red Hat Technical Support. (link:https://issues.redhat.com/browse/OCPBUGS-5023[*OCPBUGS-5023*])
 
@@ -73,10 +73,12 @@ The following advisory is available for the OpenShift File Integrity Operator 1.
 
 * Previously, when FIO was reconciling `FileIntegrity` CRDs, it would pause scanning until the reconciliation was done. This caused an overly aggressive re-initiatization process on nodes not impacted by the reconciliation. This problem also resulted in unnecessary daemonsets for machine config pools which are unrelated to the `FileIntegrity` being changed. FIO correctly handles these cases and only pauses AIDE scanning for nodes that are affected by file integrity changes. (link:https://issues.redhat.com/browse/CMP-1097[*CMP-1097*])
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [id="file-integrity-operator-1-3-1-known-issues"]
 === Known Issues
 
 In FIO 1.3.1, increasing nodes in {ibmzProductName} clusters might result in `Failed` File Integrity node status. For more information, see link:https://access.redhat.com/solutions/7028861[Adding nodes in IBM Power clusters can result in failed File Integrity node status].
+endif::[]
 
 [id="file-integrity-operator-release-notes-1-2-1"]
 == OpenShift File Integrity Operator 1.2.1
@@ -129,6 +131,7 @@ The following advisory is available for the OpenShift File Integrity Operator 0.
 
 * link:https://access.redhat.com/errata/RHBA-2022:5538[RHBA-2022:5538 OpenShift File Integrity Operator Bug Fix and Enhancement Update]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [id="file-integrity-operator-0-1-30-new-features-and-enhancements"]
 === New features and enhancements
 
@@ -136,6 +139,7 @@ The following advisory is available for the OpenShift File Integrity Operator 0.
 +
 ** IBM Power
 ** IBM Z and LinuxONE
+endif::[]
 
 [id="file-integrity-operator-0-1-30-bug-fixes"]
 === Bug fixes
@@ -171,7 +175,7 @@ The following advisory is available for the OpenShift File Integrity Operator 0.
 [id="openshift-file-integrity-operator-0-1-22-bug-fixes"]
 === Bug fixes
 
-* Previously, a system with a File Integrity Operator installed might interrupt the {product-title} update, due to the  `/etc/kubernetes/aide.reinit` file. This occurred if the `/etc/kubernetes/aide.reinit` file was present, but later removed prior to the `ostree` validation. With this update, `/etc/kubernetes/aide.reinit` is moved to the `/run` directory so that it does not conflict with the {product-title} update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033311[*BZ#2033311*])
+* Previously, a system with a File Integrity Operator installed might interrupt the {product-title} update, due to the  `/etc/kubernetes/aide.reinit` file. This occurred if the `/etc/kubernetes/aide.reinit` file was present, but later removed before the `ostree` validation. With this update, `/etc/kubernetes/aide.reinit` is moved to the `/run` directory so that it does not conflict with the {product-title} update. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2033311[*BZ#2033311*])
 
 [id="file-integrity-operator-release-notes-0-1-21"]
 == OpenShift File Integrity Operator 0.1.21

--- a/security/file_integrity_operator/file-integrity-operator-troubleshooting.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-troubleshooting.adoc
@@ -37,7 +37,12 @@ To see the `FileIntegrity` object's current status, run:
 +
 [source,terminal]
 ----
+ifndef::openshift-dedicated,openshift-rosa[]
 $ oc get fileintegrities/worker-fileintegrity  -o jsonpath="{ .status }"
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+$ oc get fileintegrities/worker-fileintegrity  -o jsonpath="{ .status }" -n openshift-file-integrity
+endif::[]
 ----
 +
 Once the `FileIntegrity` object and the backing daemon set are created, the status

--- a/security/index.adoc
+++ b/security/index.adoc
@@ -20,19 +20,25 @@ It is important to understand how to properly secure various aspects of your {pr
 A good starting point to understanding {product-title} security is to review the concepts in xref:../security/container_security/security-understanding.adoc#security-understanding[Understanding container security]. This and subsequent sections provide a high-level walkthrough of the container security measures available in {product-title}, including solutions for the host layer, the container and orchestration layer, and the build and application layer. These sections also include information on the following topics:
 
 * Why container security is important and how it compares with existing security standards.
-* Which container security measures are provided by the host ({op-system} and {op-system-base}) layer and
-which are provided by {product-title}.
+ifndef::openshift-dedicated,openshift-rosa[]
+* Which container security measures are provided by the host ({op-system} and {op-system-base}) layer and which are provided by {product-title}.
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* Which container security measures are provided by the host ({op-system}) layer and which are provided by {product-title}.
+endif::[]
 * How to evaluate your container content and sources for vulnerabilities.
 * How to design your build and deployment process to proactively check container content.
 * How to control access to containers through authentication and authorization.
 * How networking and attached storage are secured in {product-title}.
 * Containerized solutions for API management and SSO.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [discrete]
 [id="auditing"]
 === Auditing
 
 {product-title} auditing provides a security-relevant chronological set of records documenting the sequence of activities that have affected the system by individual users, administrators, or other components of the system. Administrators can xref:../security/audit-log-policy-config.adoc#audit-log-policy-config[configure the audit log policy] and xref:../security/audit-log-view.adoc#audit-log-view[view audit logs].
+endif::[]
 
 [discrete]
 [id="certificates"]
@@ -40,6 +46,7 @@ which are provided by {product-title}.
 
 Certificates are used by various components to validate access to the cluster. Administrators can xref:../security/certificates/replacing-default-ingress-certificate.adoc#replacing-default-ingress[replace the default ingress certificate], xref:../security/certificates/api-server.adoc#api-server-certificates[add API server certificates], or xref:../security/certificates/service-serving-certificate.adoc#add-service-serving[add a service certificate].
 
+ifndef::openshift-dedicated,openshift-rosa[]
 You can also review more details about the types of certificates used by the cluster:
 
 // TODO: there isn't a cert description landing page. Consider adding one instead of all of these links?
@@ -56,18 +63,25 @@ You can also review more details about the types of certificates used by the clu
 * xref:../security/certificate_types_descriptions/ingress-certificates.adoc#cert-types-ingress-certificates[Ingress certificates]
 * xref:../security/certificate_types_descriptions/monitoring-and-cluster-logging-operator-component-certificates.adoc#cert-types-monitoring-and-cluster-logging-operator-component-certificates[Monitoring and cluster logging Operator component certificates]
 * xref:../security/certificate_types_descriptions/control-plane-certificates.adoc#cert-types-control-plane-certificates[Control plane certificates]
+endif::[]
 
+
+ifndef::openshift-dedicated,openshift-rosa[]
 [discrete]
 [id="encrypting-data"]
 === Encrypting data
 
 You can xref:../security/encrypting-etcd.adoc#encrypting-etcd[enable etcd encryption] for your cluster to provide an additional layer of data security. For example, it can help protect the loss of sensitive data if an etcd backup is exposed to the incorrect parties.
+endif::[]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [discrete]
 [id="vulnerability-scanning"]
 === Vulnerability scanning
 
 Administrators can use the {rhq-cso} to run xref:../security/pod-vulnerability-scan.adoc#pod-vulnerability-scan[vulnerability scans] and review information about detected vulnerabilities.
+endif::[]
+
 
 [id="compliance-overview"]
 == Compliance overview
@@ -80,18 +94,25 @@ For many {product-title} customers, regulatory readiness, or compliance, on some
 
 Administrators can use the xref:../security/compliance_operator/co-concepts/compliance-operator-understanding.adoc#understanding-compliance-operator[Compliance Operator] to run compliance scans and recommend remediations for any issues found. The xref:../security/compliance_operator/co-scans/oc-compliance-plug-in-using.adoc#using-oc-compliance-plug-in[`oc-compliance` plugin] is an OpenShift CLI (`oc`) plugin that provides a set of utilities to easily interact with the Compliance Operator.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [discrete]
 [id="file-integrity-checking"]
 === File integrity checking
 
 Administrators can use the xref:../security/file_integrity_operator/file-integrity-operator-understanding.adoc#understanding-file-integrity-operator[File Integrity Operator] to continually run file integrity checks on cluster nodes and provide a log of files that have been modified.
+endif::[]
 
 [id="additional-resources_security-compliance-overview"]
 [role="_additional-resources"]
 == Additional resources
-
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../authentication/understanding-authentication.adoc#understanding-authentication[Understanding authentication]
 * xref:../authentication/configuring-internal-oauth.adoc#configuring-internal-oauth[Configuring the internal OAuth server]
 * xref:../authentication/understanding-identity-provider.adoc#understanding-identity-provider[Understanding identity provider configuration]
 * xref:../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions]
+endif::[]
 * xref:../authentication/managing-security-context-constraints.adoc#managing-pod-security-policies[Managing security context constraints]
+ifdef::openshift-dedicated,openshift-rosa[]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-policy-process-security.adoc#rosa-policy-process-security[Understanding security for {product-rosa}]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-service-definition[ROSA service definition]
+endif::[]


### PR DESCRIPTION
This PR is to port the "Security and compliance" OCP content to ROSA. Reference that section only for comments, reviews, etc.
[OSDOCS-3995](https://issues.redhat.com//browse/OSDOCS-3995)

Version(s): 

Link to docs preview (local build): https://file.rdu.redhat.com/tlove/sd-port-security-tlove/security/index.html (Updated 3/5)

QE review:
- [ ] QE has approved this change.

