### PR TITLE
OCPBUGS-7621-note: Removed L2 vSphere external LB note

### DIFF
--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -59,11 +59,6 @@ ifdef::vsphere[]
 * Optional: If you are using multiple networks, you can create targets for every IP address in the network that can host nodes. This configuration can reduce the maintenance overhead of your cluster.
 endif::vsphere[]
 
-[IMPORTANT]
-====
-External load balancing services and the control plane nodes must run on the same L2 network, and on the same VLAN when using VLANs to route traffic between the load balancing services and the control plane nodes.
-====
-
 .Procedure
 
 . Enable access to the cluster from your load balancer on ports 6443, 443, and 80.


### PR DESCRIPTION
[OCPBUGS-7621](https://issues.redhat.com/browse/OCPBUGS-7621)

Version(s):
4.14 through to 4.10

Link to docs preview:
[Configuring an external load balancer](https://62749--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#nw-osp-configuring-external-load-balancer_installing-vsphere-installer-provisioned-customizations)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Clark to provide the following items:

* Generic graphic illustration that covers the three health check resources.
* Provide a better example for step 1 in the procedure that is more production-environment focused.
* Revise the Configuring external LB section to ensure the content is more accurate. Information for port 1936 was removed but maybe it needs to be added back but with more accurate information.
* Clarify if we need to point to the RHEL Cluster add-on (toolkit) that provides a better way to configure a LB. We need to be more generic as F5 is maintained by a third-party vendor. 
