### PR TITLE
[enterprise-4.10] OCPBUGS-9122: Improved configuring your firewall install info

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -27,9 +27,9 @@ If your environment has a dedicated load balancer in front of your {product-titl
 |443, 80
 |Provides core container images
 
-|`access.redhat.com`
+|`access.redhat.com` ^[1]^
 |443, 80
-|Provides core container images
+|Hosts all the container images that are stored on the Red Hat Ecosytem Catalog, including core container images.
 
 |`quay.io`
 |443, 80
@@ -54,8 +54,13 @@ If your environment has a dedicated load balancer in front of your {product-titl
 |`sso.redhat.com`
 |443, 80
 |The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
-
+[.small]
 |===
++
+[.small]
+--
+1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container tool requires for verifying images when pulling them from `registry.access.redhat.com`.
+--
 +
 You can use the wildcard `\*.quay.io` instead of `cdn0[1-3].quay.io` in your allowlist. When you add a site, such as `quay.io`, to your allowlist, do not add a wildcard entry, such as `*.quay.io`, to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, image downloads are denied when the initial download request redirects to a hostname such as `cdn01.quay.io`.
 

--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -53,9 +53,9 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides {op-system-first} images.
 
-|`registry.access.redhat.com`
+|`registry.access.redhat.com` ^[1]^
 |443
-|Provides access to the `odo` CLI tool that helps developers build on OpenShift and Kubernetes.
+|Hosts all the container images that are stored on the Red Hat Ecosytem Catalog. Additionally, the registry provides access to the `odo` CLI tool that helps developers build on OpenShift and Kubernetes.
 
 |`console.redhat.com`
 |443, 80
@@ -73,10 +73,11 @@ This section provides the necessary details that enable you to control egress tr
 |443
 |Provides core container images as a fallback when quay.io is not available.
 |===
-//[NOTE]
-//====
-//Creating a firewall with a ROSA private cluster (non-PrivateLink) is not supported.
-//====
++
+[.small]
+--
+1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container tool requires for verifying images when pulling them from `registry.access.redhat.com`.
+--
 +
 When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `*.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.
 +


### PR DESCRIPTION
Cherry-picked from commit xref: #62848

[OCPBUGS-9122](https://issues.redhat.com/browse/OCPBUGS-9122)

Version(s):
4.10

Link to docs preview:
* [Configuring your firewall for OCP](https://dfitzmau.github.io/previews/configuring-firewall.html)
* [AWS firewall prerequisites](https://dfitzmau.github.io/previews/rosa-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_prerequisites) 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [Useful link for stakeholders](https://github.com/openshift/openshift-docs/pull/41850)