### PR TITLE
OSDOCS-7071: Adding note of plans for PSA restricted enforcement in 4.15

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -174,6 +174,26 @@ For further information about gathering debugging information relating to low-la
 // Note: use [discrete] for these sub-headings.
 
 [discrete]
+[id="ocp-4-14-planned-psa-restricted-enforcement"]
+=== Future restricted enforcement for pod security admission
+
+Currently, pod security violations are shown as warnings and logged in the audit logs, but do not cause the pod to be rejected.
+
+Global restricted enforcement for pod security admission is currently planned for the next minor release of {product-title}. When this restricted enforcement is enabled, pods with pod security violations will be rejected.
+
+To prepare for this upcoming change, ensure that your workloads match the pod security admission profile that applies to them. Workloads that are not configured according to the enforced security standards defined globally or at the namespace level will be rejected. The `restricted-v2` SCC admits workloads according to the link:https://kubernetes.io/docs/concepts/security/pod-security-standards/#restricted[Restricted] Kubernetes definition.
+
+If you are receiving pod security violations, see the following resources:
+
+* See xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-alert-eval_understanding-and-managing-pod-security-admission[Identifying pod security violations] for information about how to find which workloads are causing pod security violations.
+
+* See xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-synchronization_understanding-and-managing-pod-security-admission[Security context constraint synchronization with pod security standards] to understand when pod security admission label synchronization is performed. Pod security admission labels are not synchronized in certain situations, such as the following situations:
+** The workload is running in a system-created namespace that is prefixed with `openshift-`.
+** The workload is running on a pod that was created directly without a pod controller.
+
+* If necessary, you can set a custom admission profile on the namespace or pod by setting the `pod-security.kubernetes.io/enforce` label.
+
+[discrete]
 [id="ocp-4-14-cert-manager-operator-1-11-1"]
 === cert-manager Operator general availability
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7071

Link to docs preview:
https://62826--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-planned-psa-restricted-enforcement

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**This text was already approved and used in the 4.13 release notes** See PR #57448.
