### PR TITLE
OSDOCS-6622: Updating WinC 5.1.1 Release Notes to include link to errata

### DIFF
--- a/modules/wmco-prerequisites.adoc
+++ b/modules/wmco-prerequisites.adoc
@@ -14,9 +14,9 @@ Docker], Red Hat no longer supports Windows Azure for WMCO releases earlier than
 ====
 
 [id="wmco-prerequisites-supported-5.1.0_{context}"]
-== WMCO 5.1.0 supported platforms and Windows Server versions
+== WMCO 5.1.x supported platforms and Windows Server versions
 
-The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 5.1.0, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
+The following table lists the link:https://docs.microsoft.com/en-us/windows/release-health/windows-server-release-info[Windows Server versions] that are supported by WMCO 5.1.1 and 5.1.0, based on the applicable platform. Windows Server versions not listed are not supported and attempting to use them will cause errors. To prevent these errors, use only an appropriate version for your platform.
 
 [cols="3,7",options="header"]
 |===
@@ -24,6 +24,9 @@ The following table lists the link:https://docs.microsoft.com/en-us/windows/rele
 |Supported Windows Server version
 
 |Amazon Web Services (AWS)
+|Windows Server 2019 (version 1809)
+
+|Microsoft Azure
 |Windows Server 2019 (version 1809)
 
 |VMware vSphere

--- a/windows_containers/windows-containers-release-notes-5-x.adoc
+++ b/windows_containers/windows-containers-release-notes-5-x.adoc
@@ -11,7 +11,7 @@ toc::[]
 
 {productwinc} enables running Windows compute nodes in an {product-title} cluster. Running Windows workloads is possible by using the Red Hat Windows Machine Config Operator (WMCO) to install and manage Windows nodes. With Windows nodes available, you can run Windows container workloads in {product-title}.
 
-The release notes for {productwinc} tracks the development of the WMCO, which provides all Windows container workload capabilities in {product-title}.
+These release notes track the development of the WMCO, which provides all Windows container workload capabilities in {product-title}.
 
 Version 5.x of the WMCO is compatible only with {product-title} 4.10.
 
@@ -35,6 +35,25 @@ For more information, see the Red Hat OpenShift Container Platform Life Cycle Po
 
 If you do not have this additional Red Hat subscription, you can use the Community Windows Machine Config Operator, a distribution that lacks official support.
 endif::openshift-origin[]
+
+[id="wmco-5-1-1"]
+== Release notes for Red Hat Windows Machine Config Operator 5.1.1
+
+This release of the WMCO is now available with a bug fix and a few improvements. The components of the WMCO 5.1.1 are now available in link:https://access.redhat.com/errata/RHBA-2023:4487[RHBA-2023:4487].
+https://errata.devel.redhat.com/advisory/101759
+
+[id="wmco-5-1-1-bug-fixes"]
+=== Bug fix
+
+* Previously, an endpoint object missing required information caused the WMCO pod to fail during startup. With this fix, WMCO verifies the endpoint object is present with the required fields. As a result, WMCO is able to start and reconcile an invalid or misconfigured endpoint object. (https://issues.redhat.com/browse/OCPBUGS-5131[**OCPBUGS-5131**]) 
+
+[id="wmco-5-1-1-removed"]
+=== Removed features
+
+[id="wmco-5-1-1-removed-azure"]
+==== Support for Microsoft Azure has been removed
+
+Support for Microsoft Azure has been removed. Microsoft is removing images from the Azure registry that have Docker preinstalled, which is a prerequisite for using the WCMO 5.x on Microsoft Azure. 
 
 [id="wmco-5-1-0"]
 == Release notes for Red Hat Windows Machine Config Operator 5.1.0


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->
[OSDOCS-6622](https://issues.redhat.com/browse/OSDOCS-6622)

Add bug fixes, link to errata (link doesn't work until the errata is released)

Preview:
[Release notes for Red Hat Windows Machine Config Operator 5.1.0](https://file.rdu.redhat.com/mburke/winc-511-release-notes/windows_containers/windows-containers-release-notes-5-x.html#wmco-5-1-1)

[WMCO 5.1.x supported platforms and Windows Server versions](https://file.rdu.redhat.com/mburke/winc-511-release-notes/windows_containers/windows-containers-release-notes-5-x.html#wmco-prerequisites-supported-5.1.0_windows-containers-release-notes)

This PR replaces [ WMCO 5.1.1 release notes #61542 ](https://github.com/openshift/openshift-docs/pull/61542)