### PR TITLE
OSDOCS#6222: Adding a release note for custom security groups in AWS

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -56,6 +56,15 @@ This release adds improvements related to the following components and concepts.
 
 User-defined tags for Microsoft Azure was previously introduced as Technology Preview in {product-title} 4.13 and is now generally available in {product-title} 4.14. For more information, see xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-user-defined-tags_installing-azure-customizations[Configuring the user-defined tags for Azure].
 
+[id="ocp-4-14-aws-security-groups"]
+==== Applying existing AWS security groups to a cluster
+
+By default, the installation program creates and attaches security groups to control plane and compute machines. The rules associated with the default security groups cannot be modified.
+
+With {product-title} {product-version}, if you deploy a cluster to an existing Amazon Virtual Private Cloud (VPC), you can apply additional existing AWS security groups to control plane and compute machines. These security groups must be associated with the VPC that you are deploying the cluster to. Applying custom security groups can help you meet the security needs of your organization, in such cases where you must control the incoming or outgoing traffic of these machines.
+
+For more information, see xref:../installing/installing_aws/installing-aws-vpc.adoc#installation-aws-vpc-security-groups_installing-aws-vpc[Applying existing AWS security groups to the cluster].
+
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
This PR addresses the release note for [osdocs-6222](https://issues.redhat.com/browse/OSDOCS-6222).

Link to docs preview:

[Applying existing AWS security groups to a cluster](https://62792--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-aws-security-groups)

QE review:
- [ ] QE has approved this change.
