### PR TITLE
[WIP] RHDEVDOCS-5553: Document removal of deprecated .spec.resourceCustomiz…

### DIFF
--- a/modules/gitops-argo-cd-properties.adoc
+++ b/modules/gitops-argo-cd-properties.adoc
@@ -70,7 +70,9 @@ a|* _<AutoTLS>_ - Use the provider to create the Redis server's TLS certificate 
   * _<Image>_ - The container image for Redis. This overrides the `ARGOCD_REDIS_IMAGE` environment variable.
   * _<Resources>_ - The container compute resources.
   * _<Version>_ - The tag to use with the Redis container image.
-|`ResourceCustomizations` |Customize resource behavior.|`__<empty>__` |
+|`ResourceHealthChecks` |Customize resource health check behavior.|`__<empty>__` |
+|`ResourceIgnoreDifferences` |Customize resource ignore difference behavior.|`__<empty>__` |
+|`ResourceActions` |Customize resource action behavior.|`__<empty>__` |
 |`ResourceExclusions` |Completely ignore entire classes of resource group.|`__<empty>__` |
 |`ResourceInclusions` |The configuration to configure which resource group/kinds are applied.|`__<empty>__` |
 |`Server` |Argo CD Server configuration options.|`__<Object>__`


### PR DESCRIPTION
**For GitOps version 1.10**
Please **DO NOT** merge this issue. The intention is to keep the **PRs merge ready with all approvals**. The PR merging can happen only on the GA date (September 26th). So please hold off merging until I let you know. thank you!

• **Aligned team**: Dev Tools
• **OCP version for cherry-picking**: enterprise-4.12 and later
• **JIRA issue**: [RHDEVDOCS-5553](https://issues.redhat.com/browse/RHDEVDOCS-5553)
• **Preview page**:  [Argo CD custom resource properties](https://63663--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/argo-cd-custom-resource-properties#argo-cd-properties_argo-cd-custom-resource-properties)
• **SME Review**: Completed by @svghadi 
• **QE review**: Completed by @varshab1210
• **Peer-review**: Completed by @abrennan89 