### PR TITLE
OSDOCS#7463: Adds notes for MS 4.12.29 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -80,7 +80,7 @@ Issued: 2023-01-30
 
 {product-title} release 4.12.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0452[RHBA-2023:0452] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0449[RHSA-2023:0449] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-2-dp"]
 === RHBA-2023:0572 - {product-title} 4.12.2 bug fix update
@@ -89,7 +89,7 @@ Issued: 2023-02-07
 
 {product-title} release 4.12.2 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0572[RHBA-2023:0572] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0569[RHSA-2023:0569] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-3-dp"]
 === RHBA-2023:0731 - {product-title} 4.12.3 bug fix update
@@ -98,7 +98,7 @@ Issued: 2023-02-16
 
 {product-title} release 4.12.3 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0731[RHBA-2023:0731] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0728[RHSA-2023:0728] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-4-dp"]
 === RHSA-2023:0769 - {product-title} 4.12.4 bug fix and security update
@@ -107,7 +107,7 @@ Issued: 2023-02-20
 
 {product-title} release 4.12.4, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:0769[RHSA-2023:0769] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:0768[RHBA-2023:0768] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-5-dp"]
 === RHBA-2023:0893 - {product-title} 4.12.5 bug fix update
@@ -116,7 +116,7 @@ Issued: 2023-02-28
 
 {product-title} release 4.12.5 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:0893[RHBA-2023:0893] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:0890[RHSA-2023:0890] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-6-dp"]
 === RHBA-2023:1037 - {product-title} 4.12.6 bug fix update
@@ -125,7 +125,7 @@ Issued: 2023-03-07
 
 {product-title} release 4.12.6 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1037[RHBA-2023:1037] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1034[RHBA-2023:1034] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-7-dp"]
 === RHBA-2023:1166 - {product-title} 4.12.7 bug fix update
@@ -134,7 +134,7 @@ Issued: 2023-03-13
 
 {product-title} release 4.12.7 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1166[RHBA-2023:1166] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1163[RHBA-2023:1163] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-8-dp"]
 === RHBA-2023:1272 - {product-title} 4.12.8 bug fix update
@@ -143,7 +143,7 @@ Issued: 2023-03-21
 
 {product-title} release 4.12.8 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1272[RHBA-2023:1272] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1269[RHBA-2023:1269] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-9-dp"]
 === RHBA-2023:1412 - {product-title} 4.12.9 bug fix and security update
