### PR TITLE
WMCO 8.0.1 release notes fix bad link

### DIFF
--- a/windows_containers/windows-containers-release-notes-8-x.adoc
+++ b/windows_containers/windows-containers-release-notes-8-x.adoc
@@ -31,7 +31,7 @@ endif::openshift-origin[]
 [id="wmco-8-0-1"]
 == Release notes for Red Hat Windows Machine Config Operator 8.0.1
 
-This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of WMCO 8.0.1 were released in link:https://access.redhat.com/errata/RHSA-2023:NEED[RHSA-2023:NEED].
+This release of the WMCO provides new features and bug fixes for running Windows compute nodes in an {product-title} cluster. The components of WMCO 8.0.1 were released in link:https://access.redhat.com/errata/RHBA-2023:3738[RHBA-2023:3738].
 
 [id="wmco-8-0-1-new-features"]
 === New features and improvements


### PR DESCRIPTION
Fixing a bad link in the Windows Containers 8.0.1 release notes

Preview: [Release notes for Red Hat Windows Machine Config Operator 8.0.1](https://62966--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/windows-containers-release-notes-8-x.html#wmco-8-0-1)

No QE needed
