### PR TITLE
Nodes Containers docs fixes during ROSA review

### DIFF
--- a/modules/nodes-cluster-enabling-features-cli.adoc
+++ b/modules/nodes-cluster-enabling-features-cli.adoc
@@ -36,6 +36,7 @@ apiVersion: config.openshift.io/v1
 kind: FeatureGate
 metadata:
   name: cluster <1>
+# ...
 spec:
   featureSet: TechPreviewNoUpgrade <2>
 ----

--- a/modules/nodes-cluster-enabling-features-console.adoc
+++ b/modules/nodes-cluster-enabling-features-console.adoc
@@ -35,8 +35,7 @@ apiVersion: config.openshift.io/v1
 kind: FeatureGate
 metadata:
   name: cluster <1>
-....
-
+# ...
 spec:
   featureSet: TechPreviewNoUpgrade <2>
 ----

--- a/modules/nodes-cluster-worker-latency-profiles-using.adoc
+++ b/modules/nodes-cluster-worker-latency-profiles-using.adoc
@@ -57,41 +57,11 @@ metadata:
 spec:
   workerLatencyProfile: MediumUpdateAverageReaction <1>
 
- ...
+# ...
 ----
 <1> Specifies the medium worker latency policy.
 +
 Scheduling on each worker node is disabled as the change is being applied.
-+
-When all nodes return to the `Ready` condition, you can use the following command to look in the Kubernetes Controller Manager to ensure it was applied:
-+
-[source,terminal]
-----
-$ oc get KubeControllerManager -o yaml | grep -i workerlatency -A 5 -B 5
-----
-+
-.Example output
-[source,terminal]
-----
- ...
-    - lastTransitionTime: "2022-07-11T19:47:10Z"
-      reason: ProfileUpdated
-      status: "False"
-      type: WorkerLatencyProfileProgressing
-    - lastTransitionTime: "2022-07-11T19:47:10Z" <1>
-      message: all static pod revision(s) have updated latency profile
-      reason: ProfileUpdated
-      status: "True"
-      type: WorkerLatencyProfileComplete
-    - lastTransitionTime: "2022-07-11T19:20:11Z"
-      reason: AsExpected
-      status: "False"
-      type: WorkerLatencyProfileDegraded
-    - lastTransitionTime: "2022-07-11T19:20:36Z"
-      status: "False"
- ...
-----
-<1> Specifies that the profile is applied and active.
 
 . Optional: Move to the low worker latency profile:
 
@@ -128,11 +98,43 @@ metadata:
 spec:
   workerLatencyProfile: LowUpdateSlowReaction <1>
 
- ...
+# ...
 ----
 <1> Specifies to use the low worker latency policy.
 +
 Scheduling on each worker node is disabled as the change is being applied.
+
+.Verification
+
+* When all nodes return to the `Ready` condition, you can use the following command to look in the Kubernetes Controller Manager to ensure it was applied:
++
+[source,terminal]
+----
+$ oc get KubeControllerManager -o yaml | grep -i workerlatency -A 5 -B 5
+----
++
+.Example output
+[source,terminal]
+----
+# ...
+    - lastTransitionTime: "2022-07-11T19:47:10Z"
+      reason: ProfileUpdated
+      status: "False"
+      type: WorkerLatencyProfileProgressing
+    - lastTransitionTime: "2022-07-11T19:47:10Z" <1>
+      message: all static pod revision(s) have updated latency profile
+      reason: ProfileUpdated
+      status: "True"
+      type: WorkerLatencyProfileComplete
+    - lastTransitionTime: "2022-07-11T19:20:11Z"
+      reason: AsExpected
+      status: "False"
+      type: WorkerLatencyProfileDegraded
+    - lastTransitionTime: "2022-07-11T19:20:36Z"
+      status: "False"
+# ...
+----
+<1> Specifies that the profile is applied and active.
 
 To change the low profile to medium or change the medium to low, edit the `node.config` object and set the `spec.workerLatencyProfile` parameter to the appropriate value.
 

