### PR TITLE
PR for OCPBUGS-17511

### DIFF
--- a/modules/builds-strategy-docker-build-arguments.adoc
+++ b/modules/builds-strategy-docker-build-arguments.adoc
@@ -5,7 +5,7 @@
 [id="builds-strategy-docker-build-arguments_{context}"]
 = Adding docker build arguments
 
-You can set link:http://docs.docker.com/v1.7/reference/api/hub_registry_spec/#docker-registry-1-0[docker build arguments] using the `buildArgs` array. The build arguments are passed to docker when a build is started.
+You can set link:https://docs.docker.com/engine/reference/builder/#arg[docker build arguments] using the `buildArgs` array. The build arguments are passed to docker when a build is started.
 
 [TIP]
 ====


### PR DESCRIPTION
Description of problem:

Broken link

Version-Release number of selected component (if applicable):

 

How reproducible:

Always

Steps to Reproduce:

1.https://docs.openshift.com/container-platform/4.12/cicd/builds/build-strategies.html#builds-strategy-docker-build-arguments_build-strategies
2. Press docker build arguments link

Actual results:

Non-existing page

Expected results:

Most likely this: https://docs.docker.com/engine/reference/builder/#arg


