### PR TITLE
OCPBUGS-7621-health-Ex-LB: Adding h. check for vSphere external LB se…

### DIFF
--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -162,3 +162,49 @@ content-type: text/html; charset=utf-8
 set-cookie: 1e2670d92730b515ce3a1bb65da45062=9b714eb87e93cf34853e87a92d6894be; path=/; HttpOnly; Secure; SameSite=None
 cache-control: private
 ----
+
+.Verification
+
+To determine that an external load balancer functions correctly, perform a health check on each backend service. A healthy backend service must establish a connection with all health check probes/connection requests.
+
+Create a `Pod` object/health check resource and then specify parameters the probe checks. The settings you apply to the resource depend on the type of external load balancer that you configured for your cluster. Ensure that you create a resource for each backend service. You can then issue the following command to perform a health check on the resource:
+
+[source,terminal]
+----
+$ oc describe pod health-check
+----
+
+Each of the following examples demonstrates a configured health check resource for a specific type of backend service:
+
+* Kubernetes API server
++
+[source,yaml]
+----
+Path: HTTPS:6443/readyz
+Healthy threshold: 2
+Unhealthy threshold: 2
+Timeout: 10
+Interval: 10
+----
+
+* Machine config server:
++
+[source,yaml]
+----
+Path: HTTPS:22623/healthz
+Healthy threshold: 2
+Unhealthy threshold: 2
+Timeout: 10
+Interval: 10
+----
+
+* Ingress Controller for HTTP and HTTPS traffic:
++
+[source,yaml]
+----
+Path: HTTP:1936/healthz/ready 
+Healthy threshold: 2
+Unhealthy threshold: 2
+Timeout: 5
+Interval: 10
+----


### PR DESCRIPTION
[OCPBUGS-7621](https://issues.redhat.com/browse/OCPBUGS-7621)

Version(s):
4.14 through to 4.10

Link to docs preview:
[Configuring an external load balancer](https://62828--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.html#nw-osp-configuring-external-load-balancer_installing-vsphere-installer-provisioned-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [GCP](https://cloud.google.com/load-balancing/docs/health-check-concepts)
