### PR TITLE
Fixed missing callout errors

### DIFF
--- a/modules/declarative-configuration-examples.adoc
+++ b/modules/declarative-configuration-examples.adoc
@@ -103,7 +103,7 @@ rules:
     clusterLabelSelectors:
         - requirements:
             key: kubernetes.io/metadata.name
-            operator: IN
+            operator: IN <3>
             values:
             - production
             - staging

--- a/modules/install-central-operator.adoc
+++ b/modules/install-central-operator.adoc
@@ -37,9 +37,9 @@ spec:
   central:
     declarativeConfiguration:
       configMaps:
-      - name: "declarative-configs"
+      - name: "<declarative-configs>" <1>
       secrets:
-      - name: "sensitive-declarative-configs"
+      - name: "<sensitive-declarative-configs>" <2>
 ...
 ----
 <1> Replace <declarative-configs> with the name of the config maps that you are using.


### PR DESCRIPTION
Fixes the following AsciiDoctor errors in the `rhacs-docs` builds:
```
asciidoctor: WARNING: modules/install-central-operator.adoc: line 45: no callout found for <1>
asciidoctor: WARNING: modules/install-central-operator.adoc: line 46: no callout found for <2>
asciidoctor: WARNING: modules/declarative-configuration-examples.adoc: line 114: no callout found for <3>
```

- Cherry pick to `rhacs-docs-4.1`

Preview:
- https://62712--docspreview.netlify.app/openshift-acs/latest/configuration/declarative-configuration-using.html#declarative-config-example-access-scope
- https://62712--docspreview.netlify.app/openshift-acs/latest/installing/installing_ocp/install-central-ocp.html#install-central-operator_install-central-ocp

