### PR TITLE
OSDOCS-7087: remove "optional" from greenboot

### DIFF
--- a/microshift_install/microshift-greenboot.adoc
+++ b/microshift_install/microshift-greenboot.adoc
@@ -6,13 +6,13 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Greenboot is the generic health check framework for the `systemd` service on RPM-OSTree-based systems. The `microshift-greenboot` RPM and `greenboot-default-health-checks` are optional RPM packages you can install. Greenboot is used to assess system health and automate a rollback to the last healthy state in the event of software trouble.
+Greenboot is the generic health check framework for the `systemd` service on RPM-OSTree-based systems. The `microshift-greenboot` RPM and `greenboot-default-health-checks` are RPM packages installed with {product-title}. Greenboot is used to assess system health and automate a rollback to the last healthy state in the event of software trouble.
 
 This health check framework is especially useful when you need to check for software problems and perform system rollbacks on edge devices where direct serviceability is either limited or non-existent. When health check scripts are installed and configured, health checks run every time the system starts.
 
 Using greenboot can reduce your risk of being locked out of edge devices during updates and prevent a significant interruption of service if an update fails. When a failure is detected, the system boots into the last known working configuration using the `rpm-ostree` rollback capability.
 
-A {product-title} health check script is included in the `microshift-greenboot` RPM. The `greenboot-default-health-checks` RPM includes health check scripts verifying that DNS and `ostree` services are accessible. You can also create your own health check scripts based on the workloads you are running. You can write one that verifies that an application has started, for example.
+A {product-title} application health check script is included in the `microshift-greenboot` RPM. The `greenboot-default-health-checks` RPM also includes health check scripts verifying that DNS and `ostree` services are accessible. In addition, you can create your own health check scripts for the workloads you are running. You can write one that verifies that an application has started, for example.
 
 [NOTE]
 ====
@@ -39,6 +39,6 @@ include::modules/microshift-greenboot-prerollback-log.adoc[leveloffset=+1]
 
 include::modules/microshift-greenboot-check-update.adoc[leveloffset=+1]
 
-//[role="_additional-resources_microshift-greenboot"]
-//.Additional resources
-//once the greenboot application health check is merged, an assembly-level xref can go here
+[role="_additional-resources_microshift-greenboot"]
+.Additional resources
+* xref:../microshift_running_apps/microshift-greenboot-workload-scripts.adoc#microshift-greenboot-workload-scripts[Greenboot workload health check scripts]

--- a/microshift_running_apps/microshift-greenboot-workload-scripts.adoc
+++ b/microshift_running_apps/microshift-greenboot-workload-scripts.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-Greenboot health check scripts are helpful on edge devices where direct serviceability is either limited or non-existent. If you installed the `microshift-greenboot` RPM package, you can also create health check scripts assess the health of your workloads and applications. These additional health check scripts are useful components of software problem checks and automatic system rollbacks.
+Greenboot health check scripts are helpful on edge devices where direct serviceability is either limited or non-existent. You can create health check scripts to assess the health of your workloads and applications. These additional health check scripts are useful components of software problem checks and automatic system rollbacks.
 
 A {product-title} health check script is included in the `microshift-greenboot` RPM. You can also create your own health check scripts based on the workloads you are running. For example, you can write one that verifies that a service has started.
 

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -28,17 +28,11 @@ groups = []
 name = "microshift"
 version = "*"
 
-[[packages]]
-name = "microshift-greenboot" <1>
-version = "*"
-
 [customizations.services]
 enabled = ["microshift"]
 EOF
 ----
-[.small]
-<1> Optional `microshift-greenboot` RPM. For more information, read the "Greenboot health check" guide in the "Running Applications" section.
-+
+
 [NOTE]
 ====
 The wildcard `*` in the commands uses the latest {product-title} RPMs. If you need a specific version, substitute the wildcard for the version you want. For example, insert `4.13.1` to download the {product-title} 4.13.1 RPMs.

--- a/modules/microshift-greenboot-microshift-health-script.adoc
+++ b/modules/microshift-greenboot-microshift-health-script.adoc
@@ -6,7 +6,7 @@
 [id="microshift-health-script_{context}"]
 = The {product-title} health script
 
-The `40_microshift_running_check.sh` health check script only performs validation of core {product-title} services. Install your customized workload validation scripts in the greenboot directories to ensure successful application operations after system updates. Scripts run in alphabetical order.
+The `40_microshift_running_check.sh` health check script only performs validation of core {product-title} services. Install your customized workload health check scripts in the greenboot directories to ensure successful application operations after system updates. Scripts run in alphabetical order.
 
 {product-title} health checks are listed in the following table:
 

--- a/modules/microshift-greenboot-systemd-journal-data.adoc
+++ b/modules/microshift-greenboot-systemd-journal-data.adoc
@@ -6,7 +6,7 @@
 [id="microshift-greenboot-systemd-journal-data_{context}"]
 = Enabling systemd journal service data persistency
 
-The default configuration of the `systemd` journal service stores the data in the volatile `/run/log/journal` directory. To persist system logs across system starts and restarts, you must enable log persistence and set limits on the maximal journal data size.
+The default configuration of the `systemd` journal service stores the data in the volatile `/run/log/journal` directory. To view system logs across system starts and restarts, you must enable log persistence and set limits on the maximal journal data size.
 
 .Procedure
 

--- a/modules/microshift-install-rpms.adoc
+++ b/modules/microshift-install-rpms.adoc
@@ -31,13 +31,6 @@ $ sudo subscription-manager repos \
 $ sudo dnf install -y microshift
 ----
 
-. Optional: Install greenboot for {product-title} by running the following command:
-+
-[source,terminal]
-----
-$ sudo dnf install -y microshift-greenboot
-----
-
 . Download your installation pull secret from the https://console.redhat.com/openshift/install/pull-secret[Red Hat Hybrid Cloud Console] to a temporary folder, for example, `$HOME/openshift-pull-secret`. This pull secret allows you to authenticate with the container registries that serve the container images used by {product-title}.
 
 . To copy the pull secret to the `/etc/crio` folder of your {op-system} machine, run the following command:


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-7087

Link to docs preview:
https://63035--docspreview.netlify.app/microshift/latest/microshift_install/microshift-greenboot.html (intro text)
https://63035--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm.html#installing-microshift-from-rpm-package_microshift-install-rpm (procedure)
https://63035--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree.html#adding-microshift-service-to-blueprint_microshift-embed-in-rpm-ostree (table footnote)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
