### PR TITLE
OSDOCS-6545: [Doc] Cite issues with multiple NICs in the same subnet for bare metal IPI installs.

### DIFF
--- a/modules/ipi-install-node-requirements.adoc
+++ b/modules/ipi-install-node-requirements.adoc
@@ -38,6 +38,11 @@ Do not deploy a cluster with only one worker node, because the cluster will depl
 ====
 
 * *Network interfaces:* Each node must have at least one network interface for the routable `baremetal` network. Each node must have one network interface for a `provisioning` network when using the `provisioning` network for deployment. Using the `provisioning` network is the default configuration.
++
+[NOTE]
+====
+Only one network card (NIC) on the same subnet can route traffic through the gateway. By default, Address Resolution Protocol (ARP) uses the lowest numbered NIC. Use a single NIC for each node in the same subnet to ensure that network load balancing works as expected. When using multiple NICs for a node in the same subnet, use a single bond or team interface. Then add the other IP addresses to that interface in the form of an alias IP address. If you require fault tolerance or load balancing at the network interface level, use an alias IP address on the bond or team interface. Alternatively, you can disable a secondary NIC on the same subnet or ensure that it has no IP address.
+====
 
 * *Unified Extensible Firmware Interface (UEFI):* Installer-provisioned installation requires UEFI boot on all {product-title} nodes when using IPv6 addressing on the `provisioning` network. In addition, UEFI Device PXE Settings must be set to use the IPv6 protocol on the `provisioning` network NIC, but omitting the `provisioning` network removes this requirement.
 +


### PR DESCRIPTION
Added an admonishment about using multiple NICs in the same subnet.

Fixes: [OSDOCS-6545](https://issues.redhat.com//browse/OSDOCS-6545)

See https://issues.redhat.com/browse/OSDOCS-6545 for additional details.

Preview URL: http://jowilkin.com:8080/main/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#node-requirements_ipi-install-prerequisites

For release(s): 4.14, 4.13
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
