### PR TITLE
OCPBUGS-12788: Style fix to general references

### DIFF
--- a/modules/ipi-install-additional-install-config-parameters.adoc
+++ b/modules/ipi-install-additional-install-config-parameters.adoc
@@ -26,11 +26,11 @@ and the `bmc` parameter for the `install-config.yaml` file.
 
 | `bootstrapExternalStaticIP`
 |
-| The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the `baremetal` network.
+| The static IP address for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
 
 | `bootstrapExternalStaticGateway`
 |
-| The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the `baremetal` network.
+| The static IP address of the gateway for the bootstrap VM. You must set this value when deploying a cluster with static IP addresses when there is no DHCP server on the bare-metal network.
 
 | `sshKey`
 |
@@ -94,7 +94,7 @@ controlPlane:
 |
 |Replicas sets the number of control plane (master) nodes included as part of the {product-title} cluster.
 
-a| `provisioningNetworkInterface` |  | The name of the network interface on nodes connected to the `provisioning` network. For {product-title} 4.9 and later releases, use the `bootMACAddress` configuration setting to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` configuration setting to identify the name of the NIC.
+a| `provisioningNetworkInterface` |  | The name of the network interface on nodes connected to the provisioning network. For {product-title} 4.9 and later releases, use the `bootMACAddress` configuration setting to enable Ironic to identify the IP address of the NIC instead of using the `provisioningNetworkInterface` configuration setting to identify the name of the NIC.
 
 
 | `defaultMachinePlatform` | | The default configuration used for machine pools without a platform configuration.
@@ -132,27 +132,27 @@ Before {product-title} 4.12, the cluster installation program only accepted an I
 
 |`provisioningDHCPRange`
 |`172.22.0.10,172.22.0.100`
-|Defines the IP range for nodes on the `provisioning` network.
+|Defines the IP range for nodes on the provisioning network.
 
 a|`provisioningNetworkCIDR`
 |`172.22.0.0/24`
-|The CIDR for the network to use for provisioning. This option is required when not using the default address range on the `provisioning` network.
+|The CIDR for the network to use for provisioning. This option is required when not using the default address range on the provisioning network.
 
 |`clusterProvisioningIP`
 |The third IP address of the `provisioningNetworkCIDR`.
-|The IP address within the cluster where the provisioning services run. Defaults to the third IP address of the `provisioning` subnet. For example, `172.22.0.3`.
+|The IP address within the cluster where the provisioning services run. Defaults to the third IP address of the provisioning subnet. For example, `172.22.0.3`.
 
 |`bootstrapProvisioningIP`
 |The second IP address of the `provisioningNetworkCIDR`.
-|The IP address on the bootstrap VM where the provisioning services run while the installer is deploying the control plane (master) nodes. Defaults to the second IP address of the `provisioning` subnet. For example, `172.22.0.2` or `2620:52:0:1307::2`.
+|The IP address on the bootstrap VM where the provisioning services run while the installer is deploying the control plane (master) nodes. Defaults to the second IP address of the provisioning subnet. For example, `172.22.0.2` or `2620:52:0:1307::2`.
 
 | `externalBridge`
 | `baremetal`
-| The name of the `baremetal` bridge of the hypervisor attached to the `baremetal` network.
+| The name of the bare-metal bridge of the hypervisor attached to the bare-metal network.
 
 | `provisioningBridge`
 | `provisioning`
-| The name of the `provisioning` bridge on the `provisioner` host attached to the `provisioning` network.
+| The name of the provisioning bridge on the `provisioner` host attached to the provisioning network.
 
 |`architecture`
 |
@@ -169,9 +169,9 @@ a|`provisioningNetworkCIDR`
 
 | `provisioningNetwork`
 |
-| The `provisioningNetwork` configuration setting determines whether the cluster uses the `provisioning` network. If it does, the configuration setting also determines if the cluster manages the network.
+| The `provisioningNetwork` configuration setting determines whether the cluster uses the provisioning network. If it does, the configuration setting also determines if the cluster manages the network.
 
-`Disabled`: Set this parameter to `Disabled` to disable the requirement for a `provisioning` network. When set to `Disabled`, you must only use virtual media based provisioning, or bring up the cluster using the assisted installer. If `Disabled` and using power management, BMCs must be accessible from the `baremetal` network. If `Disabled`, you must provide two IP addresses on the `baremetal` network that are used for the provisioning services.
+`Disabled`: Set this parameter to `Disabled` to disable the requirement for a provisioning network. When set to `Disabled`, you must only use virtual media based provisioning, or bring up the cluster using the assisted installer. If `Disabled` and using power management, BMCs must be accessible from the bare-metal network. If `Disabled`, you must provide two IP addresses on the bare-metal network that are used for the provisioning services.
 
 `Managed`: Set this parameter to `Managed`, which is the default, to fully manage the provisioning network, including DHCP, TFTP, and so on.
 
@@ -217,11 +217,11 @@ The `hosts` parameter is a list of separate bare metal assets used to build the 
 
 | `bootMACAddress`
 |
-a| The MAC address of the NIC that the host uses for the `provisioning` network. Ironic retrieves the IP address using the `bootMACAddress` configuration setting. Then, it binds to the host.
+a| The MAC address of the NIC that the host uses for the provisioning network. Ironic retrieves the IP address using the `bootMACAddress` configuration setting. Then, it binds to the host.
 
 [NOTE]
 ====
-You must provide a valid MAC address from the host if you disabled the `provisioning` network.
+You must provide a valid MAC address from the host if you disabled the provisioning network.
 ====
 
 | `networkConfig`

--- a/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
+++ b/modules/ipi-install-configuring-host-network-interfaces-in-the-install-config.yaml-file.adoc
@@ -8,9 +8,9 @@
 
 Before installation, you can set the `networkConfig` configuration setting in the `install-config.yaml` file to configure host network interfaces using NMState.
 
-The most common use case for this functionality is to specify a static IP address on the `baremetal` network, but you can also configure other networks such as a storage network. This functionality supports other NMState features such as VLAN, VXLAN, bridges, bonds, routes, MTU, and DNS resolver settings.
+The most common use case for this functionality is to specify a static IP address on the bare-metal network, but you can also configure other networks such as a storage network. This functionality supports other NMState features such as VLAN, VXLAN, bridges, bonds, routes, MTU, and DNS resolver settings.
 
-.Prequisites
+.Prerequisites
 
 * Configure a `PTR` DNS record with a valid hostname for each node with a static IP address.
 * Install the NMState CLI (`nmstate`).

--- a/modules/ipi-install-configuring-networking.adoc
+++ b/modules/ipi-install-configuring-networking.adoc
@@ -6,7 +6,7 @@
 [id="configuring-networking_{context}"]
 = Configuring networking
 
-Before installation, you must configure the networking on the provisioner node. Installer-provisioned clusters deploy with a `baremetal` bridge and network, and an optional `provisioning` bridge and network.
+Before installation, you must configure the networking on the provisioner node. Installer-provisioned clusters deploy with a bare-metal bridge and network, and an optional provisioning bridge and network.
 
 image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_1.png[Configure networking]
 
@@ -17,14 +17,14 @@ You can also configure networking from the web console.
 
 .Procedure
 
-. Export the `baremetal` network NIC name:
+. Export the bare-metal network NIC name:
 +
 [source,terminal]
 ----
 $ export PUB_CONN=<baremetal_nic_name>
 ----
 
-. Configure the `baremetal` network:
+. Configure the bare-metal network:
 +
 [NOTE]
 ====
@@ -45,14 +45,14 @@ $ sudo nohup bash -c "
 "
 ----
 
-. Optional: If you are deploying with a `provisioning` network, export the `provisioning` network NIC name:
+. Optional: If you are deploying with a provisioning network, export the provisioning network NIC name:
 +
 [source,terminal]
 ----
 $ export PROV_CONN=<prov_nic_name>
 ----
 
-. Optional: If you are deploying with a `provisioning` network, configure the `provisioning` network:
+. Optional: If you are deploying with a provisioning network, configure the provisioning network:
 +
 [source,terminal]
 ----
@@ -71,12 +71,12 @@ $ sudo nohup bash -c "
 ====
 The ssh connection might disconnect after executing these steps.
 
-The IPv6 address can be any address as long as it is not routable via the `baremetal` network.
+The IPv6 address can be any address as long as it is not routable via the bare-metal network.
 
 Ensure that UEFI is enabled and UEFI PXE settings are set to the IPv6 protocol when using IPv6 addressing.
 ====
 
-. Optional: If you are deploying with a `provisioning` network, configure the IPv4 address on the `provisioning` network connection:
+. Optional: If you are deploying with a provisioning network, configure the IPv4 address on the provisioning network connection:
 +
 [source,terminal]
 ----

--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -93,8 +93,8 @@ sshKey: '<ssh_pub_key>'
 +
 --
 <1> Scale the worker machines based on the number of worker nodes that are part of the {product-title} cluster. Valid options for the `replicas` value are `0` and integers greater than or equal to `2`. Set the number of replicas to `0` to deploy a three-node cluster, which contains only three control plane machines. A three-node cluster is a smaller, more resource-efficient cluster that can be used for testing, development, and production. You cannot install the cluster with only one worker.
-<2> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticIP` configuration setting to specify the static IP address of the bootstrap VM when there is no DHCP server on the `baremetal` network.
-<3> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticGateway` configuration setting to specify the gateway IP address for the bootstrap VM when there is no DHCP server on the `baremetal` network.
+<2> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticIP` configuration setting to specify the static IP address of the bootstrap VM when there is no DHCP server on the bare-metal network.
+<3> When deploying a cluster with static IP addresses, you must set the `bootstrapExternalStaticGateway` configuration setting to specify the gateway IP address for the bootstrap VM when there is no DHCP server on the bare-metal network.
 <4> See the BMC addressing sections for more options.
 <5> To set the path to the installation disk drive, enter the kernel name of the disk. For example, `/dev/sda`.
 +


### PR DESCRIPTION
OCPBUGS-12788: Style fix to general references to the bare-metal and provisioning network. 
`baremetal` network > bare-metal network
`provisionining` network > provisioning network

See related convo in CCS style channel: https://redhat-internal.slack.com/archives/C04HKR61MN1/p1691751804854569

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-12788

Link to docs preview:
https://63490--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow

QE not required