### PR TITLE
CNV-27160_414: Release note removed

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -114,8 +114,6 @@ Deprecated features are included in the current release and supported. However, 
 
 //CNV-26426 [DOCS] Release note: Deprecate TTO
 
-//CNV-28717 Release notes: Depr or Removed func. (Drop RPM virtctl builds RHEL7 and RHEL9)
-
 //CNV-29048 Release note: DEPRECATED FEATURE (Metrics backlog 4.14)
 
 
@@ -129,7 +127,8 @@ Removed features are not supported in the current release.
 
 //NOTE: RNs related to 4.14 Removed features begin here.
 
-//CNV-27160 Release note: REMOVED (could be dupe of CNV-28717; asked Avital)
+//CNV-27160 Release note: REMOVED RHEL 7/virtctl RPMs 
+* Installing the `virtctl` client as an RPM is no longer supported for {op-system-base-full} 7 and {op-system-base} 9.
 
 [id="virt-4-14-changes"]
 == Notable technical changes


### PR DESCRIPTION
Version(s): 4.14

Issue: [CNV-27160](https://issues.redhat.com/issues/?filter=12412370)

Link to docs preview: [Removed features in the 4.14 RNs](https://63009--docspreview.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes.html#virt-4-14-removed) 

QE review:
- [x] QE has approved this change.

Additional information:

