### PR TITLE
CMP-2039: FIO 1.3.1 release notes

### DIFF
--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -15,6 +15,34 @@ For an overview of the File Integrity Operator, see xref:../../security/file_int
 
 To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-updating.adoc#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator].
 
+[id="file-integrity-operator-release-notes-1-3-1"]
+== OpenShift File Integrity Operator 1.3.1
+
+The following advisory is available for the OpenShift File Integrity Operator 1.3.1:
+
+* link:https://access.redhat.com/errata/RHBA-2023:3600[RHBA-2023:3600 OpenShift File Integrity Operator Bug Fix Update]
+
+[id="file-integrity-operator-1-3-1-new-features-and-enhancements"]
+=== New features and enhancements
+
+* FIO now includes kubelet certificates as default files, excluding them from issuing warnings when they're managed by {product-title}. (link:https://issues.redhat.com/browse/OCPBUGS-14348[*OCPBUGS-14348*])
+
+* FIO now correctly directs email to the address for Red Hat Technical Support. (link:https://issues.redhat.com/browse/OCPBUGS-5023[*OCPBUGS-5023*])
+
+[id="file-integrity-operator-1-3-1-bug-fixes"]
+=== Bug fixes
+
+* Previously, FIO would not clean up `FileIntegrityNodeStatus` CRDs when nodes are removed from the cluster. FIO has been updated to correctly clean up node status CRDs on node removal.  (link:https://issues.redhat.com/browse/OCPBUGS-4321[*OCPBUGS-4321*])
+
+* Previously, FIO would also erroneously indicate that new nodes failed integrity checks. FIO has been updated to correctly show node status CRDs when adding new nodes to the cluster. This provides correct node status notifications. (link:https://issues.redhat.com/browse/OCPBUGS-8502[*OCPBUGS-8502*])
+
+* Previously, when FIO was reconciling `FileIntegrity` CRDs, it would pause scanning until the reconciliation was done. This caused an overly aggressive re-initiatization process on nodes not impacted by the reconciliation. This problem also resulted in unnecessary daemonsets for machine config pools which are unrelated to the `FileIntegrity` being changed. FIO correctly handles these cases and only pauses AIDE scanning for nodes that are affected by file integrity changes. (link:https://issues.redhat.com/browse/CMP-1097[*CMP-1097*])
+
+[id="file-integrity-operator-1-3-1-known-issues"]
+=== Known Issues
+
+In FIO 1.3.1, increasing nodes in {ibmzProductName} clusters might result in `Failed` File Integrity node status. For more information, see link:https://access.redhat.com/solutions/7028861[Adding nodes in IBM Power clusters can result in failed File Integrity node status].
+
 [id="file-integrity-operator-release-notes-1-2-1"]
 == OpenShift File Integrity Operator 1.2.1
 


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/CMP-2039

Link to docs preview (VPN required):
[OpenShift File Integrity Operator 1.3.1](https://file.rdu.redhat.com/antaylor/CMP-1097/security/file_integrity_operator/file-integrity-operator-release-notes.html#file-integrity-operator-release-notes-1-3-1)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This is a clone of https://github.com/openshift/openshift-docs/pull/61261 so I can make final adjustments prior to the release on Monday. Adding QE approval and `peer-review-done` labels applied in the previous PR.
