### PR TITLE
Support Remote Health docs fixes during ROSA review

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -683,7 +683,7 @@ Topics:
     File: enabling-remote-health-reporting
   - Name: Using Insights to identify issues with your cluster
     File: using-insights-to-identify-issues-with-your-cluster
-  - Name: Using Insights Operator
+  - Name: Using the Insights Operator
     File: using-insights-operator
   - Name: Using remote health reporting in a restricted network
     File: remote-health-reporting-from-restricted-network

--- a/modules/disabling-insights-advisor-recommendations.adoc
+++ b/modules/disabling-insights-advisor-recommendations.adoc
@@ -22,10 +22,15 @@ Disabling a recommendation for all of your clusters also applies to any future c
 .Procedure
 
 . Navigate to *Advisor* -> *Recommendations* on {cluster-manager-url}.
-. Click the name of the recommendation to disable. You are directed to the single recommendation page.
-. To disable the recommendation for a single cluster:
-.. Click the *Options* menu {kebab} for that cluster, and then click *Disable recommendation for cluster*.
+. Optional: Use the *Clusters Impacted* and *Status* filters as needed.
+. Disable an alert by using one of the following methods: 
++
+* To disable an alert:
+.. Click the *Options* menu {kebab} for that alert, and then click *Disable recommendation*.
 .. Enter a justification note and click *Save*.
-. To disable the recommendation for all of your clusters:
-.. Click *Actions* -> *Disable recommendation*.
++
+* To view the clusters affected by this alert before disabling the alert:
+.. Click the name of the recommendation to disable. You are directed to the single recommendation page.
+.. Review the list of clusters in the *Affected clusters* section.
+.. Click *Actions* -> *Disable recommendation* to disable the alert for all of your clusters.
 .. Enter a justification note and click *Save*.

--- a/modules/disabling-insights-operator-alerts.adoc
+++ b/modules/disabling-insights-operator-alerts.adoc
@@ -7,14 +7,41 @@
 [id="disabling-insights-operator-alerts_{context}"]
 = Disabling Insights Operator alerts
 
