### PR TITLE
OSDOCS#7110: Added europe-west12 to supported GCP regions

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -31,6 +31,7 @@ regions:
 * `europe-west6` (Zürich, Switzerland)
 * `europe-west8` (Milan, Italy)
 * `europe-west9` (Paris, France)
+* `europe-west12` (Turin, Italy)
 * `northamerica-northeast1` (Montréal, Québec, Canada)
 * `northamerica-northeast2` (Toronto, Ontario, Canada)
 * `southamerica-east1` (São Paulo, Brazil)


### PR DESCRIPTION
Version(s):
4.11

Issue:
This issue addresses [osdocs-7110](https://issues.redhat.com/browse/OSDOCS-7110).

Link to docs preview:

[Supported GCP regions](https://mjpytlak.github.io/previews/osdocs-7110/installing/installing_gcp/installing-gcp-account.html#installation-gcp-regions_installing-gcp-account)

QE review:
- [ ] QE has approved this change.
