### PR TITLE
OCPBUGS-123: Update LSO install channel

### DIFF
--- a/modules/persistent-storage-local-install.adoc
+++ b/modules/persistent-storage-local-install.adoc
@@ -68,15 +68,6 @@ Once finished, the Local Storage Operator will be listed in the *Installed Opera
 .From the CLI
 . Install the Local Storage Operator from the CLI.
 
-.. Run the following command to get the {product-title} major and minor version. It is required for the `channel` value in the next
-step.
-+
-[source,terminal]
-----
-$ OC_VERSION=$(oc version -o yaml | grep openshiftVersion | \
-    grep -o '[0-9]*[.][0-9]*' | head -1)
-----
-
 .. Create an object YAML file to define an Operator group and subscription for the Local Storage Operator,
 such as `openshift-local-storage.yaml`:
 +
@@ -98,7 +89,7 @@ metadata:
   name: local-storage-operator
   namespace: openshift-local-storage
 spec:
-  channel: "${OC_VERSION}"
+  channel: stable
   installPlanApproval: Automatic <1>
   name: local-storage-operator
   source: redhat-operators


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

**Version(s):**
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11+

**Issue:**
https://issues.redhat.com/browse/OCPBUGS-123

<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
We renamed the local storage operator install channel to `stable` from 4.11.

<!---Link to docs preview: --->
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
