### PR TITLE
Updates manual pruning command in Images docs

### DIFF
--- a/modules/pruning-images-manual.adoc
+++ b/modules/pruning-images-manual.adoc
@@ -287,16 +287,15 @@ pruning.
 
 Ensure that images you want removed occur at higher positions in each tag
 history than your chosen tag revisions threshold. For example, consider an old
-and obsolete image named `sha:abz`. By running the following command in
-namespace `N`, where the image is tagged, the image is tagged three times in a
+and obsolete image named `sha256:abz`. By running the following command in your
+namespace, where the image is tagged, the image is tagged three times in a
 single image stream named `myapp`:
 
 [source,terminal]
 ----
-$ oc get is -n N -o go-template='{{range $isi, $is := .items}}{{range $ti, $tag := $is.status.tags}}'\
-  '{{range $ii, $item := $tag.items}}{{if eq $item.image "'"sha:abz"\
-  $'"}}{{$is.metadata.name}}:{{$tag.tag}} at position {{$ii}} out of {{len $tag.items}}\n'\
-  '{{end}}{{end}}{{end}}{{end}}'
+$ oc get is -n <namespace> -o go-template='{{range $isi, $is := .items}}{{range $ti, $tag := $is.status.tags}}'\
+'{{range $ii, $item := $tag.items}}{{if eq $item.image "sha256:<hash>"}}{{$is.metadata.name}}:{{$tag.tag}} at position {{$ii}} out of {{len $tag.items}}\n'\
+'{{end}}{{end}}{{end}}{{end}}'
 ----
 
 .Example output


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-9438, https://issues.redhat.com/browse/OCPBUGS-16006

Link to docs preview:
https://63304--docspreview.netlify.app/openshift-enterprise/latest/applications/pruning-objects#pruning-images-problems_pruning-objects


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
