### PR TITLE
OCPBUGS-15980: small OTA typo

### DIFF
--- a/modules/update-common-terms.adoc
+++ b/modules/update-common-terms.adoc
@@ -20,7 +20,7 @@ Recommended update edge:: A _recommended update edge_ is a recommended update be
 
 ifndef::openshift-origin[]
 
-Extended Update Support:: All post-4.7 even-numbered minor releases are labeled as _Extended Update Support_ (EUS) releases. These releases introduce a verified update path between EUS releases, permitting customers to streamline updates of worker worker nodes and formulate update strategies of EUS-to-EUS {product-title} releases that will cause fewer reboots of worker nodes.
+Extended Update Support:: All post-4.7 even-numbered minor releases are labeled as _Extended Update Support_ (EUS) releases. These releases introduce a verified update path between EUS releases, permitting customers to streamline updates of worker nodes and formulate update strategies of EUS-to-EUS {product-title} releases that result in fewer reboots of worker nodes.
 +
 For more information, see link:https://access.redhat.com/support/policy/updates/openshift-eus[Red Hat OpenShift Extended Update Support (EUS) Overview].
 


### PR DESCRIPTION
[OCPBUGS-15980](https://issues.redhat.com/browse/OCPBUGS-15980)

Version(s): 4.10+

This PR fixes a small typo in the Common Terms section for Update docs

No QE required

Preview: [Common terms](https://63563--docspreview.netlify.app/openshift-enterprise/latest/updating/understanding_updates/intro-to-updates#update-common-terms_understanding-openshift-updates)