-You can stop Insights Operator from firing alerts to the cluster Prometheus instance.
+ifndef::openshift-rosa,openshift-dedicated[]
+To prevent the Insights Operator from sending alerts to the cluster Prometheus instance, you edit the `support` secret. If the `support` secret doesn't exist, you must create it when you first add custom configurations. Note that configurations within the `support` secret take precedence over the default settings defined in the `pod.yaml` file.
+endif::openshift-rosa,openshift-dedicated[]
+ifndef::openshift-rosa,openshift-dedicated[]
+To prevent the Insights Operator from sending alerts to the cluster Prometheus instance, you edit the `support` secret. Note that this `secret` is created by default. The configurations stored in the support secret take precedence over any default settings specified in the `pod.yaml` file.
+endif::openshift-rosa,openshift-dedicated[]
+
+.Prerequisites
+
+* Remote health reporting is enabled, which is the default.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as `cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+
+.Procedure
 
 . Navigate to *Workloads* -> *Secrets*.
 . On the *Secrets* page, select *All Projects* from the *Project* list, and then set *Show default projects* to on.
 . Select the *openshift-config* project from the *Projects* list.
-. Search for the *support* secret using the *Search by name* field. If the secret does not exist, click *Create* -> *Key/value secret* to create it.
+. Search for the *support* secret by using the *Search by name* field. 
++
+* If the secret exists:
 . Click the *Options* menu {kebab}, and then click *Edit Secret*.
 . Click *Add Key/Value*.
-. Enter `disableInsightsAlerts` as the key with the value `True`, and click *Save*.
+.. In the *Key* field, enter `disableInsightsAlerts`.
+.. In the *Value* field, enter `True`.
++
+* If the secret does not exist:
+.. Click *Create* -> *Key/value secret*.
+... In the *Secret name* field, enter `support`.
+... In the *Key* field, enter `disableInsightsAlerts`.
+... In the *Value* field, enter `True`.
+.. Click *Create*.
 
-After you save the changes, Insights Operator will no longer send alerts to the cluster Prometheus instance. 
+After you save the changes, Insights Operator no longer sends alerts to the cluster Prometheus instance. 

--- a/modules/disabling-insights-operator-gather.adoc
+++ b/modules/disabling-insights-operator-gather.adoc
@@ -32,7 +32,8 @@ endif::openshift-rosa,openshift-dedicated[]
 . On the *CustomResourceDefinitions* page, use the *Search by name* field to find the *InsightsDataGather* resource definition and click it.
 . On the *CustomResourceDefinition details* page, click the *Instances* tab.
 . Click *cluster*, and then click the *YAML* tab.
-. To disable all the gather operations, edit the `InsightsDataGather` configuration file:
+. Disable the gather operations by performing one of the following edits to the `InsightsDataGather` configuration file: 
+.. To disable all the gather operations, enter `all` under the `disabledGatherers` key:
 +
 [source,yaml]
 ----
@@ -51,7 +52,8 @@ spec: <1>
 <1> The `spec` parameter specifies gather configurations. 
 <2> The `all` value disables all gather operations.
 --
-To disable individual gather operations, enter their values under the `disabledGatherers` key:
+
+.. To disable individual gather operations, enter their values under the `disabledGatherers` key:
 +
 [source,yaml]
 ----

--- a/modules/displaying-the-insights-status-in-the-web-console.adoc
+++ b/modules/displaying-the-insights-status-in-the-web-console.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
+// * sd_support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc
 
 :_content-type: PROCEDURE
 [id="displaying-the-insights-status-in-the-web-console_{context}"]

--- a/modules/enabling-insights-advisor-recommendations.adoc
+++ b/modules/enabling-insights-advisor-recommendations.adoc
@@ -6,7 +6,7 @@
 [id="enabling-insights-advisor-recommendations_{context}"]
 = Enabling a previously disabled Insights Advisor recommendation
 
-When a recommendation is disabled for all clusters, you will no longer see the recommendation in Insights Advisor. You can change this behavior.
+When a recommendation is disabled for all clusters, you no longer see the recommendation in the Insights Advisor. You can change this behavior.
 
 .Prerequisites
 
@@ -17,6 +17,9 @@ When a recommendation is disabled for all clusters, you will no longer see the r
 .Procedure
 
 . Navigate to *Advisor* -> *Recommendations* on {cluster-manager-url}.
-. Filter the recommendations by *Status* -> *Disabled*.
+. Filter the recommendations to display on the disabled recommendations:
+.. From the *Status* drop-down menu, select *Status*.
+.. From the *Filter by status* drop-down menu, select *Disabled*.
+.. Optional: Clear the *Clusters impacted* filter.
 . Locate the recommendation to enable.
 . Click the *Options* menu {kebab}, and then click *Enable recommendation*.

--- a/modules/enabling-insights-operator-alerts.adoc
+++ b/modules/enabling-insights-operator-alerts.adoc
@@ -1,0 +1,31 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+
+:_content-type: CONCEPT
+[id="enabling-insights-operator-alerts_{context}"]
+= Enabling Insights Operator alerts
+
+When alerts are disabled, the Insights Operator no longer sends alerts to the cluster Prometheus instance. You can change this behavior.
+
+.Prerequisites
+
+* Remote health reporting is enabled, which is the default.
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as `cluster-admin`.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+
+.Procedure
+
+. Navigate to *Workloads* -> *Secrets*.
+. On the *Secrets* page, select *All Projects* from the *Project* list, and then set *Show default projects* to *ON*.
+. Select the *openshift-config* project from the *Projects* list.
+. Search for the *support* secret by using the *Search by name* field. 
+. Click the *Options* menu {kebab}, and then click *Edit Secret*.
+. For the `disableInsightsAlerts` key, set the *Value* field to `false`.
+
+After you save the changes, Insights Operator again sends alerts to the cluster Prometheus instance. 

--- a/modules/enabling-insights-operator-gather.adoc
+++ b/modules/enabling-insights-operator-gather.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+
+:_content-type: PROCEDURE
+[id="enabling-insights-operator-gather_{context}"]
+= Enabling the Insights Operator gather operations
+
+You can enable the Insights Operator gather operations, if the gather operations have been disabled.
+
+:FeatureName: The `InsightsDataGather` custom resource 
+include::snippets/technology-preview.adoc[] 
+
+.Prerequisites
+
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+
+.Procedure
+
+. Navigate to *Administration* -> *CustomResourceDefinitions*.
+. On the *CustomResourceDefinitions* page, use the *Search by name* field to find the *InsightsDataGather* resource definition and click it.
+. On the *CustomResourceDefinition details* page, click the *Instances* tab.
+. Click *cluster*, and then click the *YAML* tab.
+. Enable the gather operations by performing one of the following edits: 
+
+** To enable all disabled gather operations, remove the `gatherConfig` stanza:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1alpha1
+kind: InsightsDataGather
+metadata:
+....
+
+spec:
+  gatherConfig: <1>
+    disabledGatherers: all
+----
++
+--
+<1> Remove the `gatherConfig` stanza to enable all gather operations.
+--
+
+** To enable individual gather operations, remove their values under the `disabledGatherers` key:
++
+[source,yaml]
+----
+spec:
+  gatherConfig:
+    disabledGatherers:
+      - clusterconfig/container_images <1>
+      - clusterconfig/host_subnets
+      - workloads/workload_info
+----
++
+--
+<1> Remove one or more gather operations. 
+--
++
+. Click *Save*.
++
+After you save the changes, the Insights Operator gather configurations are updated and the affected gather operations start. 
+
+[NOTE]
+====
+Disabling gather operations degrades Insights Advisor's ability to offer effective recommendations for your cluster.
+====

--- a/modules/insights-operator-configuring-sca.adoc
+++ b/modules/insights-operator-configuring-sca.adoc
@@ -7,7 +7,7 @@
 [id="insights-operator-configuring-sca_{context}"]
 = Configuring simple content access import interval
 
-You can configure how often the Insights Operator imports the simple content access entitlements using the `support` secret in the `openshift-config` namespace. The entitlement import normally occurs every eight hours, but you can shorten this interval if you update your simple content access configuration in Red Hat Subscription Management.
+You can configure how often the Insights Operator imports the simple content access entitlements by using the `support` secret in the `openshift-config` namespace. The entitlement import normally occurs every eight hours, but you can shorten this interval if you update your simple content access configuration in Red Hat Subscription Management.
 
 This procedure describes how to update the import interval to one hour. 
 
@@ -24,10 +24,22 @@ endif::openshift-rosa,openshift-dedicated[]
 
 . Navigate to *Workloads* -> *Secrets*.
 . Select the *openshift-config* project.
-. Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
+. Search for the *support* secret by using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it. 
++
+--
+* If the secret exists:
 . Click the *Options* menu {kebab}, and then click *Edit Secret*.
 . Click *Add Key/Value*.
-. Create a key named `scaInterval` with a value of `1h`, and click *Save*.
+.. In the *Key* field, enter `scaInterval`.
+.. In the *Value* field, enter `1h`.
++
+* If the secret does not exist:
+.. Click *Create* -> *Key/value secret*.
+... In the *Secret name* field, enter `support`.
+... In the *Key* field, enter `scaInterval`.
+... In the *Value* field, enter `1h`.
+.. Click *Create*.
+--
 +
 [NOTE]
 ====

--- a/modules/insights-operator-configuring.adoc
+++ b/modules/insights-operator-configuring.adoc
@@ -4,7 +4,7 @@
 
 
 :_content-type: PROCEDURE
-[id="insights-operator-configuring-sca_{context}"]
+[id="insights-operator-configuring_{context}"]
 = Configuring Insights Operator
 
 You can configure Insights Operator to meet the needs of your organization. The Insights Operator is configured using a combination of the default configurations in the `pod.yaml` file in the Insights Operator `Config` directory and the configurations stored in the `support` secret in the `openshift-config` namespace. The `support` secret does not exist by default and must be created when adding custom configurations for the first time. Configurations in the `support` secret override the defaults set in the `pod.yaml` file.

--- a/modules/insights-operator-disabling-sca.adoc
+++ b/modules/insights-operator-disabling-sca.adoc
@@ -7,7 +7,7 @@
 [id="insights-operator-disabling-sca_{context}"]
 = Disabling simple content access import
 
-You can disable the importing of simple content access entitlements using the `support` secret in the `openshift-config` namespace.
+You can disable the importing of simple content access entitlements by using the `support` secret in the `openshift-config` namespace.
 
 .Prerequisites
 
@@ -17,10 +17,22 @@ You can disable the importing of simple content access entitlements using the `s
 
 . Navigate to *Workloads* -> *Secrets*.
 . Select the *openshift-config* project.
