### PR TITLE
[OSDOCS-7449]: Clarify 'pausing reconciliation' docs for hosted control planes

### DIFF
--- a/modules/hosted-control-planes-pause-reconciliation.adoc
+++ b/modules/hosted-control-planes-pause-reconciliation.adoc
@@ -10,14 +10,14 @@ If you are a cluster instance administrator, you can pause the reconciliation of
 
 .Procedure
 
-. To pause reconciliation for a hosted cluster and hosted control plane, populate the `pausedUntil` field of the `HostedCluster` resource, as shown in the following examples:
+. To pause reconciliation for a hosted cluster and hosted control plane, populate the `pausedUntil` field of the `HostedCluster` resource, as shown in the following examples. In the examples, the value for `pausedUntil` is defined in an environment variable prior to the command.
 +
 ** To pause the reconciliation until a specific time, specify an RFC339 timestamp:
 +
 [source,terminal]
 ----
 PAUSED_UNTIL="2022-03-03T03:28:48Z"
-kubectl patch -n <hosted-cluster-namespace> hostedclusters/<hosted-cluster-name> -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
+oc patch -n <hosted-cluster-namespace> hostedclusters/<hosted-cluster-name> -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
 ----
 +
 The reconciliation is paused until the specified time is passed.
@@ -27,7 +27,7 @@ The reconciliation is paused until the specified time is passed.
 [source,terminal]
 ----
 PAUSED_UNTIL="true"
-kubectl patch -n <hosted-cluster-namespace> hostedclusters/<hosted-cluster-name> -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
+oc patch -n <hosted-cluster-namespace> hostedclusters/<hosted-cluster-name> -p '{"spec":{"pausedUntil":"'${PAUSED_UNTIL}'"}}' --type=merge
 ----
 +
 The reconciliation is paused until you remove the field from the `HostedCluster` resource.
@@ -38,7 +38,7 @@ When the pause reconciliation field is populated for the `HostedCluster` resourc
 +
 [source,terminal]
 ----
-kubectl patch -n <hosted-cluster-namespace> hostedclusters/<hosted-cluster-name> -p '{"spec":{"pausedUntil":null}}' --type=merge
+oc patch -n <hosted-cluster-namespace> hostedclusters/<hosted-cluster-name> -p '{"spec":{"pausedUntil":null}}' --type=merge
 ----
 
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7449
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63491--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-managing#hosted-control-planes-pause-reconciliation_hcp-managing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
