### PR TITLE
OSDOCS 6764:Removed info on PV backups.

### DIFF
--- a/modules/policy-incident.adoc
+++ b/modules/policy-incident.adoc
@@ -41,7 +41,7 @@ The following activities can trigger notifications:
 
 [id="backup-recovery_{context}"]
 == Backup and recovery
-All {product-title} clusters are backed up using cloud provider snapshots. Notably, this does not include customer data stored on persistent volumes. All snapshots are taken using the appropriate cloud provider snapshot APIs and are uploaded to a secure object storage bucket (S3 in AWS, and GCS in Google Cloud) in the same account as the cluster.
+All {product-title} clusters are backed up using cloud provider snapshots. Notably, this does not include customer data stored on persistent volumes (PVs). All snapshots are taken using the appropriate cloud provider snapshot APIs and are uploaded to a secure object storage bucket (S3 in AWS, and GCS in Google Cloud) in the same account as the cluster.
 
 //Verify if the corresponding tables in rosa-sdpolicy-platform.adoc and rosa-policy-incident.adoc also need to be updated.
 
@@ -53,10 +53,10 @@ All {product-title} clusters are backed up using cloud provider snapshots. Notab
 |Retention
 |Notes
 
-.2+|Full object store backup, all cluster persistent volumes (PVs)
+.2+|Full object store backup
 |Daily
 |7 days
-.2+|This is a full backup of all Kubernetes objects like etcd, as well as all PVs in the cluster.
+.2+|This is a full backup of all Kubernetes objects like etcd. No PVs are backed up in this backup schedule.
 
 |Weekly
 |30 days

--- a/modules/rosa-sdpolicy-platform.adoc
+++ b/modules/rosa-sdpolicy-platform.adoc
@@ -31,10 +31,10 @@ The following table outlines the cluster backup policy.
 |Retention
 |Notes
 
-.2+|Full object store backup, all cluster persistent volumes (PVs)
+.2+|Full object store backup
 |Daily
 |7 days
-.2+|This is a full backup of all Kubernetes objects like etcd, as well as all PVs in the cluster.
+.2+|This is a full backup of all Kubernetes objects like etcd. No persistent volumes (PVs) are backed up in this backup schedule.
 
 |Weekly
 |30 days


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-6764

Link to docs preview:
OSD: https://62498--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-process-security.html#backup-recovery_policy-process-security

ROSA: https://62498--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-backup-policy_rosa-service-definition

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.

Peer review:
- [x] Peer reviewer has approved this change. 


