### PR TITLE
OCPBUGS-9122-RE: Change noun for OCPBUGS-9122 update

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -59,7 +59,7 @@ If your environment has a dedicated load balancer in front of your {product-titl
 +
 [.small]
 --
-1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container tool requires for verifying images when pulling them from `registry.access.redhat.com`.
+1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container client requires for verifying images when pulling them from `registry.access.redhat.com`.
 --
 +
 You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn0[1-3].quay.io` in your allowlist. When you add a site, such as `quay.io`, to your allowlist, do not add a wildcard entry, such as `*.quay.io`, to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, image downloads are denied when the initial download request redirects to a hostname such as `cdn01.quay.io`.

--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -100,7 +100,7 @@ This section provides the necessary details that enable you to control egress tr
 +
 [.small]
 --
-1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container tool requires for verifying images when pulling them from `registry.access.redhat.com`.
+1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container client requires for verifying images when pulling them from `registry.access.redhat.com`.
 --
 +
 When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `*.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.


### PR DESCRIPTION
**Engineer requested a quick noun change after the original PR was merged. Original PR:https://github.com/openshift/openshift-docs/pull/62848**

![Screenshot from 2023-08-01 17-02-19](https://github.com/openshift/openshift-docs/assets/57954076/f8644e46-a265-48ed-b0d6-88b4df0c7b65)

[OCPBUGS-9122](https://issues.redhat.com/browse/OCPBUGS-9122)

Version(s):
4.14 to 4.10

Link to docs preview:
* [Configuring your firewall for OCP](https://63044--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall.html)
* [AWS firewall prerequisites](https://63044--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.html#rosa-aws-policy-provisioned_prerequisites) 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* [Useful link for stakeholders](https://github.com/openshift/openshift-docs/pull/41850)