### PR TITLE
[OSDOCS-9373]: Azure CPMS failure domain misc updates (prework)

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-configuration.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-configuration.adoc
@@ -43,12 +43,12 @@ Some sections of the control plane machine set CR are provider-specific. The fol
 //Sample AWS provider specification
 include::modules/cpmso-yaml-provider-spec-aws.adoc[leveloffset=+2]
 
-//Sample AWS failure domain configuration
-include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+2]
-
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-supported-features-aws_cpmso-using[Enabling Amazon Web Services features for control plane machines]
+
+//Sample AWS failure domain configuration
+include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+2]
 
 [id="cpmso-sample-yaml-gcp_{context}"]
 == Sample YAML for configuring Google Cloud Platform clusters
@@ -58,14 +58,13 @@ Some sections of the control plane machine set CR are provider-specific. The fol
 //Sample GCP provider specification
 include::modules/cpmso-yaml-provider-spec-gcp.adoc[leveloffset=+2]
 
-//Sample GCP failure domain configuration
-include::modules/cpmso-yaml-failure-domain-gcp.adoc[leveloffset=+2]
-////
-//To be added in a later PR
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-supported-features-gcp_cpmso-using[Enabling Google Cloud Platform features for control plane machines]
-////
+
+//Sample GCP failure domain configuration
+include::modules/cpmso-yaml-failure-domain-gcp.adoc[leveloffset=+2]
+
 [id="cpmso-sample-yaml-azure_{context}"]
 == Sample YAML for configuring Microsoft Azure clusters
 
@@ -74,12 +73,12 @@ Some sections of the control plane machine set CR are provider-specific. The fol
 //Sample Azure provider specification
 include::modules/cpmso-yaml-provider-spec-azure.adoc[leveloffset=+2]
 
-//Sample Azure failure domain configuration
-include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+2]
-
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-supported-features-azure_cpmso-using[Enabling Microsoft Azure features for control plane machines]
+
+//Sample Azure failure domain configuration
+include::modules/cpmso-yaml-failure-domain-azure.adoc[leveloffset=+2]
 
 [id="cpmso-sample-yaml-nutanix_{context}"]
 == Sample YAML for configuring Nutanix clusters

--- a/modules/cpmso-yaml-failure-domain-aws.adoc
+++ b/modules/cpmso-yaml-failure-domain-aws.adoc
@@ -13,25 +13,36 @@ When configuring AWS failure domains in the control plane machine set, you must 
 .Sample AWS failure domain values
 [source,yaml]
 ----
-failureDomains:
-  aws:
-  - placement:
-      availabilityZone: <aws_zone_a> <1>
-    subnet: <2>
-      filters:
-      - name: tag:Name
-        values:
-        - <cluster_id>-private-<aws_zone_a> <3>
-      type: Filters <4>
-  - placement:
-      availabilityZone: <aws_zone_b> <5>
-    subnet:
-      filters:
-      - name: tag:Name
-        values:
-        - <cluster_id>-private-<aws_zone_b> <6>
-      type: Filters
-  platform: AWS <7>
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+    machines_v1beta1_machine_openshift_io:
+      failureDomains:
+        aws:
+        - placement:
+            availabilityZone: <aws_zone_a> <1>
+          subnet: <2>
+            filters:
+            - name: tag:Name
+              values:
+              - <cluster_id>-private-<aws_zone_a> <3>
+            type: Filters <4>
+        - placement:
+            availabilityZone: <aws_zone_b> <5>
+          subnet:
+            filters:
+            - name: tag:Name
+              values:
+              - <cluster_id>-private-<aws_zone_b> <6>
+            type: Filters
+        platform: AWS <7>
+# ...
 ----
 <1> Specifies an AWS availability zone for the first failure domain.
 <2> Specifies a subnet configuration. In this example, the subnet type is `Filters`, so there is a `filters` stanza.

