### PR TITLE
Experiment using {context} in xrefs for anchor links in an assembly

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc
@@ -71,8 +71,10 @@ stringData:
 To install a cluster that is configured to use the Cloud Credential Operator (CCO) in manual mode with STS:
 
 //[pre-4.8]. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-installing-manual-config_cco-mode-sts[Create the required AWS resources]
-. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-configuring_cco-mode-sts[Configure the Cloud Credential Operator utility].
-. Create the required AWS resources xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-creating-individually_cco-mode-sts[individually], or xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-creating-at-once_cco-mode-sts[with a single command].
+//Experiment 1: just the _{context} ending
+. xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-configuring_{context}[Configure the Cloud Credential Operator utility].
+//Experiment 2: the _{context} ending and the file name
+. Create the required AWS resources xref:../../authentication/managing_cloud_provider_credentials/{context}.adoc#cco-ccoctl-creating-individually_{context}[individually], or xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-creating-at-once_cco-mode-sts[with a single command].
 . xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-installing-manual-run-installer_cco-mode-sts[Run the {product-title} installer].
 . xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#sts-mode-installing-verifying_cco-mode-sts[Verify that the cluster is using short-lived credentials].
 


### PR DESCRIPTION
Local asciibinder build for this works as expected. My SSH setup is currently messed up so I can't upload the preview :upside_down_face: Local Travis checks also completed successfully. Pulled against 4.9 for minimal consequences if this doesn't cooperate.