### PR TITLE
OCPBUGS-16288 - Remove incorrect namespace from example AgentServiceConfig CR

### DIFF
--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -65,7 +65,6 @@ apiVersion: agent-install.openshift.io/v1beta1
 kind: AgentServiceConfig
 metadata:
   name: agent
-  namespace: assisted-installer
 spec:
   databaseStorage:
     volumeName: <db_pv_name>


### PR DESCRIPTION
Remove incorrect namespace from example AgentServiceConfig CR in the ZTP docs.

Version(s):
openshift-4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-16288

Link to docs preview:
https://63574--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-preparing-the-hub-cluster

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