@@ -157,7 +157,7 @@ Issued: 2023-03-27
 
 * Previously, installing and starting {product-title} using an 4.12.7 RPM failed with an error. With this update, {product-title} starts successfully. (link:https://issues.redhat.com/browse/OCPBUGS-10347[*OCPBUGS-10347*])
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-10-dp"]
 === RHBA-2023:1511 - {product-title} 4.12.10 bug fix update
@@ -166,7 +166,7 @@ Issued: 2023-04-03
 
 {product-title} release 4.12.10 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1511[RHBA-2023:1511] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1508[RHBA-2023:1508] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-11-dp"]
 === RHBA-2023:1648 - {product-title} 4.12.11 bug fix update
@@ -175,7 +175,7 @@ Issued: 2023-04-10
 
 {product-title} release 4.12.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1648[RHBA-2023:1648] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1508[RHBA-2023:1645] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-13-dp"]
 === RHBA-2023:1753 - {product-title} 4.12.13 bug fix update
@@ -184,7 +184,7 @@ Issued: 2023-04-18
 
 {product-title} release 4.12.13 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1753[RHBA-2023:1753] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1750[RHBA-2023:1750] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-14-dp"]
 === RHBA-2023:1861 - {product-title} 4.12.14 bug fix update
@@ -193,7 +193,7 @@ Issued: 2023-04-24
 
 {product-title} release 4.12.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:1861[RHBA-2023:1861] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:1858[RHBA-2023:1858] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-15-dp"]
 === RHBA-2023:2040 - {product-title} 4.12.15 bug fix update
@@ -202,7 +202,7 @@ Issued: 2023-05-03
 
 {product-title} release 4.12.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2040[RHBA-2023:2040] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:2037[RHBA-2023:2037] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-16-dp"]
 === RHBA-2023:2113 - {product-title} 4.12.16 bug fix and security update
@@ -211,7 +211,7 @@ Issued: 2023-05-10
 
 {product-title} release 4.12.16, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:2113[RHBA-2023:2113] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:2110[RHSA-2023:2110] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-18-dp"]
 === RHBA-2023:3211 - {product-title} 4.12.18 bug fix update
@@ -220,7 +220,7 @@ Issued: 2023-05-23
 
 {product-title} release 4.12.18 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3211[RHBA-2023:3211] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:3208[RHBA-2023:3208] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-19-dp"]
 === RHBA-2023:3290 - {product-title} 4.12.19 bug fix and security update
@@ -229,7 +229,7 @@ Issued: 2023-05-31
 
 {product-title} release 4.12.19, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3290[RHBA-2023:3290] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3287[RHSA-2023:3287] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-21-dp"]
 === RHBA-2023:3549 - {product-title} 4.12.21 bug fix update
@@ -238,7 +238,7 @@ Issued: 2023-06-14
 
 {product-title} release 4.12.21 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3549[RHBA-2023:3549] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:3546[RHBA-2023:3546] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-22-dp"]
 === RHBA-2023:3621 - {product-title} 4.12.22 bug fix and security update
@@ -247,7 +247,7 @@ Issued: 2023-06-26
 
 {product-title} release 4.12.22, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3621[RHBA-2023:3621] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3615[RHSA-2023:3615] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-23-dp"]
 === RHBA-2023:3928 - {product-title} 4.12.23 bug fix and security update
@@ -256,7 +256,7 @@ Issued: 2023-07-06
 
 {product-title} release 4.12.23, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3928[RHBA-2023:3928] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3925[RHSA-2023:3925] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-24-dp"]
 === RHBA-2023:3677 - {product-title} 4.12.24 bug fix and security update
@@ -265,7 +265,7 @@ Issued: 2023-07-12
 
 {product-title} release 4.12.24, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:3980[RHBA-2023:3980] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:3977[RHSA-2023:3977] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-25-dp"]
 === RHBA-2023:4047 - {product-title} 4.12.25 bug fix update
@@ -274,7 +274,7 @@ Issued: 2023-07-19
 
 {product-title} release 4.12.25 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4047[RHBA-2023:4047] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4048[RHBA-2023:4048] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-26-dp"]
 === RHBA-2023:4223 - {product-title} 4.12.26 bug fix update
@@ -283,7 +283,7 @@ Issued: 2023-07-26
 
 {product-title} release 4.12.26 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4223[RHBA-2023:4223] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4221[RHBA-2023:4221] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-27-dp"]
 === RHBA-2023:4321 - {product-title} 4.12.27 bug fix update
@@ -292,7 +292,7 @@ Issued: 2023-08-02
 
 {product-title} release 4.12.27 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4321[RHBA-2023:4321] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4319[RHBA-2023:4319] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
 
 [id="microshift-4-12-28-dp"]
 === RHBA-2023:4442 - {product-title} 4.12.28 bug fix update
@@ -301,4 +301,13 @@ Issued: 2023-08-09
 
 {product-title} release 4.12.28 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4442[RHBA-2023:4442] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4440[RHBA-2023:4440] advisory.
 
-For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-29-dp"]
+=== RHBA-2023:4610 - {product-title} 4.12.29 bug fix update
+
+Issued: 2023-08-16
+
+{product-title} release 4.12.29 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4610[RHBA-2023:4610] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4608[RHBA-2023:4608] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#7463: Adds notes for MS 4.12.29 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-7463

Link to docs preview:
https://63606--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes#microshift-4-12-29-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Fixes backticks based on peer review comment in #63274
