### PR TITLE
OSDOCS-7285: IMDSv2 OCP version limitation

### DIFF
--- a/modules/machineset-creating-imds-options.adoc
+++ b/modules/machineset-creating-imds-options.adoc
@@ -9,6 +9,9 @@
 
 You can specify whether to require the use of IMDSv2 by adding or editing the value of `metadataServiceOptions.authentication` in the machine set YAML file for your machines.
 
+.Prerequisites
+* To use IMDSv2, your AWS cluster must have been created with {product-title} version 4.7 or later.
+
 .Procedure
 * Add or edit the following lines under the `providerSpec` field:
 +

--- a/modules/machineset-imds-options.adoc
+++ b/modules/machineset-imds-options.adoc
@@ -13,7 +13,12 @@ endif::[]
 
 You can use machine sets to create machines that use a specific version of the Amazon EC2 Instance Metadata Service (IMDS). Machine sets can create machines that allow the use of both IMDSv1 and link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/configuring-instance-metadata-service.html[IMDSv2] or machines that require the use of IMDSv2.
 
-To change the IMDS configuration for existing machines, edit the machine set YAML file that manages those machines. 
+[NOTE]
+====
+Using IMDSv2 is only supported on AWS clusters that were created with {product-title} version 4.7 or later.
+====
+
+To change the IMDS configuration for existing machines, edit the machine set YAML file that manages those machines.
 ifndef::cpmso[]
 To deploy new compute machines with your preferred IMDS configuration, create a compute machine set YAML file with the appropriate values.
 endif::cpmso[]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OSDOCS-7285](https://issues.redhat.com//browse/OSDOCS-7285) for [OCPBUGS-9971](https://issues.redhat.com/browse/OCPBUGS-9971)

Link to docs preview:
[Machine set options for the Amazon EC2 Instance Metadata Service](https://63117--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-imds-options_creating-machineset-aws)

QE review:
- [x] QE has approved this change.

Additional information: