### PR TITLE
RHACS: Update date for patch release

### DIFF
--- a/release_notes/40-release-notes.adoc
+++ b/release_notes/40-release-notes.adoc
@@ -16,6 +16,7 @@ toc::[]
 |`4.0.1` |18 May 2023
 |`4.0.2` |31 May 2023
 |`4.0.3` | 13 July 2023
+|`4.0.4` |9 August 2023
 |====
 
 [id="about-this-release-40"]
@@ -483,6 +484,13 @@ Release date: 13 July 2023
 * Fixed an issue with failed database migration due to a duplicate key value. (ROX-18059)
 * Fixed a memory leak in Collector. (ROX-17553, ROX-17096)
 * Provides a Python3 security update. link:https://access.redhat.com/errata/RHSA-2023:3591[(RHSA-2023:3591)].
+
+[id="resolved-in-version-404"]
+=== Resolved in version 4.0.4
+
+Release date: 9 August 2023
+
+* Removed the Pod Security Policies (PSPs) from the Helm release manifest when upgrading from an outdated version. (ROX-17687)
 
 [id="known-issues-40"]
 === Known issues


### PR DESCRIPTION
New PR for https://github.com/openshift/openshift-docs/pull/63377 to fix release date