--- a/modules/cpmso-yaml-failure-domain-azure.adoc
+++ b/modules/cpmso-yaml-failure-domain-azure.adoc
@@ -8,17 +8,33 @@
 
 The control plane machine set concept of a failure domain is analogous to existing Azure concept of an link:https://learn.microsoft.com/en-us/azure/azure-web-pubsub/concept-availability-zones[_Azure availability zone_]. The `ControlPlaneMachineSet` CR spreads control plane machines across multiple failure domains when possible.
 
-When configuring Azure failure domains in the control plane machine set, you must specify the availability zone name.
+When configuring Azure failure domains in the control plane machine set, you must specify the availability zone name. An Azure cluster uses a single subnet that spans multiple zones.
 
 .Sample Azure failure domain values
 [source,yaml]
 ----
-failureDomains:
-  azure: <1>
-  - zone: "1"
-  - zone: "2"
-  - zone: "3"
-  platform: Azure <2>
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+    machines_v1beta1_machine_openshift_io:
+      failureDomains:
+        azure:
+        - zone: "1" # <1>
+        - zone: "2"
+        - zone: "3"
+        platform: Azure # <2>
+# ...
 ----
 <1> Each instance of `zone` specifies an Azure availability zone for a failure domain.
++
+[NOTE]
+====
+If the cluster is configured to use a single zone for all failure domains, the `zone` parameter is configured in the provider specification instead of in the failure domain configuration.
+====
 <2> Specifies the cloud provider platform name. Do not change this value.

--- a/modules/cpmso-yaml-failure-domain-gcp.adoc
+++ b/modules/cpmso-yaml-failure-domain-gcp.adoc
@@ -13,13 +13,24 @@ When configuring GCP failure domains in the control plane machine set, you must 
 .Sample GCP failure domain values
 [source,yaml]
 ----
-failureDomains:
-  gcp:
-  - zone: <gcp_zone_a> <1>
-  - zone: <gcp_zone_b> <2>
-  - zone: <gcp_zone_c>
-  - zone: <gcp_zone_d>
-  platform: GCP <3>
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+    machines_v1beta1_machine_openshift_io:
+      failureDomains:
+        gcp:
+        - zone: <gcp_zone_a> <1>
+        - zone: <gcp_zone_b> <2>
+        - zone: <gcp_zone_c>
+        - zone: <gcp_zone_d>
+        platform: GCP <3>
+# ...
 ----
 <1> Specifies a GCP zone for the first failure domain.
 <2> Specifies an additional failure domain. Further failure domains are added the same way.

--- a/modules/cpmso-yaml-failure-domain-openstack.adoc
+++ b/modules/cpmso-yaml-failure-domain-openstack.adoc
@@ -6,23 +6,34 @@
 [id="cpmso-yaml-failure-domain-openstack_{context}"]
 = Sample {rh-openstack} failure domain configuration
 // TODO: Replace that link.
-The control plane machine set concept of a failure domain is analogous to existing {rh-openstack-first} concept of an link:https://docs.openstack.org/nova/latest/admin/availability-zones.html[availability zone]. The `ControlPlaneMachineSet` CR spreads control plane machines across multiple failure domains when possible.
+The control plane machine set concept of a failure domain is analogous to the existing {rh-openstack-first} concept of an link:https://docs.openstack.org/nova/latest/admin/availability-zones.html[availability zone]. The `ControlPlaneMachineSet` CR spreads control plane machines across multiple failure domains when possible.
 
 The following example demonstrates the use of multiple Nova availability zones as well as Cinder availability zones.
 
 .Sample OpenStack failure domain values
 [source,yaml]
 ----
-failureDomains:
-  platform: OpenStack
-  openstack:
-  - availabilityZone: nova-az0
-    rootVolume:
-      availabilityZone: cinder-az0
-  - availabilityZone: nova-az1
-    rootVolume:
-      availabilityZone: cinder-az1
-  - availabilityZone: nova-az2
-    rootVolume:
-      availabilityZone: cinder-az2
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+    machines_v1beta1_machine_openshift_io:
+      failureDomains:
+        platform: OpenStack
+        openstack:
+        - availabilityZone: nova-az0
+          rootVolume:
+            availabilityZone: cinder-az0
+        - availabilityZone: nova-az1
+          rootVolume:
+            availabilityZone: cinder-az1
+        - availabilityZone: nova-az2
+          rootVolume:
+            availabilityZone: cinder-az2
+# ...
 ----

