### PR TITLE
OSDOCS 5806: Adding docs for using the secrets store CSI driver

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -192,3 +192,5 @@ endif::[]
 // Web terminal
 :web-terminal-op: Web Terminal Operator
 :devworkspace-op: DevWorkspace Operator
+:secrets-store-driver: Secrets Store CSI driver
+:secrets-store-operator: Secrets Store CSI Driver Operator

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2221,8 +2221,10 @@ Topics:
     File: nodes-pods-autoscaling
   - Name: Automatically adjust pod resource levels with the vertical pod autoscaler
     File: nodes-pods-vertical-autoscaler
-  - Name: Providing sensitive data to pods
+  - Name: Providing sensitive data to pods by using secrets
     File: nodes-pods-secrets
+  - Name: Providing sensitive data to pods by using an external secrets store
+    File: nodes-pods-secrets-store
   - Name: Creating and using config maps
     File: nodes-pods-configmaps
   - Name: Using Device Manager to make devices available to nodes

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -74,6 +74,10 @@ endif::openshift-dedicated[]
 
 |`registry.redhat.io/openshift-gitops-1/must-gather-rhel8:v<installed_version_GitOps>`
 |Data collection for {gitops-title}.
+
+|`registry.redhat.io/openshift4/ose-csi-driver-shared-resource-mustgather-rhel8:v<installed_version_secret_store>`
+|Data collection for the {secrets-store-operator}.
+
 |===
 
 [NOTE]
@@ -112,6 +116,9 @@ ifndef::openshift-dedicated[]
 |`quay.io/openshift/origin-local-storage-mustgather`
 |Data collection for Local Storage Operator.
 endif::openshift-dedicated[]
+
+|`quay.io/openshift/origin-secrets-store-csi-mustgather`
+|Data collection for the {secrets-store-operator}.
 
 |===
 

--- a/modules/persistent-storage-csi-secrets-store-driver-install.adoc
+++ b/modules/persistent-storage-csi-secrets-store-driver-install.adoc
@@ -5,7 +5,7 @@
 
 :_content-type: PROCEDURE
 [id="persistent-storage-csi-secrets-store-driver-install_{context}"]
-= Installing the Secrets Store CSI Driver
+= Installing the {secrets-store-driver}
 
 .Prerequisites
 * Access to the {product-title} web console.
@@ -14,12 +14,12 @@
 
 .Procedure
 
-To install the Secrets Store CSI Driver:
+To install the {secrets-store-driver}:
 
-. Install the Secrets Store Container Storage Interface (CSI) driver operator:
+. Install the {secrets-store-operator}:
 .. Log in to the web console.
 .. Click *Operators* → *OperatorHub*.
-.. Locate the Secrets Store CSI Operator by typing "Secrets Store CSI" in the filter box.
+.. Locate the {secrets-store-operator} by typing "Secrets Store CSI" in the filter box.
 .. Click the *Secrets Store CSI Driver Operator* button.
 .. On the *Secrets Store CSI Driver Operator* page, click *Install*.
 .. On the *Install Operator* page, ensure that:
@@ -29,7 +29,7 @@ To install the Secrets Store CSI Driver:
 * *Installed Namespace* is set to *openshift-cluster-csi-drivers*.
 .. Click *Install*.
 +
-After the installation finishes, the Secrets Store CSI Operator is listed in the *Installed Operators* section of the web console.
+After the installation finishes, the {secrets-store-operator} is listed in the *Installed Operators* section of the web console.
 
 . Create the `ClusterCSIDriver` instance for the driver (`secrets-store.csi.k8s.io`):
 .. Click *Administration* -> *CustomResourceDefinitions* -> *ClusterCSIDriver*.
@@ -47,6 +47,3 @@ spec:
   managementState: Managed
 ----
 .. Click *Create*.
-
-. Install a third-party provider plugin for your chosen secret store.
-// TODO: Add link authentication content//

--- a/modules/persistent-storage-csi-secrets-store-driver-overview.adoc
+++ b/modules/persistent-storage-csi-secrets-store-driver-overview.adoc
@@ -1,14 +1,33 @@
 // Module included in the following assemblies:
 //
 // * storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
-//
+// * nodes/pods/nodes-pods-secrets-store.adoc
+
+ifeval::["{context}" == "persistent-storage-csi-secrets-store"]
+:storage:
+endif::[]
+ifeval::["{context}" == "nodes-pods-secrets-store"]
+:nodes:
+endif::[]
 
 :_content-type: CONCEPT
 [id="persistent-storage-csi-secrets-store-driver-overview_{context}"]
+ifdef::storage[]
 = Overview
+endif::storage[]
+ifdef::nodes[]
+= About the {secrets-store-operator}
+endif::nodes[]
 
