### PR TITLE
CNV-19628: HCO bump for 4.11.5

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -108,7 +108,7 @@ endif::[]
 :VirtProductName: OpenShift Virtualization
 :VirtVersion: 4.11
 :KubeVirtVersion: v0.53.2
-:HCOVersion: 4.11.4
+:HCOVersion: 4.11.5
 :delete: image:delete.png[title="Delete"]
 ifdef::openshift-origin[]
 :VirtProductName: OKD Virtualization


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11 only (no CP)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-19628](https://issues.redhat.com//browse/CNV-19628)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: N/A
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: To be merged when OCP Virt 4.11.5 is shipped live
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
