### PR TITLE
OSDOCS#6982: Nutanix CCM steps for installs

### DIFF
--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -45,6 +45,8 @@ include::modules/cli-installing-cli.adoc[leveloffset=+1]
 
 include::modules/manually-configure-iam-nutanix.adoc[leveloffset=+1]
 
+include::modules/installation-nutanix-ccm.adoc[leveloffset=+1]
+
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
 == Configuring the default storage container

--- a/modules/installation-nutanix-ccm.adoc
+++ b/modules/installation-nutanix-ccm.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+
+:_content-type: PROCEDURE
+[id="nutanix-ccm-config_{context}"]
+= Adding config map and secret resources required for Nutanix CCM
+
+Installations on Nutanix require additional `ConfigMap` and `Secret` resources to integrate with the Nutanix Cloud Controller Manager (CCM).
+
+.Prerequisites
+
+* You have created a `manifests` directory within your installation directory.
+
+.Procedure
+
+. Navigate to the `manifests` directory:
++
+[source,terminal]
+----
+$ cd <path_to_installation_directory>/manifests
+----
+
+. Create a file with the name `openshift-cloud-controller-manager-nutanix-credentials-credentials.yaml` and add the following information:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: nutanix-credentials
+  namespace: openshift-cloud-controller-manager
+type: Opaque
+stringData:
+  credentials: "[{
+    \"type\":\"basic_auth\",
+    \"data\":{
+          \"prismCentral\":{
+            \"username\":\"<username_for_prism_central>\", <1>
+            \"password\":\"<password_for_prism_central>\"}, <2>
+            \"prismElements\":null
+          }
+    }]"
+----
+<1> Specify the Prism Central username.
+<2> Specify the Prism Central password.
+
+. Create the `cloud-conf` `ConfigMap` file with the name `openshift-cloud-controller-manager-cloud-config.yaml` and add the following information:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloud-conf
+  namespace: openshift-cloud-controller-manager
+data:
+  cloud.conf: "{
+      \"prismCentral\": {
+          \"address\": \"<prism_central_FQDN/IP>\", <1>
+          \"port\": 9440,
+            \"credentialRef\": {
+                \"kind\": \"Secret\",
+                \"name\": \"nutanix-credentials\",
+                \"namespace\": \"openshift-cloud-controller-manager\"
+            }
+       },
+       \"topologyDiscovery\": {
+           \"type\": \"Prism\",
+           \"topologyCategories\": null
+       },
+       \"enableCustomLabeling\": true
+     }"
+----
+<1> Specify the Prism Central FQDN/IP.
+
+. Verify that the file `cluster-infrastructure-02-config.yml` exists and has the following information:
++
+[source,yaml]
+----
+spec:
+  cloudConfig:
+    key: config
+    name: cloud-provider-config
+----

--- a/modules/manually-configure-iam-nutanix.adoc
+++ b/modules/manually-configure-iam-nutanix.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing/installing_nutanix/configuring-iam-nutanix.adoc
+// * installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
 // * installing/installing-restricted-networks-nutanix-installer-provisioned.adoc
 
 :_content-type: PROCEDURE


### PR DESCRIPTION
[OSDOCS-6982](https://issues.redhat.com/browse/OSDOCS-6982)

Versions: 4.13+

This PR documents steps needed for users who want to install OCP clusters on the Nutanix platform. Previously, user installations on Nutanix would fail without these additional files.

QE review:
- [x] QE has approved this change.

Preview: [Adding the ConfigMaps and Secret needed for Nutanix CCM](https://63075--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#nutanix-ccm-config_installing-nutanix-installer-provisioned)
