### PR TITLE
OSDOCS-6971: Documented the 4.13.6 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3031,3 +3031,24 @@ $ oc adm release info 4.13.5 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-13-6"]
+=== RHSA-2023:4226 - {product-title} 4.13.6 bug fix and security update
+
+Issued: 2023-07-27
+
+{product-title} release 4.13.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:4226[RHSA-2023:4226] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4229[RHBA-2023:4229] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.6 --pullspecs
+----
+
+[id="ocp-4-13-6-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-6971](https://issues.redhat.com/browse/OSDOCS-6971)

Version(s):
4.13

Link to docs preview:
[4.13.6](https://62807--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes.html#ocp-4-13-6)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
