### PR TITLE
[OSDOCS-6377] Update kuryr-ovn kubernetes migration docs

### DIFF
--- a/modules/nw-kuryr-cleanup.adoc
+++ b/modules/nw-kuryr-cleanup.adoc
@@ -12,9 +12,15 @@ plugin, you must clean up the resources that Kuryr created previously.
 [NOTE]
 ====
 The clean up process relies on a Python virtual environment to ensure that the package versions that you use support tags for Octavia objects. You do not need a virtual environment if you are certain that your environment uses at minimum:
-* `openstacksdk` version 0.54.0
-* `python-openstackclient` version 5.5.0
-* `python-octaviaclient` version 2.3.0 
+
+* The `openstacksdk` Python package version 0.54.0
+
+* The `python-openstackclient` Python package version 5.5.0
+
+* The `python-octaviaclient` Python package version 2.3.0
+
+If you decide to use these particular versions, be sure to pull `python-neutronclient` prior to version 9.0.0, as it prevents you from accessing trunks.
+
 ====
 
 .Prerequisites
@@ -46,13 +52,13 @@ $ source /tmp/venv/bin/activate
 +
 [source,terminal]
 ----
-(venv) $ pip install pip --upgrade
+(venv) $ pip install --upgrade pip
 ----
 .. Install the required Python packages by running the following command:
 +
 [source,terminal]
 ----
-(venv) $ pip install openstacksdk==0.54.0 python-openstackclient==5.5.0 python-octaviaclient==2.3.0
+(venv) $ pip install openstacksdk==0.54.0 python-openstackclient==5.5.0 python-octaviaclient==2.3.0 'python-neutronclient<9.0.0'
 ----
 
 . In your terminal, set variables to cluster and Kuryr identifiers by running the following commands:
@@ -74,7 +80,7 @@ $ source /tmp/venv/bin/activate
 +
 [source,terminal]
 ----
-(venv) $ ROUTERID=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.routerId"|head -n 1)
+(venv) $ ROUTERID=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.routerId"|uniq)
 ----
 
 . Create a Bash function that removes finalizers from specified resources by running the following command:
@@ -84,12 +90,12 @@ $ source /tmp/venv/bin/activate
 (venv) $ function REMFIN {
     local resource=$1
     local finalizer=$2
-    for res in $(oc get $resource -A --template='{{range $i,$p := .items}}{{ $p.metadata.name }}|{{ $p.metadata.namespace }}{{"\n"}}{{end}}'); do
+    for res in $(oc get "${resource}" -A --template='{{range $i,$p := .items}}{{ $p.metadata.name }}|{{ $p.metadata.namespace }}{{"\n"}}{{end}}'); do
         name=${res%%|*}
         ns=${res##*|}
-        yaml=$(oc get -n $ns $resource $name -o yaml)
+        yaml=$(oc get -n "${ns}" "${resource}" "${name}" -o yaml)
         if echo "${yaml}" | grep -q "${finalizer}"; then
-            echo "${yaml}" | grep -v  "${finalizer}" | oc replace -n $ns $resource $name -f -
+            echo "${yaml}" | grep -v  "${finalizer}" | oc replace -n "${ns}" "${resource}" "${name}" -f -
         fi
     done
 }
@@ -109,7 +115,7 @@ The named resource is removed from the cluster and its definition is replaced wi
 +
 [source,terminal]
 ----
-(venv) $ if $(oc get -n openshift-kuryr service service-subnet-gateway-ip &>/dev/null); then
+(venv) $ if oc get -n openshift-kuryr service service-subnet-gateway-ip &>/dev/null; then
     oc -n openshift-kuryr delete service service-subnet-gateway-ip
 fi
 ----
@@ -118,8 +124,8 @@ fi
 +
 [source,terminal]
 ----
-(venv) $ for lb in $(openstack loadbalancer list --tags $CLUSTERTAG -f value -c id); do
-    openstack loadbalancer delete --cascade $lb
+(venv) $ for lb in $(openstack loadbalancer list --tags "${CLUSTERTAG}" -f value -c id); do
+    openstack loadbalancer delete --cascade "${lb}"
 done
 ----
 
@@ -141,14 +147,14 @@ done
 +
 [source,terminal]
 ----
-(venv) $ openstack router remove subnet $ROUTERID ${CLUSTERID}-kuryr-service-subnet
+(venv) $ openstack router remove subnet "${ROUTERID}" "${CLUSTERID}-kuryr-service-subnet"
 ----
 
 . To remove the Kuryr service network, enter the following command:
 +
 [source,terminal]
 ----
-(venv) $ openstack network delete ${CLUSTERID}-kuryr-service-network
+(venv) $ openstack network delete "${CLUSTERID}-kuryr-service-network"
 ----
 
 . To remove Kuryr finalizers from all pods, enter the following command:
@@ -184,9 +190,10 @@ This command deletes the `KuryrPort` CRs.
 +
 [source,terminal]
 ----
-(venv) $ read -ra trunks <<< $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))") && \
+(venv) $ mapfile trunks < <(python -c "import openstack; n = openstack.connect().network; print('\n'.join([x.id for x in n.trunks(any_tags='$CLUSTERTAG')]))") && \
 i=0 && \
 for trunk in "${trunks[@]}"; do
