### PR TITLE
TELCODOCS-1214 - CNF-7365 GitOps ZTP independence from deployed clust…

### DIFF
--- a/modules/ztp-customizing-the-install-extra-manifests.adoc
+++ b/modules/ztp-customizing-the-install-extra-manifests.adoc
@@ -16,29 +16,53 @@ You can define a set of extra manifests for inclusion in the installation phase 
 
 . Create a set of extra manifest CRs that the {ztp} pipeline uses to customize the cluster installs.
 
-. In your custom `/siteconfig` directory, create an `/extra-manifest` folder for your extra manifests. The following example illustrates a sample `/siteconfig` with `/extra-manifest` folder:
+. In your custom `/siteconfig` directory, create a subdirectory `/custom-manifest` for your extra manifests. The following example illustrates a sample `/siteconfig` with `/custom-manifest` folder:
 +
 [source,text]
 ----
 siteconfig
 ├── site1-sno-du.yaml
 ├── site2-standard-du.yaml
-└── extra-manifest
+├── extra-manifest/
+└── custom-manifest
     └── 01-example-machine-config.yaml
 ----
++
+[NOTE]
+====
+The subdirectory names `/custom-manifest` and `/extra-manifest` used throughout are example names only. There is no requirement to use these names and no restriction on how you name these subdirectories.
+In this example `/extra-manifest` refers to the Git subdirectory that stores the contents of `/extra-manifest` from the `ztp-site-generate` container.
+====
 
-. Add your custom extra manifest CRs to the `siteconfig/extra-manifest` directory.
+. Add your custom extra manifest CRs to the `siteconfig/custom-manifest` directory.
 
-. In your `SiteConfig` CR, enter the directory name in the `extraManifestPath` field, for example:
+. In your `SiteConfig` CR, enter the directory name in the `extraManifests.searchPaths` field, for example:
 +
 [source,yaml]
 ----
 clusters:
 - clusterName: "example-sno"
   networkType: "OVNKubernetes"
-  extraManifestPath: extra-manifest
+  extraManifests:
+    searchPaths:
+      - extra-manifest/ <1>
+      - custom-manifest/ <2>
 ----
+<1> Folder for manifests copied from the `ztp-site-generate` container.
+<2> Folder for custom manifests.
 
-. Save the `SiteConfig` CRs  and `/extra-manifest` CRs and push them to the site configuration repo.
+. Save the `SiteConfig`, `/extra-manifest`, and `/custom-manifest` CRs, and push them to the site configuration repo.
 
-The {ztp} pipeline appends the CRs in the `/extra-manifest` directory to the default set of extra manifests during cluster provisioning.
+During cluster provisioning, the {ztp} pipeline appends the CRs in the `/custom-manifest` directory to the default set of extra manifests stored in `extra-manifest/`.
+
+[NOTE]
+====
+As of version 4.14 `extraManifestPath` is subject to a deprecation warning. 
+
+While `extraManifestPath` is still supported, we recommend that you use `extraManifests.searchPaths`. 
+If you define `extraManifests.searchPaths` in the `SiteConfig` file, the {ztp} pipeline does not fetch manifests from the `ztp-site-generate` container during site installation.
+
+If you define both `extraManifestPath` and `extraManifests.searchPaths` in the `Siteconfig` CR, the setting defined for `extraManifests.searchPaths` takes precedence.
+
+It is strongly recommended that you extract the contents of `/extra-manifest` from the `ztp-site-generate` container and push it to the GIT repository.
+====

--- a/modules/ztp-generating-install-and-config-crs-manually.adoc
+++ b/modules/ztp-generating-install-and-config-crs-manually.adoc
@@ -64,6 +64,13 @@ $ mkdir -p ./site-install
 ----
 include::snippets/ztp_example-sno.yaml[]
 ----
++
+[NOTE]
+====
+Once you have extracted reference CR configuration files from the `out/extra-manifest` directory of the `ztp-site-generate` container, you can use `extraManifests.searchPaths` to include the path to the git directory containing those files. 
+This allows the {ztp} pipeline to apply those CR files during cluster installation. 
+If you configure a `searchPaths` directory, the {ztp} pipeline does not fetch manifests from the `ztp-site-generate` container during site installation.
+====
 
 . Generate the Day 0 installation CRs by processing the modified `SiteConfig` CR `site-1-sno.yaml` by running the following command:
 +

