### PR TITLE
OSDOCS-6875: add opt in for on-cluster builds

### DIFF
--- a/modules/coreos-layering-on-cluster-applying-new-configs.adoc
+++ b/modules/coreos-layering-on-cluster-applying-new-configs.adoc
@@ -1,0 +1,80 @@
+// Modules included in the following assemblies:
+//
+// * post-installation_configuration/coreos-layering.adoc
+
+:_content-type: PROCEDURE
+[id="coreos-layering-on-cluster-applying-new-configs_{context}"]
+= Applying new configurations to on-cluster builds
+
+Any opted-in machine config pools must be paused before you can update any machine configs for that pool. The following example uses a machine config file `layered-os-image-override.yaml` that was created for an opted-in machine config pool.
+
+.Prerequisites
+
+. You have a running {product-title} cluster.
+. You installed the OpenShift CLI (`oc`).
+. You are logged in to the cluster as a user with administrative privileges.
+. You have at least one SSH key pair configured either using the `install-config.yaml` file or a machine config file.
+. You have access to an image registry and those permissions have been added to the global pull secret.
+. You have opted in any machine config pools.
+
+.Procedure
+
+. Pause the machine config pool:
++
+[source,terminal]
+----
+$ oc patch mcp/infra --patch='{"spec": {"paused": true}}' --type=merge
+----
+
+. Apply any new configurations:
++
+[source,terminal]
+----
+$ oc apply -f - <<EOF
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: layered
+  name: new-file-layered
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    storage:
+      files:
+        - contents:
+        ¦   source: data:,hello%20layered%0A
+        ¦ mode: 420
+        ¦ path: /etc/hello-layered
+EOF
+----
++
+Although the machine config pool is paused, the new machine config gets rendered and the image build still occurs. You can watch for the `machineconfiguration.openshift.io/newestImageEquivalentConfig` annotation to change on the `MachineConfigPool` object to determine if the build completes. You can also watch the logs of the `machine-os-builder` pod in the MCO namespace to determine the same thing.
+
+. Once the build completes, update the `layered-os-image.yaml` file to point to the new {op-system} image:
++
+[source,terminal]
+----
+$ oc patch mc/layered-os-image-override && \
+  --patch="$(oc get mcp/layered -o template='{"spec": {"osImageURL": "{{ index .metadata.annotations "machineconfiguration.openshift.io/newestImageEquivalentConfig" }}" } }')" && \ <1>
+  --type=merge
+----
+<1> The machine config `layered-os-image-override.yaml` created for the machine config pool that was opted into layering.
+
+. Unpause the machine config pool:
++
+[source,terminal]
+----
+$ oc patch mcp/infra --patch='{"spec": {"paused": false}}' --type=merge
+----
++
+[NOTE]
+====
+The updated image in the `layered-os-image-override.yaml` machine config will roll out with all the machine configs contained within it.
+====

--- a/modules/coreos-layering-on-cluster-building-images.adoc
+++ b/modules/coreos-layering-on-cluster-building-images.adoc
@@ -1,0 +1,53 @@
+// Modules included in the following assemblies:
+//
+// * post-installation_configuration/coreos-layering.adoc
+
+:_content-type: PROCEDURE
+[id="coreos-layering-on-cluster-building-images_{context}"]
+= Building and rolling out on-cluster custom images
+
+Once a machine config pool has been opted into to on-cluster builds, you need to update any machine configs in this pool to point to the newly built operating system. The following example uses a machine config file `layered-os-image-override.yaml` that was created for an opted-in machine config pool.
+
+
+.Prerequisites
+
+. You have a running {product-title} cluster.
+. You installed the OpenShift CLI (`oc`).
+. You are logged in to the cluster as a user with administrative privileges.
+. You have at least one SSH key pair configured either using the `install-config.yaml` file or a machine config file.
+. You have access to an image registry and those permissions have been added to the global pull secret.
+. You have opted in any machine config pools.
+
+.Procedure
+
+. Currently, the `osImageURL` field in the machine config file is set to a tagged image. Update it to point to the new {op-system} image:
++
+[source,terminal]
+----
+$ oc patch mc/layered-os-image-override && \
+  --patch="$(oc get mcp/layered -o template='{"spec": {"osImageURL": "{{ index .metadata.annotations "machineconfiguration.openshift.io/newestImageEquivalentConfig" }}" } }')" && \ <1>
+  --type=merge
+----
+<1> The machine config `layered-os-image-override.yaml` for the machine config pool that was opted into layering.
++
+[NOTE]
+====
+This command creates another rendered machine config that starts another on-cluster build. While the node will roll forward to the new rendered config, it only applies what is present within the newly built {op-system} image.
+====
+
+. Label a node with the `layered` node role so that the MCO applies the new configuration:
++
+[source,terminal]
+----
+$ oc label node/node-name 'node-role.kubernetes.io/layered='
+----
++
+This will cordone, drain, and apply the new config.
+
+.Verification
+* Verify that the node reboots into the new configuration:
++
+[source,terminal]
+----
+$ oc debug node/node-name -- chroot /host rpm-ostree status
+----

