### PR TITLE
OSDOCS#6447: Added a new ImageSet config example to include multi-arch feature.

### DIFF
--- a/modules/oc-mirror-image-set-config-examples.adoc
+++ b/modules/oc-mirror-image-set-config-examples.adoc
@@ -209,6 +209,33 @@ mirror:
     targetCatalog: my-namespace/my-operator-catalog
 ----
 
+// New example; multi-arch; all versions
+[discrete]
+[id="oc-mirror-image-set-examples-multi-arch_{context}"]
+== Use case: Including all versions of OpenShift Container Platform from a minimum to the latest
+
+The following `ImageSetConfiguration` file sets the `architectures` field to `multi` to include `multi` as the platform architecture which mirrors a multi-arch release image.
+
+Previously, oc-mirror users are able to mirror x86_64 release images when no platform architecture is specified in imageSetConfig. They could also mirror other architectures individually by adding other platform architectures in the imageSetConfig.
+
+With this feature, users can specify multi as the platform architecture which mirrors a multi-arch release image.
+
+
+.Example `ImageSetConfiguration` file
+[source,yaml]
+----
+apiVersion: mirror.openshift.io/v1alpha2
+kind: ImageSetConfiguration
+mirror:
+  platform:
+architectures:
+   - "multi" # Valid values are: amd64(default), arm64, ppc64le, s390x and multi.
+channels:
+   - name: stable-4.13
+     minVersion: 4.13.4
+     maxVersion: 4.13.6
+----
+
 // Moved to last; unchanged
 [discrete]
 [id="oc-mirror-image-set-examples-helm_{context}"]


### PR DESCRIPTION
Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-6447](https://issues.redhat.com/browse/OSDOCS-6447)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Doc Preview](https://63191--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected#oc-mirror-image-set-examples_installing-mirroring-disconnected)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
