### PR TITLE
[enterprise-4.10] OCPBUGS#13804: Removed support of standardSSD_LRS disk type from Azur…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1464,7 +1464,7 @@ Additional Azure configuration parameters are described in the following table:
 
 |`compute.platform.azure.osDisk.diskType`
 |Defines the type of disk.
-|`standard_LRS`, `premium_LRS`, or `standardSSD_LRS`. The default is `premium_LRS`.
+|`standard_LRS` or `premium_LRS`. The default is `premium_LRS`.
 
 |`controlPlane.platform.azure.osDisk.diskSizeGB`
 |The Azure disk size for the VM.
@@ -1472,7 +1472,7 @@ Additional Azure configuration parameters are described in the following table:
 
 |`controlPlane.platform.azure.osDisk.diskType`
 |Defines the type of disk.
-|`premium_LRS` or `standardSSD_LRS`. The default is `premium_LRS`.
+|`premium_LRS`.
 
 |`platform.azure.armEndpoint`
 |The URL of the Azure Resource Manager endpoint that your Azure Stack Hub operator provides.


### PR DESCRIPTION
This is a manual CP for https://github.com/openshift/openshift-docs/pull/62526

Cherry picked from 82cdc97fd87979eff1cfccdc92039eb19e5ec85f