### PR TITLE
OSDOCS-6047: replace non persistent device names

### DIFF
--- a/modules/bmo-getting-the-baremetalhost-resource.adoc
+++ b/modules/bmo-getting-the-baremetalhost-resource.adoc
@@ -69,7 +69,7 @@ spec:
   hardwareProfile: unknown
   online: true
   rootDeviceHints:
-    deviceName: /dev/sda
+    deviceName: /dev/disk/by-id/scsi-<serial_number>
   userData:
     name: worker-user-data-managed
     namespace: openshift-machine-api
@@ -107,7 +107,7 @@ status:
     storage:
     - hctl: "0:0:0:0"
       model: VK000960GWTTB
-      name: /dev/sda
+      name: /dev/disk/by-id/scsi-<serial_number>
       sizeBytes: 960197124096
       type: SSD
       vendor: ATA
@@ -130,7 +130,7 @@ status:
       hardwareRAIDVolumes: null
       softwareRAIDVolumes: []
     rootDeviceHints:
-      deviceName: /dev/sda
+      deviceName: /dev/disk/by-id/scsi-<serial_number>
     state: provisioned
   triedCredentials:
     credentials:

--- a/modules/cnf-topology-aware-lifecycle-manager-backup-feature.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-backup-feature.adoc
@@ -35,12 +35,12 @@ nodes:
     role: "master"
     rootDeviceHints:
         hctl: "0:2:0:0"
-        deviceName: /dev/sda
-........
-........
-    #Disk /dev/sda: 893.3 GiB, 959119884288 bytes, 1873281024 sectors
+        deviceName: /dev/disk/by-id/scsi-3600508b400105e210000900000490000
+...
+    #Disk /dev/disk/by-id/scsi-3600508b400105e210000900000490000:
+    #893.3 GiB, 959119884288 bytes, 1873281024 sectors
     diskPartition:
-        - device: /dev/sda
+        - device: /dev/disk/by-id/scsi-3600508b400105e210000900000490000
         partitions:
         - mount_point: /var/recovery
             size: 51200

--- a/modules/ibmz-configure-nbde-with-static-ip.adoc
+++ b/modules/ibmz-configure-nbde-with-static-ip.adoc
@@ -91,7 +91,7 @@ endif::ibm-z-kvm[]
 ----
 $ coreos-installer pxe customize \
     /root/rhcos-bootfiles/rhcos-<release>-live-initramfs.s390x.img \
-    --dest-device /dev/sda --dest-karg-append \
+    --dest-device /dev/disk/by-id/scsi-<serial-number> --dest-karg-append \
     ip=<ip-address>::<gateway-ip>:<subnet-mask>::<network-device>:none \
     --dest-karg-append nameserver=<nameserver-ip> \
     --dest-karg-append rd.neednet=1 -o \

--- a/modules/installation-disk-partitioning-upi-templates.adoc
+++ b/modules/installation-disk-partitioning-upi-templates.adoc
@@ -93,7 +93,7 @@ metadata:
   name: 98-var-partition
 storage:
   disks:
-  - device: /dev/<device_name> <1>
+  - device: /dev/disk/by-id/<device_name> <1>
     partitions:
     - label: var
       start_mib: <partition_start_offset> <2>

--- a/modules/installation-disk-partitioning.adoc
+++ b/modules/installation-disk-partitioning.adoc
@@ -92,7 +92,7 @@ metadata:
   name: 98-var-partition
 storage:
   disks:
-  - device: /dev/<device_name> <1>
+  - device: /dev/disk/by-id/<device_name> <1>
     partitions:
     - label: var
       start_mib: <partition_start_offset> <2>

--- a/modules/installation-ibm-z-user-infra-machines-iso.adoc
+++ b/modules/installation-ibm-z-user-infra-machines-iso.adoc
@@ -79,7 +79,7 @@ Write all options in the parameter file as a single line and make sure you have 
 ====
 When you install with multiple paths, you must enable multipathing directly after the installation, not at a later point in time, as this can cause problems.
 ====
-... Set the install device as: `coreos.inst.install_dev=/dev/sda`.
+... Set the install device as: `coreos.inst.install_dev=/dev/disk/by-id/scsi-<serial_number>`.
 +
 [NOTE]
 ====