--- a/modules/nodes-containers-copying-files-about.adoc
+++ b/modules/nodes-containers-copying-files-about.adoc
@@ -19,15 +19,15 @@ $ oc rsync <source> <destination> [-c <container>]
 Specifying the Copy Source::
 The source argument of the `oc rsync` command must point to either a local
 directory or a pod directory. Individual files are not supported.
-
++
 When specifying a pod directory the directory name must be prefixed with the pod
 name:
-
++
 [source,terminal]
 ----
 <pod name>:<dir>
 ----
-
++
 If the directory name ends in a path separator (`/`), only the contents of the directory are copied to the destination. Otherwise, the
 directory and its contents are copied to the destination.
 
@@ -44,11 +44,11 @@ Continuous Syncing on File Change::
 Using the `--watch` option causes the command to monitor the source path for any
 file system changes, and synchronizes changes when they occur. With this
 argument, the command runs forever.
-
++
 Synchronization occurs after short quiet periods to ensure a
 rapidly changing file system does not result in continuous synchronization
 calls.
-
++
 When using the `--watch` option, the behavior is effectively the same as
 manually invoking `oc rsync` repeatedly, including any arguments normally passed
 to `oc rsync`. Therefore, you can control the behavior via the same flags used

--- a/modules/nodes-containers-copying-files-procedure.adoc
+++ b/modules/nodes-containers-copying-files-procedure.adoc
@@ -12,19 +12,18 @@ Support for copying local files to or from a container is built into the CLI.
 
 When working with `oc rsync`, note the following:
 
-rsync must be installed::
-The `oc rsync` command uses the local `rsync` tool if present on the client
+* rsync must be installed. The `oc rsync` command uses the local `rsync` tool, if present on the client
 machine and the remote container.
-
++
 If `rsync` is not found locally or in the remote container, a *tar* archive
 is created locally and sent to the container where the *tar* utility is used to
 extract the files. If *tar* is not available in the remote container, the
 copy will fail.
-
++
 The *tar* copy method does not provide the same functionality as `oc rsync`. For
 example, `oc rsync` creates the destination directory if it does not exist and
 only sends files that are different between the source and the destination.
-
++
 [NOTE]
 ====
 In Windows, the `cwRsync` client should be installed and added to the PATH for

--- a/modules/nodes-containers-copying-files-rsync.adoc
+++ b/modules/nodes-containers-copying-files-rsync.adoc
@@ -13,7 +13,7 @@ environment variable as a workaround, as follows:
 
 [source,terminal]
 ----
-$ rsync --rsh='oc rsh' --exclude-from=FILE SRC POD:DEST
+$ rsync --rsh='oc rsh' --exclude-from=<file_name> <local-dir> <pod-name>:/<remote-dir>
 ----
 
 or:
@@ -29,7 +29,7 @@ Then, run the rsync command:
 
 [source,terminal]
 ----
-$ rsync --exclude-from=FILE SRC POD:DEST
+$ rsync --exclude-from=<file_name> <local-dir> <pod-name>:/<remote-dir>
 ----
 
 Both of the above examples configure standard `rsync` to use `oc rsh` as its

--- a/modules/nodes-containers-downward-api-container-configmaps.adoc
+++ b/modules/nodes-containers-downward-api-container-configmaps.adoc
@@ -11,7 +11,9 @@ so image and application authors can create an image for specific environments.
 
 .Procedure
 
-. Create a `*_configmap.yaml_*` file:
+. Create a config map with the values to inject:
+
+.. Create a `*_configmap.yaml_*` file similar to the following:
 +
 [source,yaml]
 ----
@@ -23,14 +25,16 @@ data:
   mykey: myvalue
 ----
 
-. Create a `ConfigMap` object from the `*_configmap.yaml_*` file:
+.. Create the config map from the `configmap.yaml` file:
 +
 [source,terminal]
 ----
 $ oc create -f configmap.yaml
 ----
 
-. Create a `*_pod.yaml_*` file that references the above `ConfigMap` object:
+. Create a pod that references the above config map:
+
+.. Create a `pod.yaml` file similar to the following:
 +
 [source,yaml]
 ----
