### PR TITLE
OSDOCS#7310: Adds notes for MS 4.13.8 release

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -163,7 +163,7 @@ Issued: 2023-05-17
 
 {product-title} release 4.13.0 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:1329[RHSA-2023:1329] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:1326[RHSA-2023:1326] advisory.
 
-For the `TopoLVM image`, read link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the `TopoLVM` image, read link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
 
 [id="microshift-4-13-1-dp"]
 === RHSA-2023:3307 - {product-title} 4.13.1 bug fix and security update
@@ -172,7 +172,7 @@ Issued: 2023-05-30
 
 {product-title} release 4.13.1, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3307[RHBA-2023:3307] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3304[RHSA-2023:3304] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
 
 [id="microshift-4-13-3-dp"]
 === RHSA-2023:3540 - {product-title} 4.13.3 bug fix and security update
@@ -186,7 +186,7 @@ Issued: 2023-06-13
 
 * Previously, when the operating system was not set to the default route, OVN-Kubernetes caused the cluster to function improperly. With this update, the default routes were removed and the OVN-Kubernetes pod runs as expected. (link:https://issues.redhat.com/browse/OCPBUGS-13548)([*OCPBUGS-13548*])
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
 
 [id="microshift-4-13-4-dp"]
 === RHBA-2023:3620 - {product-title} 4.13.4 bug fix and security update
@@ -195,7 +195,7 @@ Issued: 2023-06-23
 
 {product-title} release 4.13.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3620[RHBA-2023:3620] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3614[RHSA-2023:3614] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
 
 [id="microshift-4-13-5-dp"]
 === RHBA-2023:3620 - {product-title} 4.13.5 bug fix and security update
@@ -209,7 +209,7 @@ Issued: 2023-07-20
 
 * {product-title} uses the OVN-Kubernetes `local gateway` mode. All pod egress traffic goes through the host kernel before entering or leaving the host. With this release, the flag `externalGatewayInterface` to specify a second gateway interface is removed.(link:https://issues.redhat.com/browse/OCPBUGS-14880)([*OCPBUGS-14880*])
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
 
 [id="microshift-4-13-6-dp"]
 === RHBA-2023:4428 - {product-title} 4.13.6 bug fix and security update
@@ -218,4 +218,13 @@ Issued: 2023-07-26
 
 {product-title} release 4.13.6, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4428[RHBA-2023:4428] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4426[RHSA-2023:4426] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-8-dp"]
+=== RHBA-2023:4458 - {product-title} 4.13.8 bug fix and security update
+
+Issued: 2023-08-08
+
+{product-title} release 4.13.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4458[RHBA-2023:4458] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4456[RHSA-2023:4456] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Adds notes for MS 4.13.8 release

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-7310

Link to docs preview:
https://63274--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-8-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
