### PR TITLE
[OSDOCS-6133] ROSA OSD UI cluster autoscaling

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -130,6 +130,8 @@ Topics:
   Topics:
   - Name: Accessing the service logs
     File: osd-accessing-the-service-logs
+# - Name: Cluster autoscaling
+#   File: osd-cluster-autoscaling
 ---
 # Name: Security and compliance
 # Dir: security

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -225,6 +225,8 @@ Topics:
     Distros: openshift-rosa
   - Name: About autoscaling nodes on a cluster
     File: rosa-nodes-about-autoscaling-nodes
+# - Name: Cluster autoscaling
+#   File: rosa-cluster-autoscaling
 ---
 # Name: Security and compliance
 # Dir: security

--- a/modules/rosa-cluster-autoscaler-settings.adoc
+++ b/modules/rosa-cluster-autoscaler-settings.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling.adoc
+:_content-type: REFERENCE
+[id="rosa-cluster-autoscale-settings_{context}"]
+= Cluster autoscaling settings using OpenShift Cluster Manager
+
+The tables explain all the configurable UI settings when using cluster autoscaling with OpenShift Cluster Manager.
+
+== Balancing behavior
+
+[cols="4",options="header"]
+|===
+|Setting
+|Description
+|Type or Range
+|Default
+
+|`balanceSimilarNodeGroups`
+|If `true`, this setting automatically identifies node groups with the same instance type and the same set of labels and tries to keep the respective sizes of those node groups balanced.
+|`boolean`
+|false
+
+|`logVerbosity`
+|Sets the autoscaler log level. Default value is 1, level 4 is recommended for debugging and level 6 enables almost everything.
+|`integer`
+|1
+
+|`maxPodGracePeriod`
+|Gives pods graceful termination time before scaling down.
+|`integer`
+|600
+
+|`skipNodesWithLocalStorage`
+|If `true`, the cluster autoscaler never deletes nodes with pods with local storage, e.g. EmptyDir or HostPath.
+|`boolean`
+|true
+|===
+
+== Resource limits
+
+[cols="4",options="header"]
+|===
+|Setting
+|Description
+|Type or Range
+|Default
+
+|`maxNodesTotal`
+|Maximum number of nodes in all node groups. Includes all nodes, not just automatically scaled nodes. The cluster autoscaler does not grow the cluster beyond this number.
+|`integer`
+|0
+
+|`cores.min`
+|Minimum number of cores in cluster. The cluster autoscaler does not scale the cluster beyond these numbers.
+|`object`
+|1
+
+|`cores.max`
+|Maximum number of cores in cluster. The cluster autoscaler does not scale the cluster beyond these numbers.
+|`object`
+|320000
+
+|`memory.min`
+|Minimum number of gigabytes of memory in cluster. The cluster autoscaler does not scale the cluster beyond these numbers.
+|`object`
+|1
+
+|`memory.max`
+|Maximum number of gigabytes of memory in cluster. The cluster autoscaler does not scale the cluster beyond these numbers.
+|`object`
+|6400000
+|===
+
+== Scale down configuration
+
+[cols="4",options="header"]
+|===
+|Setting
+|Description
+|Type or Range
+|Default
+
+|`enable`
+|Should the cluster autoscaler scale down the cluster.
+|`boolean`
+|`true`
+
+|`scaleDown.unneededTime`
+|How long a node should be unneeded before it is eligible for scale down.
+|`string`
+|10m
+
+|`scaleDown.utilizationThreshold`
+|Node utilization level, defined as sum of requested resources divided by capacity, below which a node can be considered for scale down.
+|`string`
+|0.5
+
+|`scaleDown.delayAfterAdd`
+|How long after scale up that scale down evaluation resumes.
+|`string`
+|10m
+
+|`scaleDown.delayAfterDelete`
+|How long after node deletion that scale down evaluation resumes.
+|`string`
+|0s
+
+|`scaleDown.delayAfterFailure`
+|How long after scale down failure that scale down evaluation resumes.
+|`string`
+|3m
+|===

