### PR TITLE
Updated kubevirt metrics names

### DIFF
--- a/modules/virt-live-migration-metrics.adoc
+++ b/modules/virt-live-migration-metrics.adoc
@@ -8,19 +8,18 @@
 
 The following metrics can be queried to show live migration status:
 
-`kubevirt_migrate_vmi_data_processed_bytes`:: The amount of guest operating system data that has migrated to the new virtual machine (VM). Type: Gauge.
+`kubevirt_vmi_migration_data_processed_bytes`:: The amount of guest operating system data that has migrated to the new virtual machine (VM). Type: Gauge.
 
-`kubevirt_migrate_vmi_data_remaining_bytes`:: The amount of guest operating system data that remains to be migrated. Type: Gauge.
+`kubevirt_vmi_migration_data_remaining_bytes`:: The amount of guest operating system data that remains to be migrated. Type: Gauge.
 
-`kubevirt_migrate_vmi_dirty_memory_rate_bytes`:: The rate at which memory is becoming dirty in the guest operating system. Dirty memory is data that has been changed but not yet written to disk. Type: Gauge.
+`kubevirt_vmi_migration_memory_transfer_rate_bytes`:: The rate at which memory is becoming dirty in the guest operating system. Dirty memory is data that has been changed but not yet written to disk. Type: Gauge.
 
-`kubevirt_migrate_vmi_pending_count`:: The number of pending migrations. Type: Gauge.
+`kubevirt_vmi_migrations_in_pending_phase`:: The number of pending migrations. Type: Gauge.
 
-`kubevirt_migrate_vmi_scheduling_count`:: The number of scheduling migrations. Type: Gauge.
+`kubevirt_vmi_migrations_in_scheduling_phase`:: The number of scheduling migrations. Type: Gauge.
 
-`kubevirt_migrate_vmi_running_count`:: The number of running migrations. Type: Gauge.
+`kubevirt_vmi_migrations_in_running_phase`:: The number of running migrations. Type: Gauge.
 
-`kubevirt_migrate_vmi_succeeded`:: The number of successfully completed migrations. Type: Gauge.
+`kubevirt_vmi_migration_succeeded`:: The number of successfully completed migrations. Type: Gauge.
 
-`kubevirt_migrate_vmi_failed`:: The number of failed migrations. Type: Gauge.
-
+`kubevirt_vmi_migration_failed`:: The number of failed migrations. Type: Gauge.

--- a/modules/virt-querying-metrics.adoc
+++ b/modules/virt-querying-metrics.adoc
@@ -17,7 +17,7 @@ The following examples use `topk` queries that specify a time period. If virtual
 
 The following query can identify virtual machines that are waiting for Input/Output (I/O):
 
-`kubevirt_vmi_vcpu_wait_seconds`::
+`kubevirt_vmi_vcpu_wait_seconds_total`::
 Returns the wait time (in seconds) for a virtual machine's vCPU. Type: Counter.
 
 A value above '0' means that the vCPU wants to run, but the host scheduler cannot run it yet. This inability to run indicates that there is an issue with I/O.
@@ -30,7 +30,7 @@ To query the vCPU metric, the `schedstats=enable` kernel argument must first be 
 .Example vCPU wait time query
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (rate(kubevirt_vmi_vcpu_wait_seconds[6m]))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_vcpu_wait_seconds_total[6m]))) > 0 <1>
 ----
 <1> This query returns the top 3 VMs waiting for I/O at every given moment over a six-minute time period.
 
@@ -76,7 +76,7 @@ topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_read_traffic_bytes_t
 [id="virt-storage-snapshot-data_{context}"]
 === Storage snapshot data
 
-`kubevirt_vmsnapshot_disks_restored_from_source_total`::
+`kubevirt_vmsnapshot_disks_restored_from_source`::
 Returns the total number of virtual machine disks restored from the source virtual machine. Type: Gauge.
 
 `kubevirt_vmsnapshot_disks_restored_from_source_bytes`::
@@ -85,7 +85,7 @@ Returns the amount of space in bytes restored from the source virtual machine. T
 .Examples of storage snapshot data queries
 [source,promql]
 ----
-kubevirt_vmsnapshot_disks_restored_from_source_total{vm_name="simple-vm", vm_namespace="default"} <1>
+kubevirt_vmsnapshot_disks_restored_from_source{vm_name="simple-vm", vm_namespace="default"} <1>
 ----
 <1> This query returns the total number of virtual machine disks restored from the source virtual machine.
 
@@ -118,16 +118,16 @@ topk(3, sum by (name, namespace) (rate(kubevirt_vmi_storage_iops_read_total[6m])
 
 The following queries can identify which swap-enabled guests are performing the most memory swapping:
 
-`kubevirt_vmi_memory_swap_in_traffic_bytes_total`::
+`kubevirt_vmi_memory_swap_in_traffic_bytes`::
 Returns the total amount (in bytes) of memory the virtual guest is swapping in. Type: Gauge.
 
-`kubevirt_vmi_memory_swap_out_traffic_bytes_total`::
+`kubevirt_vmi_memory_swap_out_traffic_bytes`::
 Returns the total amount (in bytes) of memory the virtual guest is swapping out. Type: Gauge.
 
 .Example memory swapping query
 [source,promql]
 ----
-topk(3, sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes_total[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_out_traffic_bytes_total[6m]))) > 0 <1>
+topk(3, sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_in_traffic_bytes[6m])) + sum by (name, namespace) (rate(kubevirt_vmi_memory_swap_out_traffic_bytes[6m]))) > 0 <1>
 ----
 <1> This query returns the top 3 VMs where the guest is performing the most memory swapping at every given moment over a six-minute time period.
 


### PR DESCRIPTION
Updated kubevirt metrics names:

kubevirt_vmi_vcpu_wait_seconds to kubevirt_vmi_vcpu_wait_seconds_total

kubevirt_vmsnapshot_disks_restored_from_source_total to kubevirt_vmsnapshot_disks_restored_from_source

kubevirt_vmi_memory_swap_in_traffic_bytes_total to kubevirt_vmi_memory_swap_in_traffic_bytes

kubevirt_vmi_memory_swap_out_traffic_bytes_total to kubevirt_vmi_memory_swap_out_traffic_bytes

kubevirt_migrate_vmi_data_processed_bytes to kubevirt_vmi_migration_data_processed_bytes

kubevirt_migrate_vmi_data_remaining_bytes to kubevirt_vmi_migration_data_remaining_bytes

kubevirt_migrate_vmi_dirty_memory_rate_bytes to kubevirt_vmi_migration_memory_transfer_rate_bytes

kubevirt_migrate_vmi_pending_count to kubevirt_vmi_migrations_in_pending_phase

kubevirt_migrate_vmi_scheduling_count to kubevirt_vmi_migrations_in_scheduling_phase

kubevirt_migrate_vmi_running_count to kubevirt_vmi_migrations_in_running_phase

kubevirt_migrate_vmi_succeeded to kubevirt_vmi_migration_succeeded

kubevirt_migrate_vmi_failed to kubevirt_vmi_migration_failed

Based on PR https://github.com/kubevirt/kubevirt/pull/9821

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
