### PR TITLE
Nodes: Added dedicated-user for ROSA content port

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-gather.adoc
+++ b/modules/nodes-cma-autoscaling-custom-gather.adoc
@@ -23,7 +23,12 @@ The standard {product-title} `must-gather` command, `oc adm must-gather`, does n
 
 .Prerequisites
 
-* Access to the cluster as a user with the `cluster-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * The {product-title} CLI (`oc`) installed.
 
 .Procedure

--- a/modules/nodes-descheduler-configuring-interval.adoc
+++ b/modules/nodes-descheduler-configuring-interval.adoc
@@ -10,7 +10,12 @@ You can configure the amount of time between descheduler runs. The default is 36
 
 .Prerequisites
 
-* Cluster administrator privileges
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/nodes-descheduler-configuring-profiles.adoc
+++ b/modules/nodes-descheduler-configuring-profiles.adoc
@@ -10,7 +10,12 @@ You can configure which profiles the descheduler uses to evict pods.
 
 .Prerequisites
 
-* Cluster administrator privileges
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 

--- a/modules/nodes-descheduler-installing.adoc
+++ b/modules/nodes-descheduler-installing.adoc
@@ -25,7 +25,12 @@ If you have enabled hosted control planes in your cluster, set a custom priority
 
 .Prerequisites
 
-* Cluster administrator privileges.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * Access to the {product-title} web console.
 ifdef::openshift-origin[]
 * Ensure that you have downloaded the {cluster-manager-url-pull} as shown in _Obtaining the installation program_ in the installation documentation for your platform.

--- a/modules/nodes-descheduler-uninstalling.adoc
+++ b/modules/nodes-descheduler-uninstalling.adoc
@@ -10,7 +10,12 @@ You can remove the descheduler from your cluster by removing the descheduler ins
 
 .Prerequisites
 
-* Cluster administrator privileges.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * Access to the {product-title} web console.
 
 .Procedure

--- a/modules/nodes-nodes-configuring-graceful-shutdown.adoc
+++ b/modules/nodes-nodes-configuring-graceful-shutdown.adoc
@@ -14,7 +14,12 @@ If you do not configure graceful node shutdown, the default grace period is `0` 
 
 .Prerequisites
 
-* You have access to the cluster with the `cluster-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * You have defined priority classes for pods that require critical or regular classification.
 
 .Procedure

--- a/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
+++ b/modules/nodes-scheduler-pod-topology-spread-constraints-configuring.adoc
@@ -12,7 +12,13 @@ You can specify multiple pod topology spread constraints, but you must ensure th
 
 .Prerequisites
 
-* A cluster administrator has added the required labels to nodes.
+ifndef::openshift-rosa,openshift-dedicated[]
+* A user with the `cluster-admin` role has added the required labels to nodes.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* A user with the `dedicated-admin` role has added the required labels to nodes.
+endif::openshift-rosa,openshift-dedicated[]
+
 
 .Procedure
 

--- a/modules/nodes-secondary-scheduler-configuring-console.adoc
+++ b/modules/nodes-secondary-scheduler-configuring-console.adoc
@@ -10,7 +10,12 @@ After you have installed the {secondary-scheduler-operator}, you can deploy a se
 
 .Prerequisities
 
-* You have access to the cluster with `cluster-admin` privileges.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * You have access to the {product-title} web console.
 * The {secondary-scheduler-operator-full} is installed.
 

--- a/modules/nodes-secondary-scheduler-install-console.adoc
+++ b/modules/nodes-secondary-scheduler-install-console.adoc
@@ -10,7 +10,12 @@ You can use the web console to install the {secondary-scheduler-operator-full}.
 
 .Prerequisites
 
-* You have access to the cluster with `cluster-admin` privileges.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * You have access to the {product-title} web console.
 
 .Procedure

--- a/modules/nodes-secondary-scheduler-pod-console.adoc
+++ b/modules/nodes-secondary-scheduler-pod-console.adoc
@@ -10,7 +10,12 @@ To schedule a pod using the secondary scheduler, set the `schedulerName` field i
 
 .Prerequisities
 
-* You have access to the cluster with `cluster-admin` privileges.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * You have access to the {product-title} web console.
 * The {secondary-scheduler-operator-full} is installed.
 * A secondary scheduler is configured.

--- a/modules/nodes-secondary-scheduler-remove-resources-console.adoc
+++ b/modules/nodes-secondary-scheduler-remove-resources-console.adoc
@@ -10,7 +10,12 @@ Optionally, after uninstalling the {secondary-scheduler-operator-full}, you can 
 
 .Prerequisites
 
-* You have access to the cluster with `cluster-admin` privileges.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * You have access to the {product-title} web console.
 
 .Procedure

--- a/modules/nodes-secondary-scheduler-uninstall-console.adoc
+++ b/modules/nodes-secondary-scheduler-uninstall-console.adoc
@@ -10,7 +10,12 @@ You can uninstall the {secondary-scheduler-operator-full} by using the web conso
 
 .Prerequisites
 
-* You have access to the cluster with `cluster-admin` privileges.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * You have access to the {product-title} web console.
 * The {secondary-scheduler-operator-full} is installed.
 

--- a/modules/support-collecting-host-network-trace.adoc
+++ b/modules/support-collecting-host-network-trace.adoc
@@ -31,10 +31,10 @@ However, you can run any command in the container image that is specified in the
 .Prerequisites
 
 ifndef::openshift-rosa,openshift-dedicated[]
-* You have access to the cluster as a user with the `cluster-admin` role.
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
 endif::openshift-rosa,openshift-dedicated[]
 ifdef::openshift-rosa,openshift-dedicated[]
