### PR TITLE
OSDOCS-7050: cluster wide proxy doc issues

### DIFF
--- a/modules/cluster-wide-proxy-preqs.adoc
+++ b/modules/cluster-wide-proxy-preqs.adoc
@@ -28,10 +28,10 @@ endif::openshift-dedicated[]
 [id="cluster-wide-proxy-network-prereqs_{context}"]
 == Network requirements
 
-* If your proxy re-encyrpts egress traffic, you must create exclusions to the domain and port combinations. The following table offers guidance into these exceptions.
+* If your proxy re-encrypts egress traffic, you must create exclusions to the domain and port combinations. The following table offers guidance into these exceptions.
 +
 --
-** Add the following OpenShift URLs to your allowlist for re-encryption.
+** Your proxy must exclude re-encrypting the following OpenShift URLs:
 +
 [cols="6,1,6",options="header"]
 |===
@@ -45,7 +45,7 @@ endif::openshift-dedicated[]
 |The https://cloud.redhat.com/openshift site uses authentication from sso.redhat.com to download the cluster pull secret and use Red Hat SaaS solutions to facilitate monitoring of your subscriptions, cluster inventory, and chargeback reporting.
 |===
 +
-** Add the following site reliability engineering (SRE) and management URLs to your allowlist for re-encryption.
+** Your proxy must exclude re-encrypting the following site reliability engineering (SRE) and management URLs: 
 +
 [cols="6,1,6",options="header"]
 |===


### PR DESCRIPTION
[OSDOCS-7050](https://issues.redhat.com/browse/OSDOCS-7050): cluster wide proxy doc issues

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
Preview pages: [Click to see the build preview in your browser](https://63094--docspreview.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy#cluster-wide-proxy-prereqs_configuring-a-cluster-wide-proxy)
SME review **completed**: @paulczar 
QE review **completed**: @yingzhanredhat 
Peer review **completed**: @nalhadef