### PR TITLE
PR for SRVOCF-524: [DOC] Serverless section location on d.o.c

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2115,6 +2115,16 @@ Topics:
   File: red-hat-marketplace
   Distros: openshift-origin,openshift-enterprise
 ---
+Name: Serverless
+Dir: serverless
+Distros: openshift-enterprise
+Topics:
+- Name: About Serverless
+  Dir: about
+  Topics:
+  - Name: Serverless overview
+    File: about-serverless
+---
 Name: Machine management
 Dir: machine_management
 Distros: openshift-origin,openshift-enterprise
@@ -3865,13 +3875,4 @@ Topics:
 #  - Name: Collecting OKD Virtualization data for community report
 #    File: virt-collecting-virt-data
 #    Distros: openshift-origin
----
-Name: Serverless
-Dir: serverless
-Distros: openshift-enterprise
-Topics:
-- Name: About Serverless
-  Dir: about
-  Topics:
-  - Name: Serverless overview
-    File: about-serverless
+


### PR DESCRIPTION
**Affected versions for cherry-picking:** Openshift 4.10+

**Dedicated JIRA:** https://issues.redhat.com/browse/SRVOCF-524?src=confmacro

**Description:**  In `_topic_map.yml`, changed the location of the **Serverless** section. It is now present under the **Building application** section. 

**Doc preview:** 
NOTE: I was unable to provide a build preview and Netlify preview is also not generating so I have attached the screenshot of my local build preview. (You can see that Serverless is now present under Building applications.)
![image](https://github.com/openshift/openshift-docs/assets/43639538/1a60982e-7f9c-4a85-821b-b5ea4d0bb293)
