### PR TITLE
Fix mixed up Pods and Nodes in taint/toleration examples

### DIFF
--- a/modules/nodes-scheduler-taints-tolerations-about.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-about.adoc
@@ -18,7 +18,7 @@ You apply taints to a node through the `Node` specification (`NodeSpec`) and app
 apiVersion: v1
 kind: Node
 metadata:
-  name: my-pod
+  name: my-node
 #...
 spec:
   taints:
@@ -32,7 +32,7 @@ spec:
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...
@@ -104,7 +104,7 @@ metadata:
   annotations:
     machine.openshift.io/machine: openshift-machine-api/ci-ln-62s7gtb-f76d1-v8jxv-master-0
     machineconfiguration.openshift.io/currentConfig: rendered-master-cdc1ab7da414629332cc4c3926e6e59c
-  name: my-pod
+  name: my-node
 #...
 spec:
   taints:
@@ -151,7 +151,7 @@ You can specify how long a pod can remain bound to a node before being evicted b
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...
@@ -209,7 +209,7 @@ $ oc adm taint nodes node1 key2=value2:NoSchedule
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...
@@ -276,7 +276,7 @@ For more information, see link:https://kubernetes.io/docs/concepts/architecture/
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...
@@ -314,7 +314,7 @@ Pods with this toleration are not removed from a node that has taints.
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...

--- a/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding-machineset.adoc
@@ -17,7 +17,7 @@ You can add taints to nodes using a compute machine set. All nodes associated wi
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...
@@ -39,7 +39,7 @@ For example:
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...
@@ -66,10 +66,10 @@ $ oc edit machineset <machineset>
 .Example taint in a compute machine set specification
 [source,yaml]
 ----
-apiVersion: v1
-kind: Node
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
 metadata:
-  name: my-pod
+  name: my-machineset
 #...
 spec:
 #...

--- a/modules/nodes-scheduler-taints-tolerations-adding.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-adding.adoc
@@ -17,7 +17,7 @@ You add tolerations to pods and taints to nodes to allow the node to control whi
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...
@@ -39,11 +39,11 @@ For example:
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...
-spec: 
+spec:
    tolerations:
     - key: "key1"
       operator: "Exists" <1>
@@ -85,7 +85,7 @@ metadata:
   annotations:
     machine.openshift.io/machine: openshift-machine-api/ci-ln-62s7gtb-f76d1-v8jxv-master-0
     machineconfiguration.openshift.io/currentConfig: rendered-master-cdc1ab7da414629332cc4c3926e6e59c
-  name: my-pod
+  name: my-node
 #...
 spec:
   taints:

--- a/modules/nodes-scheduler-taints-tolerations-binding.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-binding.adoc
@@ -33,7 +33,7 @@ You can alternatively apply the following YAML to add the taint:
 kind: Node
 apiVersion: v1
 metadata:
-  name: my-pod
+  name: my-node
 #...
 spec:
   taints:

--- a/modules/nodes-scheduler-taints-tolerations-removing.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-removing.adoc
@@ -38,7 +38,7 @@ node/ip-10-0-132-248.ec2.internal untainted
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...

--- a/modules/nodes-scheduler-taints-tolerations-special.adoc
+++ b/modules/nodes-scheduler-taints-tolerations-special.adoc
@@ -22,7 +22,7 @@ For example:
 [source,yaml]
 ----
 apiVersion: v1
-kind: Node
+kind: Pod
 metadata:
   name: my-pod
 #...


### PR DESCRIPTION
- Nodes have `taints` and probably should not be called `my-pod`
- Pods have `tolerations` and probably should not be called `my-node`

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Version(s):
4.10+

Issue:
haven't filed one

Link to docs preview:
https://62753--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks.html#post-install-taints-tolerations

QE review:
- [ ] QE has approved this change.
