### PR TITLE
[enterprise-4.10] OCPBUGS#2890 Removing supported instance types from AWS UPI restricted doc

### DIFF
--- a/installing/installing_aws/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/installing-aws-secret-region.adoc
@@ -41,7 +41,7 @@ include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
+include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -50,8 +50,6 @@ include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]
 
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
-
 include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
 
 include::modules/installation-aws-permissions.adoc[leveloffset=+2]

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -69,8 +69,6 @@ include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]
 
-include::modules/installation-supported-aws-machine-types.adoc[leveloffset=+2]
-
 include::modules/installation-aws-user-infra-requirements.adoc[leveloffset=+1]
 
 include::modules/installation-aws-permissions.adoc[leveloffset=+2]

--- a/modules/installation-aws-tested-machine-types.adoc
+++ b/modules/installation-aws-tested-machine-types.adoc
@@ -5,9 +5,14 @@
 // installing/installing_aws/installing-aws-government-region.adoc
 // installing/installing_aws/installing-aws-network-customizations.adoc
 // installing/installing_aws/installing-aws-private.adoc
+// installing/installing_aws/installing-aws-secret-region.adoc
 // installing/installing_aws/installing-aws-user-infra.adoc
 // installing/installing_aws/installing-aws-vpc.adoc
 // installing/installing_aws/installing-restricted-networks-aws.adoc
+
+ifeval::["{context}" == "installing-aws-secret-region"]
+:secretregion:
+endif::[]
 
 [id="installation-aws-tested-machine-types_{context}"]
 = Tested instance types for AWS
@@ -19,8 +24,28 @@ The following Amazon Web Services (AWS) instance types have been tested with {pr
 Use the machine types included in the following charts for your AWS instances. If you use an instance type that is not listed in the chart, ensure that the instance size you use matches the minimum resource requirements that are listed in "Minimum resource requirements for cluster installation". 
 ====
 
+ifndef::secretregion[]
 .Machine types based on 64-bit x86 architecture
 [%collapsible]
 ====
 include::https://raw.githubusercontent.com/openshift/installer/master/docs/user/aws/tested_instance_types_x86_64.md[]
 ====
+endif::secretregion[]
+ifdef::secretregion[]
+.Machine types based on 64-bit x86 architecture for secret regions
+[%collapsible]
+====
+* `c4.*`
+* `c5.*`
+* `i3.*`
+* `m4.*`
+* `m5.*`
+* `r4.*`
+* `r5.*`
+* `t3.*`
+====
+endif::secretregion[]
+
+ifeval::["{context}" == "installing-aws-secret-region"]
+:!secretregion:
+endif::[]


### PR DESCRIPTION
4.10 CP of b0c7a583ded6550040176b218278ea231755e7ba