### PR TITLE
OSDOCS#7002: Adds notes for Microshift 4.12.26 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -268,10 +268,19 @@ Issued: 2023-07-12
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-25-dp"]
-=== RHBA-2023:3677 - {product-title} 4.12.25 bug fix and security update
+=== RHBA-2023:3677 - {product-title} 4.12.25 bug fix update
 
 Issued: 2023-07-19
 
-{product-title} release 4.12.25, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4047[RHBA-2023:4047] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4048[RHBA-2023:4048] advisory.
+{product-title} release 4.12.25 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4047[RHBA-2023:4047] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4048[RHBA-2023:4048] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-26-dp"]
+=== RHBA-2023:4223 - {product-title} 4.12.26 bug fix update
+
+Issued: 2023-07-26
+
+{product-title} release 4.12.26 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4223[RHBA-2023:4223] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4221[RHBA-2023:4221] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#7002: Adds notes for Microshift 4.12.26 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-7002

Link to docs preview:
https://62812--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-26-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
