### PR TITLE
ODSOC#7393: Removed unsupported message for k8s nmstate

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -47,7 +47,7 @@ ifeval::["{context}" == "about-openshift-sdn"]
 
 |IPsec encryption|Not supported|Supported
 
-|IPv6|Not supported|Supported ^[3]^ ^[4]^
+|IPv6|Not supported|Supported ^[3]^
 
 |Kubernetes network policy|Supported|Supported
 
@@ -65,6 +65,4 @@ endif::[]
 2. Egress router for OVN-Kubernetes supports only redirect mode.
 
 3. IPv6 is supported only on bare metal, vSphere, IBM Power, and {ibmzProductName} clusters.
-
-4. IPv6 single stack does not support xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState].
 --

--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -24,7 +24,7 @@ ifeval::["{context}" == "about-ovn-kubernetes"]
 
 |IPsec encryption for intra-cluster communication|Supported|Not supported
 
-|IPv6|Supported ^[3]^ ^[4]^|Not supported
+|IPv6|Supported ^[3]^|Not supported
 
 |Kubernetes network policy|Supported|Supported
 


### PR DESCRIPTION
Version(s):4.14

Issue: https://issues.redhat.com/browse/OSDOCS-7393

Link to docs preview: https://63410--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#nw-ovn-kubernetes-matrix_about-ovn-kubernetes

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change.