@@ -99,7 +99,7 @@ The following is an example parameter file `worker-1.parm` for a worker node wit
 ----
 rd.neednet=1 \
 console=ttysclp0 \
-coreos.inst.install_dev=/dev/sda \
+coreos.inst.install_dev=/dev/disk/by-id/scsi-<serial_number> \
 coreos.live.rootfs_url=http://cl1.provide.example.com:8080/assets/rhcos-live-rootfs.s390x.img \
 coreos.inst.ignition_url=http://cl1.provide.example.com:8080/ignition/worker.ign \
 ip=172.18.78.2::172.18.78.1:255.255.255.0:::none nameserver=172.18.78.1 \

--- a/modules/installation-special-config-raid.adoc
+++ b/modules/installation-special-config-raid.adoc
@@ -35,16 +35,16 @@ metadata:
 boot_device:
   mirror:
     devices:
-      - /dev/sda
-      - /dev/sdb
+      - /dev/disk/by-id/scsi-3600508b400105e210000900000490000
+      - /dev/disk/by-id/scsi-SSEAGATE_ST373453LW_3HW1RHM6
 storage:
   disks:
-    - device: /dev/sda
+    - device: /dev/disk/by-id/scsi-3600508b400105e210000900000490000
       partitions:
         - label: root-1
           size_mib: 25000 <1>
         - label: var-1
-    - device: /dev/sdb
+    - device: /dev/disk/by-id/scsi-SSEAGATE_ST373453LW_3HW1RHM6
       partitions:
         - label: root-2
           size_mib: 25000 <1>

--- a/modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc
@@ -23,13 +23,13 @@ $ coreos-installer iso customize rhcos-<version>-live.x86_64.iso \
   --dest-ignition <path> \//<1>
   --dest-console tty0 \//<2>
   --dest-console ttyS0,<options> \//<3>
-  --dest-device /dev/sda <4>
+  --dest-device /dev/disk/by-id/scsi-<serial_number> <4>
 ----
 +
 <1> The location of the Ignition config to install.
 <2> The desired secondary console. In this case, the graphical console. Omitting this option will disable the graphical console.
 <3> The desired primary console. In this case, the serial console. The `options` field defines the baud rate and other settings. A common value for this field is `115200n8`. If no options are provided, the default kernel value of `9600n8` is used. For more information on the format of this option, see the link:https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html[Linux kernel serial console] documentation.
-<4> The specified disk to install to. In this case, `/dev/sda`. If you omit this option, the {boot-media} automatically runs the installation program which will fail unless you also specify the `coreos.inst.install_dev` kernel argument.
+<4> The specified disk to install to. If you omit this option, the {boot-media} automatically runs the installation program which will fail unless you also specify the `coreos.inst.install_dev` kernel argument.
 +
 [NOTE]
 ====
@@ -58,14 +58,14 @@ $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
   --dest-ignition <path> \//<1>
   --dest-console tty0 \//<2>
   --dest-console ttyS0,<options> \//<3>
-  --dest-device /dev/sda \//<4>
+  --dest-device /dev/disk/by-id/scsi-<serial_number> \//<4>
   -o rhcos-<version>-custom-initramfs.x86_64.img
 ----
 +
 <1> The location of the Ignition config to install.
 <2> The desired secondary console. In this case, the graphical console. Omitting this option will disable the graphical console.
 <3> The desired primary console. In this case, the serial console. The `options` field defines the baud rate and other settings. A common value for this field is `115200n8`. If no options are provided, the default kernel value of `9600n8` is used. For more information on the format of this option, see the link:https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html[Linux kernel serial console] documentation.
-<4> The specified disk to install to. In this case, `/dev/sda`. If you omit this option, the {boot-media} automatically runs the installer which will fail unless you also specify the `coreos.inst.install_dev` kernel argument.
+<4> The specified disk to install to. If you omit this option, the {boot-media} automatically runs the installer which will fail unless you also specify the `coreos.inst.install_dev` kernel argument.
 +
 Your customizations are applied and affect every subsequent boot of the {boot-media}.
 endif::[]

--- a/modules/installation-user-infra-machines-advanced-customizing-live.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live.adoc
@@ -28,7 +28,7 @@ ifeval::["{boot-media}" == "ISO image"]
 ----
 $ coreos-installer iso customize rhcos-<version>-live.x86_64.iso \
     --dest-ignition bootstrap.ign \ <1>
