### PR TITLE
OSDOCS-6974 Z-stream RNs for 4.10.64

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -4096,3 +4096,22 @@ $ oc adm release info 4.10.63 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-10-64"]
+=== RHBA-2023:4217 - {product-title} 4.10.64 bug fix update
+
+Issued: 2023-07-26
+
+{product-title} release 4.10.64 is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:4217[RHBA-2023:4217] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4219[RHBA-2023:4219] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.64 --pullspecs
+----
+
+[id="ocp-4-10-64-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.10

Issue:
[OSDOCS-6974](https://issues.redhat.com/browse/OSDOCS-6974)

Link to docs preview:
[Preview](https://file.rdu.redhat.com/cbippley/OSDOCS-6974/release_notes/ocp-4-10-release-notes.html#ocp-4-10-64) (Needs VPN)

Additional information:
Z stream release notes for 4.10.64. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
