### PR TITLE
OSDOCS-6479: update RHDE page with compat matrix

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -11,5 +11,7 @@
 :op-system-ostree-first: Red Hat Enterprise Linux (RHEL) for Edge
 :op-system-ostree: RHEL for Edge
 :op-system-version: 9.2
+:op-system-version-major: 9
 :microshift-first: Red Hat build of MicroShift
 :microshift: MicroShift
+:microshift-version: 4.14

--- a/_topic_map.yml
+++ b/_topic_map.yml
@@ -26,6 +26,6 @@ Name: Overview
 Dir: overview
 Distros: openshift-rhde
 Topics:
-- Name: Overview
+- Name: About Red Hat Device Edge
   File: rhde-overview
 

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -6,7 +6,7 @@
 [id="about-rhde_{context}"]
 = About {product-title}
 
-{product-title} is for organizations who need small-form-factor edge devices with support for bare metal, virtualized, or containerized applications. {product-title} helps address many of the emerging questions around large-scale edge computing at the device edge by incorporating Kubernetes features in a new, smaller, lighter-weight footprint with an edge-optimized Linux OS built from the world's leading enterprise Linux platform in {op-system}.
+{product-title} is for organizations that need small-form-factor edge devices and support for bare metal, virtualized, or containerized applications. {product-title} helps address many of the emerging questions around large-scale edge computing at the device edge by incorporating Kubernetes features in a new, smaller, lighter-weight footprint with an edge-optimized Linux operating system built from the world's leading enterprise Linux platform in {op-system}.
 
 .{product-title} components
 image::RHDevice_Edge_Overview_1.png[]
@@ -14,37 +14,54 @@ image::RHDevice_Edge_Overview_1.png[]
 .{product-title} layers
 image::RHDevice_Edge_Overview_2.png[]
 
+For a non-technical description of {product-title}, see link:https://www.redhat.com/en/technologies/device-edge[Red Hat Device Edge].
+
 [id="device-edge-relnotes_{context}"]
 == {product-title} product release notes
 
-The release notes for each product that is part of {product-title} are available at the following links:
+The latest release notes for each product that is part of {product-title} are available at the following links:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.13/html/release_notes/index[{microshift-first}]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9-beta/html/9.2_release_notes/index[{op-system-ostree-first}] release notes contain details about {op-system-ostree}
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}/html/release_notes/index[{microshift-first}]
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.2_release_notes/index[{op-system-ostree-first}] release notes contain details about {op-system-ostree}
 
 [id="device-edge-compatibility"]
 == {product-title} product release compatibility matrix
 
 The two products of {product-title} work together as a single solution for device-edge computing. To successfully pair your products, use the verified releases together for each as listed in the following table:
 
-[cols="3",%autowidth]
+[cols="4",%autowidth]
 |===
-|*{op-system-ostree} version*
-|*{microshift} version*
-|*{microshift} release status*
+^|*{op-system-ostree} version*
+^|*{microshift} version*
+^|*{microshift} release status*
+^|*{microshift} supported updates*
 
-|8.7
-|4.12
-|Developer Preview
+^|9.2
+^|4.14
+^|Generally Available
+^|4.14.0&#8594;4.14.z and 4.14&#8594;4.15
 
-|9.2
-|4.13
-|Technology Preview
+^|9.2
+^|4.13
+^|Technology Preview
+^|None
 
+^|8.7
+^|4.12
+^|Developer Preview
+^|None
 |===
 
-For more information about the {product-title} products, read the following documentation:
+For more information about the {product-title} products, see the following documentation:
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.13[Red Hat build of MicroShift]
-* link:https://access.redhat.com/documentation/en-us/edge_management/2022[Product Documentation for Edge management 2022]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14[Red Hat build of MicroShift]
+
+* link:https://access.redhat.com/documentation/en-us/edge_management/2023[Product Documentation for Edge management 2023]
+//the RHEL team owns the edge management page; date change to apply before GA
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
+
+For details about {product-title} upgrade paths, see the following documentation:
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}/html/updates/index[{microshift} updates]

--- a/overview/rhde-overview.adoc
+++ b/overview/rhde-overview.adoc
@@ -3,9 +3,6 @@
 include::_attributes/common-attributes.adoc[]
 :context: device-edge-overview
 
-{product-title} delivers an enterprise-ready distribution of the Red Hat-led open source community project {microshift}, a lightweight Kubernetes orchestration solution built from the edge capabilities of Red Hat OpenShift, along with an edge-optimized operating system built from {op-system-first}.
-
-:FeatureName: {product-title}
-include::snippets/technology-preview.adoc[]
+{product-title} delivers an enterprise-ready distribution of the Red Hat-led open source community project {microshift-first}. {microshift} is a lightweight Kubernetes orchestration solution built from the edge capabilities of {OCP}, along with an edge-optimized operating system built from {op-system-first}.
 
 include::modules/about-rhde.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 
4.0 RHDE
In re: MicroShift 4.14/RHEL 9.2

Issue:
https://issues.redhat.com/browse/OSDOCS-6479

Link to docs preview:
https://63486--docspreview.netlify.app/openshift-rhde/latest/overview/rhde-overview

QE review:
- N/A

Additional info: 
OK to merge now; page will not go live until GA. 