### PR TITLE
[OSDOCS-7140]: Removing node tuning topic from assembly

### DIFF
--- a/hosted_control_planes/hcp-managing.adoc
+++ b/hosted_control_planes/hcp-managing.adoc
@@ -13,7 +13,6 @@ include::snippets/technology-preview.adoc[]
 
 include::modules/updates-for-hosted-control-planes.adoc[leveloffset=+1]
 include::modules/updating-node-pools-for-hcp.adoc[leveloffset=+1]
-include::modules/configuring-node-pools-for-hcp.adoc[leveloffset=+1]
 //restarting hosted control plane components
 include::modules/hosted-control-planes-pause-reconciliation.adoc[leveloffset=+1]
 //debugging why nodes have not joined the cluster


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7140
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63012--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-managing.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
-No QE required, as no content was changed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR is related to https://github.com/openshift/openshift-docs/pull/62943, which was recently merged. In that PR, I grouped the tasks related to node tuning into the AWS subsection of the `hcp-configuring.adoc` assembly. When I did that, I forgot to also remove the `node-tuning-hosted-cluster.adoc` module from the `hcp-managing.adoc` file. This PR does not change any existing content. It simply removes duplicate content.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
