### PR TITLE
OSDOCS-7288: Documented 4.10.65 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-10-release-notes.adoc
+++ b/release_notes/ocp-4-10-release-notes.adoc
@@ -4115,3 +4115,22 @@ $ oc adm release info 4.10.64 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-10-65"]
+=== RHBA-2023:4445 - {product-title} 4.10.65 bug fix update
+
+Issued: 2023-08-09
+
+{product-title} release 4.10.65 is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:4445[RHBA-2023:4445] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4447[RHBA-2023:4447] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.10.65 --pullspecs
+----
+
+[id="ocp-4-10-65-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.10 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-7288](https://issues.redhat.com/browse/OSDOCS-7288)

Version(s):
4.10

Link to docs preview:
[Release notes 4.10.65](https://dfitzmau.github.io/previews/ocp-4-10-release-notes.html#ocp-4-10-65)

QE review:
- [ ] QE approval is not required for z-stream release notes

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
