### PR TITLE
OSDOCS#5792: adding warnings in update assemblies

### DIFF
--- a/modules/about-manually-maintained-credentials-upgrade.adoc
+++ b/modules/about-manually-maintained-credentials-upgrade.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/preparing-manual-creds-update.adoc
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
 // * authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
 
 :_content-type: CONCEPT

--- a/modules/cco-ccoctl-configuring.adoc
+++ b/modules/cco-ccoctl-configuring.adoc
@@ -6,7 +6,7 @@
 // * installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs.doc
 // * installing/installing_alibaba/manually-creating-alibaba-ram.adoc
 // * installing/installing_nutanix/preparing-to-install-on-nutanix.adoc
-// * updating/preparing-manual-creds-update.adoc
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
 
 ifeval::["{context}" == "cco-mode-sts"]
 :aws-sts:

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/preparing-manual-creds-update.adoc
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
 
 
 :_content-type: PROCEDURE

--- a/modules/cco-determine-mode-cli.adoc
+++ b/modules/cco-determine-mode-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/preparing-manual-creds-update.adoc
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
 // * authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
 
 :_content-type: PROCEDURE

--- a/modules/cco-determine-mode-gui.adoc
+++ b/modules/cco-determine-mode-gui.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/preparing-manual-creds-update.adoc
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
 // * authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
 
 :_content-type: PROCEDURE

--- a/modules/cco-manual-upgrade-annotation.adoc
+++ b/modules/cco-manual-upgrade-annotation.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
-// * updating/preparing-manual-creds-update.adoc
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
 
 :_content-type: PROCEDURE
 

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -43,7 +43,7 @@
 // * openshift_images/samples-operator-alt-registry.adoc
 // * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
 // * microshift_cli_ref/microshift-oc-cli-install.adoc
-// * updating/updating-restricted-network-cluster.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 // * installing/installing-nutanix-installer-provisioned.adoc
 // * installing/installing-restricted-networks-nutanix-installer-provisioned.adoc
 // * installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc

--- a/modules/configuring-node-pools-for-hcp.adoc
+++ b/modules/configuring-node-pools-for-hcp.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updates/updating-hosted-control-planes.adoc
+// * updates/updating_a_cluster/updating-hosted-control-planes.adoc
 // * hosted_control_planes/hcp-managing.adoc
 
 :_content-type: PROCEDURE

--- a/modules/disconnected-osus-overview.adoc
+++ b/modules/disconnected-osus-overview.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/understanding-openshift-updates.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
 
 :_content-type: CONCEPT
 [id="update-service-overview_{context}"]

--- a/modules/generating-icsp-object-scoped-to-a-registry.adoc
+++ b/modules/generating-icsp-object-scoped-to-a-registry.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-restricted-network-cluster/restricted-network-update.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
 
 :_content-type: PROCEDURE
 [id="generating-icsp-object-scoped-to-a-registry_{context}"]

--- a/modules/images-configuration-registry-mirror-convert.adoc
+++ b/modules/images-configuration-registry-mirror-convert.adoc
@@ -2,15 +2,15 @@
 //
 // * openshift_images/image-configuration.adoc
 // * post_installation_configuration/preparing-for-users.adoc
-// * updating/updating-restricted-network-cluster/restricted-network-update.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
 
 :_content-type: PROCEDURE
 [id="images-configuration-registry-mirror-convert_{context}"]
 = Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring
 
-Using an `ImageContentSourcePolicy` (ICSP) object to configure repository mirroring is a deprecated feature. This functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. 
+Using an `ImageContentSourcePolicy` (ICSP) object to configure repository mirroring is a deprecated feature. This functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments.
 
-ICSP objects are being replaced by `ImageDigestMirrorSet` and `ImageTagMirrorSet` objects to configure repository mirroring. If you have existing YAML files that you used to create `ImageContentSourcePolicy` objects, you can use the `oc adm migrate icsp` command to convert those files to an `ImageDigestMirrorSet` YAML file. The command updates the API to the current version, changes the `kind` value to `ImageDigestMirrorSet`, and changes `spec.repositoryDigestMirrors` to `spec.imageDigestMirrors`. The rest of the file is not changed. 
+ICSP objects are being replaced by `ImageDigestMirrorSet` and `ImageTagMirrorSet` objects to configure repository mirroring. If you have existing YAML files that you used to create `ImageContentSourcePolicy` objects, you can use the `oc adm migrate icsp` command to convert those files to an `ImageDigestMirrorSet` YAML file. The command updates the API to the current version, changes the `kind` value to `ImageDigestMirrorSet`, and changes `spec.repositoryDigestMirrors` to `spec.imageDigestMirrors`. The rest of the file is not changed.
 
 For more information about `ImageDigestMirrorSet` or `ImageTagMirrorSet` objects, see "Configuring image registry repository mirroring" in the previous section.
 

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -2,7 +2,7 @@
 //
 // * openshift_images/image-configuration.adoc
 // * post_installation_configuration/preparing-for-users.adoc
-// * updating/updating-restricted-network-cluster/restricted-network-update.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
 
 :_content-type: PROCEDURE
 [id="images-configuration-registry-mirror_{context}"]
@@ -39,7 +39,7 @@ If you did not configure mirroring during {product-title} installation, you can 
 +
 [IMPORTANT]
 ====
-Using an `ImageContentSourcePolicy` (ICSP) object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. If you have existing YAML files that you used to create `ImageContentSourcePolicy` objects, you can use the `oc adm migrate icsp` command to convert those files to an `ImageDigestMirrorSet` YAML file. For more information, see "Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring" in the following section. 
+Using an `ImageContentSourcePolicy` (ICSP) object to configure repository mirroring is a deprecated feature. Deprecated functionality is still included in {product-title} and continues to be supported; however, it will be removed in a future release of this product and is not recommended for new deployments. If you have existing YAML files that you used to create `ImageContentSourcePolicy` objects, you can use the `oc adm migrate icsp` command to convert those files to an `ImageDigestMirrorSet` YAML file. For more information, see "Converting ImageContentSourcePolicy (ICSP) files for image registry repository mirroring" in the following section.
 ====
 
 Both of these custom resource objects identify the following information:
