### PR TITLE
OSDOCS 6914: Updating pod examples to comply with restricted PSA (Nod…

### DIFF
--- a/modules/nodes-cluster-resource-configure-request-limit.adoc
+++ b/modules/nodes-cluster-resource-configure-request-limit.adoc
@@ -22,6 +22,10 @@ kind: Pod
 metadata:
   name: test
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: test
     image: fedora:latest
@@ -44,6 +48,10 @@ spec:
         memory: 384Mi
       limits:
         memory: 512Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 <1> Add this stanza to discover the application memory request value.
 <2> Add this stanza to discover the application memory limit value.

--- a/modules/nodes-cluster-resource-levels-command.adoc
+++ b/modules/nodes-cluster-resource-levels-command.adoc
@@ -31,6 +31,10 @@ metadata:
     app: guestbook
     tier: frontend
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: php-redis
     image: gcr.io/google-samples/gb-frontend:v4
@@ -42,6 +46,10 @@ spec:
       requests:
         cpu: 150m
         memory: 100Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 
 .. Create the cluster role:

--- a/modules/nodes-cluster-resource-levels-job.adoc
+++ b/modules/nodes-cluster-resource-levels-job.adoc
@@ -87,6 +87,10 @@ metadata:
     app: guestbook
     tier: frontend
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: php-redis
     image: gcr.io/google-samples/gb-frontend:v4
@@ -98,6 +102,10 @@ spec:
       requests:
         cpu: 150m
         memory: 100Mi
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 
 .. Create the pod by running the following command:

--- a/modules/nodes-containers-downward-api-container-configmaps.adoc
+++ b/modules/nodes-containers-downward-api-container-configmaps.adoc
@@ -43,6 +43,10 @@ kind: Pod
 metadata:
   name: dapi-env-test-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: env-test-container
       image: gcr.io/google_containers/busybox
@@ -53,6 +57,10 @@ spec:
             configMapKeyRef:
               name: myconfigmap
               key: mykey
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   restartPolicy: Always
 # ...
 ----

--- a/modules/nodes-containers-downward-api-container-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-envars.adoc
@@ -24,6 +24,10 @@ kind: Pod
 metadata:
   name: dapi-env-test-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: env-test-container
       image: gcr.io/google_containers/busybox
@@ -33,6 +37,10 @@ spec:
           value: my_value
         - name: MY_ENV_VAR_REF_ENV
           value: $(MY_EXISTING_ENV)
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   restartPolicy: Never
 # ...
 ----

--- a/modules/nodes-containers-downward-api-container-escaping.adoc
+++ b/modules/nodes-containers-downward-api-container-escaping.adoc
@@ -23,6 +23,10 @@ kind: Pod
 metadata:
   name: dapi-env-test-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: env-test-container
       image: gcr.io/google_containers/busybox
@@ -30,6 +34,10 @@ spec:
       env:
         - name: MY_NEW_ENV
           value: $$(SOME_OTHER_ENV)
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   restartPolicy: Never
 # ...
 ----

--- a/modules/nodes-containers-downward-api-container-secrets.adoc
+++ b/modules/nodes-containers-downward-api-container-secrets.adoc
@@ -46,6 +46,10 @@ kind: Pod
 metadata:
   name: dapi-env-test-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: env-test-container
       image: gcr.io/google_containers/busybox
@@ -56,6 +60,10 @@ spec:
             secretKeyRef:
               name: mysecret
               key: username
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   restartPolicy: Never
 # ...
 ----

--- a/modules/nodes-containers-downward-api-container-values-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-values-envars.adoc
@@ -31,6 +31,10 @@ kind: Pod
 metadata:
   name: dapi-env-test-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: env-test-container
       image: gcr.io/google_containers/busybox
@@ -44,6 +48,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.namespace
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   restartPolicy: Never
 # ...
 ----

--- a/modules/nodes-containers-downward-api-container-values-plugin.adoc
+++ b/modules/nodes-containers-downward-api-container-values-plugin.adoc
@@ -40,6 +40,10 @@ metadata:
     annotation1: "345"
     annotation2: "456"
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: volume-test-container
       image: gcr.io/google_containers/busybox
@@ -48,6 +52,10 @@ spec:
         - name: podinfo
           mountPath: /tmp/etc
           readOnly: false
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
   - name: podinfo
     downwardAPI:

--- a/modules/nodes-containers-init-creating.adoc
+++ b/modules/nodes-containers-init-creating.adoc
@@ -23,18 +23,33 @@ metadata:
   labels:
     app: myapp
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: myapp-container
     image: registry.access.redhat.com/ubi9/ubi:latest
     command: ['sh', '-c', 'echo The app is running! && sleep 3600']
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   initContainers:
   - name: init-myservice
     image: registry.access.redhat.com/ubi9/ubi:latest
     command: ['sh', '-c', 'until getent hosts myservice; do echo waiting for myservice; sleep 2; done;']
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   - name: init-mydb
     image: registry.access.redhat.com/ubi9/ubi:latest
     command: ['sh', '-c', 'until getent hosts mydb; do echo waiting for mydb; sleep 2; done;']
-# ...
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 
 .. Create the pod:

--- a/modules/nodes-containers-projected-volumes-about.adoc
+++ b/modules/nodes-containers-projected-volumes-about.adoc
@@ -51,6 +51,10 @@ kind: Pod
 metadata:
   name: volume-test
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: container-test
     image: busybox
@@ -58,6 +62,10 @@ spec:
     - name: all-in-one
       mountPath: "/projected-volume"<2>
       readOnly: true <3>
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   volumes: <4>
   - name: all-in-one <5>
     projected:
@@ -111,6 +119,10 @@ kind: Pod
 metadata:
   name: volume-test
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: container-test
     image: busybox
@@ -118,6 +130,10 @@ spec:
     - name: all-in-one
       mountPath: "/projected-volume"
       readOnly: true
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   volumes:
   - name: all-in-one
     projected:
@@ -156,6 +172,10 @@ kind: Pod
 metadata:
   name: volume-test
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: container-test
     image: busybox
@@ -163,6 +183,10 @@ spec:
     - name: all-in-one
       mountPath: "/projected-volume"
       readOnly: true
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   volumes:
   - name: all-in-one
     projected:

--- a/modules/nodes-containers-projected-volumes-creating.adoc
+++ b/modules/nodes-containers-projected-volumes-creating.adoc
@@ -138,6 +138,10 @@ kind: Pod
 metadata:
   name: test-projected-volume
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: test-projected-volume
     image: busybox
@@ -148,11 +152,10 @@ spec:
     - name: all-in-one
       mountPath: "/projected-volume"
       readOnly: true
-      securityContext:
-        allowPrivilegeEscalation: false
-        capabilities:
-          drop:
-            - ALL
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   volumes:
   - name: all-in-one
     projected:

--- a/modules/nodes-containers-volumes-subpath.adoc
+++ b/modules/nodes-containers-volumes-subpath.adoc
@@ -41,6 +41,10 @@ kind: Pod
 metadata:
   name: my-site
 spec:
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
     containers:
     - name: mysql
       image: mysql
@@ -48,12 +52,20 @@ spec:
       - mountPath: /var/lib/mysql
         name: site-data
         subPath: mysql <1>
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
     - name: php
       image: php
       volumeMounts:
       - mountPath: /var/www/html
         name: site-data
         subPath: html <2>
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
     volumes:
     - name: site-data
       persistentVolumeClaim:

--- a/modules/nodes-pods-configmaps-use-case-consuming-in-env-vars.adoc
+++ b/modules/nodes-pods-configmaps-use-case-consuming-in-env-vars.adoc
@@ -52,6 +52,10 @@ kind: Pod
 metadata:
   name: dapi-test-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
@@ -71,6 +75,10 @@ spec:
       envFrom: <6>
         - configMapRef:
             name: env-config <7>
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   restartPolicy: Never
 ----
 <1> Stanza to pull the specified environment variables from a `ConfigMap`.

--- a/modules/nodes-pods-configmaps-use-case-consuming-in-volumes.adoc
+++ b/modules/nodes-pods-configmaps-use-case-consuming-in-volumes.adoc
@@ -34,6 +34,10 @@ kind: Pod
 metadata:
   name: dapi-test-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
@@ -41,6 +45,10 @@ spec:
       volumeMounts:
       - name: config-volume
         mountPath: /etc/config
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: config-volume
       configMap:
@@ -64,6 +72,10 @@ kind: Pod
 metadata:
   name: dapi-test-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
@@ -71,6 +83,10 @@ spec:
       volumeMounts:
       - name: config-volume
         mountPath: /etc/config
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: config-volume
       configMap:

--- a/modules/nodes-pods-configmaps-use-case-setting-command-line-arguments.adoc
+++ b/modules/nodes-pods-configmaps-use-case-setting-command-line-arguments.adoc
@@ -35,6 +35,10 @@ kind: Pod
 metadata:
   name: dapi-test-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: test-container
       image: gcr.io/google_containers/busybox
@@ -50,6 +54,10 @@ spec:
             configMapKeyRef:
               name: special-config
               key: special.type
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   restartPolicy: Never
 ----
 <1> Inject the values into a command in a container using the keys you want to use as environment variables.

--- a/modules/nodes-pods-configuring-pod-critical.adoc
+++ b/modules/nodes-pods-configuring-pod-critical.adoc
@@ -29,6 +29,7 @@ spec:
     metadata:
       name: critical-pod
     priorityClassName: system-cluster-critical <1>
+# ...
 ----
 <1> Default priority class for pods that should never be evicted from a node.
 +

--- a/modules/nodes-pods-priority-configuring.adoc
+++ b/modules/nodes-pods-priority-configuring.adoc
@@ -61,10 +61,18 @@ metadata:
   labels:
     env: test
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: nginx
     image: nginx
     imagePullPolicy: IfNotPresent
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   priorityClassName: high-priority <1>
 ----
 <1> Specify the priority class to use with this pod.

--- a/modules/nodes-pods-secrets-certificates-creating.adoc
+++ b/modules/nodes-pods-secrets-certificates-creating.adoc
@@ -96,12 +96,20 @@ kind: Pod
 metadata:
   name: my-service-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: mypod
     image: redis
     volumeMounts:
     - name: my-container
       mountPath: "/etc/my-path"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
   volumes:
   - name: my-volume
     secret:

--- a/modules/nodes-pods-secrets-creating.adoc
+++ b/modules/nodes-pods-secrets-creating.adoc
@@ -61,6 +61,10 @@ kind: Pod
 metadata:
   name: secret-example-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: secret-test-container
       image: busybox
@@ -69,6 +73,10 @@ spec:
           - name: secret-volume
             mountPath: /etc/secret-volume <2>
             readOnly: true <3>
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   volumes:
     - name: secret-volume
       secret:
@@ -89,6 +97,10 @@ kind: Pod
 metadata:
   name: secret-example-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: secret-test-container
       image: busybox
@@ -99,6 +111,10 @@ spec:
             secretKeyRef: <1>
               name: test-secret
               key: username
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   restartPolicy: Never
 ----
 <1> Specifies the environment variable that consumes the secret key.

--- a/modules/nodes-pods-using-example.adoc
+++ b/modules/nodes-pods-using-example.adoc
@@ -7,7 +7,7 @@
 
 {product-title} leverages the Kubernetes concept of a _pod_, which is one or more containers deployed together on one host, and the smallest compute unit that can be defined, deployed, and managed.
 
-The following is an example definition of a pod from a Rails application. It demonstrates many features of pods, most of which are discussed in other topics and thus only briefly mentioned here:
+The following is an example definition of a pod. It demonstrates many features of pods, most of which are discussed in other topics and thus only briefly mentioned here:
 
 [id="example-pod-definition_{context}"]
 .`Pod` object definition (YAML)
@@ -18,103 +18,52 @@ kind: Pod
 apiVersion: v1
 metadata:
   name: example
-  namespace: default
-  selfLink: /api/v1/namespaces/default/pods/example
-  uid: 5cc30063-0265780783bc
-  resourceVersion: '165032'
-  creationTimestamp: '2019-02-13T20:31:37Z'
-  labels:                  
-    app: hello-openshift <1>
-  annotations:
-    openshift.io/scc: anyuid
+  labels:
+    environment: production
+    app: abc <1>
 spec:
   restartPolicy: Always <2>
-  serviceAccountName: default
-  imagePullSecrets:
-    - name: default-dockercfg-5zrhb
-  priority: 0
-  schedulerName: default-scheduler
-  terminationGracePeriodSeconds: 30
-  nodeName: ip-10-0-140-16.us-east-2.compute.internal
   securityContext: <3>
-    seLinuxOptions:
-      level: 's0:c11,c10'
-  containers: <4>        
-    - resources: {}
-      terminationMessagePath: /dev/termination-log
-      name: hello-openshift
-      securityContext:
-        capabilities:
-          drop:
-            - MKNOD
-        procMount: Default
-      ports:
-        - containerPort: 8080
-          protocol: TCP
-      imagePullPolicy: Always
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
+  containers: <4>
+    - name: abc
+      args:
+      - sleep
+      - "1000000"
       volumeMounts: <5>
-        - name: default-token-wbqsl
-          readOnly: true
-          mountPath: /var/run/secrets/kubernetes.io/serviceaccount <6>
-      terminationMessagePolicy: File
-      image: registry.redhat.io/openshift4/ose-ogging-eventrouter:v4.3 <7>
-  serviceAccount: default <8>
-  volumes: <9>
-    - name: default-token-wbqsl
-      secret:
-        secretName: default-token-wbqsl
-        defaultMode: 420
-  dnsPolicy: ClusterFirst
-status:
-  phase: Pending
-  conditions:
-    - type: Initialized
-      status: 'True'
-      lastProbeTime: null
-      lastTransitionTime: '2019-02-13T20:31:37Z'
-    - type: Ready
-      status: 'False'
-      lastProbeTime: null
-      lastTransitionTime: '2019-02-13T20:31:37Z'
-      reason: ContainersNotReady
-      message: 'containers with unready status: [hello-openshift]'
-    - type: ContainersReady
-      status: 'False'
-      lastProbeTime: null
-      lastTransitionTime: '2019-02-13T20:31:37Z'
-      reason: ContainersNotReady
-      message: 'containers with unready status: [hello-openshift]'
-    - type: PodScheduled
-      status: 'True'
-      lastProbeTime: null
-      lastTransitionTime: '2019-02-13T20:31:37Z'
-  hostIP: 10.0.140.16
-  startTime: '2019-02-13T20:31:37Z'
-  containerStatuses:
-    - name: hello-openshift
-      state:
-        waiting:
-          reason: ContainerCreating
-      lastState: {}
-      ready: false
-      restartCount: 0
-      image: openshift/hello-openshift
-      imageID: ''
-  qosClass: BestEffort
+       - name: cache-volume
+         mountPath: /cache <6>
+      image: registry.access.redhat.com/ubi7/ubi-init:latest <7>
+      securityContext:
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        capabilities:
+          drop: ["ALL"]
+      resources:
+        limits:
+          memory: "100Mi"
+          cpu: "1"
+        requests:
+          memory: "100Mi"
+          cpu: "1"
+  volumes: <8>
+  - name: cache-volume
+    emptyDir:
+      sizeLimit: 500Mi
 ----
 
 <1> Pods can be "tagged" with one or more labels, which can then be used to select and manage groups of pods in a single operation. The labels are stored in key/value format in the `metadata` hash.
 <2> The pod restart policy with possible values `Always`, `OnFailure`, and `Never`. The default value is `Always`.
 <3> {product-title} defines a security context for containers which specifies whether they are allowed to run as privileged containers, run as a user of their choice, and more. The default context is very restrictive but administrators can modify this as needed.
 <4> `containers` specifies an array of one or more container definitions.
-<5> The container specifies where external storage volumes are mounted within the container. In this case, there is a volume for storing access to credentials the registry needs for making requests against the {product-title} API.
+<5> The container specifies where external storage volumes are mounted within the container.
 <6> Specify the volumes to provide for the pod. Volumes mount at the specified path. Do not mount to the container root, `/`, or any path that is the same in the host and the container. This can corrupt your host system if the container is sufficiently privileged, such as the host `/dev/pts` files. It is safe to mount the host by using `/host`.
 <7> Each container in the pod is instantiated from its own container image.
-<8> Pods making requests against the {product-title} API is a common enough pattern that there is a `serviceAccount` field for specifying which service account user the pod should authenticate as when making the requests. This enables fine-grained access control for custom infrastructure components.
-<9> The pod defines storage volumes that are available to its container(s) to use. In this case, it provides an ephemeral volume for a `secret` volume containing the default service account tokens. 
+<8> The pod defines storage volumes that are available to its container(s) to use.
 +
-If you attach persistent volumes that have high file counts to pods, those pods can fail or can take a long time to start. For
-more information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].
+If you attach persistent volumes that have high file counts to pods, those pods can fail or can take a long time to start. For more information, see link:https://access.redhat.com/solutions/6221251[When using Persistent Volumes with high file counts in OpenShift, why do pods fail to start or take an excessive amount of time to achieve "Ready" state?].
 
 [NOTE]
 ====

