### PR TITLE
OCPBUGS-12894-11: Explicitly stated Rhel versions for RHEL compute ma…

### DIFF
--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -136,7 +136,7 @@ endif::ibm-z[]
 ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power[|{op-system}]
-ifndef::ibm-z,ibm-power[|{op-system}, {op-system-base} 8.4, or {op-system-base} 8.5 ^[3]^]
+ifndef::ibm-z,ibm-power[|{op-system}, {op-system-base} 8.6, 8.7, or 8.8 ^[3]^]
 |2
 |8 GB
 |100 GB


### PR DESCRIPTION
[OCPBUGS-12894](https://issues.redhat.com/browse/OCPBUGS-12894)

Version(s):
4.11

Link to docs preview:
[Minimum resource requirements for cluster installation](https://file.emea.redhat.com/dfitzmau/OCPBUGS-12894-11/installing-bare-metal.html#installation-minimum-resource-requirements_installing-bare-metal)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
