### PR TITLE
Nodes Clusters docs fixes during ROSA review

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2393,6 +2393,9 @@ Topics:
   - Name: Analyzing cluster resource levels
     File: nodes-cluster-resource-levels
     Distros: openshift-enterprise,openshift-origin
+  - Name: Configuring a cluster for pods
+    File: nodes-cluster-pods-configuring
+    Distros: openshift-enterprise,openshift-origin
   - Name: Setting limit ranges
     File: nodes-cluster-limit-ranges
   - Name: Configuring cluster memory to meet container memory and risk requirements

--- a/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
+++ b/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
@@ -2,6 +2,7 @@
 //
 // * scalability_and_performance/using-node-tuning-operator.adoc
 // * post_installation_configuration/node-tasks.adoc
+// * nodes/nodes/nodes-node-tuning-operator
 
 [id="supported-tuned-daemon-plug-ins_{context}"]
 = Supported TuneD daemon plugins
@@ -38,8 +39,8 @@ that is not supported. The following TuneD plugins are currently not supported:
 The TuneD bootloader plugin is currently supported on {op-system-first} 8.x worker nodes. For {op-system-base-full} 7.x worker nodes, the TuneD bootloader plugin is currently not supported.
 ====
 
-See
-link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance#available-tuned-plug-ins_customizing-tuned-profiles[Available
-TuneD Plugins] and
-link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/getting-started-with-tuned_monitoring-and-managing-system-status-and-performance[Getting
-Started with TuneD] for more information.
+.Additional references
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/customizing-tuned-profiles_monitoring-and-managing-system-status-and-performance#available-tuned-plug-ins_customizing-tuned-profiles[Available TuneD Plugins]
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/monitoring_and_managing_system_status_and_performance/getting-started-with-tuned_monitoring-and-managing-system-status-and-performance[Getting Started with TuneD]

--- a/modules/nodes-cluster-limit-ranges-creating.adoc
+++ b/modules/nodes-cluster-limit-ranges-creating.adoc
@@ -64,6 +64,7 @@ spec:
 
 . Create the object:
 +
+[source,terminal]
 ----
 $ oc create -f <limit_range_file> -n <project> <1>
 ----

--- a/modules/nodes-cluster-limit-ranges-deleting.adoc
+++ b/modules/nodes-cluster-limit-ranges-deleting.adoc
@@ -8,8 +8,9 @@
 
 To remove any active `LimitRange` object to no longer enforce the limits in a project:
 
-. Run the following command:
+* Run the following command:
 +
+[source,terminal]
 ----
 $ oc delete limits <limit_name>
 ----

--- a/modules/nodes-cluster-limit-ranges-viewing.adoc
+++ b/modules/nodes-cluster-limit-ranges-viewing.adoc
@@ -13,10 +13,12 @@ You can also use the CLI to view limit range details:
 . Get the list of `LimitRange` object defined in the project. For example, for a
 project called *demoproject*:
 +
+[source,terminal]
 ----
 $ oc get limits -n demoproject
 ----
 +
+[source,terminal]
 ----
 NAME              CREATED AT
 resource-limits   2020-07-15T17:14:23Z
@@ -25,10 +27,14 @@ resource-limits   2020-07-15T17:14:23Z
 . Describe the `LimitRange` object you are interested in, for example the
 `resource-limits` limit range:
 +
+
+[source,terminal]
 ----
 $ oc describe limits resource-limits -n demoproject
 ----
 +
+
+[source,terminal]
 ----
 Name:                           resource-limits
 Namespace:                      demoproject

--- a/modules/nodes-cluster-overcommit-node-enforcing.adoc
+++ b/modules/nodes-cluster-overcommit-node-enforcing.adoc
@@ -18,7 +18,7 @@ If you disable CPU limit enforcement, it is important to understand the impact o
 
 .Prerequisites
 
-. Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command:
+* Obtain the label associated with the static `MachineConfigPool` CRD for the type of node you want to configure by entering the following command:
 +
 [source,terminal]
 ----
