### PR TITLE
RHDEVDOCS-5545: Pipelines 1.10.5 Release Notes

### DIFF
--- a/modules/op-release-notes-1-10.adoc
+++ b/modules/op-release-notes-1-10.adoc
@@ -212,3 +212,20 @@ With this update, {pipelines-title} General Availability (GA) 1.10.4 is availabl
 * Before this update, the `pipelinerun.timeouts` field was reset to the `timeouts.pipeline` value, ignoring the `timeouts.tasks` and `timeouts.finally` values. This update fixes the issue and sets the correct default timeout value for a `PipelineRun` resource.
 
 * Before this update, the controller logs contained unnecessary data. This update fixes the issue.
+
+[id="release-notes-1-10-5_{context}"]
+== Release notes for {pipelines-title} General Availability 1.10.5
+
+With this update, {pipelines-title} General Availability (GA) 1.10.5 is available on {product-title} 4.10 in addition to 4.11, 4.12, and 4.13.
+
+[IMPORTANT]
+====
+{pipelines-title} 1.10.5 is only available in the `pipelines-1.10` channel on {product-title} 4.10, 4.11, 4.12, and 4.13. It is not available in the `latest` channel for any {product-title} version.
+====
+
+[id="fixed-issues-1-10-5_{context}"]
+=== Fixed issues
+
+* Before this update, huge pipeline runs were not getting listed or deleted using the `oc` and `tkn` commands. This update mitigates this issue by compressing the huge annotations that were causing this problem. Remember that if the pipeline runs are still too huge after compression, then the same error still recurs.
+
+* Before this update, only the pod template specified in the `pipelineRun.spec.taskRunSpecs[].podTemplate` object would be considered for a pipeline run. With this update, the pod template specified in the `pipelineRun.spec.podTemplate` object is also considered and merged with the template specified in the `pipelineRun.spec.taskRunSpecs[].podTemplate` object.

--- a/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
+++ b/modules/op-tkn-pipelines-compatibility-support-matrix.adoc
@@ -20,7 +20,7 @@ GA:: General Availability
 | Operator | Pipelines | Triggers | CLI | Catalog | Chains | Hub | {pac} | Results | |
 |1.11 | 0.47.x | 0.24.x | 0.31.x | NA | 0.16.x (GA) | 1.13.x (TP) | 0.19.x (GA) | 0.6.x (TP) | 4.12, 4.13, 4.14 (planned)  | GA
 
-|1.10 | 0.44.x | 0.23.x | 0.30.x | NA | 0.15.x (TP) | 1.12.x (TP) | 0.17.x (GA) | NA | 4.11, 4.12, 4.13  | GA
+|1.10 | 0.44.x | 0.23.x | 0.30.x | NA | 0.15.x (TP) | 1.12.x (TP) | 0.17.x (GA) | NA | 4.10, 4.11, 4.12, 4.13  | GA
 
 |1.9 | 0.41.x | 0.22.x | 0.28.x | NA | 0.13.x (TP) | 1.11.x (TP) | 0.15.x (GA) | NA | 4.10, 4.11, 4.12, 4.13  | GA
 


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: enterprise-4.10 and later
• **JIRA issue**: [RHDEVDOCS-5545](https://issues.redhat.com/browse/RHDEVDOCS-5545)
• **Preview page**: [Release notes for Red Hat OpenShift Pipelines General Availability 1.10.5](https://62724--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/op-release-notes.html#release-notes-1-10-5_op-release-notes)
• **SME Review**: Completed by @concaf
• **QE review**: Completed by @ppitonak 
• **Peer-review**: Completed by @shipsing 