### PR TITLE
OSDOCS-7202: Fix broken link in ROSA CLI Tools

### DIFF
--- a/cli_reference/rosa_cli/rosa-get-started-cli.adoc
+++ b/cli_reference/rosa_cli/rosa-get-started-cli.adoc
@@ -8,6 +8,14 @@ toc::[]
 include::modules/rosa-about.adoc[leveloffset=+1]
 include::modules/rosa-setting-up-cli.adoc[leveloffset=+1]
 include::modules/rosa-configure.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-setting-up-cli_rosa-getting-started-cli[Setting up the ROSA CLI]
+
+* xref:../../cli_reference/openshift_cli/getting-started-cli.adoc#cli-getting-started[Getting started with the OpenShift CLI]
+
 include::modules/rosa-initialize.adoc[leveloffset=+1]
 include::modules/rosa-using-bash-script.adoc[leveloffset=+1]
 include::modules/rosa-updating-rosa-cli.adoc[leveloffset=+1]

--- a/modules/rosa-configure.adoc
+++ b/modules/rosa-configure.adoc
@@ -188,7 +188,7 @@ $ rosa verify quota --region=us-west-2
 
 Download the latest compatible version of the `rosa` CLI.
 
-After you download `rosa`, extract the contents of the archive and add it to your path. See xref:../rosa_cli/rosa-get-started-cli.adoc#rosa-setting-up-cli_rosa-getting-started-cli[Setting up the ROSA CLI] for more details.
+After you download `rosa`, extract the contents of the archive and add it to your path.
 
 .Syntax
 [source,terminal]


### PR DESCRIPTION
[OSDOCS-7202](https://issues.redhat.com//browse/OSDOCS-7202): Fix broken link in ROSA CLI Tools

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7202

Link to docs preview:
ROSA: https://63026--docspreview.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-get-started-cli.html#rosa-initialize_rosa-getting-started-cli

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