--- a/modules/nodes-scheduler-node-affinity-about.adoc
+++ b/modules/nodes-scheduler-node-affinity-about.adoc
@@ -31,6 +31,10 @@ kind: Pod
 metadata:
   name: with-node-affinity
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   affinity:
     nodeAffinity: <1>
       requiredDuringSchedulingIgnoredDuringExecution: <2>
@@ -44,7 +48,11 @@ spec:
   containers:
   - name: with-node-affinity
     image: docker.io/ocpqe/hello-pod
-#...
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+# ...
 ----
 
 <1> The stanza to configure node affinity.
@@ -62,6 +70,10 @@ kind: Pod
 metadata:
   name: with-node-affinity
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   affinity:
     nodeAffinity: <1>
       preferredDuringSchedulingIgnoredDuringExecution: <2>
@@ -76,7 +88,11 @@ spec:
   containers:
   - name: with-node-affinity
     image: docker.io/ocpqe/hello-pod
-#...
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+# ...
 ----
 
 <1> The stanza to configure node affinity.

--- a/modules/nodes-scheduler-node-affinity-example.adoc
+++ b/modules/nodes-scheduler-node-affinity-example.adoc
@@ -50,9 +50,17 @@ kind: Pod
 metadata:
   name: pod-s1
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - image: "docker.io/ocpqe/hello-pod"
       name: hello-pod
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -122,9 +130,17 @@ kind: Pod
 metadata:
   name: pod-s1
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - image: "docker.io/ocpqe/hello-pod"
       name: hello-pod
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   affinity:
     nodeAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:

