### PR TITLE
OSDOCS-6951-RN Adding pd-balanced disk type to GCP install

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -74,9 +74,11 @@ Because {product-title} {product-version} now uses a {op-system-base} 9.2 based 
 
 [id="ocp-4-14-nat-gateway-azure"]
 ==== Installing a cluster on Microsoft Azure using a NAT gateway (Technology Preview)
-
 In {product-title} {product-version}, you can install a cluster that uses a NAT gateway for outbound networking. This is available as a Technology Preview (TP). For more information, see xref:../installing/installing_azure/installation-config-parameters-azure.adoc#installation-configuration-parameters-additional-azure_installation-config-parameters-azure[Additional Azure configuration parameters].
 
+[id="ocp-4-14-pd-balanced-disktype-gcp"]
+==== Installing a cluster on Google Cloud Platform (GCP) using pd-balanced disk type
+In {product-title} {product-version}, you can install a cluster on GCP using the `pd-balanced` disk type. This disk type is only available for compute nodes and cannot be used for control plane nodes. For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional GCP configuration parameters].
 
 [id="ocp-4-14-user-defined-tags-azure"]
 ==== User-defined tags for Microsoft Azure is now generally available


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6951

Link to docs preview:
https://63184--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-pd-balanced-disktype-gcp

QE review:
- [x] QE has approved this change.
