### PR TITLE
OSDOCS-4806: Expanded OIDC config instructions

### DIFF
--- a/modules/rosa-sts-byo-oidc-options.adoc
+++ b/modules/rosa-sts-byo-oidc-options.adoc
@@ -1,22 +1,21 @@
 // Module included in the following assemblies:
 //
-// * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
-// * rosa_getting_started/quickstart.adoc
+// * rosa_architecture/rosa-oidc-overview.adoc
 // * rosa_architecture/rosa-sts-about-iam-resources.adoc
 
 :_content-type: CONCEPT
-[id="rosa-hcp-byo-oidc-options_{context}"]
+[id="rosa-sts-byo-oidc-options_{context}"]
 = Parameter options for creating your own OpenID Connect configuration
 
 The following options may be added to the `rosa create oidc-config` command. All of these parameters are optional. Running the `rosa create oidc-config` command without parameters creates an unmanaged OIDC configuration.
 
 [NOTE]
 ====
-You are required to register the unmanaged OIDC configuration by posting a request to `/oidc_configs` through OCM. You receive an ID in the response. Use this ID to create a cluster.
+You are required to register the unmanaged OIDC configuration by posting a request to `/oidc_configs` through OpenShift Cluster Manager. You receive an ID in the response. Use this ID to create a cluster.
 ====
 
 [discrete]
-[id="rosa-oidc-raw-files_{context}"]
+[id="rosa-sts-byo-oidc-raw-files_{context}"]
 == raw-files
 
 Allows you to provide raw files for the private RSA key. This key is named `rosa-private-key-oidc-<random_label_of_length_4>.key`. You also receive a discovery document, named `discovery-document-oidc-<random_label_of_length_4>.json`, and a JSON Web Key Set, named `jwks-oidc-<random_label_of_length_4>.json`.
@@ -30,12 +29,12 @@ $ rosa create oidc-config --raw-files
 ----
 
 [discrete]
-[id="rosa-oidc-mode_{context}"]
+[id="rosa-sts-byo-oidc-mode_{context}"]
 == mode
 
-Allows you to specify the mode to create your OIDC configuration. With the `manual` option, you receive AWS commands that setup the OIDC configuration within an S3 bucket. This option stores the private key in the Secrets Manager. With the `manual` option, the OIDC Endpoint URL is the URL for the S3 bucket. You must retrieve the Secrets Manager ARN to register the OIDC configuration with OCM.
+Allows you to specify the mode to create your OIDC configuration. With the `manual` option, you receive AWS commands that set up the OIDC configuration in an S3 bucket. This option stores the private key in the Secrets Manager. With the `manual` option, the OIDC Endpoint URL is the URL for the S3 bucket. You must retrieve the Secrets Manager ARN to register the OIDC configuration with OpenShift Cluster Manager.
 
-Using the `auto` option, you receive the same OIDC configuration and AWS resources as the `manual` mode. One change is that ROSA calls AWS, so you do not need to do anything else. The OIDC Endpoint URL is the URL for the S3 bucket. The CLI retrieves the Secrets Manager ARN, registers the OIDC configuration with OCM, and reports the second `rosa` command that the user can run to continue with the creation of the STS cluster.
+You receive the same OIDC configuration and AWS resources as the `manual` mode when using the `auto` option. A significant difference between the two options is that when using the `auto` option, ROSA calls AWS, so you do not need to take any further actions. The OIDC Endpoint URL is the URL for the S3 bucket. The CLI retrieves the Secrets Manager ARN, registers the OIDC configuration with OpenShift Cluster Manager, and reports the second `rosa` command that the user can run to continue with the creation of the STS cluster.
 
 .Example
 [source,terminal]
@@ -44,7 +43,7 @@ $ rosa create oidc-config --mode=<auto|manual>
 ----
 
 [discrete]
-[id="rosa-oidc-managed_{context}"]
+[id="rosa-sts-byo-oidc-managed_{context}"]
 == managed
 
 Creates an OIDC configuration that is hosted under Red Hat's AWS account. This command creates a private key that responds directly with an OIDC Config ID for you to use when creating the STS cluster.

--- a/modules/rosa-sts-byo-oidc.adoc
+++ b/modules/rosa-sts-byo-oidc.adoc
@@ -1,29 +1,36 @@
 // Module included in the following assemblies:
 //
-// * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+// * rosa_architecture/rosa-oidc-overview.adoc
 // * rosa_architecture/rosa-sts-about-iam-resources.adoc
+// * rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+// * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+// * rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
 
 ifeval::["{context}" == "rosa-hcp-sts-creating-a-cluster-quickly"]
 :rosa-hcp:
 endif::[]
-ifeval::["{context}" == "rosa-sts-about-iam-resources"]
-:rosa-classic:
-endif::[]
 
 :_content-type: PROCEDURE
-[id="rosa-hcp-byo-oidc_{context}"]
+[id="rosa-sts-byo-oidc_{context}"]
 = Creating an OpenID Connect configuration
 
