### PR TITLE
virt: Update DPDK checkup's documentation

### DIFF
--- a/modules/virt-checking-cluster-dpdk-readiness.adoc
+++ b/modules/virt-checking-cluster-dpdk-readiness.adoc
@@ -6,12 +6,11 @@
 [id="virt-checking-cluster-dpdk-readiness_{context}"]
 = DPDK checkup
 
-Use a predefined checkup to verify that your {product-title} cluster node can run a virtual machine (VM) with a Data Plane Development Kit (DPDK) workload with zero packet loss. The DPDK checkup runs traffic between a traffic generator pod and a VM running a test DPDK application.
+Use a predefined checkup to verify that your {product-title} cluster node can run a virtual machine (VM) with a Data Plane Development Kit (DPDK) workload with zero packet loss. The DPDK checkup runs traffic between a traffic generator and a VM running a test DPDK application.
 
 You run a DPDK checkup by performing the following steps:
 
-. Create a service account, role, and role bindings for the DPDK checkup and a service account for the traffic generator pod.
-. Create a security context constraints resource for the traffic generator pod.
+. Create a service account, role, and role bindings for the DPDK checkup.
 . Create a config map to provide the input to run the checkup and to store the results.
 . Create a job to run the checkup.
 . Review the results in the config map.
@@ -19,23 +18,13 @@ You run a DPDK checkup by performing the following steps:
 . When you are finished, delete the DPDK checkup resources.
 
 .Prerequisites
-* You have access to the cluster as a user with `cluster-admin` permissions.
 * You have installed the OpenShift CLI (`oc`).
-* You have configured the compute nodes to run DPDK applications on VMs with zero packet loss.
-
-[IMPORTANT]
-====
-The traffic generator pod created by the checkup has elevated privileges:
-
-* It runs as root.
-* It has a bind mount to the node's file system.
-
-The container image of the traffic generator is pulled from the upstream Project Quay container registry.
-====
+* The cluster is configured to run DPDK applications.
+* The project is configured to run DPDK applications.
 
 .Procedure
 
-. Create a `ServiceAccount`, `Role`, and `RoleBinding` manifest for the DPDK checkup and the traffic generator pod:
+. Create a `ServiceAccount`, `Role`, and `RoleBinding` manifest for the DPDK checkup:
 +
 .Example service account, role, and rolebinding manifest file
 [%collapsible]
@@ -81,14 +70,8 @@ rules:
     resources: [ "virtualmachineinstances/console" ]
     verbs: [ "get" ]
   - apiGroups: [ "" ]
-    resources: [ "pods" ]
-    verbs: [ "create", "get", "delete" ]
-  - apiGroups: [ "" ]
-    resources: [ "pods/exec" ]
-    verbs: [ "create" ]
-  - apiGroups: [ "k8s.cni.cncf.io" ]
-    resources: [ "network-attachment-definitions" ]
-    verbs: [ "get" ]
+    resources: [ "configmaps" ]
+    verbs: [ "create", "delete" ]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
@@ -101,11 +84,6 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
   name: kubevirt-dpdk-checker
----
-apiVersion: v1
-kind: ServiceAccount
-metadata:
-  name: dpdk-checkup-traffic-gen-sa
 ----
 ====
 
@@ -114,53 +92,6 @@ metadata:
 [source,terminal]
 ----
 $ oc apply -n <target_namespace> -f <dpdk_sa_roles_rolebinding>.yaml
