### PR TITLE
OSDOCS-7235: Porting Terraform information

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -140,6 +140,8 @@ Topics:
   File: rosa-sts-required-aws-service-quotas
 - Name: Setting up your environment
   File: rosa-sts-setting-up-environment
+- Name: Preparing Terraform to install ROSA clusters
+  File: rosa-understanding-terraform
 ---
 Name: Install ROSA with HCP clusters
 Dir: rosa_hcp

--- a/modules/rosa-sts-account-roles-terraform.adoc
+++ b/modules/rosa-sts-account-roles-terraform.adoc
@@ -1,0 +1,247 @@
+// Module included in the following assemblies:
+//
+// * rosa_planning/rosa-understanding-terraform.adoc
+ifeval::["{context}" == "rosa-understanding-terraform"]
+:tf-full:
+endif::[]
+:_content-type: PROCEDURE
+
+[id="sd-terraform-account-roles_{context}"]
+ifdef::tf-full[]
+= Account roles Terraform example
+endif::tf-full[]
+ifndef::tf-full[]
+= Creating your account-wide IAM roles with Terraform
+endif::tf-full[]
+
+The following example shows how Terraform can be used to create your Amazon Web Services (AWS) Identity and Access Management (IAM) account roles for ROSA.
+
+[NOTE]
+====
+If you want to edit the Terraform files, you can use any text editor. You must re-run the `terraform init` and `terraform apply` commands if you change any values in the files.
+====
+
+.Procedure
+
+. Check your AWS account for existing roles and policies by running the following command:
++
+[source,terminal]
+----
+$ rosa list account-roles
+----
++
+
+
+. In your terminal, run the following command to export link:https://console.redhat.com/openshift/token[your {cluster-manager-first} token]. This value must include the full {cluster-manager} token:
++
+[source,terminal]
+----
+$ export RHCS_TOKEN="<your_offline_token>"
+----
++
+You can verify that your token is saved by running the following command:
++
+[source,terminal]
+----
+$ echo $RHCS_TOKEN
+----
++
+You see your token in the command line.
+
+. Optional: You can specify your own account-role prefix that prepends the roles you create by running the following command:
++
+[NOTE]
+====
+If you do not specify an account-role prefix, a prefix is generated in the format of `account-role-` followed by a string of four random characters.
+====
++
+[source,terminal]
+----
+$ export account_role_prefix=<account_role_prefix>
+----
+
+. Create the Terraform files locally by using the following code templates:
++
+[NOTE]
+====
+These files are created in your current directory. Ensure that you are in the directory where you want to run Terraform.
+====
+
+.. The `main.tf` file calls the Red Hat Cloud Services Terraform provider, which allows you to use OpenShift services with Terraform. Run the following command to create the `main.tf` file:
++
+[source,terminal]
+----
+$ cat<<-EOF>main.tf 
+  #
+  # Copyright (c) 2022 Red Hat, Inc.
+  #
+  # Licensed under the Apache License, Version 2.0 (the "License");
+  # you may not use this file except in compliance with the License.
+  # You may obtain a copy of the License at
+  #
+  #   http://www.apache.org/licenses/LICENSE-2.0
+  #
+  # Unless required by applicable law or agreed to in writing, software
+  # distributed under the License is distributed on an "AS IS" BASIS,
+  # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  # See the License for the specific language governing permissions and
+  # limitations under the License.
+  #
+
+  terraform {
+    required_providers {
+      aws = {
+        source  = "hashicorp/aws"
+        version = ">= 4.20.0"
+      }
+      rhcs = {
+        version = ">= 1.3.0"
+        source  = "terraform-redhat/rhcs"
+      }
+    }
+  }
+
+  data "rhcs_policies" "all_policies" {}
+
+  data "rhcs_versions" "all" {}
+
+  module "create_account_roles" {
+    source  = "terraform-redhat/rosa-sts/aws"
+    version = "0.0.15"
+
+    create_operator_roles = false
+    create_oidc_provider  = false
+    create_account_roles  = true
+
+    account_role_prefix    = var.account_role_prefix
+    rosa_openshift_version = var.openshift_version
+    account_role_policies  = data.rhcs_policies.all_policies.account_role_policies
+    operator_role_policies = data.rhcs_policies.all_policies.operator_role_policies
+    all_versions           = data.rhcs_versions.all
+    tags                   = var.tags
+  }
+EOF
+----
+
+.. You define the account role prefix structure in the `output.tf` file. This output definition allows you to specify how the various generated roles are constructed. Run the following command to create your `output.tf` file:
++
+[source,terminal]
+----
+$ cat<<-EOF>output.tf 
+  output "account_role_prefix" {
+    value = module.create_account_roles.account_role_prefix
+  }
+EOF  
+----
+
+.. The `variables.tf` allows you to specify values you want for select variables. If you exported a variable for the `account_role_prefix` earlier, leave this variable's default value blank. Setting the variable in both places with different values can produce unexpected results. Run the following command to create your `variables.tf` file:
++
+[IMPORTANT]
+====
+Do not include your {cluster-manager} token in this file if it is not stored in a safe location.
+====
++
+[source,terminal]
+----
+$ cat<<-EOF>variables.tf 
+  variable "openshift_version" {
+    type = string
+    default = "4.13"
+    description = "Enter the desired OpenShift version as X.Y. This version should match what you intend for your ROSA cluster. For example, if you plan to create a ROSA cluster using '4.13.10', then this version should be '4.13'. You can see the supported versions of OpenShift by running 'rosa list version'."
+  }
+
+  variable "account_role_prefix" {
+    type    = string
+    default = ""
+    description = "Your account roles are prepended with whatever value you enter here. The default value in the ROSA CLI is 'ManagedOpenshift-' before all of your account roles."
+  }
+
+  variable "tags" { <1>
+    type        = map
+    default     = null
+    description = "(Optional) List of AWS resource tags to apply."
+  }
+EOF
+----
++
+--
+<1> The `tags` parameter uses a map of strings variable. The format that it takes looks like the following example:
++
+[source,terraform]
+----
+variable "tags" {
+  type    = "map"
+  default = {
+    "us-east-1" = "image-1234"
+    "us-west-2" = "image-4567"
+  }
+}
+----
+--
+. In the directory where you saved these Terraform files, run the following command to set up Terraform to create these resources:
++
+[source,terminal]
+----
+$ terraform init
+----
+. Optional: Run the following command to confirm that the Terraform code you copied is correct:
++
+[source,terminal]
+----
+$ terraform validate
+----
++
+.Sample output
++
+[source,terminal]
+----
+Success! The configuration is valid.
+----
+. Optional: Test your Terraform template and create a reusable Terraform plan file by running the following command:
++
+[source,terminal]
+----
+$ terraform plan -out account-roles.tfplan
+----
+. Run the following command to build your account-wide IAM roles with Terraform:
++
+[source,terminal]
+----
+$ terraform apply "account-roles.tfplan"
+----
++
+[NOTE]
+====
+If you used the `terraform plan` command first, you can provide your created `account-roles.tf` file here. Otherwise, Terraform temporarily creates this plan before it applies your desired outcome.
+====
+
+.Verification
+* Run the following command to verify that your account-roles have been created:
++
+[source,terminal]
+----
+$ rosa list account-roles
+----
++
+.Sample output
+
+[source,terminal]
+----
+I: Fetching account roles
+ROLE NAME                            ROLE TYPE      ROLE ARN                                                            OPENSHIFT VERSION  AWS Managed
+account-role-6kn4-ControlPlane-Role  Control plane  arn:aws:iam::269733383066:role/account-role-6kn4-ControlPlane-Role  4.13               No
+account-role-6kn4-Installer-Role     Installer      arn:aws:iam::269733383066:role/account-role-6kn4-Installer-Role     4.13               No
+account-role-6kn4-Support-Role       Support        arn:aws:iam::269733383066:role/account-role-6kn4-Support-Role       4.13               No
+account-role-6kn4-Worker-Role        Worker         arn:aws:iam::269733383066:role/account-role-6kn4-Worker-Role        4.13               No
+----
+
+.Clean up
+
+When you are finished using the resources that you created using Terraform, you should purge these resources with the following command:
+[source,terminal]
+----
+$ terraform destroy
+----
+ifeval::["{context}" == "rosa-understanding-terraform"]
+:!tf-full:
+endif::[]

