### PR TITLE
Add OLM 1.0 relnote for 4.14

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -187,6 +187,9 @@ endif::[]
 :osdk_ver: 1.31.0
 //Operator SDK version that shipped with the previous OCP 4.x release
 :osdk_ver_n1: 1.28.0
+//Next-gen (OCP 4.13+) Operator Lifecycle Manager, aka "v1"
+:olmv1: OLM 1.0
+:olmv1-first: Operator Lifecycle Manager (OLM) 1.0
 :ztp-first: GitOps Zero Touch Provisioning (ZTP)
 :ztp: GitOps ZTP
 :3no: three-node OpenShift

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -472,6 +472,43 @@ For more information about disabling the Image Registry Operator, see xref:../in
 [id="ocp-4-14-olm"]
 === Operator lifecycle
 
+[id="ocp-4-14-olmv1"]
+==== {olmv1-first} (Technology Preview)
+
+Operator Lifecycle Manager (OLM) has been included with {product-title} 4 since its initial release. {product-title} {product-version} introduces components for a next-generation iteration of OLM as a Technology Preview feature, known during this phase as _{olmv1}_. This updated framework evolves many of the concepts that have been part of previous versions of OLM and adds new capabilities.
+
+During this Technology Preview phase of {olmv1} in {product-title} 4.14, administrators can explore the following features:
+
+Fully declarative model that supports GitOps workflows::
+{olmv1} simplifies Operator management through two key APIs:
++
+--
+* A new `Operator` API, provided as `operators.operators.operatorframework.io` by the new Operator Controller component, streamlines management of installed Operators by consolidating user-facing APIs into a single object. This empowers administrators and SREs to automate processes and define desired states by using GitOps principles.
+* The `Catalog` API, provided by the new Catalogd component, serves as the foundation for {olmv1}, unpacking catalogs for on-cluster clients so that users can discover installable content, such as Operators and Kubernetes extensions. This provides increased visibility into all available Operator bundle versions, including their details, channels, and update edges.
+--
++
+For more information, see _Operator Controller_ and _Catalogd_.
+
+Improved control over Operator updates::
+With improved insight into catalog content, administrators can specify target versions for installation and updates. This grants administrators more control over the target version of Operator updates. For more information, see _Installing an Operator from a catalog_.
+
+Flexible Operator packaging format::
+Administrators can use file-based catalogs to install and manage the following types of content:
++
+--
+* OLM-based Operators, similar to the existing OLM experience
+* _Plain bundles_, which are static collections of arbitrary Kubernetes manifests
+--
++
+In addition, bundle size is no longer constrained by the etcd value size limit. For more information, see _Managing catalogs in {olmv1}_.
+
+[NOTE]
+====
+For {product-title} {product-version}, documented procedures for {olmv1} are CLI-based only. Alternatively, administrators can create and view related objects in the web console by using normal methods, such as the *Import YAML* and *Search* pages. However, the existing *OperatorHub* and *Installed Operators* pages do not yet observe {olmv1} components.
+====
+
+For more information, see _{olmv1-first}_.
+
 [id="ocp-4-14-osdk"]
 === Operator development
 
@@ -786,9 +823,10 @@ In the following tables, features are marked with the following statuses:
 * _Removed_
 
 [discrete]
-=== Operator deprecated and removed features
+[id="ocp-4-14-operators-dep-rem"]
+=== Operator lifecycle and development deprecated and removed features
 
-.Operator deprecated and removed tracker
+.Operator lifecycle and development deprecated and removed tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.12 |4.13 |4.14
@@ -1703,25 +1741,21 @@ In the following tables, features are marked with the following statuses:
 |====
 
 [discrete]
-=== Operator Technology Preview features
+[id="ocp-4-14-operators-tech-preview"]
+=== Operator lifecycle and development Technology Preview features
 
-.Operator Technology Preview tracker
+.Operator lifecycle and development Technology Preview tracker
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.12 |4.13 |4.14
 
-|Hybrid Helm Operator
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|Java-based Operator
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|Node Observability Operator
+|Operator Lifecycle Manager (OLM) v1
 |Not Available
+|Not Available
+|Technology Preview
+
+|RukPak
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
@@ -1730,8 +1764,13 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|RukPak
-|Not Available
+|Hybrid Helm Operator
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Java-based Operator
+|Technology Preview
 |Technology Preview
 |Technology Preview
 
@@ -1789,6 +1828,11 @@ In the following tables, features are marked with the following statuses:
 
 |Hosted control planes for {product-title} on {VirtProductName}
 |Not Available
+|Technology Preview
+|Technology Preview
+
+|Multi-cluster Engine Operator
+|Technology Preview
 |Technology Preview
 |Technology Preview
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-6727

4.14

Preview: 

* [New features and enhancements: Operator Lifecycle Manager 1.0 (Technology Preview)](https://63605--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-olmv1)
* [Operator lifecycle and development Technology Preview features tracker](https://63605--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-operators-tech-preview)
* [Operator lifecycle and development deprecated and removed features tracker](https://63605--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-operators-dep-rem)