### PR TITLE
[RHACS] xref fixes for build failure on portal

### DIFF
--- a/installing/acs-high-level-overview.adoc
+++ b/installing/acs-high-level-overview.adoc
@@ -11,13 +11,13 @@ toc::[]
 
 To ensure the best installation experience, follow these guidelines:
 
-. Understand the xref:./acs-installation-platforms.adoc#install-platforms-methods_acs-installation-platforms[installation platforms and methods].
+. Understand the xref:../installing/acs-installation-platforms.adoc#install-platforms-methods_acs-installation-platforms[installation platforms and methods].
 . Understand xref:../architecture/acs-architecture.adoc#acs-architecture_acs-architecture[{product-title} architecture].
-. Check the xref:./acs-default-requirements.adoc#acs-default-requirements[default resource requirements].
+. Check the xref:../installing/acs-default-requirements.adoc#acs-default-requirements[default resource requirements].
 
 Then, see the following installation documentation for your selected platform and method:
 
-* xref:./installing_ocp/install-central-ocp.adoc#install-central-ocp[Installing Central services for {product-title-short} on {osp}]
-* xref:./installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing secured cluster services for {product-title-short} on {osp}]
-* xref:./installing_other/install-central-other.adoc#install-central-other[Installing Central services for {product-title-short} on other platforms]
-* xref:./installing_other/install-secured-cluster-other.adoc#install-secured-cluster-other[Installing secured cluster services for {product-title-short} on other platforms]
+* xref:../installing/installing_ocp/install-central-ocp.adoc#install-central-ocp[Installing Central services for {product-title-short} on {osp}]
+* xref:../installing/installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing secured cluster services for {product-title-short} on {osp}]
+* xref:../installing/installing_other/install-central-other.adoc#install-central-other[Installing Central services for {product-title-short} on other platforms]
+* xref:../installing/installing_other/install-secured-cluster-other.adoc#install-secured-cluster-other[Installing secured cluster services for {product-title-short} on other platforms]

--- a/installing/acs-installation-platforms.adoc
+++ b/installing/acs-installation-platforms.adoc
@@ -29,8 +29,8 @@ Not all installation methods are supported for all platforms.
 |Yes
 |Yes
 .3+d|Operator (recommended), Helm charts, or `roxctl` CLI ^[3]^
-.3+a| * xref:./installing_ocp/install-central-ocp.adoc#install-central-ocp[Installing Central services for {product-title-short} on Red Hat {osp}]
-* xref:./installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing secured cluster services for {product-title-short} on Red Hat {osp}]
+.3+a| * xref:../installing/installing_ocp/install-central-ocp.adoc#install-central-ocp[Installing Central services for {product-title-short} on Red Hat {osp}]
+* xref:../installing/installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing secured cluster services for {product-title-short} on Red Hat {osp}]
 
 |Azure {osp} (ARO)
 |Yes
@@ -45,8 +45,8 @@ Not all installation methods are supported for all platforms.
 |Yes
 .3+d|Helm charts (recommended), or `roxctl` CLI ^[3]^
 
-.3+a| * xref:./installing_other/install-central-other.adoc#install-central-other[Installing Central services for {product-title-short} on other platforms]
-* xref:./installing_other/install-secured-cluster-other.adoc#install-secured-cluster-other[Installing secured cluster services for {product-title-short} on other platforms]
+.3+a| * xref:../installing/installing_other/install-central-other.adoc#install-central-other[Installing Central services for {product-title-short} on other platforms]
+* xref:../installing/installing_other/install-secured-cluster-other.adoc#install-secured-cluster-other[Installing secured cluster services for {product-title-short} on other platforms]
 
 |Google Kubernetes Engine (Google GKE)
 |Limited ^[4]^
@@ -61,8 +61,8 @@ Not all installation methods are supported for all platforms.
 |Yes
 |Yes
 .2+d|Operator (recommended), Helm charts, or `roxctl` CLI ^[3]^
-.2+a| * xref:./installing_ocp/install-central-ocp.adoc#install-central-ocp[Installing Central services for {product-title-short} on Red Hat {osp}]
-* xref:./installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing secured cluster services for {product-title-short} on Red Hat {osp}]
+.2+a| * xref:../installing/installing_ocp/install-central-ocp.adoc#install-central-ocp[Installing Central services for {product-title-short} on Red Hat {osp}]
+* xref:../installing/installing_ocp/install-secured-cluster-ocp.adoc#install-secured-cluster-ocp[Installing secured cluster services for {product-title-short} on Red Hat {osp}]
 
 |{osp} Kubernetes Engine (OKE) 4.x
 |No


### PR DESCRIPTION
Portal build are failing with the following error:
```
Transforming the AsciiDoc content to DocBook XML...
asciidoctor: ERROR: master.adoc: line 13: include file not found: /var/lib/jenkins/workspace/doc-red_hat_advanced_cluster_security_for_kubernetes-4.1-installing-en-US (stage)/installing/acs-default-requirements.adoc
asciidoctor: ERROR: master.adoc: line 15: include file not found: /var/lib/jenkins/workspace/doc-red_hat_advanced_cluster_security_for_kubernetes-4.1-installing-en-US (stage)/installing/acs-recommended-requirements.adoc
asciidoctor: WARNING: includes/install-central-operator.adoc: line 60: no callouts refer to list item 1
asciidoctor: WARNING: includes/install-central-operator.adoc: line 61: no callouts refer to list item 2
```

This change fixes the issues.

Cherrypick into `rhacs-docs-4.1`