### PR TITLE
OSDOCS-6213: Reverting Azure statements

### DIFF
--- a/machine_management/capi-machine-management.adoc
+++ b/machine_management/capi-machine-management.adoc
@@ -9,7 +9,7 @@ toc::[]
 :FeatureName: Managing machines with the Cluster API
 include::snippets/technology-preview.adoc[]
 
-The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for Amazon Web Services (AWS), Google Cloud Platform (GCP), and Microsoft Azure clusters. You can use the Cluster API to create and manage compute machine sets and compute machines in your {product-title} cluster. This capability is in addition or an alternative to managing machines with the Machine API.
+The link:https://cluster-api.sigs.k8s.io/[Cluster API] is an upstream project that is integrated into {product-title} as a Technology Preview for Amazon Web Services (AWS) and Google Cloud Platform (GCP). You can use the Cluster API to create and manage compute machine sets and compute machines in your {product-title} cluster. This capability is in addition or an alternative to managing machines with the Machine API.
 
 For {product-title} {product-version} clusters, you can use the Cluster API to perform node host provisioning management actions after the cluster installation finishes. This system enables an elastic, dynamic provisioning method on top of public or private cloud infrastructure.
 
@@ -35,7 +35,7 @@ By using the Cluster API, {product-title} users and developers are able to reali
 
 Using the Cluster API to manage machines is a Technology Preview feature and has the following limitations:
 
-* Only AWS, GCP, and Azure clusters are supported.
+* Only AWS and GCP clusters are supported.
 
 * To use this feature, you must enable the `TechPreviewNoUpgrade` xref:../nodes/clusters/nodes-cluster-enabling-features.adoc#nodes-cluster-enabling-features-about_nodes-cluster-enabling[feature set]. Enabling this feature set cannot be undone and prevents minor version updates.
 

--- a/modules/cluster-capi-operator.adoc
+++ b/modules/cluster-capi-operator.adoc
@@ -7,7 +7,7 @@
 
 [NOTE]
 ====
-This Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS), Google Cloud Platform (GCP), and Microsoft Azure clusters.
+This Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Amazon Web Services (AWS) and Google Cloud Platform (GCP) clusters.
 ====
 
 [discrete]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-6213](https://issues.redhat.com//browse/OSDOCS-6213) (reverts previous work)

Link to docs preview:
- [Cluster CAPI Operator](https://63657--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference.html#cluster-capi-operator_cluster-operators-ref)
- [Managing machines with the Cluster API](https://63657--docspreview.netlify.app/openshift-enterprise/latest/machine_management/capi-machine-management.html)

QE review:
- [x] QE has approved this change.

Additional information:
Reverts the Azure support parts of #60522