### PR TITLE
[enterprise-4.11] OCPBUGS-14777

### DIFF
--- a/modules/virt-prerequisites-mediated-devices.adoc
+++ b/modules/virt-prerequisites-mediated-devices.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: CONCEPT
 [id="prerequisites_{context}"]
-== Prerequisites
+= Prerequisites
 
 * If your hardware vendor provides drivers, you installed them on the nodes where you want to create mediated devices.
 ** If you use NVIDIA cards, you link:https://access.redhat.com/solutions/6738411[installed the NVIDIA GRID driver].

--- a/modules/virt-virtual-gpus-config-overview.adoc
+++ b/modules/virt-virtual-gpus-config-overview.adoc
@@ -57,8 +57,8 @@ For example, the name file for the `nvidia-231` type contains the selector strin
 +
 [source,terminal]
 ----
-$ oc get $NODE -o json  \
-| jq '.status.allocatable | \
-with_entries(select(.key | startswith("nvidia.com/"))) | \
-with_entries(select(.value != "0"))'
+$ oc get $NODE -o json \
+  | jq '.status.allocatable \
+    | with_entries(select(.key | startswith("nvidia.com/"))) \
+    | with_entries(select(.value != "0"))'
 ----


### PR DESCRIPTION
[OCPBUGS-14777]: Fixing indention associated with "The resourceName should match that allocated on the node" needs fixed

Cherry Picked from 7e094c64bedcd84169bf67aaa9e3916d269a80ac xref: https://github.com/openshift/openshift-docs/pull/63308

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OCPBUGS-14777

Link to docs preview:
https://63308--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-mediated-devices.html#configuration-overview_virt-configuring-mediated-devices


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: All approvals tracked in https://github.com/openshift/openshift-docs/pull/63308. This PR fixes https://github.com/openshift/openshift-docs/pull/63523
<!--- Optional: Include additional context or expand the description here.--->

