### PR TITLE
OBSDOCS-154: remove-self-referential-link

### DIFF
--- a/monitoring/managing-metrics.adoc
+++ b/monitoring/managing-metrics.adoc
@@ -30,12 +30,6 @@ include::modules/monitoring-querying-metrics.adoc[leveloffset=+1]
 //include::modules/monitoring-contents-of-the-metrics-ui.adoc[leveloffset=+2]
 include::modules/monitoring-querying-metrics-for-all-projects-as-an-administrator.adoc[leveloffset=+2]
 include::modules/monitoring-querying-metrics-for-user-defined-projects-as-a-developer.adoc[leveloffset=+2]
-
-[role="_additional-resources"]
-.Additional resources
-
-* See the xref:../monitoring/managing-metrics.adoc#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics[Querying metrics for user-defined projects as a developer] for details on accessing non-cluster metrics as a developer or a privileged user
-
 include::modules/monitoring-exploring-the-visualized-metrics.adoc[leveloffset=+2]
 
 [role="_additional-resources"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->


Version(s): 4.10 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-154
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

- Fixed (with extra Additional resources section removed): https://file.rdu.redhat.com/~bburt/OBSDOCS-154-remove-self-referential-link/monitoring/managing-metrics.html#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics

- Current (with self-referential link in Additional resources section: https://docs.openshift.com/container-platform/4.10/monitoring/managing-metrics.html#querying-metrics-for-user-defined-projects-as-a-developer_managing-metrics)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A - no technical content changes; only removes a self-referential link
- [ ] No QE approval required.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR removes a self-referential link and a redundant `Additional resources` section
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
