### PR TITLE
OCPBUGS-16287: Fix yaml formatting

### DIFF
--- a/modules/compliance-operator-hcp-install.adoc
+++ b/modules/compliance-operator-hcp-install.adoc
@@ -80,9 +80,9 @@ spec:
   config:
     nodeSelector:
       node-role.kubernetes.io/worker: ""
-  env:
-  - name: PLATFORM
-    value: "HyperShift"
+    env:
+    - name: PLATFORM
+      value: "HyperShift"
 ----
 
 . Create the `Subscription` object by running the following command:


### PR DESCRIPTION
The environment variable PLATFORM was not being correctly set.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-16287

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
- https://github.com/ComplianceAsCode/compliance-operator/blob/master/doc/usage.md#how-to-use-compliance-operator-with-hypershift-hosted-cluster
- https://github.com/ComplianceAsCode/compliance-operator/blob/master/config/catalog/subscription-hypershift.yaml

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