-Kubernetes secrets are stored with Base64 encoding. etcd provides encryption at rest for these secrets, but when secrets are retrieved, they are decrypted and presented to the user. If role-based access control is not configured properly on your cluster, anyone with API or etcd access can retrieve or modify a secret. Additionally, anyone who is authorized to create a pod in a namespace can use that access to read any secret in that namespace. 
+Kubernetes secrets are stored with Base64 encoding. etcd provides encryption at rest for these secrets, but when secrets are retrieved, they are decrypted and presented to the user. If role-based access control is not configured properly on your cluster, anyone with API or etcd access can retrieve or modify a secret. Additionally, anyone who is authorized to create a pod in a namespace can use that access to read any secret in that namespace.
 
-For secure storage and management of your secrets, the {product-title} Secrets Store Container Storage Interface (CSI) Driver Operator allows you to mount secrets from an external secret management system, such as Azure Key Vault using a provider plugin. Applications can use the secret, but the secret does not persist on the system after the application pod is destroyed.
+To store and manage your secrets securely, you can configure the {product-title} Secrets Store Container Storage Interface (CSI) Driver Operator to mount secrets from an external secret management system, such as Azure Key Vault, by using a provider plugin. Applications can then use the secret, but the secret does not persist on the system after the application pod is destroyed.
 
-The Secrets Store CSI Driver Operator, `secrets-store.csi.k8s.io`, allows {product-title} to mount multiple secrets, keys, and certificates stored in enterprise-grade external secrets stores into pods as a volume. The Secrets Store CSI Driver Operator communicates with the provider using gRPC to fetch the mount contents from the specified external secrets store. After the volume is attached, the data in it is mounted into the container's file system. Secrets store volumes are mounted in-line.
+The {secrets-store-operator}, `secrets-store.csi.k8s.io`, enables {product-title} to mount multiple secrets, keys, and certificates stored in enterprise-grade external secrets stores into pods as a volume. The {secrets-store-operator} communicates with the provider using gRPC to fetch the mount contents from the specified external secrets store. After the volume is attached, the data in it is mounted into the container's file system. Secrets store volumes are mounted in-line.
+
+ifeval::["{context}" == "persistent-storage-csi-secrets-store"]
+:!storage:
+endif::[]
+ifeval::["{context}" == "nodes-pods-secrets-store"]
+:!nodes:
+endif::[]

--- a/modules/persistent-storage-csi-secrets-store-driver-uninstall.adoc
+++ b/modules/persistent-storage-csi-secrets-store-driver-uninstall.adoc
@@ -5,7 +5,7 @@
 
 :_content-type: PROCEDURE
 [id="persistent-storage-csi-secrets-store-driver-uninstall_{context}"]
-= Uninstalling the Secrets Store CSI Driver Operator
+= Uninstalling the {secrets-store-operator}
 
 .Prerequisites
 * Access to the {product-title} web console.
@@ -14,7 +14,7 @@
 
 .Procedure
 
-To uninstall the Secrets Store CSI Driver Operator:
+To uninstall the {secrets-store-operator}:
 
 . Stop all application pods that use the `secrets-store.csi.k8s.io` provider.
 . Remove any third-party provider plug-in for your chosen secret store.
@@ -23,7 +23,7 @@ To uninstall the Secrets Store CSI Driver Operator:
 .. On the *Instances* tab, for *secrets-store.csi.k8s.io*, on the far left side, click the drop-down menu, and then click *Delete ClusterCSIDriver*.
 .. When prompted, click *Delete*.
 . Verify that the CSI driver pods are no longer running.
-. Uninstall the Secrets Store CSI Driver Operator:
+. Uninstall the {secrets-store-operator}:
 +
 [NOTE]
 ====
@@ -31,8 +31,8 @@ Before you can uninstall the Operator, you must remove the CSI driver first.
 ====
 +
 .. Click *Operators* → *Installed Operators*.
-.. On the *Installed Operators* page, scroll or type Secrets Store CSI into the *Search by name* box to find the Operator, and then click it.
+.. On the *Installed Operators* page, scroll or type "Secrets Store CSI" into the *Search by name* box to find the Operator, and then click it.
 .. On the upper, right of the *Installed Operators* > *Operator details* page, click *Actions* → *Uninstall Operator*.
 .. When prompted on the *Uninstall Operator* window, click the *Uninstall* button to remove the Operator from the namespace. Any applications deployed by the Operator on the cluster need to be cleaned up manually.
 +
-After uninstalling, the Secrets Store CSI Driver Operator is no longer listed in the *Installed Operators* section of the web console.
+After uninstalling, the {secrets-store-operator} is no longer listed in the *Installed Operators* section of the web console.

