### PR TITLE
Splunk addon name change and related updates

### DIFF
--- a/integration/integrate-with-splunk.adoc
+++ b/integration/integrate-with-splunk.adoc
@@ -7,19 +7,14 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-If you are using link:https://www.splunk.com/[Splunk], you can forward alerts from {product-title} to Splunk and view vulnerability and compliance related data from within Splunk.
+If you are using link:https://www.splunk.com/[Splunk], you can forward alerts from {product-title} to Splunk and view the violations, vulnerability detection, and compliance related data from within Splunk.
 
 Depending on your use case, you can integrate {product-title} with Splunk by using the following ways:
 
-* By xref:../integration/integrate-with-splunk.adoc#integrate-splunk-http-event-collector[using an HTTP event collector] in Splunk
-** Use the event collector option to forward alerts and audit log data
-* By xref:../integration/integrate-with-splunk.adoc#integrate-splunk-add-on[using the StackRox Kubernetes Security Platform add-on]
-** Use the add-on to pull vulnerability detection and compliance data into Splunk
-+
-[NOTE]
-====
-The StackRox Kubernetes Security Platform add-on is only available if you are using {product-title} version 3.0.51.0 or newer.
-====
+* By xref:../integration/integrate-with-splunk.adoc#integrate-splunk-http-event-collector[using an HTTP event collector] in Splunk:
+** Use the event collector option to forward alerts and audit log data.
+* By xref:../integration/integrate-with-splunk.adoc#integrate-splunk-add-on[using the {product-title} add-on]:
+** Use the add-on to pull the violations, vulnerability detection, and compliance data into Splunk.
 
 You can use one or both of these integration options to integrate the {product-title} with Splunk.
 
@@ -44,10 +39,14 @@ include::modules/splunk-configuring-acs.adoc[leveloffset=+2]
 include::modules/configure-policy-notifications.adoc[leveloffset=+2]
 
 [id="integrate-splunk-add-on"]
-== Using the StackRox Kubernetes Security Platform add-on
+== Using the {product-title} add-on
 
-You can use the StackRox Kubernetes Security Platform add-on to forward the vulnerability detection and compliance related data from the {product-title} to Splunk.
+You can use the {product-title} add-on to forward the vulnerability detection and compliance related data from the {product-title} to Splunk.
 
-Begin by generating an API token with read permission for all resources in {product-title} and then use that token to install and configure the add-on.
+Generate an API token with `read` permission for all resources in {product-title} and then use that token to install and configure the add-on.
 
 include::modules/install-and-configure-the-splunk-add-on.adoc[leveloffset=+2]
+
+include::modules/update-the-splunk-add-on.adoc[leveloffset=+2]
+
+include::modules/troubleshoot-the-splunk-add-on.adoc[leveloffset=+2]

--- a/modules/install-and-configure-the-splunk-add-on.adoc
+++ b/modules/install-and-configure-the-splunk-add-on.adoc
@@ -1,26 +1,38 @@
 // Module included in the following assemblies:
 //
 // * integration/integrate-with-splunk.adoc
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="install-and-configure-the-splunk-add-on_{context}"]
 = Installing and configuring the Splunk add-on
 
-You can install the StackRox Kubernetes Security Platform add-on from your Splunk instance.
+You can install the {product-title} add-on from your Splunk instance.
+
+[NOTE]
+====
+To maintain backward compatibility with the StackRox Kubernetes Security Platform add-on, the `source_type` and `input_type` parameters for configured inputs are still called `stackrox_compliance`, `stackrox_violations`, and `stackrox_vulnerability_management`.
+====
 
 .Prerequisites
 * You must have an API token with `read` permission for all resources of {product-title}. You can assign the *Analyst* system role to grant this level of access. The *Analyst* role has read permissions for all resources.
 
 .Procedure
-. Download the StackRox Kubernetes Security Platform add-on from link:https://splunkbase.splunk.com/app/5315/[Splunkbase].
+. Download the {product-title} add-on from link:https://splunkbase.splunk.com/app/5315/[Splunkbase].
 . Navigate to the Splunk home page on your Splunk instance.
 . Navigate to *Apps* -> *Manage Apps*.
 . Select *Install app from file*.
