### PR TITLE
OSDOCS-6442 quick fix

### DIFF
--- a/modules/cli-logging-in-web.adoc
+++ b/modules/cli-logging-in-web.adoc
@@ -27,7 +27,7 @@ Logging in to the CLI through the web browser runs a server on localhost with HT
 ----
 $ oc login <cluster_url> --web <1>
 ----
-<1> If needed, you can specify the callback port and server URL.
+<1> Optionally, you can specify the server URL and callback port. For example, `oc login <cluster_url> --web --callback-port 8280 localhost:8443`.
 
 . The web browser opens automatically. If it does not, click the link in the command output. If you do not specify the {product-title} server `oc` tries to open the web console of the cluster specified in the current `oc` configuration file. If no `oc` configuration exists, `oc` prompts interactively for the server URL.
 +
@@ -38,13 +38,7 @@ $ oc login <cluster_url> --web <1>
 Opening login URL in the default browser: https://openshift.example.com
 Opening in existing browser session.
 ----
-+
-.Example 
 
-[source,terminal]
-----
-$ oc login <https://api.your-openshift-server.com> --web --callback-port 8280 localhost:8443
-----
 . If more than one identity provider is available, select your choice from the options provided. 
 
 . Enter your username and password into the corresponding browser fields. After you are logged in, the browser displays the text `access token received successfully; please return to your terminal`. 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6442](https://issues.redhat.com/browse/OSDOCS-6442)

Link to docs preview:
[Preview](https://62744--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli.html#cli-logging-in-web_cli-developer-commands)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Quick fix for this PR. ](https://github.com/openshift/openshift-docs/pull/61984)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
