### PR TITLE
[enterprise-4.12] OSDOCS#6055: Authenticating cert-manager Operator with GCP workload identity

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -994,6 +994,8 @@ Topics:
     File: cert-manager-log-levels
   - Name: Authenticating the cert-manager Operator for Red Hat OpenShift on AWS
     File: cert-manager-authentication-non-sts
+  - Name: Authenticating the cert-manager Operator for Red Hat OpenShift with GCP Workload Identity
+    File: cert-manager-authenticate-gcp
   - Name: Uninstalling the cert-manager Operator for Red Hat OpenShift
     File: cert-manager-operator-uninstall
 - Name: Viewing audit logs

--- a/modules/cert-manager-configure-cloud-credentials-gcp-sts.adoc
+++ b/modules/cert-manager-configure-cloud-credentials-gcp-sts.adoc
@@ -1,0 +1,147 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-authenticate-gcp.adoc
+
+:_content-type: PROCEDURE
+[id="cert-manager-configure-cloud-credentials-gcp-sts_{context}"]
+= Configuring cloud credentials for the {cert-manager-operator} with GCP Workload Identity
+
+Generate the cloud credentials for the {cert-manager-operator} by using the `ccoctl` binary. Then, apply them to the GCP Workload Identity cluster.
+
+.Prerequisites
+
+* You extracted and prepared the `ccoctl` binary.
+* The {cert-manager-operator} 1.11.1 or later is installed.
+* You have configured an {product-title} cluster with GCP Workload Identity by using the Cloud Credential Operator in a manual mode.
+
+.Procedure
+
+. Create a directory to store a `CredentialsRequest` resource YAML file by running the following command:
++
+[source,terminal]
+----
+$ mkdir credentials-request
+----
+
+. In the `credentials-request` directory, create a YAML file that contains the following `CredentialsRequest` manifest:
++
+[source,yaml]
+----
+apiVersion: cloudcredential.openshift.io/v1
+kind: CredentialsRequest
+metadata:
+  name: cert-manager
+  namespace: openshift-cloud-credential-operator
+spec:
+  providerSpec:
+    apiVersion: cloudcredential.openshift.io/v1
+    kind: GCPProviderSpec
+    predefinedRoles:
+    - roles/dns.admin
+  secretRef:
+    name: gcp-credentials
+    namespace: cert-manager
+  serviceAccountNames:
+  - cert-manager
+----
++
+[NOTE]
+====
+The `dns.admin` role provides admin privileges to the service account for managing Google Cloud DNS resources. To ensure that the cert-manager runs with the service account that has the least privilege, you can create a custom role with the following permissions:
+
+* `dns.resourceRecordSets.*`
+* `dns.changes.*`
+* `dns.managedZones.list`
+====
+
+. Use the `ccoctl` tool to process `CredentialsRequest` objects by running the following command:
++
+[source,terminal]
+----
+$ ccoctl gcp create-service-accounts \
+    --name <user_defined_name> --output-dir=<path_to_output_dir> \
+    --credentials-requests-dir=<path_to_credrequests_dir> \
+    --workload-identity-pool <workload_identity_pool> \
+    --workload-identity-provider <workload_identity_provider> \
+    --project <gcp_project_id>
+----
++
+.Example command
+[source,terminal]
+----
+$ ccoctl gcp create-service-accounts \
+    --name abcde-20230525-4bac2781 --output-dir=/home/outputdir \
+    --credentials-requests-dir=/home/credentials-requests \
+    --workload-identity-pool abcde-20230525-4bac2781 \
+    --workload-identity-provider abcde-20230525-4bac2781 \
+    --project openshift-gcp-devel
+----
+
+. Apply the secrets generated in the manifests directory of your cluster by running the following command:
++
+[source,terminal]
+----
+$ ls <path_to_output_dir>/manifests/*-credentials.yaml | xargs -I{} oc apply -f {}
+----
+
+. Update the subscription object for {cert-manager-operator} by running the following command:
++
+[source,terminal]
+----
+$ oc -n cert-manager-operator patch subscription openshift-cert-manager-operator --type=merge -p '{"spec":{"config":{"env":[{"name":"CLOUD_CREDENTIALS_SECRET_NAME","value":"gcp-credentials"}]}}}'
+----
+
+.Verification
+
+. Get the name of the redeployed cert-manager controller pod by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -l app.kubernetes.io/name=cert-manager -n cert-manager
+----
++
+.Example output
+[source,terminal]
+----
+NAME                          READY   STATUS    RESTARTS   AGE
+cert-manager-bd7fbb9fc-wvbbt  1/1     Running   0          15m39s
+----
+
+. Verify that the cert-manager controller pod is updated with GCP workload identity credential volumes that are mounted under the path specified in `mountPath` by running the following command:
++
+[source,terminal]
+----
+$ oc get -n cert-manager pod/<cert-manager_controller_pod_name> -o yaml
+----
++
+.Example output
+[source,terminal]
+----
+spec:
+  containers:
+  - args:
+    ...
+    volumeMounts:
+    - mountPath: /var/run/secrets/openshift/serviceaccount
+      name: bound-sa-token
+      ...
+    - mountPath: /.config/gcloud
+      name: cloud-credentials
+  ...
+  volumes:
+  - name: bound-sa-token
+    projected:
+      ...
+      sources:
+      - serviceAccountToken:
+          audience: openshift
+          ...
+          path: token
+  - name: cloud-credentials
+    secret:
+      ...
+      items:
+      - key: service_account.json
+        path: application_default_credentials.json
+      secretName: gcp-credentials
+----

--- a/security/cert_manager_operator/cert-manager-authenticate-gcp.adoc
+++ b/security/cert_manager_operator/cert-manager-authenticate-gcp.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+[id="cert-manager-authenticate-gcp"]
+= Authenticating the {cert-manager-operator} with GCP Workload Identity
+include::_attributes/common-attributes.adoc[]
+:context: cert-manager-authenticate-gcp
+
+toc::[]
+
+You can authenticate the {cert-manager-operator} on the GCP Workload Identity cluster by using the cloud credentials. You can configure the cloud credentials by using the `ccoctl` binary.
+
+include::modules/cert-manager-configure-cloud-credentials-gcp-sts.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_cert-manager-authenticate-gcp-workload-identity"]
+== Additional resources
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-sts.adoc#cco-ccoctl-configuring_cco-mode-sts[Configuring the Cloud Credential Operator utility]
+* xref:../../authentication/managing_cloud_provider_credentials/cco-mode-gcp-workload-identity.adoc#gcp-workload-identity-mode-installing[Configuring an {product-title} cluster by using the manual mode with GCP Workload Identity]


### PR DESCRIPTION

Cheery-picked from <45048e06d9365d9007df0afc023e4fadbcfd13c6> : https://github.com/openshift/openshift-docs/pull/59895
