### PR TITLE
Manual CP from PR 63311

### DIFF
--- a/modules/cnf-configuring-workload-hints.adoc
+++ b/modules/cnf-configuring-workload-hints.adoc
@@ -26,3 +26,8 @@
 ----
 <1> If `highPowerConsumption` is `true`, the node is tuned for very low latency at the cost of increased power consumption.
 <2> Disables some debugging and monitoring features that can affect system latency.
+
+[NOTE]
+====
+When the `realTime` workload hint flag is set to `true` in a performance profile, add the `cpu-quota.crio.io: disable` annotation to every guaranteed pod with pinned CPUs. This annotation is necessary to prevent the degradation of the process performance within the pod. If the `realTime` workload hint is not explicitly set then it defaults to `true`.
+====

--- a/modules/cnf-understanding-workload-hints.adoc
+++ b/modules/cnf-understanding-workload-hints.adoc
@@ -10,6 +10,7 @@ The following table describes how combinations of power consumption and real-tim
 [NOTE]
 ====
 The following workload hints can be configured manually. You can also work with workload hints using the Performance Profile Creator. For more information about the performance profile, see the "Creating a performance profile" section.
+If the workload hint is configured manually and the `realTime` workload hint is not explicitly set then it defaults to `true`.
 ====
 
 [cols="1,1,1,1",options="header"]
@@ -48,5 +49,16 @@ realTime: true
 ----
     | Far edge clusters, latency critical workloads
     | Optimized for absolute minimal latency and maximum determinism at the cost of increased power consumption.
+
+    | Per-pod power management
+    a|[source,terminal]
+----
+workloadHints:
+realTime: true
+highPowerConsumption: false
+perPodPowerManagement: true
+----
+    | Critical and non-critical workloads
+    | Allows for power management per pod.
 
 |===


### PR DESCRIPTION
[OCPBUGS-13736]: Explicitly state that the default value for performanceprofile.spec.workloadHints.realTime is true

Version(s): 4.11

Issue:
https://issues.redhat.com/browse/OCPBUGS-13736

Link to docs preview:

https://63311--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#cnf-understanding-workload-hints_cnf-master
https://63311--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning.html#configuring-workload-hints_cnf-master

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: All approvals tracked in https://github.com/openshift/openshift-docs/pull/63311. This is a manual CP of that PR failing on 4.11. 
<!--- Optional: Include additional context or expand the description here.--->