--- a/modules/rosa-cluster-autoscaler-ui-after.adoc
+++ b/modules/rosa-cluster-autoscaler-ui-after.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling.adoc
+:_content-type: REFERENCE
+[id="rosa-cluster-autoscale-ui-after_{context}"]
+= Enable autoscaling after cluster creation with OpenShift Cluster Manager
+
+You can use OpenShift Cluster Manager to autoscale after cluster creation.
+
+.Procedure
+
+. In OpenShift Cluster Manager, click the name of the cluster you want to autoscale. The Overview page for the cluster has a *Autoscaling* item that indicates if it is enabled or disabled.
+
+. Click the *Machine Pools* tab.
+
+. Click the *Edit cluster autoscaling* button. The *Edit cluster autoscaling* settings window is shown.
+
+. Check the *Enable cluster autoscaling* box at the top of the window. All the settings are now editable.
+
+. Edit any settings you want and then click *Save*.
+
+. Click the x at the top right of the screen to close the settings window.
+
+To revert all autoscaling settings to the defaults if they have been changed, click the *Revert all to defaults* button.

--- a/modules/rosa-cluster-autoscaler-ui-during.adoc
+++ b/modules/rosa-cluster-autoscaler-ui-during.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * rosa_cluster_admin/rosa-cluster-autoscaling.adoc
+:_content-type: REFERENCE
+[id="rosa-cluster-autoscale-ui-during_{context}"]
+= Enable autoscaling during cluster creation with OpenShift Cluster Manager
+
+You can use OpenShift Cluster Manager to autoscale during cluster creation.
+
+.Procedure
+
+. During cluster creation, check the *Enable autoscaling* box. The *Edit cluster autoscaling settings* button becomes selectable.
+
+.. You can also choose the minimum or maximum amount of nodes to autoscale.
+
+. Click *Edit cluster autoscaling settings*.
+
+. Edit any settings you want and then click *Close*.

--- a/osd_cluster_admin/osd-cluster-autoscaling.adoc
+++ b/osd_cluster_admin/osd-cluster-autoscaling.adoc
@@ -1,0 +1,24 @@
+:_content-type: ASSEMBLY
+[id="osd-cluster-autoscaling"]
+= Cluster autoscaling
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: osd-cluster-autoscaling
+
+toc::[]
+
+Applying autoscaling to {product-title} clusters involves configuring a cluster autoscaler and then configuring a machine autoscaler for at least one machine pool in your cluster.
+
+[IMPORTANT]
+====
+You can configure the cluster autoscaler only in clusters where the machine API is operational.
++
+Only one cluster autoscaler can be created per cluster.
+====
+
+include::modules/cluster-autoscaler-about.adoc[leveloffset=+1]
+
+include::modules/rosa-cluster-autoscaler-ui-during.adoc[leveloffset=+1]
+
+include::modules/rosa-cluster-autoscaler-ui-after.adoc[leveloffset=+1]
+
+include::modules/rosa-cluster-autoscaler-settings.adoc[leveloffset=+1]

--- a/rosa_cluster_admin/rosa-cluster-autoscaling.adoc
+++ b/rosa_cluster_admin/rosa-cluster-autoscaling.adoc
@@ -1,0 +1,24 @@
+:_content-type: ASSEMBLY
+[id="rosa-cluster-autoscaling"]
+= Cluster autoscaling
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-cluster-autoscaling
+
+toc::[]
+
+Applying autoscaling to {product-title} clusters involves configuring a cluster autoscaler and then configuring a machine autoscaler for at least one machine pool in your cluster.
+
+[IMPORTANT]
+====
+You can configure the cluster autoscaler only in clusters where the machine API is operational.
++
+Only one cluster autoscaler can be created per cluster.
+====
+
+include::modules/cluster-autoscaler-about.adoc[leveloffset=+1]
+
+include::modules/rosa-cluster-autoscaler-ui-during.adoc[leveloffset=+1]
+
+include::modules/rosa-cluster-autoscaler-ui-after.adoc[leveloffset=+1]
+
+include::modules/rosa-cluster-autoscaler-settings.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-6133] ROSA OSD cluster autoscaling

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-6133

Link to docs preview:
ROSA: https://62651--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa-cluster-autoscaling.html
OSD: https://62651--docspreview.netlify.app/openshift-dedicated/latest/osd_cluster_admin/osd-cluster-autoscaling.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
