### PR TITLE
TELCODOCS-1316: Adding lvms storage subscription for ZTP

### DIFF
--- a/modules/ztp-provisioning-lvm-storage.adoc
+++ b/modules/ztp-provisioning-lvm-storage.adoc
@@ -11,6 +11,8 @@ You can configure {lvms-first} for managed clusters that you deploy with {ztp-fi
 [NOTE]
 ====
 You use {lvms} to persist event subscriptions when you use PTP events or bare-metal hardware events with HTTP transport.
+
+Use the Local Storage Operator for persistent storage that uses local volumes in distributed units.
 ====
 
 .Prerequisites
@@ -37,13 +39,31 @@ You use {lvms} to persist event subscriptions when you use PTP events or bare-me
     channel: stable-{product-version}
   policyName: subscription-policies
 ----
++
+[NOTE]
+====
+The Storage LVMO subscription is deprecated. In future releases of {product-title}, the storage LVMO subscription will not be available. Instead, you must use the Storage LVMS subscription. 
+
+In {product-title} {product-version}, you can use the Storage LVMS subscription instead of the LVMO subscription. The LVMS subscription does not require manual overrides in the `common-ranGen.yaml` file. Add the following YAML to `spec.sourceFiles` in the `common-ranGen.yaml` file to use the Storage LVMS subscription:
+
+[source,yaml]
+----
+- fileName: StorageLVMSubscriptionNS.yaml
+  policyName: subscription-policies
+- fileName: StorageLVMSubscriptionOperGroup.yaml
+  policyName: subscription-policies
+- fileName: StorageLVMSubscription.yaml
+  policyName: subscription-policies
+----
+
+====
 
 . Add the `LVMCluster` CR to `spec.sourceFiles` in your specific group or individual site configuration file. For example, in the `group-du-sno-ranGen.yaml` file, add the following:
 +
 [source,yaml]
 ----
 - fileName: StorageLVMCluster.yaml
-  policyName: "lvmo-config" <1>
+  policyName: "lvms-config" <1>
   spec:
     storage:
       deviceClasses:


### PR DESCRIPTION
[TELCODOCS-1316](https://issues.redhat.com//browse/TELCODOCS-1316): Adding option for lvms storage subscription and flagging deprecation of lvmo subscription

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1316

Link to docs preview:
https://63623--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config#ztp-provisioning-lvm-storage_ztp-advanced-policy-config 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

