### PR TITLE
OCPBUGS-5914: Update tuned profile reference in gitops ztp flow

### DIFF
--- a/snippets/ztp-performance-profile.adoc
+++ b/snippets/ztp-performance-profile.adoc
@@ -8,8 +8,8 @@ metadata:
   name: openshift-node-performance-profile <1>
 spec:
   additionalKernelArgs:
-    - "idle=poll"
-    - "rcupdate.rcu_normal_after_boot=0"
+    - rcupdate.rcu_normal_after_boot=0
+    - "efi=runtime" <2>
   cpu:
     isolated: 2-51,54-103 <2>
     reserved: 0-1,52-53   <3>
@@ -21,20 +21,17 @@ spec:
         node: 1 <6>
   machineConfigPoolSelector:
     pools.operator.machineconfiguration.openshift.io/master: ""
-  net:
-    userLevelNetworking: true <7>
   nodeSelector:
     node-role.kubernetes.io/master: ""
   numa:
     topologyPolicy: "restricted"
   realTimeKernel:
-    enabled: true    <8>
+    enabled: true    <7>
 ----
 <1> Ensure that the value for `name` matches that specified in the `spec.profile.data` field of `TunedPerformancePatch.yaml` and the `status.configuration.source.name` field of `validatorCRs/informDuValidator.yaml`.
-<2> Set the isolated CPUs. Ensure all of the Hyper-Threading pairs match.
-<3> Set the reserved CPUs. When workload partitioning is enabled, system processes, kernel threads, and system container threads are restricted to these CPUs. All CPUs that are not isolated should be reserved.
-<4> Set the number of huge pages.
-<5> Set the huge page size.
-<6> Set `node` to the NUMA node where the `hugepages` are allocated.
-<7> Set `userLevelNetworking` to `true` to isolate the CPUs from networking interrupts.
-<8> Set `enabled` to `true` to install the real-time Linux kernel.
+<2> Configures UEFI secure boot for the cluster host.
+<3> Set the isolated CPUs. Ensure all of the Hyper-Threading pairs match.
+<4> Set the reserved CPUs. When workload partitioning is enabled, system processes, kernel threads, and system container threads are restricted to these CPUs. All CPUs that are not isolated should be reserved.
+<5> Set the number of huge pages.
+<6> Set the huge page size.
+<7> Set `enabled` to `true` to install the real-time Linux kernel.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-5914
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63408--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Original PR for main, 4.11, and 4.12 with acks is https://github.com/openshift/openshift-docs/pull/52402
The change is the same, all acks are in that PR.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
