### PR TITLE
OSDOCS#6826: Adds notes for Microshift 4.13.6 release

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -204,11 +204,18 @@ Issued: 2023-07-20
 
 {product-title} release 4.13.5, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4094[RHBA-2023:4094] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4091[RHSA-2023:4091] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
-
 [id="microshift-4-13-5-bug-fixes"]
 ==== Bug Fixes
 
 * {product-title} uses the OVN-Kubernetes `local gateway` mode. All pod egress traffic goes through the host kernel before entering or leaving the host. With this release, the flag `externalGatewayInterface` to specify a second gateway interface is removed.(link:https://issues.redhat.com/browse/OCPBUGS-14880)([*OCPBUGS-14880*])
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-6-dp"]
+=== RHBA-2023:4428 - {product-title} 4.13.6 bug fix and security update
+
+Issued: 2023-07-26
+
+{product-title} release 4.13.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4428[RHBA-2023:4428] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4426[RHSA-2023:4426] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
OSDOCS#6826: Adds notes for Microshift 4.13.6 release

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-6826

Link to docs preview:
https://62780--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes.html#microshift-4-13-6-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
