### PR TITLE
Adds documentation for configuring registry for Nutanix

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1613,6 +1613,9 @@ Topics:
   - Name: Configuring the registry for OpenShift Data Foundation
     File: configuring-registry-storage-rhodf
     Distros: openshift-enterprise,openshift-origin
+  - Name: Configuring the registry for Nutanix
+    File: configuring-registry-storage-nutanix
+    Distros: openshift-enterprise,openshift-origin
 - Name: Accessing the registry
   File: accessing-the-registry
 - Name: Exposing the registry

--- a/modules/configuring-registry-storage-nutanix.adoc
+++ b/modules/configuring-registry-storage-nutanix.adoc
@@ -1,44 +1,24 @@
 // Module included in the following assemblies:
-//
-// * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
-// * registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc
+// * registry/configuring_registry_storage/configuring-registry-storage-nutanix.adoc
 
 :_content-type: PROCEDURE
-[id="registry-configuring-storage-vsphere_{context}"]
-= Configuring registry storage for VMware vSphere
+[id="configuring-registry-storage-nutanix_{context}"]
+= Configuring registry storage for Nutanix
 
 As a cluster administrator, following installation you must configure your registry to use storage.
 
 .Prerequisites
 
-* Cluster administrator permissions.
-* A cluster on VMware vSphere.
-* Persistent storage provisioned for your cluster, such as {rh-storage-first}.
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have a cluster on Nutanix. 
+* You have provisioned persistent storage for your cluster, such as {rh-storage-first}.
 +
 [IMPORTANT]
 ====
 {product-title} supports `ReadWriteOnce` access for image registry storage when you have only one replica. `ReadWriteOnce` access also requires that the registry uses the `Recreate` rollout strategy. To deploy an image registry that supports high availability with two or more replicas, `ReadWriteMany` access is required.
 ====
 +
-* Must have "100Gi" capacity.
-
-[IMPORTANT]
-====
-Testing shows issues with using the NFS server on RHEL as storage backend for
-core services. This includes the OpenShift Container Registry and Quay,
-Prometheus for monitoring storage, and Elasticsearch for logging storage.
-Therefore, using RHEL NFS to back PVs used by core services is not recommended.
-
-Other NFS implementations on the marketplace might not have these issues.
-Contact the individual NFS implementation vendor for more information on any
-testing that was possibly completed against these {product-title} core
-components.
-====
+* You must have 100 Gi capacity.
 
 .Procedure
 
@@ -66,6 +46,7 @@ No resourses found in openshift-image-registry namespace
 =====
 If you do have a registry pod in your output, you do not need to continue with this procedure.
 =====
+
 . Check the registry configuration:
 +
 [source,terminal]
@@ -80,8 +61,8 @@ storage:
   pvc:
     claim: <1>
 ----
-+
 <1> Leave the `claim` field blank to allow the automatic creation of an `image-registry-storage` persistent volume claim (PVC). The PVC is generated based on the default storage class. However, be aware that the default storage class might provide ReadWriteOnce (RWO) volumes, such as a RADOS Block Device (RBD), which can cause issues when you replicate to more than one replica.
+
 
 . Check the `clusteroperator` status:
 +
@@ -94,16 +75,5 @@ $ oc get clusteroperator image-registry
 [source,terminal]
 ----
 NAME             VERSION                              AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-image-registry   4.7                                  True        False         False      6h50m
+image-registry   4.13                                  True        False         False      6h50m
 ----
-
-//+
-//There will be warning similar to:
-//+
-//----
-//- lastTransitionTime: 2019-03-26T12:45:46Z
-//message: storage backend not configured
-//reason: StorageNotConfigured
-//status: "True"
-//type: Degraded
-//----

--- a/modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout-bare-metal.adoc
@@ -14,12 +14,9 @@ To allow the image registry to use block storage types during upgrades as a clus
 
 [IMPORTANT]
 ====
-Block storage volumes, or block persistent volumes, are supported but not recommended for use with the image
-registry on production clusters. An installation where the registry is
-configured on block storage is not highly available because the registry cannot
-have more than one replica.
+Block storage volumes, or block persistent volumes, are supported but not recommended for use with the image registry on production clusters. An installation where the registry is configured on block storage is not highly available because the registry cannot have more than one replica.
 
-If you choose to use a block storage volume with the image registry, you must use a filesystem Persistent Volume Claim (PVC).
+If you choose to use a block storage volume with the image registry, you must use a filesystem persistent volume claim (PVC).
 ====
 
 .Procedure

