### PR TITLE
OSDOCS#7471: Added me-central1 to supported GCP regions

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -32,6 +32,7 @@ regions:
 * `europe-west8` (Milan, Italy)
 * `europe-west9` (Paris, France)
 * `europe-west12` (Turin, Italy)
+* `me-central1` (Doha, Qatar, Middle East)
 * `me-west1` (Tel Aviv, Israel)
 * `northamerica-northeast1` (Montréal, Québec, Canada)
 * `northamerica-northeast2` (Toronto, Ontario, Canada)


### PR DESCRIPTION
Version(s):
4.12

Issue:
This PR addresses [osdocs-7471](https://issues.redhat.com/browse/OSDOCS-7471).

Link to docs preview:

[Supported GCP regions](https://63747--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account#installation-gcp-regions_installing-gcp-account)

QE review:
- [ ] QE has approved this change.

Additional information:
This region was original added to the docs in https://github.com/openshift/openshift-docs/pull/61810. This PR backports support to 4.12.
