### PR TITLE
OSDOCS#5126: Using an Azure managed identity as an alternative to a s…

### DIFF
--- a/installing/installing_azure/installing-azure-account.adoc
+++ b/installing/installing_azure/installing-azure-account.adoc
@@ -6,8 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Before you can install {product-title}, you must configure a Microsoft Azure
-account.
+Before you can install {product-title}, you must configure a Microsoft Azure account to meet installation requirements.
 
 [IMPORTANT]
 ====
@@ -29,11 +28,13 @@ include::modules/installation-azure-network-config.adoc[leveloffset=+1]
 
 include::modules/installation-azure-increasing-limits.adoc[leveloffset=+1]
 
-include::modules/installation-azure-permissions.adoc[leveloffset=+1]
+include::modules/installation-azure-subscription-tenant-id.adoc[leveloffset=+1]
 
-include::modules/minimum-required-permissions-ipi-azure.adoc[leveloffset=+1]
+include::modules/installation-azure-identities.adoc[leveloffset=+1]
 
-include::modules/installation-azure-service-principal.adoc[leveloffset=+1]
+include::modules/minimum-required-permissions-ipi-azure.adoc[leveloffset=+2]
+include::modules/installation-using-azure-managed-identities.adoc[leveloffset=+2]
+include::modules/installation-creating-azure-service-principal.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -57,9 +57,15 @@ include::modules/installation-azure-increasing-limits.adoc[leveloffset=+2]
 
 include::modules/csr-management.adoc[leveloffset=+2]
 
-include::modules/installation-azure-permissions.adoc[leveloffset=+2]
+include::modules/installation-azure-subscription-tenant-id.adoc[leveloffset=+2]
+
+include::modules/installation-azure-identities.adoc[leveloffset=+2]
+
 include::modules/minimum-required-permissions-upi-azure.adoc[leveloffset=+2]
-include::modules/installation-azure-service-principal.adoc[leveloffset=+2]
+
+include::modules/installation-using-azure-managed-identities.adoc[leveloffset=+2]
+
+include::modules/installation-creating-azure-service-principal.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources

--- a/modules/installation-azure-identities.adoc
+++ b/modules/installation-azure-identities.adoc
@@ -1,0 +1,13 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_azure/installing-azure-account.adoc
+
+:_content-type: CONCEPT
+[id="installation-azure-identities_{context}"]
+= Supported identities to access Azure resources
+
+An {product-title} cluster requires an Azure identity to create and manage Azure resources. As such, you need one of the following types of identities to complete the installation:
+
+* A service principal
+* A system-assigned managed identity
+* A user-assigned managed identity

--- a/modules/installation-azure-subscription-tenant-id.adoc
+++ b/modules/installation-azure-subscription-tenant-id.adoc
@@ -1,0 +1,121 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_azure/installing-azure-account.adoc
+
+:_content-type: PROCEDURE
+[id="installation-azure-subscription-tenant-id_{context}"]
+= Recording the subscription and tenant IDs
+
+The installation program requires the subscription and tenant IDs that are associated with your Azure account. You can use the Azure CLI to gather this information.
+
+.Prerequisites
+
+* You have installed or updated the link:https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-yum?view=azure-cli-latest[Azure CLI].
+
+.Procedure
+
+. Log in to the Azure CLI by running the following command:
++
+[source,terminal]
+----
+$ az login
+----
+
+. Ensure that you are using the right subscription:
+
+.. View a list of available subscriptions by running the following command:
++
+[source,terminal]
+----
+$ az account list --refresh
+----
++
+.Example output
+[source,terminal]
+----
+[
+  {
+    "cloudName": "AzureCloud",
+    "id": "8xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "isDefault": true,
+    "name": "Subscription Name 1",
+    "state": "Enabled",
+    "tenantId": "6xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "user": {
+      "name": "you@example.com",
+      "type": "user"
+    }
+  },
+  {
+    "cloudName": "AzureCloud",
+    "id": "9xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "isDefault": false,
+    "name": "Subscription Name 2",
+    "state": "Enabled",
+    "tenantId": "7xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+    "user": {
+      "name": "you2@example.com",
+      "type": "user"
+    }
+  }
+]
+----
+
+.. View the details of the active account, and confirm that this is the subscription you want to use, by running the following command:
++
+[source,terminal]
+----
+$ az account show
+----
++
+.Example output
+[source,terminal]
+----
+{
+  "environmentName": "AzureCloud",
+  "id": "8xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "isDefault": true,
+  "name": "Subscription Name 1",
+  "state": "Enabled",
+  "tenantId": "6xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "user": {
+    "name": "you@example.com",
+    "type": "user"
+  }
+}
+----
+
+. If you are not using the right subscription:
+
+.. Change the active subscription by running the following command:
++
+[source,terminal]
+----
+$ az account set -s <subscription_id>
+----
+
+.. Verify that you are using the subscription you need by running the following command:
++
+[source,terminal]
+----
+$ az account show
+----
++
+.Example output
+[source,terminal]
+----
+{
+  "environmentName": "AzureCloud",
+  "id": "9xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "isDefault": true,
+  "name": "Subscription Name 2",
+  "state": "Enabled",
+  "tenantId": "7xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "user": {
+    "name": "you2@example.com",
+    "type": "user"
+  }
+}
+----
+
+. Record the `id` and `tenantId` parameter values from the output. You require these values to install an {product-title} cluster.

