### PR TITLE
OSDOCS-7053 RN Authentication operator honors noproxy setting

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -318,6 +318,13 @@ With this release, some Operators managed by Operator Lifecycle Manager (OLM) on
 For more information, see _Token authentication for Operators on cloud providers_.
 //xref :../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
 
+[id="ocp-4-14-auth-op-noproxy"]
+==== Authentication Operator honors `noProxy` during connection checks
+
+With this release, if the `noProxy` field is set and the route is reachable without the cluster-wide proxy, the Authentication Operator will bypass the proxy and perform connection checks directly through the configured ingress route. Previously, the Authentication Operator always performed connection checks through the cluster-wide proxy, regardless of the `noProxy` setting. 
+
+For more information, see xref:../networking/enable-cluster-wide-proxy.adoc#configure-the-cluster-wide-proxy[Configuring the cluster-wide proxy].
+
 [id="ocp-4-14-networking"]
 === Networking
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-7053](https://issues.redhat.com/browse/OSDOCS-7053)

Link to docs preview:
[Preview](https://63645--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-authentication-operator-noproxy)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