-. Search for the *support* secret using the *Search by name* field. If it does not exist, click *Create* -> *Key/value secret* to create it.
+. Search for the *support* secret using the *Search by name* field.
++
+--
+* If the secret exists:
 . Click the *Options* menu {kebab}, and then click *Edit Secret*.
 . Click *Add Key/Value*.
-. Create a key named `scaPullDisabled` with a value of `true`, and click *Save*.
+.. In the *Key* field, enter `scaPullDisabled`.
+.. In the *Value* field, enter `true`.
++
+* If the secret does not exist:
+.. Click *Create* -> *Key/value secret*.
+... In the *Secret name* field, enter `support`.
+... In the *Key* field, enter `scaPullDisabled`.
+... In the *Value* field, enter `true`.
+.. Click *Create*.
+--
 +
 The simple content access entitlement import is now disabled. 
 +

--- a/modules/insights-operator-enabling-sca.adoc
+++ b/modules/insights-operator-enabling-sca.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/insights-operator-simple-access.adoc
+
+
+:_content-type: PROCEDURE
+[id="insights-operator-enabling-sca_{context}"]
+= Enabling a previously disabled simple content access import
+
+If the importing of simple content access entitlements is disabled, the Insights Operator does not import simple content access entitlements. You can change this behavior.
+
+.Prerequisites
+
+ifndef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You are logged in to the {product-title} web console as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+
+.Procedure
+
+. Navigate to *Workloads* -> *Secrets*.
+. Select the *openshift-config* project.
+. Search for the *support* secret by using the *Search by name* field. 
+. Click the *Options* menu {kebab}, and then click *Edit Secret*.
+. For the `scaPullDisabled` key, set the *Value* field to `false`.
++
+The simple content access entitlement import is now disabled.

