### PR TITLE
Updates dynamic IP address assignment configuration with whereabouts …

### DIFF
--- a/modules/nw-multus-ipam-object.adoc
+++ b/modules/nw-multus-ipam-object.adoc
@@ -240,3 +240,74 @@ Whereabouts can be used for both IPv4 and IPv6 addresses.
 ifdef::sr-iov[]
 :!sr-iov:
 endif::[]
+
+[id="nw-multus-creating-whereabouts-reconciler-daemon-set_{context}"]
+== Creating a Whereabouts reconciler daemon set 
+
+The Whereabouts reconciler is responsible for managing dynamic IP address assignments for the pods within a cluster using the Whereabouts IP Address Management (IPAM) solution. It ensures that each pods gets a unique IP address from the specified IP address range. It also handles IP address releases when pods are deleted or scaled down.
+
+[NOTE]
+====
+You can also use a `NetworkAttachmentDefinition` custom resource for dynamic IP address assignment. 
+====
+
+The Whereabouts reconciler daemon set is automatically created when you configure an additional network through the Cluster Network Operator. It is not automatically created when you configure an additional network from a YAML manifest. 
+
+To trigger the deployment of the Whereabouts reconciler daemonset, you must manually create a `whereabouts-shim` network attachment by editing the Cluster Network Operator custom resource file.
+
+Use the following procedure to deploy the Whereabouts reconciler daemonset. 
+
+.Procedure
+
+. Edit the `Network.operator.openshift.io` custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc edit network.operator.openshift.io cluster
+----
+
+. Modify the `additionalNetworks` parameter in the CR to add the `whereabouts-shim` network attachment definition. For example:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: Network
+metadata:
+  name: cluster
+spec:
+  additionalNetworks:
+  - name: whereabouts-shim
+    namespace: default
+    rawCNIConfig: |-
+      {
+       "name": "whereabouts-shim",
+       "cniVersion": "0.3.1",
+       "type": "bridge",
+       "ipam": {
+         "type": "whereabouts"
+       }
+      }
+    type: Raw
+----
+
+. Save the file and exit the text editor.
+
+. Verify that the `whereabouts-reconciler` daemon set deployed successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get all -n openshift-multus | grep whereabouts-reconciler
+----
++
+.Example output
++
+[source,terminal]
+----
+pod/whereabouts-reconciler-jnp6g 1/1 Running 0 6s
+pod/whereabouts-reconciler-k76gg 1/1 Running 0 6s
+pod/whereabouts-reconciler-k86t9 1/1 Running 0 6s
+pod/whereabouts-reconciler-p4sxw 1/1 Running 0 6s
+pod/whereabouts-reconciler-rvfdv 1/1 Running 0 6s
+pod/whereabouts-reconciler-svzw9 1/1 Running 0 6s
+daemonset.apps/whereabouts-reconciler 6 6 6 6 6 kubernetes.io/os=linux 6s
+----


### PR DESCRIPTION
…docs to include manual creation of YAML manifest

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-6917

Link to docs preview:
https://62511--docspreview.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network.html#nw-multus-creating-whereabouts-reconciler-daemon-set_configuring-additional-network

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
