### PR TITLE
OCPBUGS-11899: Added redentialsRequest objects techpreview note for a…

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -391,7 +391,7 @@ spec:
     roleBindings:
     - role: Contributor
 ----
-
++
 .. Create YAML files for secrets in the `openshift-install` manifests directory that you generated previously. The secrets must be stored using the namespace and secret name defined in the `spec.secretRef` for each `CredentialsRequest` object. The format for the secret data varies for each cloud provider.
 +
 .Sample `secrets.yaml` file:
@@ -411,7 +411,8 @@ stringData:
   azure_resourcegroup: ${resource_group}
   azure_region: ${azure_region}
 ----
-
+endif::ash[]
++
 [IMPORTANT]
 ====
 The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-set: TechPreviewNoUpgrade` annotation.
@@ -420,7 +421,8 @@ The release image includes `CredentialsRequest` objects for Technology Preview f
 
 * If you are using any of these features, you must create secrets for the corresponding objects.
 ====
-
++
+ifdef::ash[]
 *** To find `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation, run the following command:
 +
 [source,terminal]


### PR DESCRIPTION
[OCPBUGS-11899](https://issues.redhat.com/browse/OCPBUGS-11899)

Version(s):
4.14 through to 4.10

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

All locations where installation-user-infra-generate-k8s-manifest-ignition site:

* [Installing a cluster on user-provisioned infrastructure in AWS by using CloudFormation templates](https://63307--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-user-infra#installation-user-infra-generate-k8s-manifest-ignition_installing-aws-user-infra)
*
*
*
*
*
*
*
*
*

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