--- a/modules/nodes-scheduler-node-names-configuring.adoc
+++ b/modules/nodes-scheduler-node-names-configuring.adoc
@@ -21,6 +21,7 @@ apiVersion: v1
 kind: Pod
 spec:
   nodeName: <value>
+# ...
 ----
 
 .Procedure
@@ -56,4 +57,3 @@ plugins:
 - name: PodNodeConstraints
   path: podnodeconstraints.yaml
 ----
-

--- a/modules/nodes-scheduler-node-selectors-about.adoc
+++ b/modules/nodes-scheduler-node-selectors-about.adoc
@@ -153,7 +153,7 @@ metadata:
 ----
 +
 .Example `Pod` object with a node selector
-[source,terminal]
+[source,yaml]
 ----
 apiVersion: v1
 kind: Pod

--- a/modules/nodes-scheduler-pod-affinity-about.adoc
+++ b/modules/nodes-scheduler-pod-affinity-about.adoc
@@ -44,6 +44,10 @@ kind: Pod
 metadata:
   name: with-pod-affinity
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   affinity:
     podAffinity: <1>
       requiredDuringSchedulingIgnoredDuringExecution: <2>
@@ -57,6 +61,10 @@ spec:
   containers:
   - name: with-pod-affinity
     image: docker.io/ocpqe/hello-pod
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 
 <1> Stanza to configure pod affinity.