-When using a {hcp-title} cluster, you must create the OpenID Connect (OIDC) configuration prior to creating your cluster. This configuration is registered to be used with OCM.
+When using a 
+ifdef::rosa-hcp[]
+{hcp-title} cluster, you must 
+endif::rosa-hcp[]
+ifndef::rosa-hcp[]
+{product-title} cluster, you can 
+endif::rosa-hcp[]
+create the OpenID Connect (OIDC) configuration prior to creating your cluster. This configuration is registered to be used with OpenShift Cluster Manager.
 
 .Prerequisites
 
 ifdef::rosa-hcp[]
 * You have completed the AWS prerequisites for {hcp-title}.
 endif::rosa-hcp[]
-ifdef::rosa-classic[]
+ifdef::rosa-hcp[]
 * You have completed the AWS prerequisites for {product-title}.
-endif::rosa-classic[]
+endif::rosa-hcp[]
 * You have installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your installation host.
 
 .Procedure

--- a/rosa_architecture/rosa-oidc-overview.adoc
+++ b/rosa_architecture/rosa-oidc-overview.adoc
@@ -16,9 +16,9 @@ include::modules/rosa-oidc-understanding.adoc[leveloffset=+1]
 
 include::modules/rosa-oidc-config-overview.adoc[leveloffset=+1]
 [discrete]
-include::modules/rosa-hcp-byo-oidc.adoc[leveloffset=+3]
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+3]
 [discrete]
-include::modules/rosa-hcp-byo-oidc-options.adoc[leveloffset=+3]
+include::modules/rosa-sts-byo-oidc-options.adoc[leveloffset=+3]
 
 include::modules/rosa-sts-oidc-provider-command.adoc[leveloffset=+1]
 
@@ -27,4 +27,4 @@ include::modules/rosa-sts-oidc-provider-command.adoc[leveloffset=+1]
 == Additional resources
 
 * See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-byo-odic-overview_rosa-sts-about-iam-resources[Creating an OpenID Connect Configuration] for the ROSA Classic instructions.
-* See xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-hcp-byo-oidc_rosa-hcp-sts-creating-a-cluster-quickly[Creating an OpenID Connect Configuration] for the {hcp-title} instructions.
+* See xref:../rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc#rosa-sts-byo-oidc_rosa-hcp-sts-creating-a-cluster-quickly[Creating an OpenID Connect Configuration] for the {hcp-title} instructions.

--- a/rosa_architecture/rosa-sts-about-iam-resources.adoc
+++ b/rosa_architecture/rosa-sts-about-iam-resources.adoc
@@ -94,8 +94,8 @@ include::modules/rosa-sts-oidc-provider-command.adoc[leveloffset=+2]
 
 include::modules/rosa-oidc-config-overview.adoc[leveloffset=+2]
 [discrete]
-include::modules/rosa-hcp-byo-oidc.adoc[leveloffset=+3]
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+3]
 [discrete]
-include::modules/rosa-hcp-byo-oidc-options.adoc[leveloffset=+3]
+include::modules/rosa-sts-byo-oidc-options.adoc[leveloffset=+3]
 
 include::modules/rosa-aws-scp.adoc[leveloffset=+1]

--- a/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly.adoc
@@ -103,7 +103,7 @@ include::modules/rosa-hcp-vpc-manual.adoc[leveloffset=+3]
 
 include::modules/rosa-hcp-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+2]
 
-include::modules/rosa-hcp-byo-oidc.adoc[leveloffset=+2]
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+2]
 
 include::modules/rosa-operator-config.adoc[leveloffset=+2]
 

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.adoc
@@ -41,6 +41,7 @@ include::modules/osd-aws-vpc-required-resources.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-a-cluster-quickly-ocm.adoc[leveloffset=+1]
 include::modules/rosa-sts-associating-your-aws-account.adoc[leveloffset=+2]
 include::modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc[leveloffset=+2]
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+2]
 include::modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc[leveloffset=+2]
 include::modules/rosa-sts-creating-a-cluster-quickly-cli.adoc[leveloffset=+1]
 

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -38,6 +38,7 @@ include::modules/osd-aws-vpc-required-resources.adoc[leveloffset=+1]
 * For more information about the default components required for an AWS cluster, see link:https://docs.aws.amazon.com/vpc/latest/userguide/default-vpc.html[Default VPCs] in the AWS documentation.
 * For instructions on creating a VPC in the AWS console, see link:https://docs.aws.amazon.com/vpc/latest/userguide/create-vpc.html[Create a VPC] in the AWS documentation.
 
+include::modules/rosa-sts-byo-oidc.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-a-cluster-using-customizations.adoc[leveloffset=+1]
 include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-4806](https://issues.redhat.com/browse/OSDOCS-4806)

Link to docs preview:
*  [Creating a ROSA cluster with STS using the default options](https://62798--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-quickly.html#rosa-sts-byo-oidc_rosa-sts-creating-a-cluster-quickly)
* [Creating a ROSA cluster with STS using customizations](https://62798--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html) 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the OIDC configuration to the ROSA Classic creation. I also renamed the modules to be less specific to ROSA with HCP.