### PR TITLE
[OCPBUGS-17411]: Create ServiceAccount cluster-capacity-sa in default namespace

### DIFF
--- a/modules/nodes-cluster-resource-levels-job.adoc
+++ b/modules/nodes-cluster-resource-levels-job.adoc
@@ -52,7 +52,7 @@ EOF
 +
 [source,terminal]
 ----
-$ oc create sa cluster-capacity-sa
+$ oc create sa cluster-capacity-sa -n default
 ----
 
 . Add the role to the service account:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
The ServiceAccount cluster-capacity-sa is supposed to be created in the default namespace. Without explicitly state that, it will be created in the current project, which is not expected, and will fail the steps that afterward.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
From 4.6 till 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-17411


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
