### PR TITLE
OSDOCS#7431: Viewing audit logs in troubleshooting MicroShift docs

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -181,5 +181,7 @@ Topics:
   File: microshift-troubleshoot-cluster
 - Name: Troubleshoot updates
   File: microshift-troubleshoot-updates
+- Name: Checking audit logs 
+  File: microshift-audit-logs
 - Name: Additional information
   File: microshift-things-to-know

--- a/microshift_troubleshooting/microshift-audit-logs.adoc
+++ b/microshift_troubleshooting/microshift-audit-logs.adoc
@@ -1,0 +1,9 @@
+:_content-type: ASSEMBLY
+[id="audit-logs-with-microshift"]
+= Checking audit logs on {product-title}
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-audit-logs
+
+toc::[]
+
+include::modules/microshift-viewing-audit-logs.adoc[leveloffset=+1]

--- a/modules/microshift-viewing-audit-logs.adoc
+++ b/modules/microshift-viewing-audit-logs.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+//microshift_troubleshooting/microshift-audit-logs.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-security-context-constraints-alert-eval_{context}"]
+= Identifying pod security violations through audit logs
+
+You can identify pod security admission violations on a workload by viewing the server audit logs. The following procedure shows you how to access the audit logs and parse them to find pod security admission violations in a workload.
+
+.Prerequisites
+
+* You have installed `jq`.
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. To retrieve the node name, run the following command: 
++
+[source,terminal]
+----
+$ <node_name>=$(oc get node -ojsonpath='{.items[0].metadata.name}')
+----
+. To view the audit logs, run the following command:
++
+[source,terminal]
+----
+$ oc adm node-logs <node_name> --path=kube-apiserver/
+----
++
+.Example output
+[source,terminal]
+----
+rhel-92.lab.local audit-2023-08-18T18-25-41.663.log
+rhel-92.lab.local audit-2023-08-19T11-21-29.225.log
+rhel-92.lab.local audit-2023-08-20T04-16-09.622.log
+rhel-92.lab.local audit-2023-08-20T21-11-41.163.log
+rhel-92.lab.local audit-2023-08-21T14-06-10.402.log
+rhel-92.lab.local audit-2023-08-22T06-35-10.392.log
+rhel-92.lab.local audit-2023-08-22T23-26-27.667.log
+rhel-92.lab.local audit-2023-08-23T16-52-15.456.log
+rhel-92.lab.local audit-2023-08-24T07-31-55.238.log
+----
+
+. To parse the affected audit logs, enter the following command:
++ 
+[source,terminal]
+----
+$ oc adm node-logs <node_name> --path=kube-apiserver/audit.log \
+  | jq -r 'select((.annotations["pod-security.kubernetes.io/audit-violations"] != null) and (.objectRef.resource=="pods")) | .objectRef.namespace + " " + .objectRef.name + " " + .objectRef.resource' \
+  | sort | uniq -c 
+----


### PR DESCRIPTION
**For Versions:** 4.14+
**Issue:** [OSDOCS-7431](https://issues.redhat.com//browse/OSDOCS-5494) 

**Description:** Adds documentation for viewing audit logs in MicroShift documentation 

**Preview:** 
- [Checking audit logs](https://62776--docspreview.netlify.app/microshift/latest/microshift_troubleshooting/microshift-audit-logs)

**QE review:** 
- [x] QE approved