### PR TITLE
OSDOCS-6454 Tech preview and RN for MaxUnavailableStatefulSet

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -173,6 +173,11 @@ The `matchLabelKeys` parameter for configuring pod topology spread constraints i
 
 For more information, see xref:../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Controlling pod placement by using pod topology spread constraints].
 
+[id="ocp-4-14-MaxUnavailableStatefulSet"]
+==== MaxUnavailableStatefulSet enabled
+
+With this release, the `MaxUnavailableStatefulSet` featureset configuration parameter is enabled by default. This allows users to define the maximum number of `StatefulSet` pods that can be unavailable during updates, and reduces application downtime when upgrading.  
+
 [id="ocp-4-14-monitoring"]
 === Monitoring
 
@@ -823,6 +828,11 @@ In the following tables, features are marked with the following statuses:
 |Cron job time zones
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|`MaxUnavailableStatefulSet` featureset
+|Not Available
+|Not Available
 |Technology Preview
 
 |====


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6454](https://issues.redhat.com/browse/OSDOCS-6454)

Link to docs preview:
[Preview](https://62591--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-MaxUnavailableStatefulSet)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
