### PR TITLE
OBSDOCS-364: remove incorrect step from querying metrics topic in 4.12

### DIFF
--- a/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
+++ b/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
@@ -20,8 +20,6 @@ As a cluster administrator or as a user with view permissions for all projects, 
 
 . Select *Observe* -> *Metrics*.
 
-. Select *Insert Metric at Cursor* to view a list of predefined queries.
-
 . To create a custom query, add your Prometheus Query Language (PromQL) query to the *Expression* field.
 +
 [NOTE]
@@ -40,8 +38,8 @@ You can also move your mouse pointer over a suggested item to view a brief descr
 
 . To disable a query from being run, select {kebab} next to the query and choose *Disable query*.
 
-. To run queries that you created, select *Run Queries*. 
-The metrics from the queries are visualized on the plot. 
+. To run queries that you created, select *Run Queries*.
+The metrics from the queries are visualized on the plot.
 If a query is invalid, the UI shows an error message.
 +
 [NOTE]

--- a/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
+++ b/modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc
@@ -38,8 +38,8 @@ You can also move your mouse pointer over a suggested item to view a brief descr
 
 . To disable a query from being run, select {kebab} next to the query and choose *Disable query*.
 
-. To run queries that you created, select *Run Queries*.
-The metrics from the queries are visualized on the plot.
+. To run queries that you created, select *Run Queries*. 
+The metrics from the queries are visualized on the plot. 
 If a query is invalid, the UI shows an error message.
 +
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Description: This PR removes an incorrect step from a procedure in the querying metrics topics in the monitoring documentation.

Aligned team: Dev Tools Docs

Version(s): 4.12 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-364
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview (RH VPN access required): https://file.rdu.redhat.com/~bburt/OBSDOCS-364-remove-step-from-querying-metrics-topic/monitoring/querying-metrics.html#querying-metrics-for-all-projects-as-an-administrator_querying-metrics
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

QE reviewer: @juzhao 
Peer reviewer: @deerskindoll 

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
