### PR TITLE
Updating apiVersion in file nodes/clusters/nodes-cluster-overcommit.adoc

### DIFF
--- a/modules/nodes-cluster-resource-override-deploy-cli.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-cli.adoc
@@ -183,7 +183,7 @@ status:
 ....
 
     mutatingWebhookConfigurationRef: <1>
-      apiVersion: admissionregistration.k8s.io/v1beta1
+      apiVersion: admissionregistration.k8s.io/v1 
       kind: MutatingWebhookConfiguration
       name: clusterresourceoverrides.admission.autoscaling.openshift.io
       resourceVersion: "127621"

--- a/modules/nodes-cluster-resource-override-deploy-console.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-console.adoc
@@ -94,7 +94,7 @@ status:
 ....
 
     mutatingWebhookConfigurationRef: <1>
-      apiVersion: admissionregistration.k8s.io/v1beta1
+      apiVersion: admissionregistration.k8s.io/v1 
       kind: MutatingWebhookConfiguration
       name: clusterresourceoverrides.admission.autoscaling.openshift.io
       resourceVersion: "127621"


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://github.com/openshift/openshift-docs/issues/45900

Link to docs preview:
[Preview](https://62386--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-resource-override-deploy-console_nodes-cluster-overcommit)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Changing the apiVersion from `admissionregistration.k8s.io/v1beta1` to `admissionregistration.k8s.io/v1` in sections:

-     Installing the Cluster Resource Override Operator using the web console
-     Installing the Cluster Resource Override Operator using the CLI


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
