### PR TITLE
[enterprise-4.11] OCPBUGS-8097-re: Updated ELB nomenclature throughout docs

### DIFF
--- a/modules/aws-limits.adoc
+++ b/modules/aws-limits.adoc
@@ -47,10 +47,10 @@ To use the `us-east-1` region, you must increase the EIP limit for your account.
 |5 VPCs per region
 |Each cluster creates its own VPC.
 
-|Elastic Load Balancing (ELB/NLB)
+|Elastic Load Balancing (ELB)
 |3
 |20 per region
-|By default, each cluster creates internal and external network load balancers for the primary API server and a single classic elastic load balancer for the router. Deploying more Kubernetes LoadBalancer Service objects will create additional link:https://aws.amazon.com/elasticloadbalancing/[load balancers].
+|By default, each cluster creates internal and external Network Load Balancers for the primary API server and a single Classic Load Balancer for the router. Deploying more Kubernetes LoadBalancer Service objects will create additional link:https://aws.amazon.com/elasticloadbalancing/[load balancers].
 
 
 |NAT Gateways
@@ -63,7 +63,7 @@ To use the `us-east-1` region, you must increase the EIP limit for your account.
 |350 per region
 |The default installation creates 21 ENIs and an ENI for each availability zone in your region. For example, the `us-east-1` region contains six availability zones, so a cluster that is deployed in that zone uses 27 ENIs. Review the link:https://aws.amazon.com/about-aws/global-infrastructure/[AWS region map] to determine how many availability zones are in each region.
 
-Additional ENIs are created for additional machines and elastic load balancers that are created by cluster usage and deployed workloads.
+Additional ENIs are created for additional machines and load balancers that are created by cluster usage and deployed workloads.
 
 |VPC Gateway
 |20

--- a/modules/ccs-aws-provisioned.adoc
+++ b/modules/ccs-aws-provisioned.adoc
@@ -46,9 +46,9 @@ Volume requirements for each EC2 instance:
 * Input/output operations per second: 900
 
 [id="aws-policy-elastic-load-balancers_{context}"]
-== Elastic load balancers
+== Elastic Load Balancing (ELB) load balancers
 
-Up to two Network Elastic Load Balancers (ELBs) for API and up to two Classic ELBs for application router. For more information, see the link:https://aws.amazon.com/elasticloadbalancing/features/#Details_for_Elastic_Load_Balancing_Products[ELB documentation for AWS].
+Up to two Network Load Balancers for API and up to two Classic Load Balancers for application router. For more information, see the link:https://aws.amazon.com/elasticloadbalancing/features/#Details_for_Elastic_Load_Balancing_Products[ELB documentation for AWS].
 
 [id="aws-policy-s3-storage_{context}"]
 == S3 storage

--- a/modules/dedicated-configuring-your-application-routes.adoc
+++ b/modules/dedicated-configuring-your-application-routes.adoc
@@ -5,11 +5,7 @@
 [id="dedicated-configuring-your-application-routes_{context}"]
 = Configuring your application routes
 
-When your cluster is provisioned, an AWS elastic load balancer (ELB) is created
-to route application traffic into the cluster. The domain for your ELB is
-configured to route application traffic via
-`http(s)://*.<cluster-id>.<shard-id>.p1.openshiftapps.com`. The `<shard-id>` is a
-random four-character string assigned to your cluster at creation time.
+When your cluster is provisioned, an Elastic Load Balancing (ELB) load balancer is created to route application traffic into the cluster. The domain for your ELB is configured to route application traffic via `http(s)://*.<cluster-id>.<shard-id>.p1.openshiftapps.com`. The `<shard-id>` is a random four-character string assigned to your cluster at creation time.
 
 If you want to use custom domain names for your application routes, {product-title} supports
 CNAME records in your DNS configuration that point to

