### PR TITLE
OCPBUGS-13961: Recording profiles from workloads is not correct

### DIFF
--- a/modules/spo-applying-profiles.adoc
+++ b/modules/spo-applying-profiles.adoc
@@ -55,8 +55,8 @@ $ oc -n my-namespace get seccompprofile profile1 --output wide
 .Example output
 [source,terminal]
 ----
-NAME       STATUS   AGE   SECCOMPPROFILE.LOCALHOSTPROFILE
-profile1   Active   14s   operator/my-namespace/profile1.json
+NAME       STATUS     AGE   SECCOMPPROFILE.LOCALHOSTPROFILE
+profile1   Installed  14s   operator/my-namespace/profile1.json
 ----
 
 . View the path to the localhost profile by running the following command:
@@ -144,7 +144,7 @@ $ oc get selinuxprofile.security-profiles-operator.x-k8s.io/nginx-secure -n ngin
 .Example output
 [source,terminal]
 ----
-nginx-secure_nginx-deploy.process%
+nginx-secure_nginx-deploy.process
 ----
 
 . Apply the output string in the workload manifest in the `.spec.containers[].securityContext.seLinuxOptions` attribute:

--- a/modules/spo-container-profile-instances.adoc
+++ b/modules/spo-container-profile-instances.adoc
@@ -2,6 +2,8 @@
 //
 // * security/security_profiles_operator/spo-seccomp.adoc
 // * security/security_profiles_operator/spo-selinux.adoc
+// JKB added conditionalization requested by QE
+
 
 ifeval::["{context}" == "spo-seccomp"]
 :seccomp:
@@ -34,6 +36,7 @@ metadata:
   # The name of the Recording is the same as the resulting {kind} CRD
   # after reconciliation.
   name: test-recording
+  namespace: my-namespace
 spec:
   kind: {kind}
   recorder: logs
@@ -43,7 +46,13 @@ spec:
       app: sp-record
 ----
 
-. Create the workload:
+. Label the namespace by running the following command:
++
+[source,terminal]
+----
+$ oc label ns my-namespace security.openshift.io/scc.podSecurityLabelSync=false pod-security.kubernetes.io/enforce=privileged pod-security.kubernetes.io/audit=privileged pod-security.kubernetes.io/warn=privileged --overwrite=true
+----
+. Create the workload with the following YAML:
 +
 [source,yaml]
 ----
@@ -51,6 +60,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: nginx-deploy
+  namespace: my-namespace
 spec:
   replicas: 3
   selector:
@@ -73,30 +83,40 @@ spec:
 +
 [source,terminal]
 ----
-$ oc delete deployment nginx-deploy
+$ oc delete deployment nginx-deploy -n my-namespace
 ----
 
 . To merge the profiles, delete the profile recording by running the following command:
 +
 [source,terminal]
 ----
-$ oc delete profilerecording test-recording
+$ oc delete profilerecording test-recording -n my-namespace
 ----
 
 . To start the merge operation and generate the results profile, run the following command:
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc get {object} -lspo.x-k8s.io/recording-id=test-recording
+$ oc get {object} -lspo.x-k8s.io/recording-id=test-recording -n my-namespace
 ----
+ifdef::selinux[]
 +
-.Example output
+.Example output for {object}
 [source,terminal]
 ----
-NAME                          USAGE                                         STATE
-test-recording-nginx-record   test-recording-nginx-record_mytest1.process   Installed
+NAME                          USAGE                                              STATE
+test-recording-nginx-record   test-recording-nginx-record_my-namespace.process   Installed
 ----
-
+endif::[]
+ifdef::seccomp[]
++
+.Example output for {object}
+[source,terminal]
+----
+NAME                          STATUS       AGE
+test-recording-nginx-record   Installed    55s
+----
+endif::[]
 . To view the permissions used by any of the containers, run the following command:
 +
 [source,terminal,subs="attributes+"]

