### PR TITLE
[virt] DPDK Checkup: Update user facing API

### DIFF
--- a/modules/virt-checking-cluster-dpdk-readiness.adoc
+++ b/modules/virt-checking-cluster-dpdk-readiness.adoc
@@ -106,12 +106,12 @@ metadata:
 data:
   spec.timeout: 10m
   spec.param.networkAttachmentDefinitionName: <network_name> <1>
-  spec.param.trafficGeneratorImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.1" <2>
-  spec.param.vmContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.1" <3>
+  spec.param.trafficGenContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.1" <2>
+  spec.param.vmUnderTestContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.1" <3>
 ----
 <1> The name of the `NetworkAttachmentDefinition` object.
-<2> The container image for the traffic generator. In this example, the image is pulled from the upstream Project Quay Container Registry.
-<3> The container disk image for the VM. In this example, the image is pulled from the upstream Project Quay Container Registry.
+<2> The container disk image for the traffic generator. In this example, the image is pulled from the upstream Project Quay Container Registry.
+<3> The container disk image for the VM under test. In this example, the image is pulled from the upstream Project Quay Container Registry.
 
 . Apply the `ConfigMap` manifest in the target namespace:
 +
@@ -186,18 +186,35 @@ kind: ConfigMap
 metadata:
   name: dpdk-checkup-config
 data:
-  spec.timeout: 1h2m
+  spec.timeout: 10m
   spec.param.NetworkAttachmentDefinitionName: "dpdk-network-1"
-  spec.param.trafficGeneratorImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.1"
-  spec.param.vmContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.1"
-  status.succeeded: true
-  status.failureReason: " "
-  status.startTimestamp: 2022-12-21T09:33:06+00:00
-  status.completionTimestamp: 2022-12-21T11:33:06+00:00
-  status.result.actualTrafficGeneratorTargetNode: worker-dpdk1
-  status.result.actualDPDKVMTargetNode: worker-dpdk2
-  status.result.dropRate: 0
+  spec.param.trafficGenContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:v0.1.1"
+  spec.param.vmUnderTestContainerDiskImage: "quay.io/kiagnose/kubevirt-dpdk-checkup-vm:v0.1.1"
+  status.succeeded: "true" <1>
+  status.failureReason: "" <2>
+  status.startTimestamp: "2023-07-31T13:14:38Z" <3>
+  status.completionTimestamp: "2023-07-31T13:19:41Z" <4>
+  status.result.trafficGenSentPackets: "480000000" <5>
+  status.result.trafficGenOutputErrorPackets: "0" <6>
+  status.result.trafficGenInputErrorPackets: "0" <7>
+  status.result.trafficGenActualNodeName: worker-dpdk1 <8>
+  status.result.vmUnderTestActualNodeName: worker-dpdk2 <9>
+  status.result.vmUnderTestReceivedPackets: "480000000" <10>
+  status.result.vmUnderTestRxDroppedPackets: "0" <11>
+  status.result.vmUnderTestTxDroppedPackets: "0" <12>
 ----
+<1> Specifies if the checkup is successful (`true`) or not (`false`).
+<2> The reason for failure if the checkup fails.
+<3> The time when the checkup started, in RFC 3339 time format.
+<4> The time when the checkup has completed, in RFC 3339 time format.
+<5> The number of packets sent from the traffic generator.
+<6> The number of error packets sent from the traffic generator.
+<7> The number of error packets received by the traffic generator.
+<8> The node on which the traffic generator VM was scheduled.
+<9> The node on which the VM under test was scheduled.
+<10> The number of packets received on the VM under test.
+<11> The ingress traffic packets that were dropped by the DPDK application.
+<12> The egress traffic packets that were dropped from the DPDK application.
 
 . Delete the job and config map that you previously created by running the following commands:
 +