--- a/modules/rosa-sts-terraform-prerequisites.adoc
+++ b/modules/rosa-sts-terraform-prerequisites.adoc
@@ -1,0 +1,114 @@
+// Module included in the following assemblies:
+//
+// * rosa_planning/rosa-understanding-terraform.adoc
+ifeval::["{context}" == "rosa-understanding-terraform"]
+:tf-full:
+endif::[]
+
+:_content-type: CONCEPT
+[id="rosa-sts-terraform-prerequisites_{context}"]
+ifdef::tf-full[]
+= Prerequisites for Terraform
+endif::tf-full[]
+ifndef::tf-full[]
+.Prerequisites
+endif::tf-full[]  
+
+To use link:https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs[the Red Hat Cloud Services provider] inside your Terraform configuration, you must meet the following prerequisites:
+
+* You have installed the {product-title} (ROSA) command-line interface (CLI) tool. 
+ifdef::tf-full[]
++
+See the Additional resources for further installation instructions.
+endif::tf-full[]
+* You have your offline link:https://console.redhat.com/openshift/token/rosa[{cluster-manager-first} token].
+ifdef::tf-full[]
++
+This token is generated through the Red Hat Hybrid Cloud Console. It is unique to your account and should not be shared. The token is generated based off your account access and permissions.
+endif::tf-full[]
+* You have installed link:https://developer.hashicorp.com/terraform/downloads[Terraform version 1.4.6] or newer.
+ifdef::tf-full[]
++
+You must have Terraform configured for your local system. The Terraform website contains installation options for MacOS, Windows, and Linux.
+endif::tf-full[]
+ifndef::tf-full[]
+* You have created your AWS account-wide IAM roles.
++
+The specific account-wide IAM roles and policies provide the STS permissions required for ROSA support, installation, control plane, and compute functionality. This includes account-wide Operator policies. See the Additional resources for more information on the AWS account roles.
+endif::tf-full[]
+* You have an link:https://aws.amazon.com/free/?all-free-tier[AWS account] and link:https://docs.aws.amazon.com/IAM/latest/UserGuide/security-creds.html[associated credentials] that allow you to create resources. The credentials are configured for the AWS provider. See the link:https://registry.terraform.io/providers/hashicorp/aws/latest/docs#authentication-and-configuration[Authentication and Configuration] section in AWS Terraform provider documentation.
+* You have, at minimum, the following permissions in your AWS IAM role policy that is operating Terraform. Check for these permissions in the AWS console.
++
+.Minimum AWS permissions for Terraform
+[%collapsible]
+====
+[source,json]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "VisualEditor0",
+      "Effect": "Allow",
+      "Action": [
+        "iam:GetPolicyVersion",
+        "iam:DeletePolicyVersion",
+        "iam:CreatePolicyVersion",
+        "iam:UpdateAssumeRolePolicy",
+        "secretsmanager:DescribeSecret",
+        "iam:ListRoleTags",
+        "secretsmanager:PutSecretValue",
+        "secretsmanager:CreateSecret",
+        "iam:TagRole",
+        "secretsmanager:DeleteSecret",
+        "iam:UpdateOpenIDConnectProviderThumbprint",
+        "iam:DeletePolicy",
+        "iam:CreateRole",
+        "iam:AttachRolePolicy",
+        "iam:ListInstanceProfilesForRole",
+        "secretsmanager:GetSecretValue",
+        "iam:DetachRolePolicy",
+        "iam:ListAttachedRolePolicies",
+        "iam:ListPolicyTags",
+        "iam:ListRolePolicies",
+        "iam:DeleteOpenIDConnectProvider",
+        "iam:DeleteInstanceProfile",
+        "iam:GetRole",
+        "iam:GetPolicy",
+        "iam:ListEntitiesForPolicy",
+        "iam:DeleteRole",
+        "iam:TagPolicy",
+        "iam:CreateOpenIDConnectProvider",
+        "iam:CreatePolicy",
+        "secretsmanager:GetResourcePolicy",
+        "iam:ListPolicyVersions",
+        "iam:UpdateRole",
+        "iam:GetOpenIDConnectProvider",
+        "iam:TagOpenIDConnectProvider",
+        "secretsmanager:TagResource",
+        "sts:AssumeRoleWithWebIdentity",
+        "iam:ListRoles"
+      ],
+      "Resource": [
+        "arn:aws:secretsmanager:*:<ACCOUNT_ID>:secret:*",
+        "arn:aws:iam::<ACCOUNT_ID>:instance-profile/*",
+        "arn:aws:iam::<ACCOUNT_ID>:role/*",
+        "arn:aws:iam::<ACCOUNT_ID>:oidc-provider/*",
+        "arn:aws:iam::<ACCOUNT_ID>:policy/*"
+      ]
+    },
+    {
+      "Sid": "VisualEditor1",
+      "Effect": "Allow",
+      "Action": [
+        "s3:*"
+        ],
+      "Resource": "*"
+    }
+  ]
+}
+----
+====
+ifeval::["{context}" == "rosa-understanding-terraform"]
+:!tf-full:
+endif::[]

