### PR TITLE
OCPBUGS-14479 - Corrects error related to UEFI secure boot and ZTP cluster installs

### DIFF
--- a/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc
@@ -61,7 +61,7 @@ When the cluster installation is complete, the ZTP pipeline applies the followin
 
 [NOTE]
 ====
-In {ztp} v4.10 and earlier, you configure UEFI secure boot with a `MachineConfig` CR. This is no longer required in {ztp} v4.11 and later. In v4.11, you configure UEFI secure boot for {sno} clusters using Performance profile CRs. For more information, see xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-configuring-performance-addons_sno-configure-for-vdu[Performance profile].
+In {ztp} v4.10 and earlier, you configure UEFI secure boot with a `MachineConfig` CR. This is no longer required in {ztp} v4.11 and later. In v4.11, you configure UEFI secure boot for {sno} clusters by updating the `spec.clusters.nodes.bootMode` field in the `SiteConfig` CR that you use to install the cluster. For more information, see xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and {ztp}].
 ====
 
 include::modules/ztp-sno-du-configuring-the-operators.adoc[leveloffset=+2]


### PR DESCRIPTION
Corrects an error related to UEFI secure boot and ZTP cluster install. Secure boot is configured in the SiteConfig CR at install time.

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-14479

Link to docs preview:
https://63335--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.html#ztp-sno-post-install-time-cluster-config

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
