### PR TITLE
OSDOCS-6891: Documented 4.11.45 z-stream release notes£

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3648,3 +3648,22 @@ $ oc adm release info 4.11.44 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-45"]
+=== RHSA-2023:4053 {product-title} 4.11.45 bug fix and security update
+
+Issued: 2023-07-19
+
+{product-title} release 4.11.45, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:4053[RHSA-2023:4053] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4052[RHBA-2023:4052] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.45 --pullspecs
+----
+
+[id="ocp-4-11-45-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-6891](https://issues.redhat.com/browse/OSDOCS-6891)

Version(s):
4.11

Link to docs preview:
[OpenShift Container Platform 4.11.45 bug fix and security update](https://dfitzmau.github.io/previews/ocp-4-11-release-notes.html#ocp-4-11-45)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