--- a/rosa_planning/rosa-understanding-terraform.adoc
+++ b/rosa_planning/rosa-understanding-terraform.adoc
@@ -1,0 +1,38 @@
+:_content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+
+[id="rosa-understanding-terraform"]
+= Preparing Terraform to install ROSA clusters
+:context: rosa-understanding-terraform
+
+toc::[]
+
+Terraform is an infrastructure-as-code tool that provides a way to configure your resources once and replicate those resources as desired. Terraform accomplishes the creation tasks by using declarative language. You declare what you want the final state of the infrastructure resource to be, and Terraform creates these resources to your specifications.
+
+:FeatureName: Red Hat Cloud Services Terraform Provider 
+include::snippets/technology-preview.adoc[]
+
+include::modules/rosa-sts-terraform-prerequisites.adoc[leveloffset=+1]
+
+[discrete]
+[role="_additional-resources"]
+[id="additional-resources_rosa-terraform-prereq"]
+.Additional resources
+
+* See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc[About IAM resources for ROSA clusters that use STS] for information about the AWS account roles.
+* See xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc[Getting started with the ROSA CLI] for information about installing the ROSA CLI.
+* See Hashicorp's link:https://developer.hashicorp.com/terraform[Terraform documentation] for a comprehensive guide to Terraform.
+* See this xref:../rosa_planning/rosa-understanding-terraform.adoc#sd-terraform-account-roles_rosa-understanding-terraform[Terraform example] to create your account-wide IAM roles.
+
+include::modules/rosa-sts-account-roles-terraform.adoc[leveloffset=+1]
+
+[id="next-steps_rosa-understanding-terraform"]
+== Next steps
+
+* xref:../rosa_planning/rosa-planning-environment.adoc#rosa-planning-environment[Planning your environment]
+
+[role="_additional-resources"]
+[id="additional-resources_rosa-understanding-terraform"]
+== Additional resources
+
+* xref:../logging/sd-accessing-the-service-logs.adoc#sd-accessing-the-service-logs[Accessing the service logs for ROSA clusters]


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-7235](https://issues.redhat.com/browse/OSDOCS-7235)

Link to docs preview:
- [Using Terraform to install ROSA clusters](https://file.rdu.redhat.com/eponvell/OSDOCS-7235_Terraform-Porting/rosa_planning/rosa-understanding-terraform.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Ported Terraform content from [the Terraform RHCS Registry page](https://registry.terraform.io/providers/terraform-redhat/rhcs/latest/docs) to documentation