### PR TITLE
OSDOCS 6914: Updating pod examples to comply with restricted PSA (Net…

### DIFF
--- a/modules/configuring-pods-secondary-network.adoc
+++ b/modules/configuring-pods-secondary-network.adoc
@@ -20,10 +20,18 @@ metadata:
   name: tinypod
   namespace: ns1
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - args:
     - pause
     image: k8s.gcr.io/e2e-test-images/agnhost:2.36
     imagePullPolicy: IfNotPresent
     name: agnhost-container
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----

--- a/modules/configuring-pods-static-ip.adoc
+++ b/modules/configuring-pods-static-ip.adoc
@@ -33,12 +33,20 @@ metadata:
   name: tinypod
   namespace: ns1
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - args:
     - pause
     image: k8s.gcr.io/e2e-test-images/agnhost:2.36
     imagePullPolicy: IfNotPresent
     name: agnhost-container
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 <1> The name of the network. This value must be unique across all `NetworkAttachmentDefinitions`.
 <2> The MAC address to be assigned for the interface.

--- a/modules/nw-egress-router-http-proxy-mode.adoc
+++ b/modules/nw-egress-router-http-proxy-mode.adoc
@@ -46,13 +46,25 @@ metadata:
   labels:
     name: app-1
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     env:
     - name: http_proxy
       value: http://egress-1:8080/ <1>
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
     - name: https_proxy
       value: http://egress-1:8080/
-    ...
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
+# ...
 ----
 <1> The service created in the previous step.
 +

--- a/modules/nw-enabling-multicast.adoc
+++ b/modules/nw-enabling-multicast.adoc
@@ -76,6 +76,10 @@ metadata:
   labels:
     app: multicast-verify
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: mlistener
       image: registry.access.redhat.com/ubi9
@@ -86,6 +90,10 @@ spec:
         - containerPort: 30102
           name: mlistener
           protocol: UDP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 EOF
 ----
 
@@ -101,12 +109,20 @@ metadata:
   labels:
     app: multicast-verify
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: msender
       image: registry.access.redhat.com/ubi9
       command: ["/bin/sh", "-c"]
       args:
         ["dnf -y install socat && sleep inf"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 EOF
 ----
 

--- a/modules/nw-multus-advanced-annotations.adoc
+++ b/modules/nw-multus-advanced-annotations.adoc
@@ -64,10 +64,18 @@ metadata:
       "default-route": ["192.0.2.1"] <2>
     }]'
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: example-pod
     command: ["/bin/bash", "-c", "sleep 2000000000000"]
     image: centos/tools
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 <1> The `name` key is the name of the additional network to associate
 with the pod.
@@ -184,6 +192,7 @@ metadata:
         "mac": "CA:FE:C0:FF:EE:00" <3>
       }
     ]'
+# ...
 ----
 
 <1> Use the `<name>` as provided when creating the `rawCNIConfig` above.

--- a/modules/nw-networkpolicy-audit-configure.adoc
+++ b/modules/nw-networkpolicy-audit-configure.adoc
@@ -110,22 +110,30 @@ networkpolicy.networking.k8s.io/deny-all created
 networkpolicy.networking.k8s.io/allow-from-same-namespace created
 ----
 
-. Create a pod for source traffic in the `default` namespace:
+. Create a pod for source traffic in the `test-namespace` namespace:
 +
 [source,terminal]
 ----
