### PR TITLE
[POC] Add helper script for local relfileprefix updates and update build_for_portal to ignore relfileprefix

### DIFF
--- a/scripts/process-relfileprefix-updates.sh
+++ b/scripts/process-relfileprefix-updates.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+# Process AsciiDoc assembly files and update with :relfileprefix: changes
+
+ASSEMBLIES=$(find . -type f -name '*.adoc' \
+  ! -path './snippets/*' \
+  ! -path './modules/*' \
+  ! -path './_unused_topics/*' \
+  ! -path './_preview/*' \
+  ! -path './_attributes/*' \
+  ! -path './microshift_rest_api/*' \
+  ! -path './drupal-build/*' \
+  ! -path './rest_api/*')
+
+process_file() {
+  local file="$1"
+  echo "Processing $file"
+  python scripts/update_for_relfileprefix.py "$file"
+}
+
+for file in $ASSEMBLIES; do
+  if grep -q '^:_mod-docs-content-type: ASSEMBLY' "$file"; then
+    process_file "$file"
+  fi
+done

--- a/scripts/update_for_relfileprefix.py
+++ b/scripts/update_for_relfileprefix.py
@@ -1,0 +1,57 @@
+# Usage: python ./scripts/update-relfileprefix.py <path_to_assembly>
+#
+# Use this script to update an assembly and included modules with relfileprefix changes. The script adds ":relfileprefix: <appropriate_dot_path_prefix>" to the assembly file metadata if it doesn't already exist and cleans all path prefixes from xrefs in the assembly and included modules.
+
+import re
+import os
+import sys
+import git
+
+xref_re = re.compile(r"xref:((\.\.\/)+)", re.DOTALL)
+relfileprefix_re = re.compile(r":relfileprefix: ((\.\.\/)*)", re.DOTALL)
+modules_include_re = re.compile(r"^include::(modules/.+)\[.*\]$", re.MULTILINE)
+
+# Calculate the root dir
+git_repo = git.Repo(os.path.abspath(os.getcwd()), search_parent_directories=True)
+git_root = git_repo.git.rev_parse("--show-toplevel")
+
+def update_files(assembly):
+    with open(assembly, "r+") as f:
+        assembly_content = f.read()
+
+        relfileprefix_match = re.search(relfileprefix_re, assembly_content)
+        if relfileprefix_match:
+            print("relfileprefix attribute already exists! There is no need to process this assembly. 😕")
+            exit()
+
+        # Calculate the relative path dot value for xref_prefix
+        assembly_dir = os.path.dirname(os.path.abspath(assembly))
+        xref_prefix = os.path.relpath(git_root, assembly_dir) + "/"
+
+        # Add :relfileprefix: to the top of the assembly
+        assembly_content = f":relfileprefix: {xref_prefix}\n{assembly_content}"
+        # Update assembly xrefs
+        assembly_content = re.sub(xref_re, "xref:", assembly_content)
+        f.seek(0)
+        f.write(assembly_content)
+        f.truncate()
+
+    # Update included modules xrefs
+    included_files = re.findall(modules_include_re, assembly_content)
+    for included_file in included_files:
+        include_path = os.path.join(git_root, included_file)
+        with open(include_path, "r+") as f:
+            module_content = f.read()
+            module_content = re.sub(xref_re, "xref:", module_content)
+            f.seek(0)
+            f.write(module_content)
+            f.truncate()
+
+    print(f"Updated xrefs in {assembly} and included modules 🥳")
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print("Usage: python update_for_relfileprefix.py <path_to_assembly>")
+    else:
+        assembly = sys.argv[1]
+        update_files(assembly)


### PR DESCRIPTION
3 separate but related changes in this PR: 

1. Helper script to calculate and add `:relfileprefix:` to assemblies and update all assembly and included module xrefs.
2. Script to run the changes for all assemblies in repo  
3. Updated build_for_portal script to ignore `:relfileprefix:` changes to assemblies and modules.

These changes would allow us to increment top-down xrefs changes in OCP docs content, assembly by assembly. The current asciibinder build supports `:relfileprefix:` since it is built on top of Asciidoctor. The current portal build which is based on ccutil does not support built-in `:relfileprefix:` attributes.  

Existing `../` style xrefs would continue to be supported since `:relfileprefix:` is just a convenience built into Asciidoctor.

Preview with `:relfileprefix:` changes applied in full: 
https://file.emea.redhat.com/aireilly/update-xrefs/welcome/index.html

Based on https://docs.asciidoctor.org/asciidoc/latest/macros/inter-document-xref/#mapping-references-to-a-different-structure