### PR TITLE
[enterprise-4.12]  OCPBUGS-10815: Enhance K8s API server LB note

### DIFF
--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -65,9 +65,9 @@ The load balancing infrastructure must meet the following requirements:
   ** A stateless load balancing algorithm. The options vary based on the load balancer implementation.
 --
 +
-[NOTE]
+[IMPORTANT]
 ====
-Session persistence is not required for the API load balancer to function properly.
+Do not configure session persistence for an API load balancer. Configuring session persistence for a Kubernetes API server might cause performance issues from excess application traffic for your {product-title} cluster and the Kubernetes API that runs inside the cluster.
 ====
 +
 Configure the following ports on both the front and back of the load balancers:


### PR DESCRIPTION
Cherry-picked from commit xref: #62996

[OCPBUGS-10815](https://issues.redhat.com/browse/OCPBUGS-10815)

Version(s):
4.12

Link to docs preview:
[Load balancing requirements for user-provisioned infrastructure](https://63455--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere.html#installation-load-balancing-user-infra_installing-vsphere)

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->