### PR TITLE
[virt] DPDK cluster config: Reduce HugePages allocation

### DIFF
--- a/modules/virt-configuring-cluster-dpdk.adoc
+++ b/modules/virt-configuring-cluster-dpdk.adoc
@@ -66,7 +66,7 @@ spec:
   hugepages:
     defaultHugepagesSize: 1G
     pages:
-    - count: 32
+    - count: 8
       node: 0
       size: 1G
   net:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Currently, the example configures the DPDK-enabled nodes to have 32 1Gi huge pages in NUMA 0.

Define a minimum number of HugePages, so a single instance of the DPDK checkup could run.

A single instance of the DPDK checkup requires eight 1Gi huge pages.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://63246--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/vm_networking/virt-attaching-vm-to-sriov-network#virt-configuring-cluster-dpdk_virt-attaching-vm-to-sriov-network

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
