### PR TITLE
osdocs#6881-rn: Added Alibaba Cloud to release notes deprecated features

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -122,7 +122,7 @@ When the Node Tuning Operator recognizes the performance conditions to activate 
 [id="ocp-4-14-networking-sriov-exclude-topology"]
 ==== Exclude SR-IOV network topology for NUMA-aware scheduling
 
-With this release, you can exclude advertising the Non-Uniform Memory Access (NUMA) node for the SR-IOV network to the Topology Manager. By not advertising the NUMA node for the SR-IOV network, you can permit more flexible SR-IOV network deployments during NUMA-aware pod scheduling. 
+With this release, you can exclude advertising the Non-Uniform Memory Access (NUMA) node for the SR-IOV network to the Topology Manager. By not advertising the NUMA node for the SR-IOV network, you can permit more flexible SR-IOV network deployments during NUMA-aware pod scheduling.
 
 For example, in some scenarios, it is a priority to maximize CPU and memory resources for a pod on a single NUMA node. By not providing a hint to the Topology Manager about the NUMA node for the pod’s SR-IOV network resource, the Topology Manager can deploy the SR-IOV network resource and the pod CPU and memory resources to different NUMA nodes. In earlier {product-title} releases, the Topology Manager attempted to place all resources on the same NUMA node only.
 
@@ -188,6 +188,7 @@ In the following tables, features are marked with the following statuses:
 * _General Availability_
 * _Deprecated_
 * _Removed_
+* _Technology Preview_
 
 [discrete]
 === Operator deprecated and removed features
@@ -260,6 +261,11 @@ In the following tables, features are marked with the following statuses:
 |`ingressVIP` and `apiVIP` settings in the `install-config.yaml` file for installer-provisioned infrastructure clusters
 |Deprecated
 |Deprecated
+|Deprecated
+
+|Alibaba Cloud clusters
+|Technology Preview
+|Technology Preview
 |Deprecated
 
 |====
@@ -524,7 +530,7 @@ Previously, container image references that have both tag and digest were not co
 "localhost:6000/cp/cpd/postgresql:13.7@sha256" is not a valid image reference: invalid reference format
 ----
 
-This behavior has been fixed, and the references are now accepted and correctly mirrored. 
+This behavior has been fixed, and the references are now accepted and correctly mirrored.
 
 [discrete]
 [id="ocp-4-14-olm-bug-fixes"]


### PR DESCRIPTION
Version(s):
4.14

Issue:
This issue addresses [osdocs-6881](https://issues.redhat.com/browse/OSDOCS-6881).

Link to docs preview:

[Deprecated and removed features](https://62582--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-deprecated-removed-features) > Installation deprecated and removed features

QE review:
- [ ] QE has approved this change.

Additional information:
This is 2 of 2 PRs for this work and addresses the release notes. The docs update is addressed by https://github.com/openshift/openshift-docs/pull/62580
