### PR TITLE
ROX-18584: Update upgrade info

### DIFF
--- a/modules/prepare-operator-upgrades.adoc
+++ b/modules/prepare-operator-upgrades.adoc
@@ -6,7 +6,14 @@
 = Preparing to upgrade
 
 [role="_abstract"]
-Before you upgrade {rh-rhacs-first} version, you must:
+Before you upgrade the {rh-rhacs-first} version, you must perform the following steps:
 
 * Verify that you are running the latest patch release version of the {product-title-short} Operator 3.74.
 * Backup your existing Central database.
+* If the `SecuredCluster` custom resource is present in the cluster, ensure the per node collection setting is set to EBPF by following these steps:
+. In the {ocp} web console, navigate to the {rh-rhacs-first} Operator page.
+. Select *Secured Cluster* in the top navigation bar, and then select the instance by clicking on the name (for example, *stackrox-secured-cluster-services*).
+. Click *YAML* to open the YAML editor view.
+. Locate the `spec.perNode.collector.collection` attribute.
+. If the value of this attribute is `KernelModule`, change it to `EBPF`.
+. Click `Save`.

--- a/upgrading/upgrade-operator.adoc
+++ b/upgrading/upgrade-operator.adoc
@@ -7,7 +7,11 @@ include::modules/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-Upgrades through the {rh-rhacs-first} Operator are performed automatically or manually, depending on the *Update approval* option you chose at installation.
+Upgrades through the {rh-rhacs-first} Operator are performed automatically or manually, depending on the *Update approval* option you chose at installation. Upgrading from version 3.74 to 4.x requires some additional steps that are described on this page. Upgrading within 4.y versions requires no additional steps.
+
+[discrete]
+[id="upgrading-from-version-3x-to-4x_{context}"]
+== Upgrading from version 3.74 to 4.x
 
 {product-title-short} 4.0 includes a significant architectural change, moving Central’s database to PostgreSQL. Because of this change, {product-title-short} 4.0 Operator is published by a new subscription channel. Therefore, as part of the upgrade instructions, you must manually change the subscription channel to upgrade from {product-title-short} 3.74 to {product-title-short} 4.0.
 


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.2`
- Cherry pick to `rhacs-docs-4.1`
- Cherry pick to `rhacs-docs-4.0`
- Cherry pick to `rhacs-docs-3.74`

Issues:

- https://issues.redhat.com/browse/ROX-18584
- https://issues.redhat.com/browse/ROX-18594

[Link to docs preview
](https://file.rdu.redhat.com/kcarmich/ROX-18976-cloud-service-versions/upgrading/upgrade-operator.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
