### PR TITLE
OSDOCS-7263: Inaccurate AWS support statement in RH ROSA docs

### DIFF
--- a/modules/rosa-getting-support.adoc
+++ b/modules/rosa-getting-support.adoc
@@ -18,10 +18,6 @@ If you experience difficulty with a procedure described in this documentation, v
 .. Complete the remaining fields.
 .. On the _Review_ page, select the correct cluster ID that you are contacting support about, and click `Submit`.
 
-You can also get support from link:https://aws.amazon.com/premiumsupport/[AWS Support] as long as you have a valid AWS Support contract and have enabled AWS Business, Enterprise On-Ramp, or Enterprise support plans.
-
-To enable an AWS Support plan, see link:http://aws.amazon.com/premiumsupport/knowledge-center/sign-up-support/[How do I sign up for an AWS Support plan?]
-
-For information about creating an AWS Support case, see the link:https://docs.aws.amazon.com/awssupport/latest/user/case-management.html[AWS support case] documentation.
+An AWS Business or Enterprise Support plan is not required to obtain support from AWS for ROSA, but AWS recommends that ROSA customers enable at least AWS Business Support. For more information, see link:https://docs.aws.amazon.com/ROSA/latest/userguide/troubleshooting-rosa.html#rosa-support[AWS Support].
 
 If you have a suggestion for improving this documentation or have found an error, submit a link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Documentation_issue&issuetype=1&components=12367614&priority=10200&versions=12385624[Jira issue] for the most relevant documentation component. Be sure to provide specific details, such as the section name and {product-title} version.


### PR DESCRIPTION
[OSDOCS-7263](https://issues.redhat.com/browse/OSDOCS-7263): Inaccurate AWS support statement in RH ROSA docs

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OSDOCS-7263](https://issues.redhat.com/browse/OSDOCS-7263)
Preview pages: [Click to see the build preview in your browser](https://63735--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-getting-support)
SME review **completed**: @codymant 
QE review **completed**: @xueli181114 
Peer review **completed**: @codymant and @michaelryanpeter 
