### PR TITLE
RHDEVDOCS-5458: Update sink -> target in dev console

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -4,7 +4,7 @@ Dir: about
 Distros: openshift-serverless
 Topics:
 - Name: Release notes
-  File: serverless-release-notes  
+  File: serverless-release-notes
 - Name: Serverless overview
   File: about-serverless
 - Name: Knative Serving overview
@@ -126,7 +126,7 @@ Topics:
   - Name: Resolving image tags to digests
     File: resolving-image-tags-to-digests
   - Name: Configuring TLS authentication
-    File: serverless-config-tls      
+    File: serverless-config-tls
   - Name: Restrictive network policies
     File: restrictive-network-policies
 - Name: Traffic splitting
@@ -223,7 +223,7 @@ Topics:
     File: serverless-kafka-developer-source
   - Name: Custom event sources
     File: serverless-custom-event-sources
-  - Name: Connecting an event source to a sink using the Developer perspective
+  - Name: Connecting an event source to an event sink by using the Developer perspective
     File: serverless-sink-source-odc
 - Name: Event sinks
   Dir: event-sinks
@@ -231,7 +231,7 @@ Topics:
   - Name: Event sinks overview
     File: serverless-event-sinks
   - Name: Creating event sinks
-    File: serverless-creating-sinks    
+    File: serverless-creating-sinks
   - Name: Sink for Apache Kafka
     File: serverless-kafka-developer-sink
 - Name: Brokers

--- a/eventing/event-sources/serverless-sink-source-odc.adoc
+++ b/eventing/event-sources/serverless-sink-source-odc.adoc
@@ -1,10 +1,10 @@
 :_content-type: ASSEMBLY
 include::_attributes/common-attributes.adoc[]
 [id="serverless-sink-source-odc"]
-= Connecting an event source to a sink using the Developer perspective
+= Connecting an event source to an event sink by using the Developer perspective
 :context: serverless-sink-source-odc
 
-When you create an event source by using the {ocp-product-title} web console, you can specify a sink that events are sent to from that source. The sink can be any addressable or callable resource that can receive incoming events from other resources.
+When you create an event source by using the {ocp-product-title} web console, you can specify a target event sink that events are sent to from that source. The event sink can be any addressable or callable resource that can receive incoming events from other resources.
 
 // Connect sinks to sources in ODC
 include::modules/serverless-connect-sink-source-odc.adoc[leveloffset=+1]

--- a/modules/odc-creating-apiserversource.adoc
+++ b/modules/odc-creating-apiserversource.adoc
@@ -6,7 +6,7 @@
 [id="odc-creating-apiserversource_{context}"]
 = Creating an API server source by using the web console
 
-After Knative Eventing is installed on your cluster, you can create an API server source by using the web console. Using the {ocp-product-title} web console provides a streamlined and intuitive user interface to create an event source. 
+After Knative Eventing is installed on your cluster, you can create an API server source by using the web console. Using the {ocp-product-title} web console provides a streamlined and intuitive user interface to create an event source.
 
 .Prerequisites
 
@@ -32,18 +32,20 @@ You can switch between the *Form view* and *YAML view*. The data is persisted wh
 // .. Select *Resource* as the *Mode*. *Mode* is the mode that the receive adapter controller runs in. `Ref` sends only the reference to the resource. `Resource` sends the full resource.
 // TODO: clarify what this is used for. Out of scope for this PR since not required.
 .. Select the *Service Account Name* for the service account that you created.
-.. Select the *Sink* for the event source. A *Sink* can be either a *Resource*, such as a channel, broker, or service, or a *URI*.
+.. In the *Target* section, select your event sink. This can be either a *Resource* or a *URI*:
+... Select *Resource* to use a channel, broker, or service as an event sink for the event source.
+... Select *URI* to specify a Uniform Resource Identifier (URI) where the events are routed to.
 . Click *Create*.
 
 .Verification
 
-* After you have created the API server source, you will see it connected to the service it is sinked to in the *Topology* view.
+* After you have created the API server source, check that it is connected to the event sink by viewing it in the *Topology* view.
 +
 image::toplogy-odc-apiserver.png[ApiServerSource Topology view]
 
 [NOTE]
 ====
-If a URI sink is used, modify the URI by right-clicking on *URI sink* -> *Edit URI*.
+If a URI sink is used, you can modify the URI by right-clicking on *URI sink* -> *Edit URI*.
 ====
 
 .Deleting the API server source

--- a/modules/serverless-connect-func-source-odc.adoc
+++ b/modules/serverless-connect-func-source-odc.adoc
@@ -19,7 +19,7 @@ Functions are deployed as Knative services on an {ocp-product-title} cluster. Wh
 
 . Create an event source of any type, by navigating to *+Add* -> *Event Source* and selecting the event source type that you want to create.
 
-. In the *Sink* section of the *Create Event Source* form view, select your function in the *Resource* list.
+. In the *Target* section of the *Create Event Source* form view, select your function in the *Resource* list.
 
 . Click *Create*.
 

--- a/modules/serverless-connect-sink-source-odc.adoc
+++ b/modules/serverless-connect-sink-source-odc.adoc
@@ -4,20 +4,22 @@
 
 :_content-type: PROCEDURE
 [id="serverless-connect-sink-source-odc_{context}"]
-= Connect an event source to a sink using the Developer perspective
+= Connect an event source to an event sink by using the Developer perspective
 
 .Prerequisites
 
 * The {ServerlessOperatorName}, Knative Serving, and Knative Eventing are installed on your {ocp-product-title} cluster.
 * You have logged in to the web console and are in the *Developer* perspective.
 * You have created a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
