### PR TITLE
OCPBUGS-8831: Add back in note about egress policy types

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -17,6 +17,11 @@ Network policy does not apply to the host network namespace. Pods with host netw
 Network policies cannot block traffic from localhost or from their resident nodes.
 ====
 
+[NOTE]
+====
+The Kubernetes v1 network policy features are available in OpenShift SDN except for egress policy types.
+====
+
 By default, all pods in a project are accessible from other pods and network endpoints. To isolate one or more pods in a project, you can create `NetworkPolicy` objects in that project to indicate the allowed incoming connections. Project administrators can create and delete `NetworkPolicy` objects within their own project.
 
 If a pod is matched by selectors in one or more `NetworkPolicy` objects, then the pod will accept only connections that are allowed by at least one of those `NetworkPolicy` objects. A pod that is not selected by any `NetworkPolicy` objects is fully accessible.


### PR DESCRIPTION
This seems to have gone missing at some point, so adding it back in.

- https://issues.redhat.com/browse/OCPBUGS-8831

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
