### PR TITLE
Change hco to hyperconverged

### DIFF
--- a/modules/virt-autoupdate-custom-bootsource.adoc
+++ b/modules/virt-autoupdate-custom-bootsource.adoc
@@ -17,9 +17,9 @@
 
 . Open the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `HyperConverged` CR, adding the appropriate template and boot source in the `dataImportCronTemplates` section. For example:

--- a/modules/virt-configuring-certificate-rotation.adoc
+++ b/modules/virt-configuring-certificate-rotation.adoc
@@ -12,21 +12,21 @@ You can do this during {VirtProductName} installation in the web console or afte
 
 . Open the `HyperConverged` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `spec.certConfig` fields as shown in the following example. To avoid overloading the system, ensure that all values are greater than or equal to 10 minutes. Express all values as strings that comply with the link:https://golang.org/pkg/time/#ParseDuration[golang `ParseDuration` format].
 
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
- name: kubevirt-hyperconverged
- namespace: openshift-cnv
+  name: kubevirt-hyperconverged
+  namespace: {CNVNamespace}
 spec:
   certConfig:
     ca:

--- a/modules/virt-configuring-cluster-dpdk.adoc
+++ b/modules/virt-configuring-cluster-dpdk.adoc
@@ -88,9 +88,9 @@ $ oc get performanceprofiles.performance.openshift.io profile-1 -o=jsonpath='{.s
 
 . Set the previously obtained `RuntimeClass` name as the default container runtime class for the `virt-launcher` pods by editing the `HyperConverged` custom resource (CR):
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc patch -n openshift-cnv hco kubevirt-hyperconverged \
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
     --type='json' -p='[{"op": "add", "path": "/spec/defaultRuntimeClass", "value":"<runtimeclass-name>"}]'
 ----
 +

--- a/modules/virt-configuring-default-cpu-model.adoc
+++ b/modules/virt-configuring-default-cpu-model.adoc
@@ -21,21 +21,21 @@ The `defaultCPUModel` is case sensitive.
 
 . Open the `HyperConverged` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the `defaultCPUModel` field to the CR and set the value to the name of a CPU model that exists in the cluster:
 
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
  name: kubevirt-hyperconverged
- namespace: openshift-cnv
+ namespace: {CNVNamespace}
 spec:
   defaultCPUModel: "EPYC"
 ----

--- a/modules/virt-configuring-highburst-profile.adoc
+++ b/modules/virt-configuring-highburst-profile.adoc
@@ -13,23 +13,22 @@ Use the `highBurst` profile to create and maintain a large number of virtual mac
 
 * Apply the following patch to enable the `highBurst` tuning policy profile:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc patch -n openshift-cnv hco kubevirt-hyperconverged \
---type=json -p='[{"op": "add", "path": "/spec/tuningPolicy", \
-"value": "highBurst"}]'
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+  --type=json -p='[{"op": "add", "path": "/spec/tuningPolicy", \
+  "value": "highBurst"}]'
 ----
 
 .Verification
 
 * Run the following command to verify the `highBurst` tuning policy profile is enabled:
-
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
 $ oc get kubevirt.kubevirt.io/kubevirt-kubevirt-hyperconverged \
--n openshift-cnv -o go-template --template='{{range $config, \
-$value := .spec.configuration}} {{if eq $config "apiConfiguration" \
-"webhookConfiguration" "controllerConfiguration" "handlerConfiguration"}} \
-{{"\n"}} {{$config}} = {{$value}} {{end}} {{end}} {{"\n"}}
+  -n {CNVNamespace} -o go-template --template='{{range $config, \
+  $value := .spec.configuration}} {{if eq $config "apiConfiguration" \
+  "webhookConfiguration" "controllerConfiguration" "handlerConfiguration"}} \
+  {{"\n"}} {{$config}} = {{$value}} {{end}} {{end}} {{"\n"}}
 ----