@@ -50,6 +50,7 @@ metadata:
 ====
 If the label is not present, add a key/value pair such as:
 
+[source,terminal]
 ----
 $ oc label machineconfigpool worker custom-kubelet=small-pods
 ----

--- a/modules/nodes-cluster-overcommit-project-disable.adoc
+++ b/modules/nodes-cluster-overcommit-project-disable.adoc
@@ -7,25 +7,21 @@
 [id="nodes-cluster-overcommit-project-disable_{context}"]
 = Disabling overcommitment for a project
 
-When enabled, overcommitment can be disabled per-project.
-For example, you can allow infrastructure components to be configured independently of overcommitment.
+When enabled, overcommitment can be disabled per-project. For example, you can allow infrastructure components to be configured independently of overcommitment.
 
 .Procedure
 
 To disable overcommitment in a project:
 
-. Edit the project object file
-
-. Add the following annotation:
+. Edit the namespace object to add the following annotation:
 +
 [source,yaml]
 ----
-quota.openshift.io/cluster-resource-override-enabled: "false"
+apiVersion: v1
+kind: Namespace
+metadata:
+  annotations:
+    quota.openshift.io/cluster-resource-override-enabled: "false" <1>
+# ...
 ----
-
-. Create the project object:
-+
-[source,terminal]
-----
-$ oc create -f <file-name>.yaml
-----
+<1> Setting this annotation to `false` disables overcommit for this namespace.

--- a/modules/nodes-cluster-resource-configure-jdk.adoc
+++ b/modules/nodes-cluster-resource-configure-jdk.adoc
@@ -36,7 +36,7 @@ override this behavior, especially if a container memory limit is also set.
 
 There are at least two ways the above can be achieved:
 
-. If the container memory limit is set and the experimental options are
+* If the container memory limit is set and the experimental options are
    supported by the JVM, set `-XX:+UnlockExperimentalVMOptions
    -XX:+UseCGroupMemoryLimitForHeap`.
 +
