### PR TITLE
updates vale packages + correct id rule error

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -2,7 +2,7 @@ StylesPath = .vale/styles
 
 MinAlertLevel = suggestion
 
-Packages = RedHat, https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/AsciiDoc.zip, https://github.com/redhat-documentation/vale-at-red-hat/releases/latest/download/OpenShiftAsciiDoc.zip
+Packages = RedHat, AsciiDoc, OpenShiftAsciiDoc
 
 Vocab = OpenShiftDocs
 
@@ -25,3 +25,4 @@ Vale.Avoid = YES
 OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO
 OpenShiftAsciiDoc.NoNestingInModules = NO
 OpenShiftAsciiDoc.NoXrefInModules = NO
+OpenShiftAsciiDoc.IdHasContextVariable = NO


### PR DESCRIPTION
Since https://github.com/errata-ai/packages/pull/15 was merged, we don't need to specify the full URL for packages.

Merge to main, CP to enterprise-4.10+