### PR TITLE
[OSDOCS 7033]: Update Network Verification sections

### DIFF
--- a/modules/automatic-network-verification-bypassing.adoc
+++ b/modules/automatic-network-verification-bypassing.adoc
@@ -6,12 +6,12 @@
 [id="automatic-network-verification-bypassing_{context}"]
 = Automatic network verification bypassing
 
-You can bypass the automatic network verification if you want to deploy  
+You can bypass the automatic network verification if you want to deploy
 ifdef::openshift-dedicated[]
-an {product-title} 
+an {product-title}
 endif::openshift-dedicated[]
 ifdef::openshift-rosa[]
-a {product-title} (ROSA) 
+a {product-title} (ROSA)
 endif::openshift-rosa[]
 cluster with known network configuration issues into an existing Virtual Private Cloud (VPC).
 
@@ -23,20 +23,21 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 When you install a cluster into an existing VPC by using {cluster-manager-first}, you can bypass the automatic verification by selecting *Bypass network verification* on the *Virtual Private Cloud (VPC) subnet settings* page.
 
-ifdef::openshift-rosa[]
-.Bypassing automatic network verification by using the ROSA CLI (`rosa`)
+//Commented out due to updates made in OSDOCS-7033
+//ifdef::openshift-rosa[]
+//.Bypassing automatic network verification by using the ROSA CLI (`rosa`)
 
-When you install a cluster into an existing VPC by using the `rosa create cluster` command, you can bypass the automatic verification by including the `--bypass-network-verify --force` arguments. The following example bypasses the network verification before creating a cluster:
+//When you install a cluster into an existing VPC by using the `rosa create cluster` command, you can bypass the automatic verification by including the `--bypass-network-verify --force` arguments. The following example bypasses the network verification before creating a cluster:
 
-[source,terminal]
-----
-$ rosa create cluster --cluster-name mycluster \
-                      --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc \
-                      --bypass-network-verify --force
-----
+//[source,terminal]
+//----
+//$ rosa create cluster --cluster-name mycluster \
+//                      --subnet-ids subnet-03146b9b52b6024cb,subnet-///03146b9b52b2034cc \
+//                      --bypass-network-verify --force
+//----
 
-[NOTE]
-====
-Alternatively, you can specify the `--interactive` argument and select the option in the interactive prompts to bypass the network verification checks.
-====
-endif::openshift-rosa[]
+//[NOTE]
+//====
+//Alternatively, you can specify the `--interactive` argument and select the option in the interactive prompts to bypass the network verification checks.
+//====
+//endif::openshift-rosa[]

--- a/modules/running-network-verification-manually-cli.adoc
+++ b/modules/running-network-verification-manually-cli.adoc
@@ -9,7 +9,7 @@
 
 You can manually run the network verification checks for an existing {product-title} (ROSA) cluster by using the ROSA CLI (`rosa`).
 
-When you run the network verification, you can specify a set of VPC subnet IDs or a cluster name. If you are using a proxy service, you can specify a proxy URL.
+When you run the network verification, you can specify a set of VPC subnet IDs or a cluster name.
 
 .Prerequisites
 
@@ -19,19 +19,44 @@ When you run the network verification, you can specify a set of VPC subnet IDs o
 
 .Procedure
 
-* Verify the network configuration by using one of the following methods: 
+* Verify the network configuration by using one of the following methods:
 ** Verify the network configuration by specifying the cluster name. The subnet IDs are automatically detected:
 +
 [source,terminal]
 ----
-$ rosa verify network -c <cluster_name> <1>
+$ rosa verify network --cluster <cluster_name> <1>
 ----
 <1> Replace `<cluster_name>` with the name of your cluster.
 +
 .Example output
 [source,terminal]
 ----