@@ -50,16 +54,19 @@ spec:
               name: myconfigmap
               key: mykey
   restartPolicy: Always
+# ...
 ----
 
-. Create the pod from the `*_pod.yaml_*` file:
+.. Create the pod from the `pod.yaml` file:
 +
 [source,terminal]
 ----
 $ oc create -f pod.yaml
 ----
 
-. Check the container's logs for the `MY_CONFIGMAP_VALUE` value:
+.Verification
+
+* Check the container's logs for the `MY_CONFIGMAP_VALUE` value:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-envars.adoc
@@ -13,7 +13,9 @@ string.
 
 .Procedure
 
-. Create a `*_pod.yaml_*` file that references an existing `environment variable`:
+. Create a pod that references an existing environment variable:
+
+.. Create a `pod.yaml` file similar to the following:
 +
 [source,yaml]
 ----
@@ -32,16 +34,19 @@ spec:
         - name: MY_ENV_VAR_REF_ENV
           value: $(MY_EXISTING_ENV)
   restartPolicy: Never
+# ...
 ----
 
-. Create the pod from the `*_pod.yaml_*` file:
+.. Create the pod from the `*_pod.yaml_*` file:
 +
 [source,terminal]
 ----
 $ oc create -f pod.yaml
 ----
 
-. Check the container's logs for the `MY_ENV_VAR_REF_ENV` value:
+.Verification
+
+* Check the container's logs for the `MY_ENV_VAR_REF_ENV` value:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-escaping.adoc
+++ b/modules/nodes-containers-downward-api-container-escaping.adoc
@@ -12,7 +12,9 @@ of the provided value.
 
 .Procedure
 
-. Create a `*_pod.yaml_*` file that references an existing `environment variable`:
+. Create a pod that references an existing environment variable:
+
+.. Create a `pod.yaml` file similar to the following:
 +
 [source,yaml]
 ----
@@ -29,16 +31,19 @@ spec:
         - name: MY_NEW_ENV
           value: $$(SOME_OTHER_ENV)
   restartPolicy: Never
+# ...
 ----
 
-. Create the pod from the `*_pod.yaml_*` file:
+.. Create the pod from the `*_pod.yaml_*` file:
 +
 [source,terminal]
 ----
 $ oc create -f pod.yaml
 ----
 
-. Check the container's logs for the `MY_NEW_ENV` value:
+.Verification
+
+* Check the container's logs for the `MY_NEW_ENV` value:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-resources-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-resources-envars.adoc
@@ -9,17 +9,28 @@
 When creating pods, you can use the Downward API to inject information about
 computing resource requests and limits using environment variables.
 
+When creating the pod configuration, specify environment variables that
+correspond to the contents of the `resources` field in the `*spec.container*`
+field.
+
+[NOTE]
+====
+If the resource limits are not included in the container configuration, the
+downward API defaults to the node's CPU and memory allocatable values.
+====
+
 .Procedure
 
-To use environment variables:
+. Create a new pod spec that contains the resources you want to inject:
 
-. When creating a pod configuration, specify environment variables that
-correspond to the contents of the `resources` field in the `*spec.container*`
-field:
+.. Create a `pod.yaml` file similar to the following:
 +
 [source,yaml]
 ----
-....
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dapi-env-test-pod
 spec:
   containers:
     - name: test-container
@@ -49,13 +60,10 @@ spec:
           valueFrom:
             resourceFieldRef:
               resource: limits.memory
-....
+# ...
 ----
-+
-If the resource limits are not included in the container configuration, the
-downward API defaults to the node's CPU and memory allocatable values.
 
-. Create the pod from the `*_pod.yaml_*` file:
+.. Create the pod from the `pod.yaml` file:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-resources-plugin.adoc
+++ b/modules/nodes-containers-downward-api-container-resources-plugin.adoc
@@ -9,17 +9,28 @@
 When creating pods, you can use the Downward API to inject information about
 computing resource requests and limits using a volume plugin.
 
