### PR TITLE
OCPBUGS-14293 Add missing feature to WriteRequestBodies audit policy …

### DIFF
--- a/modules/nodes-nodes-audit-config-about.adoc
+++ b/modules/nodes-nodes-audit-config-about.adoc
@@ -19,7 +19,7 @@ Audit log profiles define how to log requests that come to the OpenShift API ser
 |Logs only metadata for read and write requests; does not log request bodies except for OAuth access token requests. This is the default policy.
 
 |`WriteRequestBodies`
-|In addition to logging metadata for all requests, logs request bodies for every write request to the API servers (`create`, `update`, `patch`). This profile has more resource overhead than the `Default` profile. ^[1]^
+|In addition to logging metadata for all requests, logs request bodies for every write request to the API servers (`create`, `update`, `patch`, `delete`, `deletecollection`). This profile has more resource overhead than the `Default` profile. ^[1]^
 
 |`AllRequestBodies`
 |In addition to logging metadata for all requests, logs request bodies for  every read and write request to the API servers (`get`, `list`, `create`, `update`, `patch`). This profile has the most resource overhead. ^[1]^


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Documentation is missing two features provided by the WriteRequestBodies audit policy. Those features must be added to the documentation.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-14293
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://62390--docspreview.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config.html#about-audit-log-profiles_audit-log-policy-config

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
