### PR TITLE
OSDOCS 6914: Updating pod examples to comply with restricted PSA (Aut…

### DIFF
--- a/modules/bound-sa-tokens-configuring.adoc
+++ b/modules/bound-sa-tokens-configuring.adoc
@@ -111,26 +111,36 @@ kind: Pod
 metadata:
   name: nginx
 spec:
+  securityContext:
+    runAsNonRoot: true <1>
+    seccompProfile:
+      type: RuntimeDefault <2>
   containers:
   - image: nginx
     name: nginx
     volumeMounts:
     - mountPath: /var/run/secrets/tokens
       name: vault-token
-  serviceAccountName: build-robot <1>
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+  serviceAccountName: build-robot <3>
   volumes:
   - name: vault-token
     projected:
       sources:
       - serviceAccountToken:
-          path: vault-token <2>
-          expirationSeconds: 7200 <3>
-          audience: vault <4>
+          path: vault-token <4>
+          expirationSeconds: 7200 <5>
+          audience: vault <6>
 ----
-<1> A reference to an existing service account.
-<2> The path relative to the mount point of the file to project the token into.
-<3> Optionally set the expiration of the service account token, in seconds. The default is 3600 seconds (1 hour) and must be at least 600 seconds (10 minutes). The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.
-<4> Optionally set the intended audience of the token. The recipient of a token should verify that the recipient identity matches the audience claim of the token, and should otherwise reject the token. The audience defaults to the identifier of the API server.
+<1> Prevents containers from running as root to minimize compromise risks.
+<2> Sets the default seccomp profile, limiting to essential system calls, to reduce risks.
+<3> A reference to an existing service account.
+<4> The path relative to the mount point of the file to project the token into.
+<5> Optionally set the expiration of the service account token, in seconds. The default value is 3600 seconds (1 hour), and this value must be at least 600 seconds (10 minutes). The kubelet starts trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.
+<6> Optionally set the intended audience of the token. The recipient of a token should verify that the recipient identity matches the audience claim of the token, and should otherwise reject the token. The audience defaults to the identifier of the API server.
 +
 [NOTE]
 ====

--- a/modules/compliance-results.adoc
+++ b/modules/compliance-results.adoc
@@ -66,6 +66,10 @@ kind: Pod
 metadata:
   name: pv-extract
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: pv-extract-pod
       image: registry.access.redhat.com/ubi9/ubi
@@ -73,6 +77,10 @@ spec:
       volumeMounts:
       - mountPath: "/workers-scan-results"
         name: workers-scan-vol
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: workers-scan-vol
       persistentVolumeClaim:

--- a/modules/compliance-scheduling-pods-with-resource-requests.adoc
+++ b/modules/compliance-scheduling-pods-with-resource-requests.adoc
@@ -32,6 +32,10 @@ kind: Pod
 metadata:
   name: frontend
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: app
     image: images.my-company.example/app:v4
@@ -42,6 +46,10 @@ spec:
       limits: <2>
         memory: "128Mi"
         cpu: "500m"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   - name: log-aggregator
     image: images.my-company.example/log-aggregator:v6
     resources:
@@ -51,6 +59,10 @@ spec:
       limits:
         memory: "128Mi"
         cpu: "500m"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 <1> The container is requesting 64 Mi of memory and 250 m CPU.
 <2> The container's limits are 128 Mi of memory and 500 m CPU.

--- a/modules/deploying-a-pod-that-includes-an-aws-sdk.adoc
+++ b/modules/deploying-a-pod-that-includes-an-aws-sdk.adoc
@@ -35,6 +35,10 @@ metadata:
   namespace: <project_name> <1>
   name: awsboto3sdk <2>
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   serviceAccountName: <service_account_name> <3>
   containers:
   - name: awsboto3sdk
@@ -43,6 +47,10 @@ spec:
     - /bin/bash
     - "-c"
     - "sleep 100000" <5>
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   terminationGracePeriodSeconds: 0
   restartPolicy: Never
 ----

--- a/modules/spo-applying-profiles.adoc
+++ b/modules/spo-applying-profiles.adoc
@@ -37,12 +37,17 @@ metadata:
   name: test-pod
 spec:
   securityContext:
+    runAsNonRoot: true
     seccompProfile:
       type: Localhost
       localhostProfile: operator/my-namespace/profile1.json
   containers:
     - name: test-container
       image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 ----
 
 . View the profile path of the `seccompProfile.localhostProfile` attribute by running the following command:
@@ -157,10 +162,17 @@ metadata:
   name: nginx-secure
   namespace: nginx-deploy
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - image: nginxinc/nginx-unprivileged:1.21
       name: nginx
       securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
         seLinuxOptions:
           # NOTE: This uses an appropriate SELinux type
           type: nginx-secure_nginx-deploy.process

--- a/modules/spo-log-enricher-app-trace.adoc
+++ b/modules/spo-log-enricher-app-trace.adoc
@@ -33,12 +33,17 @@ metadata:
   name: log-pod
 spec:
   securityContext:
+    runAsNonRoot: true
     seccompProfile:
       type: Localhost
       localhostProfile: operator/default/log.json
   containers:
-    - name: log-container
-      image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21
+  - name: log-container
+    image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 
 . Examine the log enricher output by running the following command:

--- a/modules/spo-memory-optimzation.adoc
+++ b/modules/spo-memory-optimzation.adoc
@@ -9,7 +9,7 @@
 The controller running inside of `spod` daemon process watches all pods available in the cluster when profile recording is enabled. This can lead to very high memory usage in large clusters, resulting in the `spod` daemon running out of memory or crashing.
 
 To prevent crashes, the `spod` daemon can be configured to only load the pods labeled for profile recording into the cache memory.
-+
+
 [NOTE]
 ====
 SPO memory optimization is not enabled by default.
@@ -34,4 +34,5 @@ metadata:
   name: my-recording-pod
   labels:
     spo.x-k8s.io/enable-recording: "true"
+# ...
 ----

--- a/modules/spo-recording-profiles.adoc
+++ b/modules/spo-recording-profiles.adoc
@@ -75,13 +75,25 @@ metadata:
   labels:
     app: my-app
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: nginx
       image: quay.io/security-profiles-operator/test-nginx-unprivileged:1.21
       ports:
         - containerPort: 8080
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
     - name: redis
       image: quay.io/security-profiles-operator/redis:6.2.1
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 ----
 
 . Confirm the pod is in a `Running` state by entering the following command:


### PR DESCRIPTION
…h and Security books)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-6914

