### PR TITLE
[enterprise-4.13]OCPBUGS#16845: allocateLoadBalancerNodePorts support release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -887,6 +887,10 @@ For clusters that run on {rh-openstack} and use OVN-Kubernetes, manually reassig
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
 
+[id="ocp-4-13-networking-networkapi"]
+==== Support for allocateLoadBalancerNodePorts in Service object of Network API
+The `ServiceSpec` component in Network API under `Service` object describes the attributes that a user creates on a service. The `allocateLoadBalancerNodePorts` attribute within `ServiceSpec` is now supported in {product-title} 4.13 release. The `allocateLoadBalancerNodePorts` attribute defines whether the `NodePorts` will be automatically allocated for services with type `LoadBalancer`.
+
 [id="ocp-4-13-storage"]
 === Storage
 


### PR DESCRIPTION
Version(s): 4.13

Issue: https://issues.redhat.com/browse/OCPBUGS-16845

Link to docs preview: https://63651--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-networking-networkapi

QE review:
- [ ] QE has approved this change.