### PR TITLE
RHDEVDOCS-5457: fix attribute issues in Pipelines

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -83,7 +83,7 @@ endif::[]
 //pipelines
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: OpenShift Pipelines
-:pipelines-ver: pipelines-1.9
+:pipelines-ver: pipelines-1.11
 :tekton-chains: Tekton Chains
 :tekton-hub: Tekton Hub
 :artifact-hub: Artifact Hub

--- a/modules/op-supported-parameters-tekton-chains-configuration.adoc
+++ b/modules/op-supported-parameters-tekton-chains-configuration.adoc
@@ -167,7 +167,7 @@ To create occurrences, {pipelines-title} must first create notes that are used t
 | Parameter | Description | Supported values | Default value
 
 | `storage.grafeas.projectid`
-| The {OCP} project in which the Grafeas server for storing occurrences is located.
+| The {product-title} project in which the Grafeas server for storing occurrences is located.
 |
 |
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.12, 4.13, 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/RHDEVDOCS-5457

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://62840--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-tekton-chains-for-openshift-pipelines-supply-chain-security.html#supported-parameters-tekton-chains-configuration_using-tekton-chains-for-openshift-pipelines-supply-chain-security (Table 7)


QE review: n/a (meaning not changed)
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
A small fix. One place uses an attribute that does not exist. Also a version attribute was not updated since 1.9 and this affects some links. The affected links have been checked and work correctly. The preview link is to the place where the wrong attribute was used.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
