### PR TITLE
CNV-14623: Hot plugging network interfaces

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3776,6 +3776,8 @@ Topics:
     File: virt-connecting-vm-to-sriov
   - Name: Using DPDK with SR-IOV
     File: virt-using-dpdk-with-sriov
+  - Name: Hot plugging secondary network interfaces
+    File: virt-hot-plugging-network-interfaces 
   - Name: Connecting a VM to a service mesh
     File: virt-connecting-vm-to-service-mesh
   - Name: Configuring a dedicated network for live migration

--- a/modules/virt-hot-plugging-bridge-network-interface-cli.adoc
+++ b/modules/virt-hot-plugging-bridge-network-interface-cli.adoc
@@ -1,0 +1,99 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-hot-plugging-network-interfaces.adoc              
+
+:_content-type: PROCEDURE                                             
+[id="virt-hot-plugging-bridge-network-interface_{context}"]                                   
+= Hot plugging a bridge network interface using the CLI
+
+Hot plug a bridge network interface to a virtual machine (VM) while the VM is running. 
+
+.Prerequisites
+
+* A network attachment definition is configured in the same namespace as your VM.
+* You have installed the `virtctl` tool.
+
+.Procedure
+
+. If the VM to which you want to hot plug the network interface is not running, start it by using the following command:
++
+[source,terminal]
+----
+$ virtctl start <vm_name>
+----
+
+. Use the following command to hot plug a new network interface to the running VM. The `virtctl addinterface` command adds the new network interface to the VM and virtual machine instance (VMI) specification but does not attach it to the running VM. 
++
+[source,terminal]
+----
+$ virtctl addinterface <vm_name> --network-attachment-definition-name <net_attach_def_name> --name <interface_name>
+----
++
+where:
+
+<vm_name>:: Specifies the name of the `VirtualMachine` object.
+<net_attach_def_name>::  Specifies the name of `NetworkAttachmentDefinition` object.
+<interface_name>:: Specifies the name of the new network interface.
+
+
+. To attach the network interface to the running VM, live migrate the VM by using the following command:
++
+[source,terminal]
+----
+$ virtctl migrate <vm_name>
+----
+
+.Verification
+
+. Verify that the VM live migration is successful by using the following command:
++
+[source,terminal]
+----
+$ oc get VirtualMachineInstanceMigration -w
+----
++
+.Example output
+[source,terminal]
+----
+NAME                        PHASE             VMI
+kubevirt-migrate-vm-lj62q   Scheduling        vm-fedora
+kubevirt-migrate-vm-lj62q   Scheduled         vm-fedora
+kubevirt-migrate-vm-lj62q   PreparingTarget   vm-fedora
+kubevirt-migrate-vm-lj62q   TargetReady       vm-fedora
+kubevirt-migrate-vm-lj62q   Running           vm-fedora
+kubevirt-migrate-vm-lj62q   Succeeded         vm-fedora
+----
+
+. Verify that the new interface is added to the VM by checking the VMI status:
++
+[source,terminal]
+----
+$ oc get vmi vm-fedora -ojsonpath="{ @.status.interfaces }"
+----
++
+.Example output
+[source,json]
+----
+[
+  {
+    "infoSource": "domain, guest-agent",
+    "interfaceName": "eth0",
+    "ipAddress": "10.130.0.195",
+    "ipAddresses": [
+      "10.130.0.195",
+      "fd02:0:0:3::43c"
+    ],
+    "mac": "52:54:00:0e:ab:25",
+    "name": "default",
+    "queueCount": 1
+  },
+  {
+    "infoSource": "domain, guest-agent, multus-status",
+    "interfaceName": "eth1",
+    "mac": "02:d8:b8:00:00:2a",
+    "name": "bridge-interface", <1>
+    "queueCount": 1
+  }
+]
+----
+<1> The hot-plugged interface appears in the VMI status.