--- a/modules/installation-creating-azure-service-principal.adoc
+++ b/modules/installation-creating-azure-service-principal.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_azure/installing-azure-account.adoc
+
+:_content-type: PROCEDURE
+[id="installation-creating-azure-service-principal_{context}"]
+= Creating a service principal
+
+The installation program requires an Azure identity to complete the installation. You can use a service principal.
+
+If you are unable to use a service principal, you can use a managed identity.
+
+.Prerequisites
+
+* You have installed or updated the link:https://docs.microsoft.com/en-us/cli/azure/install-azure-cli-yum?view=azure-cli-latest[Azure CLI].
+* You have an Azure subscription ID.
+* If you are not going to assign the the `Contributor` and `User Administrator Access` roles to the service principal, you have created a custom role with the required Azure permissions.
+
+.Procedure
+
+. Create the service principal for your account by running the following command:
++
+[source,terminal]
+----
+$ az ad sp create-for-rbac --role <role_name> \// <1>
+     --name <service_principal> \// <2>
+     --scopes /subscriptions/<subscription_id> <3>
+----
+<1> Defines the role name. You can use the `Contributor` role, or you can specify a custom role which contains the necessary permissions.
+<2> Defines the service principal name.
+<3> Specifies the subscription ID.
++
+.Example output
+[source,terminal]
+----
+Creating 'Contributor' role assignment under scope '/subscriptions/<subscription_id>'
+The output includes credentials that you must protect. Be sure that you do not
+include these credentials in your code or check the credentials into your source
+control. For more information, see https://aka.ms/azadsp-cli
+{
+  "appId": "axxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx",
+  "displayName": <service_principal>",
+  "password": "00000000-0000-0000-0000-000000000000",
+  "tenantId": "8xxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+}
+----
+
+. Record the values of the `appId` and `password` parameters from the output. You require these values when installing the cluster.
+
+. If you applied the `Contributor` role to your service principal, assign the `User Administrator Access` role by running the following command:
++
+[source,terminal]
+----
+$ az role assignment create --role "User Access Administrator" \
+  --assignee-object-id $(az ad sp show --id <appId> --query id -o tsv) <1>
+----
+<1> Specify the `appId` parameter value for your service principal.

--- a/modules/installation-initializing.adoc
+++ b/modules/installation-initializing.adoc
@@ -210,30 +210,40 @@ endif::nutanix[]
 
 .Prerequisites
 
-* Obtain the {product-title} installation program and the pull secret for your cluster.
+* You have the {product-title} installation program and the pull secret for your cluster.
 ifdef::restricted[]
 For a restricted network installation, these files are on your mirror host.
 ifndef::nutanix[]
-* Have the `imageContentSources` values that were generated during mirror registry creation.
+* You have the `imageContentSources` values that were generated during mirror registry creation.
 endif::nutanix[]
 ifdef::nutanix+restricted[]
-* Have the `imageContentSourcePolicy.yaml` file that was created when you mirrored your registry.
-* Have the location of the {op-system-first} image you download.
+* You have the `imageContentSourcePolicy.yaml` file that was created when you mirrored your registry.
+* You have the location of the {op-system-first} image you download.
 endif::nutanix+restricted[]
-* Obtain the contents of the certificate for your mirror registry.
+* You have obtained the contents of the certificate for your mirror registry.
 ifndef::aws,gcp[]
-* Retrieve a {op-system-first} image and upload it to an accessible location.
+* You have retrieved a {op-system-first} image and uploaded it to an accessible location.
 endif::aws,gcp[]
 endif::restricted[]
-ifndef::nutanix[]
-* Obtain service principal permissions at the subscription level.
-endif::nutanix[]
+ifdef::azure[]
+* You have an Azure subscription ID and tenant ID.
+* If you are installing the cluster using a service principal, you have its application ID and password.
+* If you are installing the cluster using a system-assigned managed identity, you have enabled it on the virtual machine that you will run the installation program from.
+* If you are installing the cluster using a user-assigned managed identity, you have met these prerequisites:
+** You have its client ID.
+** You have assigned it to the virtual machine that you will run the installation program from.
+endif::azure[]
 ifdef::nutanix[]
-* Verify that you have met the Nutanix networking requirements. For more information, see "Preparing to install on Nutanix".
+* You have verified that you have met the Nutanix networking requirements. For more information, see "Preparing to install on Nutanix".
 endif::nutanix[]
 
 .Procedure
 
+ifdef::azure[]
+. Optional: If you have run the installation program on this computer before, and want to use an alternative service principal or managed identity, go to the `~/.azure/` directory and delete the `osServicePrincipal.json` configuration file.
++
+Deleting this file prevents the installation program from automatically reusing subscription and authentication values from a previous installation.
+endif::azure[]
 . Create the `install-config.yaml` file.
 +
 .. Change to the directory that contains the installation program and run the following command:
@@ -248,7 +258,13 @@ files that the installation program creates.
 When specifying the directory:
 * Verify that the directory has the `execute` permission. This permission is required to run Terraform binaries under the installation directory.
 * Use an empty directory. Some installation assets, such as bootstrap X.509 certificates, have short expiration intervals, therefore you must not reuse an installation directory. If you want to reuse individual files from another cluster installation, you can copy them into your directory. However, the file names for the installation assets might change between releases. Use caution when copying installation files from an earlier {product-title} version.
-
+.. At the prompts, provide the configuration details for your cloud:
+... Optional: Select an SSH key to use to access your cluster machines.
++
+[NOTE]
+====
+For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
+====
 ifdef::alibabacloud-default,alibabacloud-custom,alibabacloud-vpc[]
 ... Select *alibabacloud* as the platform to target.
 ... Select the region to deploy the cluster to.
@@ -265,16 +281,19 @@ installation program.
 endif::aws[]
 ifdef::azure[]
 ... Select *azure* as the platform to target.
-... If you do not have a Microsoft Azure profile stored on your computer, specify the
-following Azure parameter values for your subscription and service principal:
-**** *azure subscription id*: The subscription ID to use for the cluster.
-Specify the `id` value in your account output.
-**** *azure tenant id*: The tenant ID. Specify the `tenantId` value in your
-account output.
-**** *azure service principal client id*: The value of the `appId` parameter
-for the service principal.
-**** *azure service principal client secret*: The value of the `password`
-parameter for the service principal.
++
+If the installation program cannot locate the `osServicePrincipal.json` configuration file from a previous installation, you are prompted for Azure subscription and authentication values.
+... Enter the following Azure parameter values for your subscription:
+**** *azure subscription id*: Enter the subscription ID to use for the cluster.
+**** *azure tenant id*: Enter the tenant ID.
+... Depending on the Azure identity you are using to deploy the cluster, do one of the following when prompted for the *azure service principal client id*:
+**** If you are using a service principal, enter its application ID.
+**** If you are using a system-assigned managed identity, leave this value blank.
+**** If you are using a user-assigned managed identity, specify its client ID.
+... Depending on the Azure identity you are using to deploy the cluster, do one of the following when prompted for the *azure service principal client secret*:
+**** If you are using a service principal, enter its password.
+**** If you are using a system-assigned managed identity, leave this value blank.
+**** If you are using a user-assigned managed identity, leave this value blank.
 ... Select the region to deploy the cluster to.
 ... Select the base domain to deploy the cluster to. The base domain corresponds
 to the Azure DNS Zone that you created for your cluster.
@@ -557,6 +576,10 @@ it to install multiple clusters.
 The `install-config.yaml` file is consumed during the installation process. If
 you want to reuse the file, you must back it up now.
 ====
+
+ifdef::azure[]
+If previously not detected, the installation program creates an `osServicePrincipal.json` configuration file and stores this file in the `~/.azure/` directory on your computer. This ensures that the installation program can load the profile when it is creating an {product-title} cluster on the target platform.
+endif::azure[]
 
 ifdef::osp-user[You now have the file `install-config.yaml` in the directory that you specified.]
 

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -110,6 +110,7 @@ endif::[]
 ifeval::["{context}" == "installing-azure-default"]
 :no-config:
 :azure:
+:azure-default:
 endif::[]
 ifeval::["{context}" == "installing-gcp-customizations"]
 :custom-config:
@@ -147,7 +148,7 @@ endif::[]
 ifeval::["{context}" == "installing-azure-government-region"]
 :custom-config:
 :azure:
-:single-step:
+:azure-gov:
 endif::[]
 ifeval::["{context}" == "installing-azure-vnet"]
 :custom-config:
@@ -162,7 +163,7 @@ endif::[]
 ifeval::["{context}" == "installing-azure-private"]
 :custom-config:
 :azure:
-:single-step:
+:azure-private:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :custom-config:
@@ -271,15 +272,27 @@ You can run the `create cluster` command of the installation program only once, 
 
 .Prerequisites
 
-ifndef::osp,vsphere,nutanix[* Configure an account with the cloud platform that hosts your cluster.]
+ifndef::osp,vsphere,nutanix[* You have configured an account with the cloud platform that hosts your cluster.]
 
-* Obtain the {product-title} installation program and the pull secret for your
-cluster.
-
-* Verify the cloud provider account on your host has the correct permissions to deploy the cluster. An account with incorrect permissions causes the installation process to fail with an error message that displays the missing permissions.
-
+* You have the {product-title} installation program and the pull secret for your cluster.
+ifdef::azure[]
+* You have an Azure subscription ID and tenant ID.
+endif::azure[]
+ifdef::azure-default[]
+* You have the application ID and password of a service principal.
+endif::azure-default[]
+ifdef::azure-gov,azure-private[]
+* If you are installing the cluster using a service principal, you have its application ID and password.
+* If you are installing the cluster using a system-assigned managed identity, you have enabled it on the virtual machine that you will run the installation program from.
+* If you are installing the cluster using a user-assigned managed identity, you have met these prerequisites:
+** You have its client ID.
+** You have assigned it to the virtual machine that you will run the installation program from.
+endif::azure-gov,azure-private[]
+ifndef::azure[]
+* You have verified that the cloud provider account on your host has the correct permissions to deploy the cluster. An account with incorrect permissions causes the installation process to fail with an error message that displays the missing permissions.
+endif::azure[]
 ifdef::vsphere[]
-* Optional: Before you create the cluster, configure an external load balancer in place of the default load balancer. 
+* Optional: Before you create the cluster, configure an external load balancer in place of the default load balancer.
 +
 [IMPORTANT]
 ====
@@ -299,9 +312,19 @@ environment variables
 ** The `gcloud cli` default credentials
 endif::gcp[]
 
-ifdef::aws,gcp,no-config[]
+ifdef::aws,azure-gov,azure-private,gcp,no-config[]
+ifdef::azure-default[]
+. Optional: If you have run the installation program on this computer before, and want to use an alternative service principal, go to the `~/.azure/` directory and delete the `osServicePrincipal.json` configuration file.
++
+Deleting this file prevents the installation program from automatically reusing subscription and authentication values from a previous installation.
+endif::azure-default[]
+ifdef::azure-gov,azure-private[]
+. Optional: If you have run the installation program on this computer before, and want to use an alternative service principal or managed identity, go to the `~/.azure/` directory and delete the `osServicePrincipal.json` configuration file.
++
+Deleting this file prevents the installation program from automatically reusing subscription and authentication values from a previous installation.
+endif::azure-gov,azure-private[]
 . Change to the directory that contains the installation program and initialize the cluster deployment:
-endif::aws,gcp,no-config[]
+endif::aws,azure-gov,azure-private,gcp,no-config[]
 ifdef::single-step[]
 * Change to the directory that contains the installation program and initialize the cluster deployment:
 endif::single-step[]
@@ -320,6 +343,25 @@ directory name to store the files that the installation program creates.
 endif::no-config[]
 <2> To view different installation details, specify `warn`, `debug`, or
 `error` instead of `info`.
+
+ifdef::azure-gov,azure-private[]
++
+If the installation program cannot locate the `osServicePrincipal.json` configuration file from a previous installation, you are prompted for Azure subscription and authentication values.
+. Enter the following Azure parameter values for your subscription:
+** *azure subscription id*: Enter the subscription ID to use for the cluster.
+** *azure tenant id*: Enter the tenant ID.
+. Depending on the Azure identity you are using to deploy the cluster, do one of the following when prompted for the *azure service principal client id*:
+** If you are using a service principal, enter its application ID.
+** If you are using a system-assigned managed identity, leave this value blank.
+** If you are using a user-assigned managed identity, specify its client ID.
+. Depending on the Azure identity you are using to deploy the cluster, do one of the following when prompted for the *azure service principal client secret*:
+** If you are using a service principal, enter its password.
+** If you are using a system-assigned managed identity, leave this value blank.
+** If you are using a user-assigned managed identity,leave this value blank.
+
+If previously not detected, the installation program creates an `osServicePrincipal.json` configuration file and stores this file in the `~/.azure/` directory on your computer. This ensures that the installation program can load the profile when it is creating an {product-title} cluster on the target platform.
+endif::azure-gov,azure-private[]
+
 ifdef::no-config[]
 +
 When specifying the directory:
@@ -346,27 +388,18 @@ The AWS access key ID and secret access key are stored in `~/.aws/credentials` i
 .. Select the AWS region to deploy the cluster to.
 .. Select the base domain for the Route 53 service that you configured for your cluster.
 endif::aws[]
-ifdef::azure,ash[]
+ifdef::azure[]
 .. Select *azure* as the platform to target.
-.. If the installation program cannot locate the `osServicePrincipal.json` configuration file, which contains Microsoft Azure profile information, in the `~/.azure/` directory on your computer, the installer prompts you to specify the following Azure parameter values for your subscription and service principal.
-*** *azure subscription id*: The subscription ID to use for the cluster.
-Specify the `id` value in your account output.
-*** *azure tenant id*: The tenant ID. Specify the `tenantId` value in your
-account output.
-*** *azure service principal client id*: The value of the `appId` parameter
-for the service principal.
-*** *azure service principal client secret*: The value of the `password`
-parameter for the service principal.
 +
-[IMPORTANT]
-====
-After you enter values for the previously listed parameters, the installation program creates a `osServicePrincipal.json` configuration file and stores this file in
-the `~/.azure/` directory on your computer. These actions ensure that the installation program can load the profile when it is creating an {product-title} cluster on the target platform.
-====
+If the installation program cannot locate the `osServicePrincipal.json` configuration file from a previous installation, you are prompted for Azure subscription and authentication values.
+.. Specify the following Azure parameter values for your subscription and service principal:
+*** *azure subscription id*: Enter the subscription ID to use for the cluster.
+*** *azure tenant id*: Enter the tenant ID.
+*** *azure service principal client id*: Enter its application ID.
+*** *azure service principal client secret*: Enter its password.
 .. Select the region to deploy the cluster to.
-.. Select the base domain to deploy the cluster to. The base domain corresponds
-to the Azure DNS Zone that you created for your cluster.
-endif::azure,ash[]
+.. Select the base domain to deploy the cluster to. The base domain corresponds to the Azure DNS Zone that you created for your cluster.
+endif::azure[]
 ifdef::gcp[]
 .. Select *gcp* as the platform to target.
 .. If you have not configured the service account key for your GCP account on
@@ -422,11 +455,8 @@ ifdef::azure[]
 +
 [IMPORTANT]
 ====
-All Azure resources that are available through public endpoints are subject to
-resource name restrictions, and you cannot create resources that use certain
-terms. For a list of terms that Azure restricts, see
-link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-reserved-resource-name[Resolve reserved resource name errors]
-in the Azure documentation.
+All Azure resources that are available through public endpoints are subject to resource name restrictions, and you cannot create resources that use certain terms. For a list of terms that Azure restricts, see
+link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/resource-manager-reserved-resourcename[Resolve reserved resource name errors] in the Azure documentation.
 ====
 endif::azure[]
 ifdef::gcp[]
@@ -442,6 +472,10 @@ ifdef::openshift-origin[]
 * If you do not have a {cluster-manager-url-pull}, you can paste the pull secret another private registry.
 * If you do not need the cluster to pull images from a private registry, you can paste `{"auths":{"fake":{"auth":"aWQ6cGFzcwo="}}}` as the pull secret.
 endif::openshift-origin[]
+
+ifdef::azure[]
+If previously not detected, the installation program creates an `osServicePrincipal.json` configuration file and stores this file in the `~/.azure/` directory on your computer. This ensures that the installation program can load the profile when it is creating an {product-title} cluster on the target platform.
+endif::azure[]
 
 endif::no-config[]
 
@@ -554,6 +588,7 @@ endif::[]
 ifeval::["{context}" == "installing-azure-default"]
 :!no-config:
 :!azure:
+:!azure-default:
 endif::[]
 ifeval::["{context}" == "installing-azure-network-customizations"]
 :!custom-config:
@@ -596,7 +631,7 @@ endif::[]
 ifeval::["{context}" == "installing-azure-government-region"]
 :!custom-config:
 :!azure:
-:!single-step:
+:!azure-gov:
 endif::[]
 ifeval::["{context}" == "installing-azure-vnet"]
 :!custom-config:
@@ -606,7 +641,7 @@ endif::[]
 ifeval::["{context}" == "installing-azure-private"]
 :!custom-config:
 :!azure:
-:!single-step:
+:!azure-private:
 endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-default"]
 :!custom-config:

--- a/modules/installation-using-azure-managed-identities.adoc
+++ b/modules/installation-using-azure-managed-identities.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_azure/installing-azure-account.adoc
+
+:_content-type: PROCEDURE
+[id="installation-using-azure-managed-identities_{context}"]
+= Using Azure managed identities
+
+The installation program requires an Azure identity to complete the installation. You can use either a system-assigned or user-assigned managed identity.
+
+If you are unable to use a managed identity, you can use a service principal.
+
+.Procedure
+
+. If you are using a system-assigned managed identity, enable it on the virtual machine that you will run the installation program from.
+. If you are using a user-assigned managed identity:
+.. Assign it to the virtual machine that you will run the installation program from.
+.. Record its client ID. You require this value when installing the cluster.
++
+For more information about viewing the details of a user-assigned managed identity, see the Microsoft Azure documentation for link:https:https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/how-manage-user-assigned-managed-identities?pivots=identity-mi-methods-azp#list-user-assigned-managed-identities[listing user-assigned managed identities].
+. Verify that the required permissions are assigned to the managed identity.

--- a/modules/minimum-required-permissions-ipi-azure.adoc
+++ b/modules/minimum-required-permissions-ipi-azure.adoc
@@ -2,12 +2,20 @@
 //
 // * installing/installing_azure/installing-azure-account.adoc
 
+:_content-type: CONCEPT
 [id="minimum-required-permissions-ipi-azure_{context}"]
 = Required Azure permissions for installer-provisioned infrastructure
 
-When you assign `Contributor` and `User Access Administrator` roles to the service principal, you automatically grant all the required permissions.
+The installation program requires access to an Azure service principal or managed identity with the necessary permissions to deploy the cluster and to maintain its daily operation. These permissions must be granted to the Azure subscription that is associated with the identity.
 
-If your organization's security policies require a more restrictive set of permissions, you can create a link:https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles[custom role] with the necessary permissions. The following permissions are required for creating an {product-title} cluster on Microsoft Azure.
+The following options are available to you:
+
+* You can assign the identity the `Contributor` and `User Access Administrator` roles. Assigning these roles is the quickest way to grant all of the required permissions.
++
+For more information about assigning roles, see the Azure documentation for link:https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal[managing access to Azure resources using the Azure portal].
+* If your organization's security policies require a more restrictive set of permissions, you can create a link:https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles[custom role] with the necessary permissions.
+
+The following permissions are required for creating an {product-title} cluster on Microsoft Azure.
 
 .Required permissions for creating authorization resources
 [%collapsible]

--- a/modules/minimum-required-permissions-upi-azure.adoc
+++ b/modules/minimum-required-permissions-upi-azure.adoc
@@ -5,9 +5,16 @@
 [id="minimum-required-permissions-upi-azure_{context}"]
 = Required Azure permissions for user-provisioned infrastructure
 
-When you assign `Contributor` and `User Access Administrator` roles to the service principal, you automatically grant all the required permissions.
+The installation program requires access to an Azure service principal or managed identity with the necessary permissions to deploy the cluster and to maintain its daily operation. These permissions must be granted to the Azure subscription that is associated with the identity.
 
-If your organization's security policies require a more restrictive set of permissions, you can create a link:https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles[custom role] with the necessary permissions. The following permissions are required for creating an {product-title} cluster on Microsoft Azure.
+The following options are available to you:
+
+* You can assign the identity the `Contributor` and `User Access Administrator` roles. Assigning these roles is the quickest way to grant all of the required permissions.
++
+For more information about assigning roles, see the Azure documentation for link:https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal[managing access to Azure resources using the Azure portal].
+* If your organization's security policies require a more restrictive set of permissions, you can create a link:https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles[custom role] with the necessary permissions.
+
+The following permissions are required for creating an {product-title} cluster on Microsoft Azure.
 
 .Required permissions for creating authorization resources
 [%collapsible]


### PR DESCRIPTION
Version(s):
4.14+

Issue:

This issues addresses [osdocs-5126](https://issues.redhat.com/browse/OSDOCS-5126). 

Link to docs preview:

**IPI**
- Configuring an Azure account > [Recording the subscription and tenant IDs](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#installation-azure-subscription-tenant-id_installing-azure-account)
- Configuring an Azure account > [Supported identities to access Azure resources](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#installation-azure-identities_installing-azure-account)
- Configuring an Azure account > Supported identities to access Azure resources > [Required Azure permissions for installer-provisioned infrastructure](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#minimum-required-permissions-ipi-azure_installing-azure-account)
- Configuring an Azure account > Supported identities to access Azure resources > [Using Azure managed identities](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#installation-using-azure-managed-identities_installing-azure-account)
- Configuring an Azure account > Supported identities to access Azure resources > [Creating a service principal](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account.html#installation-creating-azure-service-principal_installing-azure-account)
- Installing a cluster quickly on Azure > [Deploying the cluster](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-default#installation-launching-installer_installing-azure-default) [1]
- Installing a cluster on Azure with customizations > [Creating the installation configuration file ](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations#installation-initializing_installing-azure-customizations) [2]
- Installing a private cluster on Azure >  [Deploying the cluster ](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-private#installation-launching-installer_installing-azure-private)[3]

**UPI**

- Installing a cluster on Azure using ARM templates > [Recording the subscription and tenant IDs](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#installation-azure-subscription-tenant-id_installing-azure-user-infra)
- Installing a cluster on Azure using ARM templates > [Supported identities to access Azure resources](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#installation-azure-identities_installing-azure-user-infra)
- Installing a cluster on Azure using ARM templates > [Required Azure permissions for user-provisioned infrastructure](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#minimum-required-permissions-upi-azure_installing-azure-user-infra)
- Installing a cluster on Azure using ARM templates >[ Using Azure managed identities](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#installation-using-azure-managed-identities_installing-azure-user-infra)
- Installing a cluster on Azure using ARM templates >[ Creating a service principal](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#installation-creating-azure-service-principal_installing-azure-user-infra)
- Installing a cluster on Azure using ARM templates > [Creating the installation configuration file](https://62875--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#installation-initializing_installing-azure-user-infra)

QE review:
- [ ] QE has approved this change.

Additional information:

This is is 1 of 2 doc PRs covering how to deploy an Azure cluster using a managed identity. This PR addresses the concepts and procedures associated with meeting the minimum required Azure permissions to install the cluster, the ability to use either a service principal or managed identity to complete the installation, and how to interact with the installation program survey when using  a system-assigned managed identity or a user-assigned managed identity.

The concepts and procedures associated with using the CCO to install a cluster using a managed identity will be addressed by the second PR. @jeana-redhat is covering the latter work.

[1] This section of the documentation represents a default installation. In this use case, an  admin can use the installation program to deploy a cluster using the default values -- without explicitly creating an `install-config.yaml` file. It is at this point of the installation that an admin must account for a service principal or managed identity.

[2] This section of the documentation appears in 3 other installation use cases (assemblies). In this use case, an admin can use the installation program to create the `install-config.yaml` file. It is at this point in the installation that an admin must account for a service principal or managed identity.

[3] This section of the documentation appears in 1 other installation use case (assembly). In this use case, an admin must **_manually_** create the `install-config.yaml` file and reference it when running the installation program. Because the installation configuration file was manually created, it is at this point during the installation process that an admin must account for a service principal or managed identity.