### PR TITLE
[OSDOCS#5904]: Adding links to priority ROSA troubleshooting material

### DIFF
--- a/modules/cluster-logging-deploy-console.adoc
+++ b/modules/cluster-logging-deploy-console.adoc
@@ -93,7 +93,7 @@ This option sets the `openshift.io/cluster-monitoring: "true"` label in the Name
 
 .. Choose  *Red Hat OpenShift Logging* from the list of available Operators, and click *Install*.
 
-.. Ensure that the *A specific namespace on the cluster* is selected under *Installation Mode*.
+.. Ensure that *A specific namespace on the cluster* is selected under *Installation Mode*.
 
 .. Ensure that *Operator recommended namespace* is *openshift-logging* under *Installed Namespace*.
 
@@ -242,3 +242,6 @@ You should see several pods for OpenShift Logging, Elasticsearch, Fluentd, and K
 * fluentd-fn2sb
 * fluentd-zqgqx
 * kibana-7fb4fd4cc9-bvt4p
+
+.Troubleshooting
+* If Alertmanager logs alerts such as `Prometheus could not scrape fluentd for more than 10m`, make sure that `openshift.io/cluster-monitoring` is set to `"true"` for the OpenShift Elasticsearch Operator and OpenShift Logging Operator. See the Red Hat KnowledgeBase for more information: link:https://access.redhat.com/solutions/5692801[Prometheus could not scrape fluentd for more than 10m alert in Alertmanager]

--- a/modules/life-cycle-mandatory-upgrades.adoc
+++ b/modules/life-cycle-mandatory-upgrades.adoc
@@ -2,6 +2,7 @@
 // * rosa_architecture/rosa_policy_service_definition/rosa-life-cycle.adoc
 // * osd_architecture/osd_policy/osd-life-cycle.adoc
 
+:_content-type: REFERENCE
 [id="rosa-mandatory-upgrades_{context}"]
 = Mandatory upgrades
 
@@ -10,4 +11,5 @@ impacts the security or stability of the cluster, the customer must upgrade to t
 patch release within two link:https://access.redhat.com/articles/2623321[business days].
 
 In extreme circumstances and based on Red Hat's assessment of the CVE criticality to the
-environment, Red Hat will notify customers that they have two link:https://access.redhat.com/articles/2623321[business days] to schedule or manually update their cluster to the latest, secure patch release. In the case that an update has not been performed, Red Hat will automatically update the cluster to the latest, secure patch release to mitigate potential security breach(es) or instability. Red Hat may, at its own discretion, temporarily delay an automated update if requested by a customer through a link:https://access.redhat.com/support[support case].
+environment, Red Hat will notify customers that they have two link:https://access.redhat.com/articles/2623321[business days] to schedule or manually update their cluster to the latest, secure patch release.
+In the case that an update is not performed after two link:https://access.redhat.com/articles/2623321[business days], Red Hat will automatically update the cluster to the latest, secure patch release to mitigate potential security breach(es) or instability. Red Hat may, at its own discretion, temporarily delay an automated update if requested by a customer through a link:https://access.redhat.com/support[support case].

--- a/modules/osd-applications-config-custom-domains.adoc
+++ b/modules/osd-applications-config-custom-domains.adoc
@@ -122,3 +122,7 @@ $ oc get route -n my-project
 $ curl https://hello-openshift-tls-my-project.apps.<company_name>.io
 Hello OpenShift!
 ----
+
+.Troubleshooting
+* link:https://access.redhat.com/solutions/5419501[Error creating TLS secret]
+* link:https://access.redhat.com/solutions/6546011[Troubleshooting: CustomDomain in NotReady state]

--- a/modules/osd-applications-renew-custom-domains.adoc
+++ b/modules/osd-applications-renew-custom-domains.adoc
@@ -33,3 +33,6 @@ $ oc patch customdomain <company_name> --type='merge' -p '{"spec":{"certificate"
 ----
 $ oc delete secret <secret-old> -n <my_project>
 ----
+
+.Troubleshooting
+* link:https://access.redhat.com/solutions/5419501[Error creating TLS secret]

--- a/modules/registry-exposing-secure-registry-manually.adoc
+++ b/modules/registry-exposing-secure-registry-manually.adoc
@@ -80,3 +80,6 @@ spec:
 Only set `secretName` if you are providing a custom TLS configuration for the
 registry's route.
 ====
+
+.Troubleshooting
+* link:https://access.redhat.com/solutions/5419501[Error creating TLS secret]

--- a/modules/rosa-deleting-cluster.adoc
+++ b/modules/rosa-deleting-cluster.adoc
@@ -143,3 +143,9 @@ $ rosa delete operator-roles -c <cluster_id> --mode auto <1>
 ----
 <1> Replace `<cluster_id>` with the ID of the cluster.
 endif::sts[]
+
+.Troubleshooting
+* If the cluster cannot be deleted because of missing IAM roles, see xref:../sd_support/rosa-troubleshooting-deployments.adoc#rosa-troubleshooting-cluster-deletion_rosa-troubleshooting-cluster-deployments[Repairing a cluster that cannot be deleted].
+* If the cluster cannot be deleted for other reasons:
+** Check that there are no Add-ons for your cluster pending in the link:https://console.redhat.com/openshift[Hybrid Cloud Console].
+** Check that all AWS resources and dependencies have been deleted in the Amazon Web Console.

--- a/modules/rosa-upgrading-cli-tutorial.adoc
+++ b/modules/rosa-upgrading-cli-tutorial.adoc
@@ -71,3 +71,6 @@ You will receive an email when the upgrade is complete. You can also check the s
 ifeval::["{context}" == "rosa-upgrading-sts"]
 :!sts:
 endif::[]
+
+.Troubleshooting
+* Sometimes a scheduled upgrade does not trigger. See link:https://access.redhat.com/solutions/6648291[Upgrade maintenance cancelled] for more information.

--- a/modules/rosa-upgrading-manual-ocm.adoc
+++ b/modules/rosa-upgrading-manual-ocm.adoc
@@ -57,3 +57,6 @@ The status is displayed in the *Update status* pane.
 ifeval::["{context}" == "rosa-upgrading-sts"]
 :!sts:
 endif::[]
+
+.Troubleshooting
+* Sometimes a scheduled upgrade does not trigger. See link:https://access.redhat.com/solutions/6648291[Upgrade maintenance cancelled] for more information.

--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-about-autoscaling-nodes.adoc
@@ -72,6 +72,7 @@ endif::[]
 
 [id="nodes-about-autoscaling-nodes-additional-resources"]
 == Additional resources
+* link:https://access.redhat.com/solutions/6821651[Troubleshooting: Autoscaling is not scaling down nodes]
 * xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc#rosa-nodes-machinepools-about[About machinepools]
 ifdef::openshift-rosa[]
 * xref:../../rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc#rosa-managing-worker-nodes[Managing worker nodes]


### PR DESCRIPTION
Adding links to priority ROSA troubleshooting material in Red Hat Knowledgebase.

Version(s):
4.12, 4.13, 4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-5904

Link to docs preview:
https://62748--docspreview.netlify.app/openshift-rosa/latest/welcome/index.html
See comments on "Files changed" tab for specifics.

QE review: N/A

Additional information: N/A