### PR TITLE
Nodes Support docs fixes during ROSA review

### DIFF
--- a/modules/insights-operator-new-pull-secret-enable.adoc
+++ b/modules/insights-operator-new-pull-secret-enable.adoc
@@ -51,7 +51,7 @@ $ cp pull-secret pull-secret-backup
 +
 [source,terminal]
 ----
-oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=pull-secret
+$ oc set data secret/pull-secret -n openshift-config --from-file=.dockerconfigjson=pull-secret
 ----
 
 It may take several minutes for the secret to update and your cluster to begin reporting.

--- a/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
+++ b/support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc
@@ -15,7 +15,6 @@ To use the Insights Operator in a restricted network, you must:
 
 Additionally, you can choose to xref:../../support/remote_health_monitoring/remote-health-reporting-from-restricted-network.adoc#insights-operator-enable-obfuscation_remote-health-reporting-from-restricted-network[obfuscate] the Insights Operator data before upload.
 
-
 include::modules/insights-operator-one-time-gather.adoc[leveloffset=+1]
 
 include::modules/insights-operator-manual-upload.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixing various errors in the Support docs as I find them during the ROSA content port. Mostly formatting, wording, and such.