-. In the *Upload app* pop-up box, select *Choose File* and select the StackRox Kubernetes Security Platform add-on file.
+. In the *Upload app* pop-up box, select *Choose File* and select the {product-title} add-on file.
 . Click *Upload*.
 . Click *Restart Splunk*, and confirm to restart.
-. After Splunk restarts, select *StackRox* from the *Apps* menu.
-. Click *Create New Input*.
-. Either select *StackRox Compliance* to pull compliance data or *StackRox Vulnerability Management* to pull vulnerability data into Splunk.
+. After Splunk restarts, select *{product-title}* from the *Apps* menu.
+. Go to *Configuration* and then click *Add-on Settings*.
+.. For *Central Endpoint*, enter the IP address or the name of your Central instance. For example, `central.custom:443`.
+.. Enter the *API token* you have generated for the add-on.
+.. Click *Save*.
+. Go to *Inputs*.
+. Click *Create New Input*, and select one of the following:
+** *ACS Compliance* to pull the compliance data.
+** *ACS Violations* to pull the violations data.
+** *ACS Vulnerability Management* to pull the vulnerabilities data.
 . Enter a *Name* for the input.
 . Select an *Interval* to pull data from {product-title}.
 For example, every 14400 seconds.
@@ -28,3 +40,11 @@ For example, every 14400 seconds.
 . For *Central Endpoint*, enter the IP address or the name of your Central instance.
 . Enter the *API token* you have generated for the add-on.
 . Click *Add*.
+
+
+.Verification
+* To verify the the {product-title} add-on installation, query the received data.
+.. In your Splunk instance, go to *Search* and type `index=* sourcetype="stackrox-*"` as the query.
+.. Press *Enter*.
+
+Verify that your configured sources are displayed in the search results.

--- a/modules/troubleshoot-the-splunk-add-on.adoc
+++ b/modules/troubleshoot-the-splunk-add-on.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * integration/integrate-with-splunk.adoc
+:_content-type: CONCEPT
+[id="troubleshoot-the-splunk-add-on_{context}"]
+= Troubleshoot the Splunk add-on
+
+[role="_abstract"]
+If you stop receiving events from the {product-title} add-on, check the Splunk add-on debug logs for errors.
+
+Splunk creates a debug log file for every configured input in the `/opt/splunk/var/log/splunk` directory. Find the file named `stackrox_<input>_<uid>.log`, for example, `stackrox_compliance_29a3e14798aa2363d.log` and look for issues.

--- a/modules/update-the-splunk-add-on.adoc
+++ b/modules/update-the-splunk-add-on.adoc
@@ -1,0 +1,22 @@
+// Module included in the following assemblies:
+//
+// * integration/integrate-with-splunk.adoc
+:_content-type: PROCEDURE
+[id="update-the-splunk-add-on_{context}"]
+= Update the StackRox Kubernetes Security Platform add-on
+
+[role="_abstract"]
+If you are using the StackRox Kubernetes Security Platform add-on, you must upgrade to the new {product-title} add-on.
+
+You can see the update notification on the Splunk homepage under the list of apps on the left. Alternatively, you can also go to the *Apps* -> *Manage apps* page to see the update notification.
+
+.Prerequisites
+* You must have an API token with `read` permission for all resources of {product-title}. You can assign the *Analyst* system role to grant this level of access. The *Analyst* role has read permissions for all the resources.
+
+.Procedure
+. Click *Update* on the update notification.
+. Select the checkbox for accepting the terms and conditions, and then click *Accept and Continue* to install the update.
+. After the installation, select *{product-title}* from the *Apps* menu.
+. Go to *Configuration* and then click *Add-on Settings*.
+.. Enter the *API token* you have generated for the add-on.
+.. Click *Save*.


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-18344

Added updated Splunk add-on related sections.

Preview: https://62673--docspreview.netlify.app/openshift-acs/latest/integration/integrate-with-splunk.html#integrate-splunk-add-on

Cherry pick into:
- `rhacs-docs-3.74`
- `rhacs-docs-4.0`
- `rhacs-docs-4.1`