### PR TITLE
OSDOCS-7366: Release note; CIDR removed MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -76,8 +76,8 @@ This release adds improvements related to the following components and concepts.
 //[id="microshift-4-13-deprecated-removed-features"]
 //== Deprecated and removed features
 
-[id="microshift-4-14-bug-fixes"]
-== Bug fixes
+//[id="microshift-4-14-bug-fixes"]
+//== Bug fixes
 
 //etc
 
@@ -114,6 +114,24 @@ $ ip route
 10.43.0.0/16 via 192.168.122.1 dev br-ex mtu 1400
 ----
 This routing rule matches the Kubernetes service IP address range and forwards the packet to the gateway bridge `br-ex`. You must enable `ip_forward` on the host. After the packet is forwarded to the OVS bridge `br-ex`, it is handled by OpenFlow rules in OVS. OpenFlow then steers the packet to the OVN network and eventually to the pod.
+
+[id="microshift-4-14-notable-technical-changes"]
+== Notable technical changes
+
+{product-title} {product-version} introduces the following notable technical changes.
+// Note: use [discrete] for these sub-headings.
+
+[discrete]
+[id="microshift-4-14-networking-changes"]
+=== Networking changes
+
+Networking changes to {product-title} {product-version} include IP address assignment changes, gateway changes, and other refinements.
+
+[discrete]
+[id="microshift-4-14-cidr-removal"]
+==== CIDR notation removed from configuration
+
+The CIDR notation for grouping IP addresses was removed from the `clusterNetwork` configuration. For an example, see the xref:../microshift_configuring/microshift-using-config-tools.adoc#microshift-yaml-default_microshift-using-config-tools[Using configuration tools] documentation.
 
 [id="microshift-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OSDOCS-7366

Link to docs preview:
https://63275--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-notable-technical-changes
https://63273--docspreview.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-tools#microshift-yaml-default_microshift-configuring (updated section; Netlify hasn't picked up the merge from related PR)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Doc change is here: https://github.com/openshift/openshift-docs/pull/63273

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
