### PR TITLE
ROX-18622: Add doc entry for custom TLS certificates when using operator

### DIFF
--- a/modules/custom-cert-existing.adoc
+++ b/modules/custom-cert-existing.adoc
@@ -8,6 +8,16 @@
 
 .Procedure
 
+* If you have installed {product-title} using the Operator:
++
+. Create a `central-default-tls-cert` secret that contains the appropriate TLS certificates in the namespace where the Central service is installed by entering the following command:
++
+
+[source,terminal]
+----
+oc -n <namespace> create secret tls central-default-tls-cert --cert <tls-cert.pem> --key <tls-key.pem>
+----
+
 * If you have installed {product-title} using Helm:
 +
 . Add your custom certificate and its key in the `values-private.yaml` file:

--- a/modules/custom-cert-new-install.adoc
+++ b/modules/custom-cert-new-install.adoc
@@ -8,6 +8,14 @@
 
 .Procedure
 
+* If you are installing {product-title} using the Operator:
++
+. Create a `central-default-tls-cert` secret that contains the appropriate TLS certificates in the namespace where the Central service will be installed by entering the following command:
++
+[source,terminal]
+----
+oc -n <namespace> create secret tls central-default-tls-cert --cert <tls-cert.pem> --key <tls-key.pem>
+----
 * If you are installing {product-title} using Helm:
 +
 . Add your custom certificate and its key in the `values-private.yaml` file:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Merge to rhacs-docs; cherry pick to rhacs-docs-4.1, rhacs-docs-4.2, rhacs-docs-4.3

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[ROX-18622](https://issues.redhat.com/browse/ROX-18622)

[Link to docs preview
](https://62708--docspreview.netlify.app/openshift-acs/latest/configuration/add-custom-certificates.html#custom-cert-existing_add-custom-cert)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