-I: ✓ Network verification successful
+I: Verifying the following subnet IDs are configured correctly: [subnet-03146b9b52b6024cb subnet-03146b9b52b2034cc]
+I: subnet-03146b9b52b6024cb: pending
+I: subnet-03146b9b52b2034cc: passed
+I: Run the following command to wait for verification to all subnets to complete:
+rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
+----
+*** Ensure that verification to all subnets has been completed:
++
+[source,terminal]
+----
+$ rosa verify network --watch \ <1>
+                      --status-only \ <2>
+                      --region <region_name> \ <3>
+                      --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc <4>
+----
+<1> The `watch` flag causes the command to complete after all the subnets under test are in a failed or passed state.
+<2> The `status-only` flag does not trigger a run of network verification but returns the current state, for example, `subnet-123 (verification still in-progress)`. By default, without this option, a call to this command always triggers a verification of the specified subnets.
+<3> Use a specific AWS region that overrides the _AWS_REGION_ environment variable.
+<4> Enter a list of subnet IDs separated by commas to verify. If any of the subnets do not exist, the error message `Network verification for subnet 'subnet-<subnet_number> not found` displays and no subnets are checked.
++
+.Example output
+[source,terminal]
+----
+I: Checking the status of the following subnet IDs: [subnet-03146b9b52b6024cb subnet-03146b9b52b2034cc]
+I: subnet-03146b9b52b6024cb: passed
+I: subnet-03146b9b52b2034cc: passed
 ----
 +
 [TIP]
@@ -39,36 +64,33 @@ I: ✓ Network verification successful
 To output the full list of verification tests, you can include the `--debug` argument when you run the `rosa verify network` command.
 ====
 +
-** Verify the network configuration by specifying the VPC subnets IDs:
+** Verify the network configuration by specifying the VPC subnets IDs. Replace `<region_name>` with your AWS region and `<AWS_account_ID>` with your AWS account ID:
 +
 [source,terminal]
 ----
-$ rosa verify network --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
+$ rosa verify network --subnet-ids 03146b9b52b6024cb,subnet-03146b9b52b2034cc --region <region_name> --role-arn arn:aws:iam::<AWS_account_ID>:role/my-Installer-Role
 ----
 +
 .Example output
 [source,terminal]
 ----
-E: Validating Subnet subnet-03146b9b52b6024cb egress
-E: X Egress failed to https://events.pagerduty.com
+I: Verifying the following subnet IDs are configured correctly: [subnet-03146b9b52b6024cb subnet-03146b9b52b2034cc]
+I: subnet-03146b9b52b6024cb: pending
+I: subnet-03146b9b52b2034cc: passed
+I: Run the following command to wait for verification to all subnets to complete:
+rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
 ----
-+
-** Verify the network configuration by specifying the VPC subnets IDs and a proxy URL:
+*** Ensure that verification to all subnets has been completed:
 +
 [source,terminal]
 ----
-$ rosa verify network --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc \
-                      --additional-trust-bundle-file /path/to/ca.cert \
-                      --https-proxy <proxy_url> <1>
+$ rosa verify network --watch --status-only --region us-east-1 --subnet-ids subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
 ----
-<1> Replace `<proxy_url>` with the URL of your proxy service, for example `\https://10.10.0.1`.
 +
 .Example output
 [source,terminal]
 ----
-I: Using proxy configuration
-I: Subnet IDs detected:  subnet-03146b9b52b6024cb,subnet-03146b9b52b2034cc
-
-E: Validating Subnet subnet-03146b9b52b6024cb egress
-E: X Egress failed to https://events.pagerduty.com
+I: Checking the status of the following subnet IDs: [subnet-03146b9b52b6024cb subnet-03146b9b52b2034cc]
+I: subnet-03146b9b52b6024cb: passed
+I: subnet-03146b9b52b2034cc: passed
 ----


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-7033](https://issues.redhat.com/browse/OSDOCS-7033): rosa verify network' incorrect documentation

Link to docs preview:
https://63341--docspreview.netlify.app/openshift-rosa/latest/networking/network-verification#automatic-network-verification-bypassing_network-verification

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change.

Peer review:
- [x] Peer reviewer has approved this change. 

Additional info:

- Removed _Bypassing automatic network verification by using ROSA CLI_ sub-section. 
- Added explanation of arguments for CLI commands.



