### PR TITLE
Placing the guidance about user-replaced values to its appropriate lo…

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -192,11 +192,6 @@ Try to shorten the file name as much as possible _without_ abbreviating importan
 
 If you create a directory with a multiple-word name, separate each word with an underscore, for example `backup_and_restore`.
 
-[NOTE]
-====
-Do not italicize user-replaced values. This guideline is an exception to the link:https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values[_Red Hat supplementary style guide for product documentation_].
-====
-
 Do not create or rename a top-level directory in the repository and topic map without checking with the docs program manager first.
 
 Avoid creating two levels of subdirectories because the link:https://github.com/openshift/openshift-docs/issues/52149[breadcrumb bar on docs.openshift.com breaks]. If you have a valid use case for two levels of subdirectories, talk with your DPM/CS (and, for aligned teams, the OpenShift DPM) for approval before creating it.
@@ -1165,7 +1160,14 @@ Now using project "my-project" on server "https://openshift.example.com:6443".
 ----
 ....
 
-* To mark up command syntax, use the code block and wrap any replaceable values in angle brackets (`<>`) with the required command parameter, using underscores (`_`) between words as necessary for legibility. Do not italicize user-replaced values. For example:
+* To mark up command syntax, use the code block and wrap any replaceable values in angle brackets (`<>`) with the required command parameter, using underscores (`_`) between words as necessary for legibility.
++
+[IMPORTANT]
+====
+Do not italicize user-replaced values. This guideline is an exception to the link:https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values[_Red Hat supplementary style guide for product documentation_].
+====
++
+For example:
 +
 ....
 To view a list of objects for the specified object type, enter the following command:
@@ -1679,7 +1681,7 @@ Nest admonitions when using the `collapsible` option.
 Do not use a password format that matches the format of a real password. Documenting such a password format can cause the following issues:
 
 * Indicates that Red Hat publicly exposes sensitive data in their documentation.
-* Leads to additional security incidents that the Information Security, InfoSec, team must investigate. Such security incidents, although minor, can impact the InfoSec team's resources and potentially delay them from focusing on actual security incidents.   
+* Leads to additional security incidents that the Information Security, InfoSec, team must investigate. Such security incidents, although minor, can impact the InfoSec team's resources and potentially delay them from focusing on actual security incidents.
 ====
 
 .Projects and applications


### PR DESCRIPTION
This PR updates the location of the guidance about user-replaced values. 
Removed the NOTE from [Directory names](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#directory-names) heading and added an IMPORTANT admonition under [Code blocks, command syntax, and example output](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#code-blocks-command-syntax-and-example-output)

Version(s):
`main`

Issue:
N/A

Link to docs preview:

QE review:
N/A
