### PR TITLE
OCPBUGS#14697: agent doc typos

### DIFF
--- a/modules/agent-install-networking.adoc
+++ b/modules/agent-install-networking.adoc
@@ -70,8 +70,9 @@ rendezvousIP: 192.168.111.80 <1>
           config:
             - destination: 0.0.0.0/0
               next-hop-address: 192.168.111.1 <6>
-              next-hop-interface: eth0
+              next-hop-interface: eno1
               table-id: 254
+  EOF
 ----
 <1> If a value is not specified for the `rendezvousIP` field, one address will be chosen from the static IP addresses specified in the `networkConfig` fields.
 <2> The MAC address of an interface on the host, used to determine which host to apply the configuration to.


### PR DESCRIPTION
[OCPBUGS-14697](https://issues.redhat.com/browse/OCPBUGS-14697) and [OCPBUGS-11703](https://issues.redhat.com/browse/OCPBUGS-11703)

Versions: 4.12+

This PR fixes a few typos in the sample agent-config.yaml in the [Static networking](https://docs.openshift.com/container-platform/4.13/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#static-networking) section of the agent docs.

QE review:
- [x] QE has approved this change.

Preview: [Static networking](https://63483--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#static-networking)

