### PR TITLE
OSDOCS-7311: adds release note MShift 4.12.28

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -250,7 +250,7 @@ Issued: 2023-06-26
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-23-dp"]
-=== RHBA-2023:3621 - {product-title} 4.12.23 bug fix and security update
+=== RHBA-2023:3928 - {product-title} 4.12.23 bug fix and security update
 
 Issued: 2023-07-06
 
@@ -268,7 +268,7 @@ Issued: 2023-07-12
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-25-dp"]
-=== RHBA-2023:3677 - {product-title} 4.12.25 bug fix update
+=== RHBA-2023:4047 - {product-title} 4.12.25 bug fix update
 
 Issued: 2023-07-19
 
@@ -291,5 +291,14 @@ For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers
 Issued: 2023-08-02
 
 {product-title} release 4.12.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4321[RHBA-2023:4321] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4319[RHBA-2023:4319] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-28-dp"]
+=== RHBA-2023:4442 - {product-title} 4.12.28 bug fix update
+
+Issued: 2023-08-09
+
+{product-title} release 4.12.28 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4442[RHBA-2023:4442] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4440[RHBA-2023:4440] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-7311

Link to docs preview:
https://63202--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes#microshift-4-12-28-dp

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