--- a/modules/coreos-layering-on-cluster-opt-in.adoc
+++ b/modules/coreos-layering-on-cluster-opt-in.adoc
@@ -1,0 +1,136 @@
+// Modules included in the following assemblies:
+//
+// * post-installation_configuration/coreos-layering.adoc
+
+:_content-type: PROCEDURE
+[id="coreos-layering-on-cluster-opt-in_{context}"]
+= Opting in to create on-cluster {op-system} builds
+
+In order to create on-cluster builds, you need to opt in. This process involves adding a specific annotation to any specified `MachineConfigPool` objects to signal that the Machine Config Operator (MCO) should begin an on-cluster build.
+
+.Prerequisites
+
+. You have a running {product-title} cluster.
+. You installed the OpenShift CLI (`oc`).
+. You are logged in to the cluster as a user with administrative privileges.
+. You have at least one SSH key pair configured either using the `install-config.yaml` file or a machine config file.
+. You have access to an image registry and those permissions have been added to the global pull secret.
+
+.Procedure
+
+. Perform the initial setup by obtaining the following information.
+
+.. Get the name of the pull secret for the base {op-system} image and the extensions container and add it as a secret in the MCO namespace. You can do this by cloning the global pull secret:
++
+[source,terminal]
+----
+$ oc create secret docker-registry global-pull-secret-copy && \
+  -n openshift-machine-config-operator && \
+  --from-file=.dockerconfigjson=<(oc get secret/pull-secret -n openshift-config -o json | jq -r '.data[".dockerconfigjson"] | @base64d')
+----
+
+.. Get the final image pullspec from your registry. For example:
++
+[source,terminal]
+----
+$ podman pull quay.io/my-registry/custom-image:latest
+----
++
+Any tags you provide are ignored. Instead, images are tagged with the name of the rendered machine config that was used to produce the image. For example:
++
+[source,text]
+----
+quay.io/my-registry/custom-image:rendered-worker-dd37180cefa6a1e88834966330c0c028
+----
+
+.. Get the name of the push secret to enable the final {op-system} image that will be pushed using the above pullspec. This must be created as a secret within the MCO namespace. For example:
++
+[source,terminal]
+----
+$ <command to copy final image push secret to MCO namespace>
+----
+
+.. Optional: Make a note of the original {op-system} image. You will need this to revert the node, in the case that you want to opt-out:
++
+[source,terminal]
+----
+$ oc get configmap/machine-config-osimageurl && \
+  -n openshift-machine-config-operator && \
+  -o=jsonpath='{.data.baseOSContainerImage}'
+----
+
+. Create a new `ConfigMap` object in the MCO namespace using the information from the previous step:
++
+[source,terminal]
+----
+$ oc apply -f <<EOF
+apiVersion: v1
+data:
+  baseImagePullSecretName: global-pull-secret-copy
+  finalImagePushSecretName: final-image-push-secret
+  finalImagePullspec: "quay.io/my-registry/custom-image:latest"
+kind: ConfigMap
+metadata:
+  name: on-cluster-build-config
+  namespace: openshift-machine-config-operator
+EOF
+----
+
+. Create a new `MachineConfigPool` object to use for layering:
++
+[source,terminal]
+----
+$ oc apply -f <<EOF
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  name: layering
+spec:
+  machineConfigSelector:
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [layering, worker]}
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/layering: ""
+EOF
+----
+
+. Create a new a `MachineConfig` object for this new pool that contains the image pullspec:
++
+.layered-os-image-override.yaml
+[source,terminal]
+----
+$ oc apply -f <<EOF
+---
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfig
+metadata:
+  labels:
+    machineconfiguration.openshift.io/role: layered
+  name: layered-os-image-override
+spec:
+  config:
+    ignition:
+      config: {}
+      security:
+        tls: {}
+      timeouts: {}
+      version: 3.2.0
+    storage: {}
+  osImageURL: quay.io/my-registry/custom-image:latest-layered <1>
+EOF
+----
+<1> The image pullspec must be a tagged pullspec, not a fully-qualified one. For example, `latest-layered` instead of `@sha256:abcd...`.
+
+. Label the newly created machine config pool to opt it into layering:
++
+[source,terminal]
+----
+$ oc label mcp/layered 'machineconfiguration.openshift.io/layering-enabled='
+----
++
+The machine config pool does not need to have nodes allocated to it, an on-cluster build happens regardless.
++
+After running the above command, a `machine-os-build` pod will start within the MCO namespace. Afterwards, there will also be a build pod within the MCO namespace for the layered machine config pool.
++
+Once the build finishes, the `MachineConfigPool` object will have an annotation with a fully-qualified pullspec.

--- a/post_installation_configuration/coreos-layering.adoc
+++ b/post_installation_configuration/coreos-layering.adoc
@@ -117,6 +117,9 @@ xref:../post_installation_configuration/coreos-layering.adoc#coreos-layering-upd
 include::modules/coreos-layering-removing.adoc[leveloffset=+1]
 include::modules/coreos-layering-updating.adoc[leveloffset=+1]
 
+include::modules/coreos-layering-on-cluster-opt-in.adoc[leveloffset=+1]
+include::modules/coreos-layering-on-cluster-building-images.adoc[leveloffset=+1]
+include::modules/coreos-layering-on-cluster-applying-new-configs.adoc[leveloffset=+1]
 ////
 Sources:
 https://docs.google.com/document/d/1Eow2IReNWqnIh5HvCfcKV2MWgHUmFKSnBkt2rH6_V_M/edit


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6875
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63170--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/coreos-layering#coreos-layering-on-cluster-opt-in_coreos-layering
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