--- a/modules/installation-registry-storage-block-recreate-rollout-nutanix.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout-nutanix.adoc
@@ -1,0 +1,75 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_bare_metal/installing-bare-metal.adoc
+// * installing/installing_baremetal/installing-bare-metal-network-customizations.adoc
+// * installing/installing_baremetal/installing-restricted-networks-bare-metal.adoc
+// * installing/installing_platform_agnostic/installing-platform-agnostic.adoc
+// * registry/configuring_registry_storage/configuring-registry-storage-baremetal.adoc
+
+:_content-type: PROCEDURE
+[id="installation-registry-storage-block-recreate-rollout-nutanix_{context}"]
+= Configuring block registry storage for Nutanix volumes
+
+To allow the image registry to use block storage types such as Nutanix volumes during upgrades as a cluster administrator, you can use the `Recreate` rollout strategy.
+
+[IMPORTANT]
+====
+Block storage volumes, or block persistent volumes, are supported but not recommended for use with the image registry on production clusters. An installation where the registry is configured on block storage is not highly available because the registry cannot have more than one replica.
+
+If you choose to use a block storage volume with the image registry, you must use a filesystem persistent volume claim (PVC).
+====
+
+.Procedure
+
+. To set the image registry storage as a block storage type, patch the registry so that it uses the `Recreate` rollout strategy and runs with only one (`1`) replica:
++
+[source,terminal]
+----
+$ oc patch config.imageregistry.operator.openshift.io/cluster --type=merge -p '{"spec":{"rolloutStrategy":"Recreate","replicas":1}}'
+----
+
+. Provision the PV for the block storage device, and create a PVC for that volume. The requested block volume uses the ReadWriteOnce (RWO) access mode.
+
+.. Create a `pvc.yaml` file with the following contents to define a Nutanix `PersistentVolumeClaim` object:
++
+[source,yaml]
+----
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: image-registry-storage <1>
+  namespace: openshift-image-registry <2>
+spec:
+  accessModes:
+  - ReadWriteOnce <3>
+  resources:
+    requests:
+      storage: 100Gi <4>
+----
+<1> A unique name that represents the `PersistentVolumeClaim` object.
+<2> The namespace for the `PersistentVolumeClaim` object, which is `openshift-image-registry`.
+<3> The access mode of the persistent volume claim. With `ReadWriteOnce`, the volume can be mounted with read and write permissions by a single node.
+<4> The size of the persistent volume claim.
+
+.. Create the `PersistentVolumeClaim` object from the file:
++
+[source,terminal]
+----
+$ oc create -f pvc.yaml -n openshift-image-registry
+----
+
+. Edit the registry configuration so that it references the correct PVC:
++
+[source,terminal]
+----
+$ oc edit config.imageregistry.operator.openshift.io -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+storage:
+  pvc:
+    claim: <1>
+----
+<1> By creating a custom PVC, you can leave the `claim` field blank for the default automatic creation of an `image-registry-storage` PVC.

--- a/modules/installation-registry-storage-block-recreate-rollout.adoc
+++ b/modules/installation-registry-storage-block-recreate-rollout.adoc
@@ -75,4 +75,4 @@ storage:
   pvc:
     claim: <1>
 ----
-<1> Creating a custom PVC allows you to leave the `claim` field blank for the default automatic creation of an `image-registry-storage` PVC.
+<1> By creating a custom PVC, you can leave the `claim` field blank for the default automatic creation of an `image-registry-storage` PVC.

--- a/modules/registry-configuring-storage-baremetal.adoc
+++ b/modules/registry-configuring-storage-baremetal.adoc
@@ -67,7 +67,7 @@ the `configs.imageregistry/cluster` resource.
 +
 [NOTE]
 ====
-When using shared storage, review your security settings to prevent outside access.
+When you use shared storage, review your security settings to prevent outside access.
 ====
 
 . Verify that you do not have a registry pod:

--- a/registry/configuring_registry_storage/configuring-registry-storage-nutanix.adoc
+++ b/registry/configuring_registry_storage/configuring-registry-storage-nutanix.adoc
@@ -1,0 +1,33 @@
+:_content-type: ASSEMBLY
+[id="configuring-registry-storage-nutanix"]
+= Configuring the registry for Nutanix
+include::_attributes/common-attributes.adoc[]
+:context: configuring-registry-storage-nutanix
+toc::[]
+
+By following the steps outlined in this documentation, users can optimize container image distribution, security, and access controls, enabling a robust foundation for Nutanix applications on {product-title}
+
+include::modules/registry-removed.adoc[leveloffset=+1]
+
+include::modules/registry-change-management-state.adoc[leveloffset=+1]
+
+include::modules/installation-registry-storage-config.adoc[leveloffset=+1]
+
+include::modules/configuring-registry-storage-nutanix.adoc[leveloffset=+2]
+
+include::modules/installation-registry-storage-non-production.adoc[leveloffset=+2]
+
+include::modules/installation-registry-storage-block-recreate-rollout-nutanix.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-registry-storage-rhodf-cephrgw.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-registry-storage-rhodf-nooba.adoc[leveloffset=+2]
+
+include::modules/registry-configuring-registry-storage-rhodf-cephfs.adoc[leveloffset=+1]
+
+[id="configuring-registry-storage-nutanix-addtl-resources"]
+[role="_additional-resources"]
+== Additional resources
+
+* xref:../../scalability_and_performance/optimization/optimizing-storage.adoc#optimizing-storage[Recommended configurable storage technology]
+* link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.10/html-single/managing_and_allocating_storage_resources/index#configuring-image-registry-to-use-openshift-data-foundation_rhodf[Configuring Image Registry to use OpenShift Data Foundation]


### PR DESCRIPTION
A lot of this content is copied from "Setting up and configuring the registry." Modules largely remained the same with slight variations.  

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-9431

Link to docs preview:
https://63272--docspreview.netlify.app/openshift-enterprise/latest/registry/configuring_registry_storage/configuring-registry-storage-nutanix

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
