### PR TITLE
OSDOCS 6914: Updating pod examples to comply with restricted PSA (Sto…

### DIFF
--- a/modules/ephemeral-storage-csi-inline-pod.adoc
+++ b/modules/ephemeral-storage-csi-inline-pod.adoc
@@ -22,6 +22,10 @@ apiVersion: v1
 metadata:
   name: my-csi-app
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: my-frontend
       image: busybox
@@ -29,6 +33,10 @@ spec:
       - mountPath: "/data"
         name: my-csi-inline-vol
       command: [ "sleep", "1000000" ]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes: <1>
     - name: my-csi-inline-vol
       csi:

--- a/modules/ephemeral-storage-using-a-sharedconfigmap-object-in-a-pod.adoc
+++ b/modules/ephemeral-storage-using-a-sharedconfigmap-object-in-a-pod.adoc
@@ -52,7 +52,7 @@ EOF
 +
 [source,terminal]
 ----
-oc create rolebinding shared-resource-my-share --role=shared-resource-my-share --serviceaccount=my-namespace:builder
+$ oc create rolebinding shared-resource-my-share --role=shared-resource-my-share --serviceaccount=my-namespace:builder
 ----
 
 . Access the `SharedConfigMap` CR instance from a pod:
@@ -66,6 +66,10 @@ metadata:
   name: my-app
   namespace: my-namespace
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   serviceAccountName: default
 
 # containers omitted …. Follow standard use of ‘volumeMounts’ for referencing your shared resource volume

--- a/modules/ephemeral-storage-using-a-sharedsecrets-resource-in-a-pod.adoc
+++ b/modules/ephemeral-storage-using-a-sharedsecrets-resource-in-a-pod.adoc
@@ -66,6 +66,10 @@ metadata:
   name: my-app
   namespace: my-namespace
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   serviceAccountName: default
 
 # containers omitted …. Follow standard use of ‘volumeMounts’ for referencing your shared resource volume

--- a/modules/machineset-creating-azure-ultra-disk.adoc
+++ b/modules/machineset-creating-azure-ultra-disk.adoc
@@ -45,9 +45,9 @@ get secret <role>-user-data \ <1>
 <1> Replace `<role>` with `{machine-role}`.
 <2> Specify `userData.txt` as the name of the new custom secret.
 
-. In a text editor, open the `userData.txt` file and locate the final `}` character in the file. 
+. In a text editor, open the `userData.txt` file and locate the final `}` character in the file.
 
-.. On the immediately preceding line, add a `,`. 
+.. On the immediately preceding line, add a `,`.
 
 .. Create a new line after the `,` and add the following configuration details:
 +
@@ -265,6 +265,10 @@ kind: Pod
 metadata:
   name: nginx-ultra
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   nodeSelector:
     disk: ultrassd <1>
   containers:
@@ -276,6 +280,10 @@ spec:
     volumeMounts:
     - mountPath: "/mnt/azure"
       name: volume
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   volumes:
     - name: volume
       persistentVolumeClaim:
@@ -317,6 +325,10 @@ kind: Pod
 metadata:
   name: ssd-benchmark1
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: ssd-benchmark1
     image: nginx
@@ -326,6 +338,10 @@ spec:
     volumeMounts:
     - name: lun0p1
       mountPath: "/tmp"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   volumes:
     - name: lun0p1
       hostPath:

--- a/modules/persistent-storage-csi-cloning-provisioning.adoc
+++ b/modules/persistent-storage-csi-cloning-provisioning.adoc
@@ -72,12 +72,20 @@ apiVersion: v1
 metadata:
   name: mypod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: myfrontend
       image: dockerfile/nginx
       volumeMounts:
       - mountPath: "/var/www/html"
         name: mypd
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: mypd
       persistentVolumeClaim:

--- a/modules/persistent-storage-hostpath-about.adoc
+++ b/modules/persistent-storage-hostpath-about.adoc
@@ -23,6 +23,10 @@ kind: Pod
 metadata:
   name: test-host-mount
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - image: registry.access.redhat.com/ubi9/ubi
     name: test-container
@@ -30,6 +34,10 @@ spec:
     volumeMounts:
     - mountPath: /host
       name: host-slash
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   volumes:
    - name: host-slash
      hostPath:

--- a/modules/storage-ephemeral-storage-manage.adoc
+++ b/modules/storage-ephemeral-storage-manage.adoc
@@ -25,6 +25,10 @@ kind: Pod
 metadata:
   name: frontend
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: app
     image: images.my-company.example/app:v4
@@ -36,6 +40,10 @@ spec:
     volumeMounts:
     - name: ephemeral
       mountPath: "/tmp"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   - name: log-aggregator
     image: images.my-company.example/log-aggregator:v6
     resources:
@@ -44,6 +52,10 @@ spec:
     volumeMounts:
     - name: ephemeral
       mountPath: "/tmp"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   volumes:
     - name: ephemeral
       emptyDir: {}

--- a/modules/storage-ephemeral-vols-procedure.adoc
+++ b/modules/storage-ephemeral-vols-procedure.adoc
@@ -22,6 +22,10 @@ apiVersion: v1
 metadata:
   name: my-app
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: my-frontend
       image: busybox:1.28
@@ -29,6 +33,10 @@ spec:
       - mountPath: "/mnt/storage"
         name: data
       command: [ "sleep", "1000000" ]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: data <1>
       ephemeral:

--- a/modules/storage-persistent-storage-azure-file-pod.adoc
+++ b/modules/storage-persistent-storage-azure-file-pod.adoc
@@ -23,8 +23,9 @@ kind: Pod
 metadata:
   name: pod-name <1>
 spec:
+# ...
   containers:
-    ...
+# ...
     volumeMounts:
     - mountPath: "/data" <2>
       name: azure-file-share

--- a/modules/storage-persistent-storage-block-volume-examples.adoc
+++ b/modules/storage-persistent-storage-block-volume-examples.adoc
@@ -56,6 +56,10 @@ kind: Pod
 metadata:
   name: pod-with-block-volume
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: fc-container
       image: fedora:26
@@ -64,6 +68,10 @@ spec:
       volumeDevices:  <1>
         - name: data
           devicePath: /dev/xvda <2>
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: data
       persistentVolumeClaim:

--- a/modules/storage-persistent-storage-efs-provisioner.adoc
+++ b/modules/storage-persistent-storage-efs-provisioner.adoc
@@ -31,6 +31,10 @@ apiVersion: v1
 metadata:
   name: efs-provisioner
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   serviceAccount: efs-provisioner
   containers:
     - name: efs-provisioner
@@ -60,6 +64,10 @@ spec:
       volumeMounts:
         - name: pv-volume
           mountPath: /persistentvolumes
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: pv-volume
       nfs:

--- a/modules/storage-persistent-storage-pvc.adoc
+++ b/modules/storage-persistent-storage-pvc.adoc
@@ -99,12 +99,20 @@ apiVersion: v1
 metadata:
   name: mypod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: myfrontend
       image: dockerfile/nginx
       volumeMounts:
       - mountPath: "/var/www/html" <1>
         name: mypd <2>
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: mypd
       persistentVolumeClaim:

--- a/modules/storage-persistent-storage-volume-encrypt-with-kms-key.adoc
+++ b/modules/storage-persistent-storage-volume-encrypt-with-kms-key.adoc
@@ -62,10 +62,15 @@ EOF
 [source,yaml]
 ----
 $ cat << EOF | oc create -f -
+apiVersion: v1
 kind: Pod
 metadata:
   name: mypod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: httpd
       image: quay.io/centos7/httpd-24-centos7
@@ -74,6 +79,10 @@ spec:
       volumeMounts:
         - mountPath: /mnt/storage
           name: data
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: data
       persistentVolumeClaim:


### PR DESCRIPTION
…rage book)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-6914

