### PR TITLE
OSDOCS-5604 Removing UnhealthyPodEvictionPolicy from featureset

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -27,7 +27,6 @@ The following Technology Preview features are enabled by this feature set:
 ** OpenStack Machine API Provider. This gate has no effect and is planned to be removed from this feature set in a future release. (`MachineAPIProviderOpenStack`)
 ** Insights Operator. Enables the Insights Operator, which gathers {product-title} configuration data and sends it to Red Hat. (`InsightsConfigAPI`)
 ** Retroactive Default Storage Class. Enables {product-title} to retroactively assign the default storage class to PVCs if there was no default storage class when the PVC was created.(`RetroactiveDefaultStorageClass`)
-** Pod disruption budget (PDB) unhealthy pod eviction policy. Enables support for specifying how unhealthy pods are considered for eviction when using PDBs. (`PDBUnhealthyPodEvictionPolicy`)
 ** Dynamic Resource Allocation API. Enables a new API for requesting and sharing resources between pods and containers. This is an internal feature that most users do not need to interact with. (`DynamicResourceAllocation`)
 ** Pod security admission enforcement. Enables the restricted enforcement mode for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)
 ** StatefulSet pod availability upgrading limits. Enables users to define the maximum number of statefulset pods unavailable during updates which reduces application downtime. (`MaxUnavailableStatefulSet`)

--- a/modules/pod-disruption-eviction-policy.adoc
+++ b/modules/pod-disruption-eviction-policy.adoc
@@ -15,15 +15,10 @@ You can choose one of the following policies:
 IfHealthyBudget:: Running pods that are not yet healthy can be evicted only if the guarded application is not disrupted.
 
 AlwaysAllow:: Running pods that are not yet healthy can be evicted regardless of whether the criteria in the pod disruption budget is met. This policy can help evict malfunctioning applications, such as ones with pods stuck in the `CrashLoopBackOff` state or failing to report the `Ready` status.
-
-:FeatureName: Specifying the unhealthy pod eviction policy for pod disruption budgets
-include::snippets/technology-preview.adoc[]
-
-To use this Technology Preview feature, you must have enabled the `TechPreviewNoUpgrade` feature set.
-
-[WARNING]
++
+[NOTE]
 ====
-Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone and prevents minor version updates. You should not enable this feature set on production clusters.
+It is recommended to set the `unhealthyPodEvictionPolicy` field to `AlwaysAllow` in the `PodDisruptionBudget` object to support the eviction of misbehaving applications during a node drain. The default behavior is to wait for the application pods to become healthy before the drain can proceed.
 ====
 
 .Procedure

--- a/nodes/clusters/nodes-cluster-enabling-features.adoc
+++ b/nodes/clusters/nodes-cluster-enabling-features.adoc
@@ -24,7 +24,6 @@ For more information about the features activated by the `TechPreviewNoUpgrade` 
 
 ** xref:../../storage/container_storage_interface/persistent-storage-csi-sc-manage.adoc#persistent-storage-csi-sc-manage[Managing the default storage class]
 
-** xref:../../nodes/pods/nodes-pods-configuring.adoc#pod-disruption-eviction-policy_nodes-pods-configuring[Specifying the eviction policy for unhealthy pods]
 
 ** xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Pod security admission enforcement].
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-5604](https://issues.redhat.com/browse/OSDOCS-5604)

Link to docs preview:
[Tech Preview](https://63072--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-enabling-features#nodes-cluster-enabling-features-about_nodes-cluster-enabling)
[Specifying the eviction policy for unhealthy pods](https://63072--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring#pod-disruption-eviction-policy_nodes-pods-configuring)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
