### PR TITLE
CNV-30835: must-gather instancetypes flag

### DIFF
--- a/modules/virt-must-gather-options.adoc
+++ b/modules/virt-must-gather-options.adoc
@@ -25,11 +25,13 @@ You can specify environment variables for a compatible script.
 `VM=<vm_name>`:: Collect details about a particular virtual machine. To use this option, you must also specify a namespace by using the `NS` environment variable.
 
 `PROS=<number_of_processes>`:: Modify the maximum number of parallel processes that the `must-gather` tool uses. The default value is `5`.
+
 +
 [IMPORTANT]
 ====
 Using too many parallel processes can cause performance issues. Increasing the maximum number of parallel processes is not recommended.
 ====
+
 
 .Scripts
 
@@ -41,16 +43,20 @@ Each script is compatible only with certain environment variable combinations.
 
 `/usr/bin/gather --images`:: Collect image, image-stream, and image-stream-tags custom resource information. This script is compatible only with the `PROS` variable.
 
+`/usr/bin/gather --instancetypes`:: Collect instance types information. This information is not currently collected by default; you can, however, optionally collect it.
+
 [id="usage-and-examples_{context}"]
 == Usage and examples
 
 Environment variables are optional. You can run a script by itself or with one or more compatible environment variables.
 
-[cols="1a,1a", options="header"]
+
 .Compatible parameters
+[options="header"]
 |===
 |Script |Compatible environment variable
-|`/usr/bin/gather`   |* `PROS=<number_of_processes>`
+|`/usr/bin/gather`   
+|* `PROS=<number_of_processes>`
 |`/usr/bin/gather --vms_details`
 |* For a namespace: `NS=<namespace_name>`
 
@@ -58,8 +64,8 @@ Environment variables are optional. You can run a script by itself or with one o
 
 * `PROS=<number_of_processes>`
 
-
-|`/usr/bin/gather --images`   |* `PROS=<number_of_processes>`
+|`/usr/bin/gather --images`   
+|* `PROS=<number_of_processes>`
 |===
 
 
@@ -110,4 +116,15 @@ The following command collects image, image-stream, and image-stream-tags inform
 $ oc adm must-gather \
   --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion} \
   /usr/bin/gather --images
+----
+
+.Instance types information
+
+The following command collects instance types information from the cluster:
+
+[source,terminal,subs="attributes+"]
+----
+$ oc adm must-gather \
+  --image=registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion} \
+  /usr/bin/gather --instancetypes
 ----

--- a/modules/virt-using-virt-must-gather.adoc
+++ b/modules/virt-using-virt-must-gather.adoc
@@ -17,6 +17,8 @@ The default data collection includes information about the following resources:
 * Namespaces that contain virtual machines
 * Basic virtual machine definitions
 
+Instance types information is not currently collected by default; you can, however, run a command to optionally collect it.
+
 .Procedure
 
 * Run the following command to collect data about {VirtProductName}:


### PR DESCRIPTION
Version(s): 4.14

Issue: [CNV-30835](https://issues.redhat.com/browse/CNV-30835)

Link to docs preview:
-- [Using the must-gather tool for OpenShift Virtualization](https://62954--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html#virt-using-virt-must-gather_virt-collecting-virt-data)
-- [must-gather options ](https://62954--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html#virt-must-gather-options_virt-collecting-virt-data)
-- [Usage and examples](https://62954--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-collecting-virt-data.html#usage-and-examples_virt-collecting-virt-data) 

QE review:
- [x] QE has approved this change.

Additional information:

