### PR TITLE
NodesScheduler docs fixes during ROSA review

### DIFF
--- a/modules/nodes-cluster-overcommit-configure-nodes.adoc
+++ b/modules/nodes-cluster-overcommit-configure-nodes.adoc
@@ -32,7 +32,9 @@ $ sysctl -a |grep commit
 .Example output
 [source,terminal]
 ----
-vm.overcommit_memory = 1
+#...
+vm.overcommit_memory = 0
+#...
 ----
 
 [source,terminal]
@@ -43,7 +45,9 @@ $ sysctl -a |grep panic
 .Example output
 [source,terminal]
 ----
+#...
 vm.panic_on_oom = 0
+#...
 ----
 
 [NOTE]

--- a/modules/nodes-scheduler-node-affinity-about.adoc
+++ b/modules/nodes-scheduler-node-affinity-about.adoc
@@ -44,6 +44,7 @@ spec:
   containers:
   - name: with-node-affinity
     image: docker.io/ocpqe/hello-pod
+#...
 ----
 
 <1> The stanza to configure node affinity.
@@ -75,6 +76,7 @@ spec:
   containers:
   - name: with-node-affinity
     image: docker.io/ocpqe/hello-pod
+#...
 ----
 
 <1> The stanza to configure node affinity.

--- a/modules/nodes-scheduler-node-affinity-configuring-preferred.adoc
+++ b/modules/nodes-scheduler-node-affinity-configuring-preferred.adoc
@@ -19,32 +19,43 @@ The following steps demonstrate a simple configuration that creates a node and a
 $ oc label node node1 e2e-az-name=e2e-az3
 ----
 
-. In the `Pod` spec, use the `nodeAffinity` stanza to configure the `preferredDuringSchedulingIgnoredDuringExecution` parameter:
+. Create a pod with a specific label:
 +
-.. Specify a weight for the node, as a number 1-100. The node with highest weight is preferred.
+.. Create a YAML file with the following content:
 +
-.. Specify the key and values that must be met. If you want the new pod to be scheduled on the node you edited, use the same `key` and `value` parameters as the label in the node:
+[NOTE]
+====
+You cannot add an affinity directly to a scheduled pod.
+====
 +
 [source,yaml]
 ----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: s1
 spec:
-  affinity:
+  affinity: <1>
     nodeAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 1
+      preferredDuringSchedulingIgnoredDuringExecution: <2>
+      - weight: <3>
         preference:
           matchExpressions:
-          - key: e2e-az-name
-            operator: In
+          - key: e2e-az-name <4>
             values:
             - e2e-az3
+            operator: In <5>
+#...
 ----
-+
-.. Specify an `operator`. The operator can be `In`, `NotIn`, `Exists`, `DoesNotExist`, `Lt`, or `Gt`. For example, use the Operator `In` to require the label to be in the node.
+<1> Adds a pod affinity.
+<2> Configures the `preferredDuringSchedulingIgnoredDuringExecution` parameter.
+<3> Specifies a weight for the node, as a number 1-100. The node with highest weight is preferred.
+<4> Specifies the `key` and `values` that must be met. If you want the new pod to be scheduled on the node you edited, use the same `key` and `values` parameters as the label in the node.
+<5> Specifies an `operator`. The operator can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
 
-. Create the pod.
+.. Create the pod.
 +
 [source,terminal]
 ----
-$ oc create -f e2e-az3.yaml
+$ oc create -f <file-name>.yaml
 ----

--- a/modules/nodes-scheduler-node-affinity-configuring-required.adoc
+++ b/modules/nodes-scheduler-node-affinity-configuring-required.adoc
@@ -31,34 +31,47 @@ metadata:
   name: <node_name>
   labels:
     e2e-az-name: e2e-az1
+#...
 ----
 ====
 
-. In the `Pod` spec, use the `nodeAffinity` stanza to configure the `requiredDuringSchedulingIgnoredDuringExecution` parameter:
+. Create a pod with a specific label in the pod spec:
 +
-.. Specify the key and values that must be met. If you want the new pod to be scheduled on the node you edited, use the same `key` and `value` parameters as the label in the node.
+.. Create a YAML file with the following content:
 +
-.. Specify an `operator`. The operator can be `In`, `NotIn`, `Exists`, `DoesNotExist`, `Lt`, or `Gt`. For example, use the operator `In` to require the label to be in the node:
+[NOTE]
+====
+You cannot add an affinity directly to a scheduled pod.
+====
 +
 .Example output
 [source,yaml]
 ----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: s1
 spec:
-  affinity:
+  affinity: <1>
     nodeAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
+      requiredDuringSchedulingIgnoredDuringExecution: <2>
         nodeSelectorTerms:
         - matchExpressions:
-          - key: e2e-az-name
-            operator: In
+          - key: e2e-az-name <3>
             values:
             - e2e-az1
             - e2e-az2
+            operator: In <4>
+#...
 ----
