### PR TITLE
CNV-28960: docs enabling preview features

### DIFF
--- a/virt/getting_started/virt-web-console-overview.adoc
+++ b/virt/getting_started/virt-web-console-overview.adoc
@@ -247,7 +247,7 @@ The *Cluster* tab displays the {VirtProductName} version and update status. You 
 To store Red Hat templates in multiple projects, xref:../../virt/getting_started/virt-web-console-overview.adoc#templates-page_virt-web-console-overview[clone the template] and then select a project for the cloned template.
 
 |*Preview features* section
-|Expand this section to manage preview features.
+|Expand this section to manage link:https://access.redhat.com/support/offerings/techpreview/[preview features].
 
 Preview features are disabled by default and must not be enabled in production environments.
 


### PR DESCRIPTION
**Version(s):**
4.14

**Issue:**
https://issues.redhat.com/browse/CNV-28960

**Link to docs preview:**
https://62736--docspreview.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-web-console-overview.html#overview-settings-cluster_virt-web-console-overview

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

**Additional information:**
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->