--- a/modules/virt-hot-unplugging-bridge-network-interface-cli.adoc
+++ b/modules/virt-hot-unplugging-bridge-network-interface-cli.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/vm_networking/virt-hot-plugging-network-interfaces.adoc              
+
+:_content-type: PROCEDURE                                             
+[id="virt-hot-unplugging-bridge-network-interface_{context}"]                                   
+= Hot unplugging a bridge network interface using the CLI
+
+You can remove a bridge network interface from a running virtual machine (VM). 
+
+.Prerequisites
+
+* Your VM must be running.
+* The VM must be created on a cluster running {VirtProductName} 4.14 or later.
+* The VM must have a bridge network interface attached.
+
+.Procedure
+
+. Hot unplug a bridge network interface by running the following command. The `virtctl removeinterface` command detaches the network interface from the guest, but the interface still exists in the pod.
++
+[source,terminal]
+----
+$ virtctl removeinterface <vm_name> --name <interface_name>
+----
+
+. Remove the interface from the pod by migrating the VM:
++
+[source,terminal]
+----
+$ virtctl migrate <vm_name>
+----

--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -254,6 +254,12 @@ Optional:
 
 |`virtctl removevolume <vm_name> --volume-name=<virtual_disk>`
 |Hot unplug a virtual disk.
+
+|`virtctl addinterface <vm_name> --network-attachment-definition-name <net_attach_def_name> --name <interface_name>`
+|Hot plug a Linux bridge network interface.
+
+|`virtctl removeinterface <vm_name> --name <interface_name>`
+|Hot unplug a Linux bridge network interface.
 |===
 
 [id='image-upload-commands_{context}']

--- a/virt/vm_networking/virt-hot-plugging-network-interfaces.adoc
+++ b/virt/vm_networking/virt-hot-plugging-network-interfaces.adoc
@@ -1,0 +1,34 @@
+:_content-type: ASSEMBLY                                     
+[id="virt-hot-plugging-network-interfaces"]                            
+= Hot plugging secondary network interfaces                                            
+include::_attributes/common-attributes.adoc[]                  
+:context: virt-hot-plugging-network-interfaces                        
+                                                                
+toc::[]     
+
+You can add or remove secondary network interfaces without stopping your virtual machine (VM). {VirtProductName} supports hot plugging and hot unplugging for Linux bridge interfaces that use the VirtIO device driver.
+
+:FeatureName: Hot plugging and hot unplugging bridge network interfaces
+include::snippets/technology-preview.adoc[]
+
+[id="virtio-limitations_virt-hot-plugging-network-interfaces"]
+== VirtIO limitations
+Each VirtIO interface uses one of the limited Peripheral Connect Interface (PCI) slots in the VM. There are a total of 32 slots available. The PCI slots are also used by other devices and must be reserved in advance, therefore slots might not be available on demand. {VirtProductName} reserves up to four slots for hot plugging interfaces. This includes any existing plugged network interfaces. For example, if your VM has two existing plugged interfaces, you can hot plug two more network interfaces. 
+
+[NOTE]
+====
+The actual number of slots available for hot plugging also depends on the machine type. For example, the default PCI topology for the q35 machine type supports hot plugging one additional PCIe device. For more information on PCI topology and hot plug support, see the link:https://libvirt.org/pci-hotplug.html[libvirt documentation].
+====
+
+If you restart the VM after hot plugging an interface, that interface becomes part of the standard network interfaces. 
+
+include::modules/virt-hot-plugging-bridge-network-interface-cli.adoc[leveloffset=+1]
+
+include::modules/virt-hot-unplugging-bridge-network-interface-cli.adoc[leveloffset=+1] 
+
+[role="_additional-resources"]
+[id="additional-resources_virt-hot-plugging-network-interfaces"]
+== Additional resources
+
+* xref:../../virt/getting_started/virt-using-the-cli-tools.adoc#installing-virtctl_virt-using-the-cli-tools[Installing virtctl]
+* xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#creating-linux-bridge-nad[Creating a Linux bridge network attachment definition]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-14623](https://issues.redhat.com//browse/CNV-14623)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 

- [Virtctl commands](https://62426--docspreview.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools.html#hot-plug-and-hot-unplug-commands_virt-using-the-cli-tools)
- [Hot plugging secondary network interfaces](https://62426--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-hot-plugging-network-interfaces)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
