### PR TITLE
[SRVKS-1081, SRVCOM-2511] Serverless release notes 1.29.1

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,13 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-29-1.adoc[leveloffset=+1]
+// 1.29.1 additional resources
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/solutions/7019323[Knowledgebase solution for the net-kourier-controller liveness probe error]
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-29-0.adoc[leveloffset=+1]
 // 1.29.0 additional resources
 [role="_additional-resources"]

--- a/modules/release-notes-template.adoc
+++ b/modules/release-notes-template.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-X-YY-Z_{context}"]
+= Release notes for Red Hat {ServerlessProductName} X.YY[.Z]
+// Substitute X-YY-Z with full version (e.g. 1-29-0)
+// Substitute X.YY[.Z] with:
+// * X.YY version for Y-stream releases (e.g. "1.29" for the 1.29.0 release)
+// * version for Z-stream releases (e.g. "1.29.1" for the 1.29.1 release)
+// Make sure the version in the filename matches
+// * e.g. "serverless-rn-1-29-0.adoc" for the 1.29.0 release
+// Versions for the components in New features are here (both for 1.29 and 1.29.1):
+// https://gitlab.cee.redhat.com/serverless/p12n-config/-/blob/release-1.29/config.yaml
+
+{ServerlessProductName} X.YY[.Z] is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+[id="new-features-X-YY-Z_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 0.x.
+* {ServerlessProductName} now uses Knative Eventing 0.x.
+* {ServerlessProductName} now uses Kourier 0.x.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 0.x.
+* {ServerlessProductName} now uses Knative Kafka 0.x.
+* The `kn func` CLI plug-in now uses `func` 0.x.
+
+[id="fixed-issues-X-YY-Z_{context}"]
+== Fixed issues
+
+[id="known-issues-X-YY-Z_{context}"]
+== Known issues

--- a/modules/serverless-rn-1-29-1.adoc
+++ b/modules/serverless-rn-1-29-1.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-29-1_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.29.1
+
+{ServerlessProductName} 1.29.1 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+This release of {ServerlessProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on OpenShift Container Platform 4.10 and later versions.
+
+[id="fixed-issues-1-29-1_{context}"]
+== Fixed issues
+
+* Previously, the `net-kourier-controller` sometimes failed to start due to the liveness probe error. This has been fixed.


### PR DESCRIPTION
Version(s):
Serverless 1.29+ (CP to branches `serverless-docs-1.29` and `serverless-docs-1.30`)

Issue:
https://issues.redhat.com/browse/SRVKS-1081
https://issues.redhat.com/browse/SRVCOM-2511

Link to docs preview:
https://62581--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes.html#serverless-rn-1-29-1_serverless-release-notes

QE review:
- [ ] QE has approved this change.