@@ -72,6 +80,10 @@ kind: Pod
 metadata:
   name: with-pod-antiaffinity
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   affinity:
     podAntiAffinity: <1>
       preferredDuringSchedulingIgnoredDuringExecution: <2>
@@ -87,6 +99,10 @@ spec:
   containers:
   - name: with-pod-affinity
     image: docker.io/ocpqe/hello-pod
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 
 <1> Stanza to configure pod anti-affinity.

--- a/modules/nodes-scheduler-pod-affinity-configuring.adoc
+++ b/modules/nodes-scheduler-pod-affinity-configuring.adoc
@@ -28,9 +28,17 @@ metadata:
   labels:
     security: S1
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: security-s1
     image: docker.io/ocpqe/hello-pod
+    securityContext:
+      runAsNonRoot: true
+      seccompProfile:
+        type: RuntimeDefault
 ----
 +
 .. Create the pod.
@@ -50,9 +58,9 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: security-s1-east
-#...
-spec
-  affinity <1>
+# ...
+spec:
+  affinity: <1>
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution: <2>
       - labelSelector:
@@ -62,7 +70,7 @@ spec
             - S1
             operator: In <4>
         topologyKey: topology.kubernetes.io/zone <5>
-#...
+# ...
 ----
 +
 --

--- a/modules/nodes-scheduler-pod-affinity-example.adoc
+++ b/modules/nodes-scheduler-pod-affinity-example.adoc
@@ -22,12 +22,20 @@ metadata:
   name: team4
   labels:
      team: "4"
