### PR TITLE
OCPBUGS-13736 Explicitly state that the default value for performanceprofile.spec.workloadHints.realTime is true

### DIFF
--- a/modules/cnf-configuring-workload-hints.adoc
+++ b/modules/cnf-configuring-workload-hints.adoc
@@ -29,5 +29,5 @@
 
 [NOTE]
 ====
-When the `realTime` workload hint flag is set to `true` in a performance profile, add the `cpu-quota.crio.io: disable` annotation to every guaranteed pod with pinned CPUs. This annotation is necessary to prevent the degradation of the process performance within the pod.
+When the `realTime` workload hint flag is set to `true` in a performance profile, add the `cpu-quota.crio.io: disable` annotation to every guaranteed pod with pinned CPUs. This annotation is necessary to prevent the degradation of the process performance within the pod. If the `realTime` workload hint is not explicitly set then it defaults to `true`.
 ====

--- a/modules/cnf-understanding-workload-hints.adoc
+++ b/modules/cnf-understanding-workload-hints.adoc
@@ -10,6 +10,7 @@ The following table describes how combinations of power consumption and real-tim
 [NOTE]
 ====
 The following workload hints can be configured manually. You can also work with workload hints using the Performance Profile Creator. For more information about the performance profile, see the "Creating a performance profile" section.
+If the workload hint is configured manually and the `realTime` workload hint is not explicitly set then it defaults to `true`.
 ====
 
 [cols="1,1,1,1",options="header"]


### PR DESCRIPTION
[OCPBUGS-13736]: Explicitly state that the default value for performanceprofile.spec.workloadHints.realTime is true
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11, 4.12, 4.13, 4.14 and main

Issue:
https://issues.redhat.com/browse/OCPBUGS-13736

Link to docs preview:
* https://63311--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#cnf-understanding-workload-hints_cnf-master
* https://63311--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#configuring-workload-hints_cnf-master

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