-* You have created a sink, such as a Knative service, channel or broker.
+* You have created an event sink, such as a Knative service, channel or broker.
 
 .Procedure
 
 . Create an event source of any type, by navigating to *+Add* -> *Event Source* and selecting the event source type that you want to create.
 
-. In the *Sink* section of the *Create Event Source* form view, select your sink in the *Resource* list.
+. In the *Target* section of the *Create Event Source* form view, select your event sink. This can be either a *Resource* or a *URI*:
+.. Select *Resource* to use a channel, broker, or service as an event sink for the event source.
+.. Select *URI* to specify a Uniform Resource Identifier (URI) where the events are routed to.
 
 . Click *Create*.
 
@@ -27,4 +29,4 @@ You can verify that the event source was created and is connected to the sink by
 
 . In the *Developer* perspective, navigate to *Topology*.
 
-. View the event source and click the connected sink to see the sink details in the right panel.
+. View the event source and click the connected event sink to see the sink details in the right panel.

--- a/modules/serverless-kafka-source-odc.adoc
+++ b/modules/serverless-kafka-source-odc.adoc
@@ -24,7 +24,9 @@ After the Knative broker implementation for Apache Kafka is installed on your cl
 .. Add a comma-separated list of *Topics*.
 .. Add a *Consumer Group*.
 .. Select the *Service Account Name* for the service account that you created.
-.. Select the *Sink* for the event source. A *Sink* can be either a *Resource*, such as a channel, broker, or service, or a *URI*.
+.. In the *Target* section, select your event sink. This can be either a *Resource* or a *URI*:
+... Select *Resource* to use a channel, broker, or service as an event sink for the event source.
+... Select *URI* to specify a Uniform Resource Identifier (URI) where the events are routed to.
 .. Enter a *Name* for the Kafka event source.
 . Click *Create*.
 

--- a/modules/serverless-odc-create-containersource.adoc
+++ b/modules/serverless-odc-create-containersource.adoc
@@ -32,8 +32,8 @@ You can switch between the *Form view* and *YAML view*. The data is persisted wh
 // Optional? Add options and what they mean.
 // Same for env variables...
 .. Optional: In the *Environment variables* field, add any environment variables to set in the container.
-.. In the *Sink* section, add a sink where events from the container source are routed to. If you are using the *Form* view, you can choose from the following options:
-... Select *Resource* to use a channel, broker, or service as a sink for the event source.
-... Select *URI* to specify where the events from the container source are routed to.
+.. In the *Target* section, select your event sink. This can be either a *Resource* or a *URI*:
+... Select *Resource* to use a channel, broker, or service as an event sink for the event source.
+... Select *URI* to specify a Uniform Resource Identifier (URI) where the events are routed to.
 
 . After you have finished configuring the container source, click *Create*.

--- a/modules/serverless-pingsource-odc.adoc
+++ b/modules/serverless-pingsource-odc.adoc
@@ -48,7 +48,9 @@ You can configure the *PingSource* settings by using the *Form view* or *YAML vi
 ====
 .. Enter a value for *Schedule*. In this example, the value is `*/2 * * * *`, which creates a PingSource that sends a message every two minutes.
 .. Optional: You can enter a value for *Data*, which is the message payload.
-.. Select a *Sink*. This can be either a *Resource* or a *URI*. In this example, the `event-display` service created in the previous step is used as the *Resource* sink.
+.. In the *Target* section, select your event sink. This can be either a *Resource* or a *URI*:
+... Select *Resource* to use a channel, broker, or service as an event sink for the event source. In this example, the `event-display` service created in the previous step is used as the target *Resource*.
+... Select *URI* to specify a Uniform Resource Identifier (URI) where the events are routed to.
 .. Click *Create*.
 
 .Verification

--- a/modules/serverless-sinkbinding-odc.adoc
+++ b/modules/serverless-sinkbinding-odc.adoc
@@ -96,7 +96,10 @@ You can configure the *Sink Binding* settings by using the *Form view* or *YAML 
 ====
 The `CronJob` kind is not supported directly by {ServerlessProductName} sink binding, so the *Kind* field must target the `Job` objects created by the cron job, rather than the cron job object itself.
 ====
-.. Select a *Sink*. This can be either a *Resource* or a *URI*. In this example, the `event-display` service created in the previous step is used as the *Resource* sink.
+.. In the *Target* section, select your event sink. This can be either a *Resource* or a *URI*:
+... Select *Resource* to use a channel, broker, or service as an event sink for the event source. In this example, the `event-display` service created in the previous step is used as the target *Resource*.
+... Select *URI* to specify a Uniform Resource Identifier (URI) where the events are routed to.
+
 .. In the *Match labels* section:
 ... Enter `app` in the *Name* field.
 ... Enter `heartbeat-cron` in the *Value* field.


### PR DESCRIPTION
Version(s):
serverless-docs-1.28
serverless-docs-1.29
serverless-docs-1.30

Issue:
https://issues.redhat.com/browse/RHDEVDOCS-5458

Link to docs preview:
- https://62975--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-sink-source-odc.html
- https://62975--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-kafka-developer-source#serverless-kafka-source-odc_serverless-kafka-developer-source
- https://62975--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-apiserversource#odc-creating-apiserversource_serverless-apiserversource
- https://62975--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-pingsource#serverless-pingsource-odc_serverless-pingsource
- https://62975--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-custom-event-sources#serverless-sinkbinding-odc_serverless-custom-event-sources
- https://62975--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-custom-event-sources#serverless-odc-create-containersource_serverless-custom-event-sources
- https://62975--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-eventing#serverless-connect-func-source-odc_serverless-functions-eventing

QE review:
- [x] QE has approved this change.