### PR TITLE
OSDOCS-7095: Documented the 4.12.27 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3896,3 +3896,23 @@ $ oc adm release info 4.12.26 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+
+[id="ocp-4-12-27"]
+=== RHBA-2023:4319 - {product-title} 4.12.27 bug fix update
+
+Issued: 2023-08-02
+
+{product-title} release 4.12.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4319[RHBA-2023:4319] advisory. There are no RPM packages for this update.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.27 --pullspecs
+----
+
+[id="ocp-4-12-27-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-7095](https://issues.redhat.com/browse/OSDOCS-7095)

Version(s):
4.12

Link to docs preview:
[Release notes for 4.12.27](https://62961--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes.html#ocp-4-12-27)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
