### PR TITLE
OSDOCS-5202re:Documented vSphere config provisioning of nodes with sta

### DIFF
--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -49,6 +49,15 @@ include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-installer-infra-static-ip-nodes.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks[Scaling machines to use static IP addresses]
+* xref:../../post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks[Using a machine set to scale machines with configured static IP addresses]
+
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-adding-vcenter-root-certificates.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
@@ -42,6 +42,11 @@ include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-installer-infra-static-ip-nodes.adoc[leveloffset=+2]
+
+* xref:../../post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks[Scaling machines to use static IP addresses]
+* xref:../../post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks[Using a machine set to scale machines with configured static IP addresses]
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
@@ -44,6 +44,11 @@ include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-installer-infra-static-ip-nodes.adoc[leveloffset=+2]
+
+* xref:../../post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks[Scaling machines to use static IP addresses]
+* xref:../../post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks[Using a machine set to scale machines with configured static IP addresses]
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
+++ b/installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
@@ -42,6 +42,11 @@ include::modules/vmware-csi-driver-reqs.adoc[leveloffset=+1]
 
 include::modules/installation-vsphere-installer-infra-requirements.adoc[leveloffset=+1]
 
+include::modules/installation-vsphere-installer-infra-static-ip-nodes.adoc[leveloffset=+2]
+
+* xref:../../post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks[Scaling machines to use static IP addresses]
+* xref:../../post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks[Using a machine set to scale machines with configured static IP addresses]
+
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -8,8 +8,6 @@
 // * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
 
-
-
 ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]
 :restricted:
 endif::[]
@@ -437,8 +435,17 @@ Available resources vary between clusters. The number of possible clusters withi
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-networking_{context}"]
 == Networking requirements
+Use Dynamic Host Configuration Protocol (DHCP) for the network and ensure that the DHCP server is configured to provide persistent IP addresses to the cluster machines.
+
+[NOTE]
+====
+You do not need to use the DHCP for the network if you want to provision nodes with static IP addresses.
+====
+
+Configure the default gateway to use the DHCP server. All nodes must be in the same VLAN. You cannot scale the cluster using a second VLAN as a Day 2 operation.
 
 You must use the Dynamic Host Configuration Protocol (DHCP) for the network and ensure that the DHCP server is configured to provide persistent IP addresses to the cluster machines. In the DHCP lease, you must configure the DHCP to use the default gateway. All nodes must be in the same VLAN. You cannot scale the cluster using a second VLAN as a Day 2 operation.
+
 ifdef::restricted[]
 The VM in your restricted network must have access to vCenter so that it can provision and manage nodes, persistent volume claims (PVCs), and other resources.
 endif::restricted[]
@@ -453,7 +460,7 @@ It is recommended that each {product-title} node in the cluster must have access
 [id="installation-vsphere-installer-infra-requirements-_{context}"]
 === Required IP Addresses
 ifndef::vsphere[]
-An installer-provisioned vSphere installation requires two static IP addresses:
+For a network that uses DHCP, an installer-provisioned vSphere installation requires two static IP addresses:
 
 * The **API** address is used to access the cluster API.
 * The **Ingress** address is used for cluster ingress traffic.

--- a/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
+++ b/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
@@ -1,0 +1,42 @@
+:_content-type: CONCEPT
+[discrete]
+[id="installation-vsphere-installer-infra-static-ip-nodes_{context}"]
+== Static IP addresses for vSphere nodes
+
+You can provision bootstrap, control plane, and compute nodes to be configured with static IP addresses in environments where Dynamic Host Configuration Protocol (DHCP) does not exist. To configure this environment, you must provide values to the `platform.vsphere.hosts.role` parameter in the `install-config.yaml` file.
+
+:FeatureName: Static IP addresses for vSphere nodes
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+By default, the installation program is configured to use the DHCP for the network, but this network has limited configurable capabilities.
+
+After you define one or more machine pools in your `install-config.yaml` file, you can define network definitions for nodes on your network. Ensure that the number of network definitions matches the number of machine pools that you configured for your cluster.
+
+The following example shows a network configuration for a node with the role `compute`:
+
+[source,yaml]
+----
+---
+platform:
+  vsphere:
+    hosts:
+    - role: compute <1>
+      networkDevice:
+        ipAddrs:
+        - 192.168.204.10/24 <2>
+        gateway: 192.168.204.1 <3>
+        nameservers:
+        - 192.168.204.1 <4>
+---
+----
+<1> Valid network definition values include `bootstrap`, `control-plane`, and `compute`. You must list at least one `bootstrap` network definition in your `install-config.yaml` configuration file.
+<2> Lists IPv4, IPv6, or both IP addresses that the installation program passes to the network interface. The machine API controller assigns all configured IP addresses to the default network interface.
+<3> The default gateway for the network interface. 
+<4> Lists up to 3 DNS nameservers.
++
+[IMPORTANT]
+====
+To enable the Technology Preview feature of static IP addresses for vSphere nodes for your cluster, you must include `featureSet:TechPreviewNoUpgrade` as the initial entry in the `install-config.yaml` file.
+====
+
+After you deployed your cluster to run nodes with static IP addresses, you can scale a machine to use one of these static IP addresses. Additionally, you can use a machine set to configure a machine to use one of the configured static IP addresses.

