### PR TITLE
Add information about building with docker

### DIFF
--- a/contributing_to_docs/tools_and_setup.adoc
+++ b/contributing_to_docs/tools_and_setup.adoc
@@ -77,6 +77,20 @@ of the box, but if you are on Windows you can use http://cygwin.com/[Cygwin])
 * An editor that can strip trailing whitespace, such as
 link:https://code.visualstudio.com/[Visual Studio Code].
 
+=== Building using the asciibinder container image
+
+. Install the _docker_ or _link:https://podman.io/docs/installation[Podman]_ package.
+. Change to the `openshift-docs` directory and build every distribution by entering the `run` command for the tool that you are using. The following example uses Docker and is identical for Podman on Linux. This example might require some setup on a Mac. 
++
+----
+$ cd openshift-docs
+$ docker run --rm -it -v `pwd`:/docs:Z quay.io/openshift-cs/asciibinder asciibinder build
+----
+. Open the generated HTML file in your web browser. This will be located in the
+`openshift-docs/_preview/<distro>/<branch>` directory, with the same path and
+filename as the original `.adoc` file you edited, but with an
+`.html` extension.
+
 === Install the required software dependencies on a Linux system
 The following instructions describe how to install all the required tools to do
 live content editing on a Fedora Linux system.


### PR DESCRIPTION
Add information in setup guide about building locally with docker. This method does not require installing external dependencies except `docker` or `podman`.