### PR TITLE
[OSDOCS-5331]: Adding docs about pausing reconciliation for hosted control planes

### DIFF
--- a/hosted_control_planes/hcp-managing.adoc
+++ b/hosted_control_planes/hcp-managing.adoc
@@ -15,7 +15,7 @@ include::modules/updates-for-hosted-control-planes.adoc[leveloffset=+1]
 include::modules/updating-node-pools-for-hcp.adoc[leveloffset=+1]
 include::modules/configuring-node-pools-for-hcp.adoc[leveloffset=+1]
 //restarting hosted control plane components
-//pausing reconciliation
+include::modules/hosted-control-planes-pause-reconciliation.adoc[leveloffset=+1]
 //debugging why nodes have not joined the cluster
 //using service-level DNS for control plane services
 //configuring metrics sets

--- a/modules/hosted-control-planes-pause-reconciliation.adoc
+++ b/modules/hosted-control-planes-pause-reconciliation.adoc
@@ -1,0 +1,47 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-managing.adoc
+
+:_content-type: PROCEDURE
+[id="hosted-control-planes-pause-reconciliation_{context}"]
+= Pausing the reconciliation of a hosted cluster and hosted control plane
+
+If you are a cluster instance administrator, you can pause the reconciliation of a hosted cluster and hosted control plane. You might want to pause reconciliation when you back up and restore an etcd database or when you need to debug problems with a hosted cluster or hosted control plane. 
+
+.Procedure
+
+. To pause reconciliation for a hosted cluster and hosted control plane, populate the `pausedUntil` field of the `HostedCluster` resource, as shown in the following examples:
++
+** To pause the reconciliation until a specific time, specify an RFC339 timestamp:
++
+[source,terminal]
+----
+PAUSED_UNTIL="2022-03-03T03:28:48Z"
+kubectl patch -n <hosted-cluster-namespace> hostedclusters/<hosted-cluster-name> -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
+----
++
+The reconciliation is paused until the specified time is passed.
++
+** To pause the reconciliation indefinitely, pass a Boolean value of `true`:
++
+[source,terminal]
+----
+PAUSED_UNTIL="true"
+kubectl patch -n <hosted-cluster-namespace> hostedclusters/<hosted-cluster-name> -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
+----
++
+The reconciliation is paused until you remove the field from the `HostedCluster` resource.
++
+When the pause reconciliation field is populated for the `HostedCluster` resource, the field is automatically added to the associated `HostedControlPlane` resource.
+
+. To remove the `pausedUntil` field, enter the following patch command:
++
+[source,terminal]
+----
+kubectl patch -n <hosted-cluster-namespace> hostedclusters/<hosted-cluster-name> -p '{"spec":{"pausedUntil":null}}' --type=merge
+----
+
+
+
+
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5331
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62528--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-managing.html#hosted-control-planes-pause-reconciliation_hcp-managing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
