### PR TITLE
OCPBUGS#13804: Removed support of standardSSD_LRS disk type from Azure Stack Hub

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1896,7 +1896,7 @@ Additional Azure configuration parameters are described in the following table:
 
 |`compute.platform.azure.osDisk.diskType`
 |Defines the type of disk.
-|`standard_LRS`, `premium_LRS`, or `standardSSD_LRS`. The default is `premium_LRS`.
+|`standard_LRS` or `premium_LRS`. The default is `premium_LRS`.
 
 |`compute.platform.azure.type`
 |Defines the azure instance type for compute machines.
@@ -1908,7 +1908,7 @@ Additional Azure configuration parameters are described in the following table:
 
 |`controlPlane.platform.azure.osDisk.diskType`
 |Defines the type of disk.
-|`premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
+|`premium_LRS`.
 
 |`controlPlane.platform.azure.type`
 |Defines the azure instance type for control plane machines.
@@ -1920,7 +1920,7 @@ Additional Azure configuration parameters are described in the following table:
 
 |`platform.azure.defaultMachinePlatform.osDisk.diskType`
 |Defines the type of disk.
-|`standard_LRS`, `premium_LRS`, or `standardSSD_LRS`. The default is `premium_LRS`.
+|`standard_LRS` or `premium_LRS`. The default is `premium_LRS`.
 
 |`platform.azure.defaultMachinePlatform.type`
 |The Azure instance type for control plane and compute machines.


### PR DESCRIPTION
Version(s):
4.10+

Issue:
This issue addresses [ocpbugs-13804](https://issues.redhat.com/browse/OCPBUGS-13804).

Link to docs preview:

Installation configuration parameters > [Additional Azure Stack Hub configuration parameters](https://62526--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-default.html#installation-configuration-parameters-additional-azure-stack-hub_installing-azure-stack-hub-default)

QE review:
- [ ] QE has approved this change.

Additional information:
