### PR TITLE
TELCODOCS-1237 release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -218,6 +218,32 @@ IPsec is now supported on the IBM Cloud platform for clusters that use the OVN-K
 ==== Single-stack IPv6 support for Kubernetes NMstate
 With this release, you can use Kubernetes NMState Operator in single-stack IPv6 clusters.
 
+[id="ocp-4-14-networking-egress-service"]
+==== Egress service resource to manage egress traffic for pods behind a load balancer (Technology Preview)
+
+With this update, you can use an `EgressService` custom resource (CR) to manage egress traffic for pods behind a load balancer service. This is available as a Technology Preview feature.
+
+You can use the `EgressService` CR to manage egress traffic in the following ways:
+
+* Assign the load balancer service's IP address as the source IP address of egress traffic for pods behind the load balancer service.
+
+* Assign the egress traffic for pods behind a load balancer to a different network than the default node network.
+
+For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc#configuring-egress-traffic-loadbalancer-services[Configuring an egress service].
+
+[id="ocp-4-14-networking-metallb-vrf"]
+==== Support for VRF specification in MetalLB's BGPPeer resource (Technology Preview)
+
+With this update, you can specify a Virtual Routing and Forwarding (VRF) instance in a `BGPPeer` custom resource. MetalLB can advertise services through the interfaces belonging to the VRF. This is available as a Technology Preview feature.
+
+For more information, see xref:../networking/metallb/metallb-configure-bgp-peers.adoc#nw-metallb-bgp-peer-vrf_configure-metallb-bgp-peers[Exposing a service through a network VRF].
+
+[id="ocp-4-14-networking-nmstate-vrf"]
+==== Support for VRF specification in NMState's NodeNetworkConfigurationPolicy resource (Technology Preview)
+
+With this update, you can assoicate a Virtual Routing and Forwarding (VRF) instance with a network interface by using a `NodeNetworkConfigurationPolicy` custom resource. By associating a VRF instance with a network interface, you can support traffic isolation, independent routing decisions, and the logical separation of network resources. This is available as a Technology Preview feature.
+
+For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-host-vrf_k8s_nmstate-updating-node-network-config[Example: Network interface with a VRF instance node network configuration policy].
 
 [id="ocp-4-14-storage"]
 === Storage
@@ -872,6 +898,21 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |General Availability
 |General Availability
+
+|Egress service custom resource
+|Not Available
+|Not Available
+|Technology Preview
+
+|VRF specification in `BGPPeer` custom resource
+|Not Available
+|Not Available
+|Technology Preview
+
+|VRF specification in `NodeNetworkConfigurationPolicy` custom resource
+|Not Available
+|Not Available
+|Technology Preview
 
 |====
 


### PR DESCRIPTION
[TELCODOCS-1237](https://issues.redhat.com//browse/TELCODOCS-1237): Release note to describe new tech preview features.

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-1237

- https://file.emea.redhat.com/rohennes/TELCODOCS-1237-rn/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-egress-service
- https://file.emea.redhat.com/rohennes/TELCODOCS-1237-rn/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-metallb-vrf
- https://file.emea.redhat.com/rohennes/TELCODOCS-1237-rn/release_notes/ocp-4-14-release-notes.html#ocp-4-14-networking-nmstate-vrf

