### PR TITLE
[OSDOCS-6136]: Azure `ccoctl` determining CCO mode

### DIFF
--- a/modules/cco-ccoctl-creating-at-once.adoc
+++ b/modules/cco-ccoctl-creating-at-once.adoc
@@ -142,28 +142,28 @@ endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 ifdef::aws-sts[]
 ----
 $ oc adm release extract \
---credentials-requests \
---cloud=aws \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
---from=quay.io/<path_to>/ocp-release:<version>
+  --credentials-requests \
+  --cloud=aws \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
+  --from=quay.io/<path_to>/ocp-release:<version>
 ----
 endif::aws-sts[]
 ifdef::google-cloud-platform[]
 ----
 $ oc adm release extract \
---credentials-requests \
---cloud=gcp \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
-quay.io/<path_to>/ocp-release:<version>
+  --credentials-requests \
+  --cloud=gcp \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
+  quay.io/<path_to>/ocp-release:<version>
 ----
 endif::google-cloud-platform[]
 ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 ----
 $ oc adm release extract \
---credentials-requests \
---cloud=alibabacloud \
---to=<path_to_directory_with_list_of_credentials_requests>/credrequests \ <1>
-$RELEASE_IMAGE
+  --credentials-requests \
+  --cloud=alibabacloud \
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
+  $RELEASE_IMAGE
 ----
 endif::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 +
@@ -268,20 +268,15 @@ ifdef::google-cloud-platform[]
 [source,terminal]
 ----
 $ ccoctl gcp create-all \
---name=<name> \
---region=<gcp_region> \
---project=<gcp_project_id> \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests
+  --name=<name> \// <1>
+  --region=<gcp_region> \// <2>
+  --project=<gcp_project_id> \// <3>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests <4>
 ----
-+
-where:
-+
---
-** `<name>` is the user-defined name for all created GCP resources used for tracking.
-** `<gcp_region>` is the GCP region in which cloud resources will be created.
-** `<gcp_project_id>` is the GCP project ID in which cloud resources will be created.
-** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files of `CredentialsRequest` manifests to create GCP service accounts.
---
+<1> Specify the user-defined name for all created GCP resources used for tracking.
+<2> Specify the GCP region in which cloud resources will be created.
+<3> Specify the GCP project ID in which cloud resources will be created.
+<4> Specify the directory containing the files of `CredentialsRequest` manifests to create GCP service accounts.
 +
 [NOTE]
 ====
@@ -297,20 +292,15 @@ ifdef::alibabacloud-default,alibabacloud-customizations,alibabacloud-vpc[]
 [source,terminal]
 ----
 $ ccoctl alibabacloud create-ram-users \
---name <name> \
---region=<alibaba_region> \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \
---output-dir=<path_to_ccoctl_output_dir>
+  --name <name> \// <1>
+  --region=<alibaba_region> \// <2>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <3>
+  --output-dir=<path_to_ccoctl_output_dir> <4>
 ----
-+
-where:
-+
---
-** `<name>` is the name used to tag any cloud resources that are created for tracking.
-** `<alibaba_region>` is the Alibaba Cloud region in which cloud resources will be created.
-** `<path_to_directory_with_list_of_credentials_requests>/credrequests` is the directory containing the files for the component `CredentialsRequest` objects.
-** `<path_to_ccoctl_output_dir>` is the directory where the generated component credentials secrets will be placed.
---
+<1> Specify the name used to tag any cloud resources that are created for tracking.
+<2> Specify the Alibaba Cloud region in which cloud resources will be created.
+<3> Specify the directory containing the files for the component `CredentialsRequest` objects.
+<4> Specify the directory where the generated component credentials secrets will be placed.
 +
 [NOTE]
 ====
