### PR TITLE
Nodes Miscellaneous docs fixes during ROSA review

### DIFF
--- a/modules/nodes-pods-pod-disruption-about.adoc
+++ b/modules/nodes-pods-pod-disruption-about.adoc
@@ -5,14 +5,10 @@
 // * post_installation_configuration/cluster-tasks.adoc
 
 :_content-type: CONCEPT
-[id="nodes-pods-configuring-pod-distruption-about_{context}"]
+[id="nodes-pods-pod-distruption-about_{context}"]
 = Understanding how to use pod disruption budgets to specify the number of pods that must be up
 
-A _pod disruption budget_ is part of the
-link:http://kubernetes.io/docs/admin/disruptions/[Kubernetes] API, which can be
-managed with `oc` commands like other object types. They
-allow the specification of safety constraints on pods during operations, such as
-draining a node for maintenance.
+A _pod disruption budget_ allows the specification of safety constraints on pods during operations, such as draining a node for maintenance.
 
 `PodDisruptionBudget` is an API object that specifies the minimum number or
 percentage of replicas that must be up at a time. Setting these in projects can

--- a/nodes/containers/nodes-containers-using.adoc
+++ b/nodes/containers/nodes-containers-using.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 
 The basic units of {product-title} applications are called _containers_.
-link:https://access.redhat.com/articles/1353593[Linux container technologies]
+Linux container technologies
 are lightweight mechanisms for isolating running processes so that they are
 limited to interacting with only their designated resources.
 

--- a/nodes/jobs/nodes-nodes-jobs.adoc
+++ b/nodes/jobs/nodes-nodes-jobs.adoc
@@ -45,8 +45,9 @@ spec:
 <5> The template for the pod the controller creates.
 <6> The restart policy of the pod.
 
-See the http://kubernetes.io/docs/user-guide/jobs/[Kubernetes documentation] for
-more information about jobs.
+.Additional resources
+
+* link:https://kubernetes.io/docs/concepts/workloads/controllers/job/[Jobs] in the Kubernetes documentation
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference

--- a/nodes/scheduling/nodes-scheduler-node-affinity.adoc
+++ b/nodes/scheduling/nodes-scheduler-node-affinity.adoc
@@ -32,5 +32,4 @@ include::modules/olm-overriding-operator-pod-affinity.adoc[leveloffset=+1]
 [role="_additional-resources"]
 == Additional resources
 
-* For information about changing node labels, see
-xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes].
+* xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]


### PR DESCRIPTION
Fixing various errors in the Nodes -> Cluster docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

[Understanding how to use pod disruption budgets](https://63230--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-configuring.html#nodes-pods-pod-distruption-about_nodes-pods-configuring) -- Removed broken Kubernetes link ([current doc](https://docs.openshift.com/container-platform/4.12/nodes/pods/nodes-pods-configuring.html#nodes-pods-configuring-pod-distruption-about_nodes-pods-configuring))
[Understanding Containers](https://63230--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-using.html) -- Removed broken access.redhat _Linux container technologies_ link ([current docs](https://docs.openshift.com/container-platform/4.13/nodes/containers/nodes-containers-using.html))
[Running tasks in pods using jobs](https://63230--docspreview.netlify.app/openshift-enterprise/latest/nodes/jobs/nodes-nodes-jobs.html) -- Updated Kubernetes link and changed the link to an Additional resources ([current doc](https://docs.openshift.com/container-platform/4.13/nodes/jobs/nodes-nodes-jobs.html))
[Controlling pod placement on nodes using node affinity rules](https://63230--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-node-affinity#nodes-scheduler-node-affinity-addtl-resources_nodes-scheduler-node-affinity) -- Removed _For information about_ from an Additional reference