--- a/modules/cpmso-yaml-failure-domain-vsphere.adoc
+++ b/modules/cpmso-yaml-failure-domain-vsphere.adoc
@@ -6,7 +6,7 @@
 [id="cpmso-yaml-failure-domain-vsphere_{context}"]
 = Sample VMware vSphere failure domain configuration
 
-On VMware vSphere infrastructure, the cluster-wide infrastructure Custom Resource Definition (CRD), `infrastructures.config.openshift.io`, defines failure domains for your cluster. The `providerSpec` in the `ControlPlaneMachineSet` custom resource (CR) specifies names for failure domains. A failure domain is an infrastructure resource that comprises a control plane machine set, a vCenter datacenter, vCenter datastore, and a network. 
+On VMware vSphere infrastructure, the cluster-wide infrastructure Custom Resource Definition (CRD), `infrastructures.config.openshift.io`, defines failure domains for your cluster. The `providerSpec` in the `ControlPlaneMachineSet` custom resource (CR) specifies names for failure domains. A failure domain is an infrastructure resource that comprises a control plane machine set, a vCenter datacenter, vCenter datastore, and a network.
 
 By using a failure domain resource, you can use a control plane machine set to deploy control plane machines on hardware that is separate from the primary VMware vSphere infrastructure. A control plane machine set also balances control plane machines across defined failure domains to provide fault tolerance capabilities to your infrastructure.
 
@@ -18,7 +18,7 @@ If you modify the `ProviderSpec` configuration in the `ControlPlaneMachineSet` C
 :FeatureName: Defining a failure domain for a control plane machine set
 include::snippets/technology-preview.adoc[]
 
-.Example ProviderSpec configuration with specified failure domain names
+.Sample vSphere failure domain values
 [source,yaml]
 ----
 apiVersion: machine.openshift.io/v1
@@ -29,14 +29,14 @@ metadata:
 spec:
 # ...
   template:
-    machineType: machines_v1beta1_machine_openshift_io
+# ...
     machines_v1beta1_machine_openshift_io:
       failureDomains: <1>
         platform: VSphere
         vsphere: <2>
         - name: <failure_domain_name1>
-        - name: <failure_domain_name2> 
-# ...    
+        - name: <failure_domain_name2>
+# ...
 ----
 <1> A failure domain defines the vCenter location for {product-title} cluster nodes.
 <2> Defines failure domains by name for the control plane machine set.

--- a/modules/cpmso-yaml-provider-spec-aws.adoc
+++ b/modules/cpmso-yaml-provider-spec-aws.adoc
@@ -18,44 +18,56 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 .Sample AWS `providerSpec` values
 [source,yaml]
 ----
