### PR TITLE
GitOps 1.7.5 release notes documantion.

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -42,6 +42,8 @@ include::modules/gitops-release-notes-1-8-1.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-8-0.adoc[leveloffset=+1]
 
+include::modules/gitops-release-notes-1-7-5.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-7-4.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-7-3.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-7-5.adoc
+++ b/modules/gitops-release-notes-1-7-5.adoc
@@ -1,0 +1,19 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-7-5_{context}"]
+= Release notes for {gitops-title} 1.7.5 
+
+{gitops-title} 1.7.5 is now available on {product-title} 4.10, 4.11, and 4.12.
+
+[id="fixed-issues-1-7-5_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, there was a mismatch in the RSA key for known hosts in the `argocd-ssh-known-hosts-cm` config map. This update fixes the issue by matching the RSA key with the upstream project. Now, you can use the default RSA keys on default deployments. link:https://issues.redhat.com/browse/GITOPS-3239[GITOPS-3239]
+
+* Before this update, an old Redis image version was used when deploying the {gitops-title} Operator, which resulted in vulnerabilities. This update fixes the vulnerabilities on Redis by upgrading it to the latest version of the `registry.redhat.io/rhel-8/redis-6` image. link:https://issues.redhat.com/browse/GITOPS-3240[GITOPS-3240]


### PR DESCRIPTION
Jira issue : [RHDEVDOCS-5599](https://issues.redhat.com/browse/RHDEVDOCS-5599)

Aligned team: DevTools 
OCP Version(s): 4.10 and to 4.12

Docs preview: [63730--docspreview](https://63730--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes#gitops-release-notes-1-7-5_gitops-release-notes)

SME review: @reginapizza 

QE review: @varshab1210 

Peer review: @Srivaralakshmi 