@@ -134,12 +134,12 @@ spec:
 ** `ImageTagMirrorSet`: Pulls a tag reference image.
 <3> Indicates the type of image pull method, either:
 ** `imageDigestMirrors`: Use for an `ImageDigestMirrorSet` CR.
-** `imageTagMirrors`: Use for an `ImageTagMirrorSet` CR. 
+** `imageTagMirrors`: Use for an `ImageTagMirrorSet` CR.
 <4> Indicates the name of the mirrored image registry and repository.
 <5> Optional: Indicates a secondary mirror repository for each target repository. If one mirror is down, the target repository can use another mirror.
 <6> Indicates the registry and repository source, which is the repository that is referred to in image pull specifications.
 <7> Optional: Indicates the fallback policy if the image pull fails:
-** `AllowContactingSource`: Allows continued attempts to pull the image from the source repository. This is the default. 
+** `AllowContactingSource`: Allows continued attempts to pull the image from the source repository. This is the default.
 ** `NeverContactSource`: Prevents continued attempts to pull the image from the source repository.
 <8> Optional: Indicates a namespace inside a registry, which allows you to use any image in that namespace. If you use a registry domain as a source, the object is applied to all repositories from the registry.
 <9> Optional: Indicates a registry, which allows you to use any image in that registry. If you specify a registry name, the object is applied to all repositories from a source registry to a mirror registry.
@@ -277,8 +277,8 @@ short-name-mode = ""
 <1> Indicates the repository that is referred to in a pull spec.
 <2> Indicates the mirror for that repository.
 <3> Indicates that the image pull from the mirror is a digest reference image.
-<4> Indicates that the `NeverContactSource` parameter is set for this repository. 
-<5> Indicates that the image pull from the mirror is a tag reference image. 
+<4> Indicates that the `NeverContactSource` parameter is set for this repository.
+<5> Indicates that the image pull from the mirror is a tag reference image.
 
 .. Pull an image to the node from the source and check if it is resolved by the mirror.
 +

--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 // * openshift_images/managing_images/using-image-pull-secrets.adoc
 // * post_installation_configuration/cluster-tasks.adoc
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
 // * support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc
 // * sd_support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc
 //

--- a/modules/installation-about-mirror-registry.adoc
+++ b/modules/installation-about-mirror-registry.adoc
@@ -3,7 +3,7 @@
 // * installing/disconnected_install/installing-mirroring-installation-images.adoc
 // * openshift_images/samples-operator-alt-registry.adoc
 // * scalability_and_performance/ztp-deploying-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 ifeval::["{context}" == "installing-mirroring-disconnected"]
 :oc-mirror:

--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -4,7 +4,7 @@
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
 // * openshift_images/samples-operator-alt-registry.adoc
 // * scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 ifeval::["{context}" == "mirroring-ocp-image-repository"]
 :restricted:

--- a/modules/kmm-build-validation-stage.adoc
+++ b/modules/kmm-build-validation-stage.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/kmm-preflight-validation.adoc
+// * updating/preparing_for_updates/kmm-preflight-validation.adoc
 
 :_content-type: CONCEPT
 [id="kmm-build-validation-stage_{context}"]

--- a/modules/kmm-example-cr.adoc
+++ b/modules/kmm-example-cr.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/kmm-preflight-validation.adoc
+// * updating/preparing_for_updates/kmm-preflight-validation.adoc
 
 :_content-type: CONCEPT
 [id="kmm-example-cr_{context}"]

--- a/modules/kmm-image-validation-stage.adoc
+++ b/modules/kmm-image-validation-stage.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/kmm-preflight-validation.adoc
+// * updating/preparing_for_updates/kmm-preflight-validation.adoc
 
 :_content-type: CONCEPT
 [id="kmm-image-validation-stage_{context}"]

--- a/modules/kmm-preflight-validation-stages-per-module.adoc
+++ b/modules/kmm-preflight-validation-stages-per-module.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/kmm-preflight-validation.adoc
+// * updating/preparing_for_updates/kmm-preflight-validation.adoc
 
 :_content-type: CONCEPT
 [id="kmm-preflight-validation-stages-per-module_{context}"]

--- a/modules/kmm-sign-validation-stage.adoc
+++ b/modules/kmm-sign-validation-stage.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/kmm-preflight-validation.adoc
+// * updating/preparing_for_updates/kmm-preflight-validation.adoc
 
 :_content-type: CONCEPT
 [id="kmm-sign-validation-stage_{context}"]

--- a/modules/kmm-validation-kickoff.adoc
+++ b/modules/kmm-validation-kickoff.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/kmm-preflight-validation.adoc
+// * updating/preparing_for_updates/kmm-preflight-validation.adoc
 
 :_content-type: CONCEPT
 [id="kmm-validation-kickoff_{context}"]

--- a/modules/kmm-validation-lifecycle.adoc
+++ b/modules/kmm-validation-lifecycle.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/kmm-preflight-validation.adoc
+// * updating/preparing_for_updates/kmm-preflight-validation.adoc
 
 :_content-type: CONCEPT
 [id="kmm-validation-lifecycle_{context}"]

--- a/modules/kmm-validation-status.adoc
+++ b/modules/kmm-validation-status.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/kmm-preflight-validation.adoc
+// * updating/preparing_for_updates/kmm-preflight-validation.adoc
 
 :_content-type: CONCEPT
 [id="kmm-validation-status_{context}"]

--- a/modules/machine-health-checks-pausing-web-console.adoc
+++ b/modules/machine-health-checks-pausing-web-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 
-// * updating/updating-cluster-within-minor.adoc
+// * updating/updating_a_cluster/updating-cluster-web-console.adoc
 
 :_content-type: PROCEDURE
 [id="machine-health-checks-pausing-web-console_{context}"]

