### PR TITLE
CNV-28201: Update node placement documentation

### DIFF
--- a/modules/virt-about-node-placement-virt-components.adoc
+++ b/modules/virt-about-node-placement-virt-components.adoc
@@ -16,3 +16,5 @@ Depending on the object, you can use one or more of the following rule types:
 
 `nodeSelector`:: Allows pods to be scheduled on nodes that are labeled with the key-value pair or pairs that you specify in this field. The node must have labels that exactly match all listed pairs.
 `affinity`:: Enables you to use more expressive syntax to set rules that match nodes with pods. Affinity also allows for more nuance in how the rules are applied. For example, you can specify that a rule is a preference, not a requirement. If a rule is a preference, pods are still scheduled when the rule is not satisfied.
+`tolerations`:: Allows pods to be scheduled on nodes that have matching taints. If a taint is applied to a node, that
+node only accepts pods that tolerate the taint.

--- a/modules/virt-about-node-placement-virtualization-components.adoc
+++ b/modules/virt-about-node-placement-virtualization-components.adoc
@@ -79,7 +79,7 @@ spec:
 [id="node-placement-hpp_{context}"]
 == Node placement in the HostPathProvisioner object
 
-You can configure node placement rules in the `spec.workload` field of the `HostPathProvisioner` object that you create when you install the hostpath provisioner.
+You can configure node placement rules by specifying `nodeSelector`, `affinity`, or `tolerations` for the `spec.workload` field of the `HostPathProvisioner` object that you create when you install the hostpath provisioner. If after you create the `HostPathProvisioner` you delete the `HostPathProvisioner` pod and then want to delete the virtual machine (VM), you must first update the `spec.workload` field to another value and then wait for the `HostPathProvisioner` pod to restart. You can then delete the VM from the node.
 
 [source,yaml]
 ----

--- a/modules/virt-about-node-placement-vms.adoc
+++ b/modules/virt-about-node-placement-vms.adoc
@@ -22,9 +22,10 @@ You can use the following rule types in the `spec` field of a `VirtualMachine` m
 
 `nodeSelector`:: Allows virtual machines to be scheduled on nodes that are labeled with the key-value pair or pairs that you specify in this field. The node must have labels that exactly match all listed pairs.
 `affinity`:: Enables you to use more expressive syntax to set rules that match nodes with virtual machines. For example, you can specify that a rule is a preference, rather than a hard requirement, so that virtual machines are still scheduled if the rule is not satisfied. Pod affinity, pod anti-affinity, and node affinity are supported for virtual machine placement. Pod affinity works for virtual machines because the `VirtualMachine` workload type is based on the `Pod` object.
+`tolerations`:: Allows virtual machines to be scheduled on nodes that have matching taints. If a taint is applied to a node, that node only accepts virtual machines that tolerate the taint.
+
 +
 [NOTE]
 ====
 Affinity rules only apply during scheduling. {product-title} does not reschedule running workloads if the constraints are no longer met.
 ====
-`tolerations`:: Allows virtual machines to be scheduled on nodes that have matching taints. If a taint is applied to a node, that node only accepts virtual machines that tolerate the taint.

--- a/modules/virt-node-placement-rule-examples.adoc
+++ b/modules/virt-node-placement-rule-examples.adoc
@@ -156,10 +156,12 @@ You can edit the `HostPathProvisioner` object directly or by using the web conso
 
 [WARNING]
 ====
-You must schedule the hostPath provisioner and the {VirtProductName} components on the same nodes. Otherwise, virtualization pods that use the hostPath provisioner cannot run. You cannot run virtual machines.
+You must schedule the hostpath provisioner and the {VirtProductName} components on the same nodes. Otherwise, virtualization pods that use the hostpath provisioner cannot run. You cannot run virtual machines.
 ====
 
-The `HostPathProvisioner` object supports the `nodeSelector`, `affinity`, and `tolerations` node placement rules.
+After you deploy a virtual machine (VM) with the hostpath provisioner (HPP) storage class, you can remove the hostpath provisioner pod from the same node by using the node selector. However, you must first revert that change, at least for that specific node, and wait for the pod to run before trying to delete the VM.
+
+You can configure node placement rules by specifying `nodeSelector`, `affinity`, or `tolerations` for the `spec.workload` field of the `HostPathProvisioner` object that you create when you install the hostpath provisioner.
 
 .Example `HostPathProvisioner` object with `nodeSelector` rule
 [source,yaml]


### PR DESCRIPTION
Version(s): 4.14+

Issue: [CNV-28201](https://issues.redhat.com/browse/CNV-28201)

Links to docs previews: 

- [HostPathProvisioner object node placement rule example](https://62899--docspreview.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-node-placement-virt-components#hostpathprovisioner-object-node-placement-rules_virt-node-placement-virt-components)

- [About node placement rules for OpenShift Virtualization components](https://62899--docspreview.netlify.app/openshift-enterprise/latest/virt/post_installation_configuration/virt-node-placement-virt-components#virt-about-node-placement-virt-components_virt-node-placement-virt-components). This topic was updated because the bullet point about tolerations was no longer included for some reason. If it shouldn't there, please let me know.


QE review:
- [x] QE has approved this change.

Additional info: The topic [Node placement in the HostPathProvisioner object](https://docs.openshift.com/container-platform/4.12/virt/install/virt-specifying-nodes-for-virtualization-components.html#node-placement-hpp_virt-specifying-nodes-for-virtualization-components) (virt-about-node-placement-virtualization-components.adoc), mentioned in the Description section of [CNV-28201](https://issues.redhat.com/browse/CNV-28201), is no longer being used in CNV 4.14. Please review the other two updated files.


