### PR TITLE
OCPBUGS#17482: vSphere version number updates

### DIFF
--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -16,7 +16,7 @@ Multiple compute nodes can be updated in parallel given workloads are tolerant o
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -11,7 +11,7 @@ To reduce the risk of downtime, it is recommended that control plane nodes be up
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -103,14 +103,14 @@ xref:../updating/updating-restricted-network-cluster/index.adoc#about-restricted
 [id="updating-clusters-overview-vsphere-updating-hardware"]
 == Updating hardware on nodes running in vSphere
 
-xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
+xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
 
 * xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-virtual-hardware-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Updating virtual hardware on vSphere]
 * xref:../updating/updating-hardware-on-nodes-running-on-vsphere.adoc#scheduling-virtual-hardware-update-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Scheduling an update for virtual hardware on vSphere]
 
 [IMPORTANT]
 ====
-Using hardware version 13 for your cluster nodes running on vSphere is now deprecated. This version is still fully supported, but support will be removed in a future version of {product-title}. Hardware version 15 is now the default for vSphere virtual machines in {product-title}.
+Version 4.13 of {product-title} requires VMware virtual hardware version 15 or later.
 ====
 
 [id="updating-clusters-overview-hosted-control-planes"]

--- a/updating/updating-hardware-on-nodes-running-on-vsphere.adoc
+++ b/updating/updating-hardware-on-nodes-running-on-vsphere.adoc
@@ -6,13 +6,15 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster.
+You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster.
 
 You can update your virtual hardware immediately or schedule an update in vCenter.
 
 [IMPORTANT]
 ====
-Before upgrading Openshift 4.12 to Openshift 4.13, you must update vSphere to *v7.0.2 or later*; otherwise, the Openshift 4.12 cluster is marked *un-upgradeable*.
+* Version 4.13 of {product-title} requires VMware virtual hardware version 15 or later.
+
+* Before upgrading Openshift 4.12 to Openshift 4.13, you must update vSphere to *v7.0.2 or later*; otherwise, the Openshift 4.12 cluster is marked *un-upgradeable*.
 ====
 
 [id="updating-virtual-hardware-on-vsphere_{context}"]


### PR DESCRIPTION
[OCPBUGS-17482](https://issues.redhat.com/browse/OCPBUGS-17482)

Version: 4.13 only

This PR updates outdated version requirements for vSphere in the update documentation. 

QE review:
- [x] QE has approved this change.

Previews:
- [Updating clusters overview](https://63325--docspreview.netlify.app/openshift-enterprise/latest/updating/#updating-clusters-overview-vsphere-updating-hardware)
- [Updating hardware on nodes running on vSphere](https://63325--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-hardware-on-nodes-running-on-vsphere)
