### PR TITLE
OCPBUGS314766: Fixes broken link in 4.12 RNs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3202,7 +3202,7 @@ $ oc delete pods --all -n openshift-cloud-controller-manager
 
 * There is a known issue when `cloud-provider-openstack` tries to create health monitors on OVN load balancers by using the API to create fully populated load balancers. These health monitors become stuck in a `PENDING_CREATE` status. After their deletion, associated load balancers are are stuck in a `PENDING_UPDATE` status. There is no workaround. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2143732[*BZ#2143732*])
 
-* Due to a known issue, to use stateful IPv6 networks with cluster that run on {rh-openstack}, you must include `ip=dhcp,dhcpv6` in the kernel arguments of link:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-kernel-arguments_nodes-nodes-working[worker nodes]. (link:https://issues.redhat.com/browse/OCPBUGS-2104[*OCPBUGS-2104*])
+* Due to a known issue, to use stateful IPv6 networks with cluster that run on {rh-openstack}, you must include `ip=dhcp,dhcpv6` in the kernel arguments of xref:../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-kernel-arguments_nodes-nodes-working[worker nodes]. (link:https://issues.redhat.com/browse/OCPBUGS-2104[*OCPBUGS-2104*])
 
 * It is not possible to create a macvlan on the physical function (PF) when a virtual function (VF) already exists. This issue affects the Intel E810 NIC. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2120585[*BZ#2120585*])
 


### PR DESCRIPTION
OCPBUGS 14766: Fixes broken link in 4.12 RNs

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OCPBUGS-14766

Link to docs preview:
https://62522--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-known-issues 
Search for the sentence that starts with "Due to a known issue, to use stateful IPv6 networks"

QE review:
QE review not needed for this change

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