--- a/modules/machine-health-checks-pausing.adoc
+++ b/modules/machine-health-checks-pausing.adoc
@@ -1,8 +1,8 @@
 // Module included in the following assemblies:
 
-// * updating/updating-cluster-cli.adoc
-// * updating/updating-cluster-within-minor.adoc
-// * updating/updating-restricted-network-cluster/restricted-network-update.adoc
+// * updating/updating_a_cluster/updating-cluster-cli.adoc
+// * updating/updating_a_cluster/updating-cluster-web-console.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
 
 :_content-type: PROCEDURE
 [id="machine-health-checks-pausing_{context}"]

--- a/modules/manually-maintained-credentials-upgrade.adoc
+++ b/modules/manually-maintained-credentials-upgrade.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-within-minor.adoc
-// * updating/updating-cluster-cli.adoc
+// * updating/preparing_for_updates/preparing-manual-creds-update.adoc
 
 :_content-type: PROCEDURE
 

--- a/modules/migrating-to-multi-arch-cli.adoc
+++ b/modules/migrating-to-multi-arch-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/migrating-to-multi-payload.adoc
+// * updating/updating_a_cluster/migrating-to-multi-payload.adoc
 
 :_content-type: PROCEDURE
 [id="migrating-to-multi-arch-cli_{context}"]
@@ -9,12 +9,12 @@
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
-* Your {product-title} version is up to date to at least version 4.13.0. 
+* Your {product-title} version is up to date to at least version 4.13.0.
 +
 For more information on how to update your cluster version, see _Updating a cluster using the web console_ or _Updating a cluster using the CLI_.
 * You have installed the OpenShift CLI (`oc`) that matches the version for your current cluster.
-* Your `oc` client is updated to at least verion 4.13.0. 
-* Your {product-title} cluster is installed on either the AWS or Azure platform. 
+* Your `oc` client is updated to at least verion 4.13.0.
+* Your {product-title} cluster is installed on either the AWS or Azure platform.
 +
 For more information on selecting a supported platform for your cluster installation, see _Selecting a cluster installation type_.
 
@@ -33,17 +33,17 @@ If the `RetrievedUpates` condition is `False`, you can find supplemental informa
 ----
 $ oc adm upgrade
 ----
-+ 
++
 For more information about cluster version condition types, see _Understanding cluster version condition types_.
 
-. If the condition `RetrievedUpdates` is `False`, change the channel to `stable-<4.y>` or `fast-<4.y>` with the following command: 
+. If the condition `RetrievedUpdates` is `False`, change the channel to `stable-<4.y>` or `fast-<4.y>` with the following command:
 +
 [source,terminal]
 ----
 $ oc adm upgrade channel <channel>
 ----
 +
-After setting the channel, verify if `RetrievedUpdates` is `True`. 
+After setting the channel, verify if `RetrievedUpdates` is `True`.
 +
 For more information about channels, see _Understanding update channels and releases_.
 
@@ -54,7 +54,7 @@ For more information about channels, see _Understanding update channels and rele
 $ oc adm upgrade --to-multi-arch
 ----
 
-.Verification 
+.Verification
 
 * You can monitor the migration by running the following command:
 +
@@ -69,11 +69,11 @@ Machine launches may fail as the cluster settles into the new state. To notice a
 ====
 +
 //commenting this section out until https://issues.redhat.com/browse/OCPBUGS-8256 is resolved:
-//For `oc get co`, expect `AVAILABLE=True`, `PROGRESSING=False`, and `DEGRADED=False` on all cluster Operators. 
+//For `oc get co`, expect `AVAILABLE=True`, `PROGRESSING=False`, and `DEGRADED=False` on all cluster Operators.
 +
-//For `oc get mcp`, expect `UPDATED=True`, `UPDATING=False`, and `DEGRADED=False` on all machine config pools. 
+//For `oc get mcp`, expect `UPDATED=True`, `UPDATING=False`, and `DEGRADED=False` on all machine config pools.
 +
-//For `oc adm upgrade`, here is an example of a response: 
+//For `oc adm upgrade`, here is an example of a response:
 +
 //[source,terminal]
 //----

--- a/modules/oc-mirror-about.adoc
+++ b/modules/oc-mirror-about.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: CONCEPT
 [id="installation-oc-mirror-about_{context}"]

--- a/modules/oc-mirror-command-reference.adoc
+++ b/modules/oc-mirror-command-reference.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: REFERENCE
 [id="oc-mirror-command-reference_{context}"]

--- a/modules/oc-mirror-creating-image-set-config.adoc
+++ b/modules/oc-mirror-creating-image-set-config.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="oc-mirror-creating-image-set-config_{context}"]

--- a/modules/oc-mirror-differential-updates.adoc
+++ b/modules/oc-mirror-differential-updates.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="oc-mirror-differential-updates_{context}"]

--- a/modules/oc-mirror-disk-to-mirror.adoc
+++ b/modules/oc-mirror-disk-to-mirror.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="oc-mirror-disk-to-mirror_{context}"]

--- a/modules/oc-mirror-dry-run.adoc
+++ b/modules/oc-mirror-dry-run.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="oc-mirror-dry-run_{context}"]

--- a/modules/oc-mirror-image-set-config-examples.adoc
+++ b/modules/oc-mirror-image-set-config-examples.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: REFERENCE
 [id="oc-mirror-image-set-examples_{context}"]

--- a/modules/oc-mirror-imageset-config-params.adoc
+++ b/modules/oc-mirror-imageset-config-params.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: REFERENCE
 [id="oc-mirror-imageset-config-params_{context}"]

--- a/modules/oc-mirror-installing-plugin.adoc
+++ b/modules/oc-mirror-installing-plugin.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="installation-oc-mirror-installing-plugin_{context}"]