+<1> Adds a pod affinity.
+<2> Configures the `requiredDuringSchedulingIgnoredDuringExecution` parameter.
+<3> Specifies the `key` and `values` that must be met. If you want the new pod to be scheduled on the node you edited, use the same `key` and `values` parameters as the label in the node.
+<4> Specifies an `operator`. The operator can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
 
-. Create the pod:
+.. Create the pod:
 +
 [source,terminal]
 ----
-$ oc create -f e2e-az2.yaml
+$ oc create -f <file-name>.yaml
 ----

--- a/modules/nodes-scheduler-node-affinity-example.adoc
+++ b/modules/nodes-scheduler-node-affinity-example.adoc
@@ -2,7 +2,7 @@
 //
 // * nodes/nodes-scheduler-node-affinity.adoc
 
-[id="nodes-scheduler-node-affinity-examples_{context}"]
+[id="nodes-scheduler-node-affinity-example_{context}"]
 = Sample node affinity rules
 
 The following examples demonstrate node affinity.
@@ -31,6 +31,7 @@ metadata:
   name: <node_name>
   labels:
     zone: us
+#...
 ----
 ====
 
@@ -61,6 +62,7 @@ spec:
               operator: In
               values:
               - us
+#...
 ----
 
 * The pod-s1 pod can be scheduled on Node1:
@@ -101,6 +103,7 @@ metadata:
   name: <node_name>
   labels:
     zone: emea
+#...
 ----
 ====
 
@@ -131,6 +134,7 @@ spec:
               operator: In
               values:
               - us
+#...
 ----
 
 * The pod-s1 pod cannot be scheduled on Node1:

--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -62,6 +62,7 @@ metadata:
     kubernetes.io/arch: amd64
     region: east <1>
     type: user-node
+#...
 ----
 <1> Labels to match the pod node selector.
 endif::openshift-origin[]
@@ -72,7 +73,7 @@ ifdef::openshift-origin[]
 kind: Node
 apiVersion: v1
 metadata:
-  name: ip-10-0-131-14.ec2.internal
+  name: s1
   selfLink: /api/v1/nodes/ip-10-0-131-14.ec2.internal
   uid: 7bc2580a-8b8e-11e9-8e01-021ab4174c74
   resourceVersion: '478704'
@@ -89,6 +90,7 @@ metadata:
     kubernetes.io/arch: amd64
     region: east <1>
     type: user-node
+#...
 ----
 <1> Labels to match the pod node selector.
 endif::openshift-origin[]
@@ -100,13 +102,14 @@ A pod has the `type: user-node,region: east` node selector:
 ----
 apiVersion: v1
 kind: Pod
-
-....
-
+metadata:
+  name: s1
+#...
 spec:
   nodeSelector: <1>
     region: east
     type: user-node
+#...
 ----
 <1> Node selectors to match the node label. The node must have a label for each node selector.
 +
@@ -126,11 +129,10 @@ apiVersion: config.openshift.io/v1
 kind: Scheduler
 metadata:
   name: cluster
-...
-
+#...
 spec:
   defaultNodeSelector: type=user-node,region=east
-...
+#...
 ----
 +
 A node in that cluster has the `type=user-node,region=east` labels:
@@ -142,11 +144,11 @@ apiVersion: v1
 kind: Node
 metadata:
   name: ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4
-...
+#...
   labels:
     region: east
     type: user-node
-...
+#...
 ----
 +
 .Example `Pod` object with a node selector
@@ -154,12 +156,13 @@ metadata:
 ----
 apiVersion: v1
 kind: Pod
-...
-
+metadata:
+  name: s1
+#...
 spec:
   nodeSelector:
     region: east
-...
+#...
 ----
 +
 When you create the pod using the example pod spec in the example cluster, the pod is created with the cluster-wide node selector and is scheduled on the labeled node:
@@ -192,7 +195,7 @@ metadata:
   name: east-region
   annotations:
     openshift.io/node-selector: "region=east"
-...
+#...
 ----
 +
 The following node has the `type=user-node,region=east` labels:
@@ -204,11 +207,11 @@ apiVersion: v1
 kind: Node
 metadata:
   name: ci-ln-qg1il3k-f76d1-hlmhl-worker-b-df2s4
-...
+#...
   labels:
     region: east
     type: user-node
-...
+#...
 ----
 +
 When you create the pod using the example pod spec in this example project, the pod is created with the project node selectors and is scheduled on the labeled node:
@@ -220,12 +223,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   namespace: east-region
-...
+#...
 spec:
   nodeSelector:
     region: east
     type: user-node
-...
+#...
 ----
 +
 [source,terminal]
@@ -242,11 +245,11 @@ A pod in the project is not created or scheduled if the pod contains different n
 ----
 apiVersion: v1
 kind: Pod
-...
-
+metadata:
+  name: west-region
+#...
 spec:
   nodeSelector:
     region: west
-
-....
+#...
 ----

--- a/modules/nodes-scheduler-node-selectors-pod.adoc
+++ b/modules/nodes-scheduler-node-selectors-pod.adoc
@@ -32,11 +32,13 @@ $ oc describe pod router-default-66d5cf9464-7pwkc
 .Example output
 [source,terminal]
 ----
