### PR TITLE
OCPBUGS-17471: Fix references to default-auto-apply compliance ScanS…

### DIFF
--- a/modules/compliance-crd-scan-setting.adoc
+++ b/modules/compliance-crd-scan-setting.adoc
@@ -14,73 +14,49 @@ By default, the Compliance Operator creates the following `ScanSetting` objects:
 .Example `ScanSetting` object
 [source,yaml]
 ----
-Name:                      default-auto-apply
-Namespace:                 openshift-compliance
-Labels:                    <none>
-Annotations:               <none>
-API Version:               compliance.openshift.io/v1alpha1
-Auto Apply Remediations:   true
-Auto Update Remediations:  true
-Kind:                      ScanSetting
-Metadata:
-  Creation Timestamp:  2022-10-18T20:21:00Z
-  Generation:          1
-  Managed Fields:
-    API Version:  compliance.openshift.io/v1alpha1
-    Fields Type:  FieldsV1
-    fieldsV1:
-      f:autoApplyRemediations: <1>
-      f:autoUpdateRemediations: <2>
-      f:rawResultStorage:
-        .:
-        f:nodeSelector:
-          .:
-          f:node-role.kubernetes.io/master:
-        f:pvAccessModes:
-        f:rotation:
-        f:size:
-        f:tolerations:
-      f:roles:
-      f:scanTolerations:
-      f:schedule:
-      f:showNotApplicable:
-      f:strictNodeScan:
-    Manager:         compliance-operator
-    Operation:       Update
-    Time:            2022-10-18T20:21:00Z
-  Resource Version:  38840
-  UID:               8cb0967d-05e0-4d7a-ac1c-08a7f7e89e84
-Raw Result Storage:
-  Node Selector:
-    node-role.kubernetes.io/master:
-  Pv Access Modes:
-    ReadWriteOnce
-  Rotation:  3 <3>
-  Size:      1Gi <4>
-  Tolerations:
-    Effect:              NoSchedule
-    Key:                 node-role.kubernetes.io/master
-    Operator:            Exists
-    Effect:              NoExecute
-    Key:                 node.kubernetes.io/not-ready
-    Operator:            Exists
-    Toleration Seconds:  300
-    Effect:              NoExecute
-    Key:                 node.kubernetes.io/unreachable
-    Operator:            Exists
-    Toleration Seconds:  300
-    Effect:              NoSchedule
-    Key:                 node.kubernetes.io/memory-pressure
-    Operator:            Exists
-Roles: <6>
-  master
-  worker
-Scan Tolerations:
-  Operator:           Exists
-Schedule:             "0 1 * * *" <5>
-Show Not Applicable:  false
-Strict Node Scan:     true
-Events:               <none>
+apiVersion: compliance.openshift.io/v1alpha1
+autoApplyRemediations: true <1>
+autoUpdateRemediations: true <2>
+kind: ScanSetting
+maxRetryOnTimeout: 3
+metadata:
+  creationTimestamp: "2022-10-18T20:21:00Z"
+  generation: 1
+  name: default-auto-apply
+  namespace: openshift-compliance
+  resourceVersion: "38840"
+  uid: 8cb0967d-05e0-4d7a-ac1c-08a7f7e89e84
+rawResultStorage:
+  nodeSelector:
+    node-role.kubernetes.io/master: ""
+  pvAccessModes:
+  - ReadWriteOnce
+  rotation: 3 <3>
+  size: 1Gi <4>
+  tolerations:
+  - effect: NoSchedule
+    key: node-role.kubernetes.io/master
+    operator: Exists
+  - effect: NoExecute
+    key: node.kubernetes.io/not-ready
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoExecute
+    key: node.kubernetes.io/unreachable
+    operator: Exists
+    tolerationSeconds: 300
+  - effect: NoSchedule
+    key: node.kubernetes.io/memory-pressure
+    operator: Exists
+roles: <6>
+- master
+- worker
+scanTolerations:
+- operator: Exists
+schedule: 0 1 * * * <5>
+showNotApplicable: false
+strictNodeScan: true
+timeout: 30m
 ----
 <1> Set to `true` to enable auto remediations. Set to `false` to disable auto remediations.
 <2> Set to `true` to enable auto remediations for content updates. Set to `false` to disable auto remediations for content updates.

--- a/modules/running-compliance-scans.adoc
+++ b/modules/running-compliance-scans.adoc
@@ -105,8 +105,8 @@ Namespace:                 openshift-compliance
 Labels:                    <none>
 Annotations:               <none>
 API Version:               compliance.openshift.io/v1alpha1
-Auto Apply Remediations:   true
-Auto Update Remediations:  true
+Auto Apply Remediations:   true <1>
+Auto Update Remediations:  true <1>
 Kind:                      ScanSetting
 Metadata:
   Creation Timestamp:  2022-10-18T20:21:00Z