-#...
+# ...
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: ocp
     image: docker.io/ocpqe/hello-pod
-#...
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+# ...
 ----
 
 * The pod *team4a* has the label selector `team:4` under `podAffinity`.
@@ -38,8 +46,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: team4a
-#...
+# ...
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -53,7 +65,11 @@ spec:
   containers:
   - name: pod-affinity
     image: docker.io/ocpqe/hello-pod
-#...
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+# ...
 ----
 
 * The *team4a* pod is scheduled on the same node as the *team4* pod.
@@ -73,12 +89,20 @@ metadata:
   name: pod-s1
   labels:
     security: s1
-#...
+# ...
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: ocp
     image: docker.io/ocpqe/hello-pod
-#...
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+# ...
 ----
 
 * The pod *pod-s2* has the label selector `security:s1` under `podAntiAffinity`.
@@ -89,8 +113,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-s2
-#...
+# ...
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   affinity:
     podAntiAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -104,7 +132,11 @@ spec:
   containers:
   - name: pod-antiaffinity
     image: docker.io/ocpqe/hello-pod
-#...
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+# ...
 ----
 
 * The pod *pod-s2* cannot be scheduled on the same node as `pod-s1`.
@@ -124,12 +156,20 @@ metadata:
   name: pod-s1
   labels:
     security: s1
