### PR TITLE
Removing PV and PVC for PTP events docs

### DIFF
--- a/modules/cnf-about-ptp-fast-event-notifications-framework.adoc
+++ b/modules/cnf-about-ptp-fast-event-notifications-framework.adoc
@@ -32,11 +32,6 @@ The PTP plugin reads the event from the UNIX domain socket and passes it to the 
 
 image:darkcircle-3.png[20,20] Event is persisted::
 The `cloud-event-proxy` sidecar in the PTP Operator-managed pod processes the event and publishes the cloud-native event by using a REST API.
-+
-[NOTE]
-====
-When you use HTTP transport for events, you must persist the events subscription in the PTP Operator-managed pod by using a Persistent Volume (PV) resource or similar persistent storage mechanism.
-====
 
 image:darkcircle-4.png[20,20] Message is transported::
 The message transporter transports the event to the `cloud-event-proxy` sidecar in the application pod over HTTP or AMQP 1.0 QPID.

--- a/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
+++ b/modules/cnf-configuring-the-ptp-fast-event-publisher.adoc
@@ -16,15 +16,6 @@ To start using PTP fast event notifications for a network interface in your clus
 
 * You have installed the PTP Operator.
 
-* When you use HTTP events transport, configure dynamic volume provisioning in the cluster or manually create `StorageClass`, `LocalVolume`, and `PersistentVolume` resources to persist the events subscription.
-+
-[NOTE]
-====
-When you enable dynamic volume provisioning in the cluster, a `PersistentVolume` resource is automatically created for the `PersistentVolumeClaim` that the PTP Operator deploys.
-
-For more information about manually creating persistent storage in the cluster, see "Persistent storage using local volumes".
-====
-
 .Procedure
 
 . Modify the default PTP Operator config to enable PTP fast events.
@@ -43,19 +34,14 @@ spec:
     node-role.kubernetes.io/worker: ""
   ptpEventConfig:
     enableEventPublisher: true <1>
-    storageType: "example-storage-class" <2>
 ----
 <1> Set `enableEventPublisher` to `true` to enable PTP fast event notifications.
-<2> Use the value that you set for `storageType` to populate the `StorageClassName` field for the `PersistentVolumeClaim` (`PVC`) resource that the PTP Operator automatically deploys.
-The `PVC` resource is used to persist consumer event subscriptions.
+
 +
 [NOTE]
 ====
 In {product-title} 4.13 or later, you do not need to set the `spec.ptpEventConfig.transportHost` field in the `PtpOperatorConfig` resource when you use HTTP transport for PTP events.
 Set `transportHost` only when you use AMQP transport for PTP events.
-
-The value that you set for `.spec.storageType` in the `PtpOperatorConfig` CR must match the `storageClassName` that is set in the `PersistentVolume` CR.
-If `storageType` is not set and the `transportHost` uses HTTP, the PTP daemons are not deployed.
 ====
 
 .. Update the `PtpOperatorConfig` CR:

--- a/modules/cnf-migrating-from-amqp-to-http-transport.adoc
+++ b/modules/cnf-migrating-from-amqp-to-http-transport.adoc
@@ -17,13 +17,6 @@ If you have previously deployed PTP or bare-metal events consumer applications, 
 
 * You have updated the PTP Operator or {redfish-operator} to version 4.13+ which uses HTTP transport by default.
 
-* Configure dynamic volume provisioning in the cluster or manually create `StorageClass`, `LocalVolume`, and `PersistentVolume` resources to persist the events subscription.
-+
-[NOTE]
-====
-When dynamic volume provisioning is enabled, a `PersistentVolume` resource is automatically created for the `PersistentVolumeClaim` that the PTP Operator or {redfish-operator} deploys.
-====
-
 .Procedure
 
 . Update your events consumer application to use HTTP transport.