--- a/modules/oc-mirror-mirror-to-disk.adoc
+++ b/modules/oc-mirror-mirror-to-disk.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="oc-mirror-mirror-to-disk_{context}"]

--- a/modules/oc-mirror-mirror-to-mirror.adoc
+++ b/modules/oc-mirror-mirror-to-mirror.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="oc-mirror-mirror-to-mirror_{context}"]

--- a/modules/oc-mirror-oci-format.adoc
+++ b/modules/oc-mirror-oci-format.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="oc-mirror-oci-format_{context}"]

--- a/modules/oc-mirror-support.adoc
+++ b/modules/oc-mirror-support.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: CONCEPT
 [id="oc-mirror-support_{context}"]

--- a/modules/oc-mirror-updating-cluster-manifests.adoc
+++ b/modules/oc-mirror-updating-cluster-manifests.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="oc-mirror-updating-cluster-manifests_{context}"]

--- a/modules/oc-mirror-updating-registry-about.adoc
+++ b/modules/oc-mirror-updating-registry-about.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/disconnected_install/installing-mirroring-disconnected.adoc
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: CONCEPT
 [id="oc-mirror-updating-registry-about_{context}"]

--- a/modules/rhel-compute-about-hooks.adoc
+++ b/modules/rhel-compute-about-hooks.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-rhel-compute.adoc
+// * updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
 
 :_content-type: CONCEPT
 [id="rhel-compute-about-hooks_{context}"]

--- a/modules/rhel-compute-available-hooks.adoc
+++ b/modules/rhel-compute-available-hooks.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-rhel-compute.adoc
+// * updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
 
 [id="rhel-compute-available-hooks_{context}"]
 = Available hooks for RHEL compute machines

--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-rhel-compute.adoc
+// * updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
 
 :_content-type: PROCEDURE
 [id="rhel-compute-updating-minor_{context}"]

--- a/modules/rhel-compute-using-hooks.adoc
+++ b/modules/rhel-compute-using-hooks.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-rhel-compute.adoc
+// * updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
 
 :_content-type: PROCEDURE
 [id="rhel-compute-using-hooks_{context}"]

--- a/modules/scheduling-virtual-hardware-update-on-vsphere.adoc
+++ b/modules/scheduling-virtual-hardware-update-on-vsphere.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// updating/updating-hardware-on-nodes-running-in-vsphere.adoc
+// updating/updating_a_cluster/updating-hardware-on-nodes-running-in-vsphere.adoc
 
 [id="scheduling-virtual-hardware-update-on-vsphere_{context}"]
 = Scheduling an update for virtual hardware on vSphere

--- a/modules/understanding-update-channels.adoc
+++ b/modules/understanding-update-channels.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/understanding-upgrade-channels-release.adoc
+// * updating/understanding_updates/understanding-update-channels-release.adoc
 
 
 [id="understanding-update-channels_{context}"]

--- a/modules/update-changing-update-server-cli.adoc
+++ b/modules/update-changing-update-server-cli.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-cli.adoc
-// * updating/updating-cluster-rhel-compute.adoc
+// * updating/updating_a_cluster/updating-cluster-cli.adoc
+// * updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
 
 :_content-type: PROCEDURE
 [id="update-changing-update-server-cli_{context}"]

--- a/modules/update-changing-update-server-web.adoc
+++ b/modules/update-changing-update-server-web.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-within-minor.adoc
+// * updating/updating_a_cluster/updating-cluster-web-console.adoc
 
 :_content-type: PROCEDURE
 [id="update-changing-update-server-web_{context}"]
@@ -9,7 +9,7 @@ ifndef::openshift-origin[]
 Changing the update server is optional. If you have an OpenShift Update Service (OSUS) installed and configured locally, you must set the URL for the server as the `upstream` to use the local server during updates.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-Changing the update server is optional. 
+Changing the update server is optional.
 endif::openshift-origin[]
 
 .Procedure

--- a/modules/update-conditional-updates.adoc
+++ b/modules/update-conditional-updates.adoc
@@ -1,7 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-cli.adoc
-// * updating/understanding-upgrade-channels-releases.adoc
+// * updating/updating_a_cluster/updating-cluster-cli.adoc
 
 :_content-type: PROCEDURE
 [id="update-conditional-upgrade-path{context}"]

--- a/modules/update-duration-cvo.adoc
+++ b/modules/update-duration-cvo.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/understanding-openshift-update-duration.adoc
+// * updating/understanding_updates/understanding-openshift-update-duration.adoc
 
 :_content-type: CONCEPT
 [id="cluster-version-operator_{context}"]

--- a/modules/update-duration-estimate-cluster-update-time.adoc
+++ b/modules/update-duration-estimate-cluster-update-time.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/understanding-openshift-update-duration.adoc
+// * updating/understanding_updates/understanding-openshift-update-duration.adoc
 
 :_content-type: REFERENCE
 [id="estimating-cluster-update-time_{context}"]

--- a/modules/update-duration-factors.adoc
+++ b/modules/update-duration-factors.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/understanding-openshift-update-duration.adoc
+// * updating/understanding_updates/understanding-openshift-update-duration.adoc
 
 :_content-type: REFERENCE
 [id="factors-affecting-update-duration_{context}"]

--- a/modules/update-duration-mco.adoc
+++ b/modules/update-duration-mco.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/understanding-openshift-update-duration.adoc
+// * updating/understanding_updates/understanding-openshift-update-duration.adoc
 
 :_content-type: CONCEPT
 [id="machine-config-operator-node-updates_{context}"]

--- a/modules/update-duration-rhel-nodes.adoc
+++ b/modules/update-duration-rhel-nodes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/understanding-openshift-update-duration.adoc
+// * updating/understanding_updates/understanding-openshift-update-duration.adoc
 
 :_content-type: CONCEPT
 [id="redhat-enterprise-linux-nodes_{context}"]

