### PR TITLE
OCPBUGS#16273: removes NodeSelector CRD from 4.12 docs

### DIFF
--- a/modules/nw-egressnetworkpolicy-object.adoc
+++ b/modules/nw-egressnetworkpolicy-object.adoc
@@ -77,16 +77,14 @@ egress:
   to: <2>
     cidrSelector: <cidr> <3>
     dnsName: <dns_name> <4>
-    nodeSelector: <label_name>: <label_value> <5>
-  ports: <6>
+  ports: <5>
       ...
 ----
 <1> The type of rule. The value must be either `Allow` or `Deny`.
 <2> A stanza describing an egress traffic match rule that specifies the `cidrSelector` field or the `dnsName` field. You cannot use both fields in the same rule.
 <3> An IP address range in CIDR format.
 <4> A DNS domain name.
-<5> Labels are key/value pairs that the user defines. Labels are attached to objects, such as pods. The `nodeSelector` allows for one or more node labels to be selected and attached to pods.
-<6> Optional: A stanza describing a collection of network ports and protocols for the rule.
+<5> Optional: A stanza describing a collection of network ports and protocols for the rule.
 
 .Ports stanza
 [source,yaml]
@@ -146,30 +144,6 @@ spec:
     - port: 443
 ----
 
-[id="configuringNodeSelector-example_{context}"]
-== Example nodeSelector for {kind}
-
-As a cluster administrator, you can allow or deny egress traffic to nodes in your cluster by specifying a label using `nodeSelector`. Labels can be applied to one or more nodes. The following is an example with the `region=east` label:
-
-[source,yaml]
-----
-apiVersion: v1
-kind: EgressFirewall
-metadata:
-  name: default
-spec:
-    egress:
-    - to:
-        nodeSelector:
-          matchLabels:
-            region: east
-      type: Allow
-----
-
-[TIP]
-====
-Instead of adding manual rules per node IP address, use node selectors to create a label that allows pods behind an egress firewall to access host network pods.
-====
 endif::ovn[]
 
 ifdef::kind[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-16273
https://issues.redhat.com/browse/OCPBUGS-15730
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://62461--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn.html#nw-egressnetworkpolicy-object_configuring-egress-firewall-ovn
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
