### PR TITLE
OSDOCS-6442 Release Note for 4.14

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -69,13 +69,23 @@ User-defined tags for Microsoft Azure was previously introduced as Technology Pr
 [id="ocp-4-14-openshift-cli"]
 === OpenShift CLI (oc)
 
-.Supporting multi-arch OCI local images for catalogs with oc-mirror
+[id="oc-mirror-multi-arch-oci-local-images"]
+==== Supporting multi-arch OCI local images for catalogs with oc-mirror
 
 With {product-title} {product-version}, oc-mirror supports multi-arch OCI local images for catalogs.
 
 OCI layouts consist of an `index.json` file that identifies the images held within them on disk. This `index.json` file can reference any number of single or multi-arch images. However, oc-mirror only references a single image at a time in a given OCI layout. The image stored in the OCI layout can be a single-arch image, that is, an image manifest or a multi-arch image, that is, a manifest list.
 
 The `ImageSetConfiguration` stores the OCI images. After processing the catalog, the catalog content adds new layers representing the content of all images in the layout. The ImageBuilder is modified to handle image updates for both single-arch and multi-arch images.
+
+[id="oc-logging-in-browser"]
+==== Logging in to the CLI using a web browser
+
+With {product-title} {product-version}, a new `oc` command-line interface (CLI) flag, `--web` is now available for the `oc login` command. 
+
+With this enhancement, you can log in using a web browser, which allows you to avoid inserting your access token into the command line.
+
+For more information, see xref:../cli_reference/openshift_cli/getting-started-cli.adoc#cli-logging-in-web_cli-developer-commands[Logging in to the OpenShift CLI using a web browser].
 
 [id="oc-new-build-enhancement"]
 ==== Enhancement to oc new-build


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6442](https://issues.redhat.com/browse/OSDOCS-6442)

Link to docs preview:
[Preview](https://62530--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-openshift-cli)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Approval from Ilias in Slack. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
