### PR TITLE
Remove hard line breaks from the technology preview snippet

### DIFF
--- a/snippets/technology-preview.adoc
+++ b/snippets/technology-preview.adoc
@@ -4,12 +4,7 @@
 [IMPORTANT]
 ====
 [subs="attributes+"]
-{FeatureName} is a Technology Preview feature only. Technology Preview features
-are not supported with Red Hat production service level agreements (SLAs) and
-might not be functionally complete. Red Hat does not recommend using them
-in production. These features provide early access to upcoming product
-features, enabling customers to test functionality and provide feedback during
-the development process.
+{FeatureName} is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
 For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 ====


### PR DESCRIPTION
This PR removes hard line breaks from the tech preview snippets file

[No Jira issue; no preview]

Versions: OpenShift 4.10+

QE: N/A
