### PR TITLE
OSDOCS-6970 Adding NatGateway outbound type

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -989,6 +989,9 @@ By default, if you specify availability zones in the `install-config.yaml` file,
 within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a region]. To ensure high availability for your cluster, select a region with at least three availability zones. If your region contains fewer than three availability zones, the installation program places more than one control plane machine in the available zones.
 ====
 
+//setting for 4.14 NatGateway Tech Preview snippet
+:featureName: `NatGateway`
+
 .Additional Azure parameters
 [cols=".^2,.^3a,.^3a",options="header"]
 |====
@@ -1119,8 +1122,9 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
 you are using user-defined routing, you must have pre-existing networking
 available where the outbound routing has already been configured prior to
 installing a cluster. The installation program is not responsible for
-configuring user-defined routing.
-|`LoadBalancer` or `UserDefinedRouting`. The default is `LoadBalancer`.
+configuring user-defined routing. If you specify the `NatGateway` routing strategy, the installation program will only create one NAT gateway. If you specify the `NatGateway` routing strategy, your account must have the `Microsoft.Network/natGateways/read` and `Microsoft.Network/natGateways/write` permissions.
+include::snippets/technology-preview.adoc[]
+|`LoadBalancer`, `UserDefinedRouting`, or `NatGateway`. The default is `LoadBalancer`.
 
 |`platform.azure.region`
 |The name of the Azure region that hosts your cluster.

--- a/modules/minimum-required-permissions-ipi-azure.adoc
+++ b/modules/minimum-required-permissions-ipi-azure.adoc
@@ -176,6 +176,13 @@ The following permissions are not required to create the private {product-title}
 * `Microsoft.Features/providers/features/register/action`
 ====
 
+.Optional permissions for installing a cluster using the `NatGateway` outbound type
+[%collapsible]
+====
+* `Microsoft.Network/natGateways/read`
+* `Microsoft.Network/natGateways/write`
+====
+
 .Optional permissions for installing a private cluster with Azure Network Address Translation (NAT)
 [%collapsible]
 ====


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6970

Link to docs preview:
[Installation configuration parameters](https://63181--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure#installation-configuration-parameters-additional-azure_installation-config-parameters-azure)
[Required permissions for Azure IPI](https://63181--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account#minimum-required-permissions-ipi-azure_installing-azure-account)

QE review:
- [x] QE has approved this change.
