### PR TITLE
OSDOCS-6142: Added failureDomain.template param to vSphere docs

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1756,7 +1756,11 @@ a|Multiple IP addresses
 
 |`platform.vsphere.failureDomains.zone`
 |If you define multiple failure domains for your cluster, you must attach the tag to each vCenter cluster. To define a zone, use a tag from the `openshift-zone` tag category. For a single vSphere datacenter environment, you do not need to attach a tag, but you must enter an alphanumeric value, such as `cluster`, for the parameter.
-|`String`
+|String
+
+|`platform.vsphere.failureDomains.template`
+|Specify the absolute path to a pre-existing {op-system-first} image template or virtual machine. The installation program can use the image template or virtual machine to quickly install {op-system} on vSphere hosts. Consider using this parameter as an alternative to uploading an {op-system} image on vSphere hosts. The parameter is available for use only on installer-provisioned infrastructure.
+|String
 
 |`platform.vsphere.ingressVIPs`
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
@@ -1858,7 +1862,7 @@ Optional VMware vSphere machine pool configuration parameters are described in t
 |Parameter|Description|Values
 
 |`platform.vsphere.clusterOSImage`
-|The location from which the installation program downloads the {op-system} image. You must set this parameter to perform an installation in a restricted network.
+|The location from which the installation program downloads the {op-system-first} image. Before setting a path value for this parameter, ensure that the {op-system} image's version matches the version of {op-system} that you installed on your {product-title} cluster.
 |An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
 
 |`platform.vsphere.osDisk.diskSizeGB`


### PR DESCRIPTION
[OSDOCS-6142](https://issues.redhat.com/browse/OSDOCS-6142)

Version(s):
4.14

Link to docs preview:
[Additional VMware vSphere configuration parameters](https://62391--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere.html#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