--- a/modules/insights-operator-one-time-gather.adoc
+++ b/modules/insights-operator-one-time-gather.adoc
@@ -28,16 +28,50 @@ include::https://raw.githubusercontent.com/openshift/insights-operator/release-4
 ----
 $ oc get -n openshift-insights deployment insights-operator -o yaml
 ----
++
+.Example output
++
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insights-operator
+  namespace: openshift-insights
+# ...
+spec:
+  template:
+# ...
+    spec:
+      containers:
+      - args:
+# ...
+        image: registry.ci.openshift.org/ocp/4.15-2023-10-12-212500@sha256:a0aa581400805ad0... <1>
+# ...
+----
+<1> Specifies your `insights-operator` image version.
+
 . Paste your image version in `gather-job.yaml`:
 +
 [source,yaml,subs="+quotes"]
 ----
-initContainers:
-      - name: insights-operator
-        image: _<your_insights_operator_image_version>_
-        terminationMessagePolicy: FallbackToLogsOnError
-        volumeMounts:
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: insights-operator-job
+# ...
+spec:
+# ...
+  template:
+    spec:
+    initContainers:
+    - name: insights-operator
+      image: image: registry.ci.openshift.org/ocp/4.15-2023-10-12-212500@sha256:a0aa581400805ad0... <1>
+      terminationMessagePolicy: FallbackToLogsOnError
+      volumeMounts:
 ----
+<1> Replace any existing value with your `insights-operator` image version.
+
 . Create the gather job:
 +
 [source,terminal]
@@ -54,18 +88,22 @@ $ oc describe -n openshift-insights job/insights-operator-job
 .Example output
 [source,terminal,subs="+quotes"]
 ----
+Name:             insights-operator-job
+Namespace:        openshift-insights
+# ...
 Events:
   Type    Reason            Age    From            Message
   ----    ------            ----   ----            -------
-  Normal  SuccessfulCreate  7m18s  job-controller  Created pod: insights-operator-job-_<your_job>_
+  Normal  SuccessfulCreate  7m18s  job-controller  Created pod: insights-operator-job-<your_job>
 ----
-where `insights-operator-job-_<your_job>_` is the name of the pod.
++
+where:: `insights-operator-job-<your_job>` is the name of the pod.
 
 . Verify that the operation has finished:
 +
 [source,terminal,subs="+quotes"]
 ----
-$ oc logs -n openshift-insights insights-operator-job-_<your_job>_ insights-operator
+$ oc logs -n openshift-insights insights-operator-job-<your_job> insights-operator
 ----
 +
 .Example output

--- a/modules/understanding-insights-operator-alerts.adoc
+++ b/modules/understanding-insights-operator-alerts.adoc
@@ -7,7 +7,10 @@
 [id="understanding-insights-operator-alerts_{context}"]
 = Understanding Insights Operator alerts
 
-Insights Operator declares alerts through the Prometheus monitoring system to Alertmanager. You can view these alerts in the Alerting UI accessible through the *Administrator* perspective and the *Developer* perspective in the {product-title} web console. 
+The Insights Operator declares alerts through the Prometheus monitoring system to the Alertmanager. You can view these alerts in the Alerting UI in the {product-title} web console by using one of the following methods:
+
+* In the *Administrator* perspective, click *Observe* -> *Alerting*. 
+* In the *Developer* perspective, click *Observe* -> <project_name> -> *Alerts* tab. 
 
 Currently, Insights Operator sends the following alerts when the conditions are met:
 

