### PR TITLE
TELCODOCS-492: RN for 4-14

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -212,6 +212,10 @@ With this release, the Performance Addon Operator (PAO) must-gather image is no 
 
 For further information about gathering debugging information relating to low-latency tuning, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support_cnf-master[Collecting low latency tuning debugging data for Red Hat Support].
 
+[id="ocp-4-14-nw-ipv6-spoke-cluster-support"]
+==== Support for provisioning IPv6 spoke clusters from dual-stack hub clusters
+With this update, you can provision IPv6 address spoke clusters from dual-stack hub clusters. In a zero touch provisioning (ZTP) environment, the HTTP server on the hub cluster that hosts the boot ISO now listens on both IPv4 and IPv6 networks. The provisioning service also checks the baseboard management controller (BMC) address scheme on the target spoke cluster and provides a matching URL for the installation media. These updates offer the ability to provision single-stack, IPv6 spoke clusters from a dual-stack hub cluster. 
+
 [id="ocp-4-14-hcp"]
 === Hosted control planes (Technology Preview)
 


### PR DESCRIPTION
[TELCODOCS-492](https://issues.redhat.com//browse/TELCODOCS-492): Adding support for provisioning IPv6 clusters from dual-stack hub cluster.

This was originally for 4.12 but was held up. I created a new PR for 4.14 as the conflicts were a pain trying to move to the 4.14. branch. The content has been approved by SME and QE, and passed peer review, in the 4.12 PR #52005.

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-492

Link to docs preview:
https://63515--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-nw-ipv6-spoke-cluster-support

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
