### PR TITLE
Added a reference for setting up environment labels.

### DIFF
--- a/cicd/gitops/health-information-for-resources-deployment.adoc
+++ b/cicd/gitops/health-information-for-resources-deployment.adoc
@@ -12,4 +12,5 @@ The *Application environments* page in the *Developer* perspective of the {produ
 
 The environments pages in the *Developer* perspective of the {product-title} web console are decoupled from the {gitops-title} Application Manager command-line interface (CLI), `kam`. You do not have to use `kam` to generate Application Environment manifests for the environments to show up in the *Developer* perspective of the {product-title} web console. You can use your own manifests, but the environments must still be represented by namespaces. In addition, specific labels and annotations are still needed.
 
+include::modules/go-settings-for-environment-labels-and-annotations.adoc[leveloffset=+1]
 include::modules/go-health-monitoring.adoc[leveloffset=+1]

--- a/modules/go-settings-for-environment-labels-and-annotations.adoc
+++ b/modules/go-settings-for-environment-labels-and-annotations.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * /gitops/health-information-for-resources-deployment.adoc
+
+:_content-type: REFERENCE
+[id="go-settings-for-environment-labels-and-annotations_{context}"]
+= Settings for environment labels and annotations
+
+This section provides reference settings for environment labels and annotations required to display an environment application in the *Environments* page, in the *Developer* perspective of the {product-title} web console.
+
+[discrete]
+== Environment labels
+
+The environment application manifest must contain `labels.openshift.gitops/environment` and `destination.namespace` fields. You must set identical values for the `<environment_name>` variable and the name of the environment application manifest.
+
+.Specification of the environment application manifest
+[source,yaml]
+----
+spec:
+  labels:
+    openshift.gitops/environment: <environment_name>
+  destination:
+    namespace: <environment_name>
+...
+----  
+
+.Example of an environment application manifest
+[source,yaml]
+----
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: dev-env <1>
+  namespace: openshift-gitops
+spec:
+  labels:
+    openshift.gitops/environment: dev-env
+  destination:
+    namespace: dev-env
+...
+----
+<1> The name of the environment application manifest. The value set is the same as the value of the `<environment_name>` variable.
+
+[discrete]
+== Environment annotations
+The environment namespace manifest must contain the `annotations.app.openshift.io/vcs-uri` and `annotations.app.openshift.io/vcs-ref` fields to specify the version controller code source of the application. You must set identical values for the `<environment_name>` variable and the name of the environment namespace manifest.
+
+.Specification of the environment namespace manifest
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    app.openshift.io/vcs-uri: <application_source_url>
+    app.openshift.io/vcs-ref: <branch_reference>
+  name: <environment_name> <1>
+...
+----
+<1> The name of the environment namespace manifest. The value set is the same as the value of the `<environment_name>` variable.
+
+.Example of an environment namespace manifest
+[source,yaml]
+----
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    app.openshift.io/vcs-uri: https://example.com/<your_domain>/<your_gitops.git>
+    app.openshift.io/vcs-ref: main
+  labels:
+    argocd.argoproj.io/managed-by: openshift-gitops
+  name: dev-env
+...
+----  


### PR DESCRIPTION
Jira issue : [RHDEVDOCS-5414](https://issues.redhat.com/browse/RHDEVDOCS-5414)

Aligned team: DevTools

OCP Version(s): 4.10 and later

Docs preview: [Docs_Preview](https://62617--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/health-information-for-resources-deployment.html#go-setting-environment-annotations_health-information-for-resources-deployment)

SME review: @ciiay 

QE review: @varshab1210 

Peer review: @Srivaralakshmi and @bburt-rh 