### PR TITLE
OSDOCS-6454 featureset addition

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -30,6 +30,7 @@ The following Technology Preview features are enabled by this feature set:
 ** Pod disruption budget (PDB) unhealthy pod eviction policy. Enables support for specifying how unhealthy pods are considered for eviction when using PDBs. (`PDBUnhealthyPodEvictionPolicy`)
 ** Dynamic Resource Allocation API. Enables a new API for requesting and sharing resources between pods and containers. This is an internal feature that most users do not need to interact with. (`DynamicResourceAllocation`)
 ** Pod security admission enforcement. Enables the restricted enforcement mode for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)
+** StatefulSet pod availability upgrading limits. Enables users to define the maximum number of statefulset pods unavailable during updates which reduces application downtime. (`MaxUnavailableStatefulSet`)
 --
 
 ////


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6454](https://issues.redhat.com/browse/OSDOCS-6454)

Link to docs preview:
[Preview](https://63033--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Goes with [this PR](https://github.com/openshift/openshift-docs/pull/62591). QE approval is there. 