-providerSpec:
-  value:
-    ami:
-      id: ami-<ami_id_string> <1>
-    apiVersion: machine.openshift.io/v1beta1
-    blockDevices:
-    - ebs: <2>
-        encrypted: true
-        iops: 0
-        kmsKey:
-          arn: ""
-        volumeSize: 120
-        volumeType: gp3
-    credentialsSecret:
-      name: aws-cloud-credentials <3>
-    deviceIndex: 0
-    iamInstanceProfile:
-      id: <cluster_id>-master-profile <4>
-    instanceType: m6i.xlarge <5>
-    kind: AWSMachineProviderConfig <6>
-    loadBalancers: <7>
-    - name: <cluster_id>-int
-      type: network
-    - name: <cluster_id>-ext
-      type: network
-    metadata:
-      creationTimestamp: null
-    metadataServiceOptions: {}
-    placement: <8>
-      region: <region> <9>
-    securityGroups:
-    - filters:
-      - name: tag:Name
-        values:
-        - <cluster_id>-master-sg <10>
-    subnet: {} <11>
-    userDataSecret:
-      name: master-user-data <12>
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+      spec:
+        providerSpec:
+          value:
+            ami:
+              id: ami-<ami_id_string> <1>
+            apiVersion: machine.openshift.io/v1beta1
+            blockDevices:
+            - ebs: <2>
+                encrypted: true
+                iops: 0
+                kmsKey:
+                  arn: ""
+                volumeSize: 120
+                volumeType: gp3
+            credentialsSecret:
+              name: aws-cloud-credentials <3>
+            deviceIndex: 0
+            iamInstanceProfile:
+              id: <cluster_id>-master-profile <4>
+            instanceType: m6i.xlarge <5>
+            kind: AWSMachineProviderConfig <6>
+            loadBalancers: <7>
+            - name: <cluster_id>-int
+              type: network
+            - name: <cluster_id>-ext
+              type: network
+            metadata:
+              creationTimestamp: null
+            metadataServiceOptions: {}
+            placement: <8>
+              region: <region> <9>
+              availabilityZone: "" <10>
+              tenancy: <11>
+            securityGroups:
+            - filters:
+              - name: tag:Name
+                values:
+                - <cluster_id>-master-sg <12>
+            subnet: {} <13>
+            userDataSecret:
+              name: master-user-data <14>
 ----
 <1> Specifies the {op-system-first} Amazon Machine Images (AMI) ID for the cluster. The AMI must belong to the same region as the cluster. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
 <2> Specifies the configuration of an encrypted EBS volume.
@@ -64,8 +76,20 @@ providerSpec:
 <5> Specifies the AWS instance type for the control plane.
 <6> Specifies the cloud provider platform type. Do not change this value.
 <7> Specifies the internal (`int`) and external (`ext`) load balancers for the cluster.
-<8> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.
+<8> Specifies where to create the control plane instance in AWS.
 <9> Specifies the AWS region for the cluster.
-<10> Specifies the control plane machines security group.
-<11> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.
-<12> Specifies the control plane user data secret. Do not change this value.
+<10> This parameter is configured in the failure domain and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Control Plane Machine Set Operator overwrites it with the value in the failure domain.
+<11> Specifies the AWS Dedicated Instance configuration for the control plane. For more information, see AWS documentation about link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/dedicated-instance.html[Dedicated Instances]. The following values are valid:
+* `default`: The Dedicated Instance runs on shared hardware.
+* `dedicated`: The Dedicated Instance runs on single-tenant hardware.
+* `host`: The Dedicated Instance runs on a Dedicated Host, which is an isolated server with configurations that you can control.
+<12> Specifies the control plane machines security group.
+<13> This parameter is configured in the failure domain and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Control Plane Machine Set Operator overwrites it with the value in the failure domain.
++
+[NOTE]
+====
+If the failure domain configuration does not specify a value, the value in the provider specification is used.
+Configuring a subnet in the failure domain overwrites the subnet value in the provider specification.
+====
+//TODO: clarify with dev about this one in 4.16+
+<14> Specifies the control plane user data secret. Do not change this value.

--- a/modules/cpmso-yaml-provider-spec-azure.adoc
+++ b/modules/cpmso-yaml-provider-spec-azure.adoc
@@ -18,43 +18,53 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 .Sample Azure `providerSpec` values
 [source,yaml]
 ----
