### PR TITLE
Fix error in PTP 4.13 RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1280,7 +1280,6 @@ For more information see xref:../scalability_and_performance/cnf-talm-for-cluste
 
 HTTP is now the default transport in the PTP and bare-metal events infrastructure.
 AMQ Interconnect is end of life (EOL) from 30 June 2024.
-When you use HTTP transport for PTP and bare-metal events, you must persist the events subscription in the cluster using a `PersistentVolume` resource.
 
 For more information, see xref:../networking/using-ptp.adoc#cnf-about-ptp-fast-event-notifications-framework_using-ptp[About the PTP fast event notifications framework].
 


### PR DESCRIPTION
Fixes an error that should have been updated in https://github.com/openshift/openshift-docs/pull/62938

Version(s):
openshift-4.13

Link to docs preview: 
https://63065--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-ran-http-transport

Note: the work in https://github.com/openshift/openshift-docs/pull/62938 removed a manual process for configuring PTP events from the docs. The feature is unchanged, there are no customers using this feature. The change does not require change management.

Issue:
https://issues.redhat.com/browse/TELCODOCS-1434

