### PR TITLE
OCPBUGS-16184: Fix QEMU link

### DIFF
--- a/modules/virt-adding-virtio-drivers-vm-yaml.adoc
+++ b/modules/virt-adding-virtio-drivers-vm-yaml.adoc
@@ -8,28 +8,22 @@
 [id="virt-adding-virtio-drivers-vm-yaml_{context}"]
 = Adding VirtIO drivers container disk to a virtual machine
 
-{VirtProductName} distributes VirtIO drivers for Microsoft Windows as a
-container disk, which is available from the
-link:https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virtio-win[Red Hat Ecosystem Catalog].
-To install these drivers to a Windows virtual machine, attach the
-`container-native-virtualization/virtio-win` container disk to the virtual machine as a SATA CD drive
-in the virtual machine configuration file.
+You can add a VirtIO drivers container disk to a Windows virtual machine (VM) as a SATA CD drive.
 
-.Prerequisites
+VirtIO drivers are paravirtualized device drivers required for Microsoft Windows VMs to run in {VirtProductName}.
 
-* Download the `container-native-virtualization/virtio-win` container disk from the
-link:https://access.redhat.com/containers/#/registry.access.redhat.com/container-native-virtualization/virtio-win[Red Hat Ecosystem Catalog].
-This is not mandatory, because the container disk will be downloaded from the Red Hat registry
-if it not already present in the cluster, but it can reduce installation time.
+[TIP]
+====
+Downloading the `container-native-virtualization/virtio-win` container disk from the link:https://catalog.redhat.com/software/containers/search?q=virtio-win&p=1[Red Hat Ecosystem Catalog] is not mandatory, because the container disk is downloaded from the Red Hat registry if it not already present in the cluster. However, downloading reduces the installation time.
+====
 
 .Procedure
 
-. Add the `container-native-virtualization/virtio-win` container disk as a `cdrom` disk in the
-Windows virtual machine configuration file. The container disk will be
-downloaded from the registry if it is not already present in the cluster.
+. Add the `container-native-virtualization/virtio-win` container disk as a CD drive by editing the `VirtualMachine` manifest:
 +
 [source,yaml]
 ----
+# ...
 spec:
   domain:
     devices:
@@ -43,18 +37,21 @@ volumes:
       image: container-native-virtualization/virtio-win
     name: virtiocontainerdisk
 ----
-<1> {VirtProductName} boots virtual machine disks in the order defined in the
-`VirtualMachine` configuration file. You can either define other disks for the
-virtual machine before the `container-native-virtualization/virtio-win` container disk or use the optional
-`bootOrder` parameter to ensure the virtual machine boots from the correct disk.
- If you specify the `bootOrder` for a disk, it must be specified for all disks
-in the configuration.
+<1> {VirtProductName} boots the VM disks in the order defined in the `VirtualMachine` manifest. You can either define other VM disks that boot before the `container-native-virtualization/virtio-win` container disk or use the optional `bootOrder` parameter to ensure the VM boots from the correct disk. If you configure the boot order for a disk, you must configure the boot order for the other disks.
 
-. The disk is available once the virtual machine has started:
-** If you add the container disk to a running virtual machine, use
-`oc apply -f <vm.yaml>` in the CLI or reboot the virtual machine for the changes
-to take effect.
-** If the virtual machine is not running, use `virtctl start <vm>`.
+. Apply the changes:
+* If the VM is not running, run the following command:
++
+[source, terminal]
+----
+ $ `virtctl start <vm>`
+----
 
-After the virtual machine has started, the VirtIO drivers can be installed from
-the attached SATA CD drive.
+* If the VM is running, reboot the VM or run the following command:
++
+[source, terminal]
+----
+$ run `oc apply -f <vm.yaml>`
+----
+
+. After the virtual machine has started, install the VirtIO drivers from the SATA CD drive.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: OCPBUGS-16184
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Adding VirtIO drivers container disk to a virtual machine](https://62430--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-installing-qemu-guest-agent.html#virt-adding-virtio-drivers-vm-yaml_virt-installing-qemu-guest-agent)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: NA
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
