### PR TITLE
Fix a typo in node garbage collection docs

### DIFF
--- a/modules/nodes-nodes-garbage-collection-images.adoc
+++ b/modules/nodes-nodes-garbage-collection-images.adoc
@@ -9,7 +9,7 @@
 
 Image garbage collection removes images that are not referenced by any running pods.
 
-{produt-title} determines which images to remove from a node based on the disk usage that is reported by *cAdvisor*.
+{product-title} determines which images to remove from a node based on the disk usage that is reported by *cAdvisor*.
 
 The policy for image garbage collection is based on two conditions:
 


### PR DESCRIPTION
Spotted a typo in https://docs.openshift.com/container-platform/4.13/post_installation_configuration/node-tasks.html#nodes-nodes-garbage-collection-images_post-install-node-tasks:

![image](https://github.com/openshift/openshift-docs/assets/712614/75faa1fd-7890-4802-a1c4-1c8eb78ce261)

Version(s):
4.10+

Issue:
N/A

Link to docs preview:
https://63108--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/node-tasks#nodes-nodes-garbage-collection-images_post-install-node-tasks

QE review:
N/A
