### PR TITLE
OSDOCS#7302: Release notes for the cert-manager Operator 1.10.3

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -76,6 +76,31 @@ This is the general availability (GA) release of the {cert-manager-operator}.
 
 * After uninstalling the {cert-manager-operator} by using the web console, the {cert-manager-operator} does not remove the cert-manager controller, CA injector, and Webhook pods automatically from the `cert-manager` namespace. As a workaround, you can manually delete the cert-manager controller, CA injector, and Webhook pod deployments present in the `cert-manager` namespace. (link:https://issues.redhat.com/browse/OCPBUGS-13679[*OCPBUGS-13679*])
 
+[id="cert-manager-operator-release-notes-1.10.3"]
+== Release notes for {cert-manager-operator} 1.10.3
+
+Issued: 2023-08-08
+
+The following advisory is available for the {cert-manager-operator} 1.10.3:
+
+* link:https://access.redhat.com/errata/RHSA-2023:4335[RHSA-2023:4335]
+
+The version `1.10.3` of the {cert-manager-operator} is based on the `cert-manager` upstream version `v1.10.2`. With this release, the version of the {cert-manager-operator} is `1.10.3` but the `cert-manager` operand version is `1.10.2`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.10/#v1102-changes-since-v1101[cert-manager project release notes for v1.10.2].
+
+[id="cert-manager-operator-1.10.3-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2022-41725[CVE-2022-41725]
+* link:https://access.redhat.com/security/cve/CVE-2022-41724[CVE-2022-41724]
+* link:https://access.redhat.com/security/cve/CVE-2023-24536[CVE-2023-24536]
+* link:https://access.redhat.com/security/cve/CVE-2023-24538[CVE-2023-24538]
+* link:https://access.redhat.com/security/cve/CVE-2023-24537[CVE-2023-24537]
+* link:https://access.redhat.com/security/cve/CVE-2023-24534[CVE-2023-24534]
+* link:https://access.redhat.com/security/cve/CVE-2022-41723[CVE-2022-41723]
+* link:https://access.redhat.com/security/cve/CVE-2023-29400[CVE-2023-29400]
+* link:https://access.redhat.com/security/cve/CVE-2023-24540[CVE-2023-24540]
+* link:https://access.redhat.com/security/cve/CVE-2023-24539[CVE-2023-24539]
+
 [id="cert-manager-operator-release-notes-1.10.2"]
 == Release notes for {cert-manager-operator} 1.10.2
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7302
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63188--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