+kind: Pod
+apiVersion: v1
+metadata:
+#...
 Name:               router-default-66d5cf9464-7pwkc
 Namespace:          openshift-ingress
-
 # ...
-
 Controlled By:      ReplicaSet/router-default-66d5cf9464
 # ...
 ----
@@ -45,6 +47,10 @@ The web console lists the controlling object under `ownerReferences` in the pod 
 
 [source,terminal]
 ----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: router-default-66d5cf9464-7pwkc
 # ...
   ownerReferences:
     - apiVersion: apps/v1
@@ -85,7 +91,7 @@ You can alternatively apply the following YAML to add labels to a compute machin
 apiVersion: machine.openshift.io/v1beta1
 kind: MachineSet
 metadata:
-  name: <machineset>
+  name: xf2bd-infra-us-east-2a
   namespace: openshift-machine-api
 spec:
   template:
@@ -94,6 +100,7 @@ spec:
         labels:
           region: "east"
           type: "user-node"
+#...
 ----
 ====
 
@@ -153,10 +160,11 @@ You can alternatively apply the following YAML to add labels to a node:
 kind: Node
 apiVersion: v1
 metadata:
-  name: <node_name>
+  name: hello-node-6fbccf8d9
   labels:
     type: "user-node"
     region: "east"
+#...
 ----
 ====
 
@@ -182,13 +190,12 @@ ip-10-0-142-25.ec2.internal   Ready    worker   17m   v1.26.0
 [source,yaml]
 ----
 kind: ReplicaSet
-
+apiVersion: apps/v1
+metadata:
+  name: hello-node-6fbccf8d9
 # ...
-
 spec:
-
 # ...
-
   template:
     metadata:
       creationTimestamp: null
@@ -200,6 +207,7 @@ spec:
         kubernetes.io/os: linux
         node-role.kubernetes.io/worker: ''
         type: user-node <1>
+#...
 ----
 <1> Add the node selector.
 
@@ -210,13 +218,14 @@ spec:
 ----
 apiVersion: v1
 kind: Pod
-
-# ...
-
+metadata:
+  name: hello-node-6fbccf8d9
+#...
 spec:
   nodeSelector:
     region: east
     type: user-node
+#...
 ----
 +
 [NOTE]

--- a/modules/nodes-scheduler-pod-affinity-configuring.adoc
+++ b/modules/nodes-scheduler-pod-affinity-configuring.adoc
@@ -8,13 +8,19 @@
 
 The following steps demonstrate a simple two-pod configuration that creates pod with a label and a pod that uses affinity to allow scheduling with that pod.
 
+[NOTE]
+====
+You cannot add an affinity directly to a scheduled pod.
+====
+
 .Procedure
 
-. Create a pod with a specific label in the `Pod` spec:
+. Create a pod with a specific label in the pod spec:
 +
-[source,terminal]
+.. Create a YAML file with the following content:
++
+[source,yaml]
 ----
-$ cat team4.yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -26,31 +32,48 @@ spec:
   - name: security-s1
     image: docker.io/ocpqe/hello-pod
 ----
++
+.. Create the pod.
++
+[source,terminal]
+----
+$ oc create -f <pod-spec>.yaml
+----
 
-. When creating other pods, edit the `Pod` spec as follows:
+. When creating other pods, configure the following parameters to add the affinity:
 +
-.. Use the `podAffinity` stanza to configure the `requiredDuringSchedulingIgnoredDuringExecution` parameter or `preferredDuringSchedulingIgnoredDuringExecution` parameter:
-+
-.. Specify the key and value that must be met. If you want the new pod to be scheduled with the other pod, use the same `key` and `value` parameters as the label on the first pod.
+.. Create a YAML file with the following content:
 +
 [source,yaml]
 ----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-s1-east
+#...
+spec
+  affinity <1>
     podAffinity:
-      requiredDuringSchedulingIgnoredDuringExecution:
+      requiredDuringSchedulingIgnoredDuringExecution: <2>
       - labelSelector:
           matchExpressions:
-          - key: security
-            operator: In
+          - key: security <3>
             values:
             - S1
-        topologyKey: topology.kubernetes.io/zone
+            operator: In <4>
+        topologyKey: topology.kubernetes.io/zone <5>
+#...
 ----
 +
-.. Specify an `operator`. The operator can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
-+
-.. Specify a `topologyKey`, which is a prepopulated link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[Kubernetes label] that the system uses to denote such a topology domain.
+--
+<1> Adds a pod affinity.
+<2> Configures the `requiredDuringSchedulingIgnoredDuringExecution` parameter or the `preferredDuringSchedulingIgnoredDuringExecution` parameter.
+<3> Specifies the `key` and `values` that must be met. If you want the new pod to be scheduled with the other pod, use the same `key` and `values` parameters as the label on the first pod.
+<4> Specifies an `operator`. The operator can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
+<5> Specify a `topologyKey`, which is a prepopulated link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[Kubernetes label] that the system uses to denote such a topology domain.
+--
 
