### PR TITLE
CNV-26876-FIX: attribute fix

### DIFF
--- a/modules/virt-golden-images.adoc
+++ b/modules/virt-golden-images.adoc
@@ -18,4 +18,4 @@ After the golden image is created, it is saved as a template or image file that 
 [id="virt-golden-images-implementation_{context}"]
 == Red Hat implementation of golden images
 
-Red Hat publishes golden images as container disks in the registry for versions of :op-system-base:. Container disks are virtual machine images that are stored as a container image in a container image registry. Any published image will automatically be made available in connected clusters after the installation of OpenShift Virtualization. After the images are available in a cluster, they are ready to use to create VMs.
+Red Hat publishes golden images as container disks in the registry for versions of {op-system-base-full}. Container disks are virtual machine images that are stored as a container image in a container image registry. Any published image will automatically be made available in connected clusters after the installation of OpenShift Virtualization. After the images are available in a cluster, they are ready to use to create VMs.


### PR DESCRIPTION
This is a fix for https://github.com/openshift/openshift-docs/pull/61715. The format of the attribute was incorrect.

Version: 4.14

Preview: https://63620--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-using-container-disks-with-vms.html#virt-golden-images-implementation_virt-using-container-disks-with-vms