--- a/modules/virt-dpdk-config-map-parameters.adoc
+++ b/modules/virt-dpdk-config-map-parameters.adoc
@@ -8,7 +8,7 @@
 
 The following table shows the mandatory and optional parameters that you can set in the `data` stanza of the input `ConfigMap` manifest when you run a cluster DPDK readiness checkup:
 
-.DPDK checkup config map parameters
+.DPDK checkup config map input parameters
 [cols="1,1,1", options="header"]
 |====
 |Parameter
@@ -23,52 +23,32 @@ The following table shows the mandatory and optional parameters that you can set
 |The name of the `NetworkAttachmentDefinition` object of the SR-IOV NICs connected.
 |True
 
-|`spec.param.trafficGeneratorRuntimeClassName`
-|The RuntimeClass resource that the traffic generator pod uses.
-|True
-
-|`spec.param.trafficGeneratorImage`
-|The container image for the traffic generator. The default value is `quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main`.
+|`spec.param.trafficGenContainerDiskImage`
+|The container disk image for the traffic generator. The default value is `quay.io/kiagnose/kubevirt-dpdk-checkup-traffic-gen:main`.
 |False
 
-|`spec.param.trafficGeneratorNodeSelector`
-|The node on which the traffic generator pod is to be scheduled. The node should be configured to allow DPDK traffic.
+|`spec.param.trafficGenTargetNodeName`
+|The node on which the traffic generator VM is to be scheduled. The node should be configured to allow DPDK traffic.
 |False
 
-|`spec.param.trafficGeneratorPacketsPerSecond`
-|The number of packets per second, in kilo (k) or million(m). The default value is 14m.
+|`spec.param.trafficGenPacketsPerSecond`
+|The number of packets per second, in kilo (k) or million(m). The default value is 8m.
 |False
 
-|`spec.param.trafficGeneratorEastMacAddress`
-|The MAC address of the NIC connected to the traffic generator pod or VM. The default value is a random MAC address in the format `50:xx:xx:xx:xx:01`.
+|`spec.param.vmUnderTestContainerDiskImage`
+|The container disk image for the VM under test. The default value is `quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main`.
 |False
 
-|`spec.param.trafficGeneratorWestMacAddress`
-|The MAC address of the NIC connected to the traffic generator pod or VM. The default value is a random MAC address in the format `50:xx:xx:xx:xx:02`.
-|False
-
-|`spec.param.vmContainerDiskImage`
-|The container disk image for the VM. The default value is `quay.io/kiagnose/kubevirt-dpdk-checkup-vm:main`.
-|False
-
-|`spec.param.DPDKLabelSelector`
-|The label of the node on which the VM runs. The node should be configured to allow DPDK traffic.
-|False
-
-|`spec.param.DPDKEastMacAddress`
-|The MAC address of the NIC that is connected to the VM. The default value is a random MAC address in the format `60:xx:xx:xx:xx:01`.
-|False
-
-|`spec.param.DPDKWestMacAddress`
-|The MAC address of the NIC that is connected to the VM. The default value is a random MAC address in the format `60:xx:xx:xx:xx:02`.
+|`spec.param.vmUnderTestTargetNodeName`
+|The node on which the VM under test is to be scheduled. The node should be configured to allow DPDK traffic.
 |False
 
 |`spec.param.testDuration`
 |The duration, in minutes, for which the traffic generator runs. The default value is 5 minutes.
 |False
 
-|`spec.param.portBandwidthGB`
-|The maximum bandwidth of the SR-IOV NIC. The default value is 10GB.
+|`spec.param.portBandwidthGbps`
+|The maximum bandwidth of the SR-IOV NIC. The default value is 10Gbps.
 |False
 
 |`spec.param.verbose`


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Following an upstream user-facing API change, update ConfigMap related parts.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://62967--docspreview.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups.html#virt-checking-cluster-dpdk-readiness_virt-running-cluster-checkups

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
~~Depends on PR #62804, please review only the last commit.~~

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
