### PR TITLE
[OSDOCS-7140]: Move AWS tasks for hosted control planes to AWS subsection

### DIFF
--- a/hosted_control_planes/hcp-configuring.adoc
+++ b/hosted_control_planes/hcp-configuring.adoc
@@ -8,29 +8,36 @@ toc::[]
 
 To get started with hosted control planes for {product-title}, you first configure your hosted cluster on the provider that you want to use. Then, you complete a few management tasks. 
 
-:FeatureName: Hosted control planes
-include::snippets/technology-preview.adoc[]
-
 You can view the procedures by selecting from one of the following providers:
 
 [id="hcp-configuring-aws"]
 == Amazon Web Services (AWS)
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosting-cluster-aws-infra-reqs[AWS infrastructure requirements]: Review the infrastructure requirements to create a hosted cluster on AWS.
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring the hosting cluster on AWS (Technology Preview)]: The tasks to configure a hosted cluster on AWS include creating the AWS S3 OIDC secret, creating a routable public zone, enabling external DNS, enabling AWS PrivateLink, enabling the hosted control planes feature, and installing the hosted control planes CLI.
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-manage-aws[Managing hosted control plane clusters on AWS (Technology Preview)]: Management tasks include creating, importing, accessing, or deleting a hosted cluster on AWS.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosting-service-cluster-configure-aws[Configuring the hosting cluster on AWS]: The tasks to configure a hosted cluster on AWS include creating the AWS S3 OIDC secret, creating a routable public zone, enabling external DNS, enabling AWS PrivateLink, enabling the hosted control planes feature, and installing the hosted control planes CLI.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-manage-aws[Managing hosted control plane clusters on AWS]: Management tasks include creating, importing, accessing, or deleting a hosted cluster on AWS.
+* xref:../networking/hardware_networks/configuring-sriov-operator.adoc#sriov-operator-hosted-control-planes_configuring-sriov-operator[Deploying the SR-IOV Operator for hosted control planes]: After you configure and deploy your hosting service cluster, you can create a subscription to the Single Root I/O Virtualization (SR-IOV) Operator on a hosted cluster. The SR-IOV pod runs on worker machines rather than the control plane.
+* xref:../scalability_and_performance/using-node-tuning-operator.adoc#node-tuning-hosted-cluster_node-tuning-operator[Configuring node tuning in a hosted cluster]: To set node-level tuning on the nodes in your hosted cluster, you can use the Node Tuning Operator. In hosted control planes, you can configure node tuning by creating config maps that contain `Tuned` objects and referencing those config maps in your node pools.
+* xref:../scalability_and_performance/using-node-tuning-operator.adoc#advanced-node-tuning-hosted-cluster_node-tuning-operator[Advanced node tuning for hosted clusters by setting kernel boot parameters]: More advanced tuning in hosted control planes requires setting kernel boot parameters.
 
 [id="hcp-configuring-bm"]
 == Bare metal
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#infrastructure-reqs-bare-metal[Bare metal infrastructure requirements]: Review the infrastructure requirements to create a hosted cluster on bare metal.
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-configure-bm[Configuring the hosting cluster on bare metal (Technology Preview)]: Configure DNS before you create a hosted cluster. 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal (Technology Preview)]: Create a hosted cluster, create an `InfraEnv` resource, add agents, access the hosted cluster, scale the `NodePool` object, handle Ingress, enable node auto-scaling, or delete a hosted cluster.
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#configuring-hosting-service-cluster-configure-bm[Configuring the hosting cluster on bare metal]: 
+** Configure DNS
+** Create an `InfraEnv` resource and add agents to it
+** Create a hosted cluster and verify cluster creation
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-manage-bm[Managing hosted control plane clusters on bare metal]: 
+** Scale the `NodePool` object for a hosted cluster
+** Handle Ingress for a hosted cluster
+** Enable node auto-scaling for a hosted cluster
+** Destroy a hosted cluster
 
 [id="hcp-configuring-virt"]
 == {VirtProductName}
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on OpenShift Virtualization (Technology Preview)]: Create {product-title} clusters with worker nodes that are hosted by KubeVirt virtual machines. 
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on OpenShift Virtualization]: Create {product-title} clusters with worker nodes that are hosted by KubeVirt virtual machines. 
 
 // To be added after ACM 2.9 goes live:
 

--- a/hosted_control_planes/hcp-managing.adoc
+++ b/hosted_control_planes/hcp-managing.adoc
@@ -19,8 +19,6 @@ include::modules/hosted-control-planes-pause-reconciliation.adoc[leveloffset=+1]
 //debugging why nodes have not joined the cluster
 //using service-level DNS for control plane services
 //configuring metrics sets
-include::modules/node-tuning-hosted-cluster.adoc[leveloffset=+1]
-include::modules/sriov-operator-hosted-control-planes.adoc[leveloffset=+1]
 //automated machine management
 include::modules/delete-hosted-cluster.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7140
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://62943--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-configuring.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR moves 3 modules that are AWS-specific to the AWS subsection of the "Configuring hosted control planes" book. It also removes some of the Technology Preview wording, as hosted control planes will be GA for 4.14.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
