### PR TITLE
OSDOCS-7426 Z-stream RNs 4.13.9

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3070,9 +3070,30 @@ $ oc adm release info 4.13.8 --pullspecs
 
 [id="ocp-4-13-8-bug-fixes"]
 ==== Bug fixes
-* Previously, the real loadbalancer address in the {rh-openstack-first} was not visible. With this update, the real loadbalancer address has been added and is visible in the {rh-openstack} loadbalancer object annotation. (link:https://issues.redhat.com/browse/OCPBUGS-15973[*OCPBUGS-15973*])
+* Previously, the real load balancer address in the {rh-openstack-first} was not visible. With this update, the real load balancer address has been added and is visible in the {rh-openstack} load balancer object annotation. (link:https://issues.redhat.com/browse/OCPBUGS-15973[*OCPBUGS-15973*])
 
 [id="ocp-4-13-8-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-13-9"]
+=== RHSA-2023:4603 - {product-title} 4.13.9 bug fix and security update
+
+Issued: 2023-08-16
+
+{product-title} release 4.13.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:4603[RHSA-2023:4603] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4606[RHBA-2023:4606] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.9 --pullspecs
+----
+
+[id="ocp-4-13-9-updating"]
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-7426](https://issues.redhat.com/browse/OSDOCS-7426)

Link to docs preview:
[Preview](https://63484--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-9)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Expected to ship live on Aug. 16th. Changed a small typo in the 4.13.8 RNs.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
