### PR TITLE
[OSDOCS-7530]: Adding Note Regarding Inability to Delete Default Machine Pool

### DIFF
--- a/modules/deleting-machine-pools.adoc
+++ b/modules/deleting-machine-pools.adoc
@@ -8,6 +8,7 @@
 
 You can delete a machine pool in the event that your workload requirements have changed and your current machine pools no longer meet your needs.
 // Over time, users may find that their workload needs have changed, and may want to modify the various machine pool settings. While many of these settings can be modified, certain settings (for example, instance types and availability zones) cannot be changed once a machine pool is created. If a user finds that these settings are no longer meeting their needs, they can delete the machine pool in question and create a new machine pool with the desired settings.
+
 You can delete machine pools using the
 ifdef::openshift-rosa[]
 Openshift Cluster Manager or the ROSA CLI (`rosa`).
@@ -15,6 +16,11 @@ endif::openshift-rosa[]
 ifndef::openshift-rosa[]
 Openshift Cluster Manager.
 endif::[]
+
+[NOTE]
+====
+The default machine pool cannot be deleted.
+====
 
 // Users that wish to delete the default machine pool that is automatically created during the installation of a {product-title} (ROSA) cluster can do so using the OCM or ROSA CLI.
 //


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-7530
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://63722--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes#deleting-machine-poolsrosa-managing-worker-nodes

![image](https://github.com/openshift/openshift-docs/assets/122639474/7176445e-f563-49ac-99ad-98f68bd498ba)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
