### PR TITLE
[OSDOCS-7069]: Add entry to hosted control planes glossary

### DIFF
--- a/modules/hosted-control-planes-concepts-personas.adoc
+++ b/modules/hosted-control-planes-concepts-personas.adoc
@@ -21,6 +21,8 @@ hosted control plane:: An {product-title} control plane that runs on the managem
 
 hosting cluster:: See _management cluster_.
 
+managed cluster:: A cluster that the hub cluster manages. This term is specific to the cluster lifecycle that the multicluster engine for Kubernetes Operator manages in Red Hat Advanced Cluster Management. A managed cluster is not the same thing as a _management cluster_. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/about/welcome-to-red-hat-advanced-cluster-management-for-kubernetes#managed-cluster[Managed cluster].
+
 management cluster:: An {product-title} cluster where the HyperShift Operator is deployed and where the control planes for tenant clusters are hosted. The management cluster is synonymous with the _hosting cluster_.
 
 management cluster infrastructure:: Network, compute, and storage resources of the management cluster.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7069
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62824--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/index.html#hosted-control-planes-concepts_hcp-overview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
