### PR TITLE
OCPBUGS#17344: ALBO: Configuring ALBO on STS cluster by using the AWS CLI

### DIFF
--- a/modules/bootstrap-aws-load-balancer-operator-using-aws-cli.adoc
+++ b/modules/bootstrap-aws-load-balancer-operator-using-aws-cli.adoc
@@ -1,0 +1,89 @@
+// Module included in the following assemblies:
+// * networking/installing-albo-sts-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="bootstra-aws-load-balancer-operator-using-aws-cli_{context}"]
+= Bootstrapping AWS Load Balancer Operator on Security Token Service cluster by using the AWS CLI
+
+.Prerequisites
+
+* You have installed link:https://docs.aws.amazon.com/cli/latest/#aws-cli-command-reference[AWS CLI].
+
+.Procedure
+
+. Create the `aws-load-balancer-operator` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc create namespace aws-load-balancer-operator
+----
+
+. Generate a trusted policy file using your identity provider by running the following command:
++
+[source,terminal]
+----
+$ cat <<EOF > albo-operator-trusted-policy.json
+{
+"Version": "2012-10-17",
+"Statement": [
+{
+"Effect": "Allow",
+"Principal": {
+"Federated": "${IDP_ARN}"
+},
+"Action": "sts:AssumeRoleWithWebIdentity",
+"Condition": {
+"StringEquals": {
+"${IDP}:sub": "system:serviceaccount:aws-load-balancer-operator:aws-load-balancer-operator-controller-manager"
+                }
+             }
+}
+]
+}
+EOF
+----
+
+. Create the role with the generated trusted policy by running the following command:
++
+[source,terminal]
+----
+$ aws iam create-role \
+    --role-name albo-operator \
+    --assume-role-policy-document file://albo-operator-trusted-policy.json \
+    OPERATOR_ROLE_ARN=$(aws iam get-role --role-name albo-operator | \grep '^ROLE' | \grep -Po 'arn:aws:iam[0-9a-z/:\-_]+')
+----
+
+. Download the operator's permission policy by running the following command:
++
+[source,terminal]
+----
+$ curl -o albo-operator-permission-policy.json https://raw.githubusercontent.com/alebedev87/aws-load-balancer-operator/aws-cli-commands-for-sts/hack/operator-permission-policy.json
+----
+
+. Attach the permission policy of the AWS Load Balancer Operator to the role by running the following command:
++
+[source,terminal]
+----
+$ aws iam put-role-policy --role-name albo-operator \
+    --policy-name perms-policy-albo-operator \
+    --policy-document file://albo-operator-permission-policy.json
+----
+
+. Generate the operator's aws credentials by runing the following command:
++
+[source,terminal]
+----
+$ cat <<EOF > albo-operator-aws-credentials.cfg
+[default]
+sts_regional_endpoints = regional
+role_arn = ${OPERATOR_ROLE_ARN}
+web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
+EOF
+----
+
+. Create the credentials secret of the AWS Load Balancer Operator with the generated aws credentials by running the following command:
++
+[source,terminal]
+----
+$ oc -n aws-load-balancer-operator create secret generic aws-load-balancer-operator --from-file=credentials=albo-operator-aws-credentials.cfg
+----

--- a/modules/configuring-albo-on-sts-cluster-using-aws-cli.adoc
+++ b/modules/configuring-albo-on-sts-cluster-using-aws-cli.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+// * networking/installing-albo-sts-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="configuring-albo-on-sts-using-aws-cli_{context}"]
+= Configuring the AWS Load Balancer Operator on Security Token Service cluster by using AWS CLI
+
+You can specify the credential secret by using the `spec.credentials` field in the AWS Load Balancer Controller custom resource (CR). You can use the predefined  `CredentialsRequest` object of the controller to know which roles are required.
+
+.Prerequisites
+
+* You have installed link:https://docs.aws.amazon.com/cli/latest/#aws-cli-command-reference[AWS CLI].
+
+.Procedure

--- a/networking/aws_load_balancer_operator/installing-albo-sts-cluster.adoc
+++ b/networking/aws_load_balancer_operator/installing-albo-sts-cluster.adoc
@@ -14,9 +14,13 @@ If you do not want to provision credential secret by using the Cloud Credential 
 
 include::modules/bootstrap-aws-load-balancer-operator.adoc[leveloffset=+1]
 
+include::modules/bootstrap-aws-load-balancer-operator-using-aws-cli.adoc[leveloffset=+2]
+
 include::modules/configuring-albo-on-sts-cluster.adoc[leveloffset=+1]
 
 include::modules/configuring-albo-on-sts-cluster-predefined-credentials.adoc[leveloffset=+1]
+
+include::modules/configuring-albo-on-sts-cluster-using-aws-cli.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-17344
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63107--docspreview.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/installing-albo-sts-cluster#bootstra-aws-load-balancer-operator-using-aws-cli_albo-sts-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
