### PR TITLE
OCPBUGS#9350: Update to required access policies

### DIFF
--- a/modules/installation-ibm-cloud-iam-policies-api-key.adoc
+++ b/modules/installation-ibm-cloud-iam-policies-api-key.adoc
@@ -32,6 +32,12 @@ You must assign the required access policies to your IBM Cloud account.
 |Editor, Operator, Viewer, Administrator
 |
 
+|Account management
+|Resource group only
+|All resource groups in the account
+|Administrator
+|
+
 |IAM services
 |Cloud Object Storage
 |All resources or a subset of resources ^[1]^


### PR DESCRIPTION
Version(s):
4.11

Issue:
This PR addresses [ocpbugs-9350](https://issues.redhat.com/browse/OCPBUGS-9350).

Link to docs preview:

[Required access policies](https://bscott-rh.github.io/openshift-docs/ocpbugs-9350-preview-4.11/installing/installing_ibm_cloud_public/installing-ibm-cloud-account.html#required-access-policies-ibm-cloud_installing-ibm-cloud-account)

QE review:
- [x] QE has approved this change.

Additional information:

This update was originally introduced as part of https://issues.redhat.com/browse/OCPBUGS-11224 and https://github.com/openshift/openshift-docs/pull/62272, which was merged into `main`, `4.12`, `4.13` and `4.14`

The respective update to 4.10 is [here](https://github.com/openshift/openshift-docs/pull/63655).