-. Create the pod.
+.. Create the pod.
 +
 [source,terminal]
 ----

--- a/modules/nodes-scheduler-pod-affinity-example.adoc
+++ b/modules/nodes-scheduler-pod-affinity-example.adoc
@@ -14,30 +14,31 @@ The following example demonstrates pod affinity for pods with matching labels an
 
 * The pod *team4* has the label `team:4`.
 +
-[source,terminal]
+[source,yaml]
 ----
-$ cat team4.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: team4
   labels:
      team: "4"
+#...
 spec:
   containers:
   - name: ocp
     image: docker.io/ocpqe/hello-pod
+#...
 ----
 
 * The pod *team4a* has the label selector `team:4` under `podAffinity`.
 +
 [source,yaml]
 ----
-$ cat pod-team4a.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: team4a
+#...
 spec:
   affinity:
     podAffinity:
@@ -52,6 +53,7 @@ spec:
   containers:
   - name: pod-affinity
     image: docker.io/ocpqe/hello-pod
+#...
 ----
 
 * The *team4a* pod is scheduled on the same node as the *team4* pod.
@@ -63,30 +65,31 @@ The following example demonstrates pod anti-affinity for pods with matching labe
 
 * The pod *pod-s1* has the label `security:s1`.
 +
-[source,terminal]
+[source,yaml]
 ----
-cat pod-s1.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: pod-s1
   labels:
     security: s1
+#...
 spec:
   containers:
   - name: ocp
     image: docker.io/ocpqe/hello-pod
+#...
 ----
 
 * The pod *pod-s2* has the label selector `security:s1` under `podAntiAffinity`.
 +
 [source,yaml]
 ----
-cat pod-s2.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: pod-s2
+#...
 spec:
   affinity:
     podAntiAffinity:
@@ -101,6 +104,7 @@ spec:
   containers:
   - name: pod-antiaffinity
     image: docker.io/ocpqe/hello-pod
+#...
 ----
 
 * The pod *pod-s2* cannot be scheduled on the same node as `pod-s1`.
@@ -112,30 +116,31 @@ The following example demonstrates pod affinity for pods without matching labels
 
 * The pod *pod-s1* has the label `security:s1`.
 +
-[source,terminal]
+[source,yaml]
 ----
-$ cat pod-s1.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: pod-s1
   labels:
     security: s1
+#...
 spec:
   containers:
   - name: ocp
     image: docker.io/ocpqe/hello-pod
+#...
 ----
 
 * The pod *pod-s2* has the label selector `security:s2`.
 +
-[source,terminal]
+[source,yaml]
 ----
-$ cat pod-s2.yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: pod-s2
+#...
 spec:
   affinity:
     podAffinity:
@@ -150,6 +155,7 @@ spec:
   containers:
   - name: pod-affinity
     image: docker.io/ocpqe/hello-pod
+#...
 ----
 
 * The pod *pod-s2* is not scheduled unless there is a node with a pod that has the `security:s2` label. If there is no other pod with that label, the new pod remains in a pending state:

--- a/modules/nodes-scheduler-pod-anti-affinity-configuring.adoc
+++ b/modules/nodes-scheduler-pod-anti-affinity-configuring.adoc
@@ -8,55 +8,72 @@
 
 The following steps demonstrate a simple two-pod configuration that creates pod with a label and a pod that uses an anti-affinity preferred rule to attempt to prevent scheduling with that pod.
 
+[NOTE]
+====
+You cannot add an affinity directly to a scheduled pod.
+====
+
 .Procedure
 
-. Create a pod with a specific label in the `Pod` spec:
+. Create a pod with a specific label in the pod spec:
++
+.. Create a YAML file with the following content:
 +
 [source,yaml]
 ----
-$ cat team4.yaml
 apiVersion: v1
 kind: Pod
 metadata:
-  name: security-s2
+  name: security-s1
   labels:
-    security: S2
+    security: S1
 spec:
   containers:
-  - name: security-s2
+  - name: security-s1
     image: docker.io/ocpqe/hello-pod
 ----
-
-. When creating other pods, edit the `Pod` spec to set the following parameters:
-
-. Use the `podAntiAffinity` stanza to configure the `requiredDuringSchedulingIgnoredDuringExecution` parameter or `preferredDuringSchedulingIgnoredDuringExecution` parameter:
 +
-.. Specify a weight for the node, 1-100. The node that with highest weight is preferred.
+.. Create the pod.
 +
-.. Specify the key and values that must be met. If you want the new pod to not be scheduled with the other pod, use the same `key` and `value` parameters as the label on the first pod.
+[source,terminal]
+----
+$ oc create -f <pod-spec>.yaml
+----
+
+. When creating other pods, configure the following parameters:
++
+.. Create a YAML file with the following content:
 +
 [source,yaml]
 ----
+apiVersion: v1
+kind: Pod
+metadata:
+  name: security-s2-east
+#...
+spec
+  affinity <1>
     podAntiAffinity:
