### PR TITLE
OSSM-4400: [DOC] The Kiali instruction is ambiguous

### DIFF
--- a/modules/ossm-install-ossm-operator.adoc
+++ b/modules/ossm-install-ossm-operator.adoc
@@ -11,7 +11,7 @@ To install {SMProductName}, install following Operators in this order. Repeat th
 
 * OpenShift Elasticsearch
 * {JaegerName}
-* Kiali
+* Kiali Operator provided by Red Hat
 * {SMProductName}
 
 [NOTE]
@@ -35,6 +35,6 @@ If you have already installed the OpenShift Elasticsearch Operator as part of Op
 +
 * The OpenShift Elasticsearch Operator is installed in the `openshift-operators-redhat` namespace and is available for all namespaces in the cluster.
 * The {JaegerName} is installed in the `openshift-distributed-tracing` namespace and is available for all namespaces in the cluster.
-* The Kiali and {SMProductName} Operators are installed in the `openshift-operators` namespace and are available for all namespaces in the cluster.
+* The Kiali Operator provided by Red Hat and the {SMProductName} Operator are installed in the `openshift-operators` namespace and are available for all namespaces in the cluster.
 
 . After all you have installed all four Operators, click *Operators* -> *Installed Operators* to verify that your Operators installed.

--- a/modules/ossm-installation-activities.adoc
+++ b/modules/ossm-installation-activities.adoc
@@ -12,5 +12,5 @@
 
 * *OpenShift Elasticsearch* - (Optional) Provides database storage for tracing and logging with the {JaegerShortName}. It is based on the open source link:https://www.elastic.co/[Elasticsearch] project.
 * *{JaegerName}* - Provides distributed tracing to monitor and troubleshoot transactions in complex distributed systems. It is based on the open source link:https://www.jaegertracing.io/[Jaeger] project.
-* *Kiali* - Provides observability for your service mesh. Allows you to view configurations, monitor traffic, and analyze traces in a single console. It is based on the open source link:https://www.kiali.io/[Kiali] project.
+* *Kiali Operator provided by Red Hat* - Provides observability for your service mesh. You can view configurations, monitor traffic, and analyze traces in a single console. It is based on the open source link:https://www.kiali.io/[Kiali] project.
 * *{SMProductName}* - Allows you to connect, secure, control, and observe the microservices that comprise your applications. The {SMProductShortName} Operator defines and monitors the `ServiceMeshControlPlane` resources that manage the deployment, updating, and deletion of the {SMProductShortName} components. It is based on the open source link:https://istio.io/[Istio] project.


### PR DESCRIPTION
[OSSM-4400](https://issues.redhat.com//browse/OSSM-4400): [DOC] The Kiali instruction is ambiguous

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSSM-4400

Link to docs preview:
https://62531--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/installing-ossm.html#ossm-installation-activities_installing-ossm

QE review:
Not needed as change does not impact the meaning of the docs.

Additional information:
There are 2 options for the Kiali operator found in the Operator Hub: 

Kiali Operator provided by Red Hat
Kiali Operator provided by Kiali

The user docs did not specify that only "Kiali Operator provided by Red Hat" is supported. This PR replaces "Kiali" with "Kiali Operator provided by Red Hat" to clarify which on to install.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
