### PR TITLE
Creating a new Distro to exclude books in docs.openshift.com

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -194,7 +194,7 @@ openshift-rosa-portal:
   branches:
     enterprise-4.13:
       name: ''
-      dir: rosa-portal/
+      dir: rosa-portal/   
 openshift-webscale:
   name: OpenShift Container Platform
   author: OpenShift Documentation Project <openshift-docs@redhat.com>

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -314,7 +314,7 @@ Topics:
 ---
 Name: Registry
 Dir: registry
-Distros: openshift-rosa
+Distros: openshift-rosa-portal
 Topics:
 - Name: Registry overview
   File: index


### PR DESCRIPTION
[OSDOCS-4908:](https://issues.redhat.com/browse/OSDOCS-4908) Deprecation of ROSA docs from docs.openshift.com
Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OSDOCS-4908](https://issues.redhat.com/browse/OSDOCS-4908)
Preview pages:
Peer review requested: @kalexand-rh