### PR TITLE
OSDOCS-4969: Add release note for changing OVN-Kubernetes internal subnet

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -167,6 +167,12 @@ For more information about this more flexible SR-IOV network deployment during N
 ==== Update to HAProxy 2.6
 With this release, {product-title} updated to HAProxy 2.6.
 
+[id="ocp-4-14-networking-changing-ovn-kubernetes-network-plugin-internal-range"]
+==== Support for changing the OVN-Kubernetes network plugin internal IP address range
+
+If you use the OVN-Kubernetes network plugin, the default subnets used are `169.254.169.0/29` and `fd69::/125` for IPv4 and IPv6 respectively. Now you can change these subnets on installed clusters. For more information, see xref:../networking/cluster-network-operator.adoc#nw-operator-cr-cno-object_cluster-network-operator[Cluster Network Operator configuration object].
+
+
 [id="ocp-4-14-storage"]
 === Storage
 


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-4969
- https://issues.redhat.com/browse/SDN-3516

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63226--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-networking-changing-ovn-kubernetes-network-plugin-internal-range

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