-providerSpec:
-  value:
-    acceleratedNetworking: true
-    apiVersion: machine.openshift.io/v1beta1
-    credentialsSecret:
-      name: azure-cloud-credentials <1>
-      namespace: openshift-machine-api
-    diagnostics: {}
-    image: <2>
-      offer: ""
-      publisher: ""
-      resourceID: /resourceGroups/<cluster_id>-rg/providers/Microsoft.Compute/galleries/gallery_<cluster_id>/images/<cluster_id>-gen2/versions/412.86.20220930 <3>
-      sku: ""
-      version: ""
-    internalLoadBalancer: <cluster_id>-internal <4>
-    kind: AzureMachineProviderSpec <5>
-    location: <region> <6>
-    managedIdentity: <cluster_id>-identity
-    metadata:
-      creationTimestamp: null
-      name: <cluster_id>
-    networkResourceGroup: <cluster_id>-rg
-    osDisk: <7>
-      diskSettings: {}
-      diskSizeGB: 1024
-      managedDisk:
-        storageAccountType: Premium_LRS
-      osType: Linux
-    publicIP: false
-    publicLoadBalancer: <cluster_id> <8>
-    resourceGroup: <cluster_id>-rg
-    subnet: <cluster_id>-master-subnet <9>
-    userDataSecret:
-      name: master-user-data <10>
-    vmSize: Standard_D8s_v3
-    vnet: <cluster_id>-vnet
-    zone: "" <11>
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+      spec:
+        providerSpec:
+          value:
+            acceleratedNetworking: true
+            apiVersion: machine.openshift.io/v1beta1
+            credentialsSecret:
+              name: azure-cloud-credentials <1>
+              namespace: openshift-machine-api
+            diagnostics: {}
+            image: <2>
+              offer: ""
+              publisher: ""
+              resourceID: /resourceGroups/<cluster_id>-rg/providers/Microsoft.Compute/galleries/gallery_<cluster_id>/images/<cluster_id>-gen2/        versions/412.86.20220930 <3>
+              sku: ""
+              version: ""
+            internalLoadBalancer: <cluster_id>-internal <4>
+            kind: AzureMachineProviderSpec <5>
+            location: <region> <6>
+            managedIdentity: <cluster_id>-identity
+            metadata:
+              creationTimestamp: null
+              name: <cluster_id>
+            networkResourceGroup: <cluster_id>-rg
+            osDisk: <7>
+              diskSettings: {}
+              diskSizeGB: 1024
+              managedDisk:
+                storageAccountType: Premium_LRS
+              osType: Linux
+            publicIP: false
+            publicLoadBalancer: <cluster_id> <8>
+            resourceGroup: <cluster_id>-rg
+            subnet: <cluster_id>-master-subnet <9>
+            userDataSecret:
+              name: master-user-data <10>
+            vmSize: Standard_D8s_v3
+            vnet: <cluster_id>-vnet
+            zone: "1" <11>
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the image details for your control plane machine set.
@@ -66,4 +76,10 @@ providerSpec:
 <8> Specifies the public load balancer for the control plane.
 <9> Specifies the subnet for the control plane.
 <10> Specifies the control plane user data secret. Do not change this value.
-<11> This parameter is configured in the failure domain, and is shown with an empty value here. If a value specified for this parameter differs from the value in the failure domain, the Operator overwrites it with the value in the failure domain.
+<11> Specifies the zone configuration for clusters that use a single zone for all failure domains.
++
+[NOTE]
+====
+If the cluster is configured to use a different zone for each failure domain, this parameter is configured in the failure domain.
+If you specify this value in the provider specification, the Control Plane Machine Set Operator ignores it.
+====

--- a/modules/cpmso-yaml-provider-spec-gcp.adoc
+++ b/modules/cpmso-yaml-provider-spec-gcp.adoc
@@ -33,42 +33,52 @@ $ oc -n openshift-machine-api \
 .Sample GCP `providerSpec` values
 [source,yaml]
 ----