--- a/modules/update-mirror-repository.adoc
+++ b/modules/update-mirror-repository.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-restricted-network-cluster/mirroring-image-repository.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
 
 :_content-type: PROCEDURE
 [id="update-mirror-repository-adm-release-mirror_{context}"]

--- a/modules/update-preparing-ack.adoc
+++ b/modules/update-preparing-ack.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-prepare.adoc
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
 
 :_content-type: PROCEDURE
 [id="update-preparing-ack_{context}"]

--- a/modules/update-preparing-evaluate-alerts.adoc
+++ b/modules/update-preparing-evaluate-alerts.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-prepare.adoc
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
 
 [id="update-preparing-evaluate-alerts_{context}"]
 = Reviewing alerts to identify uses of removed APIs

--- a/modules/update-preparing-evaluate-apirequestcount-workloads.adoc
+++ b/modules/update-preparing-evaluate-apirequestcount-workloads.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-prepare.adoc
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
 
 :_content-type: PROCEDURE
 [id="update-preparing-evaluate-apirequestcount-workloads_{context}"]

--- a/modules/update-preparing-evaluate-apirequestcount.adoc
+++ b/modules/update-preparing-evaluate-apirequestcount.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-prepare.adoc
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
 
 :_content-type: PROCEDURE
 [id="update-preparing-evaluate-apirequestcount_{context}"]

--- a/modules/update-preparing-list.adoc
+++ b/modules/update-preparing-list.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-prepare.adoc
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
 
 [id="update-preparing-list_{context}"]
 = Removed Kubernetes APIs

--- a/modules/update-preparing-migrate.adoc
+++ b/modules/update-preparing-migrate.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-prepare.adoc
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
 
 [id="update-preparing-migrate_{context}"]
 = Migrating instances of removed APIs

--- a/modules/update-restricted-image-digests.adoc
+++ b/modules/update-restricted-image-digests.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-restricted-network-cluster/restricted-network-update.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
 
 :_content-type: PROCEDURE
 [id="update-restricted-image-digests_{context}"]

--- a/modules/update-restricted.adoc
+++ b/modules/update-restricted.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-restricted-network-cluster/restricted-network-update.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
 
 :_content-type: PROCEDURE
 [id="update-restricted_{context}"]

--- a/modules/update-service-configure-cvo.adoc
+++ b/modules/update-service-configure-cvo.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-configure-cvo"]

--- a/modules/update-service-create-service-cli.adoc
+++ b/modules/update-service-create-service-cli.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-create-service-cli_{context}"]

--- a/modules/update-service-create-service-web-console.adoc
+++ b/modules/update-service-create-service-web-console.adoc
@@ -1,5 +1,5 @@
 //Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-create-service-web-console_{context}"]

--- a/modules/update-service-delete-service-cli.adoc
+++ b/modules/update-service-delete-service-cli.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/uninstalling-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/uninstalling-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-delete-service-cli_{context}"]

--- a/modules/update-service-delete-service-web-console.adoc
+++ b/modules/update-service-delete-service-web-console.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/uninstalling-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/uninstalling-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-delete-service-web-console_{context}"]

--- a/modules/update-service-graph-data.adoc
+++ b/modules/update-service-graph-data.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-graph-data_{context}"]

--- a/modules/update-service-install-cli.adoc
+++ b/modules/update-service-install-cli.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-install-cli_{context}"]

--- a/modules/update-service-install-web-console.adoc
+++ b/modules/update-service-install-web-console.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/restricted-network-update-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-install-web-console_{context}"]

--- a/modules/update-service-uninstall-cli.adoc
+++ b/modules/update-service-uninstall-cli.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/uninstalling-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/uninstalling-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-uninstall-cli_{context}"]

--- a/modules/update-service-uninstall-web-console.adoc
+++ b/modules/update-service-uninstall-web-console.adoc
@@ -1,5 +1,5 @@
 // Module included in the following assemblies:
-// * updating/updating-restricted-network-cluster/uninstalling-osus.adoc
+// * updating/updating_a_cluster/updating_disconnected_cluster/uninstalling-osus.adoc
 
 :_content-type: PROCEDURE
 [id="update-service-uninstall-web-console_{context}"]

--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-cli.adoc
-// * updating/updating-cluster-rhel-compute.adoc
+// * updating/updating_a_cluster/updating-cluster-cli.adoc
+// * updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
 
 :_content-type: PROCEDURE
 [id="update-upgrading-cli_{context}"]

--- a/modules/update-upgrading-web.adoc
+++ b/modules/update-upgrading-web.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-within-minor.adoc
+// * updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
+// * updating/updating_a_cluster/updating-cluster-web-console.adoc
 
 ifeval::["{context}" == "updating-cluster-rhel-compute"]
 :rhel:

--- a/modules/update-using-custom-machine-config-pools-about.adoc
+++ b/modules/update-using-custom-machine-config-pools-about.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/update-using-custom-machine-config-pools.adoc
+// * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
 
 :_content-type: CONCEPT
 [id="update-using-custom-machine-config-pools-about_{context}"]

--- a/modules/update-using-custom-machine-config-pools-canary.adoc
+++ b/modules/update-using-custom-machine-config-pools-canary.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-within-minor.adoc
+// * updating/updating_a_cluster/updating-cluster-web-console.adoc
 
 [id="update-using-custom-machine-config-pools-canary_{context}"]
 = Performing a canary rollout update

--- a/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp-remove.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/update-using-custom-machine-config-pools.adoc
+// * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
 
 [id="update-using-custom-machine-config-pools-mcp-remove_{context}"]
 = Moving a node to the original machine config pool
@@ -29,10 +29,10 @@ $ oc label node ci-ln-0qv1yp2-f76d1-kl2tq-worker-a-j2ssz node-role.kubernetes.io
 error: 'node-role.kubernetes.io/worker' already has a value (), and --overwrite is false
 ----
 +
-If the node does not have a `worker` label or a label from an updated MCP, add the label. 
+If the node does not have a `worker` label or a label from an updated MCP, add the label.
 ////
 
