### PR TITLE
OSDOCS-5604-RN 4.14 Release note for PDB unhealthy pod eviction policy

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -429,6 +429,13 @@ For more information, see xref:../nodes/scheduling/nodes-scheduler-pod-topology-
 
 With this release, the `MaxUnavailableStatefulSet` featureset configuration parameter is enabled by default. This allows users to define the maximum number of `StatefulSet` pods that can be unavailable during updates, and reduces application downtime when upgrading.
 
+[id="ocp-4-14-pdb-unhealthy-pod-eviction-policy"]
+==== Pod disruption budget (PDB) unhealthy pod eviction policy
+
+With this release, specifying an unhealthy pod eviction policy for pod disruption budgets (PDBs) is Generally Available in {product-title} and has been removed from the `TechPreviewNoUpgrade` featureset. This helps evict malfunctioning applications during a node drain. 
+
+For more information, see xref:../nodes/pods/nodes-pods-configuring.adoc#pod-disruption-eviction-policy_nodes-pods-configuring[Specifying the eviction policy for unhealthy pods].
+
 [id="ocp-4-14-monitoring"]
 === Monitoring
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-5604](https://issues.redhat.com/browse/OSDOCS-5604)

Link to docs preview:
[Preview](https://63555--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-13-pdb-eviction-policy)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
