### PR TITLE
OCPBUGS-11810-12: Updated RHEL versions for install-bare-metal-min-res…

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -158,7 +158,7 @@ endif::ibm-z[]
 ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}]
-ifndef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}, {op-system-base} 8.4, or {op-system-base} 8.5 ^[3]^]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}, {op-system-base} 8.6, {op-system-base} 8.7, or {op-system-base} 8.8 ^[3]^]
 |2
 |8 GB
 |100 GB


### PR DESCRIPTION
[OCPBUGS-11810](https://issues.redhat.com/browse/OCPBUGS-11810)

Version(s):
4.12

Link to docs preview:
[Mininimum resource requirements for cluster installation](https://63132--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal#installation-minimum-resource-requirements_installing-bare-metal)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* https://access.redhat.com/support/policy/updates/openshift
* https://access.redhat.com/support/policy/updates/errata#Full_Support_Phase
