### PR TITLE
OCPBUGS#16200: updates SDN to OVN-K migration with cloud specs for port 6081

### DIFF
--- a/modules/nw-ovn-kubernetes-migration.adoc
+++ b/modules/nw-ovn-kubernetes-migration.adoc
@@ -24,6 +24,7 @@ Perform the migration only when an interruption in service is acceptable.
 * A recent backup of the etcd database is available.
 * A reboot can be triggered manually for each node.
 * The cluster is in a known good state, without any errors.
+* On all cloud platforms after updating software, a security group rule must be in place to allow UDP packets on port `6081` for all nodes.
 
 .Procedure
 


### PR DESCRIPTION
OCPBUGS#16200: updates SDN to OVN-K migration with cloud specs for port `6081`
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-16200
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://62416--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-openshift-sdn.html#nw-ovn-kubernetes-migration_migrate-from-openshift-sdn
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