Link to docs preview:
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/ephemeral-storage-csi-inline.html#ephemeral-storage-csi-inline-pod_ephemeral-storage-csi-inline
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/ephemeral-storage-shared-resource-csi-driver-operator.html#ephemeral-storage-using-a-sharedconfigmap-object-in-a-pod_ephemeral-storage-shared-resource-csi-driver-operator
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/ephemeral-storage-shared-resource-csi-driver-operator.html#ephemeral-storage-using-a-sharedsecrets-resource-in-a-pod_ephemeral-storage-shared-resource-csi-driver-operator
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-azure.html#machineset-creating-azure-ultra-disk_persistent-storage-azure
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/container_storage_interface/persistent-storage-csi-cloning.html#persistent-storage-csi-cloning-provisioning_persistent-storage-csi-cloning
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-hostpath.html#persistent-storage-hostpath-about_persistent-storage-hostpath
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-ephemeral-storage.html#storage-ephemeral-storage-manage_understanding-ephemeral-storage
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/generic-ephemeral-vols.html#generic-ephemeral-vols-procedure_generic-ephemeral-volumes
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-azure-file.html#create-azure-file-pod_persistent-storage-azure-file
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#block-volume-examples_understanding-persistent-storage
* No preview to storage-persistent-storage-efs-provisioner.adoc - this file might not be in use anymore
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/understanding-persistent-storage.html#pvc-claims-as-volumes_understanding-persistent-storage
* https://62524--ocpdocs-pr.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent-storage-aws.html#aws-container-persistent-volumes-encrypt_persistent-storage-aws

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
