### PR TITLE
Fixing attribute for RN file

### DIFF
--- a/gitops/gitops-release-notes.adoc
+++ b/gitops/gitops-release-notes.adoc
@@ -1,9 +1,9 @@
 //OpenShift GitOps Release Notes
 :_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="gitops-release-notes"]
 = {gitops-title} release notes
 :context: gitops-release-notes
-include::_attributes/common-attributes.adoc[]
 
 toc::[]
 


### PR DESCRIPTION
Version(s):
Cherry-pick to: `gitops-docs-1.8` and `gitops-docs-1.9`

Issue:
[RHDEVDOCS-5359](https://issues.redhat.com/browse/RHDEVDOCS-5359)

Link to docs preview: [Red Hat OpenShift GitOps release notes](https://63649--docspreview.netlify.app/openshift-gitops/latest/gitops/gitops-release-notes)