-#...
+# ...
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: ocp
     image: docker.io/ocpqe/hello-pod
-#...
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+# ...
 ----
 
 * The pod *pod-s2* has the label selector `security:s2`.
@@ -140,8 +180,12 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: pod-s2
-#...
+# ...
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   affinity:
     podAffinity:
       requiredDuringSchedulingIgnoredDuringExecution:
@@ -155,7 +199,11 @@ spec:
   containers:
   - name: pod-affinity
     image: docker.io/ocpqe/hello-pod
-#...
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
+# ...
 ----
 
 * The pod *pod-s2* is not scheduled unless there is a node with a pod that has the `security:s2` label. If there is no other pod with that label, the new pod remains in a pending state:

--- a/modules/nodes-scheduler-pod-anti-affinity-configuring.adoc
+++ b/modules/nodes-scheduler-pod-anti-affinity-configuring.adoc
@@ -28,9 +28,17 @@ metadata:
   labels:
     security: S1
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: security-s1
     image: docker.io/ocpqe/hello-pod
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 +
 .. Create the pod.
@@ -50,9 +58,10 @@ apiVersion: v1
 kind: Pod
 metadata:
   name: security-s2-east
-#...
-spec
-  affinity <1>
+# ...
+spec:
+# ...
+  affinity: <1>
     podAntiAffinity:
       preferredDuringSchedulingIgnoredDuringExecution: <2>
       - weight: 100 <3>
@@ -64,7 +73,7 @@ spec
               - S1
               operator: In <5>
           topologyKey: kubernetes.io/hostname <6>
-#...
+# ...
 ----
 <1> Adds a pod anti-affinity.
 <2> Configures the `requiredDuringSchedulingIgnoredDuringExecution` parameter or the `preferredDuringSchedulingIgnoredDuringExecution` parameter.

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
@@ -34,6 +34,10 @@ metadata:
   labels:
     region: us-east
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   topologySpreadConstraints:
   - maxSkew: 1 <1>
     topologyKey: topology.kubernetes.io/zone <2>
@@ -46,6 +50,10 @@ spec:
   containers:
   - image: "docker.io/ocpqe/hello-pod"
     name: hello-pod
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 <1> The maximum difference in number of pods between any two topology domains. The default is `1`, and you cannot specify a value of `0`.
 <2> The key of a node label. Nodes with this key and identical value are considered to be in the same topology.

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-examples.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-examples.adoc
@@ -23,6 +23,10 @@ metadata:
   labels:
     region: us-east
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: topology.kubernetes.io/zone
@@ -33,6 +37,10 @@ spec:
   containers:
   - image: "docker.io/ocpqe/hello-pod"
     name: hello-pod
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 
 [id="nodes-scheduler-pod-topology-spread-constraints-example-multiple_{context}"]