--- a/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-concept-static-ip.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/node-tasks.adoc
+
+:_content-type: CONCEPT
+[id="nodes-vsphere-machine-set-concept-static-ip_{context}"]
+= Machine set scaling of machines with configured static IP addresses
+
+You can use a machine set to scale machines with configured static IP addresses. 
+
+:FeatureName: Static IP addresses for vSphere nodes
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+After you configure a machine set to request a static IP address for a machine, the machine controller creates an `IPAddressClaim` resource in the `openshift-machine-api` namespace. The external controller then creates an `IPAddress` resource and binds any static IP addresses to the `IPAddressClaim` resource.
+
+[IMPORTANT]
+====
+Your organization might use numerous types of IP address management (IPAM) services. If you want to enable a particular IPAM service on {product-title}, you might need to manually create the `IPAddressClaim` resource in a YAML definition and then bind a static IP address to this resource by entering the following command in your `oc` CLI:
+
+[source, terminal]
+----
+$ oc create -f <ipaddressclaim_filename>
+----
+====
+
+The following demonstrates an example of an `IPAddressClaim` resource:
+
+[source, yaml]
+----
+kind: IPAddressClaim
+metadata:
+  finalizers:
+  - machine.openshift.io/ip-claim-protection
+  name: cluster-dev-9n5wg-worker-0-m7529-claim-0-0
+  namespace: openshift-machine-api
+spec:
+  poolRef:
+    apiGroup: ipamcontroller.example.io
+    kind: IPPool
+    name: static-ci-pool
+status: {}
+----
+
+The machine controller updates the machine with a status of `IPAddressClaimed` to indicate that a static IP address has succesfully bound to the `IPAddressClaim` resource. The machine controller applies the same status to a machine with multiple `IPAddressClaim` resources that each contain a bound static IP address.The machine controller then creates a virtual machine and applies static IP addresses to any nodes listed in the `providerSpec` of a machine's configuration.

