### PR TITLE
OSDOCS-6130: Added IMDS information to OSD

### DIFF
--- a/modules/osd-create-cluster-ccs.adoc
+++ b/modules/osd-create-cluster-ccs.adoc
@@ -166,6 +166,23 @@ PVs created by using any other storage class are still encrypted, but the PVs ar
 After your cluster is created, you can change the number of compute nodes in your cluster, but you cannot change the compute node instance type in a machine pool. The number and types of nodes available to you depend on your {product-title} subscription.
 ====
 
+. Choose your preference for the Instance Metadata Service (IMDS) type, either using both IMDSv1 and IMDSv2 types or requiring your EC2 instances to use only IMDSv2. You can access instance metadata from a running instance in two ways:
++
+* Instance Metadata Service Version 1 (IMDSv1) - a request/response method
+* Instance Metadata Service Version 2 (IMDSv2) - a session-oriented method
++
+[IMPORTANT]
+====
+The Instance Metadata Service settings cannot be changed after your cluster is created.
+====
++
+[NOTE]
+====
+IMDSv2 uses session-oriented requests. With session-oriented requests, you create a session token that defines the session duration, which can range from a minimum of one second to a maximum of six hours. During the specified duration, you can use the same session token for subsequent requests. After the specified duration expires, you must create a new session token to use for future requests.
+====
++
+For more information regarding IMDS, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[Instance metadata and user data] in the AWS documentation.
+
 . Optional: Expand *Edit node labels* to add labels to your nodes. Click *Add label* to add more node labels and select *Next*.
 
 . On the *Network configuration* page, select *Public* or *Private* to use either public or private API endpoints and application routes for your cluster.


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-6130](https://issues.redhat.com/browse/OSDOCS-6130)

Link to docs preview:

- [OSD cluster creation](https://62577--docspreview.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/creating-an-aws-cluster#osd-create-aws-cluster-ccs_osd-creating-a-cluster-on-aws) with AWS
![image](https://github.com/openshift/openshift-docs/assets/16167833/454280f7-5aff-465f-a1c9-e105d9086168)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds the IMDS content to OSD from ROSA. This PR should remain as a work-in-progress until [OSDOCS-6908](https://issues.redhat.com/browse/OSDOCS-6908) has been merged to determine the correct location for this information.