### PR TITLE
[enterprise-4.12] OSDOCS#7064: cert-manager Operator 1.11.4 release notes

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,6 +12,22 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1.11.4"]
+== Release notes for {cert-manager-operator} 1.11.4
+
+Issued: 2023-07-26
+
+The following advisory is available for the {cert-manager-operator} 1.11.4:
+
+* link:https://access.redhat.com/errata/RHEA-2023:4081[RHEA-2023:4081]
+
+For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.11/[cert-manager project release notes for v1.11]. The golang version is updated to the version `1.19.10` to fix Common Vulnerabilities and Exposures (CVEs).
+
+[id="cert-manager-operator-1.11.4-bug-fixes"]
+=== Bug fixes
+
+* Previously, the {cert-manager-operator} did not allow you to install older versions of the {cert-manager-operator}. Now, you can install older versions of the {cert-manager-operator} using the web console or the command-line interface (CLI). For more information on how to use the web console to install older versions, see xref:../../security/cert_manager_operator/cert-manager-operator-install.adoc#cert-manager-operator-install[Installing the {cert-manager-operator}]. (link:https://issues.redhat.com/browse/OCPBUGS-16393[*OCPBUGS-16393*])
+
 [id="cert-manager-operator-release-notes-1.10.2"]
 == Release notes for {cert-manager-operator} 1.10.2
 


### PR DESCRIPTION
Manual CP PR of https://github.com/openshift/openshift-docs/pull/62616

Cherry Picked from <4ec8a1919b91f1149730d92c817d5d00cd2fb424> 

https://62817--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes.html
