### PR TITLE
OSDOCS#6278: Release note for Nutanix three-node cluster

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -76,6 +76,12 @@ All {product-title} 4.13 clusters require this administrator acknowledgment befo
 
 For more information, see xref:../updating/preparing_for_updates/updating-cluster-prepare.adoc#updating-cluster-prepare[Preparing to update to {product-title} 4.14].
 
+[id="ocp-4-14-nutanix-three-node"]
+==== Three-node cluster support for Nutanix
+Deploying a three-node cluster is supported on Nutanix as of {product-title} {product-version}. This type of {product-title} cluster is a more resource efficient cluster. It consists of only three control plane machines, which also act as compute machines.
+
+For more information, see xref:../installing/installing_nutanix/installing-nutanix-three-node.adoc#installing-nutanix-three-node[Installing a three-node cluster on Nutanix].
+
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
This PR addresses [osdocs-6278](https://issues.redhat.com/browse/OSDOCS-6278).

Link to docs preview:

[Three-node cluster support for Nutanix](https://62852--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-nutanix-three-node)

QE review:
- [ ] QE has approved this change.
