### PR TITLE
OSDOCS-6646: remove CIDR from clusterNetwork parameter

### DIFF
--- a/modules/microshift-config-yaml.adoc
+++ b/modules/microshift-config-yaml.adoc
@@ -19,7 +19,7 @@ dns:
   baseDomain: microshift.example.com <1>
 network:
   clusterNetwork:
-    - cidr: 10.42.0.0/16 <2>
+    - 10.42.0.0/16 <2>
   serviceNetwork:
     - 10.43.0.0/16 <3>
   serviceNodePortRange: 30000-32767 <4>


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-6646

Link to docs preview:
https://63273--docspreview.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-tools#microshift-yaml-default_microshift-configuring

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Release note is here: https://github.com/openshift/openshift-docs/pull/63275

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
