### PR TITLE
ROX-19044: Release notes for RHACS patch 4.1.3

### DIFF
--- a/release_notes/41-release-notes.adoc
+++ b/release_notes/41-release-notes.adoc
@@ -15,6 +15,7 @@ toc::[]
 |`4.1` |29 June 2023
 |`4.1.1` |11 July 2023
 |`4.1.2` |26 July 2023
+|`4.1.3` |21 August 2023
 |====
 
 [id="about-this-release_{context}"]
@@ -424,6 +425,15 @@ The failure occurred because the older versions did not implement PSP auto-sensi
 The updated image fixes this issue.
 * Fixed an issue where upgrading from RHACS 3.74.3 to RHACS 4.1.1 failed
 with an "insert...violates foreign key restraint" error.
+
+[id="resolved-in-version-413_{context}"]
+=== Resolved in version 4.1.3
+
+Release date: 21 August 2023
+
+* Fixed an issue where {product-title-short} reported an incorrect component version for Tomcat used in an application.
+* Removed a check that prevented a rollback to an earlier version of {product-title-short} after migration.
+* {product-title-short} now includes `ALL` as a valid value for drop capabilities. The policy implementation has been changed so that if the policy criteria specifies that a deployment must drop a capability (for example, A or B), and a deployment manifest contains `DROP ALL`, it does not violate the policy.
 
 [id="known-issues_{context}"]
 === Known issues (updated 11 July 2023)


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs-4.1`

[Issue](https://issues.redhat.com/browse/ROX-19044)

[Link to docs preview
](https://file.rdu.redhat.com/kcarmich/rhacs-docs-41-rn/release_notes/41-release-notes.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
