### PR TITLE
OSDOCS-6951 Adding pd-balanced disktype to GCP  install

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1242,7 +1242,7 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
 
 |`platform.gcp.defaultMachinePlatform.osDisk.diskType`
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type].
-|Either the default `pd-ssd` or the `pd-standard` disk type. The control plane nodes must be the `pd-ssd` disk type. Compute nodes can be either type.
+|The default disk type for all machines. Control plane nodes must use the `pd-ssd` disk type. Compute nodes can use the `pd-ssd`, `pd-balanced`, or `pd-standard` disk types.
 
 |`platform.gcp.defaultMachinePlatform.osImage.project`
 |Optional. By default, the installation program downloads and installs the {op-system} image that is used to boot control plane and compute machines. You can override the default behavior by specifying the location of a custom {op-system} image that the installation program is to use for both types of machines.
@@ -1375,7 +1375,7 @@ When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use
 
 |`compute.platform.gcp.osDisk.diskType`
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for compute machines.
-|Either the default `pd-ssd` or the `pd-standard` disk type.
+|`pd-ssd`, `pd-standard`, or `pd-balanced`. The default is `pd-ssd`.
 
 |`compute.platform.gcp.tags`
 |Optional. Additional network tags to add to the compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.tags` parameter for compute machines.


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6951

Link to docs preview:
https://63183--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp

QE review:
- [x] QE has approved this change.