### PR TITLE
OCPBUGS-11610: version numbers in updating with RHEL compute page

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -10,7 +10,7 @@ After you update your cluster, you must update the {op-system-base-full} compute
 
 [IMPORTANT]
 ====
-{op-system-base-full} versions 8.6, 8.7 and 8.8 are supported for {op-system-base} compute machines.
+{op-system-base-full} versions 8.6, 8.7, and 8.8 are supported for {op-system-base} compute machines.
 ====
 
 You can also update your compute machines to another minor version of {product-title} if you are using {op-system-base} as the operating system. You do not need to exclude any RPM packages from {op-system-base} when performing a minor version update.
@@ -52,9 +52,8 @@ By default, the base OS RHEL with "Minimal" installation option enables firewall
 +
 [source,terminal]
 ----
-# subscription-manager repos --disable=rhocp-4.11-for-rhel-8-x86_64-rpms \
-                             --disable=ansible-2.9-for-rhel-8-x86_64-rpms \
-                             --enable=rhocp-4.12-for-rhel-8-x86_64-rpms
+# subscription-manager repos --disable=rhocp-4.12-for-rhel-8-x86_64-rpms \
+                             --enable=rhocp-4.13-for-rhel-8-x86_64-rpms
 ----
 +
 [IMPORTANT]
@@ -80,7 +79,7 @@ As of {product-title} 4.11, the Ansible playbooks are provided only for {op-syst
 +
 [source,terminal]
 ----
-# subscription-manager repos --disable=rhocp-4.11-for-rhel-8-x86_64-rpms \
+# subscription-manager repos --disable=rhocp-4.12-for-rhel-8-x86_64-rpms \
                              --enable=rhocp-4.13-for-rhel-8-x86_64-rpms
 ----
 


### PR DESCRIPTION
[OCPBUGS-11610](https://issues.redhat.com/browse/OCPBUGS-11610)

Version: 4.13 only

This PR fixes some incorrect version numbers in the page for "updating a cluster with RHEL compute machines"

QE review:
- [x] QE has approved this change.

Preview: [Updating RHEL compute machines in your cluster](https://63546--docspreview.netlify.app/openshift-enterprise/latest/updating/updating-cluster-rhel-compute#rhel-compute-updating-minor_updating-cluster-rhel-compute)
