### PR TITLE
[enterprise-4.12]OCPBUGS#16845: allocateLoadBalancerNodePorts support release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -931,6 +931,12 @@ For more information, see xref:../networking/hardware_networks/switching-bf2-nic
 
 Previously, for clusters that use the xref:../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes network plugin], during cluster installation you could enable hybrid networking so that your cluster supported Windows nodes. Now you can enable hybrid networking after installation. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-hybrid-networking.adoc#configuring-hybrid-networking[Configuring hybrid networking].
 
+[id="ocp-4-12-networking-networkapi"]
+==== Support for allocateLoadBalancerNodePorts in the Network API service object
+The `ServiceSpec` component in the Network API under the `Service` object describes the attributes that a user creates on a service. The `allocateLoadBalancerNodePorts` attribute within the `ServiceSpec` component is now supported as of {product-title} 4.12.28 release. The `allocateLoadBalancerNodePorts` attribute defines whether the `NodePorts` will be automatically allocated for services of the `LoadBalancer` type.
+
+For more information, see xref:../rest_api/network_apis/service-v1.adoc#spec[Network API ServiceSpec object]
+
 [id="ocp-4-12-storage"]
 === Storage
 


### PR DESCRIPTION
Version(s): 4.12

Issue: https://issues.redhat.com/browse/OCPBUGS-16845

Link to docs preview: https://63650--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-networking-networkapi

QE review:
- [x] QE has approved this change.
- [x] SME has approved this change