### PR TITLE
modules/installation-user-infra-machines-*: PXE with Ignition kargs

### DIFF
--- a/modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing_bare_metal/installing-bare-metal-network-customizations.adoc
 
+:_content-type: PROCEDURE
 [id="installation-user-infra-machines-advanced-customizing-live-{boot}-ca-certs_{context}"]
 = Modifying a live install {boot-media} to use a custom certificate authority
 

--- a/modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc
@@ -43,4 +43,8 @@ You must use the `--dest-ignition` flag to create a customized image for each cl
 Custom CA certificates affect how Ignition fetches remote resources but they do not affect the certificates installed onto the system.
 ====
 +
+ifeval::["{boot-media}" == "PXE environment"]
+. Use the customized `initramfs` file in your PXE configuration. Add `ignition.firstboot` and `ignition.platform.id=metal` kernel arguments if not already present.
+endif::[]
++
 Your CA certificate is applied and affects every subsequent boot of the {boot-media}.

--- a/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing_bare_metal/installing-bare-metal-network-customizations.adoc
 
+:_content-type: PROCEDURE
 [id="installation-user-infra-machines-advanced-customizing-live-{boot}_network_keyfile_{context}"]
 = Modifying a live install {boot-media} with customized network settings
 You can embed a NetworkManager keyfile into the live {boot-media} and pass it through to the installed system with the `--network-keyfile` flag of the `customize` subcommand.

--- a/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
@@ -96,6 +96,7 @@ $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
     --network-keyfile bond0-proxy-em2.nmconnection \
     -o rhcos-<version>-custom-initramfs.x86_64.img
 ----
+. Use the customized `initramfs` file in your PXE configuration. Add `ignition.firstboot` and `ignition.platform.id=metal` kernel arguments if not already present.
 endif::[]
 +
 Network settings are applied to the live system and are carried over to the destination system.

--- a/modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc
@@ -66,6 +66,7 @@ $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
 <2> The desired secondary console. In this case, the graphical console. Omitting this option will disable the graphical console.
 <3> The desired primary console. In this case, the serial console. The `options` field defines the baud rate and other settings. A common value for this field is `115200n8`. If no options are provided, the default kernel value of `9600n8` is used. For more information on the format of this option, see the link:https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html[Linux kernel serial console] documentation.
 <4> The specified disk to install to. In this case, `/dev/sda`. If you omit this option, the {boot-media} automatically runs the installer which will fail unless you also specify the `coreos.inst.install_dev` kernel argument.
+. Use the customized `initramfs` file in your PXE configuration. Add `ignition.firstboot` and `ignition.platform.id=metal` kernel arguments if not already present.
 +
 Your customizations are applied and affect every subsequent boot of the {boot-media}.
 endif::[]

--- a/modules/installation-user-infra-machines-advanced-customizing-live.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing_bare_metal/installing-bare-metal-network-customizations.adoc
 
+:_content-type: PROCEDURE
 [id="installation-user-infra-machines-advanced-customizing-live-{boot}_{context}"]
 = Customizing a live {op-system} {boot-media}
 You can customize a live {op-system} {boot-media} directly with the

--- a/modules/installation-user-infra-machines-advanced-customizing-live.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live.adoc
@@ -45,6 +45,9 @@ $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
 endif::[]
 <1> The Ignition config file that is generated from `openshift-installer`.
 <2> When you specify this option, the {boot-media} automatically runs an install. Otherwise, the image remains configured for installing, but does not do so automatically unless you specify the `coreos.inst.install_dev` kernel argument.
+ifeval::["{boot-media}" == "PXE environment"]
+. Use the customized `initramfs` file in your PXE configuration. Add `ignition.firstboot` and `ignition.platform.id=metal` kernel arguments if not already present.
+endif::[]
 +
 Your customizations are applied and affect every subsequent boot of the {boot-media}.
 


### PR DESCRIPTION
Certain `coreos-installer pxe customize` options won't be applied at runtime unless the PXE boot includes the `ignition.firstboot` and `ignition.platform.id` kernel arguments.  We were always implicitly assuming this, but it wasn't documented.

cc @jldohmann 

Version(s):
4.10+

Issue:
https://github.com/coreos/fedora-coreos-tracker/issues/1426

Link to docs preview:
https://62993--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations.html

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