@@ -115,8 +115,8 @@ Metadata:
     API Version:  compliance.openshift.io/v1alpha1
     Fields Type:  FieldsV1
     fieldsV1:
-      f:autoApplyRemediations: <1>
-      f:autoUpdateRemediations: <1>
+      f:autoApplyRemediations:
+      f:autoUpdateRemediations:
       f:rawResultStorage:
         .:
         f:nodeSelector:


### PR DESCRIPTION
…etting

Build Preview (VPN required):
[ScanSetting object](https://file.rdu.redhat.com/antaylor/bugfix/OCPBUGS-17471/security/compliance_operator/compliance-operator-crd.html#scan-setting-object_compliance-crd)
[Running compliance scans](https://file.rdu.redhat.com/antaylor/bugfix/OCPBUGS-17471/security/compliance_operator/compliance-scans#running-compliance-scans_compliance-operator-scans)

Description of problem:

https://docs.openshift.com/container-platform/4.10/security/compliance_operator/compliance-operator-crd.html#configure-compliance-scan-settings_compliance-crd

references a scansetting "object" but it isn't an object -- it is a describe output of an object

Also, enumerated points 1 and 2 refer back to metadata "managedfields" which are not the fields customers should actually be modifying.

This example should ideally be a reference to a real YAML formatted object, just like all the other examples.  

It would also be good to document the default values for points 1 and 2.

Version-Release number of selected component (if applicable):

ALL

How reproducible:

N/A

Steps to Reproduce:

N/A

Actual results:

```
Name:                      default-auto-apply
Namespace:                 openshift-compliance
Labels:                    <none>
Annotations:               <none>
API Version:               compliance.openshift.io/v1alpha1
Auto Apply Remediations:   true
Auto Update Remediations:  true
Kind:                      ScanSetting
Metadata:
  Creation Timestamp:  2022-10-18T20:21:00Z
  Generation:          1
  Managed Fields:
    API Version:  compliance.openshift.io/v1alpha1
    Fields Type:  FieldsV1
    fieldsV1:
      f:autoApplyRemediations: 
      f:autoUpdateRemediations: 
      f:rawResultStorage:
        .:
        f:nodeSelector:
          .:
          f:node-role.kubernetes.io/master:
        f:pvAccessModes:
        f:rotation:
        f:size:
        f:tolerations:
      f:roles:
      f:scanTolerations:
      f:schedule:
      f:showNotApplicable:
      f:strictNodeScan:
    Manager:         compliance-operator
    Operation:       Update
    Time:            2022-10-18T20:21:00Z
  Resource Version:  38840
  UID:               8cb0967d-05e0-4d7a-ac1c-08a7f7e89e84
Raw Result Storage:
  Node Selector:
    node-role.kubernetes.io/master:
  Pv Access Modes:
    ReadWriteOnce
  Rotation:  3 
  Size:      1Gi 
  Tolerations:
    Effect:              NoSchedule
    Key:                 node-role.kubernetes.io/master
    Operator:            Exists
    Effect:              NoExecute
    Key:                 node.kubernetes.io/not-ready
    Operator:            Exists
    Toleration Seconds:  300
    Effect:              NoExecute
    Key:                 node.kubernetes.io/unreachable
    Operator:            Exists
    Toleration Seconds:  300
    Effect:              NoSchedule
    Key:                 node.kubernetes.io/memory-pressure
    Operator:            Exists
Roles: 
  master
  worker
Scan Tolerations:
  Operator:           Exists
Schedule:             "0 1 * * *" 
Show Not Applicable:  false
Strict Node Scan:     true
Events:               <none>
```

Expected results:

```
apiVersion: compliance.openshift.io/v1alpha1
autoApplyRemediations: true
autoUpdateRemediations: true
kind: ScanSetting
maxRetryOnTimeout: 3
metadata:
  creationTimestamp: "2023-07-21T14:44:47Z"
  generation: 1
  name: default-auto-apply
  namespace: openshift-compliance
  resourceVersion: "13714704"
  uid: d524c4fa-acaa-4b1c-b698-c4c59f7c7903
rawResultStorage:
  nodeSelector:
    node-role.kubernetes.io/worker: ""
  pvAccessModes:
  - ReadWriteOnce
  rotation: 3
  size: 1Gi
  tolerations:
  - effect: NoSchedule
    key: node-role.kubernetes.io/master
    operator: Exists
  - effect: NoExecute
    key: node.kubernetes.io/not-ready
    operator: Exists
    tolerationSeconds: 300
  - effect: NoExecute
    key: node.kubernetes.io/unreachable
    operator: Exists
    tolerationSeconds: 300
  - effect: NoSchedule
    key: node.kubernetes.io/memory-pressure
    operator: Exists
roles:
- master
- worker
scanTolerations:
- operator: Exists
schedule: 0 1 * * *
showNotApplicable: false
strictNodeScan: true
timeout: 30m
```

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
