### PR TITLE
OSSM-3033: [DOC] Document supported authentication strategies for Kiali

### DIFF
--- a/modules/ossm-supported-configurations.adoc
+++ b/modules/ossm-supported-configurations.adoc
@@ -57,7 +57,8 @@ endif::openshift-rosa[]
 [id="ossm-supported-configurations-kiali_{context}"]
 == Supported configurations for Kiali
 
-* The Kiali console is only supported on the two most recent releases of the Chrome, Edge, Firefox, or Safari browsers.
+* The Kiali console is only supported on the two most recent releases of the Google Chrome, Microsoft Edge, Mozilla Firefox, or Apple Safari browsers.
+* The `openshift` authentication strategy is the only supported authentication configuration when Kiali is deployed with {SMProductName} (OSSM). The `openshift` strategy controls access based on the individual's role-based access control (RBAC) roles of the {product-title}.
 
 [id="ossm-supported-configurations-jaeger_{context}"]
 == Supported configurations for Distributed Tracing


### PR DESCRIPTION
[OSSM-3033](https://issues.redhat.com//browse/OSSM-3033): [Kiali] Document supported authentication strategies

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSSM-3033

Link to docs preview:
https://63321--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/preparing-ossm-installation#ossm-supported-configurations-kiali_preparing-ossm-installation

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Changed only this section by adding "OpenShift strategy" bullet point.

[id="ossm-supported-configurations-kiali_{context}"]
== Supported configurations for Kiali

* The Kiali console is only supported on the two most recent releases of the Chrome, Edge, Firefox, or Safari browsers.
* OpenShift strategy is the only supported authentication configuration when Kiali is deployed with OpenShift Service Mesh (OSSM). OpenShift strategy controls access based on the individual's RBAC roles in OpenShift

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