-      preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
+      preferredDuringSchedulingIgnoredDuringExecution: <2>
+      - weight: 100 <3>
         podAffinityTerm:
           labelSelector:
             matchExpressions:
-            - key: security
-              operator: In
+            - key: security <4>
               values:
-              - S2
-          topologyKey: kubernetes.io/hostname
+              - S1
+              operator: In <5>
+          topologyKey: kubernetes.io/hostname <6>
+#...
 ----
-+
-.. For a preferred rule, specify a weight, 1-100.
-+
-.. Specify an `operator`. The operator can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
+<1> Adds a pod anti-affinity.
+<2> Configures the `requiredDuringSchedulingIgnoredDuringExecution` parameter or the `preferredDuringSchedulingIgnoredDuringExecution` parameter.
+<3> For a preferred rule, specifies a weight for the node, 1-100. The node that with highest weight is preferred.
+<4> Specifies the `key` and `values` that must be met. If you want the new pod to not be scheduled with the other pod, use the same `key` and `values` parameters as the label on the first pod.
+<5> Specifies an `operator`. The operator can be `In`, `NotIn`, `Exists`, or `DoesNotExist`. For example, use the operator `In` to require the label to be in the node.
+<6> Specifies a `topologyKey`, which is a prepopulated link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[Kubernetes label] that the system uses to denote such a topology domain.
 
-. Specify a `topologyKey`, which is a prepopulated link:https://kubernetes.io/docs/concepts/configuration/assign-pod-node/#interlude-built-in-node-labels[Kubernetes label] that the system uses to denote such a topology domain.
-
-. Create the pod.
+.. Create the pod.
 +
 [source,terminal]
 ----

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
@@ -26,7 +26,7 @@ kind: Pod
 metadata:
   name: my-pod
   labels:
-    foo: bar
+    region: us-east
 spec:
   topologySpreadConstraints:
   - maxSkew: 1 <1>
@@ -34,7 +34,7 @@ spec:
     whenUnsatisfiable: DoNotSchedule <3>
     labelSelector: <4>
       matchLabels:
-        foo: bar <5>
+        region: us-east <5>
     matchLabelKeys:
       - my-pod-label <6>
   containers:

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-examples.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-examples.adoc
@@ -12,7 +12,7 @@ The following examples demonstrate pod topology spread constraint configurations
 
 // TODO: Add a diagram?
 
-This example `Pod` spec defines one pod topology spread constraint. It matches on pods labeled `foo:bar`, distributes among zones, specifies a skew of `1`, and does not schedule the pod if it does not meet these requirements.
+This example `Pod` spec defines one pod topology spread constraint. It matches on pods labeled `region: us-east`, distributes among zones, specifies a skew of `1`, and does not schedule the pod if it does not meet these requirements.
 
 [source,yaml]
 ----
@@ -21,7 +21,7 @@ apiVersion: v1
 metadata:
   name: my-pod
   labels:
-    foo: bar
+    region: us-east
 spec:
   topologySpreadConstraints:
   - maxSkew: 1
@@ -29,7 +29,7 @@ spec:
     whenUnsatisfiable: DoNotSchedule
     labelSelector:
       matchLabels:
-        foo: bar
+        region: us-east
   containers:
   - image: "docker.io/ocpqe/hello-pod"
     name: hello-pod
@@ -40,7 +40,7 @@ spec:
 
 // TODO: Add a diagram?
 
-This example `Pod` spec defines two pod topology spread constraints. Both match on pods labeled `foo:bar`, specify a skew of `1`, and do not schedule the pod if it does not meet these requirements.
+This example `Pod` spec defines two pod topology spread constraints. Both match on pods labeled `region: us-east`, specify a skew of `1`, and do not schedule the pod if it does not meet these requirements.
 
 The first constraint distributes pods based on a user-defined label `node`, and the second constraint distributes pods based on a user-defined label `rack`. Both constraints must be met for the pod to be scheduled.
 
@@ -51,7 +51,7 @@ apiVersion: v1
 metadata:
   name: my-pod-2
   labels:
-    foo: bar
+    region: us-east
 spec:
   topologySpreadConstraints:
   - maxSkew: 1
@@ -59,13 +59,13 @@ spec:
     whenUnsatisfiable: DoNotSchedule
     labelSelector:
       matchLabels:
-        foo: bar
+        region: us-east
   - maxSkew: 1
     topologyKey: rack
     whenUnsatisfiable: DoNotSchedule
     labelSelector:
       matchLabels:
-        foo: bar
+        region: us-east
   containers:
   - image: "docker.io/ocpqe/hello-pod"
     name: hello-pod

--- a/modules/nodes-scheduler-profiles-configuring.adoc
+++ b/modules/nodes-scheduler-profiles-configuring.adoc
@@ -28,14 +28,12 @@ $ oc edit scheduler cluster
 apiVersion: config.openshift.io/v1
 kind: Scheduler
 metadata:
-  ...
   name: cluster