@@ -48,7 +48,7 @@ The `UseCGroupMemoryLimitForHeap` option has been removed in JDK 11. Use `-XX:+U
 This sets `-XX:MaxRAM` to the container memory limit, and the maximum heap size
 (`-XX:MaxHeapSize` / `-Xmx`) to 1/`-XX:MaxRAMFraction` (1/4 by default).
 
-. Directly override one of `-XX:MaxRAM`, `-XX:MaxHeapSize` or `-Xmx`.
+* Directly override one of `-XX:MaxRAM`, `-XX:MaxHeapSize` or `-Xmx`.
 +
 This option involves hard-coding a value, but has the advantage of allowing a
 safety margin to be calculated.

--- a/modules/nodes-cluster-resource-configure-oom.adoc
+++ b/modules/nodes-cluster-resource-configure-oom.adoc
@@ -32,6 +32,11 @@ follows:
 [source,terminal]
 ----
 $ grep '^oom_kill ' /sys/fs/cgroup/memory/memory.oom_control
+----
++
+.Example output
+[source,terminal]
+----
 oom_kill 0
 ----
 
@@ -68,6 +73,11 @@ The `137` code indicates the container process exited with code 137, indicating 
 [source,terminal]
 ----
 $ grep '^oom_kill ' /sys/fs/cgroup/memory/memory.oom_control
+----
++
+.Example output
+[source,terminal]
+----
 oom_kill 1
 ----
 +

--- a/modules/nodes-cluster-resource-configure-request-limit.adoc
+++ b/modules/nodes-cluster-resource-configure-request-limit.adoc
@@ -12,6 +12,8 @@ within a pod should use the Downward API.
 .Procedure
 
 . Configure the pod to add the `MEMORY_REQUEST` and `MEMORY_LIMIT` stanzas:
+
+.. Create a YAML file similar to the following:
 +
 [source,yaml]
 ----
@@ -46,12 +48,14 @@ spec:
 <1> Add this stanza to discover the application memory request value.
 <2> Add this stanza to discover the application memory limit value.
 
-. Create the pod:
+.. Create the pod by running the following command:
 +
 [source,terminal]
 ----
 $ oc create -f <file-name>.yaml
 ----
+
+.Verification
 
 . Access the pod using a remote shell:
 +

--- a/modules/nodes-cluster-resource-configure.adoc
+++ b/modules/nodes-cluster-resource-configure.adoc
@@ -34,6 +34,7 @@ spec:
       memoryRequestToLimitPercent: 50 <1>
       cpuRequestToLimitPercent: 25 <2>
       limitCPUToMemoryPercent: 200 <3>
+# ...
 ----
 <1> Optional. Specify the percentage to override the container memory limit, if used, between 1-100. The default is 50.
 <2> Optional. Specify the percentage to override the container CPU limit, if used, between 1-100. The default is 25.
@@ -47,11 +48,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
 
- ...
+# ...
 
   labels:
     clusterresourceoverrides.admission.autoscaling.openshift.io/enabled: "true" <1>
 
- ...
+# ...
 ----
 <1> Add this label to each project.

--- a/modules/nodes-cluster-resource-levels-about.adoc
+++ b/modules/nodes-cluster-resource-levels-about.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: CONCEPT
 [id="nodes-cluster-resource-levels-about_{context}"]
-= Understanding the {product-title} cluster capacity tool 
+= Understanding the OpenShift Cluster Capacity Tool
 
-The cluster capacity tool simulates a sequence of scheduling decisions to
+The OpenShift Cluster Capacity Tool simulates a sequence of scheduling decisions to
 determine how many instances of an input pod can be scheduled on the cluster
 before it is exhausted of resources to provide a more accurate estimation.
 
@@ -23,6 +23,6 @@ on its selection and affinity criteria. As a result, the estimation of which
 remaining pods a cluster can schedule can be difficult.
 ====
 
-You can run the cluster capacity analysis tool as a stand-alone utility from 
+You can run the OpenShift Cluster Capacity Tool as a stand-alone utility from 
 the command line, or as a job in a pod inside an {product-title} cluster. 
-Running it as job inside of a pod enables you to run it multiple times without intervention.
+Running the tool as job inside of a pod enables you to run it multiple times without intervention.

--- a/modules/nodes-cluster-resource-levels-command.adoc
+++ b/modules/nodes-cluster-resource-levels-command.adoc
@@ -4,20 +4,22 @@
 
 :_content-type: PROCEDURE
 [id="nodes-cluster-resource-levels-command_{context}"]
-= Running the cluster capacity tool on the command line
+= Running the OpenShift Cluster Capacity Tool on the command line
 
-You can run the {product-title} cluster capacity tool from the command line
+You can run the OpenShift Cluster Capacity Tool from the command line
 to estimate the number of pods that can be scheduled onto your cluster.
+
+You create a sample pod spec file, which the tool uses for estimating resource usage. The pod spec specifies its resource
+requirements as `limits` or `requests`. The cluster capacity tool takes the
+pod's resource requirements into account for its estimation analysis.
 
 .Prerequisites
 
-* Run the link:https://catalog.redhat.com/software/containers/openshift4/ose-cluster-capacity/5cca0324d70cc57c44ae8eb6?container-tabs=overview[OpenShift Cluster Capacity Tool], which is available as a container image from the Red Hat Ecosystem Catalog.
+. Run the link:https://catalog.redhat.com/software/containers/openshift4/ose-cluster-capacity/5cca0324d70cc57c44ae8eb6?container-tabs=overview[OpenShift Cluster Capacity Tool], which is available as a container image from the Red Hat Ecosystem Catalog.
 
-* Create a sample `Pod` spec file, which the tool uses for estimating resource usage. The `podspec` specifies its resource
-requirements as `limits` or `requests`. The cluster capacity tool takes the
-pod's resource requirements into account for its estimation analysis.
-+
-An example of the `Pod` spec input is:
+. Create a sample pod spec file:
+
+.. Create a YAML file similar to the following:
 +
 [source,yaml]
 ----
@@ -42,6 +44,18 @@ spec:
         memory: 100Mi
 ----
 
+.. Create the cluster role:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+For example:
++
+[source,terminal]
+----
+$ oc create -f pod-spec.yaml
+----
 
 .Procedure
 
@@ -66,10 +80,17 @@ $ podman pull registry.redhat.io/openshift4/ose-cluster-capacity
 [source,terminal]
 ----
 $ podman run -v $HOME/.kube:/kube:Z -v $(pwd):/cc:Z  ose-cluster-capacity \
-/bin/cluster-capacity --kubeconfig /kube/config --podspec /cc/pod-spec.yaml \
---verbose <1>
+/bin/cluster-capacity --kubeconfig /kube/config --<pod_spec>.yaml /cc/<pod_spec>.yaml \
+--verbose
 ----
-<1> You can also add the `--verbose` option to output a detailed description of how many pods can be scheduled on each node in the cluster.
++
+--
+where:
+
+<pod_spec>.yaml:: Specifies the pod spec to use.
+
+verbose:: Outputs a detailed description of how many pods can be scheduled on each node in the cluster.
+--
 +
 .Example output
 [source,terminal]

--- a/modules/nodes-cluster-resource-levels-job.adoc
+++ b/modules/nodes-cluster-resource-levels-job.adoc
@@ -4,29 +4,23 @@
 
 :_content-type: PROCEDURE
 [id="nodes-cluster-resource-levels-job_{context}"]
-= Running the cluster capacity tool as a job inside a pod
+= Running the OpenShift Cluster Capacity Tool as a job inside a pod
 
-Running the cluster capacity tool as a job inside of a pod has the advantage of
-being able to be run multiple times without needing user intervention. Running
-the cluster capacity tool as a job involves using a `ConfigMap` object.
+Running the OpenShift Cluster Capacity Tool as a job inside of a pod allows you to run the tool multiple times without needing user intervention. You run the OpenShift Cluster Capacity Tool as a job by using a `ConfigMap` object.
 
 .Prerequisites
 
-Download and install link:https://github.com/kubernetes-incubator/cluster-capacity[the cluster capacity tool].
+Download and install link:https://github.com/openshift/cluster-capacity[OpenShift Cluster Capacity Tool].
 
 .Procedure
 
 To run the cluster capacity tool:
 
 . Create the cluster role:
+
+.. Create a YAML file similar to the following:
 +
-[source,terminal]
-----
-$ cat << EOF| oc create -f -
-----
-+
-.Example output
-[source,terminal]
+[source,yaml]
 ----
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
@@ -45,7 +39,19 @@ rules:
 - apiGroups: ["storage.k8s.io"]
   resources: ["storageclasses"]
   verbs: ["get", "watch", "list"]
-EOF
+----
+
+.. Create the cluster role by running the following command:
++
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
+For example:
++
+[source,terminal]
+----
+$ oc create sa cluster-capacity-sa
 ----
 
 . Create the service account:
@@ -60,10 +66,16 @@ $ oc create sa cluster-capacity-sa
 [source,terminal]
 ----
 $ oc adm policy add-cluster-role-to-user cluster-capacity-role \
-    system:serviceaccount:default:cluster-capacity-sa
+    system:serviceaccount:<namespace>:cluster-capacity-sa
 ----
++
+where:
 
-. Define and create the `Pod` spec:
+<namespace>:: Specifies the namespace where the pod is located. 
+
+. Define and create the pod spec:
+
+.. Create a YAML file similar to the following:
 +
 [source,yaml]
 ----
@@ -88,18 +100,33 @@ spec:
         memory: 100Mi
 ----
 
-. The cluster capacity analysis is mounted in a volume using a
-`ConfigMap` object named `cluster-capacity-configmap` to mount input pod spec file
-`pod.yaml` into a volume `test-volume` at the path `/test-pod`.
+.. Create the pod by running the following command:
 +
-If you haven't created a `ConfigMap` object, create one before creating the job:
+[source,terminal]
+----
+$ oc create -f <file_name>.yaml
+----
 +
+For example:
++
+[source,terminal]
+----
+$ oc create -f pod.yaml
+----
+
+. Created a config map object by running the following command:
++
+[source,terminal]
 ----
 $ oc create configmap cluster-capacity-configmap \
     --from-file=pod.yaml=pod.yaml
 ----
++
+The cluster capacity analysis is mounted in a volume using a config map object named `cluster-capacity-configmap` to mount the input pod spec file `pod.yaml` into a volume `test-volume` at the path `/test-pod`.
 
 . Create the job using the below example of a job specification file:
+
+.. Create a YAML file similar to the following:
 +
 [source,yaml]
 ----
@@ -136,19 +163,18 @@ spec:
           configMap:
             name: cluster-capacity-configmap
 ----
-<1> A required environment variable letting the cluster capacity tool
- know that it is running inside a cluster as a pod.
+<1> A required environment variable letting the cluster capacity tool know that it is running inside a cluster as a pod.
  +
-The `pod.yaml` key of the `ConfigMap` object is the same as the `Pod` spec file
-name, though it is not required. By doing this, the input pod spec file can be
-accessed inside the pod as `/test-pod/pod.yaml`.
+The `pod.yaml` key of the `ConfigMap` object is the same as the `Pod` spec file name, though it is not required. By doing this, the input pod spec file can be accessed inside the pod as `/test-pod/pod.yaml`.
 
-. Run the cluster capacity image as a job in a pod:
+.. Run the cluster capacity image as a job in a pod by running the following command:
 +
 [source,terminal]
 ----
 $ oc create -f cluster-capacity-job.yaml
 ----
+
+.Verification
 
 . Check the job logs to find the number of pods that can be scheduled in the
  cluster:

--- a/modules/nodes-cluster-resource-override-deploy-cli.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-cli.adoc
@@ -180,7 +180,7 @@ spec:
       memoryRequestToLimitPercent: 50
 status:
 
-....
+# ...
 
     mutatingWebhookConfigurationRef: <1>
       apiVersion: admissionregistration.k8s.io/v1 
@@ -189,7 +189,7 @@ status:
       resourceVersion: "127621"
       uid: 98b3b8ae-d5ce-462b-8ab5-a729ea8f38f3
 
-....
+# ...
 ----
 <1> Reference to the `ClusterResourceOverride` admission webhook.
 
@@ -205,10 +205,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
 
-....
+# ...
 
   labels:
     clusterresourceoverrides.admission.autoscaling.openshift.io: enabled <1>
+# ...
 ----
 <1> Add the `clusterresourceoverrides.admission.autoscaling.openshift.io: enabled` label to the Namespace.
 ////

--- a/modules/nodes-cluster-resource-override-deploy-console.adoc
+++ b/modules/nodes-cluster-resource-override-deploy-console.adoc
@@ -39,9 +39,9 @@ To install the Cluster Resource Override Operator using the {product-title} web 
 
 . On the *Installed Operators* page, click *ClusterResourceOverride*.
 
-.. On the *ClusterResourceOverride Operator* details page, click *Create Instance*.
+.. On the *ClusterResourceOverride Operator* details page, click *Create ClusterResourceOverride*.
 
-.. On the *Create ClusterResourceOverride* page, edit the YAML template to set the overcommit values as needed:
+.. On the *Create ClusterResourceOverride* page, click *YAML view* and edit the YAML template to set the overcommit values as needed:
 +
 [source,yaml]
 ----
@@ -55,6 +55,7 @@ spec:
       memoryRequestToLimitPercent: 50 <2>
       cpuRequestToLimitPercent: 25 <3>
       limitCPUToMemoryPercent: 200 <4>
+# ...
 ----
 <1> The name must be `cluster`.
 <2> Optional. Specify the percentage to override the container memory limit, if used, between 1-100. The default is 50.
@@ -91,7 +92,7 @@ spec:
       memoryRequestToLimitPercent: 50
 status:
 
-....
+# ...
 
     mutatingWebhookConfigurationRef: <1>
       apiVersion: admissionregistration.k8s.io/v1 
@@ -100,7 +101,7 @@ status:
       resourceVersion: "127621"
       uid: 98b3b8ae-d5ce-462b-8ab5-a729ea8f38f3
 
-....
+# ...
 
 ----
 <1> Reference to the `ClusterResourceOverride` admission webhook.
@@ -119,10 +120,11 @@ apiVersion: v1
 kind: Namespace
 metadata:
 
-....
+# ...
 
   labels:
     clusterresourceoverrides.admission.autoscaling.openshift.io: enabled <1>
+# ...
 ---- 
 <1> Add the `clusterresourceoverrides.admission.autoscaling.openshift.io: enabled` label to the Namespace.
 ////

--- a/modules/nodes-cluster-resource-override.adoc
+++ b/modules/nodes-cluster-resource-override.adoc
@@ -25,6 +25,7 @@ spec:
       memoryRequestToLimitPercent: 50 <2>
       cpuRequestToLimitPercent: 25 <3>
       limitCPUToMemoryPercent: 200 <4>
+# ...
 ----
 <1> The name must be `cluster`.
 <2> Optional. If a container memory limit has been specified or defaulted, the memory request is overridden to this percentage of the limit, between 1-100. The default is 50.
@@ -47,12 +48,12 @@ apiVersion: v1
 kind: Namespace
 metadata:
 
-....
+# ...
 
   labels:
     clusterresourceoverrides.admission.autoscaling.openshift.io/enabled: "true"
 
-....
+# ...
 ----
 
 The Operator watches for the `ClusterResourceOverride` CR and ensures that the `ClusterResourceOverride` admission webhook is installed into the same namespace as the operator.

--- a/nodes/clusters/nodes-cluster-resource-levels.adoc
+++ b/nodes/clusters/nodes-cluster-resource-levels.adoc
@@ -8,11 +8,7 @@ toc::[]
 
 
 
-As a cluster administrator, you can use the cluster capacity tool to view the
-number of pods that can be scheduled to increase the current resources before
-they become exhausted, and to ensure any future pods can be scheduled. This
-capacity comes from an individual node host in a cluster, and includes CPU,
-memory, disk space, and others.
+As a cluster administrator, you can use the OpenShift Cluster Capacity Tool to view the number of pods that can be scheduled to increase the current resources before they become exhausted, and to ensure any future pods can be scheduled. This capacity comes from an individual node host in a cluster, and includes CPU, memory, disk space, and others.
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference

--- a/nodes/nodes/nodes-nodes-machine-config-daemon-metrics.adoc
+++ b/nodes/nodes/nodes-nodes-machine-config-daemon-metrics.adoc
@@ -11,5 +11,5 @@ include::modules/machine-config-daemon-metrics.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview].
-* See xref:../../support/gathering-cluster-data.adoc[the documentation on gathering data about your cluster].
+* xref:../../monitoring/monitoring-overview.adoc#monitoring-overview[Monitoring overview]
+* xref:../../support/gathering-cluster-data.adoc#gathering-cluster-data[Gathering data about your cluster]


### PR DESCRIPTION
Fixing various errors in the Nodes -> Cluster docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

[Supported TuneD daemon plugins](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-node-tuning-operator#supported-tuned-daemon-plug-ins_nodes-node-tuning-operator) - Changed links to Additional references ([current docs](https://docs.openshift.com/container-platform/4.13/nodes/nodes/nodes-node-tuning-operator.html#supported-tuned-daemon-plug-ins_nodes-node-tuning-operator))
[Creating a Limit Range](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-limit-ranges#nodes-cluster-limit-creating_nodes-cluster-limit-ranges) -- Added `[source,terminal]` to step 2.
[Deleting a Limit Range](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-limit-ranges#nodes-cluster-limit-ranges-deleting_nodes-cluster-limit-ranges) -- Added `[source,terminal]` to step 2.
[Viewing a limit](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-limit-ranges#nodes-cluster-limit-viewing_nodes-cluster-limit-ranges) -- Added `[source,terminal]` throughout
[Disabling or enforcing CPU limits using CPU CFS quotas](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-overcommit-node-enforcing_nodes-cluster-overcommit) -- Added `[source,terminal]` to prereq tip and made prereq a bullet, not a number ([current docs](https://docs.openshift.com/container-platform/4.13/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-overcommit-node-enforcing_nodes-cluster-overcommit))
[Disabling overcommitment for a project](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-overcommit-project-disable_nodes-cluster-overcommit) -- Added proper example code.
[Understanding how to override the JVM maximum heap size](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-configure#nodes-cluster-resource-configure-jdk-heap_nodes-cluster-resource-configure) -- Changed numbered list to unordered list.
[Understanding OOM kill policy](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-configure#nodes-cluster-resource-configure-oom_nodes-cluster-resource-configure) -- Split the command and output.
[Finding the memory request and limit from within a pod](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-configure#nodes-cluster-resource-configure-request-limit_nodes-cluster-resource-configure) -- Added supsteps and verification. ([current docs](https://docs.openshift.com/container-platform/4.13/nodes/clusters/nodes-cluster-resource-configure.html#nodes-cluster-resource-configure-request-limit_nodes-cluster-resource-configure))
[Configuring cluster-level overcommit](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-resource-configure_nodes-cluster-overcommit) -- Added # ...
[Understanding the OpenShift Cluster Capacity Tool](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-levels#nodes-cluster-resource-levels-about_nodes-cluster-resource-levels) -- Updated the name of the cluster capacity tool, based on [the source](https://catalog.redhat.com/software/containers/openshift4/ose-cluster-capacity/5cca0324d70cc57c44ae8eb6?container-tabs=overview). ([current docs](https://docs.openshift.com/container-platform/4.13/nodes/clusters/nodes-cluster-resource-levels.html#nodes-cluster-resource-levels-about_nodes-cluster-resource-levels))
[Running the OpenShift Cluster Capacity Tool on the command line](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-levels#nodes-cluster-resource-levels-command_nodes-cluster-resource-levels) -- Cleaned up the procedure. ([current docs](https://docs.openshift.com/container-platform/4.13/nodes/clusters/nodes-cluster-resource-levels.html#nodes-cluster-resource-levels-command_nodes-cluster-resource-levels))
[Running the OpenShift Cluster Capacity Tool as a job inside a pod](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-levels#nodes-cluster-resource-levels-job_nodes-cluster-resource-levels) -- Cleaned up the procedure. Changed link to OpenShift repo ([current docs](https://docs.openshift.com/container-platform/4.13/nodes/clusters/nodes-cluster-resource-levels.html#nodes-cluster-resource-levels-job_nodes-cluster-resource-levels))
[Installing the Cluster Resource Override Operator using the CLI](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-resource-override-deploy-cli_nodes-cluster-overcommit) -- Changed ... to # ... in Step 5.
[Installing the Cluster Resource Override Operator using the web console](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-resource-override-deploy-console_nodes-cluster-overcommit) -- Cleaned up the procedure.
[Cluster-level overcommit using the Cluster Resource Override Operator](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit#nodes-cluster-resource-override_nodes-cluster-overcommit) -- Added # ...
[Estimating the number of pods your {product-title} nodes can hold](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-resource-levels) -- Updated the name of the cluster capacity tool
[Machine Config Daemon metrics](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-machine-config-daemon-metrics) -- Changed wording of link text
[Configuring an OpenShift Container Platform cluster for pods](https://63085--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-pods-configuring.html) -- Added assembly that was created for the 3.x -> 4.x conversion, but never added. 