+    trunk=$(echo "$trunk"|tr -d '\n')
     i=$((i+1))
     echo "Processing trunk $trunk, ${i}/${#trunks[@]}."
     subports=()
@@ -198,7 +205,7 @@ for trunk in "${trunks[@]}"; do
         args+=("--subport $sub")
     done
     if [ ${#args[@]} -gt 0 ]; then
-        openstack network trunk unset ${args[*]} $trunk
+        openstack network trunk unset ${args[*]} "${trunk}"
     fi
 done
 ----
@@ -216,7 +223,7 @@ for kn in "${kuryrnetworks[@]}"; do
     echo "Processing network $netID, ${i}/${#kuryrnetworks[@]}"
     # Remove all ports from the network.
     for port in $(python -c "import openstack; n = openstack.connect().network; print(' '.join([x.id for x in n.ports(network_id='$netID') if x.device_owner != 'network:router_interface']))"); do
-        ( openstack port delete $port ) &
+        ( openstack port delete "${port}" ) &
 
         # Only allow 20 jobs in parallel.
         if [[ $(jobs -r -p | wc -l) -ge 20 ]]; then
@@ -226,10 +233,10 @@ for kn in "${kuryrnetworks[@]}"; do
     wait
 
     # Remove the subnet from the router.
-    openstack router remove subnet $ROUTERID $subnetID
+    openstack router remove subnet "${ROUTERID}" "${subnetID}"
 
     # Remove the network.
-    openstack network delete $netID
+    openstack network delete "${netID}"
 done
 ----
 
@@ -237,15 +244,15 @@ done
 +
 [source,terminal]
 ----
-(venv) $ openstack security group delete ${CLUSTERID}-kuryr-pods-security-group
+(venv) $ openstack security group delete "${CLUSTERID}-kuryr-pods-security-group"
 ----
 
 . To remove all tagged subnet pools, enter the following command:
 +
 [source,terminal]
 ----
-(venv) $ for subnetpool in $(openstack subnet pool list --tags $CLUSTERTAG -f value -c ID); do
-    openstack subnet pool delete $subnetpool
+(venv) $ for subnetpool in $(openstack subnet pool list --tags "${CLUSTERTAG}" -f value -c ID); do
+    openstack subnet pool delete "${subnetpool}"
 done
 ----
 
@@ -254,7 +261,7 @@ done
 [source,terminal]
 ----
 (venv) $ networks=$(oc get kuryrnetwork -A --no-headers -o custom-columns=":status.netId") && \
-for existingNet in $(openstack network list --tags $CLUSTERTAG -f value -c ID); do
+for existingNet in $(openstack network list --tags "${CLUSTERTAG}" -f value -c ID); do
     if [[ $networks =~ $existingNet ]]; then
         echo "Network still exists: $existingNet"
     fi
@@ -268,7 +275,7 @@ If the command returns any existing networks, intestigate and remove them before
 [source,terminal]
 ----
 (venv) $ for sgid in $(openstack security group list -f value -c ID -c Description | grep 'Kuryr-Kubernetes Network Policy' | cut -f 1 -d ' '); do
-    openstack security group delete $sgid
+    openstack security group delete "${sgid}"
 done
 ----
 
@@ -283,7 +290,7 @@ done
 +
 [source,terminal]
 ----
-(venv) $ if $(python3 -c "import sys; import openstack; n = openstack.connect().network; r = n.get_router('$ROUTERID'); sys.exit(0) if r.description != 'Created By OpenShift Installer' else sys.exit(1)"); then
-    openstack router delete $ROUTERID
+(venv) $ if python3 -c "import sys; import openstack; n = openstack.connect().network; r = n.get_router('$ROUTERID'); sys.exit(0) if r.description != 'Created By OpenShift Installer' else sys.exit(1)"; then
+    openstack router delete "${ROUTERID}"
 fi
 ----

--- a/modules/nw-kuryr-migration.adoc
+++ b/modules/nw-kuryr-migration.adoc
@@ -47,8 +47,8 @@ $ CLUSTERID=$(oc get infrastructure.config.openshift.io cluster -o=jsonpath='{.s
 +
 [source,terminal]
 ----
-$ oc patch Network.operator.openshift.io cluster --type='merge' \
-  --patch '{ "spec": { "migration": { "networkType": "OVNKubernetes" } } }'
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+    --patch '{"spec": {"migration": {"networkType": "OVNKubernetes"}}}'
 ----
 +
 [NOTE]
@@ -216,8 +216,8 @@ where:
 +
 [source,terminal]
 ----
-$ oc patch Network.config.openshift.io cluster \
-  --type='merge' --patch '{ "spec": { "networkType": "OVNKubernetes" } }'
+$ oc patch Network.config.openshift.io cluster --type=merge \
+    --patch '{"spec": {"networkType": "OVNKubernetes"}}'
 ----
 
 ** To specify a different cluster network IP address block, enter the following command:
@@ -250,24 +250,6 @@ You cannot change the service network address block during the migration.
 You cannot use any CIDR block that overlaps with the `100.64.0.0/16` CIDR block because the OVN-Kubernetes network provider uses this block internally.
 ====
 
-. Verify that the Multus daemon set rollout is complete by entering the following command:
-+
-[source,terminal]
-----
-$ oc -n openshift-multus rollout status daemonset/multus
-----
-+
-The name of the Multus pods is in the form of `multus-<xxxxx>`, where `<xxxxx>` is a random sequence of letters. It might take several moments for the pods to restart.
-+
-.Example output
-[source,text]
-----
-Waiting for daemon set "multus" rollout to finish: 1 out of 6 new pods have been updated...
-...
-Waiting for daemon set "multus" rollout to finish: 5 of 6 updated pods are available...
-daemon set "multus" successfully rolled out
-----
-
 . To complete the migration, reboot each node in your cluster. For example, you can use a bash script similar to the following example. The script assumes that you can connect to each host by using `ssh` and that you have configured `sudo` to not prompt for a password:
 +
 [source,bash]
@@ -286,7 +268,7 @@ done
 If SSH access is not available, you can use the `openstack` command:
 [source,terminal]
 ----
-$ for name in $(openstack server list --name ${CLUSTERID}\* -f value -c Name); do openstack server reboot $name; done
+$ for name in $(openstack server list --name "${CLUSTERID}*" -f value -c Name); do openstack server reboot "${name}"; done
 ----
 Alternatively, you might be able to to reboot each node through the management portal for
 your infrastructure provider. Otherwise, contact the appropriate authority to
@@ -341,6 +323,6 @@ You might encounter pods that have a `Terminating` state due to finalizers that 
 +
 [source,terminal]
 ----
-$ oc patch Network.operator.openshift.io cluster --type='merge' \
-  --patch '{ "spec": { "migration": null } }'
+$ oc patch Network.operator.openshift.io cluster --type=merge \
+    --patch '{"spec": {"migration": null}}'
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6377
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62843--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