-providerSpec:
-  value:
-    apiVersion: machine.openshift.io/v1beta1
-    canIPForward: false
-    credentialsSecret:
-      name: gcp-cloud-credentials <1>
-    deletionProtection: false
-    disks:
-    - autoDelete: true
-      boot: true
-      image: <path_to_image> <2>
-      labels: null
-      sizeGb: 200
-      type: pd-ssd
-    kind: GCPMachineProviderSpec <3>
-    machineType: e2-standard-4
-    metadata:
-      creationTimestamp: null
-    metadataServiceOptions: {}
-    networkInterfaces:
-    - network: <cluster_id>-network
-      subnetwork: <cluster_id>-master-subnet
-    projectID: <project_name> <4>
-    region: <region> <5>
-    serviceAccounts:
-    - email: <cluster_id>-m@<project_name>.iam.gserviceaccount.com
-      scopes:
-      - https://www.googleapis.com/auth/cloud-platform
-    shieldedInstanceConfig: {}
-    tags:
-    - <cluster_id>-master
-    targetPools:
-    - <cluster_id>-api
-    userDataSecret:
-      name: master-user-data <6>
-    zone: "" <7>
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+      spec:
+        providerSpec:
+          value:
+            apiVersion: machine.openshift.io/v1beta1
+            canIPForward: false
+            credentialsSecret:
+              name: gcp-cloud-credentials <1>
+            deletionProtection: false
+            disks:
+            - autoDelete: true
+              boot: true
+              image: <path_to_image> <2>
+              labels: null
+              sizeGb: 200
+              type: pd-ssd
+            kind: GCPMachineProviderSpec <3>
+            machineType: e2-standard-4
+            metadata:
+              creationTimestamp: null
+            metadataServiceOptions: {}
+            networkInterfaces:
+            - network: <cluster_id>-network
+              subnetwork: <cluster_id>-master-subnet
+            projectID: <project_name> <4>
+            region: <region> <5>
+            serviceAccounts:
+            - email: <cluster_id>-m@<project_name>.iam.gserviceaccount.com
+              scopes:
+              - https://www.googleapis.com/auth/cloud-platform
+            shieldedInstanceConfig: {}
+            tags:
+            - <cluster_id>-master
+            targetPools:
+            - <cluster_id>-api
+            userDataSecret:
+              name: master-user-data <6>
+            zone: "" <7>
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the path to the image that was used to create the disk.

--- a/modules/cpmso-yaml-provider-spec-nutanix.adoc
+++ b/modules/cpmso-yaml-provider-spec-nutanix.adoc
@@ -24,36 +24,46 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 .Sample Nutanix `providerSpec` values
 [source,yaml]
 ----
-providerSpec:
-  value:
-    apiVersion: machine.openshift.io/v1
-    bootType: "" <1>
-    categories: <2>
-    - key: <category_name>
-      value: <category_value>
-    cluster: <3>
-      type: uuid
-      uuid: <cluster_uuid>
-    credentialsSecret:
-      name: nutanix-credentials <4>
-    image: <5>
-      name: <cluster_id>-rhcos
-      type: name
-    kind: NutanixMachineProviderConfig <6>
-    memorySize: 16Gi <7>
-    metadata:
-      creationTimestamp: null
-    project: <8>
-      type: name
-      name: <project_name>
-    subnets: <9>
-    - type: uuid
-      uuid: <subnet_uuid>
-    systemDiskSize: 120Gi <10>
-    userDataSecret:
-      name: master-user-data <11>
-    vcpuSockets: 8 <12>
-    vcpusPerSocket: 1 <13>
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+      spec:
+        providerSpec:
+          value:
+            apiVersion: machine.openshift.io/v1
+            bootType: "" <1>
+            categories: <2>
+            - key: <category_name>
+              value: <category_value>
+            cluster: <3>
+              type: uuid
+              uuid: <cluster_uuid>
+            credentialsSecret:
+              name: nutanix-credentials <4>
+            image: <5>
+              name: <cluster_id>-rhcos
+              type: name
+            kind: NutanixMachineProviderConfig <6>
+            memorySize: 16Gi <7>
+            metadata:
+              creationTimestamp: null
+            project: <8>
+              type: name
+              name: <project_name>
+            subnets: <9>
+            - type: uuid
+              uuid: <subnet_uuid>
+            systemDiskSize: 120Gi <10>
+            userDataSecret:
+              name: master-user-data <11>
+            vcpuSockets: 8 <12>
+            vcpusPerSocket: 1 <13>
 ----
 <1> Specifies the boot type that the control plane machines use. For more information about boot types, see link:https://portal.nutanix.com/page/documents/kbs/details?targetId=kA07V000000H3K9SAK[Understanding UEFI, Secure Boot, and TPM in the Virtualized Environment]. Valid values are `Legacy`, `SecureBoot`, or `UEFI`. The default is `Legacy`.
 +
