### PR TITLE
WIP PR for SRVKS-977 & SRVCOM-1884: Wrong container image used in serverless documentation example

### DIFF
--- a/modules/creating-serverless-apps-yaml.adoc
+++ b/modules/creating-serverless-apps-yaml.adoc
@@ -24,17 +24,16 @@ After the service is created and the application is deployed, Knative creates an
 ----
 apiVersion: serving.knative.dev/v1
 kind: Service
-metadata:
-  name: event-delivery
-  namespace: default
-spec:
-  template:
-    spec:
-      containers:
-        - image: quay.io/openshift-knative/knative-eventing-sources-event-display:latest
-          env:
-            - name: RESPONSE
-              value: "Hello Serverless!"
+metadata: 
+  name: showcase
+spec: 
+  template: 
+    spec: 
+      containers: 
+      - image: quay.io/openshift-knative/showcase
+        env: 
+        - name: GREET
+          value: Bonjour
 ----
 . Navigate to the directory where the YAML file is contained, and deploy the application by applying the YAML file:
 +

--- a/modules/verifying-serverless-app-deployment.adoc
+++ b/modules/verifying-serverless-app-deployment.adoc
@@ -30,55 +30,55 @@ $ oc get ksvc <service_name>
 .Example output
 [source,terminal]
 ----
-NAME            URL                                        LATESTCREATED         LATESTREADY           READY   REASON
-event-delivery   http://event-delivery-default.example.com   event-delivery-4wsd2   event-delivery-4wsd2   True
+NAME       URL                                   LATESTCREATED    LATESTREADY      READY   REASON
+showcase   http://showcase-default.example.com   showcase-00001   showcase-00001   True
 ----
 . Make a request to your cluster and observe the output.
 +
-.Example HTTP request
+.Example HTTP request (using HTTPie tool)
 [source,terminal]
 ----
-$ curl http://event-delivery-default.example.com
+$ curl http://showcase-default.example.com
 ----
 +
 .Example HTTPS request
 [source,terminal]
 ----
-$ curl https://event-delivery-default.example.com
+$ curl https://showcase-default.example.com
 ----
 +
 .Example output
 [source,terminal]
 ----
-Hello Serverless!
+Bonjour
 ----
-. Optional. If you receive an error relating to a self-signed certificate in the certificate chain, you can add the `--insecure` flag to the curl command to ignore the error:
+. Optional: If you receive an error relating to a self-signed certificate in the certificate chain, you can add the `--insecure` flag to the curl command to ignore the error:
 +
 [source,terminal]
 ----
-$ curl https://event-delivery-default.example.com --insecure
+$ curl https://showcase-default.example.com --insecure
 ----
 +
 .Example output
 [source,terminal]
 ----
-Hello Serverless!
+Bonjour
 ----
 +
 [IMPORTANT]
 ====
 Self-signed certificates must not be used in a production deployment. This method is only for testing purposes.
 ====
-. Optional. If your {ocp-product-title} cluster is configured with a certificate that is signed by a certificate authority (CA) but not yet globally configured for your system, you can specify this with the `curl` command.
+. Optional: If your {ocp-product-title} cluster is configured with a certificate that is signed by a certificate authority (CA) but not yet globally configured for your system, you can specify this with the `curl` command.
 The path to the certificate can be passed to the curl command by using the `--cacert` flag:
 +
 [source,terminal]
 ----
-$ curl https://event-delivery-default.example.com --cacert <file>
+$ curl https://showcase-default.example.com --cacert <file>
 ----
 +
 .Example output
 [source,terminal]
 ----
-Hello Serverless!
+Bonjour
 ----


### PR DESCRIPTION
**Affected versions for cherry-picking:** serverless-docs 1.28+

**Dedicated JIRAs:** 
- https://issues.redhat.com/browse/SRVKS-1004
- https://issues.redhat.com/browse/SRVCOM-1884

**Description:** 

Made the changes in the following sections: 
- **Creating serverless applications using YAML**: Changed the YAML file 
- **Verifying your serverless application deployment**: Changed the verification steps 

**Doc preview:** 

- [Creating serverless applications using YAML](https://62713--docspreview.netlify.app/openshift-serverless/latest/knative-serving/getting-started/serverless-applications.html#creating-serverless-apps-yaml_serverless-applications)
- [Verifying your serverless application deployment](https://62713--docspreview.netlify.app/openshift-serverless/latest/knative-serving/getting-started/verifying-application-deployment.html#verifying-serverless-app-deployment_verifying-application-deployment)


**Reviews:** 
- SME: 
- QE: 
- Peer review: 