### PR TITLE
TELCODOCS-948: RN for removal of PAO must-gather

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -145,6 +145,13 @@ With this release, the resource limits for the descheduler operand are removed. 
 [id="ocp-4-14-scalability-and-performance"]
 === Scalability and performance
 
+[id="ocp-4-14-PAO-image-must-gather"]
+==== PAO must-gather image added to default must-gather image
+
+With this release, the Performance Addon Operator (PAO) must-gather image is no longer required as an argument for the `must-gather` command to capture debugging data related to low-latency tuning. The functions of the PAO must-gather image are now under the default plugin image used by the `must-gather` command without any image arguments.
+
+For further information about gathering debugging information relating to low-latency tuning, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support_cnf-master[Collecting low latency tuning debugging data for Red Hat Support].
+
 [id="ocp-4-14-hcp"]
 === Hosted control planes (Technology Preview)
 


### PR DESCRIPTION
[TELCODOCS-948](https://issues.redhat.com//browse/TELCODOCS-948): Release note for #59307 

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-948

Link to docs preview:
https://62459--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-PAO-image-must-gather

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