@@ -63,12 +73,28 @@ You must use the `Legacy` boot type in {product-title} {product-version}.
 ====
 <2> Specifies one or more Nutanix Prism categories to apply to control plane machines. This stanza requires `key` and `value` parameters for a category key-value pair that exists in Prism Central. For more information about categories, see link:https://portal.nutanix.com/page/documents/details?targetId=Prism-Central-Guide-vpc_2022_6:ssp-ssp-categories-manage-pc-c.html[Category management].
 <3> Specifies a Nutanix Prism Element cluster configuration. In this example, the cluster type is `uuid`, so there is a `uuid` stanza.
++
+[NOTE]
+====
+Clusters that use {product-title} version 4.15 or later can use failure domain configurations.
+
+For clusters that use failure domains, this value is specified in a failure domain configuration.
+If you specify this value in the provider specification, the Control Plane Machine Set Operator ignores it.
+====
 <4> Specifies the secret name for the cluster. Do not change this value.
 <5> Specifies the image that was used to create the disk.
 <6> Specifies the cloud provider platform type. Do not change this value.
 <7> Specifies the memory allocated for the control plane machines.
 <8> Specifies the Nutanix project that you use for your cluster. In this example, the project type is `name`, so there is a `name` stanza.
 <9> Specifies a subnet configuration. In this example, the subnet type is `uuid`, so there is a `uuid` stanza.
++
+[NOTE]
+====
+Clusters that use {product-title} version 4.15 or later can use failure domain configurations.
+
+For clusters that use failure domains, this value is specified in a failure domain configuration.
+If you specify this value in the provider specification, the Control Plane Machine Set Operator ignores it.
+====
 <10> Specifies the VM disk size for the control plane machines.
 <11> Specifies the control plane user data secret. Do not change this value.
 <12> Specifies the number of vCPU sockets allocated for the control plane machines.

--- a/modules/cpmso-yaml-provider-spec-openstack.adoc
+++ b/modules/cpmso-yaml-provider-spec-openstack.adoc
@@ -11,36 +11,46 @@ When you create a control plane machine set for an existing cluster, the provide
 .Sample OpenStack `providerSpec` values
 [source,yaml]
 ----
-providerSpec:
-  value:
-    apiVersion: machine.openshift.io/v1alpha1
-    cloudName: openstack
-    cloudsSecret:
-      name: openstack-cloud-credentials <1>
-      namespace: openshift-machine-api
-    flavor: m1.xlarge <2>
-    image: ocp1-2g2xs-rhcos
-    kind: OpenstackProviderSpec <3>
-    metadata:
-      creationTimestamp: null
-    networks:
-    - filter: {}
-      subnets:
-      - filter:
-          name: ocp1-2g2xs-nodes
-          tags: openshiftClusterID=ocp1-2g2xs
-    securityGroups:
-    - filter: {}
-      name: ocp1-2g2xs-master <4>
-    serverGroupName: ocp1-2g2xs-master
-    serverMetadata:
-      Name: ocp1-2g2xs-master
-      openshiftClusterID: ocp1-2g2xs
-    tags:
-    - openshiftClusterID=ocp1-2g2xs
-    trunk: true
-    userDataSecret:
-      name: master-user-data
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+      spec:
+        providerSpec:
+          value:
+            apiVersion: machine.openshift.io/v1alpha1
+            cloudName: openstack
+            cloudsSecret:
+              name: openstack-cloud-credentials <1>
+              namespace: openshift-machine-api
+            flavor: m1.xlarge <2>
+            image: ocp1-2g2xs-rhcos
+            kind: OpenstackProviderSpec <3>
+            metadata:
+              creationTimestamp: null
+            networks:
+            - filter: {}
+              subnets:
+              - filter:
+                  name: ocp1-2g2xs-nodes
+                  tags: openshiftClusterID=ocp1-2g2xs
+            securityGroups:
+            - filter: {}
+              name: ocp1-2g2xs-master <4>
+            serverGroupName: ocp1-2g2xs-master
+            serverMetadata:
+              Name: ocp1-2g2xs-master
+              openshiftClusterID: ocp1-2g2xs
+            tags:
+            - openshiftClusterID=ocp1-2g2xs
+            trunk: true
+            userDataSecret:
+              name: master-user-data
 ----
 <1> The secret name for the cluster. Do not change this value.
 <2> The {rh-openstack} flavor type for the control plane.