+When creating the pod configuration, use the `spec.volumes.downwardAPI.items`
+field to describe the desired resources that correspond to the
+`spec.resources` field.
+
+[NOTE]
+====
+If the resource limits are not included in the container configuration, the
+Downward API defaults to the node's CPU and memory allocatable values.
+====
+
 .Procedure
 
-To use the Volume Plugin:
+. Create a new pod spec that contains the resources you want to inject:
 
-. When creating a pod configuration, use the `spec.volumes.downwardAPI.items`
-field to describe the desired resources that correspond to the
-`spec.resources` field:
+.. Create a `pod.yaml` file similar to the following:
 +
 [source,yaml]
 ----
-....
+apiVersion: v1
+kind: Pod
+metadata:
+  name: dapi-env-test-pod
 spec:
   containers:
     - name: client-container
@@ -56,13 +67,10 @@ spec:
             resourceFieldRef:
               containerName: client-container
               resource: requests.memory
-....
+# ...
 ----
-+
-If the resource limits are not included in the container configuration, the
-Downward API defaults to the node's CPU and memory allocatable values.
 
-. Create the pod from the `*_volume-pod.yaml_*` file:
+.. Create the pod from the `*_volume-pod.yaml_*` file:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-secrets.adoc
+++ b/modules/nodes-containers-downward-api-container-secrets.adoc
@@ -12,7 +12,9 @@ for specific environments.
 
 .Procedure
 
-. Create a `secret.yaml` file:
+. Create a secret to inject:
+
+.. Create a `secret.yaml` file similar to the following:
 +
 [source,yaml]
 ----
@@ -26,14 +28,16 @@ data:
 type: kubernetes.io/basic-auth
 ----
 
-. Create a `Secret` object from the `secret.yaml` file:
+.. Create the secret object from the `secret.yaml` file:
 +
 [source,terminal]
 ----
 $ oc create -f secret.yaml
 ----
 
-. Create a `pod.yaml` file that references the `username` field from the above `Secret` object:
+. Create a pod that references the `username` field from the above `Secret` object:
+
+.. Create a `pod.yaml` file similar to the following:
 +
 [source,yaml]
 ----
@@ -53,16 +57,19 @@ spec:
               name: mysecret
               key: username
   restartPolicy: Never
+# ...
 ----
 
-. Create the pod from the `pod.yaml` file:
+.. Create the pod from the `pod.yaml` file:
 +
 [source,terminal]
 ----
 $ oc create -f pod.yaml
 ----
 
-. Check the container's logs for the `MY_SECRET_USERNAME` value:
+.Verification
+
+* Check the container's logs for the `MY_SECRET_USERNAME` value:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-downward-api-container-values-envars.adoc
+++ b/modules/nodes-containers-downward-api-container-values-envars.adoc
@@ -20,9 +20,9 @@ supported using environment variables are:
 
 .Procedure
 
-To use environment variables
+. Create a new pod spec that contains the environment variables you want the container to consume:
 
-. Create a `pod.yaml` file:
+.. Create a `pod.yaml` file similar to the following:
 +
 [source,yaml]
 ----
@@ -45,16 +45,19 @@ spec:
             fieldRef:
               fieldPath: metadata.namespace
   restartPolicy: Never
+# ...
 ----
 
-. Create the pod from the `pod.yaml` file:
+.. Create the pod from the `pod.yaml` file:
 +
 [source,terminal]
 ----
 $ oc create -f pod.yaml
 ----
 
-. Check the container's logs for the `MY_POD_NAME` and `MY_POD_NAMESPACE`
+.Verification
+
+* Check the container's logs for the `MY_POD_NAME` and `MY_POD_NAMESPACE`
 values:
 +
 [source,terminal]

--- a/modules/nodes-containers-downward-api-container-values-plugin.adoc
+++ b/modules/nodes-containers-downward-api-container-values-plugin.adoc
@@ -22,7 +22,9 @@ Containers can consume:
 
 To use the volume plugin:
 
