### PR TITLE
[OSDOCS-5337]: Adding metrics sets docs for hosted control planes

### DIFF
--- a/hosted_control_planes/hcp-managing.adoc
+++ b/hosted_control_planes/hcp-managing.adoc
@@ -17,7 +17,7 @@ include::modules/updating-node-pools-for-hcp.adoc[leveloffset=+1]
 include::modules/hosted-control-planes-pause-reconciliation.adoc[leveloffset=+1]
 //debugging why nodes have not joined the cluster
 //using service-level DNS for control plane services
-//configuring metrics sets
+include::modules/hosted-control-planes-metrics-sets.adoc[leveloffset=+1]
 //automated machine management
 include::modules/delete-hosted-cluster.adoc[leveloffset=+1]
 

--- a/modules/hosted-control-planes-metrics-sets.adoc
+++ b/modules/hosted-control-planes-metrics-sets.adoc
@@ -1,0 +1,126 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-managing.adoc
+
+:_content-type: PROCEDURE
+[id="hosted-control-planes-metrics-sets_{context}"]
+= Configuring metrics sets for hosted control planes
+
+Hosted control planes for Red Hat {product-title} creates `ServiceMonitor` resources in each control plane namespace that allow a Prometheus stack to gather metrics from the control planes. The `ServiceMonitor` resources use metrics relabelings to define which metrics are included or excluded from a particular component, such as etcd or the Kubernetes API server. The number of metrics that are produced by control planes directly impacts the resource requirements of the monitoring stack that gathers them. 
+
+Instead of producing a fixed number of metrics that apply to all situations, you can configure a metrics set that identifies a set of metrics to produce for each control plane. The following metrics sets are supported:
+
+* `Telemetry`: These metrics are needed for telemetry. This set is the default set and is the smallest set of metrics.
+* `SRE`: This set includes the necessary metrics to produce alerts and allow the troubleshooting of control plane components.
+* `All`: This set includes all of the metrics that are produced by standalone {product-title} control plane components.
+
+To configure a metrics set, set the `METRICS_SET` environment variable in the HyperShift Operator deployment by entering the following command:
+
+[source,terminal]
+----
+$ oc set env -n hypershift deployment/operator METRICS_SET=All
+----
+
+[#hosted-control-planes-sre-metrics-set]
+== Configuring the SRE metrics set
+
+When you specify the `SRE` metrics set, the HyperShift Operator looks for a config map named `sre-metric-set` with a single key: `config`. The value of the `config` key must contain a set of `RelabelConfigs` that are organized by control plane component. 
+
+You can specify the following components:
+
+* `etcd`
+* `kubeAPIServer`
+* `kubeControllerManager`
+* `openshiftAPIServer`
+* `openshiftControllerManager`
+* `openshiftRouteControllerManager`
+* `cvo`
+* `olm`
+* `catalogOperator`
+* `registryOperator`
+* `nodeTuningOperator`
+* `controlPlaneOperator`
+* `hostedClusterConfigOperator`
+
+A configuration of the `SRE` metrics set is illustrated in the following example:
+
+[source,terminal]
+----
+kubeAPIServer:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_controller_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_step_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "scheduler_(e2e_scheduling_latency_microseconds|scheduling_algorithm_predicate_evaluation|scheduling_algorithm_priority_evaluation|scheduling_algorithm_preemption_evaluation|scheduling_algorithm_latency_microseconds|binding_latency_microseconds|scheduling_latency_seconds)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_(request_count|request_latencies|request_latencies_summary|dropped_requests|storage_data_key_generation_latencies_microseconds|storage_transformation_failures_total|storage_transformation_latencies_microseconds|proxy_tunnel_sync_latency_secs)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "docker_(operations|operations_latency_microseconds|operations_errors|operations_timeout)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "reflector_(items_per_list|items_per_watch|list_duration_seconds|lists_total|short_watches_total|watch_duration_seconds|watches_total)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "etcd_(helper_cache_hit_count|helper_cache_miss_count|helper_cache_entry_count|request_cache_get_latencies_summary|request_cache_add_latencies_summary|request_latencies_summary)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "transformation_(transformation_latencies_microseconds|failures_total)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "network_plugin_operations_latency_microseconds|sync_proxy_rules_latency_microseconds|rest_client_request_latency_seconds"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)"
+    sourceLabels: ["__name__", "le"]
+kubeControllerManager:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|request|server).*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "rest_client_request_latency_seconds_(bucket|count|sum)"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "root_ca_cert_publisher_sync_duration_seconds_(bucket|count|sum)"
+    sourceLabels: ["__name__"]
+openshiftAPIServer:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_controller_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_admission_step_admission_latencies_seconds_.*"
+    sourceLabels: ["__name__"]
+  - action:       "drop"
+    regex:        "apiserver_request_duration_seconds_bucket;(0.15|0.25|0.3|0.35|0.4|0.45|0.6|0.7|0.8|0.9|1.25|1.5|1.75|2.5|3|3.5|4.5|6|7|8|9|15|25|30|50)"
+    sourceLabels: ["__name__", "le"]
+openshiftControllerManager:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|request|server).*"
+    sourceLabels: ["__name__"]
+openshiftRouteControllerManager:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|request|server).*"
+    sourceLabels: ["__name__"]
+olm:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+catalogOperator:
+  - action:       "drop"
+    regex:        "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+cvo:
+  - action: drop
+    regex: "etcd_(debugging|disk|server).*"
+    sourceLabels: ["__name__"]
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5337
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63591--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-managing#hosted-control-planes-metrics-sets_hcp-managing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
