### PR TITLE
RHDEVDOCS-5565: Expose TEKTON_HUB_API variable in the tektonconfig.

### DIFF
--- a/cicd/pipelines/remote-pipelines-tasks-resolvers.adoc
+++ b/cicd/pipelines/remote-pipelines-tasks-resolvers.adoc
@@ -21,7 +21,12 @@ Git resolver:: Retrieves a task or pipeline binding from a Git repository. You m
 
 [id="resolver-hub_{context}"]
 == Specifying a remote pipeline or task from a Tekton catalog
-You can specify a remote pipeline or task that is defined in a public Tekton catalog, either link:https://artifacthub.io/[{artifact-hub}] or link:https://hub.tekton.dev/[{tekton-hub}], by using the hub resolver.
+You can use the hub resolver to specify a remote pipeline or task that is defined either in a public Tekton catalog of link:https://artifacthub.io/[{artifact-hub}] or in an instance of {tekton-hub}.
+
+[IMPORTANT]
+====
+The {artifact-hub} project is not supported with {pipelines-title}. Only the configuration of {artifact-hub} is supported.
+====
 
 include::modules/op-resolver-hub-config.adoc[leveloffset=+2]
 include::modules/op-resolver-hub.adoc[leveloffset=+2]
@@ -29,7 +34,7 @@ include::modules/op-resolver-hub.adoc[leveloffset=+2]
 [id="resolver-bundles_{context}"]
 == Specifying a remote pipeline or task from a Tekton bundle
 
-You can specify a remote pipeline or task from a Tekton bundle by using the bundles resolver. A Tekton bundle is an OCI image available from any OCI repository, such as an OpenShift container repository.
+You can use the bundles resolver to specify a remote pipeline or task from a Tekton bundle. A Tekton bundle is an OCI image available from any OCI repository, such as an OpenShift container repository.
 
 include::modules/op-resolver-bundle-config.adoc[leveloffset=+2]
 include::modules/op-resolver-bundle.adoc[leveloffset=+2]
@@ -37,7 +42,7 @@ include::modules/op-resolver-bundle.adoc[leveloffset=+2]
 [id="resolver-cluster_{context}"]
 == Specifying a remote pipeline or task from the same cluster
 
-You can specify a remote pipeline or task that is defined in a namespace on the {product-title} cluster where {pipelines-title} is running by using the cluster resolver.
+You can use the cluster resolver to specify a remote pipeline or task that is defined in a namespace on the {product-title} cluster where {pipelines-title} is running.
 
 include::modules/op-resolver-cluster-config.adoc[leveloffset=+2]
 include::modules/op-resolver-cluster.adoc[leveloffset=+2]
@@ -45,8 +50,14 @@ include::modules/op-resolver-cluster.adoc[leveloffset=+2]
 [id="resolver-git_{context}"]
 == Specifying a remote pipeline or task from a Git repository
 
-You can specify a remote pipeline or task from a Git repostory by using the Git resolver. The repository must contain a YAML file that defines the pipeline or task. The Git resolver can access a repository either by cloning it anonymously or else by using the authenticated SCM API.
+You can use the Git resolver to specify a remote pipeline or task from a Git repostory. The repository must contain a YAML file that defines the pipeline or task. The Git resolver can access a repository either by cloning it anonymously or else by using the authenticated SCM API.
 
 include::modules/op-resolver-git-config-anon.adoc[leveloffset=+2]
 include::modules/op-resolver-git-config-scm.adoc[leveloffset=+2]
 include::modules/op-resolver-git.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_{context}"]
+== Additional resources
+
+* xref:../../cicd/pipelines/using-tekton-hub-with-openshift-pipelines.adoc#using-tekton-hub-with-openshift-pipelines[Using Tekton Hub with {pipelines-shortname}]

--- a/modules/op-resolver-hub-config.adoc
+++ b/modules/op-resolver-hub-config.adoc
@@ -33,9 +33,20 @@ spec:
       default-artifact-hub-pipeline-catalog: tekton-catalog-pipelines # <3>
       defailt-kind: pipeline # <4>
       default-type: tekton # <5>
+      tekton-hub-api: "https://my-custom-tekton-hub.example.com" # <6>
+      artifact-hub-api: "https://my-custom-artifact-hub.example.com" # <7>
 ----
 <1> The default {tekton-hub} catalog for pulling a resource.
 <2> The default {artifact-hub} catalog for pulling a task resource.
 <3> The default {artifact-hub} catalog for pulling a pipeline resource.
 <4> The default object kind for references.
 <5> The default hub for pulling a resource, either `artifact` for {artifact-hub} or `tekton` for {tekton-hub}.
+<6> The {tekton-hub} API used, if the `default-type` option is set to `tekton`.
+<7> Optional: The {artifact-hub} API used, if the `default-type` option is set to `artifact`.
++
+[IMPORTANT]
+====
+If you set the `default-type` option to `tekton`, you must configure your own instance of the {tekton-hub} by setting the `tekton-hub-api` value.
+
+If you set the `default-type` option to `artifact` then the resolver uses the public hub API at https://artifacthub.io/ by default. You can configure your own {artifact-hub} API by setting the `artifact-hub-api` value.
+====


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: enterprise-4.12 and later
• **JIRA issue**:  [RHDEVDOCS-5565](https://issues.redhat.com/browse/RHDEVDOCS-5565)
• **Preview page**: [Configuring the hub resolver](https://63192--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/remote-pipelines-tasks-resolvers#resolver-hub-config_remote-pipelines-tasks-resolvers)
• **SME Review**: Completed by @jkandasa 
• **QE review**: Completed by @ppitonak 
• **Peer-review**: Completed by @mramendi 