### PR TITLE
cert-manager Operator 1.11.4 release notes

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,6 +12,22 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1.11.4"]
+== Release notes for {cert-manager-operator} 1.11.4
+
+Issued: 2023-07-26
+
+The following advisory is available for the {cert-manager-operator} 1.11.4:
+
+* link:https://access.redhat.com/errata/RHEA-2023:4081[RHEA-2023:4081]
+
+For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.11/[cert-manager project release notes for v1.11]. The golang version is updated to the version `1.19.10` to fix Common Vulnerabilities and Exposures (CVEs).
+
+[id="cert-manager-operator-1.11.4-bug-fixes"]
+=== Bug fixes
+
+* Previously, the {cert-manager-operator} did not allow you to install older versions of the {cert-manager-operator}. Now, you can install older versions of the {cert-manager-operator} using the web console or the command-line interface (CLI). For more information on how to use the web console to install older versions, see xref:../../security/cert_manager_operator/cert-manager-operator-install.adoc#cert-manager-operator-install[Installing the {cert-manager-operator}]. (link:https://issues.redhat.com/browse/OCPBUGS-16393[*OCPBUGS-16393*])
+
 [id="cert-manager-operator-release-notes-1.11.1"]
 == Release notes for {cert-manager-operator} 1.11.1
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7064
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62616--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html#cert-manager-operator-release-notes-1.11.4

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