-. Create a `volume-pod.yaml` file:
+. Create a new pod spec that contains the environment variables you want the container to consume:
+
+.. Create a `volume-pod.yaml` file similar to the following:
 +
 [source,yaml]
 ----
@@ -64,16 +66,19 @@ spec:
           fieldPath: metadata.annotations
         path: pod_annotations
   restartPolicy: Never
+# ...
 ----
 
-. Create the pod from the `volume-pod.yaml` file:
+.. Create the pod from the `volume-pod.yaml` file:
 +
 [source,terminal]
 ----
 $ oc create -f volume-pod.yaml
 ----
 
-. Check the container's logs and verify the presence of the configured fields:
+.Verification
+
+* Check the container's logs and verify the presence of the configured fields:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-init-creating.adoc
+++ b/modules/nodes-containers-init-creating.adoc
@@ -10,7 +10,9 @@ The following example outlines a simple pod which has two Init Containers. The f
 
 .Procedure
 
-. Create a YAML file for the Init Container:
+. Create the pod for the Init Container:
+
+.. Create a YAML file similar to the following:
 +
 [source,yaml]
 ----
@@ -32,9 +34,35 @@ spec:
   - name: init-mydb
     image: registry.access.redhat.com/ubi9/ubi:latest
     command: ['sh', '-c', 'until getent hosts mydb; do echo waiting for mydb; sleep 2; done;']
+# ...
 ----
 
-. Create a YAML file for the `myservice` service.
+.. Create the pod:
++
+[source,terminal]
+----
+$ oc create -f myapp.yaml
+----
+
+.. View the status of the pod:
++
+[source,terminal]
+----
+$ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          READY     STATUS              RESTARTS   AGE
+myapp-pod                     0/1       Init:0/2            0          5s
+----
++
+The pod status, `Init:0/2`, indicates it is waiting for the two services.
+
+. Create the `myservice` service.
+
+.. Create a YAML file similar to the following:
 +
 [source,yaml]
 ----
@@ -49,7 +77,32 @@ spec:
     targetPort: 9376
 ----
 
-. Create a YAML file for the `mydb` service.
+.. Create the pod:
++
+[source,terminal]
+----
+$ oc create -f myservice.yaml
+----
+
+.. View the status of the pod:
++
+[source,terminal]
+----
+$ oc get pods
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          READY     STATUS              RESTARTS   AGE
+myapp-pod                     0/1       Init:1/2            0          5s
+----
++
+The pod status, `Init:1/2`, indicates it is waiting for one service, in this case the `mydb` service.
+
+. Create the `mydb` service:
+
+.. Create a YAML file similar to the following:
 +
 [source,yaml]
 ----
@@ -64,48 +117,14 @@ spec:
     targetPort: 9377
 ----
 
-. Run the following command to create the `myapp-pod`:
-+
-[source,terminal]
-----
-$ oc create -f myapp.yaml
-----
-+
-.Example output
-[source,terminal]
-----
-pod/myapp-pod created
-----
-
-. View the status of the pod:
-+
-[source,terminal]
-----
-$ oc get pods
-----
-+
-.Example output
-[source,terminal]
-----
-NAME                          READY     STATUS              RESTARTS   AGE
-myapp-pod                     0/1       Init:0/2            0          5s
-----
-+
-Note that the pod status indicates it is waiting
-
-. Run the following commands to create the services:
+.. Create the pod:
 +
 [source,terminal]
 ----
 $ oc create -f mydb.yaml
 ----
-+
-[source,terminal]
-----
-$ oc create -f myservice.yaml
-----
 
-. View the status of the pod:
+.. View the status of the pod:
 +
 [source,terminal]
 ----
@@ -118,3 +137,5 @@ $ oc get pods
 NAME                          READY     STATUS              RESTARTS   AGE
 myapp-pod                     1/1       Running             0          2m
 ----
++
+The pod status indicated that it is no longer waiting for the services and is running. 

--- a/modules/nodes-containers-projected-volumes-creating.adoc
+++ b/modules/nodes-containers-projected-volumes-creating.adoc
@@ -10,11 +10,41 @@ When creating projected volumes, consider the volume file path situations descri
 
 The following example shows how to use a projected volume to mount an existing secret volume source. The steps can be used to create a user name and password secrets from local files. You then create a pod that runs one container, using a projected volume to mount the secrets into the same shared directory.
 
