### PR TITLE
OSDOCS#7109: Adds notes for Microshift 4.12.27 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -284,3 +284,12 @@ Issued: 2023-07-26
 {product-title} release 4.12.26 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4223[RHBA-2023:4223] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4221[RHBA-2023:4221] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-27-dp"]
+=== RHBA-2023:4321 - {product-title} 4.12.27 bug fix update
+
+Issued: 2023-08-02
+
+{product-title} release 4.12.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4321[RHBA-2023:4321] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4319[RHBA-2023:4319] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#7109: Adds notes for Microshift 4.12.27 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-7109

Link to docs preview:
https://62930--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes.html#microshift-4-12-27-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
