### PR TITLE
OSDOCS 7182: Removing unsupported OSSO versions and adding note about…

### DIFF
--- a/nodes/scheduling/secondary_scheduler/index.adoc
+++ b/nodes/scheduling/secondary_scheduler/index.adoc
@@ -8,5 +8,8 @@ toc::[]
 
 You can install the {secondary-scheduler-operator} to run a custom secondary scheduler alongside the default scheduler to schedule pods.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // About the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-about.adoc[leveloffset=+1]

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 You can run a custom secondary scheduler in {product-title} by installing the {secondary-scheduler-operator}, deploying the secondary scheduler, and setting the secondary scheduler in the pod definition.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 toc::[]
 
 // Installing the {secondary-scheduler-operator}

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -10,58 +10,7 @@ The {secondary-scheduler-operator-full} allows you to deploy a custom secondary 
 
 These release notes track the development of the {secondary-scheduler-operator-full}.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
-
-[id="secondary-scheduler-operator-release-notes-1.1.1"]
-== Release notes for {secondary-scheduler-operator-full} 1.1.1
-
-Issued: 2023-5-18
-
-The following advisory is available for the {secondary-scheduler-operator-full} 1.1.1:
-
-* link:https://access.redhat.com/errata/RHSA-2023:0584[RHSA-2023:0584]
-
-////
-// No enhancements in this release
-[id="secondary-scheduler-operator-1.1.1-new-features-and-enhancements"]
-=== New features and enhancements
-
-* None
-////
-
-[id="secondary-scheduler-1.1.1-bug-fixes"]
-=== Bug fixes
-
-* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
-
-[id="secondary-scheduler-operator-1.1.1-known-issues"]
-=== Known issues
-
-* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
-
-[id="secondary-scheduler-operator-release-notes-1.1.0"]
-== Release notes for {secondary-scheduler-operator-full} 1.1.0
-
-Issued: 2022-9-1
-
-The following advisory is available for the {secondary-scheduler-operator-full} 1.1.0:
-
-* link:https://access.redhat.com/errata/RHSA-2022:6152[RHSA-2022:6152]
-
-[id="secondary-scheduler-operator-1.1.0-new-features-and-enhancements"]
-=== New features and enhancements
-
-* The {secondary-scheduler-operator} security context configuration has been updated to comply with xref:../../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[pod security admission enforcement].
-
-////
-// No bug fixes in this release
-[id="secondary-scheduler-1.1.0-bug-fixes"]
-=== Bug fixes
-
-* None
-////
-
-[id="secondary-scheduler-operator-1.1.0-known-issues"]
-=== Known issues
-
-* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2071684[*BZ#2071684*])

--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.adoc
@@ -8,6 +8,9 @@ toc::[]
 
 You can remove the {secondary-scheduler-operator-full} from {product-title} by uninstalling the Operator and removing its related resources.
 
+:operator-name: The {secondary-scheduler-operator}
+include::snippets/operator-not-available.adoc[]
+
 // Uninstalling the {secondary-scheduler-operator}
 include::modules/nodes-secondary-scheduler-uninstall-console.adoc[leveloffset=+1]
 

--- a/snippets/operator-not-available.adoc
+++ b/snippets/operator-not-available.adoc
@@ -1,0 +1,9 @@
+// When including this file, ensure that {operator-name} is set immediately before
+// the include. Otherwise it will result in an incorrect replacement.
+
+[IMPORTANT]
+====
+{operator-name} is not currently available for {product-title} {product-version}. The Operator is planned to be released in the near future.
+====
+// Undefine {operator-name} attribute, so that any mistakes are easily spotted
+:!operator-name:


### PR DESCRIPTION
… being released in the future

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7182

Link to docs preview:
https://62979--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Note that "Branch Build" will render as "4.14" once the PR merges

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