-    --dest-device /dev/sda <2>
+    --dest-device /dev/disk/by-id/scsi-<serial_number> <2>
 ----
 endif::[]
 
@@ -39,7 +39,7 @@ ifeval::["{boot-media}" == "PXE environment"]
 ----
 $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
     --dest-ignition bootstrap.ign \ <1>
-    --dest-device /dev/sda \ <2>
+    --dest-device /dev/disk/by-id/scsi-<serial_number> \ <2>
     -o rhcos-<version>-custom-initramfs.x86_64.img
 ----
 endif::[]

--- a/modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc
+++ b/modules/installation-user-infra-machines-advanced-enabling-serial-console.adoc
@@ -21,7 +21,7 @@ By default, the {op-system-first} serial console is disabled and all output is w
 $ coreos-installer install \
   --console=tty0 \//<1>
   --console=ttyS0,<options> \//<2>
-  --ignition-url=http://host/worker.ign /dev/sda
+  --ignition-url=http://host/worker.ign /dev/disk/by-id/scsi-<serial_number>
 ----
 +
 <1> The desired secondary console. In this case, the graphical console. Omitting this option will disable the graphical console.

--- a/modules/installation-user-infra-machines-advanced.adoc
+++ b/modules/installation-user-infra-machines-advanced.adoc
@@ -55,7 +55,7 @@ system using available RHEL tools, such as `nmcli` or `nmtui`.
 [source,terminal]
 ----
 $ sudo coreos-installer install --copy-network \
-     --ignition-url=http://host/worker.ign /dev/sda
+     --ignition-url=http://host/worker.ign /dev/disk/by-id/scsi-<serial_number>
 ----
 +
 [IMPORTANT]
@@ -163,7 +163,7 @@ metadata:
   name: 98-var-partition
 storage:
   disks:
-  - device: /dev/<device_name> <1>
+  - device: /dev/disk/by-id/<device_name> <1>
     partitions:
     - label: var
       start_mib: <partition_start_offset> <2>
@@ -242,7 +242,7 @@ This example preserves any partition in which the partition label begins with `d
 [source,terminal]
 ----
 # coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign \
-        --save-partlabel 'data*' /dev/sda
+        --save-partlabel 'data*' /dev/disk/by-id/scsi-<serial_number>
 ----
 
 The following example illustrates running the `coreos-installer` in a way that preserves
@@ -251,7 +251,7 @@ the sixth (6) partition on the disk:
 [source,terminal]
 ----
 # coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign \
-        --save-partindex 6 /dev/sda
+        --save-partindex 6 /dev/disk/by-id/scsi-<serial_number>
 ----
 
 This example preserves partitions 5 and higher:
@@ -259,7 +259,7 @@ This example preserves partitions 5 and higher:
 [source,terminal]
 ----
 # coreos-installer install --ignition-url http://10.0.2.2:8080/user.ign
-        --save-partindex 5- /dev/sda
+        --save-partindex 5- /dev/disk/by-id/scsi-<serial_number>
 ----
 
 In the previous examples where partition saving is used, `coreos-installer` recreates the partition immediately.

--- a/modules/restore-replace-stopped-baremetal-etcd-member.adoc
+++ b/modules/restore-replace-stopped-baremetal-etcd-member.adoc
@@ -428,7 +428,7 @@ spec:
   externallyProvisioned: false
   online: true
   rootDeviceHints:
-    deviceName: /dev/sda
+    deviceName: /dev/disk/by-id/scsi-<serial_number>
   userData:
     name: master-user-data-managed
     namespace: openshift-machine-api

--- a/modules/storage-ephemeral-storage-monitoring.adoc
+++ b/modules/storage-ephemeral-storage-monitoring.adoc
@@ -22,5 +22,5 @@ The output shows the ephemeral storage usage in `/var/lib`:
 [source,terminal]
 ----
 Filesystem  Size  Used Avail Use% Mounted on
-/dev/sda1    69G   32G   34G  49% /
+/dev/disk/by-partuuid/4cd1448a-01    69G   32G   34G  49% /
 ----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6047
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: changing to [persistent naming schema for RHEL9](https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/managing_file_systems/assembly_overview-of-persistent-naming-attributes_managing-file-systems#device-identifiers_assembly_overview-of-persistent-naming-attributes)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