-  resourceVersion: "601"
-  selfLink: /apis/config.openshift.io/v1/schedulers/cluster
-  uid: b351d6d0-d06f-4a99-a26b-87af62e79f59
+#...
 spec:
   mastersSchedulable: false
   profile: HighNodeUtilization <1>
+#...
 ----
 <1> Set to `LowNodeUtilization`, `HighNodeUtilization`, or `NoScoring`.
 

--- a/modules/nodes-scheduler-taints-tolerations-about.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-about.adoc
@@ -15,17 +15,27 @@ You apply taints to a node through the `Node` specification (`NodeSpec`) and app
 .Example taint in a node specification
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   taints:
   - effect: NoExecute
     key: key1
     value: value1
-....
+#...
 ----
 
 .Example toleration in a `Pod` spec
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
   - key: "key1"
@@ -33,7 +43,7 @@ spec:
     value: "value1"
     effect: "NoExecute"
     tolerationSeconds: 3600
-....
+#...
 ----
 
 
@@ -94,12 +104,13 @@ metadata:
   annotations:
     machine.openshift.io/machine: openshift-machine-api/ci-ln-62s7gtb-f76d1-v8jxv-master-0
     machineconfiguration.openshift.io/currentConfig: rendered-master-cdc1ab7da414629332cc4c3926e6e59c
-...
+  name: my-pod
+#...
 spec:
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
-...
+#...
 ----
 --
 
@@ -139,6 +150,11 @@ You can specify how long a pod can remain bound to a node before being evicted b
 .Example output
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
   - key: "key1"
@@ -146,6 +162,7 @@ spec:
     value: "value1"
     effect: "NoExecute"
     tolerationSeconds: 3600
+#...
 ----
 
 Here, if this pod is running but does not have a matching toleration, the pod stays bound to the node for 3,600 seconds and then be evicted. If the taint is removed before that time, the pod is not evicted.
@@ -191,6 +208,11 @@ $ oc adm taint nodes node1 key2=value2:NoSchedule
 +
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
   - key: "key1"
@@ -201,6 +223,7 @@ spec:
     operator: "Equal"
     value: "value1"
     effect: "NoExecute"
+#...
 ----
 
 In this case, the pod cannot be scheduled onto the node, because there is no toleration matching the third taint. The pod continues running if it is already running on the node when the taint is added, because the third taint is the only
@@ -252,6 +275,11 @@ For more information, see link:https://kubernetes.io/docs/concepts/architecture/
 
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
   - key: node.kubernetes.io/not-ready
@@ -262,6 +290,7 @@ spec:
     operator: Exists
     effect: NoExecute
     tolerationSeconds: 300
+#...
 ----
 
 <1> These tolerations ensure that the default pod behavior is to remain bound for five minutes after one of these node conditions problems is detected.
@@ -278,13 +307,19 @@ As a result, daemon set pods are never evicted because of these node conditions.
 [id="nodes-scheduler-taints-tolerations-all_{context}"]
 == Tolerating all taints
 
-You can configure a pod to tolerate all taints by adding an `operator: "Exists"` toleration with no `key` and `value` parameters.
+You can configure a pod to tolerate all taints by adding an `operator: "Exists"` toleration with no `key` and `values` parameters.
 Pods with this toleration are not removed from a node that has taints.
 
 .`Pod` spec for tolerating all taints
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
   - operator: "Exists"
+#...
 ----

--- a/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
@@ -16,6 +16,11 @@ You can add taints to nodes using a compute machine set. All nodes associated wi
 .Sample pod configuration file with `Equal` operator
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
   - key: "key1" <1>
@@ -23,6 +28,7 @@ spec:
     operator: "Equal"
     effect: "NoExecute"
     tolerationSeconds: 3600 <2>
+#...
 ----
 <1> The toleration parameters, as described in the *Taint and toleration components* table.
 <2> The `tolerationSeconds` parameter specifies how long a pod is bound to a node before being evicted.
@@ -32,12 +38,18 @@ For example:
 .Sample pod configuration file with `Exists` operator
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
   - key: "key1"
     operator: "Exists"
     effect: "NoExecute"
     tolerationSeconds: 3600
+#...
 ----
 
 . Add the taint to the `MachineSet` object:
@@ -54,16 +66,21 @@ $ oc edit machineset <machineset>
 .Example taint in a compute machine set specification
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
-....
+#...
   template:
-....
+#...
     spec:
       taints:
       - effect: NoExecute
         key: key1
         value: value1
-....
+#...
 ----
 +
 This example places a taint that has the key `key1`, value `value1`, and taint effect `NoExecute` on the nodes.

--- a/modules/nodes-scheduler-taints-tolerations-adding.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding.adoc
@@ -16,6 +16,11 @@ You add tolerations to pods and taints to nodes to allow the node to control whi
 .Sample pod configuration file with an Equal operator
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
   - key: "key1" <1>
@@ -23,6 +28,7 @@ spec:
     operator: "Equal"
     effect: "NoExecute"
     tolerationSeconds: 3600 <2>
+#...
 ----
 <1> The toleration parameters, as described in the *Taint and toleration components* table.
 <2> The `tolerationSeconds` parameter specifies how long a pod can remain bound to a node before being evicted.
