### PR TITLE
OSDOCS-6566: Add IPsec support for IBM Cloud

### DIFF
--- a/modules/nw-modifying-operator-install-config.adoc
+++ b/modules/nw-modifying-operator-install-config.adoc
@@ -55,9 +55,7 @@ metadata:
 spec:
 ----
 
-. Specify the advanced network configuration for your cluster in the `cluster-network-03-config.yml` file, such as in the following
-ifndef::ibm-cloud[examples:]
-ifdef::ibm-cloud[example:]
+. Specify the advanced network configuration for your cluster in the `cluster-network-03-config.yml` file, such as in the following examples:
 +
 --
 .Specify a different VXLAN port for the OpenShift SDN network provider
@@ -73,7 +71,6 @@ spec:
       vxlanPort: 4800
 ----
 
-ifndef::ibm-cloud[]
 .Enable IPsec for the OVN-Kubernetes network provider
 [source,yaml]
 ----
@@ -86,7 +83,6 @@ spec:
     ovnKubernetesConfig:
       ipsecConfig: {}
 ----
-endif::ibm-cloud[]
 --
 
 . Optional: Back up the `manifests/cluster-network-03-config.yml` file. The

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -261,7 +261,6 @@ ifdef::operator[]
 The UDP port for the Geneve overlay network.
 endif::operator[]
 
-ifndef::ibm-cloud[]
 |`ipsecConfig`
 |`object`
 |
@@ -271,7 +270,6 @@ endif::operator[]
 ifdef::operator[]
 If the field is present, IPsec is enabled for the cluster.
 endif::operator[]
-endif::ibm-cloud[]
 
 |`policyAuditConfig`
 |`object`
@@ -302,13 +300,6 @@ If your existing network infrastructure overlaps with the `fd98::/48` IPv6 subne
 This field cannot be changed after installation.
 | The default value is `fd98::/48`.
 |====
-
-ifdef::ibm-cloud[]
-[NOTE]
-====
-IPsec for the OVN-Kubernetes network plugin is not supported when installing a cluster on IBM Cloud.
-====
-endif::ibm-cloud[]
 
 // tag::policy-audit[]
 .`policyAuditConfig` object
@@ -374,9 +365,7 @@ defaultNetwork:
   ovnKubernetesConfig:
     mtu: 1400
     genevePort: 6081
-ifndef::ibm-cloud[]
     ipsecConfig: {}
-endif::ibm-cloud[]
 ----
 
 [discrete]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-6566

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):  4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
- [Specifying advanced network configuration](https://62429--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.html#modifying-nwoperator-config-startup_installing-ibm-cloud-network-customizations)
- [Cluster Network Operator configuration object](https://62429--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-network-customizations.html#nw-operator-cr-cno-object_installing-ibm-cloud-network-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
