### PR TITLE
OCPBUGS-16291 - Remove incorrect rootFSUrl field from the ZTP docs

### DIFF
--- a/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
+++ b/modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
@@ -85,10 +85,9 @@ spec:
     name: 'assisted-installer-mirror-config'
   osImages:
     - openshiftVersion: <ocp_version>
-      rootfs: <rootfs_url> <1>
       url: <iso_url> <1>
 ----
-<1> Must match the URLs of the HTTPD server.
+<1> Must match the URL of the HTTPD server.
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Remove incorrect rootFSUrl field from the AgentServiceConfig example CR in the ZTP docs. The field is deprecated. 

Version(s):
openshift-4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-16291

Link to docs preview:
https://63575--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#ztp-configuring-the-cluster-for-a-disconnected-environment_ztp-preparing-the-hub-cluster

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
