### PR TITLE
OSDOCS#6381:Adds release notes for console RFEs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -72,6 +72,27 @@ For more information, see xref:../installing/installing_aws/installing-aws-vpc.a
 [id="ocp-4-14-web-console"]
 === Web console
 
+[id="ocp-4-14-administrator-perspective"]
+==== Administrator Perspective
+
+With this release, there are several updates to the *Administrator* perspective of the web console. You can now perform the following actions:
+
+* Narrow down the list of resources in a list view or search page with exact search capabilities. This will help when you have similarly named resources and fuzzy search doesn't narrow down your search.
+* Provide direct feedback about features and report a bug by clicking the *Help* button on the toolbar and clicking *Share Feedback* from the drop-down list.
+* Display and hide tooltips in the YAML editor. The tooltips will persist so you don't have to change it every time you navigate to the page.
+
+[id="supported-os-types-cluster"]
+===== Operating system based filtering in Operator Hub
+
+With this update, Operators in the Operator Hub are now filtered based on the nodes operating system since cluster can contain heterogenous nodes.
+
+[id="console-supports-installing-specific-operator-versions"]
+===== Support for installing specific Operator versions in the web console
+
+With this update, you can now choose from a list of available versions for an Operator based on the selected channel on the *OperatorHub* page in the console. Additionally, you can view the metadata for that channel and version when available. When selecting an older version, a manual approval update strategy is required, otherwise the Operator will immediately update back to the latest version on the channel.
+
+//link to content in Operator book TBD
+
 [id="ocp-4-14-developer-perspective"]
 ==== Developer Perspective
 
@@ -90,7 +111,7 @@ The `ImageSetConfiguration` stores the OCI images. After processing the catalog,
 [id="oc-logging-in-browser"]
 ==== Logging in to the CLI using a web browser
 
-With {product-title} {product-version}, a new `oc` command-line interface (CLI) flag, `--web` is now available for the `oc login` command. 
+With {product-title} {product-version}, a new `oc` command-line interface (CLI) flag, `--web` is now available for the `oc login` command.
 
 With this enhancement, you can log in using a web browser, which allows you to avoid inserting your access token into the command line.
 


### PR DESCRIPTION
OSDOCS#6381:Adds release notes for console RFEs

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6381

Link to docs preview:
https://63604--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-web-console

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Still pending a QE review, but putting on peer review to move things along
