### PR TITLE
OSDOCS_7027: Add cgroup v2 version note

### DIFF
--- a/nodes/clusters/nodes-cluster-cgroups-2.adoc
+++ b/nodes/clusters/nodes-cluster-cgroups-2.adoc
@@ -10,6 +10,16 @@ By default, {product-title} uses  link:https://www.kernel.org/doc/html/latest/ad
 
 cgroup v2 is the next version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. 
 
+[NOTE]
+====
+* If you run third-party monitoring and security agents that depend on the cgroup file system, update the agents to a version that supports cgroup v2.
+* If you have configured cgroup v2 and run cAdvisor as a stand-alone daemon set for monitoring pods and containers, update cAdvisor to v0.43.0 or later.
+* If you deploy Java applications, use versions that fully support cgroup v2, such as the following packages:
+** OpenJDK / HotSpot: jdk8u372, 11.0.16, 15 and later
+** IBM Semeru Runtimes: jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
+** IBM SDK Java Technology Edition Version (IBM Java): 8.0.7.15 and later
+====
+
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference
 // modules required to cover the user story. You can also include other


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-7027

Add note to cgroup docs based on [team-node Slack conversation](https://redhat-internal.slack.com/archives/GK6BJJ1J5/p1690222952546609) per Ryan Phillips:

```
can you make sure this blurb is in the openshift cgroupsv2 docs
If you run third-party monitoring and security agents that depend on the cgroup file system, update the agents to versions that support cgroup v2.
If you run cAdvisor as a stand-alone DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
If you deploy Java applications, prefer to use versions which fully support cgroup v2:
OpenJDK / HotSpot: jdk8u372, 11.0.16, 15 and later
IBM Semeru Runtimes: jdk8u345-b01, 11.0.16.0, 17.0.4.0, 18.0.2.0 and later
IBM Java: 8.0.7.15 and later
https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/
```
Preview
https://62746--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2.html