### PR TITLE
OSDOCS-7286 Z-stream RNs for 4.13.8

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3051,3 +3051,28 @@ $ oc adm release info 4.13.6 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-13-8"]
+=== RHSA-2023:4456 - {product-title} 4.13.8 bug fix and security update
+
+Issued: 2023-08-08
+
+{product-title} release 4.13.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:4456[RHSA-2023:4456] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4459[RHSA-2023:4459] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.8 --pullspecs
+----
+
+[id="ocp-4-13-8-bug-fixes"]
+==== Bug fixes
+* Previously, the real loadbalancer address in the {rh-openstack-first} was not visible. With this update, the real loadbalancer address has been added and is visible in the {rh-openstack} loadbalancer object annotation. (link:https://issues.redhat.com/browse/OCPBUGS-15973[*OCPBUGS-15973*])
+
+[id="ocp-4-13-8-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-7286](https://issues.redhat.com/browse/OSDOCS-7286)

Link to docs preview:
[Preview](https://63216--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-8)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Expected to ship live on Aug. 8, 2023.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