-* You have access to the cluster as a user with the `dedicated-admin` role.
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
 endif::openshift-rosa,openshift-dedicated[]
 
 * You have installed the OpenShift CLI (`oc`).

--- a/modules/tls-profiles-kubelet-configuring.adoc
+++ b/modules/tls-profiles-kubelet-configuring.adoc
@@ -37,7 +37,12 @@ You can see the ciphers and the minimum TLS version of the configured TLS securi
 
 .Prerequisites
 
-* You have access to the cluster as a user with the `cluster-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to {product-title} as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 .Procedure
 


### PR DESCRIPTION
For the ROSA docs, we are using ifdefs to change cluster-admin user prereqs to dedicated-admin. This PR covers the Nodes docs.

**PEER REVIWER** Please ensure that for each of these links, the prereqs for the OCP docs refer to the `cluster-admin` role and ROSA and OSD refer to the `dedicated-admin` role. 

Gathering debugging data [OCP ](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-debugging#nodes-cma-autoscaling-custom-debugging-gather_nodes-cma-autoscaling-custom-debugging)[ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/cma/nodes-cma-autoscaling-custom-debugging.html#nodes-cma-autoscaling-custom-debugging-gather_nodes-cma-autoscaling-custom-debugging) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/cma/nodes-cma-autoscaling-custom-debugging#nodes-cma-autoscaling-custom-debugging-gather_nodes-cma-autoscaling-custom-debugging)
Configuring the descheduler interval [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-descheduler#nodes-descheduler-configuring-interval_nodes-descheduler) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-configuring-interval_nodes-descheduler) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/nodes-descheduler#nodes-descheduler-configuring-interval_nodes-descheduler)
Configuring descheduler profiles [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-descheduler#nodes-descheduler-configuring-profiles_nodes-descheduler) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-configuring-profiles_nodes-descheduler) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/nodes-descheduler#nodes-descheduler-configuring-profiles_nodes-descheduler)
Installing the descheduler [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-descheduler#nodes-descheduler-installing_nodes-descheduler) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-installing_nodes-descheduler) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/nodes-descheduler#nodes-descheduler-installing_nodes-descheduler)
Uninstalling the descheduler [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-uninstalling_nodes-descheduler) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/nodes-descheduler#nodes-descheduler-uninstalling_nodes-descheduler) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/nodes-descheduler.html#nodes-descheduler-uninstalling_nodes-descheduler)
Configuring graceful node shutdown [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-graceful-shutdown#nodes-nodes-configuring-graceful-shutdown_nodes-nodes-graceful-shutdown) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/nodes/nodes-nodes-graceful-shutdown#nodes-nodes-configuring-graceful-shutdown_nodes-nodes-graceful-shutdown) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/nodes/nodes-nodes-graceful-shutdown#nodes-nodes-configuring-graceful-shutdown_nodes-nodes-graceful-shutdown)
Configuring pod topology spread constraints [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints#nodes-scheduler-pod-topology-spread-constraints-configuring_nodes-scheduler-pod-topology-spread-constraints) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.html#nodes-scheduler-pod-topology-spread-constraints-configuring_nodes-scheduler-pod-topology-spread-constraints) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints#nodes-scheduler-pod-topology-spread-constraints-configuring_nodes-scheduler-pod-topology-spread-constraints)
Deploying a secondary scheduler [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring#nodes-secondary-scheduler-configuring-console_secondary-scheduler-configuring) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html#nodes-secondary-scheduler-configuring-console_secondary-scheduler-configuring) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring#nodes-secondary-scheduler-configuring-console_secondary-scheduler-configuring)
Installing the Secondary Scheduler Operator [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html#nodes-secondary-scheduler-install-console_secondary-scheduler-configuring) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html#nodes-secondary-scheduler-install-console_secondary-scheduler-configuring) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html#nodes-secondary-scheduler-install-console_secondary-scheduler-configuring)
Scheduling a pod using the secondary scheduler [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring#nodes-secondary-scheduler-pod-console_secondary-scheduler-configuring) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.html#nodes-secondary-scheduler-pod-console_secondary-scheduler-configuring) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring#nodes-secondary-scheduler-pod-console_secondary-scheduler-configuring)
Removing Secondary Scheduler Operator resources [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling#nodes-secondary-scheduler-remove-resources-console_secondary-scheduler-uninstalling) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.html#nodes-secondary-scheduler-remove-resources-console_secondary-scheduler-uninstalling) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling#nodes-secondary-scheduler-remove-resources-console_secondary-scheduler-uninstalling)
Uninstalling the Secondary Scheduler Operator [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling#nodes-secondary-scheduler-uninstall-console_secondary-scheduler-uninstalling) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.html#nodes-secondary-scheduler-uninstall-console_secondary-scheduler-uninstalling) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-uninstalling.html#nodes-secondary-scheduler-uninstall-console_secondary-scheduler-uninstalling)
Collecting a host network trace [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data#support-collecting-host-network-trace_gathering-cluster-data) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/support/gathering-cluster-data.html#support-collecting-host-network-trace_gathering-cluster-data) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/support/gathering-cluster-data.html#support-collecting-host-network-trace_gathering-cluster-data)
Configuring the TLS security profile for the kubelet [OCP](https://63360--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-tls#tls-profiles-kubelet-configuring_nodes-nodes-tls) [ROSA](https://file.rdu.redhat.com/mburke/nodes-dedicated-user/nodes/nodes/nodes-nodes-tls.html#tls-profiles-kubelet-configuring_nodes-nodes-tls) [Dedicated](https://file.rdu.redhat.com/mburke/dedicated/nodes-dedicated-user/nodes/nodes/nodes-nodes-tls.html#tls-profiles-kubelet-configuring_nodes-nodes-tls)