### PR TITLE
OCPBUGS#15325: updates support status of K8s-NMstate on IPv6

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -24,7 +24,7 @@ ifeval::["{context}" == "about-ovn-kubernetes"]
 
 |IPsec encryption for intra-cluster communication|Supported|Not supported
 
-|IPv6|Supported ^[3]^|Not supported
+|IPv6|Supported ^[3]^ ^[4]^|Not supported
 
 |Kubernetes network policy|Supported|Supported
 
@@ -47,7 +47,7 @@ ifeval::["{context}" == "about-openshift-sdn"]
 
 |IPsec encryption|Not supported|Supported
 
-|IPv6|Not supported|Supported ^[3]^
+|IPv6|Not supported|Supported ^[3]^ ^[4]^
 
 |Kubernetes network policy|Supported|Supported
 
@@ -65,4 +65,6 @@ endif::[]
 2. Egress router for OVN-Kubernetes supports only redirect mode.
 
 3. IPv6 is supported only on bare metal, IBM Power, and {ibmzProductName} clusters.
+
+4. IPv6 single stack does not support xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState].
 --


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10-4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-15325
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