-----
-
-. Create a `SecurityContextConstraints` manifest for the traffic generator pod:
-+
-.Example security context constraints manifest
-[source,yaml]
-----
-apiVersion: security.openshift.io/v1
-kind: SecurityContextConstraints
-metadata:
-  name: dpdk-checkup-traffic-gen
-allowHostDirVolumePlugin: true
-allowHostIPC: false
-allowHostNetwork: false
-allowHostPID: false
-allowHostPorts: false
-allowPrivilegeEscalation: false
-allowPrivilegedContainer: false
-allowedCapabilities:
-- IPC_LOCK
-- NET_ADMIN
-- NET_RAW
-- SYS_RESOURCE
-defaultAddCapabilities: null
-fsGroup:
-  type: RunAsAny
-groups: []
-readOnlyRootFilesystem: false
-requiredDropCapabilities: null
-runAsUser:
-  type: RunAsAny
-seLinuxContext:
-  type: RunAsAny
-seccompProfiles:
-- runtime/default
-- unconfined
-supplementalGroups:
-  type: RunAsAny
-users:
-- system:serviceaccount:dpdk-checkup-ns:dpdk-checkup-traffic-gen-sa
-----
-
-. Apply the `SecurityContextConstraints` manifest:
-+
-[source,terminal]
-----
-$ oc apply -f <dpdk_scc>.yaml
 ----
 
 . Create a `ConfigMap` manifest that contains the input parameters for the checkup:
@@ -175,14 +106,12 @@ metadata:
 data:
   spec.timeout: 10m
   spec.param.networkAttachmentDefinitionName: <network_name> <1>
-  spec.param.trafficGeneratorRuntimeClassName: <runtimeclass_name> <2>
-  spec.param.trafficGeneratorImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.1" <3>
-  spec.param.vmContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.1" <4>
+  spec.param.trafficGeneratorImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.1" <2>
+  spec.param.vmContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.1" <3>
 ----
 <1> The name of the `NetworkAttachmentDefinition` object.
-<2> The `RuntimeClass` resource that the traffic generator pod uses.
-<3> The container image for the traffic generator. In this example, the image is pulled from the upstream Project Quay Container Registry.
-<4> The container disk image for the VM. In this example, the image is pulled from the upstream Project Quay Container Registry.
+<2> The container image for the traffic generator. In this example, the image is pulled from the upstream Project Quay Container Registry.
+<3> The container disk image for the VM. In this example, the image is pulled from the upstream Project Quay Container Registry.
 
 . Apply the `ConfigMap` manifest in the target namespace:
 +
@@ -258,8 +187,7 @@ metadata:
   name: dpdk-checkup-config
 data:
   spec.timeout: 1h2m
-  spec.param.NetworkAttachmentDefinitionName: "mlx-dpdk-network-1"
-  spec.param.trafficGeneratorRuntimeClassName: performance-performance-zeus10
+  spec.param.NetworkAttachmentDefinitionName: "dpdk-network-1"
   spec.param.trafficGeneratorImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.1"
   spec.param.vmContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.1"
   status.succeeded: true

--- a/virt/monitoring/virt-running-cluster-checkups.adoc
+++ b/virt/monitoring/virt-running-cluster-checkups.adoc
@@ -24,6 +24,7 @@ include::modules/virt-building-vm-containerdisk-image.adoc[leveloffset=+2]
 [role="_additional-resources"]
 [id="additional-resources_running-cluster-checkups"]
 == Additional resources
+* xref:../../virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network.adoc#virt-configuring-vm-project-dpdk_virt-attaching-vm-to-sriov-network[Configuring a project for DPDK workloads]
 * xref:../../virt/virtual_machines/vm_networking/virt-attaching-vm-multiple-networks.adoc#virt-attaching-vm-multiple-networks[Attaching a virtual machine to multiple networks]
 * xref:../../networking/hardware_networks/using-dpdk-and-rdma.adoc#example-vf-use-in-dpdk-mode-intel_using-dpdk-and-rdma[Using a virtual function in DPDK mode with an Intel NIC]
 * xref:../../networking/hardware_networks/using-dpdk-and-rdma.adoc#nw-example-dpdk-line-rate_using-dpdk-and-rdma[Using SR-IOV and the Node Tuning Operator to achieve a DPDK line rate]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Following the conversion of the traffic generator pod to a VM, the following updates are required:
1. Removal of traffic-gen ServiceAccount and SCC.
2. Removal of `runtimeClass` input.
3. Removal of pod and NetworkAttachmentDefinition RBAC rules.
4. Addition of ConfigMap RBAC roles.

The checkup is now deployable and executable by a project-admin.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://62804--docspreview.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups.html#virt-checking-cluster-dpdk-readiness_virt-running-cluster-checkups

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
A follow-up PR should update the three image tags to the proper versions.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
