### PR TITLE
OADP-2134: correcting format of DPA

### DIFF
--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -8,7 +8,9 @@
 
 :FeatureName: Data Mover for CSI snapshots
 
-The OADP Data Mover enables customers to back up Container Storage Interface (CSI) volume snapshots to a remote object store. When Data Mover is enabled, you can restore stateful applications, using CSI volume snapshots pulled from the object store if a failure, accidental deletion, or corruption of the cluster occurs.
+The OADP Data Mover enables customers to back up Container Storage Interface (CSI) volume snapshots to a remote object store.
+
+When Data Mover is enabled, you can restore stateful applications, using CSI volume snapshots pulled from the object store if a failure, accidental deletion, or corruption of the cluster occurs.
 
 The Data Mover solution uses the Restic option of VolSync.
 
@@ -75,7 +77,7 @@ The VolSync Operator is required for using OADP Data Mover.
 
 .Procedure
 
-. Configure a Restic secret by creating a `.yaml` file as following:
+. Configure a Restic secret by creating a `.yaml` file:
 +
 [source,yaml]
 ----
@@ -83,18 +85,19 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: <secret_name>
-  namespace: openshift-adp
 type: Opaque
 stringData:
-  RESTIC_PASSWORD: <secure_restic_password>
+# The repository encryption key
+  RESTIC_PASSWORD: my-secure-restic-password
 ----
++
+. Create a DPA CR similar to the following example. The default plugins include CSI.
+. Add the restic secret name from the step above to your DPA CR as `spec.features.dataMover.credentialName`. If this step is not completed, then it will default to the secret name `dm-credential`.
 +
 [NOTE]
 ====
-By default, the Operator looks for a secret named `dm-credential`. If you are using a different name, you need to specify the name through a Data Protection Application (DPA) CR using `dpa.spec.features.dataMover.credentialName`.
+In this DPA, the `CSI` and `VSM` are included as `defaultPlugins`. Also included is the `dataMover.enable` flag.
 ====
-
-. Create a DPA CR similar to the following example. The default plugins include CSI.
 +
 .Example Data Protection Application (DPA) CR
 [source,yaml]
@@ -105,6 +108,19 @@ metadata:
   name: velero-sample
   namespace: openshift-adp
 spec:
+  features:
+    dataMover:
+      enable: true
+      credentialName: <secret-name>
+      maxConcurrentBackupVolumes: "3" <1>
+      maxConcurrentRestoreVolumes: "3" <2>
+      pruneInterval: "14" <3>
+      volumeOptionsForStorageClasses: <4>
+        gp2-csi-copy-1:
+          destinationVolumeOptions:
+            storageClassName: csi-copy-2
+          sourceVolumeOptions:
+            storageClassName: csi-copy-1 
   backupLocations:
     - velero:
         config:
@@ -120,42 +136,19 @@ spec:
         provider: aws
   configuration:
     restic:
-      enable: <true_or_false>
+      enable: false
     velero:
-       itemOperationSyncFrequency: "10s"
-       defaultPlugins:
+      defaultPlugins:
         - openshift
         - aws
         - csi
-        - vsm <1>
-  features:
-    dataMover:
-      credentialName: restic-secret
-      enable: true
-      maxConcurrentBackupVolumes: "3" <2>
-      maxConcurrentRestoreVolumes: "3" <3>
-      pruneInterval: "14" <4>
-      volumeOptions: <5>
-      sourceVolumeOptions:
-          accessMode: ReadOnlyMany
-          cacheAccessMode: ReadWriteOnce
-          cacheCapacity: 2Gi
-      destinationVolumeOptions:
-          storageClass: other-storageclass-name
-          cacheAccessMode: ReadWriteMany
-  snapshotLocations:
-    - velero:
-        config:
-          profile: default
-          region: us-west-2
-        provider: aws
-
+        - vsm <5>
 ----
-<1> OADP 1.2 only.
-<2> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for backup. The default value is 10.
-<3> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for restore. The default value is 10.
-<4> OADP 1.2 only. Optional: Specify the number of days, between running Restic pruning on the repository. The prune operation repacks the data to free space, but it can also generate significant I/O traffic as a part of the process. Setting this option allows a trade-off between storage consumption, from no longer referenced data, and access costs.
-<5> OADP 1.2 only. Optional: Specify VolumeSync volume options for backup and restore.
+<1> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for backup. The default value is 10.
+<2> OADP 1.2 only. Optional: Specify the upper limit of the number of snapshots allowed to be queued for restore. The default value is 10.
+<3> OADP 1.2 only. Optional: Specify the number of days, between running Restic pruning on the repository. The prune operation repacks the data to free space, but it can also generate significant I/O traffic as a part of the process. Setting this option allows a trade-off between storage consumption, from no longer referenced data, and access costs.
+<4> OADP 1.2 only. Optional: Specify VolumeSync volume options for backup and restore.
+<5> OADP 1.2 only.
 
 +
 The OADP Operator installs two custom resource definitions (CRDs), `VolumeSnapshotBackup` and `VolumeSnapshotRestore`.


### PR DESCRIPTION
OADP 1.2; OCP 4.11+
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[OADP-2134](https://issues.redhat.com/browse/OADP-2134)



Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Enterprise 4.11 → branch/enterprise-4.11
Enterprise 4.12 → branch/enterprise-4.12
Enterprise 4.13 → branch/enterprise-4.13
Enterprise 4.14 → branch/enterprise-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[OADP-2134](https://issues.redhat.com/browse/OADP-2134)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[Using Data Mover for CSI snapshots](https://62706--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-using-data-mover-for-csi-snapshots_backing-up-applications)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