--- a/modules/ztp-preparing-the-ztp-git-repository-ver-ind.adoc
+++ b/modules/ztp-preparing-the-ztp-git-repository-ver-ind.adoc
@@ -1,0 +1,99 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="ztp-preparing-the-ztp-git-repository-ver-ind_{context}"]
+= Preparing the {ztp} site configuration repository for version independence
+
+You can use {ztp} to manage source custom resources (CRs) for managed clusters that are running different versions of {product-title}. 
+This means that the version of {product-title} running on the hub cluster can be independent of the version running on the managed clusters. 
+
+.Procedure
+
+. Create a directory structure with separate paths for the `SiteConfig` and `PolicyGenTemplate` CRs.
+
+. Within the `PolicyGenTemplate` directory, create a directory for each {product-title} version you want to make available.
+For each version, create the following resources: 
+* `kustomization.yaml` file that explicitly includes the files in that directory
+* `source-crs` directory to contain reference CR configuration files from the `ztp-site-generate` container
+
+. In the `/siteconfig` directory, create a subdirectory for each {product-title} version you want to make available. For each version, create at least one directory for reference CRs to be copied from the container. There is no restriction on the naming of directories or on the number of reference directories. If you want to work with custom CRs, you must create a separate directory for those.
++
+The following example describes a structure using custom CRs for different versions of {product-title}:
++
+[source,text]
+----
+├── policygentemplates
+│   ├── kustomization.yaml <1> 
+│   ├── version_4.13 <2>
+│   │   ├── common-ranGen.yaml
+│   │   ├── group-du-sno-ranGen.yaml
+│   │   ├── group-du-sno-validator-ranGen.yaml
+│   │   ├── helix56-v413.yaml
+│   │   ├── kustomization.yaml <3>
+│   │   ├── ns.yaml
+│   │   └── source-crs/  <4>
+│   └── version_4.14 <2>
+│       ├── common-ranGen.yaml
+│       ├── group-du-sno-ranGen.yaml
+│       ├── group-du-sno-validator-ranGen.yaml
+│       ├── helix56-v414.yaml
+│       ├── kustomization.yaml <3>
+│       ├── ns.yaml
+│       └── source-crs/ <4>
+└── siteconfig    
+    ├── kustomization.yaml
+    ├── version_4.13
+    │   ├── helix56-v413.yaml
+    │   ├── kustomization.yaml
+    │   ├── extra-manifest/ <5>          
+    │   └── custom-manifest/ <6>       
+    └── version_4.14    
+        ├── helix57-v414.yaml
+        ├── kustomization.yaml
+        ├── extra-manifest/ <5>           
+        └── custom-manifest/ <6>        
+
+----
+<1> Create a top-level `kustomization` yaml file.
+<2> Create the version-specific directories within the custom `/policygentemplates` directory.
+<3> Create a `kustomization.yaml` file for each version. 
+<4> Create a `source-crs` directory for each version to contain reference CRs from the `ztp-site-generate` container. 
+<5> Create a directory within the custom `/siteconfig` directory to contain extra manifests from the `ztp-site-generate` container.
+<6> Create a folder to hold custom CRs.
++
+[NOTE]
+====
+In the previous example, each version subdirectory in the custom `/siteconfig` directory contains two further subdirectories, one containing the reference manifests copied from the container, the other for custom manifests that you provide. 
+The names assigned to those directories are examples. 
+If you use custom CRs, the last directory listed under `extraManifests.searchPaths` in the `SiteConfig` CR must be the directory containing custom CRs.
+====
+
+. Edit the `SiteConfig` CR to include the search paths of any directories you have created.
+The first directory that is listed under `extraManifests.searchPaths` must be the directory containing the reference manifests.
+Consider the order in which the directories are listed. 
+In cases where directories contain files with the same name, the file in the final directory takes precedence.
++
+.Example SiteConfig CR
++
+[source,yaml]  
+----
+extraManifests:
+    searchPaths:
+    - extra-manifest/ <1>
+    - custom-manifest/ <2>
+----
+<1>  The directory containing the reference manifests must be listed first under `extraManifests.searchPaths`.
+<2>  If you are using custom CRs, the last directory listed under `extraManifests.searchPaths` in the `SiteConfig` CR must be the directory containing those custom CRs.
+
+. Edit the top-level `kustomization.yaml` file to control which {product-title} versions are active. The following is an example of a `kustomization.yaml` file at the top level:
++
+[source,yaml]
+----
+resources:
+- version_4.13 <1>
+#- version_4.14 <2>
+----
+<1> Activate version 4.13.
+<2> Use comments to deactivate a version.

--- a/modules/ztp-preparing-the-ztp-git-repository.adoc
+++ b/modules/ztp-preparing-the-ztp-git-repository.adoc
@@ -17,6 +17,12 @@ Before you can use the {ztp-first} pipeline, you need to prepare the Git reposit
 .Procedure
 
 . Create a directory structure with separate paths for the `SiteConfig` and `PolicyGenTemplate` CRs.
++
+[NOTE]
+====
+Keep `SiteConfig` and `PolicyGenTemplate` CRs in separate directories. 
+Both the `SiteConfig` and `PolicyGenTemplate` directories must contain a `kustomization.yaml` file that explicitly includes the files in that directory.
+====
 
 . Export the `argocd` directory from the `ztp-site-generate` container image using the following commands:
 +
@@ -35,6 +41,7 @@ $ mkdir -p ./out
 $ podman run --log-driver=none --rm registry.redhat.io/openshift4/ztp-site-generate-rhel8:v{product-version} extract /home/ztp --tar | tar x -C ./out
 ----
 
+
 . Check that the `out` directory contains the following subdirectories:
 +
 * `out/extra-manifest` contains the source CR files that `SiteConfig` uses to generate extra manifest `configMap`.