--- a/modules/dedicated-exposing-TCP-services.adoc
+++ b/modules/dedicated-exposing-TCP-services.adoc
@@ -8,7 +8,7 @@
 {product-title} routes expose applications by proxying traffic through
 HTTP/HTTPS(SNI)/TLS(SNI) to pods and services. A
 link:https://kubernetes.io/docs/concepts/services-networking/#loadbalancer[LoadBalancer]
-service creates an AWS Elastic Load Balancer (ELB) for your {product-title}
+service creates an Elastic Load Balancing (ELB) load balancer for your {product-title}
 cluster, enabling direct TCP access to applications exposed by your LoadBalancer
 service.
 

--- a/modules/installation-aws-limits.adoc
+++ b/modules/installation-aws-limits.adoc
@@ -69,7 +69,7 @@ To use the `us-east-1` region, you must increase the EIP limit for your account.
 |3
 |20 per region
 |By default, each cluster creates internal and external network load balancers for the master
-API server and a single classic elastic load balancer for the router. Deploying
+API server and a single Classic Load Balancer for the router. Deploying
 more Kubernetes `Service` objects with type `LoadBalancer` will create additional
 link:https://aws.amazon.com/elasticloadbalancing/[load balancers].
 
@@ -88,7 +88,7 @@ zones, so a cluster that is deployed in that zone uses 27 ENIs. Review the
 link:https://aws.amazon.com/about-aws/global-infrastructure/[AWS region map] to
 determine how many availability zones are in each region.
 
-Additional ENIs are created for additional machines and elastic load balancers
+Additional ENIs are created for additional machines and ELB load balancers
 that are created by cluster usage and deployed workloads.
 
 |VPC Gateway

--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -46,7 +46,7 @@ Volume requirements for each EC2 instance:
 [id="rosa-elastic-load-balancers_{context}"]
 == Elastic load balancers
 
-Up to two Network Elastic Load Balancers (ELBs) for API and up to two Classic ELBs for application router. For more information, see the link:https://aws.amazon.com/elasticloadbalancing/features/#Details_for_Elastic_Load_Balancing_Products[ELB documentation for AWS].
+Up to two Network Load Balancers for API and up to two Classic Load Balancers for application router. For more information, see the link:https://aws.amazon.com/elasticloadbalancing/features/#Details_for_Elastic_Load_Balancing_Products[ELB documentation for AWS].
 
 [id="rosa-s3-storage_{context}"]
 == S3 storage
@@ -76,7 +76,7 @@ image::VPC-Diagram.png[VPC Reference Architecture]
 [id="rosa-security-groups_{context}"]
 == Security groups
 
-AWS security groups provide security at the protocol and port access level; they are associated with EC2 instances and Elastic Load Balancers. Each security group contains a set of rules that filter traffic coming in and out of an EC2 instance. You must ensure the ports required for the OpenShift installation are open on your network and configured to allow access between hosts.
+AWS security groups provide security at the protocol and port access level; they are associated with EC2 instances and Elastic Load Balancing (ELB) load balancers. Each security group contains a set of rules that filter traffic coming in and out of one or more EC2 instances. You must ensure the ports required for the OpenShift installation are open on your network and configured to allow access between hosts.
 
 [cols="2a,2a,2a,2a",options="header"]
 |===


### PR DESCRIPTION
[OCPBUGS-8097](https://issues.redhat.com/browse/OCPBUGS-8097)

Version(s):
4.11

Link to docs preview:
* [AWS account limits-OCD](https://dfitzmau.github.io/previews/aws-ccs.html#aws-limits_aws-ccs)
* [Provisioned AWS Infrastructure-OCD](https://dfitzmau.github.io/previews/aws-ccs.html#ccs-aws-provisioned_aws-ccs)
* [AWS account limits](https://dfitzmau.github.io/previews//installing-aws-account.html#installation-aws-limits_installing-aws-account)
* [Provisioned AWS Infrastructure-ROSA](https://dfitzmau.github.io/previews/rosa-sts-aws-prereqs.html#rosa-aws-policy-provisioned_rosa-sts-aws-prereqs)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [OSDOCS-5440](https://github.com/openshift/openshift-docs/pull/55321)