--- a/modules/cpmso-yaml-provider-spec-vsphere.adoc
+++ b/modules/cpmso-yaml-provider-spec-vsphere.adoc
@@ -4,38 +4,48 @@
 
 :_mod-docs-content-type: REFERENCE
 [id="cpmso-yaml-provider-spec-vsphere_{context}"]
-= Sample vSphere provider specification
+= Sample VMware vSphere provider specification
 
 When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane machine custom resource (CR) that is created by the installation program.
 
 .Sample vSphere `providerSpec` values
 [source,yaml]
 ----
-providerSpec:
-  value:
-    apiVersion: machine.openshift.io/v1beta1
-    credentialsSecret:
-      name: vsphere-cloud-credentials <1>
-    diskGiB: 120 <2>
-    kind: VSphereMachineProviderSpec <3>
-    memoryMiB: 16384 <4>
-    metadata:
-      creationTimestamp: null
-    network: <5>
-      devices:
-      - networkName: <vm_network_name>
-    numCPUs: 4 <6>
-    numCoresPerSocket: 4 <7>
-    snapshot: ""
-    template: <vm_template_name> <8>
-    userDataSecret:
-      name: master-user-data <9>
-    workspace:
-      datacenter: <vcenter_datacenter_name> <10>
-      datastore: <vcenter_datastore_name> <11>
-      folder: <path_to_vcenter_vm_folder> <12>
-      resourcePool: <vsphere_resource_pool> <13>
-      server: <vcenter_server_ip> <14>
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+metadata:
+  name: cluster
+  namespace: openshift-machine-api
+spec:
+# ...
+  template:
+# ...
+      spec:
+        providerSpec:
+          value:
+            apiVersion: machine.openshift.io/v1beta1
+            credentialsSecret:
+              name: vsphere-cloud-credentials <1>
+            diskGiB: 120 <2>
+            kind: VSphereMachineProviderSpec <3>
+            memoryMiB: 16384 <4>
+            metadata:
+              creationTimestamp: null
+            network: <5>
+              devices:
+              - networkName: <vm_network_name>
+            numCPUs: 4 <6>
+            numCoresPerSocket: 4 <7>
+            snapshot: ""
+            template: <vm_template_name> <8>
+            userDataSecret:
+              name: master-user-data <9>
+            workspace:
+              datacenter: <vcenter_datacenter_name> <10>
+              datastore: <vcenter_datastore_name> <11>
+              folder: <path_to_vcenter_vm_folder> <12>
+              resourcePool: <vsphere_resource_pool> <13>
+              server: <vcenter_server_ip> <14>
 ----
 <1> Specifies the secret name for the cluster. Do not change this value.
 <2> Specifies the VM disk size for the control plane machines.


### PR DESCRIPTION
Version(s):
4.15+

Issue:
[OSDOCS-9373](https://issues.redhat.com//browse/OSDOCS-9373)

Link to docs preview:
* [Sample AWS provider specification](https://63227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-aws_cpmso-configuration)
* [Sample GCP failure domain configuration](https://63227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-failure-domain-gcp_cpmso-configuration) (this section was mistakenly commented out from the page - no changes)
* [Sample Azure provider specification](https://63227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-azure_cpmso-configuration)
* [Sample Azure failure domain configuration](https://63227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-failure-domain-azure_cpmso-configuration)
* [Sample Nutanix provider specification](https://63227--ocpdocs-pr.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-provider-spec-nutanix_cpmso-configuration)

QE review:
- [x] QE has approved this change.

Additional information:
This was originally for the multi-subnet feature, but that is no longer in the release. However, some edits from that effort and some related changes should still be merged for 4.15