+The user name and password values can be any valid string that is *base64* encoded.
+
+The following example shows `admin` in base64:
+
+[source,terminal]
+----
+$ echo -n "admin" | base64
+----
+
+.Example output
+[source,terminal]
+----
+YWRtaW4=
+----
+
+The following example shows the password `1f2d1e2e67df` in base64:
+
+[source,terminal]
+----
+$ echo -n "1f2d1e2e67df" | base64
+----
+
+.Example output
+[source,terminal]
+----
+MWYyZDFlMmU2N2Rm
+----
+
 .Procedure
 
 To use a projected volume to mount an existing secret volume source.
 
-. Create files containing the secrets, entering the following, replacing the password and user information as appropriate:
+. Create the secret: 
+
+.. Create a YAML file similar to the following, replacing the password and user information as appropriate:
 +
 [source,yaml]
 ----
@@ -28,35 +58,7 @@ data:
   user: YWRtaW4=
 ----
 +
-The `user` and `pass` values can be any valid string that is *base64* encoded.
-+
-The following example shows `admin` in base64:
-+
-[source,terminal]
-----
-$ echo -n "admin" | base64
-----
-+
-.Example output
-[source,terminal]
-----
-YWRtaW4=
-----
-+
-The following example shows the password `1f2d1e2e67df` in base64:.
-+
-[source,terminal]
-----
-$ echo -n "1f2d1e2e67df" | base64
-----
-+
-.Example output
-[source,terminal]
-----
-MWYyZDFlMmU2N2Rm
-----
-
-. Use the following command to create the secrets:
+.. Use the following command to create the secret:
 +
 [source,terminal]
 ----
@@ -76,7 +78,7 @@ $ oc create -f secret.yaml
 secret "mysecret" created
 ----
 
-. You can check that the secret was created using the following commands:
+.. You can check that the secret was created using the following commands:
 +
 [source,terminal]
 ----
@@ -126,11 +128,12 @@ metadata:
 type: Opaque
 ----
 
-. Create a pod configuration file similar to the following that includes a `volumes` section:
+. Create a pod with a projected volume.
+
+.. Create a YAML file similar to the following, including a `volumes` section:
 +
 [source,yaml]
 ----
-apiVersion: v1
 kind: Pod
 metadata:
   name: test-projected-volume
@@ -145,18 +148,21 @@ spec:
     - name: all-in-one
       mountPath: "/projected-volume"
       readOnly: true
+      securityContext:
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
   volumes:
   - name: all-in-one
     projected:
       sources:
-      - secret:      <1>
-          name: user
-      - secret:      <1>
-          name: pass
+      - secret:
+          name: mysecret <1>
 ----
 <1> The name of the secret you created.
 
-. Create the pod from the configuration file:
+.. Create the pod from the configuration file:
 +
 [source,terminal]
 ----

--- a/modules/nodes-containers-remote-commands-about.adoc
+++ b/modules/nodes-containers-remote-commands-about.adoc
@@ -14,7 +14,7 @@ To run a command in a container:
 
 [source,terminal]
 ----
-$ oc exec <pod> [-c <container>] <command> [<arg_1> ... <arg_n>]
+$ oc exec <pod> [-c <container>] -- <command> [<arg_1> ... <arg_n>]
 ----
 
 For example:

--- a/modules/nodes-containers-volumes-subpath.adoc
+++ b/modules/nodes-containers-volumes-subpath.adoc
@@ -10,9 +10,14 @@ You can configure a volume to allows you to share one volume for
 multiple uses in a single pod using the `volumeMounts.subPath` property to specify a `subPath` value inside a volume
 instead of the volume's root.
 
+[NOTE]
+====
+You cannot add a `subPath` parameter to an existing scheduled pod.
+====
+
 .Procedure
 
