### PR TITLE
OCPBUGS#15879: etcd-defrag: remove disk quota note from Next Steps

### DIFF
--- a/modules/etcd-defrag.adoc
+++ b/modules/etcd-defrag.adoc
@@ -197,7 +197,3 @@ memberID:12345678912345678912 alarm:NOSPACE
 ----
 sh-4.4# etcdctl alarm disarm
 ----
-
-.Next steps
-
-After defragmentation, if etcd still uses more than 50% of its available space, consider increasing the disk quota for etcd.


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-15879

Link to docs preview:
https://63076--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/cluster-tasks.html#manual-defrag-etcd-data_post-install-cluster-tasks

QE review:
- [x] QE has approved this change.

Additional information:

The ability to change the disk size quota is not available to the user by default, requiring that the Operator is unmanaged. As such, describing this process may make more sense as its own procedure in the future.