### PR TITLE
OCPBUGS-17057: Removed tech preview callout and joined tables

### DIFF
--- a/modules/nw-sriov-hwol-supported-devices.adoc
+++ b/modules/nw-sriov-hwol-supported-devices.adoc
@@ -23,18 +23,12 @@ Hardware offloading is supported on the following network interface controllers:
 |15b3
 |1019
 
-|Mellanox 
+|Mellanox
 |MT2892 Family [ConnectX&#8209;6 Dx]
 |15b3
 |101d
-|===
 
-.Technology Preview network interface controllers
-[cols="1,2,1,1"]
-|===
-|Manufacturer |Model |Vendor ID | Device ID
-
-|Mellanox 
+|Mellanox
 |MT2894 Family [ConnectX-6 Lx]
 |15b3
 |101f
@@ -44,6 +38,3 @@ Hardware offloading is supported on the following network interface controllers:
 |15b3
 |a2d6
 |===
-
-:FeatureName: Using a ConnectX-6 Lx or BlueField-2 in ConnectX-6 NIC mode device
-include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
These devices are listed correctly in the Release Notes, but incorrectly listed here per discussion with @bn222 and @wizhaoredhat. The devices are GA as of 4.13.

Preview build: https://62948--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-hardware-offloading.html#supported_devices_configuring-hardware-offloading

Tracked in https://issues.redhat.com/browse/OCPBUGS-17057

No change management needed.