### PR TITLE
[OSDOCS-7023]: Updating references to hypershift CLI

### DIFF
--- a/modules/advanced-node-tuning-hosted-cluster.adoc
+++ b/modules/advanced-node-tuning-hosted-cluster.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * scalability_and_performance/using-node-tuning-operator.adoc
+// * hosted_control_planes/hcp-managing.adoc
 
 :_content-type: PROCEDURE
 [id="advanced-node-tuning-hosted-cluster_{context}"]
@@ -55,7 +56,7 @@ The `.spec.recommend.match` field is intentionally left blank. In this case, thi
 $ oc --kubeconfig="$MGMT_KUBECONFIG" create -f tuned-hugepages.yaml
 ----
 
-. Create a `NodePool` manifest YAML file, customize the upgrade type of the `NodePool`, and reference the `ConfigMap` object that you created in the `spec.tuningConfig` section. Create the `NodePool` manifest and save it in a file named `hugepages-nodepool.yaml` by using the `hypershift` CLI:
+. Create a `NodePool` manifest YAML file, customize the upgrade type of the `NodePool`, and reference the `ConfigMap` object that you created in the `spec.tuningConfig` section. Create the `NodePool` manifest and save it in a file named `hugepages-nodepool.yaml` by using the `hcp` CLI:
 +
 [source,yaml]
 ----
@@ -63,7 +64,7 @@ $ oc --kubeconfig="$MGMT_KUBECONFIG" create -f tuned-hugepages.yaml
     INSTANCE_TYPE=m5.2xlarge
     NODEPOOL_REPLICAS=2
 
-    hypershift create nodepool aws \
+    hcp create nodepool aws \
       --cluster-name $CLUSTER_NAME \
       --name $NODEPOOL_NAME \
       --node-count $NODEPOOL_REPLICAS \


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7023
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62838--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-node-tuning-operator#advanced-node-tuning-hosted-cluster_node-tuning-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