--- a/modules/virt-configuring-live-migration-limits.adoc
+++ b/modules/virt-configuring-live-migration-limits.adoc
@@ -14,19 +14,19 @@ Configure live migration limits and timeouts for the cluster by updating the `Hy
 
 * Edit the `HyperConverged` CR and add the necessary live migration parameters.
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 +
 .Example configuration file
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   liveMigrationConfig: <1>
     bandwidthPerMigration: 64Mi

--- a/modules/virt-configuring-obsolete-cpu-models.adoc
+++ b/modules/virt-configuring-obsolete-cpu-models.adoc
@@ -12,13 +12,13 @@ You can configure a list of obsolete CPU models by editing the `HyperConverged` 
 
 * Edit the `HyperConverged` custom resource, specifying the obsolete CPU models in the `obsoleteCPUs` array. For example:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   obsoleteCPUs:
     cpuModels: <1>

--- a/modules/virt-configuring-pod-log-verbosity.adoc
+++ b/modules/virt-configuring-pod-log-verbosity.adoc
@@ -12,9 +12,9 @@ You can configure the verbosity level of {VirtProductName} pod logs by editing t
 
 . To set log verbosity for specific components, open the `HyperConverged` CR in your default text editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Set the log level for one or more components by editing the `spec.logVerbosityConfig` stanza. For example:

--- a/modules/virt-configuring-secondary-dns-server.adoc
+++ b/modules/virt-configuring-secondary-dns-server.adoc
@@ -18,16 +18,17 @@ The Cluster Network Addons Operator (CNAO) deploys a Domain Name Server (DNS) se
 
 . Create a load balancer service to expose the DNS server outside the cluster by running the `oc expose` command according to the following example:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc expose -n openshift-cnv deployment/secondary-dns --name=dns-lb --type=LoadBalancer --port=53 --target-port=5353 --protocol='UDP'
+$ oc expose -n {CNVNamespace} deployment/secondary-dns --name=dns-lb \
+  --type=LoadBalancer --port=53 --target-port=5353 --protocol='UDP'
 ----
 
 . Retrieve the external IP address by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get service -n openshift-cnv
+$ oc get service -n {CNVNamespace}
 ----
 +
 .Example output
@@ -39,20 +40,20 @@ dns-lb     LoadBalancer     172.30.27.5    10.46.41.94      53:31829/TCP     5s
 
 . Edit the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Enable the DNS server and monitoring components according to the following example:
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
     featureGates:
       deployKubeSecondaryDNS: true

--- a/modules/virt-configuring-secondary-network-vm-live-migration.adoc
+++ b/modules/virt-configuring-secondary-network-vm-live-migration.adoc
@@ -21,13 +21,13 @@ To configure a dedicated secondary network for live migration, you must first cr
 . Create a `NetworkAttachmentDefinition` manifest.
 +
 .Example configuration file
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: "k8s.cni.cncf.io/v1"
 kind: NetworkAttachmentDefinition
 metadata:
   name: my-secondary-network <1>
-  namespace: openshift-cnv <2>
+  namespace: {CNVNamespace} <2>
 spec:
   config: '{
     "cniVersion": "0.3.1",
@@ -49,9 +49,9 @@ spec:
 
 . Open the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the name of the `NetworkAttachmentDefinition` object to the `spec.liveMigrationConfig` stanza of the `HyperConverged` CR. For example:

--- a/modules/virt-configuring-storage-class-bootsource-update.adoc
+++ b/modules/virt-configuring-storage-class-bootsource-update.adoc
@@ -18,9 +18,9 @@ Boot sources are created from storage using the default storage class. If your c
 
 . Open the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Define a new storage class by entering a value in the `storageClassName` field:

--- a/modules/virt-configuring-workload-update-methods.adoc
+++ b/modules/virt-configuring-workload-update-methods.adoc
@@ -21,9 +21,9 @@ If a `VirtualMachineInstance` CR contains `evictionStrategy: LiveMigrate` and th
 
 . To open the `HyperConverged` CR in your default editor, run the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `workloadUpdateStrategy` stanza of the `HyperConverged` CR. For example:

--- a/modules/virt-creating-and-exposing-mediated-devices.adoc
+++ b/modules/virt-creating-and-exposing-mediated-devices.adoc
@@ -16,21 +16,21 @@ You can expose and create mediated devices such as virtual GPUs (vGPUs) by editi
 
 . Edit the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the mediated device information to the `HyperConverged` CR `spec`, ensuring that you include the `mediatedDevicesConfiguration` and `permittedHostDevices` stanzas. For example:
 +
 .Example configuration file
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   mediatedDevicesConfiguration: <.>
     mediatedDevicesTypes: <.>

--- a/modules/virt-customizing-storage-profile.adoc
+++ b/modules/virt-customizing-storage-profile.adoc
@@ -24,9 +24,9 @@ If you create a data volume and omit YAML attributes and these attributes are no
 
 . Edit the storage profile. In this example, the provisioner is not recognized by CDI:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit -n openshift-cnv storageprofile <storage_class>
+$ oc edit -n {CNVNamespace} storageprofile <storage_class>
 ----
 +
 .Example storage profile

--- a/modules/virt-defining-storageclass.adoc
+++ b/modules/virt-defining-storageclass.adoc
@@ -16,9 +16,9 @@ You can define the storage class that the Containerized Data Importer (CDI) uses
 
 . Edit the `HyperConverged` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the `spec.scratchSpaceStorageClass` field to the CR, setting the value to the name of a storage class that exists in the cluster:

--- a/modules/virt-deleting-virt-cli.adoc
+++ b/modules/virt-deleting-virt-cli.adoc
@@ -18,30 +18,30 @@ You can uninstall {VirtProductName} by using the OpenShift CLI (`oc`).
 
 . Delete the `HyperConverged` custom resource:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc delete HyperConverged kubevirt-hyperconverged -n openshift-cnv
+$ oc delete HyperConverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Delete the {VirtProductName} Operator subscription:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc delete subscription kubevirt-hyperconverged -n openshift-cnv
+$ oc delete subscription kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Delete the {VirtProductName} `ClusterServiceVersion` resource:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc delete csv -n openshift-cnv -l operators.coreos.com/kubevirt-hyperconverged.openshift-cnv
+$ oc delete csv -n openshift-cnv -l operators.coreos.com/kubevirt-hyperconverged.{CNVNamespace}
 ----
 
 . List the {VirtProductName} custom resource definitions (CRDs) by running the `oc delete crd` command with the `dry-run` option:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc delete crd --dry-run=client -l operators.coreos.com/kubevirt-hyperconverged.openshift-cnv
+$ oc delete crd --dry-run=client -l operators.coreos.com/kubevirt-hyperconverged.{CNVNamespace}
 ----
 +
 .Example output
@@ -57,7 +57,7 @@ customresourcedefinition.apiextensions.k8s.io "tektontasks.tektontasks.kubevirt.
 
 . Delete the CRDs by running the `oc delete crd` command without the `dry-run` option:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc delete crd -l operators.coreos.com/kubevirt-hyperconverged.openshift-cnv
+$ oc delete crd -l operators.coreos.com/kubevirt-hyperconverged.{CNVNamespace}
 ----

--- a/modules/virt-deploying-tto.adoc
+++ b/modules/virt-deploying-tto.adoc
@@ -12,9 +12,9 @@ The Tekton Tasks Operator (TTO) tasks and example pipelines are not deployed by 
 
 . Open the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Set the `spec.featureGates.deployTektonTaskResources` field to `true`.

--- a/modules/virt-disable-auto-updates-single-boot-source.adoc
+++ b/modules/virt-disable-auto-updates-single-boot-source.adoc
@@ -13,9 +13,9 @@ You can disable automatic updates for an individual boot source, whether it is c
 
 . Open the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Disable automatic updates for an individual boot source by editing the `spec.dataImportCronTemplates` field.

--- a/modules/virt-disabling-tls-for-registry.adoc
+++ b/modules/virt-disabling-tls-for-registry.adoc
@@ -16,13 +16,13 @@ You can disable TLS (transport layer security) for one or more container registr
 
 * Edit the `HyperConverged` custom resource and add a list of insecure registries to the `spec.storageImport.insecureRegistries` field.
 +
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1beta1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   storageImport:
     insecureRegistries: <1>

--- a/modules/virt-exposing-pci-device-in-cluster-cli.adoc
+++ b/modules/virt-exposing-pci-device-in-cluster-cli.adoc
@@ -12,21 +12,21 @@ To expose PCI host devices in the cluster, add details about the PCI devices to 
 .Procedure
 . Edit the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the PCI device information to the `spec.permittedHostDevices.pciHostDevices` array. For example:
 +
 .Example configuration file
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   permittedHostDevices: <1>
     pciHostDevices: <2>

--- a/modules/virt-managing-auto-update-all-system-boot-sources.adoc
+++ b/modules/virt-managing-auto-update-all-system-boot-sources.adoc
@@ -22,9 +22,9 @@ Custom boot sources are not affected by this setting.
 
 ** To disable automatic boot source updates, set the `spec.featureGates.enableCommonBootImageImport` field in the `HyperConverged` CR to `false`. For example:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "replace", "path": \
   "/spec/featureGates/enableCommonBootImageImport", \
   "value": false}]'
@@ -32,9 +32,9 @@ $ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
 
 ** To re-enable automatic boot source updates, set the `spec.featureGates.enableCommonBootImageImport` field in the `HyperConverged` CR to `true`. For example:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "replace", "path": \
   "/spec/featureGates/enableCommonBootImageImport", \
   "value": true}]'

--- a/modules/virt-monitoring-upgrade-status.adoc
+++ b/modules/virt-monitoring-upgrade-status.adoc
@@ -23,9 +23,9 @@ available information.
 
 . Run the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get csv -n openshift-cnv
+$ oc get csv -n {CNVNamespace}
 ----
 
 . Review the output, checking the `PHASE` field. For example:
@@ -41,10 +41,10 @@ VERSION  REPLACES                                        PHASE
 . Optional: Monitor the aggregated status of all {VirtProductName} component
 conditions by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get hco -n openshift-cnv kubevirt-hyperconverged \
--o=jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}'
+$ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+  -o=jsonpath='{range .status.conditions[*]}{.type}{"\t"}{.status}{"\t"}{.message}{"\n"}{end}'
 ----
 +
 A successful upgrade results in the following output:

--- a/modules/virt-overriding-cpu-and-memory-defaults.adoc
+++ b/modules/virt-overriding-cpu-and-memory-defaults.adoc
@@ -16,9 +16,9 @@ Modify the default settings for CPU and memory requests and limits for your use 
 
 . Edit the `HyperConverged` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Add the `spec.resourceRequirements.storageWorkloads` stanza to the CR, setting the values based on your use case. For example:

--- a/modules/virt-overriding-default-fs-overhead-value.adoc
+++ b/modules/virt-overriding-default-fs-overhead-value.adoc
@@ -16,9 +16,9 @@ Change the amount of persistent volume claim (PVC) space that the {VirtProductNa
 
 . Open the `HCO` object for editing by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hco -n openshift-cnv kubevirt-hyperconverged
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Edit the `spec.filesystemOverhead` fields, populating them with your chosen values:

--- a/modules/virt-preventing-workload-updates-during-eus-update.adoc
+++ b/modules/virt-preventing-workload-updates-during-eus-update.adoc
@@ -22,16 +22,18 @@ When you update from one Extended Update Support (EUS) version to the next, you 
 
 . Back up the current `workloadUpdateMethods` configuration by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ WORKLOAD_UPDATE_METHODS=$(oc get kv kubevirt-kubevirt-hyperconverged -n openshift-cnv -o jsonpath='{.spec.workloadUpdateStrategy.workloadUpdateMethods}')
+$ WORKLOAD_UPDATE_METHODS=$(oc get kv kubevirt-kubevirt-hyperconverged \
+  -n {CNVNamespace} -o jsonpath='{.spec.workloadUpdateStrategy.workloadUpdateMethods}')
 ----
 
 . Turn off all workload update methods by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv --type json -p '[{"op":"replace","path":"/spec/workloadUpdateStrategy/workloadUpdateMethods", "value":[]}]'
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+  --type json -p '[{"op":"replace","path":"/spec/workloadUpdateStrategy/workloadUpdateMethods", "value":[]}]'
 ----
 +
 .Example output
@@ -42,9 +44,9 @@ hyperconverged.hco.kubevirt.io/kubevirt-hyperconverged patched
 
 . Ensure that the `HyperConverged` Operator is `Upgradeable` before you continue. Enter the following command and monitor the output:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get hco kubevirt-hyperconverged -n openshift-cnv -o json | jq ".status.conditions"
+$ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} -o json | jq ".status.conditions"
 ----
 +
 .Example output
@@ -125,18 +127,18 @@ Updating {product-title} to the next version is a prerequisite for updating {Vir
 
 . Monitor the {VirtProductName} update by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get csv -n openshift-cnv
+$ oc get csv -n {CNVNamespace}
 ----
 
 . Update {VirtProductName} to every z-stream version that is available for the non-EUS minor version, monitoring each update by running the command shown in the previous step.
 
 . Confirm that {VirtProductName} successfully updated to the latest z-stream release of the non-EUS version by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get hco kubevirt-hyperconverged -n openshift-cnv -o json | jq ".status.versions"
+$ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} -o json | jq ".status.versions"
 ----
 +
 .Example output
@@ -152,9 +154,9 @@ $ oc get hco kubevirt-hyperconverged -n openshift-cnv -o json | jq ".status.vers
 
 . Wait until the `HyperConverged` Operator has the `Upgradeable` status before you perform the next update. Enter the following command and monitor the output:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get hco kubevirt-hyperconverged -n openshift-cnv -o json | jq ".status.conditions"
+$ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} -o json | jq ".status.conditions"
 ----
 
 . Update {product-title} to the target EUS version.
@@ -172,18 +174,19 @@ $ oc get clusterversion
 
 . Monitor the {VirtProductName} update by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get csv -n openshift-cnv
+$ oc get csv -n {CNVNamespace}
 ----
 +
 The update completes when the `VERSION` field matches the target EUS version and the `PHASE` field reads `Succeeded`.
 
 . Restore the workload update methods configuration that you backed up:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv --type json -p "[{\"op\":\"add\",\"path\":\"/spec/workloadUpdateStrategy/workloadUpdateMethods\", \"value\":$WORKLOAD_UPDATE_METHODS}]"
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} --type json -p \
+  "[{\"op\":\"add\",\"path\":\"/spec/workloadUpdateStrategy/workloadUpdateMethods\", \"value\":$WORKLOAD_UPDATE_METHODS}]"
 ----
 +
 .Example output

--- a/modules/virt-removing-mediated-device-from-cluster-cli.adoc
+++ b/modules/virt-removing-mediated-device-from-cluster-cli.adoc
@@ -12,21 +12,21 @@ To remove a mediated device from the cluster, delete the information for that de
 
 . Edit the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Remove the device information from the `spec.mediatedDevicesConfiguration` and `spec.permittedHostDevices` stanzas of the `HyperConverged` CR. Removing both entries ensures that you can later create a new mediated device type on the same node. For example:
 +
 .Example configuration file
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   mediatedDevicesConfiguration:
     mediatedDevicesTypes: <1>

--- a/modules/virt-removing-pci-device-from-cluster-cli.adoc
+++ b/modules/virt-removing-pci-device-from-cluster-cli.adoc
@@ -12,21 +12,21 @@ To remove a PCI host device from the cluster, delete the information for that de
 .Procedure
 . Edit the `HyperConverged` CR in your default editor by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc edit hyperconverged kubevirt-hyperconverged -n openshift-cnv
+$ oc edit hyperconverged kubevirt-hyperconverged -n {CNVNamespace}
 ----
 
 . Remove the PCI device information from the `spec.permittedHostDevices.pciHostDevices` array by deleting the `pciDeviceSelector`, `resourceName` and `externalResourceProvider` (if applicable) fields for the appropriate device. In this example, the `intel.com/qat` resource has been deleted.
 +
 .Example configuration file
-[source,yaml]
+[source,yaml,subs="attributes+"]
 ----
 apiVersion: hco.kubevirt.io/v1
 kind: HyperConverged
 metadata:
   name: kubevirt-hyperconverged
-  namespace: openshift-cnv
+  namespace: {CNVNamespace}
 spec:
   permittedHostDevices:
     pciHostDevices:

--- a/modules/virt-verify-status-bootsource-update.adoc
+++ b/modules/virt-verify-status-bootsource-update.adoc
@@ -13,9 +13,9 @@ You can determine if a boot source is system-defined or custom by viewing the `H
 
 . View the contents of the `HyperConverged` CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get hco -n openshift-cnv kubevirt-hyperconverged -o yaml
