### PR TITLE
OSSM-4592: Fix indentation in ossm-config-operator-infrastructure-node

### DIFF
--- a/modules/ossm-config-operator-infrastructure-node.adoc
+++ b/modules/ossm-config-operator-infrastructure-node.adoc
@@ -18,29 +18,36 @@ If the operator will run on a worker node, skip this task.
 
 .Procedure
 
+. List the operators installed in the namespace:
++
+[source,terminal]
+----
+$ oc -n openshift-operators get subscriptions
+----
+
 . Edit the {SMProductShortName} Operator `Subscription` resource to specify where the operator should run:
 +
 [source,terminal]
 ----
 $ oc -n openshift-operators edit subscription <name> <1>
 ----
-<1> `<name>` represents the name of the `Subscription` resource.
+<1> `<name>` represents the name of the `Subscription` resource. The default name of the `Subscription` resource is `servicemeshoperator`.
 
 . Add the `nodeSelector` and `tolerations` to `spec.config` in the `Subscription` resource:
 +
 [source,yaml]
 ----
 spec:
- config:
-   nodeSelector: <1>
-     node-role.kubernetes.io/infra: ""
-   tolerations: <2>
-   - effect: NoSchedule
-     key: node-role.kubernetes.io/infra
-     value: reserved
-   - effect: NoExecute
-     key: node-role.kubernetes.io/infra
-     value: reserved
+  config:
+    nodeSelector: <1>
+      node-role.kubernetes.io/infra: ""
+    tolerations: <2>
+    - effect: NoSchedule
+      key: node-role.kubernetes.io/infra
+      value: reserved
+    - effect: NoExecute
+      key: node-role.kubernetes.io/infra
+      value: reserved
 ----
 <1> Ensures that the operator pod is only scheduled on an infrastructure node.
 <2> Ensures that the pod is accepted by the infrastructure node.


### PR DESCRIPTION
…e.adoc

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSSM-4592
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63368--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/installing-ossm#ossm-config-operator-infrastructure-node_installing-ossm
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
