### PR TITLE
[OSDOCS-7505] added what's new for ROSA CLI 1.2.25

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 [id="rosa-q3-2023_{context}"]
 === Q3 2023
 
+* **ROSA CLI update:** The ROSA CLI (`rosa`) was updated to a new version. For information about what's changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.25[release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc[Getting started with the ROSA CLI].
+
 * **ROSA regional availability update:** {product-title} (ROSA) is now available in the following regions:
 +
 ** Hyderabad (`ap-south-2`)


### PR DESCRIPTION
[OSDOCS-7505] added what's new for ROSA CLI 1.2.25

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7505

Link to docs preview:
https://63642--docspreview.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes#rosa-q3-2023_rosa-whats-new

QE review:
- [x] QE not needed.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
