### PR TITLE
OCPBUGS#9250: Set CPU quota as false

### DIFF
--- a/modules/nodes-cluster-overcommit-node-enforcing.adoc
+++ b/modules/nodes-cluster-overcommit-node-enforcing.adoc
@@ -72,12 +72,11 @@ spec:
     matchLabels:
       pools.operator.machineconfiguration.openshift.io/worker: "" <2>
   kubeletConfig:
-    cpuCfsQuota: <3>
-      - "true"
+    cpuCfsQuota: false <3>
 ----
 <1> Assign a name to CR.
 <2> Specify the label from the machine config pool.
-<3> Set the `cpuCfsQuota` parameter to `true`.
+<3> Set the `cpuCfsQuota` parameter to `false`.
 
 . Run the following command to create the CR:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-9250
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63734--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-overcommit.html#nodes-cluster-overcommit-node-enforcing_nodes-cluster-overcommit
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
