### PR TITLE
[OSDOCS-6908] IMDSv2 Documentation wrongly under Node Management

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -134,6 +134,9 @@ a|--cluster-name <cluster_name>
 |--dry-run
 |Simulates creating the cluster.
 
+|--ec2-metadata-http-tokens string
+|Configures the use of IMDSv2 for EC2 instances. Valid values are `optional` (default) or `required`.
+
 |--enable-autoscaling
 |Enables autoscaling of compute nodes. By default, autoscaling is set to `2` nodes. To set non-default node limits, use this argument with the `--min-replicas` and `--max-replicas` arguments.
 

--- a/modules/rosa-imds-cli.adoc
+++ b/modules/rosa-imds-cli.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+
+:_content-type: PROCEDURE
+[id="rosa-imds-cli_{context}"]
+= Enabling Instance Metadata Service in CLI
+
+You can select your Instance Metadata Service (IMDS) type when creating your cluster in the ROSA CLI. You can select to use both IMDSv1 and IMDSv2, or you can select only IMDSv2.
+
+.Prerequisites
+
+* You installed and configured the latest AWS (`aws`), ROSA (`rosa`), and OpenShift (`oc`) CLIs on your workstation.
+* You logged in to your Red Hat account using the `rosa` CLI.
+* You have the permissions to create and manage clusters.
+
+.Procedure
+
+. In your terminal, create a ROSA cluster with your specifications by running the following command:
++
+[source,terminal]
+----
+$ rosa create cluster --cluster <name_of_cluster> --ec2-metadata-http-tokens <required_or_optional> <1>
+----
++
+<1> You can provide a value for the `--ec2-metadata-http-tokens` flag. Provide the `required` value to enable IMDSv2, or provide the `optional` value for a combination of IMDSv1 and IMDSv2. If you do not include this flag, you must select your IMDS type during the cluster creation prompts.
+
+. Confirm the selection:
++
+[source,terminal]
+----
+? Configure the use of IMDSv2 for ec2 instances optional/required: required
+----
+
+.Verification
+
+* After your cluster has been created, navigate to the cluster *Overview* tab in {cluster-manager-url} to see the *Instance Metadata Service (IMDS)* field that notes your IMDS version support.

--- a/modules/rosa-imds-ui.adoc
+++ b/modules/rosa-imds-ui.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+
+:_content-type: PROCEDURE
+[id="rosa-imds-ui_{context}"]
+= Enabling Instance Metadata Service in {cluster-manager}
+
+You can select your Instance Metadata Service (IMDS) type when creating your cluster in {cluster-manager}. You can select both IMDSv1 and IMDSv2, or you can select only IMDSv2.
+
+.Prerequisites
+
+* You installed and configured the latest AWS (`aws`), ROSA (`rosa`), and OpenShift (`oc`) CLIs on your workstation.
+* You logged in to your Red Hat account by using the `rosa` CLI.
+* You have the permissions to create and manage clusters.
+* You have access to {cluster-manager-url}.
+
+.Procedure
+
+. Log in to the web console.
+. Create a ROSA cluster using your preferences.
+. In the *Create a ROSA Cluster** wizard on the **Cluster settings* -> *Machine pool* page, under the *Instance Metadata Service (IMDS)* section, select whether your machine pools use both IMDSv1 and IMDSv2, or only IMDSv2.
+. Select *Next* to save this selection.
+
+.Verification
+
+. After your cluster has been created, see the *Instance Metadata Service (IMDS)* field that notes your IMDS version support on the cluster *Overview* tab.

--- a/modules/rosa-imds.adoc
+++ b/modules/rosa-imds.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+//
+// * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+
+:_content-type: CONCEPT
+[id="rosa-imds{context}"]
+= Instance Metadata Service
+
+There are two types of ways to access instance metadata from a running instance:
+
+* Instance Metadata Service Version 1 (IMDSv1) - a request/response method
+* Instance Metadata Service Version 2 (IMDSv2) - a session-oriented method
+
+IMDSv2 uses session-oriented requests. With session-oriented requests, you create a session token that defines the session duration, which can be a minimum of one second and a maximum of six hours. During the specified duration, you can use the same session token for subsequent requests. After the specified duration expires, you must create a new session token to use for future requests.
+
+When creating your ROSA cluster, you can configure your cluster to use both IMDSv1 and IMDSv2, or only IMDSv2. The instance metadata service distinguishes between IMDSv1 and IMDSv2 requests based on whether, for any given request, either the PUT or GET headers, which are unique to IMDSv2, are present in that request. If you specify to use IMDSv2 only, IMDSv1 ceases to function for your cluster. All machine pools on your cluster will use whichever IMDS type you select.

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -223,19 +223,21 @@ $ rosa create cluster --interactive --sts
 I: Interactive mode enabled.
 Any optional fields can be left empty and a default will be selected.
 ? Cluster name: <cluster_name>