-. View the list of files in the volume, run the `oc rsh` command:
+. To view the list of files in the volume, run the `oc rsh` command:
 +
 [source,terminal]
 ----

--- a/snippets/nodes-cluster-enabling-features-verification.adoc
+++ b/snippets/nodes-cluster-enabling-features-verification.adoc
@@ -33,11 +33,11 @@ sh-4.2# cat /etc/kubernetes/kubelet.conf
 +
 [source,terminal]
 ----
- ...
+# ...
 featureGates:
   InsightsOperatorPullingSCA: true,
   LegacyNodeRoleBehavior: false
- ...
+# ...
 ----
 +
 The features that are listed as `true` are enabled on your cluster.


### PR DESCRIPTION
Fixing various errors in the Nodes -> Container docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

Previews:
[Understanding how to copy files](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-copying-files.html#nodes-containers-copying-files-about_nodes-containers-copying-files) -- Fixed the definition list formatting. No new text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-copying-files.html#nodes-containers-copying-files-about_nodes-containers-copying-files).
[Copying files to and from containers](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-copying-files.html#nodes-containers-copying-files-procedure_nodes-containers-copying-files) --  Fixed the definition list formatting.  No new text. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-copying-files.html#nodes-containers-copying-files-procedure_nodes-containers-copying-files)
[Using advanced Rsync features](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-copying-files.html#nodes-containers-copying-files-rsync_nodes-containers-copying-files) -- Made code examples consistent with the rest of the assembly. ~~**NEED QE** for this change.~~ 
[Consuming configuration maps using the Downward API](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-configmaps_nodes-containers-downward-api) -- Changed steps to include sub-steps. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-configmaps_nodes-containers-downward-api).
[Referencing environment variables](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-envars_nodes-containers-downward-api) -- Changed steps to include sub-steps. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-envars_nodes-containers-downward-api) 
[Escaping environment variable references](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-escaping_nodes-containers-downward-api) -- Changed steps to include sub-steps. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-escaping_nodes-containers-downward-api)
[Consuming container resources using environment variables](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-resources-envars_nodes-containers-downward-api) -- Changed steps to include sub-steps; moved some text from the procedure steps to intro. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-resources-envars_nodes-containers-downward-api).
[Consuming container resources using a volume plugin](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-resources-plugin_nodes-containers-downward-api) --  -- Changed steps to include sub-steps; moved some text from the procedure steps to intro. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-resources-plugin_nodes-containers-downward-api)
[Consuming secrets using the Downward API](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-secrets_nodes-containers-downward-api) -- Changed steps to include sub-steps. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-secrets_nodes-containers-downward-api)
[Consuming container values using environment variables](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-values-envars_nodes-containers-downward-api) -- Changed steps to include sub-steps.  [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-values-envars_nodes-containers-downward-api)[
Consuming container values using a volume plugin](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-values-plugin_nodes-containers-downward-api) -- Changed steps to include sub-steps. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-downward-api.html#nodes-containers-downward-api-container-values-plugin_nodes-containers-downward-api)
[Creating Init Containers](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-init.html#nodes-containers-init-creating_nodes-containers-init) -- Changed steps to include sub-steps; moved some sub-steps for better flow; added command output. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-init.html#nodes-containers-init-creating_nodes-containers-init).
[Configuring a Projected Volume for a Pod](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-projected-volumes.html#nodes-containers-projected-volumes-creating_nodes-containers-projected-volumes) -- Changed steps to include sub-steps; moved base-64 info from the procedure to the intro, [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-projected-volumes.html#nodes-containers-projected-volumes-creating_nodes-containers-projected-volumes).
[Executing remote commands in containers](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-remote-commands.html#nodes-containers-remote-commands-about_nodes-containers-remote-commands) -- Fixed a command example. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-remote-commands.html#nodes-containers-remote-commands-about_nodes-containers-remote-commands)
[Configuring volumes for multiple uses in a pod](https://62704--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-volumes.html#nodes-containers-volumes-subpath_nodes-containers-volumes) -- Added note about not being able to edit a pod spec. ~~**NEED QE** for this change.~~