### PR TITLE
Optimize the Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 language: python
-cache: pip
+cache:
+  pip: true
+  directories:
+    - /home/travis/.rvm/gems
 # env:
 #   - PR_AUTHOR=${TRAVIS_PULL_REQUEST_SLUG::-15}
 git:
@@ -8,60 +11,41 @@ jobs:
   allow_failures:
     env:
       - CAN_FAIL=true
+
   include:
-    # fail if asciidoctor encounters errors
-    - stage: validate
-      name: "Validate updated assemblies with Asciidoctor"
+    - stage: cache-and-validate
+      name: "Create install cache and validate updated assemblies"
       install:
-        - gem install asciidoctor
-        - gem install asciidoctor-diagram
-        - gem install rouge
+        - gem install asciidoctor asciidoctor-diagram rouge
+        - pip3 install pyyaml aura.tar.gz
       script:
-        - chmod +x ./scripts/check-asciidoctor-build.sh
-        - ./scripts/check-asciidoctor-build.sh
+        # Fail if Asciidoctor encounters errors. Run only if there are modified AsciiDoc files
+        - if ! [[ -z $(git diff --name-only HEAD~1 HEAD --diff-filter=d '*.adoc' ':(exclude)_unused_topics/*') ]]; then chmod +x ./scripts/check-asciidoctor-build.sh && ./scripts/check-asciidoctor-build.sh; fi
+
     - stage: build
+      if: branch IN (main, enterprise-4.13, enterprise-4.14)
       name: "Build openshift-enterprise distro"
-      before_install:
-        - gem install asciidoctor
-        - gem install asciidoctor-diagram
-      install:
-        - pip3 install pyyaml
-        - pip3 install aura.tar.gz
       script:
         - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.14 --no-upstream-fetch && python3 makeBuild.py
+
     - # stage name not required, will continue to use `build`
       if: branch IN (main, enterprise-4.13, enterprise-4.14)
       name: "Build openshift-dedicated distro"
-      before_install:
-        - gem install asciidoctor
-        - gem install asciidoctor-diagram
-      install:
-        - pip3 install pyyaml
-        - pip3 install aura.tar.gz
       script:
         - python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch && python3 makeBuild.py
+
     - # stage name not required, will continue to use `build`
       if: branch IN (main, enterprise-4.13, enterprise-4.14)
       name: "Build openshift-rosa distro"
-      before_install:
-        - gem install asciidoctor
-        - gem install asciidoctor-diagram
-      install:
-        - pip3 install pyyaml
-        - pip3 install aura.tar.gz
       script:
         - python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch && python3 makeBuild.py
+
     - # stage name not required, will continue to use `build`
       if: branch IN (main, enterprise-4.13, enterprise-4.14)
       name: "Build microshift distro"
-      before_install:
-        - gem install asciidoctor
-        - gem install asciidoctor-diagram
-      install:
-        - pip3 install pyyaml
-        - pip3 install aura.tar.gz
       script:
-        - python3 build.py --distro microshift --product "MicroShift" --version 4 --no-upstream-fetch && python3 makeBuild.py
+        - python3 build.py --distro microshift --product "Microshift" --version 4 --no-upstream-fetch && python3 makeBuild.py
+
     # Remove Vale stage until PR commenting feature is ready
     # - stage: check-with-vale
     #   env:
@@ -69,29 +53,31 @@ jobs:
     #   if: type IN (pull_request) AND sender != "openshift-cherrypick-robot"
     #   name: "Run Vale against PR asciidoc files"
     #   language: minimal
-    #   before_script:
-    #     - gem install asciidoctor
     #   script:
     #     - travis_retry wget https://github.com/errata-ai/vale/releases/download/v2.15.4/vale_2.15.4_Linux_64-bit.tar.gz --retry-connrefused
     #     - mkdir bin && tar -xvzf vale_2.15.4_Linux_64-bit.tar.gz -C bin
     #     - export PATH=./bin:"$PATH"
     #     - travis_retry vale sync # pull down VRH rules package
     #     - chmod +x ./scripts/check-with-vale.sh
-    #     - ./scripts/check-with-vale.sh
+    #     - ./scripts/check-with-vale.sh; fi
+
     # Commenting out to disable auto-merging of PRs
     # - stage: automerge
     #   if: env(PR_AUTHOR)=openshift-cherrypick-robot
     #   script: bash ./automerge.sh
+
     - stage: netlify
+      name: "Build and deploy with Netlify"
       env:
         - CAN_FAIL=true
       language: minimal
       if: type IN (pull_request) AND branch IN (main, enterprise-4.13, enterprise-4.14) AND sender != "openshift-cherrypick-robot"
       script:
-        - chmod +x autopreview.sh && ./autopreview.sh
+        - chmod +x autopreview.sh
+        - ./autopreview.sh
 
 stages:
-  - validate
+  - cache-and-validate
   - build
   - netlify
   #- check-with-vale

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-aura~=0.0.0
+./aura.tar.gz
 lxml~=4.9.1
-PyYAML~=6.0
-requests~=2.28.1
+pyyaml~=6.0
+requests~=2.27.1


### PR DESCRIPTION
There is a lot of unnecessary dependencies installed during the OCP docs travis build. `gem install asciidoctor` and related AsciiDoc tools installs are expensive, sometimes adding ~30 seconds to each build stage. This PR consolidates these installs and removes duplication where possible. 

Summary of changes: 

1. Install gems once per job, and then caches them for use in the various stages. See https://docs.travis-ci.com/user/build-stages/warm-cache/
2. Cleaned up `requirements.txt`
3. Removed pip install steps from python stages because `requirements.txt` gets installed every time anyway
4. Added some logic to skip steps when there are no changed AsciiDoc files for the Validate stage

Reduces the time to do the travis build by roughly 30-40% overall - I think.