### PR TITLE
OCPBUGS-16044: Updates broken link in Microshift networking RNs

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -66,7 +66,7 @@ For more information, read xref:../microshift_support/microshift-sos-report.adoc
 
 With this release, {product-title} etcd is run as a separate process whose lifecycle is managed automatically by {product-title}. You can gather `journalctl` logs to observe and debug the etcd server logs.
 
-For more information, read xref:../microshift_support/microshift-etcd.html#microshift-observe-debug-etcd-server_microshift-etcd[Observe and debug the MicroShift etcd server].
+For more information, read xref:../microshift_support/microshift-etcd.adoc#microshift-observe-debug-etcd-server_microshift-etcd[Observe and debug the MicroShift etcd server].
 
 //[id="microshift-4-13-post-installation"]
 //=== Post-installation configuration


### PR DESCRIPTION
OCPBUGS-16044: Updates broken link in Microshift networking RNs

Version(s):
4.13 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-16044

Link to docs preview:
https://62770--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
