### PR TITLE
OSDOCS 7228: Adding release notes for secondary scheduler operator 1.1.2

### DIFF
--- a/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
+++ b/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes.adoc
@@ -12,6 +12,33 @@ These release notes track the development of the {secondary-scheduler-operator-f
 
 For more information, see xref:../../../nodes/scheduling/secondary_scheduler/index.adoc#nodes-secondary-scheduler-about_nodes-secondary-scheduler-about[About the {secondary-scheduler-operator}].
 
+[id="secondary-scheduler-operator-release-notes-1.1.2"]
+== Release notes for {secondary-scheduler-operator-full} 1.1.2
+
+Issued: 2023-8-23
+
+The following advisory is available for the {secondary-scheduler-operator-full} 1.1.2:
+
+* link:https://access.redhat.com/errata/RHSA-2023:4657[RHSA-2023:4657]
+
+////
+// No enhancements in this release
+[id="secondary-scheduler-operator-1.1.2-new-features-and-enhancements"]
+=== New features and enhancements
+
+* None
+////
+
+[id="secondary-scheduler-1.1.2-bug-fixes"]
+=== Bug fixes
+
+* This release of the {secondary-scheduler-operator} addresses several Common Vulnerabilities and Exposures (CVEs).
+
+[id="secondary-scheduler-operator-1.1.2-known-issues"]
+=== Known issues
+
+* Currently, you cannot deploy additional resources, such as config maps, CRDs, or RBAC policies through the {secondary-scheduler-operator}. Any resources other than roles and role bindings that are required by your custom secondary scheduler must be applied externally. (link:https://issues.redhat.com/browse/WRKLDS-645[*WRKLDS-645*])
+
 [id="secondary-scheduler-operator-release-notes-1.1.1"]
 == Release notes for {secondary-scheduler-operator-full} 1.1.1
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12 and 4.13 only
(This does NOT apply to 4.14)

Issue:
https://issues.redhat.com/browse/OSDOCS-7228

Link to docs preview:
https://63055--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-release-notes#secondary-scheduler-operator-release-notes-1.1.2

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**The link to the advisory will 404 until the day it is released**