@@ -332,9 +322,8 @@ If your cluster uses Technology Preview features that are enabled by the `TechPr
 +
 [NOTE]
 ====
-A RAM user can have up to two AccessKeys at the same time. If you run `ccoctl alibabacloud create-ram-users` more than twice, the previous generated manifests secret becomes stale and you must reapply the newly generated secrets.
+A RAM user can have up to two AccessKeys at the same time. If you run `ccoctl alibabacloud create-ram-users` more than twice, the previously generated manifests secret becomes stale and you must reapply the newly generated secrets.
 ====
-// Above output was in AWS area but I believe belongs here.
 
 .. Verify that the {product-title} secrets are created:
 +

--- a/modules/cco-ccoctl-upgrading.adoc
+++ b/modules/cco-ccoctl-upgrading.adoc
@@ -11,8 +11,6 @@ The process for upgrading an {product-title} cluster that was configured using t
 
 [NOTE]
 ====
-By default, `ccoctl` creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag. This procedure uses `<path_to_ccoctl_output_dir>` to refer to this directory.
-
 On AWS clusters, some `ccoctl` commands make AWS API calls to create or modify AWS resources. You can use the `--dry-run` flag to avoid making API calls. Using this flag creates JSON files on the local file system instead. You can review and modify the JSON files and then apply them with the AWS CLI tool using the `--cli-input-json` parameters.
 ====
 
@@ -28,18 +26,14 @@ On AWS clusters, some `ccoctl` commands make AWS API calls to create or modify A
 +
 [source,terminal]
 ----
-$ oc adm release extract --credentials-requests \
-  --cloud=<provider_type> \
-  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \
+$ oc adm release extract \
+  --credentials-requests \
+  --cloud=<provider_type> \// <1>
+  --to=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <2>
   quay.io/<path_to>/ocp-release:<version>
 ----
-+
-where:
-+
---
-* `<provider_type>` is the value for your cloud provider. Valid values are `alibabacloud`, `aws`, `gcp`, `ibmcloud`, and `nutanix`.
-* `credrequests` is the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
---
+<1> Specify the value for your cloud provider. Valid values are `alibabacloud`, `aws`, `azure`, `gcp`, `ibmcloud`, and `nutanix`.
+<2> Specify the directory where the list of `CredentialsRequest` objects is stored. This command creates the directory if it does not exist.
 
 . For each `CredentialsRequest` CR in the release image, ensure that a namespace that matches the text in the `spec.secretRef.namespace` field exists in the cluster. This field is where the generated secrets that hold the credentials configuration are stored.
 +
@@ -79,17 +73,97 @@ $ oc create namespace <component_namespace>
 
 . Use the `ccoctl` tool to process all `CredentialsRequest` objects in the `credrequests` directory by running the command for your cloud provider. The following commands process `CredentialsRequest` objects:
 +
---
-* {alibaba}: `ccoctl alibabacloud create-ram-users`
-* Amazon Web Services (AWS): `ccoctl aws create-iam-roles`
-* Google Cloud Platform (GCP): `ccoctl gcp create-all`
-* IBM Cloud: `ccoctl ibmcloud create-service-id`
-* Nutanix: `ccoctl nutanix create-shared-secrets`
---
-+
-[IMPORTANT]
+.{alibaba}
+[%collapsible]
 ====
-Refer to the `ccoctl` utility instructions in the installation content for your cloud provider for important platform-specific details about the required arguments and special considerations.
+[source,terminal]
+----
+$ ccoctl alibabacloud create-ram-users \
+  --name <name> \// <1>
+  --region=<alibaba_region> \// <2>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <3>
+  --output-dir=<path_to_ccoctl_output_dir> <4>
+----
+<1> Specify the name used to tag any cloud resources that are created for tracking.
+<2> Specify the Alibaba Cloud region in which cloud resources will be created.
+<3> Specify the directory containing the files for the component `CredentialsRequest` objects.
+<4> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+
+[NOTE]
+=====
+A RAM user can have up to two AccessKeys at the same time. If you run `ccoctl alibabacloud create-ram-users` more than twice, the previously generated manifests secret becomes stale and you must reapply the newly generated secrets.
+=====
+====
++
+.Amazon Web Services (AWS)
+[%collapsible]
+====
+[source,terminal]
+----
+$ ccoctl aws create-all \// <1>
+  --name=<name> \// <2>
+  --region=<aws_region> \// <3>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <4>
+  --output-dir=<path_to_ccoctl_output_dir> \// <5>
+  --create-private-s3-bucket <6>
+----
+<1> To create the AWS resources individually, use the "Creating AWS resources individually" procedure in the "Installing a cluster on AWS with customizations" content. This option might be useful if you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization.
+<2> Specify the name used to tag any cloud resources that are created for tracking.
+<3> Specify the AWS region in which cloud resources will be created.
+<4> Specify the directory containing the files for the component `CredentialsRequest` objects.
+<5> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<6> Optional: By default, the `ccoctl` utility stores the OpenID Connect (OIDC) configuration files in a public S3 bucket and uses the S3 URL as the public OIDC endpoint. To store the OIDC configuration in a private S3 bucket that is accessed by the IAM identity provider through a public CloudFront distribution URL instead, use the `--create-private-s3-bucket` parameter.
+====
++
+.Google Cloud Platform (GCP)
+[%collapsible]
+====
+[source,terminal]
+----
+$ ccoctl gcp create-all \
+  --name=<name> \// <1>
+  --region=<gcp_region> \// <2>
+  --project=<gcp_project_id> \// <3>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <4>
+  --output-dir=<path_to_ccoctl_output_dir> <5>
+----
+<1> Specify the user-defined name for all created GCP resources used for tracking.
+<2> Specify the GCP region in which cloud resources will be created.
+<3> Specify the GCP project ID in which cloud resources will be created.
+<4> Specify the directory containing the files of `CredentialsRequest` manifests to create GCP service accounts.
+<5> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+====
++
+.IBM Cloud
+[%collapsible]
+====
+[source,terminal]
+----
+$ ccoctl ibmcloud create-service-id \
+  --credentials-requests-dir=<path_to_credential_requests_directory> \// <1>
+  --name=<cluster_name> \// <2>
+  --output-dir=<installation_directory> \// <3>
+  --resource-group-name=<resource_group_name> <4>
+----
+<1> Specify the directory containing the files for the component `CredentialsRequest` objects.
+<2> Specify the name of the {product-title} cluster.
+<3> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<4> Optional: Specify the name of the resource group used for scoping the access policies.
+====
++
+.Nutanix
+[%collapsible]
+====
+[source,terminal]
+----
+$ ccoctl nutanix create-shared-secrets \
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
+  --output-dir=<ccoctl_output_dir> \// <2>
+  --credentials-source-filepath=<path_to_credentials_file> <3>
+----
+<1> Specify the path to the directory that contains the files for the component `CredentialsRequests` objects.
+<2> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<3> Optional: Specify the directory that contains the credentials data YAML file. By default, `ccoctl` expects this file to be in `<home_directory>/.nutanix/credentials`.
 ====
 +
 For each `CredentialsRequest` object, `ccoctl` creates the required provider resources and a permissions policy as defined in each `CredentialsRequest` object from the {product-title} release image.

--- a/modules/cco-determine-mode-cli.adoc
+++ b/modules/cco-determine-mode-cli.adoc
@@ -50,14 +50,14 @@ The following output values are possible, though not all are supported on all pl
 +
 [IMPORTANT]
 ====
-To determine the specific configuration of an AWS or GCP cluster that has a `spec.credentialsMode` of `''`, `Mint`, or `Manual`, you must investigate further.
+To determine the specific configuration of an AWS, GCP, or global Microsoft Azure cluster that has a `spec.credentialsMode` of `''`, `Mint`, or `Manual`, you must investigate further.
 
 AWS and GCP clusters support using mint mode with the root secret deleted.
 ifdef::update[]
 If the cluster is specifically configured to use mint mode or uses mint mode by default, you must determine if the root secret is present on the cluster before updating.
 endif::update[]
 
-An AWS or GCP cluster that uses manual mode might be configured to create and manage cloud credentials from outside of the cluster using the AWS Security Token Service (STS) or GCP Workload Identity. You can determine whether your cluster uses this strategy by examining the cluster `Authentication` object.
+An AWS, GCP, or global Microsoft Azure cluster that uses manual mode might be configured to create and manage cloud credentials from outside of the cluster with AWS STS, GCP Workload Identity, or Azure AD Workload Identity. You can determine whether your cluster uses this strategy by examining the cluster `Authentication` object.
 ====
 
 ifdef::about-cco[]
@@ -95,7 +95,7 @@ where `<secret_name>` is `aws-creds` for AWS or `gcp-credentials` for GCP.
 +
 If the root secret is present, the output of this command returns information about the secret. An error indicates that the root secret is not present on the cluster.
 
-. AWS or GCP clusters that use manual mode only: To determine whether the cluster is configured to create and manage cloud credentials from outside of the cluster, run the following command:
+. AWS, GCP, or global Microsoft Azure clusters that use manual mode only: To determine whether the cluster is configured to create and manage cloud credentials from outside of the cluster, run the following command:
 +
 [source,terminal]
 ----

--- a/modules/cco-determine-mode-gui.adoc
+++ b/modules/cco-determine-mode-gui.adoc
@@ -49,14 +49,14 @@ Only Amazon Web Services (AWS), global Microsoft Azure, and Google Cloud Platfor
 +
 [IMPORTANT]
 ====
-To determine the specific configuration of an AWS or GCP cluster that has a `spec.credentialsMode` of `''`, `Mint`, or `Manual`, you must investigate further.
+To determine the specific configuration of an AWS, GCP, or global Microsoft Azure cluster that has a `spec.credentialsMode` of `''`, `Mint`, or `Manual`, you must investigate further.
 
 AWS and GCP clusters support using mint mode with the root secret deleted.
 ifdef::update[]
 If the cluster is specifically configured to use mint mode or uses mint mode by default, you must determine if the root secret is present on the cluster before updating.
 endif::update[]
 
-An AWS or GCP cluster that uses manual mode might be configured to create and manage cloud credentials from outside of the cluster using the AWS Security Token Service (STS) or GCP Workload Identity. You can determine whether your cluster uses this strategy by examining the cluster `Authentication` object.
+An AWS, GCP, or global Microsoft Azure cluster that uses manual mode might be configured to create and manage cloud credentials from outside of the cluster with AWS STS, GCP Workload Identity, or Azure AD Workload Identity. You can determine whether your cluster uses this strategy by examining the cluster `Authentication` object.
 ====
 
 ifdef::about-cco[]
@@ -117,7 +117,7 @@ Ensure that the *Project* dropdown is set to *All Projects*.
 * If you do not see these values, your cluster is using the CCO in mint mode with the root secret removed.
 --
 
-. AWS or GCP clusters that use manual mode only: To determine whether the cluster is configured to create and manage cloud credentials from outside of the cluster, you must check the cluster `Authentication` object YAML values.
+. AWS, GCP, or global Microsoft Azure clusters that use manual mode only: To determine whether the cluster is configured to create and manage cloud credentials from outside of the cluster, you must check the cluster `Authentication` object YAML values.
 
 .. Navigate to *Administration* -> *Cluster Settings*.
 

--- a/modules/manually-configure-iam-nutanix.adoc
+++ b/modules/manually-configure-iam-nutanix.adoc
@@ -85,14 +85,14 @@ quay.io/<path_to>/ocp-release:<version>
 [source,terminal]
 ----
 $ ccoctl nutanix create-shared-secrets \
---credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
---output-dir=<ccoctl_output_dir> \// <2>
---credentials-source-filepath=<path_to_credentials_file> <3>
+  --credentials-requests-dir=<path_to_directory_with_list_of_credentials_requests>/credrequests \// <1>
+  --output-dir=<ccoctl_output_dir> \// <2>
+  --credentials-source-filepath=<path_to_credentials_file> <3>
 ----
 +
 <1> Specify the path to the directory that contains the files for the component `CredentialsRequests` objects.
-<2> Specify the directory that contains the files of the component credentials secrets, under the `manifests` directory. By default, the `ccoctl` tool creates objects in the directory in which the commands are run. To create the objects in a different directory, use the `--output-dir` flag.
-<3> Optional: Specify the directory that contains the credentials data YAML file. By default, `ccoctl` expects this file to be in `<home_directory>/.nutanix/credentials`. To specify a different directory, use the `--credentials-source-filepath` flag.
+<2> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<3> Optional: Specify the directory that contains the credentials data YAML file. By default, `ccoctl` expects this file to be in `<home_directory>/.nutanix/credentials`.
 
 . Edit the `install-config.yaml` configuration file so that the `credentialsMode` parameter is set to `Manual`.
 +

--- a/modules/manually-create-iam-ibm-cloud.adoc
+++ b/modules/manually-create-iam-ibm-cloud.adoc
@@ -154,14 +154,15 @@ endif::ibm-power-vs[]
 [source,terminal]
 ----
 $ ccoctl ibmcloud create-service-id \
-    --credentials-requests-dir <path_to_credential_requests_directory> \ <1>
-    --name <cluster_name> \ <2>
-    --output-dir <installation_directory> \
-    --resource-group-name <resource_group_name> <3>
+  --credentials-requests-dir=<path_to_credential_requests_directory> \// <1>
+  --name=<cluster_name> \// <2>
+  --output-dir=<installation_directory> \// <3>
+  --resource-group-name=<resource_group_name> <4>
 ----
-<1> The directory where the credential requests are stored.
-<2> The name of the {product-title} cluster.
-<3> Optional: The name of the resource group used for scoping the access policies.
+<1> Specify the directory containing the files for the component `CredentialsRequest` objects.
+<2> Specify the name of the {product-title} cluster.
+<3> Optional: Specify the directory in which you want the `ccoctl` utility to create objects. By default, the utility creates objects in the directory in which the commands are run.
+<4> Optional: Specify the name of the resource group used for scoping the access policies.
 +
 --
 [NOTE]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-5128](https://issues.redhat.com//browse/OSDOCS-5128) > [OSDOCS-6136](https://issues.redhat.com//browse/OSDOCS-6136)

**Link to docs preview**
Additions of Azure statements:
* [Updating cloud provider resources with the Cloud Credential Operator utility](https://62900--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/preparing-manual-creds-update.html#cco-ccoctl-upgrading_preparing-manual-creds-update)
* [Determining the Cloud Credential Operator mode by using the web console](https://62900--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.html#cco-determine-mode-gui_about-cloud-credential-operator)
* [Determining the Cloud Credential Operator mode by using the CLI](https://62900--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.html#cco-determine-mode-cli_about-cloud-credential-operator)

Formatting tweaks for consistency:
* [Creating credentials for OpenShift Container Platform components with the ccoctl tool](https://62900--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_alibaba/installing-alibaba-default.html#cco-ccoctl-creating-at-once_installing-alibaba-default) (AliCloud)
* [Creating AWS resources with the Cloud Credential Operator utility](https://62900--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#sts-mode-create-aws-resources-ccoctl_installing-aws-customizations)
* [Creating GCP resources with the Cloud Credential Operator utility](https://62900--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#cco-ccoctl-creating-at-once_installing-gcp-customizations)
* [Manually creating IAM](https://62900--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-customizations.html#manually-create-iam-ibm-cloud_installing-ibm-cloud-customizations) (IBM)
* [Configuring IAM for Nutanix](https://62900--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned.html#manually-create-iam-nutanix_installing-nutanix-installer-provisioned)

QE review:
- [x] QE has approved this change.

Additional information:
* Includes Azure in steps to determine if cluster is using `ccoctl` 
* Enhancements to the specifics of creating resources in `cco-ccoctl-upgrading.adoc` (Consider backporting these to 4.10+)
* Edits to install versions of the step to create resources for consistency