### PR TITLE
TELCODOCS-1367 Update power saving configurations documentation

### DIFF
--- a/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
+++ b/modules/cnf-provisioning-real-time-and-low-latency-workloads.adoc
@@ -345,20 +345,18 @@ When you configure a node with a power saving configuration, you must configure 
 By disabling P-states and C-states at the pod level, you can configure high priority workloads for best performance and lowest latency.
 
 .Configuration for high priority workloads
-[cols="1,2", options="header"]
-|====
-|Annotation
-|Description
+[cols="1,2,3", options="header"]
 
-a|[source,yaml]
-----
-annotations:
-  cpu-c-states.crio.io: "disable"
-  cpu-freq-governor.crio.io: "<governor>"
-----
-|Provides the best performance for a pod by disabling C-states and specifying the governor type for CPU scaling. The `performance` governor is recommended for high priority workloads.
-|====
+|===
+| Annotation | Possible Values | Description
 
+|`cpu-c-states.crio.io:` a|  * `"enable"`
+* `"disable"`
+* `"max_latency:microseconds"` | This annotation allows you to enable or disable C-states for each CPU. Alternatively, you can also specify a maximum latency in microseconds for the C-states. For example, enable C-states with a maximum latency of 10 microseconds with the setting `cpu-c-states.crio.io`: `"max_latency:10"`. Set the value to `"disable"` to provide the best performance for a pod.
+
+| `cpu-freq-governor.crio.io:` | Any supported `cpufreq governor`. | Sets the `cpufreq` governor for each CPU. The `"performance"` governor is recommended for high priority workloads.
+
+|===
 
 .Prerequisites
 
@@ -435,7 +433,7 @@ metadata:
   annotations:
     ...
     cpu-c-states.crio.io: "disable"
-    cpu-freq-governor.crio.io: "<governor>"
+    cpu-freq-governor.crio.io: "performance"
     ...
   ...
 spec:


### PR DESCRIPTION
[TELCODOCS-1367]: Update power saving configurations documentation

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1367
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63463--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#node-tuning-operator-pod-power-saving-config_cnf-master
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
