### PR TITLE
OSDOCS-6890 Z-stream release notes 4.12.25

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3858,3 +3858,22 @@ For more information, see xref:../scalability_and_performance/cnf-numa-aware-sch
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-12-25"]
+=== RHBA-2023:4048 - {product-title} 4.12.25 bug fix update
+
+Issued: 2023-07-19
+
+{product-title} release 4.12.25 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4048[RHBA-2023:4048] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4047[RHBA-2023:4047] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.25 --pullspecs
+----
+
+[id="ocp-4-12-25-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-6890](https://issues.redhat.com/browse/OSDOCS-6890)

Link to docs preview:
[Preview](https://62424--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-25)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Z-stream release notes for 4.12.25. Check that links work before merging.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
