### PR TITLE
RHDEVDOCS-5412: GitOps 1.8.4 release notes

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -32,6 +32,8 @@ ifdef::openshift-enterprise[]
 * xref:../../operators/admin/olm-configuring-proxy-support.adoc#olm-inject-custom-ca_olm-configuring-proxy-support[Injecting a custom CA certificate]
 endif::[]
 
+include::modules/gitops-release-notes-1-8-4.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-8-3.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-8-2.adoc[leveloffset=+1]

--- a/cicd/gitops/installing-openshift-gitops.adoc
+++ b/cicd/gitops/installing-openshift-gitops.adoc
@@ -24,6 +24,13 @@ If you have already installed the Community version of the Argo CD Operator, rem
 
 This guide explains how to install the {gitops-title} Operator to an {product-title} cluster and log in to the Argo CD instance.
 
+[IMPORTANT]
+====
+The `latest` channel enables installation of the most recent stable version of the {gitops-title} Operator. Currently, it is the default channel for installing the {gitops-title} Operator.
+
+To install a specific version of the {gitops-title} Operator, cluster administrators can use the corresponding `gitops-<version>` channel. For example, to install the {gitops-title} Operator version 1.8.x, you can use the `gitops-1.8` channel.
+====
+
 include::modules/installing-gitops-operator-in-web-console.adoc[leveloffset=+1]
 
 include::modules/installing-gitops-operator-using-cli.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-8-4.adoc
+++ b/modules/gitops-release-notes-1-8-4.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+:_content-type: REFERENCE
+[id="gitops-release-notes-1-8-4_{context}"]
+= Release notes for {gitops-title} 1.8.4
+
+{gitops-title} 1.8.4 is now available on {product-title} 4.10, 4.11, 4.12, and 4.13.
+
+[id="new-features-1-8-4_{context}"]
+== New features
+
+The current release adds the following improvements:
+
+* With this update, the bundled Argo CD has been updated to version 2.6.13.
+
+[id="fixed-issues-1-8-4_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, Argo CD was becoming unresponsive when there was an increase in namespaces and applications. The functions competing for resources caused a deadlock. This update fixes the issue by removing the deadlock. Now, you should not experience crashes or unresponsiveness when there is an increase in namespaces or applications. link:https://issues.redhat.com/browse/GITOPS-3192[GITOPS-3192]
+
+* Before this update, the Argo CD application controller resource could suddenly stop working when resynchronizing applications. This update fixes the issue by adding logic to prevent a cluster cache deadlock. Now, applications should resynchronize successfully. link:https://issues.redhat.com/browse/GITOPS-3052[GITOPS-3052]
+
+* Before this update, there was a mismatch in the RSA key for known hosts in the `argocd-ssh-known-hosts-cm` config map. This update fixes the issue by matching the RSA key with the upstream project. Now, you can use the default RSA keys on default deployments. link:https://issues.redhat.com/browse/GITOPS-3144[GITOPS-3144]
+
+* Before this update, an old Redis image version was used when deploying the {gitops-title} Operator, which resulted in vulnerabilities. This update fixes the vulnerabilities on Redis by upgrading it to the latest version of the `registry.redhat.io/rhel-8/redis-6` image. link:https://issues.redhat.com/browse/GITOPS-3069[GITOPS-3069]
+
+* Before this update, users could not connect to Microsoft Team Foundation Server (TFS) type Git repositories through Argo CD deployed by the Operator. This update fixes the issue by updating the Git version to 2.39.3 in the Operator. Now, you can set the `Force HTTP basic auth` flag during repository configurations to connect with the TFS type Git repositories. link:https://issues.redhat.com/browse/GITOPS-1315[GITOPS-1315]
+
+[id="known-issues-1-8-4_{context}"]
+== Known issues
+
+* Currently, {gitops-title} 1.8.4 is not available in the `latest` channel of {product-title} 4.10 and 4.11. The `latest` channel is taken by {gitops-shortname} 1.9.z, which is only released on {product-title} 4.12 and later versions.
++
+As a workaround, switch to the `gitops-1.8` channel to get the new update. link:https://issues.redhat.com/browse/GITOPS-3158[GITOPS-3158]


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: enterprise-4.10 and later
• **JIRA issue**: [RHDEVDOCS-5412](https://issues.redhat.com/browse/RHDEVDOCS-5412)
• **Preview page**: [Release notes for Red Hat OpenShift GitOps 1.8.4](https://62613--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes.html#gitops-release-notes-1-8-4_gitops-release-notes)
• **SME Review**: Completed by @reginapizza 
• **QE review**: Completed by @varshab1210 
• **Peer-review**: Completed by @deerskindoll 