-. Remove the custom label from the node. 
+. Remove the custom label from the node.
 +
 [source,terminal]
 ----

--- a/modules/update-using-custom-machine-config-pools-mcp.adoc
+++ b/modules/update-using-custom-machine-config-pools-mcp.adoc
@@ -1,11 +1,11 @@
 // Module included in the following assemblies:
 //
-// * updating/update-using-custom-machine-config-pools.adoc
+// * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
 
 [id="update-using-custom-machine-config-pools-mcp_{context}"]
 = Creating machine config pools to perform a canary rollout update
 
-The first task in performing this canary rollout update is to create one or more machine config pools (MCP). 
+The first task in performing this canary rollout update is to create one or more machine config pools (MCP).
 
 . Create an MCP from a worker node.
 
@@ -61,7 +61,7 @@ spec:
          key: machineconfiguration.openshift.io/role,
          operator: In,
          values: [worker,workerpool-canary]
-        } 
+        }
   nodeSelector:
     matchLabels:
       node-role.kubernetes.io/workerpool-canary: "" <3>

--- a/modules/update-using-custom-machine-config-pools-pause.adoc
+++ b/modules/update-using-custom-machine-config-pools-pause.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/update-using-custom-machine-config-pools.adoc
+// * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
 
 [id="update-using-custom-machine-config-pools-pause_{context}"]
 = Pausing the machine config pools

--- a/modules/update-using-custom-machine-config-pools-unpause.adoc
+++ b/modules/update-using-custom-machine-config-pools-unpause.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/update-using-custom-machine-config-pools.adoc
+// * updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
 
 [id="update-using-custom-machine-config-pools-unpause_{context}"]
 = Unpausing the machine config pools

--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// updating/updating-hardware-on-nodes-running-in-vsphere.adoc
+// updating/updating_a_cluster/updating-hardware-on-nodes-running-in-vsphere.adoc
 
 :_content-type: PROCEDURE
 [id="update-vsphere-virtual-hardware-on-compute-nodes_{context}"]

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// updating/updating-hardware-on-nodes-running-in-vsphere.adoc
+// updating/updating_a_cluster/updating-hardware-on-nodes-running-in-vsphere.adoc
 
 :_content-type: PROCEDURE
 [id="update-vsphere-virtual-hardware-on-control-plane-nodes_{context}"]

--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// updating/updating-hardware-on-nodes-running-in-vsphere.adoc
+// updating/updating_a_cluster/updating-hardware-on-nodes-running-in-vsphere.adoc
 
 :_content-type: PROCEDURE
 [id="update-vsphere-virtual-hardware-on-template_{context}"]

--- a/modules/updates-for-hosted-control-planes.adoc
+++ b/modules/updates-for-hosted-control-planes.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updates/updating-hosted-control-planes.adoc
+// * updates/updating_a_cluster/updating-hosted-control-planes.adoc
 // * hosted_control_planes/hcp-managing.adoc
 
 :_content-type: CONCEPT
@@ -25,14 +25,14 @@ With node pools, you can configure the software that is running in the nodes by 
 * Changing any platform-specific field, such as the AWS instance type. The result is a set of new instances with the new type.
 * Changing the cluster configuration, if the change propagates to the node.
 
-Node pools support replace updates and in-place updates. The `nodepool.spec.release` value dictates the version of any particular node pool. A `NodePool` object completes a replace or an in-place rolling update according to the `.spec.management.upgradeType` value. 
+Node pools support replace updates and in-place updates. The `nodepool.spec.release` value dictates the version of any particular node pool. A `NodePool` object completes a replace or an in-place rolling update according to the `.spec.management.upgradeType` value.
 
-After you create a node pool, you cannot change the update type. If you want to change the update type, you must create a node pool and delete the other one. 
+After you create a node pool, you cannot change the update type. If you want to change the update type, you must create a node pool and delete the other one.
 
 [id="updates-for-nodepools-replace_{context}"]
 === Replace updates for node pools
 
-A _replace_ update creates instances in the new version while it removes old instances from the previous version. This update type is effective in cloud environments where this level of immutability is cost effective. 
+A _replace_ update creates instances in the new version while it removes old instances from the previous version. This update type is effective in cloud environments where this level of immutability is cost effective.
 
 Replace updates do not preserve any manual changes because the node is entirely re-provisioned.
 

--- a/modules/updating-eus-to-eus-layered-products.adoc
+++ b/modules/updating-eus-to-eus-layered-products.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/preparing-eus-eus-upgrade.adoc
+// * updating/updating_a_cluster/eus-eus-update.adoc
 
 :_content-type: PROCEDURE
 [id="updating-eus-to-eus-olm-operators_{context}"]

--- a/modules/updating-eus-to-eus-upgrade-cli.adoc
+++ b/modules/updating-eus-to-eus-upgrade-cli.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/preparing-eus-eus-upgrade.adoc
+// * updating/updating_a_cluster/eus-eus-update.adoc
 
 :_content-type: PROCEDURE
 [id="updating-eus-to-eus-upgrade-cli_{context}"]

--- a/modules/updating-eus-to-eus-upgrade-console.adoc
+++ b/modules/updating-eus-to-eus-upgrade-console.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/preparing-eus-eus-upgrade.adoc
+// * updating/updating_a_cluster/eus-eus-update.adoc.adoc
 
 :_content-type: PROCEDURE
 [id="updating-eus-to-eus-upgrade-console_{context}"]
@@ -24,31 +24,31 @@ To view the status of all machine config pools, click *Compute* -> *MachineConfi
 If your machine config pools have an `Updating` status, please wait for this status to change to `Up to date`. This process could take several minutes.
 ====
 
-. Set your channel to `eus-<4.y+2>`. 
+. Set your channel to `eus-<4.y+2>`.
 +
 To set your channel, click *Administration* -> *Cluster Settings* -> *Channel*. You can edit your channel by clicking on the current hyperlinked channel.
 
 . Pause all worker machine pools except for the master pool. You can perform this action on the *MachineConfigPools* tab under the *Compute* page. Select the vertical ellipses next to the machine config pool you'd like to pause and click *Pause updates*.
 
