### PR TITLE
OCPBUGS-15937: small syntax fix

### DIFF
--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -15,7 +15,7 @@
 
 . If the RHCOS template is configured as a vSphere template follow link:https://docs.vmware.com/en/VMware-vSphere/7.0/com.vmware.vsphere.vm_admin.doc/GUID-D632CAC5-BA5E-4A1E-959B-382D9ACB1DD0_copy.html[Convert a Template to a Virtual Machine]
 in the VMware documentation prior to the next step.
-
++
 [NOTE]
 ====
 Once converted from a template, do not power on the virtual machine.


### PR DESCRIPTION
[OCPBUGS-15937](https://issues.redhat.com/browse/OCPBUGS-15937)

Versions: 4.10+

This PR fixes a small error in update documentation, where the continuity of a procedure was broken because of a NOTE that wasn't properly attached to its preceding step.

QE not required.

Preview: [Updating the virtual hardware for template on vSphere](https://63322--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere#update-vsphere-virtual-hardware-on-template_updating-hardware-on-nodes-running-in-vsphere)
