### PR TITLE
Fixes small typo in main branch of IR docs

### DIFF
--- a/modules/applications-create-using-cli-modify.adoc
+++ b/modules/applications-create-using-cli-modify.adoc
@@ -214,7 +214,7 @@ $ oc new-app --search php
 
 To set the import mode when using `oc new-app`, add the `--import-mode` flag. This flag can be appended with `Legacy` or `PreserveOriginal`, which provides users the option to create image streams using a single sub-manifest, or all manifests, respectively. 
 
-[souce,terminal]
+[source,terminal]
 ----
 $ oc new-app --image=registry.redhat.io/ubi8/httpd-24:latest  --import-mode=Legacy --name=test
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Main only. Has been fixed in 4.14. 

See: https://github.com/openshift/openshift-docs/pull/62965

Issue:
https://issues.redhat.com/browse/OSDOCS-7181

Link to docs preview:
https://62978--docspreview.netlify.app/openshift-enterprise/latest/applications/creating_applications/creating-applications-using-cli.html#setting-the-import-mode

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
