### PR TITLE
Remove mentions of `use-octavia`

### DIFF
--- a/modules/cluster-cloud-controller-config-osp.adoc
+++ b/modules/cluster-cloud-controller-config-osp.adoc
@@ -30,7 +30,7 @@ data:
     secret-namespace = kube-system
     region = regionOne
     [LoadBalancer]
-    use-octavia = True
+    enabled = True
 kind: ConfigMap
 metadata:
   creationTimestamp: "2022-12-20T17:01:08Z"
@@ -125,10 +125,6 @@ Neutron-LBaaS support is deprecated.
 | `enabled`
 | Whether or not to enable the `LoadBalancer` type of services integration. The default value is `true`.
 
-// Always enforced.
-// | `use-octavia`
-// | Whether or not to use Octavia for the `LoadBalancer` type of service implementation rather than Neutron-LBaaS. The default value is `true`.
-
 | `floating-network-id`
 | Optional. The external network used to create floating IP addresses for load balancer virtual IP addresses (VIPs). If there are multiple external networks in the cloud, this option must be set or the user must specify `loadbalancer.openstack.org/floating-network-id` in the service annotation.
 
@@ -195,7 +191,7 @@ This option is unsupported if you use {rh-openstack} earlier than version 17 wit
 // | The id of the loadbalancer flavor to use. Uses octavia default if not set.
 
 // | `availability-zone`
-// | The name of the loadbalancer availability zone to use. It is applicable if use-octavia is set to True and requires Octavia API version 2.14 or later (Ussuri release). The Octavia availability zone capabilities will not be used if it is not set. The parameter will be ignored if the Octavia version doesn't support availability zones yet.
+// | The name of the loadbalancer availability zone to use. The Octavia availability zone capabilities will not be used if it is not set. The parameter will be ignored if the Octavia version doesn't support availability zones yet.
 
 | `LoadBalancerClass "ClassName"`
 a| This is a config section that comprises a set of options:

--- a/modules/installation-osp-setting-cloud-provider-options.adoc
+++ b/modules/installation-osp-setting-cloud-provider-options.adoc
@@ -37,22 +37,20 @@ Configuring Octavia for load balancing is a common case for clusters that do not
 ----
 #...
 [LoadBalancer]
-use-octavia=true <1>
-lb-provider = "amphora" <2>
-floating-network-id="d3deb660-4190-40a3-91f1-37326fe6ec4a" <3>
-create-monitor = True <4>
-monitor-delay = 10s <5>
-monitor-timeout = 10s <6>
-monitor-max-retries = 1 <7>
+lb-provider = "amphora" <1>
+floating-network-id="d3deb660-4190-40a3-91f1-37326fe6ec4a" <2>
+create-monitor = True <3>
+monitor-delay = 10s <4>
+monitor-timeout = 10s <5>
+monitor-max-retries = 1 <6>
 #...
 ----
-<1> This property enables Octavia integration.
-<2> This property sets the Octavia provider that your load balancer uses. It accepts `"ovn"` or `"amphora"` as values. If you choose to use OVN, you must also set `lb-method` to `SOURCE_IP_PORT`.
-<3> This property is required if you want to use multiple external networks with your cluster. The cloud provider creates floating IP addresses on the network that is specified here.
-<4> This property controls whether the cloud provider creates health monitors for Octavia load balancers. Set the value to `True` to create health monitors. As of {rh-openstack} 16.1 and 16.2, this feature is only available for the Amphora provider.
-<5> This property sets the frequency with which endpoints are monitored. The value must be in the `time.ParseDuration()` format. This property is required if the value of the `create-monitor` property is `True`.
-<6> This property sets the time that monitoring requests are open before timing out. The value must be in the `time.ParseDuration()` format. This property is required if the value of the `create-monitor` property is `True`.
-<7> This property defines how many successful monitoring requests are required before a load balancer is marked as online. The value must be an integer. This property is required if the value of the `create-monitor` property is `True`.
+<1> This property sets the Octavia provider that your load balancer uses. It accepts `"ovn"` or `"amphora"` as values. If you choose to use OVN, you must also set `lb-method` to `SOURCE_IP_PORT`.
+<2> This property is required if you want to use multiple external networks with your cluster. The cloud provider creates floating IP addresses on the network that is specified here.
+<3> This property controls whether the cloud provider creates health monitors for Octavia load balancers. Set the value to `True` to create health monitors. As of {rh-openstack} 16.1 and 16.2, this feature is only available for the Amphora provider.
+<4> This property sets the frequency with which endpoints are monitored. The value must be in the `time.ParseDuration()` format. This property is required if the value of the `create-monitor` property is `True`.
+<5> This property sets the time that monitoring requests are open before timing out. The value must be in the `time.ParseDuration()` format. This property is required if the value of the `create-monitor` property is `True`.
+<6> This property defines how many successful monitoring requests are required before a load balancer is marked as online. The value must be an integer. This property is required if the value of the `create-monitor` property is `True`.
 
 +
 [IMPORTANT]

--- a/modules/nw-openstack-external-ccm.adoc
+++ b/modules/nw-openstack-external-ccm.adoc
@@ -36,7 +36,6 @@ cloud = openstack
 ...
 
 [LoadBalancer]
-use-octavia = true
 enabled = true <1>
 ----
 <1> If the network is configured to use Kuryr, this value is `false`.


### PR DESCRIPTION
openshift/cluster-cloud-controller-manager-operator#262 and openshift/openstack-test#115 are removing enforcement and testing of `use-octavia` option. The parameter is no longer used by the cloud-provider-openstack. This commit removes the mentions of it from the docs.

Version(s):
4.14

Issue:

Link to docs preview:

QE review:
- [x] QE has approved this change.

Additional information:
