### PR TITLE
Nodes Pods docs fixes during ROSA review part 2

### DIFF
--- a/modules/nodes-pods-configmap-creating-from-directories.adoc
+++ b/modules/nodes-pods-configmap-creating-from-directories.adoc
@@ -1,30 +1,50 @@
 // Module included in the following assemblies:
 //
-//* authentication/configmaps.adoc
+//* nodes/pods/nodes-pods-configmap.adoc
 
 :_content-type: PROCEDURE
 [id="nodes-pods-configmap-creating-from-directories_{context}"]
 = Creating a config map from a directory
 
-You can create a config map from a directory. This method allows you to use multiple files within a directory to create a config map.
+You can create a config map from a directory by using the `--from-file` flag. This method allows you to use multiple files within a directory to create a config map.
 
-.Procedure
+Each file in the directory is used to populate a key in the config map, where the name of the key is the file name, and the value of the key is the content of the file.
 
-The following example procedure outlines how to create a config map from a directory.
+For example, the following command creates a config map with the contents of the `example-files` directory:
 
-. Start with a directory with some files that already contain the data with which you want to populate a config map:
-+
 [source,terminal]
 ----
-$ ls example-files
+$ oc create configmap game-config --from-file=example-files/
 ----
-+
+
+View the keys in the config map:
+
+[source,terminal]
+----
+$ oc describe configmaps game-config
+----
+
 .Example output
 [source,terminal]
 ----
-game.properties
-ui.properties
+Name:           game-config
+Namespace:      default
+Labels:         <none>
+Annotations:    <none>
+
+Data
+
+game.properties:        158 bytes
+ui.properties:          83 bytes
 ----
+
+You can see that the two keys in the map are created from the file names in the directory specified in the command. The content of those keys might be large, so the output of `oc describe` only shows the names of the keys and their sizes.
+
+.Prerequisite
+
+* You must have a directory with files that contain the data you want to populate a config map with.
++
+The following procedure uses these example files: `game.properties` and `ui.properties`:
 +
 [source,terminal]
 ----
@@ -57,40 +77,19 @@ allow.textmode=true
 how.nice.to.look=fairlyNice
 ----
 
-. Create a config map holding the content of each file in this directory by entering the following command:
+.Procedure
+
+* Create a config map holding the content of each file in this directory by entering the following command:
 +
 [source,terminal]
 ----
 $ oc create configmap game-config \
     --from-file=example-files/
 ----
-+
-When the `--from-file` option points to a directory, each file directly in that directory is used to populate a key in the config map, where the name of the key is the file name, and the value of the key is the content of the file.
-+
-For example, the previous command creates the following config map:
-+
-[source,terminal]
-----
-$ oc describe configmaps game-config
-----
-+
-.Example output
-[source,terminal]
-----
-Name:           game-config
-Namespace:      default
-Labels:         <none>
-Annotations:    <none>
 
-Data
+.Verification
 
-game.properties:        158 bytes
-ui.properties:          83 bytes
-----
-+
-You can see that the two keys in the map are created from the file names in the directory specified in the command. Because the content of those keys might be large, the output of `oc describe` only shows the names of the keys and their sizes.
-+
-. Enter the `oc get` command for the object with the `-o` option to see the values of the keys:
+* Enter the `oc get` command for the object with the `-o` option to see the values of the keys:
 +
 [source,terminal]
 ----

--- a/modules/nodes-pods-configmap-creating-from-files.adoc
+++ b/modules/nodes-pods-configmap-creating-from-files.adoc
@@ -6,20 +6,60 @@
 [id="nodes-pods-configmap-creating-from-files_{context}"]
 = Creating a config map from a file
 
-You can create a config map from a file.
+You can create a config map from a file by using the `--from-file` flag. You can pass the `--from-file` option multiple times to the CLI.
 
-.Procedure
+You can also specify the key to set in a config map for content imported from a file by passing a `key=value` expression to the `--from-file` option. For example:
 
-The following example procedure outlines how to create a config map from a file.
+[source,terminal]
+----
+$ oc create configmap game-config-3 --from-file=game-special-key=example-files/game.properties
+----
 
 [NOTE]
 ====
 If you create a config map from a file, you can include files containing non-UTF8 data that are placed in this field without corrupting the non-UTF8 data. {product-title} detects binary files and transparently encodes the file as `MIME`. On the server, the `MIME` payload is decoded and stored without corrupting the data.
 ====
 
-You can pass the `--from-file` option multiple times to the CLI. The following example yields equivalent results to the creating from directories example.
+.Prerequisite
 
-. Create a config map by specifying a specific file:
+* You must have a directory with files that contain the data you want to populate a config map with.
++
+The following procedure uses these example files: `game.properties` and `ui.properties`:
++
+[source,terminal]
+----
+$ cat example-files/game.properties
+----
++
+.Example output
+[source,terminal]
+----
+enemies=aliens
+lives=3
+enemies.cheat=true
+enemies.cheat.level=noGoodRotten
+secret.code.passphrase=UUDDLRLRBABAS
+secret.code.allowed=true
+secret.code.lives=30
+----
++
+[source,terminal]
+----
+$ cat example-files/ui.properties
+----
++
+.Example output
+[source,terminal]
+----
+color.good=purple
+color.bad=yellow
+allow.textmode=true
+how.nice.to.look=fairlyNice
+----
+
+.Procedure
+
+* Create a config map by specifying a specific file:
 +
 [source,terminal]
 ----
@@ -27,8 +67,18 @@ $ oc create configmap game-config-2 \
     --from-file=example-files/game.properties \
     --from-file=example-files/ui.properties
 ----
+
+* Create a config map by specifying a key-value pair:
 +
-. Verify the results:
+[source,terminal]
+----
+$ oc create configmap game-config-3 \
+    --from-file=game-special-key=example-files/game.properties
+----
+
+.Verification
+
+* Enter the `oc get` command for the object with the `-o` option to see the values of the keys from the file:
 +
 [source,terminal]
 ----
@@ -63,17 +113,7 @@ metadata:
   uid: b4952dc3-d670-11e5-8cd0-68f728db1985
 ----
 
-You can specify the key to set in a config map for content imported from a file. This can be set by passing a `key=value` expression to the `--from-file` option. For example:
-
-. Create a config map by specifying a key-value pair:
-+
-[source,terminal]
-----
-$ oc create configmap game-config-3 \
-    --from-file=game-special-key=example-files/game.properties
-----
-
-. Verify the results:
+* Enter the `oc get` command for the object with the `-o` option to see the values of the keys from the key-value pair:
 +
 [source,terminal]
 ----

--- a/modules/nodes-pods-configmap-creating-from-literal-values.adoc
+++ b/modules/nodes-pods-configmap-creating-from-literal-values.adoc
@@ -8,11 +8,11 @@
 
 You can supply literal values for a config map.
 
+The `--from-literal` option takes a `key=value` syntax, which allows literal values to be supplied directly on the command line.
+
 .Procedure
 
-The `--from-literal` option takes a `key=value` syntax that allows literal values to be supplied directly on the command line.
-
-. Create a config map by specifying a literal value:
+* Create a config map by specifying a literal value:
 +
 [source,terminal]
 ----
@@ -21,7 +21,9 @@ $ oc create configmap special-config \
     --from-literal=special.type=charm
 ----
 
-. Verify the results:
+.Verification
+
+* Enter the `oc get` command for the object with the `-o` option to see the values of the keys:
 +
 [source,terminal]
 ----

--- a/modules/nodes-pods-priority-configuring.adoc
+++ b/modules/nodes-pods-priority-configuring.adoc
@@ -6,10 +6,22 @@
 [id="nodes-pods-priority-configuring_{context}"]
 = Configuring priority and preemption
 
-You apply pod priority and preemption by creating a priority class object and associating pods to the priority using the
-`priorityClassName` in your `Pod` specs.
+You apply pod priority and preemption by creating a priority class object and associating pods to the priority by using the
+`priorityClassName` in your pod specs.
 
-.Sample priority class object
+[NOTE]
+====
+You cannot add a priority class directly to an existing scheduled pod.
+====
+
+.Procedure
+
+To configure your cluster to use priority and preemption:
+
+. Create one or more priority classes:
+
+.. Create a YAML file similar to the following:
++
 [source,yaml]
 ----
 apiVersion: scheduling.k8s.io/v1
@@ -23,23 +35,21 @@ description: "This priority class should be used for XYZ service pods only." <5>
 ----
 <1> The name of the priority class object.
 <2> The priority value of the object.
-<3> Optional field that indicates whether this priority class is preempting or non-preempting. The preemption policy defaults to `PreemptLowerPriority`, which allows pods of that priority class to preempt lower-priority pods. If the preemption policy is set to `Never`, pods in that priority class are non-preempting.
-<4> Optional field that indicates whether this priority class should be used for pods without a priority class name specified. This field is `false` by default. Only one priority class with `globalDefault` set to `true` can exist in the cluster. If there is no priority class with `globalDefault:true`, the priority of pods with no priority class name is zero. Adding a priority class with `globalDefault:true` affects only pods created after the priority class is added and does not change the priorities of existing pods.
-<5> Optional arbitrary text string that describes which pods developers should use with this priority class.
+<3> Optional. Specifies whether this priority class is preempting or non-preempting. The preemption policy defaults to `PreemptLowerPriority`, which allows pods of that priority class to preempt lower-priority pods. If the preemption policy is set to `Never`, pods in that priority class are non-preempting.
+<4> Optional. Specifies whether this priority class should be used for pods without a priority class name specified. This field is `false` by default. Only one priority class with `globalDefault` set to `true` can exist in the cluster. If there is no priority class with `globalDefault:true`, the priority of pods with no priority class name is zero. Adding a priority class with `globalDefault:true` affects only pods created after the priority class is added and does not change the priorities of existing pods.
+<5> Optional. Describes which pods developers should use with this priority class. Enter an arbitrary text string.
 
-.Procedure
-
-To configure your cluster to use priority and preemption:
-
-. Create one or more priority classes:
-
-.. Specify a name and value for the priority.
-
-.. Optionally specify the `globalDefault` field in the priority class and a description.
-
-. Create a `Pod` spec or edit existing pods to include the name of a priority class, similar to the following:
+.. Create the priority class:
 +
-.Sample `Pod` spec with priority class name
+[source,terminal]
+----
+$ oc create -f <file-name>.yaml
+----
+
+. Create a pod spec to include the name of a priority class:
+
+.. Create a YAML file similar to the following:
++
 [source,yaml]
 ----
 apiVersion: v1
@@ -57,7 +67,7 @@ spec:
 ----
 <1> Specify the priority class to use with this pod.
 
-. Create the pod:
+.. Create the pod:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Fixing various errors in the Nodes docs as I find them during the ROSA content port. Mostly formatting, wording, and such. Follow up to https://github.com/openshift/openshift-docs/pull/62205

Preview:
[Creating a config map from a directory](https://62747--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmap-creating-from-directories_configmaps) -- Moved some contextual information from a procedure to the intro. 
[Creating a config map from a file](https://62747--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmap-creating-from-files_configmaps) -- Moved some contextual information from a procedure to the intro. 
[Creating a config map from literal values](https://62747--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configmaps.html#nodes-pods-configmap-creating-from-literal-values_configmaps) -- Moved some contextual information from a procedure to the intro. 
[Configuring priority and preemption](https://62747--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-priority.html#nodes-pods-priority-configuring_nodes-pods-priority) -- Split steps into sub-steps, added a note on not editing pods.