### PR TITLE
[RHACS] Added patch release notes for 4.1.2

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -53,7 +53,7 @@ endif::[]
 :osp: Red Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.1.1
+:rhacs-version: 4.1.2
 :ocp-supported-version: 4.10
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 4.1

--- a/release_notes/41-release-notes.adoc
+++ b/release_notes/41-release-notes.adoc
@@ -14,6 +14,7 @@ toc::[]
 |{product-title-short} version |Released on
 |`4.1` |29 June 2023
 |`4.1.1` |11 July 2023
+|`4.1.2` |26 July 2023
 |====
 
 [id="about-this-release_{context}"]
@@ -57,7 +58,7 @@ If you are using {ocp} and the {product-title-short} Operator, and your upgrades
 [id="manual-renewal-of-central-and-sensor-certificates_{context}"]
 === Manual renewal of Central and Sensor certificates
 
-You now have the ability to renew certificates for {product-title-short} components when security breaches occur or when you want to renew certificates on your preferred schedule. With {product-title-short} 4.1, you can renew certificates for Central, Scanner, and `scanner-db` directly from the RHACS portal. This ensures continuous and secure communication between Central and all the Sensor components.
+You now have the ability to renew certificates for {product-title-short} components when security breaches occur or when you want to renew certificates on your preferred schedule. With {product-title-short} 4.1, you can renew certificates for Central, Scanner, and `scanner-db` directly from the {product-title-short} portal. This ensures continuous and secure communication between Central and all the Sensor components.
 
 Previously, you would receive an information banner notifying you when the Central certificate expired. Additionally, you were provided with new certificates for Central along with instructions for renewing Scanner and `scanner-db` certificates. Only users with administrative access to {product-title-short} can initiate the renewal and replacement of these certificates.
 
@@ -409,8 +410,20 @@ When Central was reinstalled, the password of the new secret didn't match the on
 
 Release date: 11 July 2023
 
-* Previously, upgrading from RHACS 4.0.2 to RHACS 4.1 using the RHACS Operator would fail because of the deprecated KernelModule collector support in RHACS 4.1.
+* Previously, upgrading from {product-title-short} 4.0.2 to {product-title-short} 4.1 using the {product-title-short} Operator would fail because of the deprecated KernelModule collector support in {product-title-short} 4.1.
 The updated image fixes this issue.
+
+[id="resolved-in-version-412_{context}"]
+=== Resolved in version 4.1.2
+
+Release date: 26 July 2023
+
+* {product-title-short} 4.1.2 includes a fix for an issue where an operator-based {product-title-short} installation failed to upgrade from versions earlier than {product-title-short} 3.71.
+The failure occurred because the older versions did not implement PSP auto-sensing on the Kubernetes cluster 1.25 or later.
+* Previously, if you were using {product-title-short} with Istio, the Scanner pods would crash if Istio reported the version as `latest` instead of the actual version number, such as `1.17`.
+The updated image fixes this issue.
+* Fixed an issue where upgrading from RHACS 3.74.3 to RHACS 4.1.1 failed
+with an "insert...violates foreign key restraint" error.
 
 [id="known-issues_{context}"]
 === Known issues (updated 11 July 2023)
@@ -431,22 +444,22 @@ This can lead to inaccuracies or inconsistencies in the reported GID. This issue
 
 | Main
 | Includes Central, Sensor, Admission controller, and Compliance. Also includes `roxctl` for use in continuous integration (CI) systems.
-a| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:4.1.1`
+a| `registry.redhat.io/advanced-cluster-security/rhacs-main-rhel8:4.1.2`
 
 | Scanner
 | Scans images and nodes.
-a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:4.1.1`
+a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-rhel8:4.1.2`
 
 | Scanner DB
 | Stores image scan results and vulnerability definitions.
-a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:4.1.1`
+a|`registry.redhat.io/advanced-cluster-security/rhacs-scanner-db-rhel8:4.1.2`
 
 | Collector
 | Collects runtime activity in Kubernetes or {ocp} clusters.
-a| * `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:4.1.1`
-* `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:4.1.1`
+a| * `registry.redhat.io/advanced-cluster-security/rhacs-collector-rhel8:4.1.2`
+* `registry.redhat.io/advanced-cluster-security/rhacs-collector-slim-rhel8:4.1.2`
 
 | Central DB
 | Postgres instance that provides the database storage for Central.
-a| `registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8:4.1.1`
+a| `registry.redhat.io/advanced-cluster-security/rhacs-central-db-rhel8:4.1.2`
 |===


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-18543

Added patch release notes for RHACS 4.1.2

Cherrypick into `rhacs-docs-4.1`

Preview: https://62556--docspreview.netlify.app/openshift-acs/latest/release_notes/41-release-notes.html#resolved-in-version-412_release-notes-41

---

NOTE:

- This PR is for RHACS docs.
- It doesn't require any special labels or milestones.
- Do not merge this.
