### PR TITLE
OSDOCS-5912: OSUS architecture recommendations

### DIFF
--- a/modules/disconnected-osus-overview.adoc
+++ b/modules/disconnected-osus-overview.adoc
@@ -11,4 +11,12 @@ The OpenShift Update Service (OSUS) provides update recommendations to {product-
 
 However, clusters in a disconnected environment cannot access these public APIs to retrieve update information. To have a similar update experience in a disconnected environment, you can install and configure the OpenShift Update Service locally so that it is available within the disconnected environment.
 
+A single OSUS instance is capable of serving recommendations to thousands of clusters.
+OSUS can be scaled horizontally to cater to more clusters by changing the replica value.
+So for most disconnected use cases, one OSUS instance is enough.
+For example, Red Hat hosts just one OSUS instance for the entire fleet of connected clusters.
+
+If you want to keep update recommendations separate in different environments, you can run one OSUS instance for each environment.
+For example, in a case where you have separate test and stage environments, you might not want a cluster in a stage environment to receive update recommendations to version A if that version has not been tested in the test environment yet.
+
 The following sections describe how to install a local OSUS instance and configure it to provide update recommendations to a cluster.


### PR DESCRIPTION
[OSDOCS-5912](https://issues.redhat.com/browse/OSDOCS-5912)

Versions: 4.10+

This PR adds clarity/recommendations for how many OSUS instances are necessary for clusters in disconnected environments. It is meant to discourage users from unnecessarily using more than one instance.

QE review:
- [x] QE has approved this change.

Preview: [Using the OpenShift Update Service in a disconnected environment](https://63218--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus#update-service-overview_updating-restricted-network-cluster-osus)