-$ cat <<EOF| oc create -n default -f -
+$ cat <<EOF| oc create -n test-namespace -f -
 apiVersion: v1
 kind: Pod
 metadata:
   name: client
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: client
       image: registry.access.redhat.com/rhel7/rhel-tools
       command: ["/bin/sh", "-c"]
       args:
         ["sleep inf"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 EOF
 ----
 
@@ -140,12 +148,20 @@ kind: Pod
 metadata:
   name: ${name}
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: ${name}
       image: registry.access.redhat.com/rhel7/rhel-tools
       command: ["/bin/sh", "-c"]
       args:
         ["sleep inf"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 EOF
 done
 ----
@@ -166,11 +182,11 @@ pod/server created
 $ POD_IP=$(oc get pods server -n verify-audit-logging -o jsonpath='{.status.podIP}')
 ----
 
-.. Ping the IP address from the previous command from the pod named `client` in the `default` namespace and confirm that all packets are dropped:
+.. Ping the IP address from the previous command from the pod named `client` in the `test-namespace` namespace and confirm that all packets are dropped:
 +
 [source,terminal]
 ----
-$ oc exec -it client -n default -- /bin/ping -c 2 $POD_IP
+$ oc exec -it client -n test-namespace -- /bin/ping -c 2 $POD_IP
 ----
 +
 .Example output

--- a/modules/nw-osp-enabling-ovs-offload.adoc
+++ b/modules/nw-osp-enabling-ovs-offload.adoc
@@ -18,7 +18,7 @@ OVS is a multi-layer virtual switch that enables large-scale, multi-server netwo
 
 [NOTE]
 ====
-Application layer gateway flows are broken in {product-title} version 4.10, 4.11, and 4.12. Also, you cannot offload the application layer gateway flow for {product-title} version 4.13. 
+Application layer gateway flows are broken in {product-title} version 4.10, 4.11, and 4.12. Also, you cannot offload the application layer gateway flow for {product-title} version 4.13.
 ====
 
 .Procedure
@@ -119,8 +119,16 @@ metadata:
     k8s.v1.cni.cncf.io/resourceName: openshift.io/hwoffload9
     k8s.v1.cni.cncf.io/resourceName: openshift.io/hwoffload10
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   restartPolicy: Never
   containers:
   - name: dpdk-testpmd
     image: quay.io/krister/centos8_nfv-container-dpdk-testpmd:latest
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----

--- a/modules/nw-sctp-about.adoc
+++ b/modules/nw-sctp-about.adoc
@@ -28,13 +28,21 @@ metadata:
   namespace: project1
   name: example-pod
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: example-pod
-...
+# ...
       ports:
         - containerPort: 30100
           name: sctpserver
           protocol: SCTP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 ----
 
 In the following example, a service is configured to use SCTP:

--- a/modules/nw-sctp-verifying.adoc
+++ b/modules/nw-sctp-verifying.adoc
@@ -35,6 +35,10 @@ metadata:
   labels:
     app: sctpserver
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: sctpserver
       image: {image}
@@ -45,6 +49,10 @@ spec:
         - containerPort: 30102
           name: sctpserver
           protocol: SCTP
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 ----
 
 .. Create the pod by entering the following command:
@@ -97,12 +105,20 @@ metadata:
   labels:
     app: sctpclient
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
     - name: sctpclient
       image: {image}
       command: ["/bin/sh", "-c"]
       args:
         ["dnf install -y nc && sleep inf"]
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop: [ALL]
 ----
 
 .. To create the `Pod` object, enter the following command:

--- a/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
+++ b/modules/nw-sriov-cfg-bond-interface-with-virtual-functions.adoc
@@ -86,10 +86,18 @@ apiVersion: v1
       annotations:
         k8s.v1.cni.cncf.io/networks: demo/sriovnet1, demo/sriovnet2, demo/bond-net1 <1>
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       containers:
       - name: podexample
         image: quay.io/openshift/origin-network-interface-bond-cni:4.11.0
         command: ["/bin/bash", "-c", "sleep INF"]
+        securityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop: [ALL]
 ----
 <1> Note the network annotation: it contains two SR-IOV network attachments, and one bond network attachment. The bond attachment uses the two SR-IOV interfaces as bonded port interfaces.
 

--- a/modules/nw-sriov-configure-exclude-topology-manager.adoc
+++ b/modules/nw-sriov-configure-exclude-topology-manager.adoc
@@ -116,11 +116,19 @@ metadata:
         }
       ]
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: <container_name>
     image: <image>
     imagePullPolicy: IfNotPresent
     command: ["sleep", "infinity"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 <1> This is the name of the `SriovNetwork` resource that uses the `SriovNetworkNodePolicy` resource.
 

--- a/modules/nw-sriov-runtime-config.adoc
+++ b/modules/nw-sriov-runtime-config.adoc
@@ -45,11 +45,19 @@ metadata:
         }
       ]
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: sample-container
     image: <image>
     imagePullPolicy: IfNotPresent
     command: ["sleep", "infinity"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 
 [id="runtime-config-infiniband_{context}"]
@@ -88,9 +96,17 @@ metadata:
         }
       ]
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: sample-container
     image: <image>
     imagePullPolicy: IfNotPresent
     command: ["sleep", "infinity"]
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----

--- a/modules/nw-sriov-topology-manager.adoc
+++ b/modules/nw-sriov-topology-manager.adoc
@@ -34,6 +34,10 @@ metadata:
   annotations:
     k8s.v1.cni.cncf.io/networks: <name> <1>
 spec:
+  securityContext:
+    runAsNonRoot: true
+    seccompProfile:
+      type: RuntimeDefault
   containers:
   - name: sample-container
     image: <image> <2>
@@ -45,6 +49,10 @@ spec:
       requests:
         memory: "1Gi"
         cpu: "2"
+    securityContext:
+      allowPrivilegeEscalation: false
+      capabilities:
+        drop: [ALL]
 ----
 <1> Replace `<name>` with the name of the SR-IOV network attachment definition CR.
 <2> Replace `<image>` with the name of the `sample-pod` image.


### PR DESCRIPTION
…working book)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-6914

Link to docs preview:
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network#configuring-pods-secondary-network_configuring-additional-network
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/configuring-additional-network#configuring-pods-static-ip_configuring-additional-network
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/deploying-egress-router-http-redirection#nw-egress-router-http-proxy-mode_deploying-egress-router-http-redirection
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/enabling-multicast#nw-enabling-multicast_ovn-kubernetes-enabling-multicast
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/multiple_networks/attaching-pod#nw-multus-advanced-annotations_attaching-pod
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/logging-network-policy#nw-networkpolicy-audit-configure_logging-network-policy
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/post_installation_configuration/network-configuration#nw-osp-enabling-ovs-offload_post-install-network-configuration
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/using-sctp#example_configurations_using-sctp
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/using-sctp#nw-sctp-verifying_using-sctp
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/using-pod-level-bonding#nw-sriov-cfg-creating-pod-using-interface_using-pod-level-bonding
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-device#nw-sriov-configure-exclude-topology-manager_configuring-sriov-device
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/add-pod#runtime-config-ethernet_configuring-sr-iov
* https://62624--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/hardware_networks/add-pod#nw-sriov-topology-manager_configuring-sr-iov

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
