### PR TITLE
CNV-27160_413: Release note deprecated

### DIFF
--- a/virt/virt-4-13-release-notes.adoc
+++ b/virt/virt-4-13-release-notes.adoc
@@ -96,11 +96,13 @@ All VM templates that are included with {VirtProductName} now use this machine t
 //CNV-21838 Release note: NEW OpenShift Virtualization supports jumbo frames with OVN Kubernetes
 * You can now xref:../virt/virtual_machines/vm_networking/virt-using-the-default-pod-network-with-virt.adoc#virt-jumbo-frames-vm-pod-nw_virt-using-the-default-pod-network-with-virt[send unfragmented jumbo frame packets] between two virtual machines (VMs) that are connected on the default pod network when you use the OVN-Kubernetes CNI plugin.
 
+
 [id="virt-4-13-storage-new"]
 === Storage
 
 //CNV-18462 Release note: CHANGE Retire alpha APIs for Storage
 * {VirtProductName} storage resources now migrate automatically to the beta API versions. Alpha API versions are no longer supported.
+
 
 [id="virt-4-13-web-new"]
 === Web console
@@ -123,20 +125,21 @@ All VM templates that are included with {VirtProductName} now use this machine t
 //CNV-25541 Release note: NEW -- UI can disable graphical display
 * You can now enable headless mode for high performance VMs in the web console.
 
-//NOTE: Comment out deprecated and removed features (and their IDs) if not used in a release
-//[id="virt-4-13-deprecated-removed"]
-//== Deprecated and removed features
 
-
-//[id="virt-4-13-deprecated"]
-//=== Deprecated features
+[id="virt-4-13-deprecated-removed"]
+== Deprecated and removed features
 // NOTE: when uncommenting deprecated features list, change the header level below to ===
 
-//Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
+[id="virt-4-13-deprecated"]
+=== Deprecated features
 
+Deprecated features are included and supported in the current release. However, they will be removed in a future release and are not recommended for new deployments.
+
+//CNV-27160 
+* Support for `virtctl` command line tool installation for {op-system-base-full} 7 and {op-system-base} 9 by an RPM is deprecated and is planned to be removed in a future release.
 
 [id="virt-4-13-removed"]
-== Removed features
+=== Removed features
 
 Removed features are not supported in the current release.
 
@@ -193,10 +196,12 @@ link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_mana
 //CNV-20963 leave in
 * You can now use Microsoft Windows 11 as a guest operating system. However, {VirtProductName} {VirtVersion} does not support USB disks, which are required for a critical function of BitLocker recovery. To protect recovery keys, use other methods described in the link:https://learn.microsoft.com/en-us/windows/security/information-protection/bitlocker/bitlocker-recovery-guide-plan[BitLocker recovery guide].
 
+
 [id="virt-4-13-bug-fix"]
 == Bug fix
 
 * The virtual machine snapshot restore operation no longer hangs indefinitely due to some persistent volume claim (PVC) annotations created by the Containerized Data Importer (CDI). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2070366[*BZ#2070366*])
+
 
 [id="virt-4-13-known-issues"]
 == Known issues


### PR DESCRIPTION
Version(s): 4.13

Issue: [CNV-27160](https://issues.redhat.com/browse/CNV-27160)

Link to docs preview: [Deprecated feature in the 4.13 RNs](https://63024--docspreview.netlify.app/openshift-enterprise/latest/virt/virt-4-13-release-notes.html#virt-4-13-deprecated)


QE review:
- [x] QE has approved this change.
