### PR TITLE
OCPBUGS#6009: removes cloud url from install docs

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -79,7 +79,7 @@ You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn
 |443, 80
 |Required for Telemetry
 
-|`console.redhat.com/api/ingress`, `cloud.redhat.com/api/ingress`
+|`console.redhat.com/api/ingress`
 |443, 80
 |Required for Telemetry and for `insights-operator`
 |===


### PR DESCRIPTION
OCPBUGS#6009: removes `cloud.redhat.com/api/ingress` from install docs allowlist
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-6009
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://62692--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
