### PR TITLE
OCPBUGS-14777  improving alignment of codeblock

### DIFF
--- a/modules/virt-virtual-gpus-config-overview.adoc
+++ b/modules/virt-virtual-gpus-config-overview.adoc
@@ -57,8 +57,8 @@ For example, the name file for the `nvidia-231` type contains the selector strin
 +
 [source,terminal]
 ----
-$ oc get $NODE -o json  \
-| jq '.status.allocatable | \
-with_entries(select(.key | startswith("nvidia.com/"))) | \
-with_entries(select(.value != "0"))'
+$ oc get $NODE -o json \
+  | jq '.status.allocatable \
+    | with_entries(select(.key | startswith("nvidia.com/"))) \
+    | with_entries(select(.value != "0"))'
 ----


### PR DESCRIPTION
[OCPBUGS-14777]: Fixing indention associated with "The resourceName should match that allocated on the node" needs fixed

Version(s):
Main, 4.14, 4.13, 4.12, 4.11, 4.10

Issue:
https://issues.redhat.com/browse/OCPBUGS-14777

Link to docs preview:
https://63308--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-mediated-devices.html#configuration-overview_virt-configuring-mediated-devices

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
