### PR TITLE
OCPBUGS#12686: Added port reqs for Prism Central and Prism Element

### DIFF
--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -16,7 +16,10 @@ In {product-title} version {product-version}, you can install a cluster on your 
 == Prerequisites
 
 * You have reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall, you have configured it to xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[grant access] to the sites that {product-title} requires. This includes the use of Telemetry.
+* The installation program requires access to port 9440 on Prism Central and Prism Element. You verified that port 9440 is accessible.
+* If you use a firewall, you have met these prerequisites:
+** You confirmed that port 9440 is accessible. Control plane nodes must be able to reach Prism Central and Prism Element on port 9440 for the installation to succeed.
+** You configured the firewall to xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[grant access] to the sites that {product-title} requires. This includes the use of Telemetry.
 * If your Nutanix environment is using the default self-signed SSL certificate, replace it with a certificate that is signed by a CA. The installation program requires a valid CA-signed certificate to access to the Prism Central API. For more information about replacing the self-signed certificate, see the  https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html[Nutanix AOS Security Guide].
 +
 [IMPORTANT]

--- a/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
@@ -11,7 +11,10 @@ In {product-title} {product-version}, you can install a cluster on Nutanix infra
 == Prerequisites
 
 * You have reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
-* If you use a firewall, you have configured it to xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[grant access] to the sites that {product-title} requires. This includes the use of Telemetry.
+* The installation program requires access to port 9440 on Prism Central and Prism Element. You verified that port 9440 is accessible.
+* If you use a firewall, you have met these prerequisites:
+** You confirmed that port 9440 is accessible. Control plane nodes must be able to reach Prism Central and Prism Element on port 9440 for the installation to succeed.
+** You configured the firewall to xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[grant access] to the sites that {product-title} requires. This includes the use of Telemetry.
 * If your Nutanix environment is using the default self-signed SSL/TLS certificate, replace it with a certificate that is signed by a CA. The installation program requires a valid CA-signed certificate to access to the Prism Central API. For more information about replacing the self-signed certificate, see the  https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html[Nutanix AOS Security Guide].
 +
 [IMPORTANT]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
This PR addresses [ocpbugs-12686](https://issues.redhat.com/browse/OCPBUGS-12686)

Link to docs preview:

- Installing a cluster on Nutanix > [Prerequisites](https://62520--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#prerequisites)
- Installing a cluster on Nutanix in a restricted network >  [Prerequisites](https://62520--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.html#prerequisites)

QE review:
- [ ] QE has approved this change.