--- a/support/remote_health_monitoring/insights-operator-simple-access.adoc
+++ b/support/remote_health_monitoring/insights-operator-simple-access.adoc
@@ -28,3 +28,5 @@ endif::openshift-rosa,openshift-dedicated[]
 include::modules/insights-operator-configuring-sca.adoc[leveloffset=+1]
 
 include::modules/insights-operator-disabling-sca.adoc[leveloffset=+1]
+
+include::modules/insights-operator-enabling-sca.adoc[leveloffset=+1]

--- a/support/remote_health_monitoring/using-insights-operator.adoc
+++ b/support/remote_health_monitoring/using-insights-operator.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="using-insights-operator"]
-= Using Insights Operator
+= Using the Insights Operator
 include::_attributes/common-attributes.adoc[]
 ifdef::openshift-dedicated[]
 include::_attributes/attributes-openshift-dedicated.adoc[]
@@ -23,6 +23,7 @@ endif::openshift-rosa,openshift-dedicated[]
 include::modules/understanding-insights-operator-alerts.adoc[leveloffset=+1]
 ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/disabling-insights-operator-alerts.adoc[leveloffset=+1]
+include::modules/enabling-insights-operator-alerts.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated[]
 // cannot create resource "pods/exec" in API group "" in the namespace "openshift-insights"
 ifndef::openshift-rosa,openshift-dedicated[]
@@ -33,6 +34,7 @@ endif::openshift-rosa,openshift-dedicated[]
 // InsightsDataGather is a Tech Preview feature. When the feature goes GA, verify if it can be added to ROSA/OSD.
 ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/disabling-insights-operator-gather.adoc[leveloffset=+1]
+include::modules/enabling-insights-operator-gather.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated[]
 // tech preview feature
 ifndef::openshift-rosa,openshift-dedicated[]
@@ -55,4 +57,3 @@ endif::openshift-rosa,openshift-dedicated[]
 ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/insights-operator-configuring.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated[]
-


### PR DESCRIPTION
Fixing various errors in the Support/Remote Health Monitoring docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

Previews:
[Disabling Insights Advisor recommendations](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster#disabling-insights-advisor-recommendations_using-insights-to-identify-issues-with-your-cluster) -- Updated the procedure
[Disabling Insights Operator alerts](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator#disabling-insights-operator-alerts_using-insights-operator) -- Updated the procedure
[Disabling the Insights Operator gather operations](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator#disabling-insights-operator-gather_using-insights-operator) -- Updated the procedure
[Enabling a previously disabled Insights Advisor recommendation](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster#enabling-insights-advisor-recommendations_using-insights-to-identify-issues-with-your-cluster) -- Updated procedure.
[Enabling Insights Operator alerts](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator#enabling-insights-operator-alerts_using-insights-operator) -- New module to match other assemblies that have module to enable previously disabled features.
[Enabling the Insights Operator gather operations](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator#enabling-insights-operator-gather_using-insights-operator) -- New module to match other assemblies that have module to enable previously disabled features.
[Configuring simple content access import interval](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/insights-operator-simple-access#insights-operator-configuring-sca_remote-health-reporting-from-restricted-network) -- Updated the procedure
[Disabling simple content access import](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/insights-operator-simple-access#insights-operator-disabling-sca_remote-health-reporting-from-restricted-network) -- Updated the procedure
[Enabling simple content access import](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/insights-operator-simple-access#insights-operator-enabling-sca_remote-health-reporting-from-restricted-network) -- New module to match other assemblies that have module to enable previously disabled features.
[Modifying the global cluster pull secret to disable remote health reporting](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/opting-out-of-remote-health-reporting#insights-operator-new-pull-secret_opting-out-remote-health-reporting) -- Updated the procedure to incorporate the _Updating the global cluster pull secret_ section. [Current docs](https://docs.openshift.com/container-platform/4.13/support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-new-pull-secret_opting-out-remote-health-reporting), see sentence after Step 4. 
[Modifying your global cluster pull secret to enable remote health reporting](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/enabling-remote-health-reporting#insights-operator-new-pull-secret-enable_enabling-remote-health-reporting) -- Added `$` to Step 8.
[Understanding Insights Operator alerts](https://63644--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator#understanding-insights-operator-alerts_using-insights-operator) -- Clarify procedure. [Current docs](https://docs.openshift.com/container-platform/4.13/support/remote_health_monitoring/using-insights-operator.html#understanding-insights-operator-alerts_using-insights-operator)

I added a few `ifdef` tags for ROSA/OSD. As the Remote Health Monitoring docs will be removed from the ROSA/OSD docs, I have not provided a preview. I added the tags in case the docs get added to ROSA/OSD later. 