### PR TITLE
OCPBUGS#7985: spell out IOPS

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -131,10 +131,10 @@ ifdef::bare-metal[]
 endif::bare-metal[]
 |Storage
 ifndef::ibm-z,ibm-cloud-vpc[]
-|IOPS ^[2]^
+|Input/Output Per Second (IOPS)^[2]^
 endif::ibm-z,ibm-cloud-vpc[]
 ifdef::ibm-z,ibm-cloud-vpc[]
-|IOPS
+|Input/Output Per Second (IOPS)
 endif::ibm-z,ibm-cloud-vpc[]
 
 |Bootstrap


### PR DESCRIPTION
Version(s):
4.14
4.13

Issue:
[OCPBUGS#7985](https://issues.redhat.com/browse/OCPBUGS-7985)>

Link to docs preview:
[Link to Table 2 where change appear](https://62453--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installation-minimum-resource-requirements_installing-restricted-networks-aws)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
