### PR TITLE
OCPBUGS#17482: vSphere version number updates

### DIFF
--- a/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-compute-nodes.adoc
@@ -16,7 +16,7 @@ Multiple compute nodes can be updated in parallel given workloads are tolerant o
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-control-plane-nodes.adoc
@@ -11,7 +11,7 @@ To reduce the risk of downtime, it is recommended that control plane nodes be up
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/modules/update-vsphere-virtual-hardware-on-template.adoc
+++ b/modules/update-vsphere-virtual-hardware-on-template.adoc
@@ -9,7 +9,7 @@
 .Prerequisites
 
 * You have cluster administrator permissions to execute the required permissions in the vCenter instance hosting your {product-title} cluster.
-* Your vSphere ESXi hosts are version 6.7U3 or later.
+* Your vSphere ESXi hosts are version 7.0U2 or later.
 
 .Procedure
 

--- a/updating/index.adoc
+++ b/updating/index.adoc
@@ -63,14 +63,14 @@ xref:../updating/updating_a_cluster/updating_disconnected_cluster/index.adoc#abo
 [id="updating-clusters-overview-vsphere-updating-hardware"]
 == Updating hardware on nodes running in vSphere
 
-xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
+xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-hardware-on-nodes-running-on-vsphere[Updating hardware on vSphere]: You must ensure that your nodes running in vSphere are running on the hardware version supported by OpenShift Container Platform. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster. For more information, see the following:
 
 * xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#updating-virtual-hardware-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Updating virtual hardware on vSphere]
 * xref:../updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc#scheduling-virtual-hardware-update-on-vsphere_updating-hardware-on-nodes-running-in-vsphere[Scheduling an update for virtual hardware on vSphere]
 
 [IMPORTANT]
 ====
-Using hardware version 13 for your cluster nodes running on vSphere is now deprecated. This version is still fully supported, but support will be removed in a future version of {product-title}. Hardware version 15 is now the default for vSphere virtual machines in {product-title}.
+Version {product-version} of {product-title} requires VMware virtual hardware version 15 or later.
 ====
 
 [id="updating-clusters-overview-hosted-control-planes"]

--- a/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
+++ b/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere.adoc
@@ -12,13 +12,15 @@ WARNING: This assembly has been moved into a subdirectory for 4.14+. Changes to 
 To do: Remove this comment once 4.13 docs are EOL.
 ////
 
-You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 13 or later is supported for vSphere virtual machines in a cluster.
+You must ensure that your nodes running in vSphere are running on the hardware version supported by {product-title}. Currently, hardware version 15 or later is supported for vSphere virtual machines in a cluster.
 
 You can update your virtual hardware immediately or schedule an update in vCenter.
 
 [IMPORTANT]
 ====
-Before upgrading Openshift 4.12 to Openshift 4.13, you must update vSphere to *v7.0.2 or later*; otherwise, the Openshift 4.12 cluster is marked *un-upgradeable*.
+* Version {product-version} of {product-title} requires VMware virtual hardware version 15 or later.
+
+* Before upgrading Openshift 4.12 to Openshift 4.13, you must update vSphere to *v7.0.2 or later*; otherwise, the Openshift 4.12 cluster is marked *un-upgradeable*.
 ====
 
 [id="updating-virtual-hardware-on-vsphere_{context}"]


### PR DESCRIPTION
[OCPBUGS-17482](https://issues.redhat.com/browse/OCPBUGS-17482)

Version: 4.14+

This PR updates outdated version requirements for vSphere in the update documentation.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Preview: [Updating hardware on nodes running on vSphere](https://63327--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-hardware-on-nodes-running-on-vsphere)