+$ oc get hyperconverged kubevirt-hyperconverged -n {CNVNamespace} -o yaml
 ----
 +
 .Example output

--- a/modules/virt-viewing-logs-cli.adoc
+++ b/modules/virt-viewing-logs-cli.adoc
@@ -12,9 +12,9 @@ You can view logs for the {VirtProductName} pods by using the `oc` CLI tool.
 
 . View a list of pods in the {VirtProductName} namespace by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc get pods -n openshift-cnv
+$ oc get pods -n {CNVNamespace}
 ----
 +
 .Example output
@@ -38,9 +38,9 @@ virt-operator-7ccfdbf65f-vllz8     1/1     Running   0          32m
 
 . View the pod log by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc logs -n openshift-cnv <pod_name>
+$ oc logs -n {CNVNamespace} <pod_name>
 ----
 +
 [NOTE]

--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -190,9 +190,9 @@ The formula for calculating the PVC size is `(VMMemorySize + 100Mi) * FileSystem
 
 * You must enable the hot plug feature gate in the `HyperConverged` custom resource by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc patch hco kubevirt-hyperconverged -n openshift-cnv \
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
   --type json -p '[{"op": "add", "path": "/spec/featureGates", \
   "value": "HotplugVolumes"}]'
 ----
@@ -203,7 +203,7 @@ You must use the `virtctl vmexport download` command to download the memory dump
 
 [source,terminal]
 ----
-$ virtctl vmexport download <vmexport_name> --vm\|pvc=<object_name> \
+$ virtctl vmexport download <vmexport_name> --vm|pvc=<object_name> \
   --volume=<volume_name> --output=<output_file>
 ----
 

--- a/virt/virtual_machines/advanced_vm_management/virt-configuring-mediated-devices.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-configuring-mediated-devices.adoc
@@ -3,6 +3,7 @@
 = Configuring mediated devices
 include::_attributes/common-attributes.adoc[]
 :context: virt-configuring-mediated-devices
+:toclevels: 3
 
 toc::[]
 

--- a/virt/virtual_machines/advanced_vm_management/virt-vm-control-plane-tuning.adoc
+++ b/virt/virtual_machines/advanced_vm_management/virt-vm-control-plane-tuning.adoc
@@ -1,7 +1,6 @@
 :_content-type: ASSEMBLY
 [id="virt-vm-control-plane-tuning"]
 = Virtual machine control plane tuning
-
 include::_attributes/common-attributes.adoc[]
 :context: virt-control-plane-tuning
 

--- a/virt/vm_networking/virt-dedicated-network-live-migration.adoc
+++ b/virt/vm_networking/virt-dedicated-network-live-migration.adoc
@@ -3,6 +3,7 @@
 = Configuring a dedicated network for live migration
 include::_attributes/common-attributes.adoc[]
 :context: virt-dedicated-network-live-migration
+
 toc::[]
 
 You can configure a dedicated xref:../../virt/vm_networking/virt-connecting-vm-to-linux-bridge.adoc#virt-connecting-vm-to-linux-bridge[Multus network] for live migration. A dedicated network minimizes the effects of network saturation on tenant workloads during live migration.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Changed 'hco' to 'hyperconverged' in '$ oc' commands to align with OCP guidelines.
Changed 'openshift-cnv' to CNV namespace attribute.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: None
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- [Adding templates to custom namespace](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_templates/virt-deploying-vm-template-to-custom-namespace#virt-adding-templates-to-custom-namespace_virt-deploying-vm-template-to-custom-namespace)
- [Enabling automatic updates for custom boot sources](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_templates/virt-automatic-bootsource-updates#virt-autoupdate-custom-bootsource_virt-automatic-bootsource-updates)
- [Configuring certificate rotation](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-certificate-rotation#virt-configuring-certificate-rotation_virt-configuring-certificate-rotation)
- [Configuring a cluster for DPDK workloads](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-using-dpdk-with-sriov#virt-configuring-cluster-dpdk_virt-using-dpdk-with-sriov)
- [Configuring the default CPU model](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-default-cpu-model#virt-configuring-default-cpu-model_virt-configuring-default-cpu-model)
- [Configuring a highBurst profile](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-vm-control-plane-tuning)
- [Configuring live migration limits and timeouts](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/live_migration/virt-live-migration-limits#virt-configuring-live-migration-limits_virt-live-migration-limits)
- [Configuring obsolete CPU models](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/node_maintenance/virt-managing-node-labeling-obsolete-cpu-models#virt-configuring-obsolete-cpu-models_virt-managing-node-labeling-obsolete-cpu-models)
- [Configuring OpenShift Virtualization pod log verbosity](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-troubleshooting#virt-configuring-pod-log-verbosity_virt-troubleshooting)
- [Configuring a DNS server for secondary networks](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-accessing-vm-secondary-network-fqdn#virt-configuring-secondary-dns-server_virt-accessing-vm-secondary-network-fqdn)
- [Configuring a dedicated secondary network for virtual machine live migration](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-dedicated-network-live-migration)
- [Configuring a storage class for custom boot source updates](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_templates/virt-automatic-bootsource-updates#virt-configuring-storage-class-bootsource-update_virt-automatic-bootsource-updates)
- [Configuring workload update methods](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt#virt-configuring-workload-update-methods_upgrading-virt)
- [Creating and exposing mediated devices](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-mediated-devices#virt-adding-and-removing-mediated-devices_context)
- [Customizing the storage profile](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-creating-data-volumes#virt-customizing-storage-profile_virt-creating-data-volumes)
- [Defining a storage class](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-preparing-cdi-scratch-space#virt-defining-storageclass_virt-preparing-cdi-scratch-space)
- [Deleting templates from a custom namespace](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_templates/virt-deploying-vm-template-to-custom-namespace#virt-deleting-templates-from-custom-namespace_virt-deploying-vm-template-to-custom-namespace)
- [Uninstalling OpenShift Virtualization by using the CLI](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/install/uninstalling-virt#virt-deleting-virt-cli_uninstalling-virt)
- [Deploying the Tekton Tasks Operator resources](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-managing-vms-openshift-pipelines#virt-deploying-tto_virt-managing-vms-openshift-pipelines)
- [Disabling automatic updates for a single boot source](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_templates/virt-automatic-bootsource-updates#virt-disable-auto-updates-single-boot-source_virt-automatic-bootsource-updates)
- [Disabling TLS for a container registry to use as insecure registry](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms#virt-disabling-tls-for-registry_virt-using-container-disks-with-vms)
- [Exposing PCI host devices in the cluster using the CLI](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough#virt-exposing-pci-device-in-cluster-cli_virt-configuring-pci-passthrough)
- [Managing automatic updates for all system-defined boot sources](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_templates/virt-automatic-bootsource-updates#virt-managing-auto-update-all-system-boot-sources_virt-automatic-bootsource-updates)
- [Monitoring OpenShift Virtualization upgrade status](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt#virt-monitoring-upgrade-status_upgrading-virt)
- [Overriding CPU and memory defaults](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-cdi-for-namespace-resourcequota#virt-overriding-cpu-and-memory-defaults_virt-configuring-cdi-for-namespace-resourcequota)
- [Overriding the default file system overhead value](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-reserving-pvc-space-fs-overhead#virt-overriding-default-fs-overhead-value_virt-reserving-pvc-space-fs-overhead)
- [Preventing workload updates during an EUS-to-EUS update](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/updating/upgrading-virt#virt-preventing-workload-updates-during-eus-update_upgrading-virt)
- [Removing mediated devices from the cluster using the CLI](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-mediated-devices#virt-adding-and-removing-mediated-devices_context)
- [Removing PCI host devices from the cluster using the CLI](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-pci-passthrough#virt-removing-pci-device-from-cluster_virt-configuring-pci-passthrough)
- [Verifying the status of a boot source](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_templates/virt-automatic-bootsource-updates#virt-verify-status-bootsource-update_virt-automatic-bootsource-updates)
- [Viewing OpenShift Virtualization pod logs with the CLI](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/support/virt-troubleshooting#virt-viewing-logs-cli_virt-troubleshooting)
- [VM memory dump commands](https://63616--docspreview.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools#vm-memory-dump-commands_virt-using-the-cli-tools)


QE review: NA
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
