### PR TITLE
OSDOCS#7448: Observe NodeNetworkState from console

### DIFF
--- a/modules/virt-viewing-network-state-of-node-console.adoc
+++ b/modules/virt-viewing-network-state-of-node-console.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assemblies:
+//
+// * networking/k8s_nmstate/k8s-observing-node-network-state.adoc
+
+:_content-type: PROCEDURE
+[id="virt-viewing-network-state-of-node-console_{context}"]
+= Viewing the network state of a node from the web console
+
+As an administrator, you can use the {product-title} web console to observe `NodeNetworkState` resources and network interfaces, and access network details.
+
+.Procedure
+. Navigate to *Networking* → *NodeNetworkState*.
++
+In the *NodeNetworkState* page, you can view the list of `NodeNetworkState` resources and the corresponding interfaces that are created on the nodes. You can use *Filter* based on *Interface state*, *Interface type*, and *IP*, or the search bar based on criteria *Name* or *Label*, to narrow down the displayed `NodeNetworkState` resources.
+
+. To access the detailed information about `NodeNetworkState` resource, click the `NodeNetworkState` resource name listed in the *Name* column .
+
+. to expand and view the *Network Details* section for the `NodeNetworkState` resource, click the *>* icon . Alternatively, you can click on each interface type under the *Network interface* column to view the network details.
+

--- a/modules/virt-viewing-network-state-of-node.adoc
+++ b/modules/virt-viewing-network-state-of-node.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="virt-viewing-network-state-of-node_{context}"]
-= Viewing the network state of a node
+= Viewing the network state of a node by using the CLI
 
 A `NodeNetworkState` object exists on every node in the cluster. This object is periodically updated and captures the state of the network for that node.
 

--- a/networking/k8s_nmstate/k8s-nmstate-observing-node-network-state.adoc
+++ b/networking/k8s_nmstate/k8s-nmstate-observing-node-network-state.adoc
@@ -12,3 +12,5 @@ Node network state is the network configuration for all nodes in the cluster.
 include::modules/virt-about-nmstate.adoc[leveloffset=+1]
 
 include::modules/virt-viewing-network-state-of-node.adoc[leveloffset=+1]
+
+include::modules/virt-viewing-network-state-of-node-console.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OSDOCS-7448

Link to docs preview: https://63518--docspreview.netlify.app/openshift-enterprise/latest/networking/k8s_nmstate/k8s-nmstate-observing-node-network-state#virt-viewing-network-state-of-node-console_k8s-nmstate-observing-node-network-state

QE review:
- [x] QE has approved this change. @gouyang
- [x] SME has approved this change. @upalatucci 