### PR TITLE
OSDOCS-6803: adds 4.13.5 to RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2998,3 +2998,36 @@ $ oc adm release info 4.13.4 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-13-5"]
+=== RHSA-2023:4091 - {product-title} 4.13.5 bug fix and security update
+
+Issued: 2023-07-20
+
+{product-title} release 4.13.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:4091[RHSA-2023:4091] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4093[RHSA-2023:4093] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.5 --pullspecs
+----
+
+[id="ocp-4-13-5-bug-fixes"]
+==== Bug fixes
+* Previosly, the Gateway API feature did not provide DNS records with a trailing dot for the Gateway domain. This caused the status of the DNS record to never become available on the GCP platform. With this update, the DNS records for Gateway API Gateways are properly provisioned and the Gateway API feature works on GCP because the gateway service dns controller now adds a trailing dot if it is missing in the domain. (link:https://issues.redhat.com/browse/OCPBUGS-15434[*OCPBUGS-15434*])
+
+* Previously, if you used the *Pipelines* page of the *Developer* console to add a repository, and you entered a GitLab or Bitbucket Pipelines as Code repository URL as the *Git Repo URL*, the created `Repository` resource was invalid. This was caused by a missing schema issue in the `git_provider.url` spec, which is now fixed. (link:https://issues.redhat.com/browse/OCPBUGS-15410[*OCPBUGS-15410*])
+
+* In this release, the `git_provider.user` spec has been added for Pipelines as Code `Repository` objects. This spec requires you to provide a username if the Git provider is Bitbucket. (link:https://issues.redhat.com/browse/OCPBUGS-15410[*OCPBUGS-15410*])
+
+* In this release, the *Secret* field in the *Pipelines* -> *Create* -> *Add Git Repository* page is now mandatory. You must click *Show configuration options*, and then configure either a Git access token or a Git access token secret for your repository. (link:https://issues.redhat.com/browse/OCPBUGS-15410[*OCPBUGS-15410*])
+
+* Previously, if you tried to edit a Helm chart repository in the *Developer* console by navigating to *Helm*, clicking the *Repositories* tab, then selecting *Edit HelmChartRepository* through the kebab menu for your Helm chart repository, an *Error* page was displayed that showed a *404: Page Not Found* error. This was caused by a component path that was not up to date. This issue is now fixed. (link:https://issues.redhat.com/browse/OCPBUGS-15130[*OCPBUGS-15130*])
+
+[id="ocp-4-13-5-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
OSDOCS#6803: adds 4.13.5 to RNs
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-6803
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://62388--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-5
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
