### PR TITLE
ALBO: fix mistakes in multiple ingresses in single ALB examples

### DIFF
--- a/modules/adding-tls-termination.adoc
+++ b/modules/adding-tls-termination.adoc
@@ -21,13 +21,12 @@ You can route the traffic for the domain to pods of a service and add TLS termin
 apiVersion: networking.olm.openshift.io/v1
 kind: AWSLoadBalancerController
 metadata:
-  name: cluster <1>
+  name: cluster
 spec:
-  subnetTagging: auto
-  ingressClass: tls-termination <2>
+  subnetTagging: Auto
+  ingressClass: tls-termination <1>
 ----
-<1> Defines the `aws-load-balancer-controller` instance.
-<2> Defines the name of an `ingressClass` resource reconciled by the AWS Load Balancer Controller. This `ingressClass` resource gets created if it is not present. You can add additional `ingressClass` values. The controller reconciles the `ingressClass` values if the `spec.controller` is set to `ingress.k8s.aws/alb`.
+<1> Defines the name of an `ingressClass` resource reconciled by the AWS Load Balancer Controller. This `ingressClass` resource gets created if it is not present. You can add additional `ingressClass` values. The controller reconciles the `ingressClass` values if the `spec.controller` is set to `ingress.k8s.aws/alb`.
 
 . Create an `Ingress` resource:
 +

--- a/modules/creating-multiple-ingress-through-single-alb.adoc
+++ b/modules/creating-multiple-ingress-through-single-alb.adoc
@@ -21,7 +21,7 @@ You can route the traffic to multiple Ingresses through a single AWS Load Balanc
 apiVersion: elbv2.k8s.aws/v1beta1 <1>
 kind: IngressClassParams
 metadata:
-  name: <single-lb-params> <2>
+  name: single-lb-params <2>
 spec:
   group:
     name: single-lb <3>
@@ -37,29 +37,50 @@ spec:
 $ oc create -f sample-single-lb-params.yaml
 ----
 
-. Create an `IngressClass` resource YAML file, for example, `sample-single-lb.yaml`, as follows:
+. Create an `IngressClass` resource YAML file, for example, `sample-single-lb-class.yaml`, as follows:
 +
 [source,yaml]
 ----
 apiVersion: networking.k8s.io/v1 <1>
 kind: IngressClass
 metadata:
-  name: <single-lb> <2>
+  name: single-lb <2>
 spec:
   controller: ingress.k8s.aws/alb <3>
   parameters:
     apiGroup: elbv2.k8s.aws <4>
     kind: IngressClassParams <5>
-    name: single-lb <6>
+    name: single-lb-params <6>
 ----
-<1> Defines the API group and the version of the `IngressClass` resource.
+<1> Defines the API group and version of the `IngressClass` resource.
 <2> Specifies the name of the `IngressClass`.
-<3> Defines the controller name, common for all `IngressClasses`. The `aws-load-balancer-controller` reconciles the controller.
+<3> Defines the controller name. `ingress.k8s.aws/alb` denotes that all Ingresses of this class should be managed by the `aws-load-balancer-controller`.
 <4> Defines the API group of the `IngressClassParams` resource.
 <5> Defines the resource type of the `IngressClassParams` resource.
 <6> Defines the name of the `IngressClassParams` resource.
 
 . Create an `IngressClass` resource by running the following command:
++
+[source,terminal]
+----
+$ oc create -f sample-single-lb-class.yaml
+----
+
+. Create an `AWSLoadBalancerController` resource YAML file, for example, `sample-single-lb.yaml`, as follows:
++
+[source,yaml]
+----
+apiVersion: networking.olm.openshift.io/v1
+kind: AWSLoadBalancerController
+metadata:
+  name: cluster
+spec:
+  subnetTagging: Auto
+  ingressClass: single-lb <1>
+----
+<1> Defines the name of the `IngressClass` resource.
+
+. Create an `AWSLoadBalancerController` resource by running the following command:
 +
 [source,terminal]
 ----
@@ -70,70 +91,81 @@ $ oc create -f sample-single-lb.yaml
 +
 [source,yaml]
 ----
-apiVersion: networking.k8s.io/v1 <1>
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: <example-1> <1>
+  name: example-1 <1>
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing <2>
     alb.ingress.kubernetes.io/group.order: "1" <3>
+    alb.ingress.kubernetes.io/target-type: instance <4>
 spec:
-  ingressClass: alb <4>
+  ingressClassName: single-lb <5>
   rules:
-  - host: example.com <5>
+  - host: example.com <6>
     http:
         paths:
-        - path: /blog <6>
+        - path: /blog <7>
+          pathType: Prefix
           backend:
             service:
-              name: <example-1> <7>
+              name: example-1 <8>
               port:
-                number: 80 <8>
+                number: 80 <9>
+---
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: <example-2>
+  name: example-2
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/group.order: "2"
+    alb.ingress.kubernetes.io/target-type: instance
 spec:
-  ingressClass: alb
+  ingressClassName: single-lb
   rules:
   - host: example.com
     http:
         paths:
         - path: /store
+          pathType: Prefix
           backend:
             service:
-              name: <example-2>
+              name: example-2
               port:
                 number: 80
+---
+apiVersion: networking.k8s.io/v1
 kind: Ingress
-  metadata:
-  name: <example-3>
+metadata:
+  name: example-3
   annotations:
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/group.order: "3"
+    alb.ingress.kubernetes.io/target-type: instance
 spec:
-  ingressClass: alb
+  ingressClassName: single-lb
   rules:
   - host: example.com
     http:
         paths:
         - path: /
+          pathType: Prefix
           backend:
             service:
-              name: <example-3>
+              name: example-3
               port:
                 number: 80
 ----
 <1> Specifies the name of an ingress.
 <2> Indicates the load balancer to provision in the public subnet and makes it accessible over the internet.
 <3> Specifies the order in which the rules from the Ingresses are matched when the request is received at the load balancer.
-<4> Specifies the Ingress Class that belongs to this ingress.
-<5> Defines the name of a domain used for request routing.
-<6> Defines the path that must route to the service.
-<7> Defines the name of the service that serves the endpoint configured in the ingress.
-<8> Defines the port on the service that serves the endpoint.
+<4> Indicates the load balancer will target OpenShift nodes to reach the service.
+<5> Specifies the Ingress Class that belongs to this ingress.
+<6> Defines the name of a domain used for request routing.
+<7> Defines the path that must route to the service.
+<8> Defines the name of the service that serves the endpoint configured in the ingress.
+<9> Defines the port on the service that serves the endpoint.
 
 . Create the `Ingress` resources by running the following command:
 +


### PR DESCRIPTION
I found some mistakes in the ALBO examples. This PR is an example of how to fix them, feel free to take over and create a bug if necessary. The removal of `<>` is optional (it was not a mistake), I just thought that this way it would be easier for the user to apply the examples. `ingressClassName`, `alb.ingress.kubernetes.io/target-type` and `pathType` are absolutely necessary though.


Preview build: https://63312--docspreview.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/multiple-ingress-through-single-alb

Addresses:

- https://issues.redhat.com/browse/OSDOCS-6813
-  https://issues.redhat.com/browse/OSDOCS-6812
-  https://issues.redhat.com/browse/OSDOCS-6816
- https://issues.redhat.com/browse/OCPBUGS-17489.