### PR TITLE
OCPBUGS-7621-vsphere-only: Added ifdef statement to isolate update fr…

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -278,12 +278,14 @@ cluster.
 
 * Verify the cloud provider account on your host has the correct permissions to deploy the cluster. An account with incorrect permissions causes the installation process to fail with an error message that displays the missing permissions.
 
+ifdef::vsphere[]
 * Optional: Before you create the cluster, configure an external load balancer in place of the default load balancer. 
 +
 [IMPORTANT]
 ====
 You do not need to specify API and Ingress static addresses for your installation program. If you choose this configuration, you must take additional actions to define network targets that accept an IP address from each referenced vSphere subnet. See the section "Configuring an external load balancer".
 ====
+endif::vsphere[]
 
 .Procedure
 


### PR DESCRIPTION
This is an internal docs fix to add an ifdef statement to the update made in https://github.com/openshift/openshift-docs/pull/62343

[OCPBUGS-7621](https://issues.redhat.com/browse/OCPBUGS-7621)

Version(s):
4.14 and 4.13

Links to docs previews:

Doc set where optional step now displays (vSphere)
* [One example from vSphere docs](https://63120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-launching-installer_installing-vsphere-installer-provisioned-network-customizations)

Doc set where optional step no longer displays (non-vSphere and only some examples as list is large in the installation-launching-installer file)
* [Installing a cluster on AWS with network customizations](https://63120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations#installation-launching-installer_installing-aws-network-customizations)
* [Installing a cluster on GCP with network customizations](https://63120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations#installation-launching-installer_installing-gcp-network-customizations)

QE review:
- [ ] No QE needed for this change. Internal docs fix.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
