### PR TITLE
TELCODOCS-1415: Add information about status.state.AtLatestKnown for Subscription CRs

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-about-subscription-crs.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-about-subscription-crs.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+// Epic CNF-2600 (CNF-2133) (4.10), Story TELCODOCS-285
+// * scalability_and_performance/cnf-talm-for-cluster-upgrades.adoc
+
+:_content-type: PROCEDURE
+[id="talo-about-subscription-crs_{context}"]
+= Configuring Operator subscriptions for managed clusters that you install with {cgu-operator}
+
+{cgu-operator} can only approve the install plan for an Operator if the `Subscription` CR of the Operator contains a valid `status` field. You can use the following fields:
+
+* `status.state.AtLatestKnown` for the latest Operator version
+* `status.installedCSV` for a specific Operator version
+
+.Procedure
+
+. Add one of the following status fields to the `Subscription` CR of the Operator:
+
+.. Add the `status.state.AtLatestKnown` field for the latest Operator version:
++
+.Example Subscription CR
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  channel: "stable"
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  state: AtLatestKnown <1>
+----
+<1> The `status.state: AtLatestKnown` field is used for the latest Operator version available from the Operator catalog.
+
++
+[NOTE]
+====
+When a new version of the Operator is available in the registry, the associated policy becomes non-compliant.
+====
+
+.. Add the `status.installedCSV` field for a specific Operator version:
++
+.Example Subscription CR
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: cluster-logging
+  namespace: openshift-logging
+  annotations:
+    ran.openshift.io/ztp-deploy-wave: "2"
+spec:
+  channel: "stable"
+  name: cluster-logging
+  source: redhat-operators
+  sourceNamespace: openshift-marketplace
+  installPlanApproval: Manual
+status:
+  installedCSV: cluster-logging.v5.7.5 <1>
+----
+<1> The `status.installedCSV` field with the CSV value is used for a specific version of an Operator, for example, `status.installedCSV: cluster-logging.v5.7.5`.
+
++
+. Apply the changed `Subscription` policy to your managed clusters with a `ClusterGroupUpgrade` CR.

--- a/scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades.adoc
+++ b/scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades.adoc
@@ -29,6 +29,8 @@ include::modules/cnf-topology-aware-lifecycle-manager-policies-concept.adoc[leve
 
 For more information about the `PolicyGenTemplate` CRD, see xref:../../scalability_and_performance/ztp_far_edge/ztp-configuring-managed-clusters-policies.adoc#ztp-the-policygentemplate_ztp-configuring-managed-clusters-policies[About the PolicyGenTemplate CRD].
 
+include::modules/cnf-topology-aware-lifecycle-manager-about-subscription-crs.adoc[leveloffset=+2]
+
 include::modules/cnf-topology-aware-lifecycle-manager-apply-policies.adoc[leveloffset=+2]
 
 include::modules/cnf-topology-aware-lifecycle-manager-backup-concept.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12, 4.13, 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1415
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62928--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades#talo-about-subscription-crs_cnf-topology-aware-lifecycle-manager

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