--- a/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
+++ b/modules/nodes-vsphere-machine-set-scaling-static-ip.adoc
@@ -1,0 +1,158 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/node-tasks.adoc
+
+:_content-type: PROCEDURE
+[id="nodes-vsphere-machine-set-scaling-static-ip_{context}"]
+= Using a machine set to scale machines with configured static IP addresses
+
+You can use a machine set to scale machines with configured static IP addresses. 
+
+:FeatureName: Static IP addresses for vSphere nodes
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+The example in the procedure demonstrates the use of controllers for scaling machines in a machine set.
+
+.Prerequisites
+
+* You included `featureSet:TechPreviewNoUpgrade` as the initial entry in the `install-config.yaml` file.
+* You deployed a cluster that runs at least one node with a configured static IP address.
+
+.Procedure
+. Configure a machine set by specifying IP pool information in the `network.devices.addressesFromPools` schema of the machine set's YAML file: 
++
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  annotations:
+    machine.openshift.io/memoryMb: "8192"
+    machine.openshift.io/vCPU: "4"
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+  name: <infrastructure_id>-<role>
+  namespace: openshift-machine-api
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
+  template:
+    metadata:
+      labels:
+        ipam: "true"
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+        machine.openshift.io/cluster-api-machine-role: worker
+        machine.openshift.io/cluster-api-machine-type: worker
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
+    spec:
+      lifecycleHooks: {}
+      metadata: {}
+      providerSpec:
+        value:
+          apiVersion: machine.openshift.io/v1beta1
+          credentialsSecret:
+            name: vsphere-cloud-credentials
+          diskGiB: 120
+          kind: VSphereMachineProviderSpec
+          memoryMiB: 8192
+          metadata: {}
+          network:
+            devices:
+            - addressesFromPools: <1>
+              - group: ipamcontroller.example.io
+                name: static-ci-pool
+                resource: IPPool
+              nameservers:
+              - "192.168.204.1" <2>
+              networkName: qe-segment-204
+          numCPUs: 4
+          numCoresPerSocket: 2
+          snapshot: ""
+          template: rvanderp4-dev-9n5wg-rhcos-generated-region-generated-zone
+          userDataSecret:
+            name: worker-user-data
+          workspace:
+            datacenter: IBMCdatacenter
+            datastore: /IBMCdatacenter/datastore/vsanDatastore
+            folder: /IBMCdatacenter/vm/rvanderp4-dev-9n5wg
+            resourcePool: /IBMCdatacenter/host/IBMCcluster//Resources
+            server: vcenter.ibmc.devcluster.openshift.com
+----
+<1> Specifies an IP pool, which lists a static IP address or a range of static IP addresses. The IP Pool can either be a reference to a custom resource definition (CRD) or a resource supported by the `IPAddressClaims` resource handler. The machine controller accesses static IP addresses listed in the machine set's configuration and then allocates each address to each machine. 
+<2> Lists a nameserver. You must specify a nameserver for nodes that receive static IP address, because the Dynamic Host Configuration Protocol (DHCP) network configuration does not support static IP addresses. 
+
+. Scale the machine set by entering the following commands in your `oc` CLI:
++
+[source, terminal]
+----
+$ oc scale --replicas=2 machineset <machineset> -n openshift-machine-api
+----
++
+Or:
++
+[source, terminal]
+----
+$ oc edit machineset <machineset> -n openshift-machine-api
+----
++
+After each machine is scaled up, the machine controller creates an `IPAddresssClaim` resource.
+
+. Optional: Check that the `IPAddressClaim` resource exists in the `openshift-machine-api` namespace by entering the following command:
++ 
+[source, terminal]
+----
+$ oc get ipaddressclaims.ipam.cluster.x-k8s.io -n openshift-machine-api
+----
++
+.Example `oc` CLI output that lists two IP pools listed in the `openshift-machine-api` namespace
+[source, terminal]
+----
+NAME                                         POOL NAME        POOL KIND
+cluster-dev-9n5wg-worker-0-m7529-claim-0-0   static-ci-pool   IPPool
+cluster-dev-9n5wg-worker-0-wdqkt-claim-0-0   static-ci-pool   IPPool
+----
+
+. Create an `IPAddress` resource by entering the following command:
++
+[source, terminal]
+----
+$ oc create -f ipaddress.yaml
+----
++
+The following example shows an `IPAddress` resource with defined network configuration information and one defined static IP address:
++
+[source,yaml]
+----
+apiVersion: ipam.cluster.x-k8s.io/v1alpha1
+kind: IPAddress
+metadata:
+  name: cluster-dev-9n5wg-worker-0-m7529-ipaddress-0-0
+  namespace: openshift-machine-api
+spec:
+  address: 192.168.204.129
+  claimRef: <1>
+    name: cluster-dev-9n5wg-worker-0-m7529-claim-0-0
+  gateway: 192.168.204.1
+  poolRef: <2>
+    apiGroup: ipamcontroller.example.io
+    kind: IPPool
+    name: static-ci-pool
+  prefix: 23
+----
+<1> The name of the target `IPAddressClaim` resource. 
+<2> Details information about the static IP address or addresses from your nodes. 
++
+[NOTE]
+====
+By default, the external controller automatically scans any resources in the machine set for recognizable address pool types. When the external controller finds `kind: IPPool` defined in the `IPAddress` resource, the controller binds any static IP addresses to the `IPAddressClaim` resource.
+====
+
+. Update the `IPAddressClaim` status with a reference to the `IPAddress` resource:
++
+[source, terminal]
+----
+$ oc --type=merge patch IPAddressClaim cluster-dev-9n5wg-worker-0-m7529-claim-0-0 -p='{"status":{"addressRef": {"name": "cluster-dev-9n5wg-worker-0-m7529-ipaddress-0-0"}}}' -n openshift-machine-api --subresource=status
+----