@@ -53,6 +61,10 @@ metadata:
   labels:
     region: us-east
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   topologySpreadConstraints:
   - maxSkew: 1
     topologyKey: node
@@ -69,4 +81,8 @@ spec:
   containers:
   - image: "docker.io/ocpqe/hello-pod"
     name: hello-pod
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----

--- a/modules/nodes-secondary-scheduler-pod-console.adoc
+++ b/modules/nodes-secondary-scheduler-pod-console.adoc
@@ -35,11 +35,19 @@ metadata:
   name: nginx
   namespace: default
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: nginx
       image: nginx:1.14.2
       ports:
         - containerPort: 80
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
   schedulerName: secondary-scheduler <1>
 ----
 <1> The `schedulerName` field must match the name that is defined in the config map when you configured the secondary scheduler.

--- a/modules/rodoo-enable-override.adoc
+++ b/modules/rodoo-enable-override.adoc
@@ -40,16 +40,16 @@ metadata:
   namespace: <namespace>                 <1>
 spec:
   restartPolicy: Never                   <2>
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: busybox
       securityContext:
         allowPrivilegeEscalation: false
         capabilities:
-          drop: ["ALL"]
-        runAsNonRoot:
-          true
-        seccompProfile:
-          type: "RuntimeDefault"
+          drop: [ALL]
       image: busybox:1.25
       command:
         - /bin/sh


### PR DESCRIPTION
…es book)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-6914

Link to docs preview:
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-configure.html#nodes-cluster-resource-configure-request-limit_nodes-cluster-resource-configure
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-levels.html#nodes-cluster-resource-levels-command_nodes-cluster-resource-levels
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-levels.html#nodes-cluster-resource-levels-job_nodes-cluster-resource-levels
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-configmaps_nodes-containers-downward-api
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-envars_nodes-containers-downward-api
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-escaping_nodes-containers-downward-api
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-secrets_nodes-containers-downward-api
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-values-envars_nodes-containers-downward-api
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-values-plugin_nodes-containers-downward-api
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-init.html#nodes-containers-init-creating_nodes-containers-init
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-projected-volumes.html#projected-volumes-examples_nodes-containers-projected-volumes
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-projected-volumes.html#nodes-containers-projected-volumes-creating_nodes-containers-projected-volumes
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-volumes.html#nodes-containers-volumes-subpath_nodes-containers-volumes
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmaps-use-case-consuming-in-env-vars_configmaps
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmaps-use-case-consuming-in-volumes_configmaps
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmaps-use-case-setting-command-line-arguments_configmaps
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-critical_nodes-pods-configuring
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-priority.html#nodes-pods-priority-configuring_nodes-pods-priority
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-certificates-creating_nodes-pods-secrets
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-secrets.html#nodes-pods-secrets-creating_nodes-pods-secrets
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-using.html#nodes-pods-using-example_nodes-pods-using-ssy
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity.html#nodes-scheduler-node-affinity-about_nodes-scheduler-node-affinity
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity.html#nodes-scheduler-node-affinity-example_nodes-scheduler-node-affinity
* No preview for nodes-scheduler-node-names-configuring.adoc
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-selectors.html#nodes-scheduler-node-selectors-about_nodes-scheduler-node-selectors
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html#nodes-scheduler-pod-affinity-about_nodes-scheduler-pod-affinity
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html#nodes-scheduler-pod-affinity-configuring_nodes-scheduler-pod-affinity
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html#nodes-scheduler-pod-affinity-example_nodes-scheduler-pod-affinity
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity.html#nodes-scheduler-pod-anti-affinity-configuring_nodes-scheduler-pod-affinity
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.html#nodes-scheduler-pod-topology-spread-constraints-configuring_nodes-scheduler-pod-topology-spread-constraints
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.html#nodes-scheduler-pod-topology-spread-constraints-examples_nodes-scheduler-pod-topology-spread-constraints
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html#nodes-secondary-scheduler-pod-console_secondary-scheduler-configuring
* https://62602--ocpdocs-pr.netlify.app/openshift-enterprise/latest/nodes/pods/run_once_duration_override/run-once-duration-override-install.html#rodoo-enable-override_run-once-duration-override-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