Link to docs preview:

**OCP**

* https://62472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/bound-service-account-tokens.html#bound-sa-tokens-configuring_bound-service-account-tokens
* https://62472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-raw-results#compliance-results_compliance-raw-results
* https://62472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-scans#compliance-scheduling-pods-with-resource-requests_compliance-operator-scans
* (See ROSA section below for preview for deploying-a-pod-that-includes-an-aws-sdk.adoc)
* https://62472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#security-context-constraints-example_configuring-internal-oauth
* https://62472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-seccomp.html#spo-applying-profiles_spo-seccomp
* https://62472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-advanced.html#spo-log-enricher-app-trace_spo-advanced
* https://62472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-advanced.html#spo-memory-optimization_spo-advanced (just added a truncated ...)
* https://62472--ocpdocs-pr.netlify.app/openshift-enterprise/latest/security/security_profiles_operator/spo-seccomp.html#spo-recording-profiles_spo-seccomp

**ROSA**

For [modules/deploying-a-pod-that-includes-an-aws-sdk.adoc](https://github.com/openshift/openshift-docs/pull/62472/files#diff-27ef42898c49b138136953bb216995586e7d657eb74ea659868b51445fdec9fe)

ROSA: https://62472--ocpdocs-pr.netlify.app/openshift-rosa/latest/authentication/assuming-an-aws-iam-role-for-a-service-account.html#deploying-a-pod-that-includes-an-aws-sdk_assuming-an-aws-iam-role-for-a-service-account

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