--- a/modules/spo-creating-profiles.adoc
+++ b/modules/spo-creating-profiles.adoc
@@ -43,6 +43,7 @@ The {type} profile will be saved in `/var/lib/kubelet/{type}/operator/<namespace
 
 An `init` container creates the root directory of the Security Profiles Operator to run the Operator without `root` group or user ID privileges. A symbolic link is created from the rootless profile storage `/var/lib/openshift-security-profiles` to the default `seccomp` root path inside of the kubelet root `/var/lib/kubelet/{type}/operator`.
 endif::[]
+
 ifdef::selinux[]
 The `{kind}` object has several features that allow for better security hardening and readability:
 

--- a/modules/spo-recording-profiles.adoc
+++ b/modules/spo-recording-profiles.adoc
@@ -46,6 +46,7 @@ $ oc label ns my-namespace spo.x-k8s.io/enable-recording=true
 apiVersion: security-profiles-operator.x-k8s.io/v1alpha1
 kind: ProfileRecording
 metadata:
+  namespace: my-namespace
   name: test-recording
 spec:
   kind: {kind}
@@ -62,6 +63,7 @@ spec:
 apiVersion: v1
 kind: Pod
 metadata:
+  namespace: my-namespace
   name: my-pod
   labels:
     app: my-app
@@ -79,7 +81,7 @@ spec:
 +
 [source,terminal]
 ----
-$ oc -n openshift-security-profiles get pods
+$ oc -n my-namespace get pods
 ----
 +
 .Example output
@@ -95,12 +97,25 @@ my-pod   2/2     Running   0          18s
 ----
 $ oc -n openshift-security-profiles logs --since=1m --selector name=spod -c log-enricher
 ----
+
+ifdef::seccomp[]
++
+.Example output
+[source,terminal]
+----
+I0523 14:19:08.747313  430694 enricher.go:445] log-enricher "msg"="audit" "container"="redis" "executable"="/usr/local/bin/redis-server" "namespace"="my-namespace" "node"="xiyuan-23-5g2q9-worker-eastus2-6rpgf" "pid"=656802 "pod"="my-pod" "syscallID"=0 "syscallName"="read" "timestamp"="1684851548.745:207179" "type"="seccomp"
+----
+endif::[]
+
+ifdef::selinux[]
 +
 .Example output
 [source,terminal,subs="attributes+"]
 ----
-I0517 13:55:36.383187  348295 enricher.go:376] log-enricher "msg"="audit" "container"="redis" "namespace"="my-namespace" "node"="ip-10-0-189-53.us-east-2.compute.internal" "perm"="name_bind" "pod"="my-pod" "profile"="test-recording_redis_6kmrb_1684331729" "scontext"="system_u:system_r:selinuxrecording.process:s0:c4,c27" "tclass"="tcp_socket" "tcontext"="system_u:object_r:redis_port_t:s0" "timestamp"="1684331735.105:273965" "type"="{type}"
+I0517 13:55:36.383187  348295 enricher.go:376] log-enricher "msg"="audit" "container"="redis" "namespace"="my-namespace" "node"="ip-10-0-189-53.us-east-2.compute.internal" "perm"="name_bind" "pod"="my-pod" "profile"="test-recording_redis_6kmrb_1684331729" "scontext"="system_u:system_r:selinuxrecording.process:s0:c4,c27" "tclass"="tcp_socket" "tcontext"="system_u:object_r:redis_port_t:s0" "timestamp"="1684331735.105:273965" "type"="selinux"
 ----
+endif::[]
+
 
 .Verification
 
@@ -108,23 +123,42 @@ I0517 13:55:36.383187  348295 enricher.go:376] log-enricher "msg"="audit" "conta
 +
 [source,terminal]
 ----
-$ oc -n openshift-security-profiles delete pod my-pod
+$ oc -n my-namepace delete pod my-pod
 ----
 
 . Confirm the Security Profiles Operator reconciles the two {type} profiles:
+
+ifdef::seccomp[]
 +
-[source,terminal,subs="attributes+"]
+[source,terminal]
 ----
-$ oc get {object} -n my-namespace
+$ oc get seccompprofiles -lspo.x-k8s.io/recording-id=test-recording -n my-namespace
 ----
 +
-.Example output
+.Example output for seccompprofile
+[source,terminal]
+----
+NAME                   STATUS      AGE
+test-recording-nginx   Installed   2m48s
+test-recording-redis   Installed   2m48s
+----
+endif::[]
+
+ifdef::selinux[]
++
+[source,terminal]
+----
+$ oc get selinuxprofiles -lspo.x-k8s.io/recording-id=test-recording -n my-namespace
+----
++
+.Example output for selinuxprofile
 [source,terminal]
 ----
 NAME                   USAGE                                       STATE
 test-recording-nginx   test-recording-nginx_my-namespace.process   Installed
 test-recording-redis   test-recording-redis_my-namespace.process   Installed
 ----
+endif::[]
 
 ifeval::["{context}" == "spo-seccomp"]
 :!seccomp:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+

Issue: https://issues.redhat.com/browse/OCPBUGS-13961

Link to seccomp preview: https://62471--docspreview.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-seccomp#spo-recording-profiles_spo-seccomp

Link to selinux preview: https://62471--docspreview.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-selinux

NOTE TO REVIEWERS: These are the most up-to-date previews.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