--- a/modules/secrets-store-auto-rotation.adoc
+++ b/modules/secrets-store-auto-rotation.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-secrets-store.adoc
+
+:_content-type: CONCEPT
+[id="secrets-store-auto-rotation_{context}"]
+= Automatic rotation
+
+The {secrets-store-driver} periodically rotates the content in the mounted volume with the content from the external secrets store. If a secret is updated in the external secrets store, the secret will be updated in the mounted volume. The {secrets-store-operator} polls for updates every 2 minutes.
+
+If you enabled synchronization of mounted content as Kubernetes secrets, the Kubernetes secrets are also rotated.
+
+Applications consuming the secret data must watch for updates to the secrets.

--- a/modules/secrets-store-aws.adoc
+++ b/modules/secrets-store-aws.adoc
@@ -1,0 +1,372 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-secrets-store.adoc
+//
+// IMPORTANT: This file requires you to define :secrets-store-provider: before including this module.
+
+ifeval::["{secrets-store-provider}" == "AWS Secrets Manager"]
+:aws-secrets-manager:
+endif::[]
+ifeval::["{secrets-store-provider}" == "AWS Systems Manager Parameter Store"]
+:aws-systems-manager-parameter-store:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="secrets-store-aws_{context}"]
+= Mounting secrets from {secrets-store-provider}
+
+You can use the {secrets-store-operator} to mount secrets from {secrets-store-provider} to a CSI volume in {product-title}. To mount secrets from {secrets-store-provider}, your cluster must be installed on AWS and use AWS Security Token Service (STS).
+
+[IMPORTANT]
+====
+It is not supported to use the {secrets-store-operator} with {secrets-store-provider} in a hosted control plane cluster.
+====
+
+.Prerequisites
+
+* Your cluster is installed on AWS and uses AWS Security Token Service (STS).
+* You have installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
+* You have configured {secrets-store-provider} to store the required secrets.
+* You have extracted and prepared the `ccoctl` binary.
+* You have installed the `jq` CLI tool.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Install the {secrets-store-provider} provider:
+
+.. Create a YAML file with the following configuration for the provider resources:
++
+[IMPORTANT]
+====
+The {secrets-store-provider} provider for the {secrets-store-driver} is an upstream provider.
+
+This configuration is modified from the configuration provided in the upstream link:https://github.com/aws/secrets-store-csi-driver-provider-aws#installing-the-aws-provider[AWS documentation] so that it works properly with {product-title}. Changes to this configuration might impact functionality.
+====
++
+.Example `aws-provider.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-aws
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-secrets-store-provider-aws-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-secrets-store-provider-aws-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-secrets-store-provider-aws-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: csi-secrets-store-provider-aws
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: openshift-cluster-csi-drivers
+  name: csi-secrets-store-provider-aws
+  labels:
+    app: csi-secrets-store-provider-aws
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-aws
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-aws
+    spec:
+      serviceAccountName: csi-secrets-store-provider-aws
+      hostNetwork: false
+      containers:
+        - name: provider-aws-installer
+          image: public.ecr.aws/aws-secrets-manager/secrets-store-csi-driver-provider-aws:1.0.r2-50-g5b4aca1-2023.06.09.21.19
+          imagePullPolicy: Always
+          args:
+              - --provider-volume=/etc/kubernetes/secrets-store-csi-providers
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          securityContext:
+            privileged: true
+          volumeMounts:
+            - mountPath: "/etc/kubernetes/secrets-store-csi-providers"
+              name: providervol
+            - name: mountpoint-dir
+              mountPath: /var/lib/kubelet/pods
+              mountPropagation: HostToContainer
+      tolerations:
+      - operator: Exists
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "/etc/kubernetes/secrets-store-csi-providers"
+        - name: mountpoint-dir
+          hostPath:
+            path: /var/lib/kubelet/pods
+            type: DirectoryOrCreate
+      nodeSelector:
+        kubernetes.io/os: linux
+----
+
+.. Grant privileged access to the `csi-secrets-store-provider-aws` service account by running the following command:
++
+[source,terminal]
+----
+$ oc adm policy add-scc-to-user privileged -z csi-secrets-store-provider-aws -n openshift-cluster-csi-drivers
+----
+
+.. Create the provider resources by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f aws-provider.yaml
+----
+
+. Grant permission to allow the service account to read the AWS secret object:
+
+.. Create a directory to contain the credentials request by running the following command:
++
+[source,terminal]
+----
+$ mkdir credentialsrequest-dir-aws
+----
+
+.. Create a YAML file with the following configuration for the credentials request:
++
+.Example `credentialsrequest.yaml` file
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: aws-provider-test
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: AWSProviderSpec
+ifdef::aws-secrets-manager[]
+    statementEntries:
+    - action:
+      - "secretsmanager:GetSecretValue"
+      - "secretsmanager:DescribeSecret"
+      effect: Allow
+      resource: "arn:*:secretsmanager:*:*:secret:testSecret-??????"
+endif::aws-secrets-manager[]
+ifdef::aws-systems-manager-parameter-store[]
+    statementEntries:
+    - action:
+      - "ssm:GetParameter"
+      - "ssm:GetParameters"
+      effect: Allow
+      resource: "arn:*:ssm:*:*:parameter/testParameter*"
+endif::aws-systems-manager-parameter-store[]
+  secretRef:
+    name: aws-creds
+    namespace: my-namespace
+  serviceAccountNames:
+  - aws-provider
+----
+
+.. Retrieve the OIDC provider by running the following command:
++
+[source,terminal]
+----
+$ oc get --raw=/.well-known/openid-configuration | jq -r '.issuer'
+----
++
+.Example output
+[source,terminal]
+----
+https://<oidc_provider_name>
+----
+Copy the OIDC provider name `<oidc_provider_name>` from the output to use in the next step.
+
+.. Use the `ccoctl` tool to process the credentials request by running the following command:
++
+[source,terminal]
+----
+$ ccoctl aws create-iam-roles \
+    --name my-role --region=<aws_region> \
+    --credentials-requests-dir=credentialsrequest-dir-aws \
+    --identity-provider-arn arn:aws:iam::<aws_account>:oidc-provider/<oidc_provider_name> --output-dir=credrequests-ccoctl-output
+----
++
+.Example output
+[source,terminal]
+----
+2023/05/15 18:10:34 Role arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds created
+2023/05/15 18:10:34 Saved credentials configuration to: credrequests-ccoctl-output/manifests/my-namespace-aws-creds-credentials.yaml
+2023/05/15 18:10:35 Updated Role policy for Role my-role-my-namespace-aws-creds
+----
++
+Copy the `<aws_role_arn>` from the output to use in the next step. For example, `arn:aws:iam::<aws_account_id>:role/my-role-my-namespace-aws-creds`.
+
+.. Bind the service account with the role ARN by running the following command:
++
+[source,terminal]
+----
+$ oc annotate -n my-namespace sa/aws-provider eks.amazonaws.com/role-arn="<aws_role_arn>"
+----
+
+. Create a secret provider class to define your secrets store provider:
+
+.. Create a YAML file that defines the `SecretProviderClass` object:
++
+.Example `secret-provider-class-aws.yaml`
+[source,yaml]
+----
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: my-aws-provider                   <1>
+  namespace: my-namespace                 <2>
+spec:
+  provider: aws                           <3>
+  parameters:                             <4>
+ifdef::aws-secrets-manager[]
+    objects: |
+      - objectName: "testSecret"
+        objectType: "secretsmanager"
+endif::aws-secrets-manager[]
+ifdef::aws-systems-manager-parameter-store[]
+    objects: |
+      - objectName: "testParameter"
+        objectType: "ssmparameter"
+endif::aws-systems-manager-parameter-store[]
+----
+<1> Specify the name for the secret provider class.
+<2> Specify the namespace for the secret provider class.
+<3> Specify the provider as `aws`.
+<4> Specify the provider-specific configuration parameters.
+
+.. Create the `SecretProviderClass` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f secret-provider-class-aws.yaml
+----
+
+. Create a deployment to use this secret provider class:
+
+.. Create a YAML file that defines the `Deployment` object:
++
+.Example `deployment.yaml`
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-aws-deployment                              <1>
+  namespace: my-namespace                              <2>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-storage
+  template:
+    metadata:
+      labels:
+        app: my-storage
+    spec:
+      containers:
+      - name: busybox
+        image: k8s.gcr.io/e2e-test-images/busybox:1.29
+        command:
+          - "/bin/sleep"
+          - "10000"
+        volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+      volumes:
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "my-aws-provider" <3>
+----
+<1> Specify the name for the deployment.
+<2> Specify the namespace for the deployment. This must be the same namespace as the secret provider class.
+<3> Specify the name of the secret provider class.
+
+.. Create the `Deployment` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f deployment.yaml
+----
+
+.Verification
+
+* Verify that you can access the secrets from {secrets-store-provider} in the pod volume mount:
+
+.. List the secrets in the pod mount:
++
+[source,terminal]
+----
+$ oc exec busybox-<hash> -n my-namespace -- ls /mnt/secrets-store/
+----
++
+.Example output
+[source,terminal]
+----
+ifdef::aws-secrets-manager[]
+testSecret
+endif::aws-secrets-manager[]
+ifdef::aws-systems-manager-parameter-store[]
+testParameter
+endif::aws-systems-manager-parameter-store[]
+----
+
+.. View a secret in the pod mount:
++
+[source,terminal]
+----
+$ oc exec busybox-<hash> -n my-namespace -- cat /mnt/secrets-store/testSecret
+----
++
+.Example output
+[source,terminal]
+----
+<secret_value>
+----
+
+ifeval::["{secrets-store-provider}" == "AWS Secrets Manager"]
+:!aws-secrets-manager:
+endif::[]
+ifeval::["{secrets-store-provider}" == "AWS Systems Manager Parameter Store"]
+:!aws-systems-manager-parameter-store:
+endif::[]

--- a/modules/secrets-store-azure.adoc
+++ b/modules/secrets-store-azure.adoc
@@ -1,0 +1,310 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-secrets-store.adoc
+
+:_content-type: PROCEDURE
+[id="secrets-store-azure_{context}"]
+= Mounting secrets from Azure Key Vault
+
+You can use the {secrets-store-operator} to mount secrets from Azure Key Vault to a CSI volume in {product-title}. To mount secrets from Azure Key Vault, your cluster must be installed on Microsoft Azure.
+
+.Prerequisites
+
+* Your cluster is installed on Azure.
+* You have installed the {secrets-store-operator}. See _Installing the {secrets-store-driver}_ for instructions.
+* You have configured Azure Key Vault to store the required secrets.
+* You have installed the Azure CLI (`az`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Install the Azure Key Vault provider:
+
+.. Create a YAML file with the following configuration for the provider resources:
++
+[IMPORTANT]
+====
+The Azure Key Vault provider for the {secrets-store-driver} is an upstream provider.
+
+This configuration is modified from the configuration provided in the upstream link:https://azure.github.io/secrets-store-csi-driver-provider-azure/docs/getting-started/installation/[Azure documentation] so that it works properly with {product-title}. Changes to this configuration might impact functionality.
+====
++
+.Example `azure-provider.yaml` file
+[source,yaml]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: csi-secrets-store-provider-azure
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: csi-secrets-store-provider-azure-cluster-role
+rules:
+- apiGroups: [""]
+  resources: ["serviceaccounts/token"]
+  verbs: ["create"]
+- apiGroups: [""]
+  resources: ["serviceaccounts"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["pods"]
+  verbs: ["get"]
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: csi-secrets-store-provider-azure-cluster-rolebinding
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: csi-secrets-store-provider-azure-cluster-role
+subjects:
+- kind: ServiceAccount
+  name: csi-secrets-store-provider-azure
+  namespace: openshift-cluster-csi-drivers
+---
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  namespace: openshift-cluster-csi-drivers
+  name: csi-secrets-store-provider-azure
+  labels:
+    app: csi-secrets-store-provider-azure
+spec:
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      app: csi-secrets-store-provider-azure
+  template:
+    metadata:
+      labels:
+        app: csi-secrets-store-provider-azure
+    spec:
+      serviceAccountName: csi-secrets-store-provider-azure
+      hostNetwork: true
+      containers:
+        - name: provider-azure-installer
+          image: mcr.microsoft.com/oss/azure/secrets-store/provider-azure:v1.4.1
+          imagePullPolicy: IfNotPresent
+          args:
+            - --endpoint=unix:///provider/azure.sock
+            - --construct-pem-chain=true
+            - --healthz-port=8989
+            - --healthz-path=/healthz
+            - --healthz-timeout=5s
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8989
+            failureThreshold: 3
+            initialDelaySeconds: 5
+            timeoutSeconds: 10
+            periodSeconds: 30
+          resources:
+            requests:
+              cpu: 50m
+              memory: 100Mi
+            limits:
+              cpu: 50m
+              memory: 100Mi
+          securityContext:
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            runAsUser: 0
+            capabilities:
+              drop:
+              - ALL
+          volumeMounts:
+            - mountPath: "/provider"
+              name: providervol
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: type
+                operator: NotIn
+                values:
+                - virtual-kubelet
+      volumes:
+        - name: providervol
+          hostPath:
+            path: "/var/run/secrets-store-csi-providers"
+      tolerations:
+      - operator: Exists
+      nodeSelector:
+        kubernetes.io/os: linux
+----
+
+.. Grant privileged access to the `csi-secrets-store-provider-azure` service account by running the following command:
++
+[source,terminal]
+----
+$ oc adm policy add-scc-to-user privileged -z csi-secrets-store-provider-azure -n openshift-cluster-csi-drivers
+----
+
+.. Create the provider resources by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f azure-provider.yaml
+----
+
+. Create a service principal to access the key vault:
+
+.. Set the service principal client secret as an environment variable by running the following command:
++
+[source,terminal]
+----
+$ SERVICE_PRINCIPAL_CLIENT_SECRET="$(az ad sp create-for-rbac --name https://$KEYVAULT_NAME --query 'password' -otsv)"
+----
+
+.. Set the service principal client ID as an environment variable by running the following command:
++
+[source,terminal]
+----
+$ SERVICE_PRINCIPAL_CLIENT_ID="$(az ad sp list --display-name https://$KEYVAULT_NAME --query '[0].appId' -otsv)"
+----
+
+.. Create a generic secret with the service principal client secret and ID by running the following command:
++
+[source,terminal]
+----
+$ oc create secret generic secrets-store-creds -n my-namespace --from-literal clientid=${SERVICE_PRINCIPAL_CLIENT_ID} --from-literal clientsecret=${SERVICE_PRINCIPAL_CLIENT_SECRET}
+----
+
+.. Apply the `secrets-store.csi.k8s.io/used=true` label to allow the provider to find this `nodePublishSecretRef` secret:
++
+[source,terminal]
+----
+$ oc -n my-namespace label secret secrets-store-creds secrets-store.csi.k8s.io/used=true
+----
+
+. Create a secret provider class to define your secrets store provider:
+
+.. Create a YAML file that defines the `SecretProviderClass` object:
++
+.Example `secret-provider-class-azure.yaml`
+[source,yaml]
+----
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: my-azure-provider                 <1>
+  namespace: my-namespace                 <2>
+spec:
+  provider: azure                         <3>
+  parameters:                             <4>
+    usePodIdentity: "false"
+    useVMManagedIdentity: "false"
+    userAssignedIdentityID: ""
+    keyvaultName: "kvname"
+    objects: |
+      array:
+        - |
+          objectName: secret1
+          objectType: secret
+    tenantId: "tid"
+----
+<1> Specify the name for the secret provider class.
+<2> Specify the namespace for the secret provider class.
+<3> Specify the provider as `azure`.
+<4> Specify the provider-specific configuration parameters.
+
+.. Create the `SecretProviderClass` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f secret-provider-class-azure.yaml
+----
+
+. Create a deployment to use this secret provider class:
+
+.. Create a YAML file that defines the `Deployment` object:
++
+.Example `deployment.yaml`
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: my-azure-deployment                            <1>
+  namespace: my-namespace                              <2>
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: my-storage
+  template:
+    metadata:
+      labels:
+        app: my-storage
+    spec:
+      containers:
+      - name: busybox
+        image: k8s.gcr.io/e2e-test-images/busybox:1.29
+        command:
+          - "/bin/sleep"
+          - "10000"
+        volumeMounts:
+        - name: secrets-store-inline
+          mountPath: "/mnt/secrets-store"
+          readOnly: true
+      volumes:
+        - name: secrets-store-inline
+          csi:
+            driver: secrets-store.csi.k8s.io
+            readOnly: true
+            volumeAttributes:
+              secretProviderClass: "my-azure-provider" <3>
+            nodePublishSecretRef:
+              name: secrets-store-creds                <4>
+----
+<1> Specify the name for the deployment.
+<2> Specify the namespace for the deployment. This must be the same namespace as the secret provider class.
+<3> Specify the name of the secret provider class.
+<4> Specify the name of the Kubernetes secret that contains the service principal credentials to access Azure Key Vault.
+
+.. Create the `Deployment` object by running the following command:
++
+[source,terminal]
+----
+$ oc create -f deployment.yaml
+----
+
+.Verification
+
+* Verify that you can access the secrets from Azure Key Vault in the pod volume mount:
+
+.. List the secrets in the pod mount:
++
+[source,terminal]
+----
+$ oc exec busybox-<hash> -n my-namespace -- ls /mnt/secrets-store/
+----
++
+.Example output
+[source,terminal]
+----
+secret1
+----
+
+.. View a secret in the pod mount:
++
+[source,terminal]
+----
+$ oc exec busybox-<hash> -n my-namespace -- cat /mnt/secrets-store/secret1
+----
++
+.Example output
+[source,terminal]
+----
+my-secret-value
+----

--- a/modules/secrets-store-providers.adoc
+++ b/modules/secrets-store-providers.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-secrets-store.adoc
+
+:_content-type: CONCEPT
+[id="secrets-store-providers_{context}"]
+= Secrets store providers
+
+The following secrets store providers are available for use with the {secrets-store-operator}:
+
+* AWS Secrets Manager
+* AWS Systems Manager Parameter Store
+* Azure Key Vault

--- a/modules/secrets-store-sync-secrets.adoc
+++ b/modules/secrets-store-sync-secrets.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-secrets-store.adoc
+
+:_content-type: PROCEDURE
+[id="secrets-store-sync-secrets_{context}"]
+= Enabling synchronization of mounted content as Kubernetes secrets
+
+You can enable synchronization to create Kubernetes secrets from the content on a mounted volume. An example where you might want to enable synchronization is to use an environment variable in your deployment to reference the Kubernetes secret.
+
+[WARNING]
+====
+Do not enable synchronization if you do not want to store your secrets on your {product-title} cluster and in etcd. Enable this functionality only if you require it, such as when you want to use environment variables to refer to the secret.
+====
+
+If you enable synchronization, the secrets from the mounted volume are synchronized as Kubernetes secrets after you start a pod that mounts the secrets.
+
+The synchronized Kubernetes secret is deleted when all pods that mounted the content are deleted.
+
+.Prerequisites
+
+* You have installed the {secrets-store-operator}.
+* You have installed a secrets store provider.
+* You have created the secret provider class.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Edit the `SecretProviderClass` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit secretproviderclass my-azure-provider <1>
+----
+<1> Replace `my-azure-provider` with the name of your secret provider class.
+
+. Add the `secretsObjects` section with the configuration for the synchronized Kubernetes secrets:
++
+[source,yaml]
+----
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: my-azure-provider
+  namespace: my-namespace
+spec:
+  provider: azure
+  secretObjects:                                   <1>
+    - secretName: tlssecret                        <2>
+      type: kubernetes.io/tls                      <3>
+      labels:
+        environment: "test"
+      data:
+        - objectName: tlskey                       <4>
+          key: tls.key                             <5>
+        - objectName: tlscrt
+          key: tls.crt
+  parameters:
+    usePodIdentity: "false"
+    keyvaultName: "kvname"
+    objects:  |
+      array:
+        - |
+          objectName: tlskey
+          objectType: secret
+        - |
+          objectName: tlscrt
+          objectType: secret
+    tenantId: "tid"
+----
+<1> Specify the configuration for synchronized Kubernetes secrets.
+<2> Specify the name of the Kubernetes `Secret` object to create.
+<3> Specify the type of Kubernetes `Secret` object to create. For example, `Opaque` or `kubernetes.io/tls`.
+<4> Specify the object name or alias of the mounted content to synchronize.
+<5> Specify the data field from the specified `objectName` to populate the Kubernetes secret with.
+
+. Save the file to apply the changes.

--- a/modules/secrets-store-viewing-secret-versions.adoc
+++ b/modules/secrets-store-viewing-secret-versions.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * nodes/pods/nodes-pods-secrets-store.adoc
+
+:_content-type: PROCEDURE
+[id="secrets-store-viewing-secret-versions_{context}"]
+= Viewing the status of secrets in the pod volume mount
+
+You can view detailed information, including the versions, of the secrets in the pod volume mount.
+
+The {secrets-store-operator} creates a `SecretProviderClassPodStatus` resource in the same namespace as the pod. You can review this resource to see detailed information, including versions, about the secrets in the pod volume mount.
+
+.Prerequisites
+
+* You have installed the {secrets-store-operator}.
+* You have installed a secrets store provider.
+* You have created the secret provider class.
+* You have deployed a pod that mounts a volume from the {secrets-store-operator}.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+* View detailed information about the secrets in a pod volume mount by running the following command:
++
+[source,terminal]
+----
+$ oc get secretproviderclasspodstatus <secret_provider_class_pod_status_name> -o yaml <1>
+----
+<1> The name of the secret provider class pod status object is in the format of `<pod_name>-<namespace>-<secret_provider_class_name>`.
++
+.Example output
+[source,terminal]
+----
+...
+status:
+  mounted: true
+  objects:
+  - id: secret/tlscrt
+    version: f352293b97da4fa18d96a9528534cb33
+  - id: secret/tlskey
+    version: 02534bc3d5df481cb138f8b2a13951ef
+  podName: busybox-<hash>
+  secretProviderClassName: my-azure-provider
+  targetPath: /var/lib/kubelet/pods/f0d49c1e-c87a-4beb-888f-37798456a3e7/volumes/kubernetes.io~csi/secrets-store-inline/mount
+----

--- a/nodes/pods/nodes-pods-secrets-store.adoc
+++ b/nodes/pods/nodes-pods-secrets-store.adoc
@@ -1,0 +1,73 @@
+:_content-type: ASSEMBLY
+[id="nodes-pods-secrets-store"]
+= Providing sensitive data to pods by using an external secrets store
+include::_attributes/common-attributes.adoc[]
+:context: nodes-pods-secrets-store
+
+toc::[]
+
+Some applications need sensitive information, such as passwords and user names, that you do not want developers to have.
+
+As an alternative to using Kubernetes `Secret` objects to provide sensitive information, you can use an external secrets store to store the sensitive information. You can use the {secrets-store-operator} to integrate with an external secrets store and mount the secret content as a pod volume.
+
+:FeatureName: The {secrets-store-operator}
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+// About the {secrets-store-operator}
+include::modules/persistent-storage-csi-secrets-store-driver-overview.adoc[leveloffset=+1]
+
+// Secrets store providers
+include::modules/secrets-store-providers.adoc[leveloffset=+2]
+
+// Automatic rotation
+include::modules/secrets-store-auto-rotation.adoc[leveloffset=+2]
+
+// Installing the {secrets-store-driver}
+include::modules/persistent-storage-csi-secrets-store-driver-install.adoc[leveloffset=+1]
+
+[id="mounting-secrets-external-secrets-store"]
+== Mounting secrets from an external secrets store to a CSI volume
+
+After installing the {secrets-store-operator}, you can mount secrets from one of the following external secrets stores to a CSI volume:
+
+* xref:../../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-aws_nodes-pods-secrets-store[AWS Secrets Manager]
+* xref:../../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-aws_nodes-pods-secrets-store-parameter-store[AWS Systems Manager Parameter Store]
+* xref:../../nodes/pods/nodes-pods-secrets-store.adoc#secrets-store-azure_nodes-pods-secrets-store[Azure Key Vault]
+
+// Mounting secrets from AWS Secrets Manager
+:secrets-store-provider: AWS Secrets Manager
+include::modules/secrets-store-aws.adoc[leveloffset=+2]
+:!secrets-store-provider:
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_aws/installing-aws-customizations.adoc#cco-ccoctl-configuring_installing-aws-customizations[Configuring the Cloud Credential Operator utility]
+
+// --- START OF CONTEXT CHANGE ---
+// Setting a unique context for including the secrets-store-aws.adoc module a second time in this assembly
+:context: nodes-pods-secrets-store-parameter-store
+
+// Mounting secrets from AWS Systems Manager Parameter Store
+:secrets-store-provider: AWS Systems Manager Parameter Store
+include::modules/secrets-store-aws.adoc[leveloffset=+2]
+:!secrets-store-provider:
+
+// Resetting the context back to original context
+:context: nodes-pods-secrets-store
+// --- END OF CONTEXT CHANGE ---
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_aws/installing-aws-customizations.adoc#cco-ccoctl-configuring_installing-aws-customizations[Configuring the Cloud Credential Operator utility]
+
+// Mounting secrets from Azure Key Vault
+include::modules/secrets-store-azure.adoc[leveloffset=+2]
+
+// Enabling synchronization of mounted content as Kubernetes secrets
+include::modules/secrets-store-sync-secrets.adoc[leveloffset=+1]
+
+// Viewing the status of secrets in the pod volume mount
+include::modules/secrets-store-viewing-secret-versions.adoc[leveloffset=+1]
+
+// Uninstalling the {secrets-store-operator}
+include::modules/persistent-storage-csi-secrets-store-driver-uninstall.adoc[leveloffset=+1]

--- a/nodes/pods/nodes-pods-secrets.adoc
+++ b/nodes/pods/nodes-pods-secrets.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 :context: nodes-pods-secrets
 [id="nodes-pods-secrets"]
-= Providing sensitive data to pods
+= Providing sensitive data to pods by using secrets
 include::_attributes/common-attributes.adoc[]
 
 toc::[]

--- a/storage/container_storage_interface/ephemeral-storage-csi-inline.adoc
+++ b/storage/container_storage_interface/ephemeral-storage-csi-inline.adoc
@@ -14,7 +14,7 @@ This feature is only available with supported Container Storage Interface (CSI) 
 
 * Shared Resource CSI driver
 * Azure File CSI driver
-* Secrets Store CSI driver
+* {secrets-store-driver}
 
 include::modules/ephemeral-storage-csi-inline-overview.adoc[leveloffset=+1]
 

--- a/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc
@@ -1,5 +1,5 @@
 [id="persistent-storage-csi-secrets-store"]
-= Secrets Store CSI Driver
+= {secrets-store-driver}
 include::_attributes/common-attributes.adoc[]
 :context: persistent-storage-csi-secrets-store
 
@@ -9,16 +9,21 @@ include::modules/persistent-storage-csi-secrets-store-driver-overview.adoc[level
 
 For more information about CSI inline volumes, see xref:../../storage/container_storage_interface/ephemeral-storage-csi-inline.adoc#ephemeral-storage-csi-inline[CSI inline ephemeral volumes].
 
-:FeatureName: Secrets Store CSI Driver Operator
+:FeatureName: The {secrets-store-operator}
 include::snippets/technology-preview.adoc[leveloffset=+1]
 
-//TODO Add module for supported providers dules/secrets-store-providers.adoc
-
 Familiarity with xref:../../storage/understanding-persistent-storage.adoc#understanding-persistent-storage[persistent storage] and xref:../../storage/container_storage_interface/persistent-storage-csi.adoc#persistent-storage-csi[configuring CSI volumes] is recommended when working with a CSI driver.
+
+// Secrets store providers
+include::modules/secrets-store-providers.adoc[leveloffset=+2]
 
 include::modules/persistent-storage-csi-about.adoc[leveloffset=+1]
 
 include::modules/persistent-storage-csi-secrets-store-driver-install.adoc[leveloffset=+1]
+
+.Next steps
+
+* xref:../../nodes/pods/nodes-pods-secrets-store.adoc#mounting-secrets-external-secrets-store[Mounting secrets from an external secrets store to a CSI volume]
 
 include::modules/persistent-storage-csi-secrets-store-driver-uninstall.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-5806

Link to docs preview:
https://62385--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets-store.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

~~Relies on #60607 being merged first to get the install/uninstall modules. And possibly the about content, depending on which PR we add that under.~~

~~Sending for peer review now, though there are one or two last outstanding TODO's in here; these can be ignored~~