--- a/modules/nodes-vsphere-scaling-machines-static-ip.adoc
+++ b/modules/nodes-vsphere-scaling-machines-static-ip.adoc
@@ -1,0 +1,82 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/node-tasks.adoc
+
+:_content-type: PROCEDURE
+[id="nodes-vsphere-scaling-machines-static-ip_{context}"]
+= Scaling machines to use static IP addresses
+
+You can scale additional machine sets to use pre-defined static IP addresses on your cluster. For this configuration, you need to create a machine resource YAML file and then define static IP addresses in this file.
+
+:FeatureName: Static IP addresses for vSphere nodes
+include::snippets/technology-preview.adoc[leveloffset=+1]
+
+.Prerequisites
+
+* You included `featureSet:TechPreviewNoUpgrade` as the initial entry in the `install-config.yaml` file.
+* You deployed a cluster that runs at least one node with a configured static IP address.
+
+.Procedure
+
+. Create a machine resource YAML file and define static IP address network information in the `network` parameter.
++
+.Example of a machine resource YAML file with static IP address information defined in the `network` parameter.
++
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: Machine
+metadata:
+  creationTimestamp: null
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> 
+    machine.openshift.io/cluster-api-machine-role: <role> 
+    machine.openshift.io/cluster-api-machine-type: <role> 
+    machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>
+  name: <infrastructure_id>-<role>
+  namespace: openshift-machine-api
+spec:
+  lifecycleHooks: {}
+  metadata: {}
+  providerSpec:
+    value:
+      apiVersion: machine.openshift.io/v1beta1
+      credentialsSecret:
+        name: vsphere-cloud-credentials
+      diskGiB: 120
+      kind: VSphereMachineProviderSpec
+      memoryMiB: 8192
+      metadata:
+        creationTimestamp: null
+      network:
+        devices:
+        - gateway: 192.168.204.1 <1>
+          ipAddrs:
+          - 192.168.204.8/24 <2>
+          nameservers: <3>
+          - 192.168.204.1
+          networkName: qe-segment-204
+      numCPUs: 4
+      numCoresPerSocket: 2
+      snapshot: ""
+      template: <vm_template_name>
+      userDataSecret:
+        name: worker-user-data
+      workspace:
+        datacenter: <vcenter_datacenter_name> 
+        datastore: <vcenter_datastore_name> 
+        folder: <vcenter_vm_folder_path> 
+        resourcepool: <vsphere_resource_pool> 
+        server: <vcenter_server_ip> 
+status: {}
+----
+<1> The IP address for the default gateway for the network interface.
+<2> Lists IPv4, IPv6, or both IP addresses that installation program passes to the network interface. Both IP families must use the same network interface for the default network.
+<3> Lists a DNS nameserver. You can define up to 3 DNS nameservers. Consider defining more than one DNS nameserver to take advantage of DNS resolution if that one DNS nameserver becomes unreachable.
+
+* Create a `machine` custom resource (CR) by entering the following command in your terminal:
++
+[source, terminal]
+----
+$ oc create -f <file_name>.yaml
+----

--- a/post_installation_configuration/node-tasks.adoc
+++ b/post_installation_configuration/node-tasks.adoc
@@ -159,3 +159,21 @@ include::modules/cluster-node-tuning-operator-default-profiles-set.adoc[leveloff
 include::modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc[leveloffset=+2]
 
 include::modules/nodes-nodes-managing-max-pods-proc.adoc[leveloffset=+1]
+
+[id="nodes-vsphere-scale-static-ip-addresses"]
+== Machine scaling with static IP addresses
+
+After you deployed your cluster to run nodes with static IP addresses, you can scale an instance of a machine or a machine set to use one of these static IP addresses.  
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.html#installation-vsphere-installer-infra-requirements_installing-vsphere-installer-provisioned[Static IP addresses for vSphere nodes]
+
+// Scaling machines to use static IP addresses
+include::modules/nodes-vsphere-scaling-machines-static-ip.adoc[leveloffset=+2]
+
+// Machine set scaling of machines with configured static IP addresses
+include::modules/nodes-vsphere-machine-set-concept-static-ip.adoc[leveloffset=+2]
+
+// Using a machine set to scale machines with configured static IP addresses
+include::modules/nodes-vsphere-machine-set-scaling-static-ip.adoc[leveloffset=+2]


### PR DESCRIPTION
[OSDOCS-5202](https://issues.redhat.com/browse/OSDOCS-5202)

Version(s):
4.14

Link to docs preview:
* [Static IP addresses for vSphere nodes](https://62677--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-vsphere-installer-infra-requirements_installing-vsphere-installer-provisioned-customizations)
* [Scaling machines to use static IP addresses](https://62677--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#nodes-vsphere-scaling-machines-static-ip_post-install-node-tasks)
* [How a machine set scales machines with configured static IP addresses
](https://62677--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-concept-static-ip_post-install-node-tasks)
* [Using a machine set to scale machines with configured static IP addresses](https://62677--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#nodes-vsphere-machine-set-scaling-static-ip_post-install-node-tasks)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
