### PR TITLE
[OSDOCS-7396]: Remove titles from customer portal and add 'Gathering audit logs' back to ROSA/OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -203,13 +203,13 @@ Topics:
   - Name: Accessing the service logs
     File: osd-accessing-the-service-logs
 ---
-# Name: Security and compliance
-# Dir: security
-# Distros: openshift-dedicated
-# Topics:
-# - Name: Viewing audit logs
-#   File: audit-log-view
-# ---
+ Name: Security and compliance
+ Dir: security
+ Distros: openshift-dedicated
+ Topics:
+ - Name: Audit logs
+   File: audit-log-view
+---
 Name: Authentication and authorization
 Dir: authentication
 Distros: openshift-dedicated
@@ -435,7 +435,7 @@ Topics:
 - Name: Configuring the monitoring stack
   File: configuring-the-monitoring-stack
 - Name: Disabling monitoring for user-defined projects
-  File: sd-disabling-monitoring-for-user-defined-projects  
+  File: sd-disabling-monitoring-for-user-defined-projects
 - Name: Enabling alert routing for user-defined projects
   File: enabling-alert-routing-for-user-defined-projects
 - Name: Managing metrics

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -297,17 +297,17 @@ Topics:
   - Name: About autoscaling nodes on a cluster
     File: rosa-nodes-about-autoscaling-nodes
 ---
-# Name: Security and compliance
-# Dir: security
-# Distros: openshift-rosa
-# Topics:
-# - Name: Viewing audit logs
-#   File: audit-log-view
-# # - Name: Security
-# #   File: rosa-security
-# # - Name: Application and cluster compliance
-# #   File: rosa-app-security-compliance
-# ---
+Name: Security and compliance
+Dir: security
+Distros: openshift-rosa
+Topics:
+- Name: Audit logs
+  File: audit-log-view
+#- Name: Security
+#  File: rosa-security
+#- Name: Application and cluster compliance
+#  File: rosa-app-security-compliance
+---
 Name: Authentication and authorization
 Dir: authentication
 Distros: openshift-rosa

--- a/security/audit-log-view.adoc
+++ b/security/audit-log-view.adoc
@@ -1,22 +1,30 @@
 :_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="audit-log-view"]
 = Viewing audit logs
-include::_attributes/common-attributes.adoc[]
+endif::openshift-rosa,openshift-dedicated[]
+
+ifdef::openshift-rosa,openshift-dedicated[]
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="audit-log-view"]
+= Audit logs
+endif::openshift-rosa,openshift-dedicated[]
 :context: audit-log-view
 
 toc::[]
 
 {product-title} auditing provides a security-relevant chronological set of records documenting the sequence of activities that have affected the system by individual users, administrators, or other components of the system.
 
-// About the API audit log
 include::modules/nodes-nodes-audit-log-basic.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 // Viewing the audit log
 include::modules/nodes-nodes-audit-log-basic-viewing.adoc[leveloffset=+1]
 
 // Filtering audit logs
 include::modules/security-audit-log-filtering.adoc[leveloffset=+1]
-
+endif::openshift-rosa,openshift-dedicated[]
 // Gathering audit logs
 include::modules/gathering-data-audit-logs.adoc[leveloffset=+1]
 

--- a/support/gathering-cluster-data.adoc
+++ b/support/gathering-cluster-data.adoc
@@ -20,7 +20,7 @@ It is recommended to provide:
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-You can use the following tools to get debugging information about your {product-title} cluster. 
+You can use the following tools to get debugging information about your {product-title} cluster.
 endif::openshift-origin[]
 
 // About the must-gather tool
@@ -40,8 +40,10 @@ include::modules/gathering-data-specific-features.adoc[leveloffset=+2]
 
 * link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy]
 
+ifdef::openshift-rosa,openshift-dedicated[]
 // Gathering audit logs
 include::modules/gathering-data-audit-logs.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
 // Gathering network logs
 include::modules/gathering-data-network-logs.adoc[leveloffset=+2]


### PR DESCRIPTION

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-7396
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
ROSA: https://63421--docspreview.netlify.app/openshift-rosa/latest/security/audit-log-view
OSD: https://63421--docspreview.netlify.app/openshift-dedicated/latest/security/audit-log-view
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
