### PR TITLE
Remove attribute in title to fix CP display

### DIFF
--- a/cloud_service/rhacs-cloud-service-service-description.adoc
+++ b/cloud_service/rhacs-cloud-service-service-description.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
+include::modules/common-attributes.adoc[]
 [id="rhacs-cloud-service-service-description"]
 = {product-title-managed-short} service description
-include::modules/common-attributes.adoc[]
 :context: access-policy-service-description
 
 toc::[]


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.2`
- Cherry pick to `rhacs-docs-4.1`
 
Issue: none
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[Link to docs preview
](https://62867--docspreview.netlify.app/openshift-acs/latest/cloud_service/rhacs-cloud-service-service-description.html)

QE review:
- [x] QE has approved this change. (**N/A**)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Attribute not showing up properly in Customer Portal. Move include up so that the include happens before the title is rendered. (Thanks @aireilly for the help!)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
