### PR TITLE
OADP-2163: fixing typo in oadp-creating-restore-cr.adoc

### DIFF
--- a/modules/oadp-creating-restore-cr.adoc
+++ b/modules/oadp-creating-restore-cr.adoc
@@ -40,7 +40,7 @@ spec:
 ----
 <1> Name of the `Backup` CR.
 <2> Optional: Specify an array of resources to include in the restore process. Resources might be shortcuts (for example, `po` for `pods`) or fully-qualified. If unspecified, all resources are included.
-<3> Optional: The `restorePVs` parameter can be set to `false` in order to turn off restore of `PersistentVolumes` from `VolumeSnapshot` of Container Storage Interface (CSI) snapshots, or from native snapshots when `VolumeSnaphshotLocation` is configured.
+<3> Optional: The `restorePVs` parameter can be set to `false` in order to turn off restore of `PersistentVolumes` from `VolumeSnapshot` of Container Storage Interface (CSI) snapshots, or from native snapshots when `VolumeSnapshotLocation` is configured.
 
 . Verify that the status of the `Restore` CR is `Completed` by entering the following command:
 +


### PR DESCRIPTION
OADP 1.1 & OADP 1.2; OCP 4.11+
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[OADP-2163](https://issues.redhat.com/browse/OADP-2163)

Simple typo fix

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Enterprise 4.11 → branch/enterprise-4.11
Enterprise 4.12 → branch/enterprise-4.12
Enterprise 4.13 → branch/enterprise-4.13
Enterprise 4.14 → branch/enterprise-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OADP-2163

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[Preview](https://62660--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications#oadp-creating-restore-cr_restoring-applications)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
