### PR TITLE
OSDOCS-5864: Refined datastore cluster capability in vSphere docs

### DIFF
--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -326,6 +326,13 @@ After you create the installation configuration file, you can modify the file to
 ====
 
 ... Select the default vCenter datastore to use.
++
+[WARNING]
+====
+You can specify the path of any datastore that exists in a datastore cluster. By default, Storage Distributed Resource Scheduler (SDRS), which uses Storage vMotion, is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable Storage DRS to avoid data loss issues for your {product-title} cluster.
+
+You cannot specify more than one datastore path. If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
+====
 ... Select the vCenter cluster to install the {product-title} cluster in. The installation program uses the root resource pool of the vSphere cluster as the default resource pool.
 ... Select the network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 ... Enter the virtual IP address that you configured for control plane API access.

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -44,7 +44,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <9>
+  networkType: OVNKubernetes <10>
   serviceNetwork:
   - 172.30.0.0/16
 endif::network[]
@@ -59,10 +59,10 @@ platform:
       topology:
         computeCluster: "/<datacenter>/host/<cluster>"
         datacenter: <datacenter>
-        datastore: "/<datacenter>/datastore/<datastore>"
+        datastore: "/<datacenter>/datastore/<datastore>" <7>
         networks:
         - <VM_Network_name>
-        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <7>
+        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <8>
         folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>"
       zone: <default_zone_name>
     ingressVIPs:
@@ -74,9 +74,9 @@ platform:
       port: 443
       server: <fully_qualified_domain_name>
       user: administrator@vsphere.local
-    diskType: thin <8>
+    diskType: thin <9>
 ifdef::restricted[]
-    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <9>
+    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <10>
 endif::restricted[]
 ifndef::openshift-origin[]
 fips: false
@@ -85,15 +85,15 @@ ifndef::restricted[]
 pullSecret: '{"auths": ...}'
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <10>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <11>
 endif::restricted[]
 sshKey: 'ssh-ed25519 AAAA...'
 ifdef::restricted[]
-additionalTrustBundle: | <11>
+additionalTrustBundle: | <12>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <12>
+imageContentSources: <13>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -112,21 +112,29 @@ to increase the performance of your machines' cores. You can disable it by setti
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Your machines must use at least 8 CPUs and 32 GB of RAM if you disable simultaneous multithreading.
 ====
 <4> The cluster name that you specified in your DNS records.
-<5> Optional parameter for providing additional configuration for the machine pool parameters for the compute and control plane machines.
+<5> Optional: Provides additional configuration for the machine pool parameters for the compute and control plane machines.
 <6> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-<7> Optional parameter for providing an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
-<8> The vSphere disk provisioning method.
+<7> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images. 
++
+[IMPORTANT]
+====
+You can specify the path of any datastore that exists in a datastore cluster. By default, Storage vMotion is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
+
+If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
+====
+<8> Optional: Provides an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
+<9> The vSphere disk provisioning method.
 ifdef::network[]
-<9> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
+<10> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
 endif::network[]
 ifdef::restricted[]
-<9> The location of the {op-system-first} image that is accessible from the bastion server.
-<10> For `<local_registry>`, specify the registry domain name, and optionally the
+<10> The location of the {op-system-first} image that is accessible from the bastion server.
+<11> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
-<11> Provide the contents of the certificate file that you used for your mirror registry.
-<12> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<12> Provide the contents of the certificate file that you used for your mirror registry.
+<13> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::restricted[]
 
 [NOTE]

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -51,11 +51,11 @@ platform:
       topology:
         computeCluster: "/<datacenter>/host/<cluster>"
         datacenter: <datacenter> <8>
-        datastore: "/<datacenter>/datastore/<datastore>"
+        datastore: "/<datacenter>/datastore/<datastore>" <9>
         networks:
         - <VM_Network_name>
-        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <9>
-        folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <10>
+        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <10>
+        folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <11>
       zone: <default_zone_name>
     ingressVIPs:
     - 10.0.0.2
@@ -64,42 +64,42 @@ platform:
       - <datacenter>
       password: <password> <12>
       port: 443
-      server: <fully_qualified_domain_name> <11>
+      server: <fully_qualified_domain_name> <13>
       user: administrator@vsphere.local
-    diskType: thin <13>
+    diskType: thin <14>
 ifndef::restricted[]
 ifndef::openshift-origin[]
-fips: false <14>
+fips: false <15>
 endif::openshift-origin[]
 ifndef::openshift-origin[]
+pullSecret: '{"auths": ...}' <16>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
 pullSecret: '{"auths": ...}' <15>
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-pullSecret: '{"auths": ...}' <14>
-endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-fips: false <14>
+fips: false <15>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <16>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
 pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <15>
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <14>
-endif::openshift-origin[]
 endif::restricted[]
 ifndef::openshift-origin[]