-. Update to version <4.y+1> and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources". 
+. Update to version <4.y+1> and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources".
 
-. Ensure that the <4.y+1> updates are complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab. 
+. Ensure that the <4.y+1> updates are complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab.
 
 . If necessary, update your OLM Operators by using the Administrator perspective on the web console. You can find more information on how to perform these actions in "Updating installed Operators"; see "Additional resources".
 
-. Update to version <4.y+2> and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources". 
+. Update to version <4.y+2> and complete up to the *Save* step. You can find more information on how to perform these actions in "Updating a cluster by using the web console"; see "Additional resources".
 
-. Ensure that the <4.y+2> update is complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab. 
+. Ensure that the <4.y+2> update is complete by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab.
 
-. Unpause all previously paused machine config pools. You can perform this action on the *MachineConfigPools* tab under the *Compute* page. Select the vertical ellipses next to the machine config pool you'd like to unpause and click *Unpause updates*. 
+. Unpause all previously paused machine config pools. You can perform this action on the *MachineConfigPools* tab under the *Compute* page. Select the vertical ellipses next to the machine config pool you'd like to unpause and click *Unpause updates*.
 +
 [IMPORTANT]
 ====
 If pools are paused, the cluster is not permitted to upgrade to any future minor versions, and some maintenance tasks are inhibited. This puts the cluster at risk for future degradation.
 ====
 
-. Verify that your previously paused pools are updated and that your cluster has completed the update to version <4.y+2>. 
+. Verify that your previously paused pools are updated and that your cluster has completed the update to version <4.y+2>.
 +
 You can verify that your pools have updated on the *MachineConfigPools* tab under the *Compute* page by confirming that the *Update status* has a value of *Up to date*.
 +
-You can verify that your cluster has completed the update by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab. 
+You can verify that your cluster has completed the update by viewing the *Last completed version* of your cluster. You can find this information on the *Cluster Settings* page under the *Details* tab.

--- a/modules/updating-eus-to-eus-upgrade.adoc
+++ b/modules/updating-eus-to-eus-upgrade.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updating/preparing-eus-eus-upgrade.adoc
+// * updating/updating_a_cluster/eus-eus-update.adoc
 
 :_content-type: PROCEDURE
 [id="updating-eus-to-eus-upgrade_{context}"]

--- a/modules/updating-node-pools-for-hcp.adoc
+++ b/modules/updating-node-pools-for-hcp.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * updates/updating-hosted-control-planes.adoc
+// * updates/updating_a_cluster/updating-hosted-control-planes.adoc
 // * hosted_control_planes/hcp-managing.adoc
 
 :_content-type: PROCEDURE

--- a/modules/updating-sno.adoc
+++ b/modules/updating-sno.adoc
@@ -1,7 +1,7 @@
 // Module included in the following assemblies:
 //
-// * updating/updating-cluster-within-minor.adoc
-// * updating/updating-cluster-cli.adoc
+// * updating/updating_a_cluster/updating-cluster-web-console.adoc
+// * updating/updating_a_cluster/updating-cluster-cli.adoc
 
 :_content-type: CONCEPT
 [id="update-single-node-openshift_{context}"]

--- a/updating/preparing_for_updates/kmm-preflight-validation.adoc
+++ b/updating/preparing_for_updates/kmm-preflight-validation.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 Before performing an upgrade on the cluster with applied KMM modules, the administrator must verify that kernel modules installed using KMM are able to be installed on the nodes after the cluster upgrade and possible kernel upgrade. Preflight attempts to validate every `Module` loaded in the cluster, in parallel. Preflight does not wait for validation of one `Module` to complete before starting validation of another `Module`.
 
 :FeatureName: Kernel Module Management Operator Preflight validation

--- a/updating/preparing_for_updates/preparing-manual-creds-update.adoc
+++ b/updating/preparing_for_updates/preparing-manual-creds-update.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 The Cloud Credential Operator (CCO) `Upgradable` status for a cluster with manually maintained credentials is `False` by default.
 
 * For minor releases, for example, from 4.12 to 4.13, this status prevents you from updating until you have addressed any updated permissions and annotated the `CloudCredential` resource to indicate that the permissions are updated as needed for the next version. This annotation changes the `Upgradable` status to `True`.

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 {product-title} 4.13 uses Kubernetes 1.26, which removed several deprecated APIs.
 
 A cluster administrator must provide a manual acknowledgment before the cluster can be updated from {product-title} 4.12 to 4.13. This is to help prevent issues after upgrading to {product-title} 4.13, where APIs that have been removed are still in use by workloads, tools, or other components running on or interacting with the cluster. Administrators must evaluate their cluster for any APIs in use that will be removed and migrate the affected components to use the appropriate new API version. After this evaluation and migration is complete, the administrator can provide the acknowledgment.

--- a/updating/understanding_updates/understanding-openshift-update-duration.adoc
+++ b/updating/understanding_updates/understanding-openshift-update-duration.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 {product-title} update duration varies based on the deployment topology. This page helps you understand the factors that affect update duration and estimate how long the cluster update takes in your environment.
 
 [id="update-duration-prerequisites"]

--- a/updating/understanding_updates/understanding-update-channels-release.adoc
+++ b/updating/understanding_updates/understanding-update-channels-release.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 Update channels are the mechanism by which users declare the {product-title} minor version they intend to update their clusters to. They also allow users to choose the timing and level of support their updates will have through the `fast`, `stable`, `candidate`, and `eus` channel options. The Cluster Version Operator uses an update graph based on the channel declaration, along with other conditional information, to provide a list of recommended and conditional updates available to the cluster.
 
 Update channels correspond to a minor version of {product-title}. The version number in the channel represents the target minor version that the cluster will eventually be updated to, even if it is higher than the cluster's current minor version.

