### PR TITLE
Revert "Adds a release note for MCO handling IR CAs"

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -184,11 +184,6 @@ With this release, you can access the NMstate Operator and resources such as the
 [id="ocp-4-14-machine-config-operator"]
 === Machine Config Operator
 
-[id="ocp-4-14-mco-ca-distribution"]
-==== Handling of registry certificate authorities 
-
-The Machine Config Operator now handles distributing certificate authorities for image registries. This change does not affect end users. 
-
 [id="ocp-4-14-nodes"]
 === Nodes
 


### PR DESCRIPTION
Reverts openshift/openshift-docs#63598

Feature was reverted due to being a blocker for Hypershift. It will not make it into 4.14. 

Conversation: 

Getting optional ImageRegistry to work with HyperShift seems like it will take some thinking, so my impression is it's off the table for 4.14.  Would be great to have someone closer to https://issues.redhat.com/browse/IR-351 confirm