-? OpenShift version: 4.8.9 <1>
-I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role for the Installer role <2>
+Deploy cluster with Hosted Control Plane (optional): No
+? OpenShift version: 4.13.4 <1>
+? Configure the use of IMDSv2 for ec2 instances optional/required (optional): <2>
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role for the Installer role <3>
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for the Support role
 ? External ID (optional):
-? Operator roles prefix: <cluster_name>-<random_string> <3>
-? Multiple availability zones (optional): No <4>
+? Operator roles prefix: <cluster_name>-<random_string> <4>
+? Multiple availability zones (optional): No <5>
 ? AWS region: us-east-1
 ? PrivateLink cluster (optional): No
 ? Install into an existing VPC (optional): No
 ? Select availability zones (optional): No
-? Enable Customer Managed key (optional): No <5>
+? Enable Customer Managed key (optional): No <6>
 ? Compute nodes instance type (optional):
 ? Enable autoscaling (optional): No
 ? Compute nodes: 2
@@ -243,26 +245,32 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for th
 ? Service CIDR: 172.30.0.0/16
 ? Pod CIDR: 10.128.0.0/14
 ? Host prefix: 23
-? Encrypt etcd data (optional): No <6>
+? Encrypt etcd data (optional): No <7>
 ? Disable Workload monitoring (optional): No
 I: Creating cluster '<cluster_name>'
 I: To create this cluster again in the future, you can run:
-   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <7>
+   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <8>
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
 I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
 ...
 ----
-<1> When creating the cluster, the listed `OpenShift version` options include the major, minor, and patch versions, for example `4.8.9`.
-<2> If you have more than one set of account roles in your AWS account for your cluster version, an interactive list of options is provided.
-<3> Optional: By default, the cluster-specific Operator role names are prefixed with the cluster name and random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _Defining an Operator IAM role prefix_.
+<1> When creating the cluster, the listed `OpenShift version` options include the major, minor, and patch versions, for example `4.13.4`.
+<2> Optional: Specify 'optional' to configure all EC2 instances to use both v1 and v2 endpoints of EC2 Instance Metadata Service (IMDS). This is the default value. Specify 'required' to configure all EC2 instances to use IMDSv2 only.
++
+[IMPORTANT]
+====
+The Instance Metadata Service settings cannot be changed after your cluster is created.
+====
+<3> If you have more than one set of account roles in your AWS account for your cluster version, an interactive list of options is provided.
+<4> By default, the cluster-specific Operator role names are prefixed with the cluster name and random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _Defining an Operator IAM role prefix_.
 +
 [NOTE]
 ====
 If you specified custom ARN paths when you created the associated account-wide roles, the custom path is automatically detected. The custom path is applied to the cluster-specific Operator roles when you create them in a later step.
 ====
-<4> Multiple availability zones are recommended for production workloads. The default is a single availability zone.
-<5> Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN to in the preceding step.
+<5> Optional: Multiple availability zones are recommended for production workloads. The default is a single availability zone.
+<6> Optional: Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN to in the preceding step.
 +
 [IMPORTANT]
 ====
@@ -271,14 +279,14 @@ Only persistent volumes (PVs) created from the default storage class are encrypt
 PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
 ====
 
-<6> Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted, but not the keys.
+<7> Optional: Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted, but not the keys.
 +
 [IMPORTANT]
 ====
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Red Hat recommends that you enable etcd encryption only if you specifically require it for your use case.
 ====
 +
-<7> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
+<8> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
 --
 +
 As an alternative to using the `--interactive` mode, you can specify the customization options directly when you run the `rosa create cluster` command. Run the `rosa create cluster --help` command to view a list of available CLI options, or see _create cluster_ in _Managing objects with the ROSA CLI_.

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -264,6 +264,13 @@ Alternatively, you can set your autoscaling preferences for the default machine 
 ** If you deployed your cluster using a single availability zone, select a *Compute node count* from the drop-down menu. This defines the number of compute nodes to provision to the machine pool for the zone.
 ** If you deployed your cluster using multiple availability zones, select a *Compute node count (per zone)* from the drop-down menu. This defines the number of compute nodes to provision to the machine pool per zone.
 
+. Optional: Select an EC2 Instance Metadata Service (IMDS) configuration - `optional` (default) or `required` - to enforce use of IMDSv2. For more information regarding IMDS, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-metadata.html[Instance metadata and user data] in the AWS documentation.
++
+[IMPORTANT]
+====
+The Instance Metadata Service settings cannot be changed after your cluster is created.
+====
+
 . Optional: Expand *Edit node labels* to add labels to your nodes. Click *Add label* to add more node labels and select *Next*.
 
 . In the *Cluster privacy* section of the *Network configuration* page, select *Public* or *Private* to use either public or private API endpoints and application routes for your cluster.

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -25,6 +25,9 @@ The following table describes the interactive cluster creation mode options:
 |`OpenShift version`
 |Select the version of OpenShift to install, for example {product-version}. The default is the latest version.
 
