### PR TITLE
OSDOCS-4325: Revised Scaling the Cluster Monitoring Operator content

### DIFF
--- a/modules/configuring-cluster-monitoring.adoc
+++ b/modules/configuring-cluster-monitoring.adoc
@@ -44,15 +44,10 @@ metadata:
   name: cluster-monitoring-config
   namespace: openshift-monitoring
 ----
-<1> A typical value is `PROMETHEUS_RETENTION_PERIOD=15d`. Units are measured in
-time using one of these suffixes: s, m, h, d.
+<1> The default value of Prometheus retention is `PROMETHEUS_RETENTION_PERIOD=15d`. Units are measured in time using one of these suffixes: s, m, h, d.
 <2> The storage class for your cluster.
-<3> A typical value is `PROMETHEUS_STORAGE_SIZE=2000Gi`. Storage values can be a
-plain integer or as a fixed-point integer using one of these suffixes: E, P, T,
-G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
-<4> A typical value is `ALERTMANAGER_STORAGE_SIZE=20Gi`. Storage values can be a
-plain integer or as a fixed-point integer using one of these suffixes: E, P, T,
-G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
+<3> A typical value is `PROMETHEUS_STORAGE_SIZE=2000Gi`. Storage values can be a plain integer or a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
+<4> A typical value is `ALERTMANAGER_STORAGE_SIZE=20Gi`. Storage values can be a plain integer or a fixed-point integer using one of these suffixes: E, P, T, G, M, K. You can also use the power-of-two equivalents: Ei, Pi, Ti, Gi, Mi, Ki.
 
 . Add values for the retention period, storage class, and storage sizes.
 

--- a/modules/prometheus-database-storage-requirements.adoc
+++ b/modules/prometheus-database-storage-requirements.adoc
@@ -10,40 +10,36 @@ Red Hat performed various tests for different scale sizes.
 
 [NOTE]
 ====
-The Prometheus storage requirements below are not prescriptive. Higher resource consumption might be observed in your cluster depending on workload activity and resource use.
+The Prometheus storage requirements below are not prescriptive and should be used as a reference. Higher resource consumption might be observed in your cluster depending on workload activity and resource density, including the number of pods, containers, routes, or other resources exposing metrics collected by Prometheus.
 ====
 
 .Prometheus Database storage requirements based on number of nodes/pods in the cluster
 [options="header"]
 |===
-|Number of Nodes |Number of pods |Prometheus storage growth per day |Prometheus storage growth per 15 days |RAM Space (per scale size) |Network (per tsdb chunk)
+|Number of Nodes |Number of pods (2 containers per pod) |Prometheus storage growth per day |Prometheus storage growth per 15 days |Network (per tsdb chunk)
 
 |50
 |1800
 |6.3 GB
 |94 GB
-|6 GB
 |16 MB
 
 |100
 |3600
 |13 GB
 |195 GB
-|10 GB
 |26 MB
 
 |150
 |5400
 |19 GB
 |283 GB
-|12 GB
 |36 MB
 
 |200
 |7200
 |25 GB
 |375 GB
-|14 GB
 |46 MB
 |===
 
@@ -58,5 +54,5 @@ CPU utilization has minor impact. The ratio is approximately 1 core out of 40 pe
 
 *Recommendations for {product-title}*
 
-* Use at least three infrastructure (infra) nodes.
-* Use at least three *openshift-container-storage* nodes with non-volatile memory express (NVMe) drives.
+* Use at least two infrastructure (infra) nodes.
+* Use at least three *openshift-container-storage* nodes with non-volatile memory express (SSD or NVMe) drives.


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-4325

Link to docs preview:
https://63485--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices#scaling-cluster-monitoring-operator_recommended-infrastructure-practices
