### PR TITLE
OCPBUGS#16396: Removed - in vSphere sample YAML file

### DIFF
--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -29,7 +29,7 @@ compute: <2>
   platform: {}
   replicas: 3
 controlPlane: <2>
-- architecture: amd64
+  architecture: amd64
   hyperthreading: Enabled <3>
   name: <parent_node>
   platform: {}


### PR DESCRIPTION
[OCPBUGS-16396](https://issues.redhat.com/browse/OCPBUGS-16396)

Version(s):
4.14 and 4.13

Link to docs preview:
[Sample install-config.yaml file for VMware vSphere](https://62620--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.html#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-network-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