+|`Configure the use of IMDSv2 for ec2 instances optional/required (optional)`
+|Specify whether all EC2 instances will use both v1 and v2 endpoints of EC2 Instance Metadata Service (IMDS)(optional) or only IMDSv2 (required).
+
 |`Installer role ARN`
 |If you have more than one set of account roles in your AWS account for your cluster version, a list of installer role ARNs are provided. Select the ARN for the installer role that you want to use with your cluster. The cluster uses the account-wide roles and policies that relate to the selected installer role.
 

--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -15,12 +15,12 @@ endif::[]
 [id="rosa-sts-overview-of-the-default-cluster-specifications_{context}"]
 = Overview of the default cluster specifications
 
-You can quickly create a 
+You can quickly create a
 ifdef::rosa-hcp[]
-{hcp-title} 
+{hcp-title}
 endif::rosa-hcp[]
 ifndef::rosa-hcp[]
-{product-title} (ROSA) 
+{product-title} (ROSA)
 endif::rosa-hcp[]
 cluster with the AWS Security Token Service (STS) by using the default installation options. The following summary describes the default cluster specifications.
 
@@ -45,6 +45,7 @@ ifndef::rosa-hcp[]
 * Default AWS region for installations using the {cluster-manager-first} {hybrid-console-second}: us-east-1 (US East, North Virginia)
 endif::rosa-hcp[]
 * Default AWS region for installations using the ROSA CLI (`rosa`): Defined by your `aws` CLI configuration
+* Default EC2 IMDS endpoints (both v1 and v2) are enabled
 * Availability: Single zone for the data plane
 * Monitoring for user-defined projects: Enabled
 

--- a/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
@@ -31,15 +31,15 @@ include::modules/rosa-osd-node-label-about.adoc[leveloffset=+1]
 * For more information about labels, see link:https://kubernetes.io/docs/concepts/overview/working-with-objects/labels/[Kubernetes Labels and Selectors overview].
 
 include::modules/rosa-adding-node-labels.adoc[leveloffset=+2]
-include::modules/rosa-imds-machine-pools.adoc[leveloffset=+1]
+// include::modules/rosa-imds-machine-pools.adoc[leveloffset=+1]
 
-[role="_additional-resources"]
-.Additional resources
+// [role="_additional-resources"]
+// .Additional resources
 
-* For more information about Instance Metadata Service, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[Use IMDSv2] in the AWS documentation.
+// * For more information about Instance Metadata Service, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[Use IMDSv2] in the AWS documentation.
 
-include::modules/rosa-imds-machine-pools-ui.adoc[leveloffset=+2]
-include::modules/rosa-imds-machine-pools-cli.adoc[leveloffset=+2]
+// include::modules/rosa-imds-machine-pools-ui.adoc[leveloffset=+2]
+// include::modules/rosa-imds-machine-pools-cli.adoc[leveloffset=+2]
 include::modules/rosa-adding-taints.adoc[leveloffset=+1]
 include::modules/rosa-adding-taints-ocm.adoc[leveloffset=+2]
 include::modules/rosa-adding-taints-cli.adoc[leveloffset=+2]

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -40,7 +40,6 @@ include::modules/osd-aws-vpc-required-resources.adoc[leveloffset=+1]
 
 include::modules/rosa-sts-creating-a-cluster-using-customizations.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[leveloffset=+2]
-
 [role="_additional-resources"]
 .Additional resources
 * xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster] in _Managing objects with the ROSA CLI_.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-6908
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://62606--docspreview.netlify.app/openshift-rosa/latest/rosa_cli/rosa-manage-objects-cli.html#rosa-create-cluster-command_rosa-managing-objects-cli
![image](https://github.com/openshift/openshift-docs/assets/122639474/d34baf34-7227-45f1-9e22-d8beff405bb8)

https://62606--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html
![image](https://github.com/openshift/openshift-docs/assets/122639474/c87aeb62-a68a-4cc5-a4fe-7e5ad3d9506c)

https://62606--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations
![image](https://github.com/openshift/openshift-docs/assets/122639474/2614542d-1d05-4e01-8200-b9caadf6b205)

https://62606--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-ocm_rosa-sts-creating-a-cluster-with-customizations
![image](https://github.com/openshift/openshift-docs/assets/122639474/07c9394e-271e-4bf2-a353-4eb95faad7a4)

https://62606--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html#rosa-sts-overview-of-the-default-cluster-specifications_rosa-sts-creating-a-cluster-quickly
![image](https://github.com/openshift/openshift-docs/assets/122639474/9f6be9a8-3fe2-4efd-bec9-d45c78550292)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
