### PR TITLE
OSDOCS-7462: adds release note MicroShift 4.13.9

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -228,3 +228,12 @@ Issued: 2023-08-08
 {product-title} release 4.13.8, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4458[RHBA-2023:4458] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4456[RHSA-2023:4456] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-9-dp"]
+=== RHBA-2023:4605 - {product-title} 4.13.9 bug fix and security update
+
+Issued: 2023-08-16
+
+{product-title} release 4.13.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4605[RHBA-2023:4605] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4603[RHSA-2023:4603] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Version(s):
4.13 only

Issue:
https://issues.redhat.com/browse/OSDOCS-7462

Link to docs preview:
https://63537--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-9-dp

QE review:
- N/A, release note placeholder text

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