--- a/updating/updating_a_cluster/eus-eus-update.adoc
+++ b/updating/updating_a_cluster/eus-eus-update.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 Due to fundamental Kubernetes design, all {product-title} updates between minor versions must be serialized.
 You must update from {product-title} <4.y> to <4.y+1>, and then to <4.y+2>. You cannot update from {product-title} <4.y> to <4.y+2> directly.
 However, administrators who want to update between two Extended Update Support (EUS) versions can do so incurring only a single reboot of non-control plane hosts.

--- a/updating/updating_a_cluster/migrating-to-multi-payload.adoc
+++ b/updating/updating_a_cluster/migrating-to-multi-payload.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 You can migrate your current cluster with single-architecture compute machines to a cluster with multi-architecture compute machines by updating to a multi-architecture, manifest-listed payload. This allows you to add mixed architecture compute nodes to your cluster.
 
 For information about configuring your multi-architecture compute machines, see _Configuring multi-architecture compute machines on an {product-title} cluster_.

--- a/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
+++ b/updating/updating_a_cluster/update-using-custom-machine-config-pools.adoc
@@ -6,7 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
 
+To do: Remove this comment once 4.13 docs are EOL.
+////
 
 There might be some scenarios where you want a more controlled rollout of an update to the worker nodes in order to ensure that mission-critical applications stay available during the whole update, even if the update process causes your applications to fail. Depending on your organizational needs, you might want to update a small subset of worker nodes, evaluate cluster and workload health over a period of time, then update the remaining nodes. This is commonly referred to as a _canary_ update. Or, you might also want to fit worker node updates, which often require a host reboot, into smaller defined maintenance windows when it is not possible to take a large maintenance window to update the entire cluster at one time.
 

--- a/updating/updating_a_cluster/updating-cluster-cli.adoc
+++ b/updating/updating_a_cluster/updating-cluster-cli.adoc
@@ -11,6 +11,12 @@ All OpenShift advisories link directly to this assembly. If you are doing work t
 But if you really need to, please contact the release notes team so they can change the advisory templates. These templates are not part of the openshift-docs repo.
 ////
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 You can update, or upgrade, an {product-title} cluster within a minor version by using the OpenShift CLI (`oc`). You can also update a cluster between minor versions by following the same instructions.
 
 == Prerequisites

--- a/updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
+++ b/updating/updating_a_cluster/updating-cluster-rhel-compute.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 You can update, or upgrade, an {product-title} cluster. If your cluster contains
 Red Hat Enterprise Linux (RHEL) machines, you must perform more steps to update
 those machines.

--- a/updating/updating_a_cluster/updating-cluster-web-console.adoc
+++ b/updating/updating_a_cluster/updating-cluster-web-console.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 You can update, or upgrade, an {product-title} cluster by using the web console. The following steps update a cluster within a minor version. You can use the same instructions for updating a cluster between minor versions.
 
 [NOTE]

--- a/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
+++ b/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster.
 
 You can update your virtual hardware immediately or schedule an update in vCenter.

--- a/updating/updating_a_cluster/updating-hosted-control-planes.adoc
+++ b/updating/updating_a_cluster/updating-hosted-control-planes.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 On hosted control planes for {product-title}, updates are decoupled between the control plane and the nodes. Your service cluster provider, which is the user that hosts the cluster control planes, can manage the updates as needed. The hosted cluster handles control plane updates, and node pools handle node updates.
 
 include::modules/updates-for-hosted-control-planes.adoc[leveloffset=+1]

--- a/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 To get an update experience similar to connected clusters, you can use the following procedures to install and configure the OpenShift Update Service (OSUS) in a disconnected environment.
 
 The following steps outline the high-level workflow on how to update a cluster in a disconnected environment using OSUS:

--- a/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update.adoc
@@ -12,6 +12,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 Use the following procedures to update a cluster in a disconnected environment without access to the OpenShift Update Service.
 
 == Prerequisites

--- a/updating/updating_a_cluster/updating_disconnected_cluster/index.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/index.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 A disconnected environment is one in which your cluster nodes cannot access the internet.
 For this reason, you must populate a registry with the installation images.
 If your registry host cannot access both the internet and the cluster, you can mirror the images to a file system that is disconnected from that environment and then bring that host or removable media across that gap.

--- a/updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 You must mirror container images onto a mirror registry before you can update a cluster in a disconnected environment. You can also use this procedure in connected environments to ensure your clusters run only approved container images that have satisfied your organizational controls for external content.
 
 [NOTE]

--- a/updating/updating_a_cluster/updating_disconnected_cluster/uninstalling-osus.adoc
+++ b/updating/updating_a_cluster/updating_disconnected_cluster/uninstalling-osus.adoc
@@ -6,6 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+////
+WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to this assembly for earlier versions should be done in separate PRs based off of their respective version branches. Otherwise, your cherry picks may fail.
+
+To do: Remove this comment once 4.13 docs are EOL.
+////
+
 To remove a local copy of the OpenShift Update Service (OSUS) from your cluster, you must first delete the OSUS application and then uninstall the OSUS Operator.
 
 [id="update-service-delete-service"]


### PR DESCRIPTION
[OSDOCS-5792](https://issues.redhat.com/browse/OSDOCS-5792) and [OSDOCS-5813](https://issues.redhat.com/browse/OSDOCS-5813)

Versions: 4.14+

This PR adds a warning to every recently relocated assembly in the update docs, warning others that changes to these assemblies for earlier versions will likely need to be done in their own separate PRs. It also updates the module include statements for all modules included in these relocated assemblies.

QE not needed

Preview: N/A, all changes are in comments. Here is a link to a page in the update section in case you would like to double check:  [Understanding update channels and releases](https://62699--docspreview.netlify.app/openshift-enterprise/latest/updating/understanding_updates/understanding-update-channels-release.html)