-sshKey: 'ssh-ed25519 AAAA...' <16>
+sshKey: 'ssh-ed25519 AAAA...' <17>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: 'ssh-ed25519 AAAA...' <15>
+sshKey: 'ssh-ed25519 AAAA...' <16>
 endif::openshift-origin[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <17>
+additionalTrustBundle: | <18>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <18>
+imageContentSources: <19>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -108,11 +108,11 @@ imageContentSources: <18>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <16>
+additionalTrustBundle: | <17>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <17>
+imageContentSources: <18>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -153,13 +153,21 @@ value must match the number of control plane machines that you deploy.
 <6> The cluster name that you specified in your DNS records.
 <7> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
 <8> The vSphere datacenter.
-<9> Optional parameter. For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
-<10> Optional parameter For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
-<11> The fully-qualified hostname or IP address of the vCenter server.
+<9> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
++
+[IMPORTANT]
+====
+You can specify the path of any datastore that exists in a datastore cluster. By default, Storage vMotion is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable Storage vMotion to avoid data loss issues for your {product-title} cluster.
+
+If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
+====
+<10> Optional: For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
+<11> Optional: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
 <12> The password associated with the vSphere user.
-<13> The vSphere disk provisioning method.
+<13> The fully-qualified hostname or IP address of the vCenter server.
+<14> The vSphere disk provisioning method.
 ifndef::openshift-origin[]
-<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<15> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
@@ -168,13 +176,13 @@ The use of FIPS Validated / Modules in Process cryptographic libraries is only s
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]
-<15> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<16> The public portion of the default SSH key for the `core` user in
+<16> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<17> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<15> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<16> The public portion of the default SSH key for the `core` user in
+<16> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<17> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 +
 [NOTE]
@@ -185,6 +193,19 @@ endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
+<16> For `<local_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
+<17> The public portion of the default SSH key for the `core` user in
+{op-system-first}.
++
+[NOTE]
+====
+For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
+====
+endif::openshift-origin[]
+ifdef::openshift-origin[]
 <15> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
@@ -197,31 +218,18 @@ specify the base64-encoded user name and password for your mirror registry.
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 endif::openshift-origin[]
-ifdef::openshift-origin[]
-<14> For `<local_registry>`, specify the registry domain name, and optionally the
-port, that your mirror registry uses to serve content. For example
-`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
-specify the base64-encoded user name and password for your mirror registry.
-<15> The public portion of the default SSH key for the `core` user in
-{op-system-first}.
-+
-[NOTE]
-====
-For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
-====
-endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<17> Provide the contents of the certificate file that you used for your mirror
+<18> Provide the contents of the certificate file that you used for your mirror
 registry.
-<18> Provide the `imageContentSources` section from the output of the command to
+<19> Provide the `imageContentSources` section from the output of the command to
 mirror the repository.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<16> Provide the contents of the certificate file that you used for your mirror
+<17> Provide the contents of the certificate file that you used for your mirror
 registry.
-<17> Provide the `imageContentSources` section from the output of the command to
+<18> Provide the `imageContentSources` section from the output of the command to
 mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]

--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -393,6 +393,13 @@ For more information about vMotion and anti-affinity rules, see the VMware vSphe
 --
 * If you are using vSphere volumes in your pods, migrating a VM across datastores either manually or through Storage vMotion causes, invalid references within {product-title} persistent volume (PV) objects. These references prevent affected pods from starting up and can result in data loss.
 * Similarly, {product-title} does not support selective migration of VMDKs across datastores, using datastore clusters for VM provisioning or for dynamic or static provisioning of PVs, or using a datastore that is part of a datastore cluster for dynamic or static provisioning of PVs.
++
+[IMPORTANT]
+====
+You can specify the path of any datastore that exists in a datastore cluster. By default, Storage Distributed Resource Scheduler (SDRS), which uses Storage vMotion, is automatically enabled for a datastore cluster. Red Hat does not support Storage vMotion, so you must disable Storage DRS to avoid data loss issues for your {product-title} cluster.
+
+If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
+====
 
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-resources_{context}"]


### PR DESCRIPTION
[OSDOCS-5864](https://issues.redhat.com/browse/OSDOCS-5864)

Version(s):
4.14

Link to docs preview:
* [Sample of vSphere IPI docs](https://62723--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-customizations)
* [Sample of vSphere UPI docs](https://62723--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-vsphere-config-yaml_installing-vsphere)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [Slack chat](https://app.slack.com/client/T027F3GAJ/C05HHFFP9Q9)
