### PR TITLE
Updating http redirects

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -179,6 +179,9 @@ AddType text/vtt                            vtt
 
     RewriteRule ^container-platform/(4\.11|4\.12)/scalability_and_performance/cnf-performance-addon-operator-for-low-latency-nodes.html /container-platform/$1/scalability_and_performance/cnf-low-latency-tuning.html [NE,R=302]
 
+    # redirect for scalability and performance per Shane Lovern 7/19
+    RewriteRule ^container-platform/4\.13/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.html /container-platform/4.13/scalability_and_performance/enabling-workload-partitioning.html [NE,R=302]
+
     # CNV scenarios based redirect
     RewriteRule ^container-platform/4\.8/virt/learn_more_about_ov.html /container-platform/4.8/virt/virt-learn-more-about-openshift-virtualization.html [NE,R=301]
 


### PR DESCRIPTION
Redirecting https://docs.openshift.com/container-platform/4.13/scalability_and_performance/sno-du-enabling-workload-partitioning-on-single-node-openshift.html to https://docs.openshift.com/container-platform/4.13/scalability_and_performance/enabling-workload-partitioning.html per @slovern 's request.

