### PR TITLE
RHDEVDOCS-5172 set main branch to gitops-docs for netlify build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ jobs:
       env:
         - CAN_FAIL=true
       language: minimal
-      if: type IN (pull_request) AND branch IN (main, gitops-docs-1.8, gitops-docs-1.9) AND sender != "openshift-cherrypick-robot"
+      if: type IN (pull_request) AND branch IN (gitops-docs, gitops-docs-1.8, gitops-docs-1.9) AND sender != "openshift-cherrypick-robot"
       script:
         - chmod +x autopreview.sh && ./autopreview.sh
 


### PR DESCRIPTION

Version(s):
gitops-docs, gitops-docs-1.8,  gitops-docs-1.9

Issue:
[RHDEVDOCS-5172](https://issues.redhat.com//browse/RHDEVDOCS-5172)

