### PR TITLE
OSDOCS#7292: Agent disk encryption

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -31,8 +31,6 @@ include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+2]
 
 You can create additional manifests to further configure your cluster beyond the configurations available in the `install-config.yaml` and `agent-config.yaml` files.
 
-If you do not want to make additional configurations, proceed to xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-ocp-agent-boot_installing-with-agent-based-installer[Creating and booting the agent image].
-
 // Partitioning the disk
 include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+3]
 
@@ -44,6 +42,14 @@ include::modules/installing-ocp-agent-ZTP.adoc[leveloffset=+2]
 * xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#sample-ztp-custom-resources_installing-with-agent-based-installer[Sample {ztp} custom resources].
 
 * See xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-deploying-far-edge-clusters-at-scale[Challenges of the network far edge] to learn more about {ztp-first}.
+
+// Optional: Encrypting the disk
+include::modules/installing-ocp-agent-encrypt.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-encrypt-disk_installing-customizing[About disk encryption]
 
 // Creating and booting the agent image
 include::modules/installing-ocp-agent-boot.adoc[leveloffset=+2]

--- a/modules/installing-ocp-agent-encrypt.adoc
+++ b/modules/installing-ocp-agent-encrypt.adoc
@@ -1,0 +1,56 @@
+// Module included in the following assemblies:
+//
+// * installing-with-agent/installing-with-agent-based-installer.adoc
+
+:_content-type: PROCEDURE
+[id="installing-ocp-agent-encrypt_{context}"]
+= Optional: Encrypting the disk
+
+Use this procedure to encrypt your disk or partition while installing {product-title} with the Agent-based Installer.
+
+.Prerequisites
+
+* You have created and configured the `install-config.yaml` and `agent-config.yaml` files, unless you are using ZTP manifests.
+
+* You have placed the `openshift-install` binary in a directory that is on your `PATH`.
+
+.Procedure
+
+. Use the following command to generate ZTP cluster manifests:
++
+[source,terminal]
+----
+$ openshift-install agent create cluster-manifests --dir <installation_directory>
+----
++
+[IMPORTANT]
+====
+If you have created the `install-config.yaml` and `agent-config.yaml` files, those files are deleted and replaced by the cluster manifests generated through this command.
+
+Any configurations made to the `install-config.yaml` and `agent-config.yaml` files are imported to the ZTP cluster manifests when you run the `openshift-install agent create cluster-manifests` command.
+====
++
+[NOTE]
+====
+If you have already generated ZTP manifests, skip this step.
+====
+
+. Navigate to the `cluster-manifests` directory:
++
+[source,terminal]
+----
+$ cd <installation_directory>/cluster-manifests
+----
+
+. Add the following section to the `agent-cluster-install.yaml` file:
++
+[source,yaml]
+----
+diskEncryption:
+    enableOn: all <1>
+    mode: tang <2>
+    tangServers: "server1": "http://tang-server-1.example.com:7500" <3>
+----
+<1> Specify which nodes to enable disk encryption on. Valid values are 'none', 'all', 'master', and 'worker'.
+<2> Specify which disk encryption mode to use. Valid values are 'tpmv2' and 'tang'.
+<3> Optional: If you are using Tang, specify the Tang servers.


### PR DESCRIPTION
[OSDOCS-7292](https://issues.redhat.com/browse/OSDOCS-7292)

Versions: 4.14+

This PR documents disk encryption during an Agent-based installation.

QE review:
- [x] QE has approved this change.

Preview: "[Optional: Encrypting the disk](https://63659--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-encrypt_installing-with-agent-based-installer)"