@@ -42,7 +49,43 @@ $ podman run --log-driver=none --rm registry.redhat.io/openshift4/ztp-site-gener
 * `out/argocd/deployment` contains patches and YAML files to apply on the hub cluster for use in the next step of this procedure.
 * `out/argocd/example` contains the examples for `SiteConfig` and `PolicyGenTemplate` files that represent the recommended configuration.
 
-The directory structure under `out/argocd/example` serves as a reference for the structure and content of your Git repository. The example includes `SiteConfig` and `PolicyGenTemplate` reference CRs for single-node, three-node, and standard clusters. Remove references to cluster types that you are not using. The following example describes a set of CRs for a network of single-node clusters:
+
+. Copy the `out/source-crs` folder and contents to the `PolicyGentemplate` directory.
+
+. The out/extra-manifests directory contains the reference manifests for a RAN DU cluster. 
+Copy the `out/extra-manifests` directory into the `SiteConfig` folder.
+This directory should contain CRs from the `ztp-site-generate` container only. 
+Do not add custom CRs here.  
+If you want to work with custom CRs you must create another directory for that content. 
++
+[NOTE]
+====
+Here is an example of the directory structure: 
+source,text]
+----
+example
+├── policygentemplates
+│   ├── kustomization.yaml
+│   └── source-crs/
+└── siteconfig
+    ├── extra-manifests
+    └── kustomization.yaml
+----
+====
+
+. Commit the directory structure and the `kustomization.yaml` files and push to your Git repository. 
+The initial push to Git should include the `kustomization.yaml` files.
+
+You can use the directory structure under `out/argocd/example` as a reference for the structure and content of your Git repository. 
+That structure includes `SiteConfig` and `PolicyGenTemplate` reference CRs for single-node, three-node, and standard clusters. 
+Remove references to cluster types that you are not using. 
+
+For all cluster types, you must:
+
+* Add the `source-crs` subdirectory to the `policygentemplate` directory.
+* Add the `extra-manifests` directory to the `siteconfig` directory.
+
+The following example describes a set of CRs for a network of single-node clusters:
 
 [source,text]
 ----
@@ -53,15 +96,14 @@ example
 │   ├── group-du-sno-ranGen.yaml
 │   ├── group-du-sno-validator-ranGen.yaml
 │   ├── kustomization.yaml
+│   ├── source-crs/
 │   └── ns.yaml
 └── siteconfig
     ├── example-sno.yaml
+    ├── extra-manifests/ <1> 
+    ├── custom-manifests/ <2>
     ├── KlusterletAddonConfigOverride.yaml
     └── kustomization.yaml
 ----
-
-Keep `SiteConfig` and `PolicyGenTemplate` CRs in separate directories. Both the `SiteConfig` and `PolicyGenTemplate` directories must contain a `kustomization.yaml` file that explicitly includes the files in that directory.
-
-This directory structure and the `kustomization.yaml` files must be committed and pushed to your Git repository. The initial push to Git should include the `kustomization.yaml` files. The `SiteConfig` (`example-sno.yaml`) and `PolicyGenTemplate` (`common-ranGen.yaml`, `group-du-sno*.yaml`, and `example-sno-site.yaml`) files can be omitted and pushed at a later time as required when deploying a site.
-
-The `KlusterletAddonConfigOverride.yaml` file is only required if one or more `SiteConfig` CRs which make reference to it are committed and pushed to Git. See `example-sno.yaml` for an example of how this is used.
+<1> Contains reference manifests from the `ztp-container`.
+<2> Contains custom manifests.

--- a/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
@@ -51,3 +51,5 @@ include::modules/ztp-configuring-the-hub-cluster-to-use-unauthenticated-registri
 include::modules/ztp-preparing-the-hub-cluster-for-ztp.adoc[leveloffset=+1]
 
 include::modules/ztp-preparing-the-ztp-git-repository.adoc[leveloffset=+1]
+
+include::modules/ztp-preparing-the-ztp-git-repository-ver-ind.adoc[leveloffset=+2]


### PR DESCRIPTION
[TELCODOCS-1214](https://issues.redhat.com//browse/TELCODOCS-1214) - [CNF-7365](https://issues.redhat.com//browse/CNF-7365) GitOps ZTP independence from deployed cluster version

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1214
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Links to docs previews:
**Preparing the GitOps ZTP site configuration repository for version independence** (new document)
 https://63133--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#ztp-preparing-the-ztp-git-repository-ver-ind_ztp-preparing-the-hub-cluster

**Preparing the GitOps ZTP site configuration repository**
[https://63133--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-prepa](https://63133--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster)

**Customizing extra installation manifests in the GitOps ZTP pipeline**
https://63133--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-install-ztp.html#ztp-customizing-the-install-extra-manifests_ztp-advanced-install-ztp

**Generating GitOps ZTP installation and configuration CRs manually** (update to sample YAML)
https://63133--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-manual-install.html#ztp-generating-install-and-config-crs-manually_ztp-manual-install

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
