### PR TITLE
OBSDOCS-344: add-info-about-deleting-expired-silenced-alerts

### DIFF
--- a/modules/monitoring-expiring-silences.adoc
+++ b/modules/monitoring-expiring-silences.adoc
@@ -8,6 +8,12 @@
 
 You can expire a silence. Expiring a silence deactivates it forever.
 
+[NOTE]
+====
+You cannot delete expired, silenced alerts.
+Expired silences older than 120 hours are garbage collected.
+====
+
 .Procedure
 
 To expire a silence in the *Administrator* perspective:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-344
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63535--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts#expiring-silences_managing-alerts
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE reviewer: @juzhao 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR adds a note to tell users that expired, silenced alerts cannot be deleted.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