@@ -32,12 +38,18 @@ For example:
 .Sample pod configuration file with an Exists operator
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec: 
    tolerations:
     - key: "key1"
       operator: "Exists" <1>
       effect: "NoExecute"
       tolerationSeconds: 3600
+#...
 ----
 <1> The `Exists` operator does not take a `value`.
 +
@@ -73,12 +85,13 @@ metadata:
   annotations:
     machine.openshift.io/machine: openshift-machine-api/ci-ln-62s7gtb-f76d1-v8jxv-master-0
     machineconfiguration.openshift.io/currentConfig: rendered-master-cdc1ab7da414629332cc4c3926e6e59c
-...
+  name: my-pod
+#...
 spec:
   taints:
   - effect: NoSchedule
     key: node-role.kubernetes.io/master
-...
+#...
 ----
 ====
 +

--- a/modules/nodes-scheduler-taints-tolerations-binding.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-binding.adoc
@@ -33,14 +33,14 @@ You can alternatively apply the following YAML to add the taint:
 kind: Node
 apiVersion: v1
 metadata:
-  name: <node_name>
-  labels:
-    ...
+  name: my-pod
+#...
 spec:
   taints:
     - key: dedicated
       value: groupName
       effect: NoSchedule
+#...
 ----
 ====
 

--- a/modules/nodes-scheduler-taints-tolerations-removing.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-removing.adoc
@@ -37,10 +37,16 @@ node/ip-10-0-132-248.ec2.internal untainted
 +
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
   - key: "key2"
     operator: "Exists"
     effect: "NoExecute"
     tolerationSeconds: 3600
+#...
 ----

--- a/modules/nodes-scheduler-taints-tolerations-special.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-special.adoc
@@ -21,6 +21,11 @@ For example:
 +
 [source,yaml]
 ----
+apiVersion: v1
+kind: Node
+metadata:
+  name: my-pod
+#...
 spec:
   tolerations:
     - key: "disktype"
@@ -28,6 +33,7 @@ spec:
       operator: "Equal"
       effect: "NoSchedule"
       tolerationSeconds: 3600
+#...
 ----
 
 . Taint the nodes that have the specialized hardware using one of the following commands:
@@ -53,13 +59,13 @@ You can alternatively apply the following YAML to add the taint:
 kind: Node
 apiVersion: v1
 metadata:
-  name: <node_name>
-  labels:
-    ...
+  name: my_node
+#...
 spec:
   taints:
     - key: disktype
       value: ssd
       effect: PreferNoSchedule
+#...
 ----
 ====

--- a/modules/olm-overriding-operator-pod-affinity.adoc
+++ b/modules/olm-overriding-operator-pod-affinity.adoc
@@ -59,7 +59,7 @@ endif::node[]
 
 ifndef::pod[]
 .Node affinity example that places the Operator pod on a specific node
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -80,12 +80,12 @@ spec:
               operator: In
               values:
               - ip-10-0-163-94.us-west-2.compute.internal
- ...
+#...
 ----
 <1> A node affinity that requires the Operator's pod to be scheduled on a node named `ip-10-0-163-94.us-west-2.compute.internal`.
 
 .Node affinity example that places the Operator pod on a node with a specific platform
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -110,6 +110,7 @@ spec:
               operator: In
               values:
               - linux
+#...
 ----
 <1> A node affinity that requires the Operator's pod to be scheduled on a node with the `kubernetes.io/arch=arm64` and `kubernetes.io/os=linux` labels.
 endif::pod[]
@@ -120,7 +121,7 @@ endif::pod[]
 
 ifndef::node[]
 .Pod affinity example that places the Operator pod on one or more specific nodes
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -142,11 +143,12 @@ spec:
               values:
               - test
           topologyKey: kubernetes.io/hostname
+#...
 ----
 <1> A pod affinity that places the Operator's pod on a node that has pods with the `app=test` label.
 
 .Pod anti-affinity example that prevents the Operator pod from one or more specific nodes
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -168,7 +170,7 @@ spec:
               values:
               - high
           topologyKey: kubernetes.io/hostname
- ...
+#...
 ----
 <1> A pod anti-affinity that prevents the Operator's pod from being scheduled on a node that has pods with the `cpu=high` label.
 endif::node[]
@@ -184,7 +186,7 @@ To control the placement of an Operator pod, complete the following steps:
 . Edit the Operator `Subscription` object to add an affinity:
 +
 ifndef::pod[]
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -205,7 +207,7 @@ spec:
               operator: In
               values:
               - ip-10-0-185-229.ec2.internal
- ...
+#...
 ----
 ifdef::olm[]
 <1> Add a `nodeAffinity`, `podAffinity`, or `podAntiAffinity`. See the Additional resources section that follows for information about creating the affinity.
@@ -215,7 +217,7 @@ ifdef::node[]
 endif::[]
 endif::pod[]
 ifdef::pod[]
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
@@ -238,7 +240,7 @@ spec:
                 values:
                 - ip-10-0-185-229.ec2.internal
             topologyKey: topology.kubernetes.io/zone
