### PR TITLE
OSDOCS#6881: Adding deprecation notice to Alibaba install docs

### DIFF
--- a/installing/installing_alibaba/installing-alibaba-customizations.adoc
+++ b/installing/installing_alibaba/installing-alibaba-customizations.adoc
@@ -14,7 +14,7 @@ The scope of the {product-title} installation configurations is intentionally na
 ====
 
 :FeatureName: Alibaba Cloud on {product-title}
-include::snippets/technology-preview.adoc[]
+include::snippets/deprecated-feature.adoc[]
 
 [id="prerequisites_installing-alibaba-customizations"]
 == Prerequisites

--- a/installing/installing_alibaba/installing-alibaba-default.adoc
+++ b/installing/installing_alibaba/installing-alibaba-default.adoc
@@ -10,7 +10,7 @@ In {product-title} version {product-version}, you can install a cluster on
 Alibaba Cloud that uses the default configuration options.
 
 :FeatureName: Alibaba Cloud on {product-title}
-include::snippets/technology-preview.adoc[]
+include::snippets/deprecated-feature.adoc[]
 
 [id="prerequisites_installing-alibaba-default"]
 == Prerequisites

--- a/installing/installing_alibaba/installing-alibaba-network-customizations.adoc
+++ b/installing/installing_alibaba/installing-alibaba-network-customizations.adoc
@@ -12,7 +12,7 @@ VXLAN configurations.
 You must set most of the network configuration parameters during installation, and you can modify only `kubeProxy` configuration parameters in a running cluster.
 
 :FeatureName: Alibaba Cloud on {product-title}
-include::snippets/technology-preview.adoc[]
+include::snippets/deprecated-feature.adoc[]
 
 [id="prerequisites_installing-alibaba-network-customizations"]
 == Prerequisites

--- a/installing/installing_alibaba/installing-alibaba-vpc.adoc
+++ b/installing/installing_alibaba/installing-alibaba-vpc.adoc
@@ -14,7 +14,7 @@ The scope of the {product-title} installation configurations is intentionally na
 ====
 
 :FeatureName: Alibaba Cloud on {product-title}
-include::snippets/technology-preview.adoc[]
+include::snippets/deprecated-feature.adoc[]
 
 [id="prerequisites_installing-alibaba-vpc"]
 == Prerequisites
@@ -69,4 +69,3 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
 //Given that manual mode is required to install on Alibaba Cloud, I do not believe this xref is necessary.
 //* If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].
-

--- a/installing/installing_alibaba/manually-creating-alibaba-ram.adoc
+++ b/installing/installing_alibaba/manually-creating-alibaba-ram.adoc
@@ -9,7 +9,7 @@ toc::[]
 Before you install {product-title}, you must use the Alibaba Cloud console to create a Resource Access Management (RAM) user that has sufficient permissions to install {product-title} into your Alibaba Cloud. This user must also have permissions to create new RAM users. You can also configure and use the `ccoctl` tool to create new credentials for the {product-title} components with the permissions that they require.
 
 :FeatureName: Alibaba Cloud on {product-title}
-include::snippets/technology-preview.adoc[]
+include::snippets/deprecated-feature.adoc[]
 
 //Task part 1: Manually creating the required RAM user
 include::modules/manually-creating-alibaba-ram-user.adoc[leveloffset=+1]
@@ -31,4 +31,3 @@ include::modules/cco-ccoctl-configuring.adoc[leveloffset=+1]
 ** **xref:../../installing/installing_alibaba/installing-alibaba-default.adoc#installing-alibaba-default[Installing a cluster quickly on Alibaba Cloud]**: You can install a cluster quickly by using the default configuration options.
 
 ** **xref:../../installing/installing_alibaba/installing-alibaba-customizations.adoc#installing-alibaba-customizations[Installing a customized cluster on Alibaba Cloud]**: The installation program allows for some customization to be applied at the installation stage. Many other customization options are available xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-cluster-tasks[post-installation].
-

--- a/installing/installing_alibaba/preparing-to-install-on-alibaba.adoc
+++ b/installing/installing_alibaba/preparing-to-install-on-alibaba.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 :FeatureName: Alibaba Cloud on {product-title}
-include::snippets/technology-preview.adoc[]
+include::snippets/deprecated-feature.adoc[]
 
 [id="prerequisites_preparing-to-install-on-alibaba"]
 == Prerequisites
@@ -32,4 +32,3 @@ include::modules/installation-alibaba-regions.adoc[leveloffset=+1]
 == Next steps
 
 * xref:../../installing/installing_alibaba/manually-creating-alibaba-ram.adoc#manually-creating-alibaba-ram[Create the required Alibaba Cloud resources].
-


### PR DESCRIPTION
Version(s):
4.14+

Issue:
This issue addresses [osdocs-6881](https://issues.redhat.com/browse/OSDOCS-6881).

Link to docs preview:

- [Preparing to install on Alibaba Cloud](https://62580--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/preparing-to-install-on-alibaba.html)
- [Creating the required Alibaba Cloud resources](https://62580--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/manually-creating-alibaba-ram.html)
- [Installing a cluster quickly on Alibaba Cloud](https://62580--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-default.html)
- [Installing a cluster on Alibaba Cloud with customizations](https://62580--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-customizations.html)
- [Installing a cluster on Alibaba Cloud with network customizations](https://62580--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-network-customizations.html)
- [Installing a cluster on Alibaba Cloud into an existing VPC](https://62580--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-vpc.html)

QE review:
- [ ] QE has approved this change.

Additional information:
This is 1 of 2 PRs for this work and addresses the docs. The RN update is being addressed by https://github.com/openshift/openshift-docs/pull/62582
