### PR TITLE
OSDOCS-7427: Documented 4.12.29 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -3952,3 +3952,34 @@ $ oc adm release info 4.12.28 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-12-29"]
+=== RHBA-2023:4608 - {product-title} 4.12.29 bug fix update
+
+Issued: 2023-08-16
+
+{product-title} release 4.12.29 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4608[RHBA-2023:4608] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4611[RHBA-2023:4611] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.29 --pullspecs
+----
+
+[id="ocp-4-12-29-bug-fixes"]
+==== Bug fixes
+
+* Previously, the Ingress Operator did not include an Amazon Web Services (AWS) permission in its cloud credentials request. This impacted the management of domain name system (DNS) records in the Commercial Cloud Services (C2S) `us-iso-east-1` and the Secret Commercial Cloud Services (SC2S) `us-isob-east-1` AWS Regions. If you installed an {product-title} cluster in a C2S or an SC2S AWS Region, the Ingress Operator failed to publish DNS records for the Route 53 service and you received an error message similar to the following example:
++
+[source,terminal]
+----
+The DNS provider failed to ensure the record: failed to find hosted zone for record: failed to get tagged resources: AccessDenied: User: [...] is not authorized to perform: route53:ListTagsForResources on resource: [...]
+----
++
+With this update, the Ingress Operator's cloud credentials request includes the `route53:ListTagsForResources` permission, so that the Operator can publish DNS records in the C2S and SC2S AWS Regions for the Route 53 service. (link:https://issues.redhat.com/browse/OCPBUGS-15467[OCPBUGS-15467])
+
+[id="ocp-4-12-29-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-7427](https://issues.redhat.com/browse/OSDOCS-7427)

Version(s):
4.12

Link to docs preview:
[RHBA-2023:4608 - OpenShift Container Platform 4.12.29 bug fix update](https://63516--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-29)

QE review:
- [ ] QE not required