### PR TITLE
Removes prune-registry flag - false from documentation

### DIFF
--- a/modules/pruning-images.adoc
+++ b/modules/pruning-images.adoc
@@ -76,5 +76,4 @@ However, the `managementState` of the Image Registry Operator alters the behavio
 
 * `Managed`: the `--prune-registry` flag for the image pruner is set to `true`.
 * `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metatdata in etcd.
-* `Unmanaged`: the `--prune-registry` flag for the image pruner is set to `false`.
 ====

--- a/registry/configuring-registry-operator.adoc
+++ b/registry/configuring-registry-operator.adoc
@@ -39,7 +39,6 @@ However, the `managementState` of the Image Registry Operator alters the behavio
 
 * `Managed`: the `--prune-registry` flag for the image pruner is set to `true`.
 * `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metatdata in etcd.
-* `Unmanaged`: the `--prune-registry` flag for the image pruner is set to `false`.
 ====
 
 ifndef::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-8960

Link to docs preview:
https://63257--docspreview.netlify.app/openshift-enterprise/latest/registry/configuring-registry-operator#image-registry-on-cloud

https://63257--docspreview.netlify.app/openshift-enterprise/latest/applications/pruning-objects#pruning-images_pruning-objects

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