--- a/modules/nw-rfhe-creating-hardware-event.adoc
+++ b/modules/nw-rfhe-creating-hardware-event.adoc
@@ -18,15 +18,6 @@ To start using bare-metal events, create the `HardwareEvent` custom resource (CR
 
 * You have created a `BMCEventSubscription` CR for the BMC Redfish hardware.
 
-* You have configured dynamic volume provisioning in the cluster or you have manually created `StorageClass`, `LocalVolume`, and `PersistentVolume` CRs to persist the events subscription.
-+
-[NOTE]
-====
-When you enable dynamic volume provisioning in the cluster, a `PersistentVolume` resource is automatically created for the `PersistentVolumeClaim` that the {redfish-operator} deploys.
-
-For more information about manually creating persistent storage in the cluster, see "Persistent storage using local volumes".
-====
-
 .Procedure
 
 . Create the `HardwareEvent` custom resource (CR):
@@ -47,25 +38,20 @@ metadata:
 spec:
   nodeSelector:
     node-role.kubernetes.io/hw-event: "" <1>
-  storageType: "example-storage-class" <2>
-  logLevel: "debug" <3>
-  msgParserTimeout: "10" <4>
+  logLevel: "debug" <2>
+  msgParserTimeout: "10" <3>
 ----
 +
 --
 <1> Required. Use the `nodeSelector` field to target nodes with the specified label, for example, `node-role.kubernetes.io/hw-event: ""`.
-<2> The value of `storageType` is used to populate the `StorageClassName` field for the `PersistentVolumeClaim` (`PVC`) resource that the {redfish-operator} automatically deploys.
-The `PVC` resource is used to persist consumer event subscriptions.
 +
 [NOTE]
 ====
 In {product-title} 4.13 or later, you do not need to set the `spec.transportHost` field in the `HardwareEvent` resource when you use HTTP transport for bare-metal events.
 Set `transportHost` only when you use AMQP transport for bare-metal events.
-
-The value that you set for `.spec.storageType` in the `HardwareEvent` CR must match the `storageClassName` that is set in the `PersistentVolume` CR.
 ====
-<3> Optional. The default value is `debug`. Sets the log level in `hw-event-proxy` logs. The following log levels are available: `fatal`, `error`, `warning`, `info`, `debug`, `trace`.
-<4> Optional. Sets the timeout value in milliseconds for the Message Parser. If a message parsing request is not responded to within the timeout duration, the original hardware event message is passed to the cloud native event framework. The default value is 10.
+<2> Optional. The default value is `debug`. Sets the log level in `hw-event-proxy` logs. The following log levels are available: `fatal`, `error`, `warning`, `info`, `debug`, `trace`.
+<3> Optional. Sets the timeout value in milliseconds for the Message Parser. If a message parsing request is not responded to within the timeout duration, the original hardware event message is passed to the cloud native event framework. The default value is 10.
 --
 
 .. Apply the `HardwareEvent` CR in the cluster:

--- a/modules/ztp-configuring-hwevents-using-pgt.adoc
+++ b/modules/ztp-configuring-hwevents-using-pgt.adoc
@@ -39,84 +39,15 @@ You can configure bare-metal events that use HTTP transport on managed clusters 
   policyName: "config-policy"
   spec:
     nodeSelector: {}
-    storageType: <storage_class_name> <2>
     transportHost: "http://hw-event-publisher-service.openshift-bare-metal-events.svc.cluster.local:9043"
     logLevel: "info"
 ----
 <1> Each baseboard management controller (BMC) requires a single `HardwareEvent` CR only.
-<2> The value that you set for `storageType` is used to populate the `StorageClassName` field for the `PersistentVolumeClaim` (`PVC`) CR that the {redfish-operator} Operator automatically deploys.
-The `PVC` CR is used to persist consumer event subscriptions.
 +
 [NOTE]
 ====
 In {product-title} 4.13 or later, you do not need to set the `transportHost` field in the `HardwareEvent` custom resource (CR) when you use HTTP transport with bare-metal events.
 ====
-
-. Configure a `PersistentVolume` (`PV`) to persist the events subscription.
-+
-[NOTE]
-====
-A `PersistentVolume` (`PV`) CR for persisting events subscriptions is required only when you use HTTP transport for events.
-====
-+
-For example, add the following YAML to the `group-du-sno-ranGen.yaml` file:
-+
-[source,yaml]
-----
-- fileName: StorageLV.yaml <1>
-  policyName: "config-policy"
-  spec:
-    storageClassDevices:
-      - storageClassName: "storage-class-http-events" <2>
-        volumeMode: Filesystem
-        fsType: xfs
-        devicePaths:
-          - /dev/disk/by-partlabel/httpevent1
-          - /dev/disk/by-partlabel/httpevent2
-- fileName: StoragePV.yaml  <3>
-  policyName: "config-policy"
-  metadata:
-    name: pv-storage-bmer
-  spec:
-    storageClassName: "storage-class-http-events" <4>
-      capacity:
-        storage: 10Mi
-----
-+
---
-<1> Bare-metal events with HTTP transport requires local storage on the cluster node provided by the Local Storage Operator.
-<2> You need `storage-class-http-events` to use HTTP transport with the {redfish-operator}.
-Use the `ignitionConfigOverride` field in the related `SiteConfig` CR to manage the disk labels.
-<3> Storage for the `cloud-event-proxy` pubsubstore.
-+
-[NOTE]
-====
-You need the `StoragePV.yaml` YAML file that creates the `PV` CR only if the `PV` CR is not dynamically created by the Local Storage Operator.
-====
-<4> The `storageClassName` (`storage-class-http-events`) must match the name that is set in the `PVC` CR that the {redfish-operator} Operator deploys.
---
-
-. Configure a namespace and Operator group for the persistent storage this is used by the HTTP message transporter.
-For example, add the following YAML to `spec.sourceFiles` in `common-ranGen.yaml` file:
-+
-[source,yaml]
-----
-- fileName: StorageNS.yaml
-  policyName: "storage-sub-policy"
-- fileName: StorageOperGroup.yaml
-  policyName: "storage-sub-policy"
-- fileName: StorageOperatorStatus.yaml
-  policyName: "storage-sub-policy"
-----
-
-. Configure the individual site `SiteConfig` CR that you use to provision the managed cluster.
-For example, in `example-sno-site-1.yaml`, add the following YAML to the `spec.clusters.nodes` field:
-+
-[source,yaml]
-----
-ignitionConfigOverride:
-  '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
-----
 
 . Merge any other required changes and files with your custom site repository.
 

--- a/modules/ztp-configuring-ptp-fast-events.adoc
+++ b/modules/ztp-configuring-ptp-fast-events.adoc
@@ -2,7 +2,7 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
 
-:_module-type: PROCEDURE
+:_content-type: PROCEDURE
 [id="ztp-configuring-ptp-fast-events_{context}"]
 = Configuring PTP events that use HTTP transport
 
@@ -30,11 +30,8 @@ You can configure PTP events that use HTTP transport on managed clusters that yo
     daemonNodeSelector: {}
     ptpEventConfig:
       enableEventPublisher: true
-      storageType: "storage-class-http-events" <1>
       transportHost: http://ptp-event-publisher-service-NODE_NAME.openshift-ptp.svc.cluster.local:9043
 ----
-<1> The value that you set for `storageType` is used to populate the `StorageClassName` field for the `PersistentVolumeClaim` (`PVC`) resource that the PTP Operator automatically deploys.
-The `PVC` resource is used to persist consumer event subscriptions.
 +
 [NOTE]
 ====
@@ -65,58 +62,6 @@ In {product-title} 4.13 or later, you do not need to set the `transportHost` fie
 <3> You must append the `--summary_interval -4` value to `ptp4lOpts` in `.spec.sourceFiles.spec.profile` to enable PTP fast events.
 <4> Required `phc2sysOpts` values. `-m` prints messages to `stdout`. The `linuxptp-daemon` `DaemonSet` parses the logs and generates Prometheus metrics.
 <5> Optional. If the `ptpClockThreshold` stanza is not present, default values are used for the `ptpClockThreshold` fields. The stanza shows default `ptpClockThreshold` values. The `ptpClockThreshold` values configure how long after the PTP master clock is disconnected before PTP events are triggered. `holdOverTimeout` is the time value in seconds before the PTP clock event state changes to `FREERUN` when the PTP master clock is disconnected. The `maxOffsetThreshold` and `minOffsetThreshold` settings configure offset values in nanoseconds that compare against the values for `CLOCK_REALTIME` (`phc2sys`) or master offset (`ptp4l`). When the `ptp4l` or `phc2sys` offset value is outside this range, the PTP clock state is set to `FREERUN`. When the offset value is within this range, the PTP clock state is set to `LOCKED`.
-
-. Configure a `LocalVolume` (`LV`) to persist the PTP events subscription on the host.
-+
-For example, add the following YAML to the `group-du-sno-ranGen.yaml` file:
-+
-[source,yaml]
-----
-- fileName: StorageLV.yaml <1>
-  policyName: "config-policy"
-  spec:
-    storageClassDevices:
-      - storageClassName: "storage-class-http-events" <2>
-        volumeMode: Filesystem
-        fsType: xfs
-        devicePaths:
-          - /dev/disk/by-partlabel/httpevent1
-          - /dev/disk/by-partlabel/httpevent2
-- fileName: StoragePV.yaml <3>
-  policyName: "config-policy"
-  metadata:
-    name: pv-storage-ptp
-  spec:
-    storageClassName: "storage-class-http-events" <4>
-----
-<1> PTP events with HTTP transport requires local storage on the cluster node provided by the Local Storage Operator.
-<2> Set `storageClassName` to `storage-class-http-events` to use HTTP transport with the PTP Operator.
-Use the `ignitionConfigOverride` field in the related `SiteConfig` CR to manage the disk labels.
-<3> Optional. Configure storage for the `cloud-event-proxy` pubsubstore.
-`StoragePV.yaml` is required only if the `PersistentVolume` (`PV`) CR is not dynamically created by the Local Storage Operator.
-<4> Set the value of `storageClassName` to match the name set in the `PVC` CR that the PTP Operator deploys.
-
-. Configure a namespace and Operator group for the persistent storage this is used by the HTTP message transporter.
-For example, add the following YAML to `spec.sourceFiles` in `common-ranGen.yaml` file:
-+
-[source,yaml]
-----
-- fileName: StorageNS.yaml
-  policyName: "storage-sub-policy"
-- fileName: StorageOperGroup.yaml
-  policyName: "storage-sub-policy"
-- fileName: StorageOperatorStatus.yaml
-  policyName: "storage-sub-policy"
-----
-
-. Configure the individual site `SiteConfig` CR that you use to provision the managed cluster.
-For example, in `example-sno-site-1.yaml`, add the following YAML to the `spec.clusters.nodes` field:
-+
-[source,yaml]
-----
-ignitionConfigOverride:
-  '{"ignition":{"version":"3.2.0"},"storage":{"disks":[{"device":"/dev/disk/by-id/wwn-0x11111000000asd123","wipeTable":false,"partitions":[{"sizeMiB":16,"label":"httpevent1","startMiB":350000},{"sizeMiB":16,"label":"httpevent2","startMiB":350016}]}],"filesystem":[{"device":"/dev/disk/by-partlabel/httpevent1","format":"xfs","wipeFilesystem":true},{"device":"/dev/disk/by-partlabel/httpevent2","format":"xfs","wipeFilesystem":true}]}}'
-----
 
 . Merge any other required changes and files with your custom site repository.
 

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -105,8 +105,6 @@ include::modules/cnf-configuring-the-ptp-fast-event-publisher.adoc[leveloffset=+
 
 * For a complete example CR that configures `linuxptp` services as an ordinary clock with PTP fast events, see xref:../networking/using-ptp.adoc#configuring-linuxptp-services-as-ordinary-clock_using-ptp[Configuring linuxptp services as ordinary clock].
 
-* For more information about manually configuring persistent storage in the cluster, see xref:../storage/persistent_storage/persistent_storage_local/persistent-storage-local.adoc#persistent-storage-using-local-volume[Persistent storage using local volumes].
-
 include::modules/cnf-migrating-from-amqp-to-http-transport.adoc[leveloffset=+2]
 
 include::modules/cnf-installing-amq-interconnect-messaging-bus.adoc[leveloffset=+2]
@@ -118,4 +116,4 @@ include::modules/cnf-monitoring-fast-events-metrics.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../monitoring/managing-metrics.adoc[Managing metrics]
+* xref:../monitoring/managing-metrics.adoc#managing-metrics[Managing metrics]


### PR DESCRIPTION
Removes docs for PV/PVC based PTP events storage. An automatically generated `ConfigMap` CR is now used for event storage.

Version(s):
4.13+

**Note**: this work removes a manual process for configuring PTP events. The feature is unchanged, there are no customers using this feature, and the feature is not called out in release notes.   The change does not require change management.

Issue:
https://issues.redhat.com/browse/TELCODOCS-1434

Link to docs preview:
* https://62938--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp.html#cnf-configuring-the-ptp-fast-event-publisher_using-ptp
* https://62938--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html#ztp-advanced-policy-config-ptp_ztp-advanced-policy-config
* https://62938--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.html#ztp-advanced-policy-config-bare-metal_ztp-advanced-policy-config

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
