### PR TITLE
[OSDOCS-6488]: Adding troubleshooting docs for hosted control planes

### DIFF
--- a/hosted_control_planes/hcp-managing.adoc
+++ b/hosted_control_planes/hcp-managing.adoc
@@ -19,5 +19,6 @@ include::modules/hosted-control-planes-pause-reconciliation.adoc[leveloffset=+1]
 //using service-level DNS for control plane services
 //configuring metrics sets
 //automated machine management
+include::modules/hosted-control-planes-troubleshooting.adoc[leveloffset=+1]
 include::modules/delete-hosted-cluster.adoc[leveloffset=+1]
 

--- a/modules/hosted-control-planes-troubleshooting.adoc
+++ b/modules/hosted-control-planes-troubleshooting.adoc
@@ -1,0 +1,147 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-managing.adoc
+
+:_content-type: PROCEDURE
+[id="hosted-control-planes-troubleshooting_{context}"]
+= Troubleshooting hosted control planes
+
+When you need to troubleshoot an issue with hosted control plane clusters, you can gather information by running the `hypershift dump cluster` command. The command generates output for the management cluster and the hosted cluster.
+
+The output for the management cluster contains the following content:
+
+* *Cluster-scoped resources:* These resources are node definitions of the management cluster.
+* *The `hypershift-dump` compressed file:* This file is useful if you need to share the content with other people.
+* *Namespaced resources:* These resources include all of the objects from the relevant namespaces, such as config maps, services, events, and logs.
+* *Network logs:* These logs include the OVN northbound and southbound databases and the status for each one.
+* *Hosted clusters:* This level of output involves all of the resources inside of the hosted cluster.
+
+The output for the hosted cluster contains the following content:
+
+* *Cluster-scoped resources:* These resources include all of the cluster-wide objects, such as nodes and CRDs.
+* *Namespaced resources:* These resources include all of the objects from the relevant namespaces, such as config maps, services, events, and logs.
+
+Although the output does not contain any secret objects from the cluster, it can contain references to the names of secrets.
+
+.Prerequisites
+
+* You must have `cluster-admin` access to the management cluster.
+
+* You need the `name` value for the `HostedCluster` resource and the namespace where the CR is deployed.
+
+* You must have the `hcp` command line interface installed. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.8/html/clusters/cluster_mce_overview#hosted-install-cli[Installing the hosted control planes command line interface].
+
+* You must have the OpenShift CLI (`oc`) installed.
+
+* You must ensure that the `kubeconfig` file is loaded and is pointing to the management cluster.
+
+.Procedure
+
+* To gather output for troubleshooting, enter the following commands:
++
+[source,terminal]
+----
+$ CLUSTERNAME="samplecluster"
+----
++
+[source,terminal]
+----
+$ CLUSTERNS="clusters"
+----
++
+[source,terminal]
+----
+$ mkdir clusterDump-${CLUSTERNS}-${CLUSTERNAME}
+----
++
+[source, terminal]
+----
+$ hypershift dump cluster \
+    --name ${CLUSTERNAME} \
+    --namespace ${CLUSTERNS} \
+    --dump-guest-cluster \
+    --artifact-dir clusterDump-${CLUSTERNS}-${CLUSTERNAME}
+----
++
+.Example output
++
+[source,terminal]
+----
+2023-06-06T12:18:20+02:00   INFO    Archiving dump  {"command": "tar", "args": ["-cvzf", "hypershift-dump.tar.gz", "cluster-scoped-resources", "event-filter.html", "namespaces", "network_logs", "timestamp"]}
+2023-06-06T12:18:21+02:00   INFO    Successfully archived dump  {"duration": "1.519376292s"}
+----
+
+* To configure the command-line interface so that it impersonates all of the queries against the management cluster by using a username or service account, enter the `hypershift dump cluster` command with the `--as` flag. 
++
+The service account must have enough permissions to query all of the objects from the namespaces, so the `cluster-admin` role is recommended to make sure you have enough permissions. The service account must be located in or have permissions to query the namespace of the `HostedControlPlane` resource.
++
+If your username or service account does not have enough permissions, the output contains only the objects that you have permissions to access. During that process, you might see `forbidden` errors.
++
+** To use impersonation by using a service account, enter the following commands. Replace values as necessary:
++
+[source,terminal]
+----
+$ CLUSTERNAME="samplecluster"
+----
++
+[source,terminal]
+----
+$ CLUSTERNS="clusters"
+----
++
+[source,terminal]
+----
+$ SA="samplesa"
+----
++
+[source,terminal]
+----
+$ SA_NAMESPACE="default"
+----
++
+[source,terminal]
+----
+$ mkdir clusterDump-${CLUSTERNS}-${CLUSTERNAME}
+----
++
+[source,terminal]
+----
+$ hypershift dump cluster \
+    --name ${CLUSTERNAME} \
+    --namespace ${CLUSTERNS} \
+    --dump-guest-cluster \
+    --as "system:serviceaccount:${SA_NAMESPACE}:${SA}" \
+    --artifact-dir clusterDump-${CLUSTERNS}-${CLUSTERNAME}
+----
+
+** To use impersonation by using a username, enter the following commands. Replace values as necessary:
++
+[source,terminal]
+----
+$ CLUSTERNAME="samplecluster"
+----
++
+[source,terminal]
+----
+$ CLUSTERNS="clusters"
+----
++
+[source,terminal]
+----
+$ CLUSTERUSER="cloud-admin"
+----
++
+[source,terminal]
+----
+$ mkdir clusterDump-${CLUSTERNS}-${CLUSTERNAME}
+----
++
+[source,terminal]
+----
+$ hypershift dump cluster \
+    --name ${CLUSTERNAME} \
+    --namespace ${CLUSTERNS} \
+    --dump-guest-cluster \
+    --as "${CLUSTERUSER}" \
+    --artifact-dir clusterDump-${CLUSTERNS}-${CLUSTERNAME}
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6488
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63373--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-managing#hosted-control-planes-troubleshooting_hcp-managing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