- ...
+#...
 ----
 <1> Add a `podAffinity` or `podAntiAffinity`.
 endif::pod[]
@@ -247,13 +249,14 @@ endif::pod[]
 
 * To ensure that the pod is deployed on the specific node, run the following command:
 +
-[source,terminal]
+[source,yaml]
 ----
 $ oc get pods -o wide
 ----
 +
 .Example output
 +
+[source,terminal]
 ----
 NAME                                                  READY   STATUS    RESTARTS   AGE   IP            NODE                           NOMINATED NODE   READINESS GATES
 custom-metrics-autoscaler-operator-5dcc45d656-bhshg   1/1     Running   0          50s   10.131.0.20   ip-10-0-185-229.ec2.internal   <none>           <none>


### PR DESCRIPTION
Fixing various errors in the Nodes -> Scheduler docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

[Understanding nodes overcommitment](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-overcommit.html) -- Added `#...` to code block. No new text.
[Understanding node affinity](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity.html#nodes-scheduler-node-affinity-about_nodes-scheduler-node-affinity) -- Added `#...` to code block. No new text.
[Configuring a preferred node affinity rule](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity.html#nodes-scheduler-node-affinity-configuring-preferred_nodes-scheduler-node-affinity) -- Updated the structure of the procedure, added a note. New text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/scheduling/nodes-scheduler-node-affinity.html#nodes-scheduler-node-affinity-configuring-preferred_nodes-scheduler-node-affinity).
[Configuring a required node affinity rule](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity.html#nodes-scheduler-node-affinity-configuring-required_nodes-scheduler-node-affinity) -- Updated the structure of the procedure, added a note. New text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/scheduling/nodes-scheduler-node-affinity.html#nodes-scheduler-node-affinity-configuring-required_nodes-scheduler-node-affinity)
[Sample node affinity rules](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity.html#nodes-scheduler-node-affinity-example_nodes-scheduler-node-affinity) -- Added `#...` and updated ID to match file name.  New text.
[About node selectors](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-about_nodes-scheduler-node-selectors) -- Added `#...` and metadata  to code block.  New text.
[Using node selectors to control pod placement](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-pod_nodes-scheduler-node-selectors) -- Added `#...` and metadata  to code block.  New text.
[Configuring a pod affinity rule](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html#nodes-scheduler-pod-affinity-configuring_nodes-scheduler-pod-affinity) -- Updated the structure of the procedure, added a note. New text. [Current docs]
[Sample pod affinity and anti-affinity rules](https://docs.openshift.com/container-platform/4.13/nodes/scheduling/nodes-scheduler-pod-affinity.html#nodes-scheduler-pod-affinity-example_nodes-scheduler-pod-affinity) -- Added `#...` to code block and s/[source,terminal]/[source,yaml].  New text.
[Configuring a pod anti-affinity rule](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html#nodes-scheduler-pod-anti-affinity-configuring_nodes-scheduler-pod-affinity)-- Updated the structure of the procedure, added a note. New text. [Current docs]
[Configuring pod topology spread constraints](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.html#nodes-scheduler-pod-topology-spread-constraints-configuring_nodes-scheduler-pod-topology-spread-constraints)-- Removed foo/bar.
[Example pod topology spread constraints](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.html#nodes-scheduler-pod-topology-spread-constraints-examples_nodes-scheduler-pod-topology-spread-constraints)-- Removed foo/bar.
[Understanding pod affinity](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html#nodes-scheduler-pod-affinity-about_nodes-scheduler-pod-affinity) Added `#...` and metadata  to code block.  New text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations).
[Adding taints and tolerations using a compute machine set](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-adding-machineset_nodes-scheduler-taints-tolerations) -- Added `#...` and metadata  to code block.  New text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-adding-machineset_nodes-scheduler-taints-tolerations)
[Adding taints and tolerations](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-adding_nodes-scheduler-taints-tolerations) -- Added `#...` and metadata  to code block.  New text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-adding_nodes-scheduler-taints-tolerations)
[Binding a user to a node using taints and tolerations](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-bindings_nodes-scheduler-taints-tolerations) -- Added `#...` and metadata  to code block.  New text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-bindings_nodes-scheduler-taints-tolerations)
[Removing taints and tolerations](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-removing_nodes-scheduler-taints-tolerations) -- Added `#...` and metadata  to code block.  New text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-removing_nodes-scheduler-taints-tolerations)
[Controlling nodes with special hardware using taints and tolerations](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-special_nodes-scheduler-taints-tolerations) -- Added `#...` and metadata  to code block.  New text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/scheduling/nodes-scheduler-taints-tolerations.html#nodes-scheduler-taints-tolerations-special_nodes-scheduler-taints-tolerations)
[Using node affinity to control where an Operator is installed](https://62484--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity.html#olm-overriding-operator-pod-affinity_nodes-scheduler-node-affinity)-- s/[source,terminal]/[source,yaml]. No new text. 

