### PR TITLE
OCPBUGS#11614: Note root permissions for etcd backup script

### DIFF
--- a/modules/backup-etcd.adoc
+++ b/modules/backup-etcd.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * disaster_recovery/backing-up-etcd.adoc
+// * backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
 // * post_installation_configuration/cluster-tasks.adoc
 
 :_content-type: PROCEDURE
@@ -26,23 +26,23 @@ You can check whether the proxy is enabled by reviewing the output of `oc get pr
 
 .Procedure
 
-. Start a debug session for a control plane node:
+. Start a debug session as root for a control plane node:
 +
 [source,terminal]
 ----
-$ oc debug node/<node_name>
+$ oc debug --as-root node/<node_name>
 ----
 
-. Change your root directory to `/host`:
+. Change your root directory to `/host` in the debug shell:
 +
 [source,terminal]
 ----
-sh-4.2# chroot /host
+sh-4.4# chroot /host
 ----
 
 . If the cluster-wide proxy is enabled, be sure that you have exported the `NO_PROXY`, `HTTP_PROXY`, and `HTTPS_PROXY` environment variables.
 
-. Run the `cluster-backup.sh` script and pass in the location to save the backup to.
+. Run the `cluster-backup.sh` script in the debug shell and pass in the location to save the backup to.
 +
 [TIP]
 ====


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-11614

Link to docs preview:
https://63079--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.html#backing-up-etcd-data_backup-etcd

QE review:
- [x] QE has approved this change.

Additional information:

N/A