### PR TITLE
[enterprise-4.14] CNV-30838: RN - DV GC is now disabled by default

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -74,6 +74,9 @@ The SVVP Certification applies to:
 
 //CNV-28732 Release note: NEW
 
+//CNV-30838 Release note: datavolume garbage collection no longer default
+* Garbage collection for data volumes is disabled by default.
+
 
 [id="virt-4-14-quick-starts"]
 === Quick starts


### PR DESCRIPTION
**Version(s):**
4.14

**Issue:**
https://issues.redhat.com/browse/CNV-30838

**Link to docs preview:**
https://63270--docspreview.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes#virt-4-14-new

**QE review:**
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->