### PR TITLE
OSDOCS#7519: Custom RHCOS image for control plane and compute machines

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1437,6 +1437,14 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type].
 |Either the default `pd-ssd` or the `pd-standard` disk type. The control plane nodes must be the `pd-ssd` disk type. Compute nodes can be either type.
 
+|`platform.gcp.defaultMachinePlatform.osImage.project`
+|Optional. By default, the installation program downloads and installs the {op-system} image that is used to boot control plane and compute machines. You can override the default behavior by specifying the location of a custom {op-system} image for the installation program to use for both types of machines.
+|String. The name of GCP project where the image is located.
+
+|`platform.gcp.defaultMachinePlatform.osImage.name`
+|The name of the custom {op-system} image for the installation program to use to boot control plane and compute machines. If you use `platform.gcp.defaultMachinePlatform.osImage.project`, this field is required.
+|String. The name of the RHCOS image.
+
 |`platform.gcp.defaultMachinePlatform.tags`
 |Optional. Additional network tags to add to the control plane and compute machines.
 |One or more strings, for example `network-tag1`.
@@ -1505,6 +1513,14 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for control plane machines.
 |Control plane machines must use the `pd-ssd` disk type, which is the default.
 
+|`controlPlane.platform.gcp.osImage.project`
+|Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by specifying the location of a custom {op-system} image for the installation program to use for control plane machines only.
+|String. The name of GCP project where the image is located.
+
+|`controlPlane.platform.gcp.osImage.name`
+|The name of the custom {op-system} image for the installation program to use to boot control plane machines. If you use `controlPlane.platform.gcp.osImage.project`, this field is required.
+|String. The name of the {op-system} image.
+
 |`controlPlane.platform.gcp.tags`
 |Optional. Additional network tags to add to the control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.tags` parameter for control plane machines.
 |One or more strings, for example `control-plane-tag1`.
@@ -1557,6 +1573,14 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 |`compute.platform.gcp.osDisk.diskType`
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for compute machines.
 |Either the default `pd-ssd` or the `pd-standard` disk type.
+
+|`compute.platform.gcp.osImage.project`
+|Optional. By default, the installation program downloads and installs the {op-system} image that is used to boot compute machines. You can override the default behavior by specifying the location of a custom {op-system} image for the installation program to use for compute machines only.
+|String. The name of GCP project where the image is located.
+
+|`compute.platform.gcp.osImage.name`
+|The name of the custom {op-system} image for the installation program to use to boot compute machines. If you use `compute.platform.gcp.osImage.project`, this field is required.
+|String. The name of the {op-system} image.
 
 |`compute.platform.gcp.tags`
 |Optional. Additional network tags to add to the compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.tags` parameter for compute machines.

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -58,6 +58,9 @@ controlPlane: <2> <3>
       tags: <6>
       - control-plane-tag1
       - control-plane-tag2
+      osImage: <7>
+        project: example-project-name
+        name: example-image-name
   replicas: 3
 compute: <2> <3>
 - hyperthreading: Enabled <4>
@@ -77,9 +80,12 @@ compute: <2> <3>
             keyRing: test-machine-keys
             location: global
             projectID: project-id
-        tags: <6>
+      tags: <6>
         - compute-tag1
         - compute-tag2
+      osImage: <7>
+        project: example-project-name
+        name: example-image-name
   replicas: 3
 metadata:
   name: test-cluster <1>
@@ -94,7 +100,7 @@ endif::[]
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <7>
+  networkType: OVNKubernetes <8>
   serviceNetwork:
   - 172.30.0.0/16
 platform:
@@ -105,36 +111,30 @@ platform:
       tags: <6>
       - global-tag1
       - global-tag2
+      osImage: <7>
+        project: example-project-name
+        name: example-image-name
 ifdef::vpc,restricted[]
-    network: existing_vpc <8>
-    controlPlaneSubnet: control_plane_subnet <9>
-    computeSubnet: compute_subnet <10>
+    network: existing_vpc <9>
+    controlPlaneSubnet: control_plane_subnet <10>
+    computeSubnet: compute_subnet <11>
 endif::vpc,restricted[]
 ifndef::restricted[]
 pullSecret: '{"auths": ...}' <1>
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <11>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <12>
 endif::restricted[]
 ifndef::vpc,restricted[]
 ifndef::openshift-origin[]
-fips: false <8>
-sshKey: ssh-ed25519 AAAA... <9>
+fips: false <9>
+sshKey: ssh-ed25519 AAAA... <10>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <8>
+sshKey: ssh-ed25519 AAAA... <9>
 endif::openshift-origin[]
 endif::vpc,restricted[]
 ifdef::vpc[]
-ifndef::openshift-origin[]
-fips: false <11>
-sshKey: ssh-ed25519 AAAA... <12>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <11>
-endif::openshift-origin[]
-endif::vpc[]
-ifdef::restricted[]
 ifndef::openshift-origin[]
 fips: false <12>
 sshKey: ssh-ed25519 AAAA... <13>
@@ -142,22 +142,31 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 sshKey: ssh-ed25519 AAAA... <12>
 endif::openshift-origin[]
+endif::vpc[]
+ifdef::restricted[]
+ifndef::openshift-origin[]
+fips: false <13>
+sshKey: ssh-ed25519 AAAA... <14>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+sshKey: ssh-ed25519 AAAA... <13>
+endif::openshift-origin[]
 endif::restricted[]
 ifdef::private[]
 ifndef::openshift-origin[]
-publish: Internal <13>
+publish: Internal <14>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-publish: Internal <12>
+publish: Internal <13>
 endif::openshift-origin[]
 endif::private[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <14>
+additionalTrustBundle: | <15>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <15>
+imageContentSources: <16>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -166,11 +175,11 @@ imageContentSources: <15>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <13>
+additionalTrustBundle: | <14>
   -----BEGIN CERTIFICATE-----
   <MY_TRUSTED_CA_CERT>
   -----END CERTIFICATE-----
-imageContentSources: <14>
+imageContentSources: <15>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -191,36 +200,17 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 ====
 <5> Optional: The custom encryption key section to encrypt both virtual machines and persistent volumes. Your default compute service account must have the permissions granted to use your KMS key and have the correct IAM role assigned. The default service account name follows the `service-<project_number>@compute-system.iam.gserviceaccount.com` pattern. For more information about granting the correct permissions for your service account, see "Machine management" -> "Creating compute machine sets" -> "Creating a compute machine set on GCP".
 <6> Optional: A set of network tags to apply to the control plane or compute machine sets. The `platform.gcp.defaultMachinePlatform.tags` parameter will apply to both control plane and compute machines. If the `compute.platform.gcp.tags` or `controlPlane.platform.gcp.tags` parameters are set, they override the `platform.gcp.defaultMachinePlatform.tags` parameter.
-<7> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
+<7> Optional: A custom {op-system-first} for the installation program to use to boot control plane and compute machines. The `project` and `name` parameters under `platform.gcp.defaultMachinePlatform.osImage` apply to both control plane and compute machines. If the `project` and `name` parameters under `controlPlane.platform.gcp.osImage` or `compute.platform.gcp.osImage` are set, they override the `platform.gcp.defaultMachinePlatform.osImage` parameters.
+<8> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
 ifdef::vpc,restricted[]
-<8> Specify the name of an existing VPC.
-<9> Specify the name of the existing subnet to deploy the control plane machines to. The subnet must belong to the VPC that you specified.
-<10> Specify the name of the existing subnet to deploy the compute machines to. The subnet must belong to the VPC that you specified.
+<9> Specify the name of an existing VPC.
+<10> Specify the name of the existing subnet to deploy the control plane machines to. The subnet must belong to the VPC that you specified.
+<11> Specify the name of the existing subnet to deploy the compute machines to. The subnet must belong to the VPC that you specified.
 endif::vpc,restricted[]
 ifdef::restricted[]
-<11> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+<12> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
 endif::restricted[]
 ifdef::vpc[]
-ifndef::openshift-origin[]
-<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
-+
-[IMPORTANT]
-====
-{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
-====
-//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default ///Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-//+
-//[IMPORTANT]
-//====
-//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
-//====
-<12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-endif::vpc[]
-ifdef::restricted[]
 ifndef::openshift-origin[]
 <12> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
@@ -239,10 +229,10 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 <12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
-endif::restricted[]
-ifndef::vpc,restricted[]
+endif::vpc[]
+ifdef::restricted[]
 ifndef::openshift-origin[]
-<8> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
+<13> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
 +
 [IMPORTANT]
 ====
@@ -254,10 +244,30 @@ ifndef::openshift-origin[]
 //====
 //The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
 //====
-<9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<14> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<8> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+endif::openshift-origin[]
+endif::restricted[]
+ifndef::vpc,restricted[]
+ifndef::openshift-origin[]
+<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled.
++
+[IMPORTANT]
+====
+{product-title} {product-version} is based on {op-system-base-full} 9.2. {op-system-base} 9.2 cryptographic modules have not yet been submitted for FIPS validation. For more information, see "About this release" in the 4.13 _{product-title} Release Notes_.
+====
+//If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default //Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+//+
+//[IMPORTANT]
+//====
+//The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} //deployments on the `x86_64` architecture.
+//====
+<10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 endif::vpc,restricted[]
 +
@@ -267,20 +277,20 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 ifdef::private[]
 ifndef::openshift-origin[]
-<13> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<14> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<12> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<13> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::openshift-origin[]
 endif::private[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<14> Provide the contents of the certificate file that you used for your mirror registry.
-<15> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<15> Provide the contents of the certificate file that you used for your mirror registry.
+<16> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<13> Provide the contents of the certificate file that you used for your mirror registry.
-<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<14> Provide the contents of the certificate file that you used for your mirror registry.
+<15> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]
 

--- a/modules/installation-gcp-marketplace.adoc
+++ b/modules/installation-gcp-marketplace.adoc
@@ -4,45 +4,39 @@
 
 :_content-type: PROCEDURE
 [id="installation-gcp-marketplace_{context}"]
-= Using a GCP Marketplace image
-If you want to deploy an {product-title} cluster using a GCP Marketplace image, you must create the manifests and edit the compute machine set definitions to specify the GCP Marketplace image.
+= Using the GCP Marketplace offering
+
+Using the GCP Marketplace offering lets you deploy an {product-title} cluster, which is billed on pay-per-use basis (hourly, per core) through GCP, while still being supported directly by Red{nbsp}Hat.
+
+By default, the installation program downloads and installs the {op-system-first} image that is used to deploy compute machines. To deploy an {product-title} cluster using an {op-system} image from the GCP Marketplace, override the default behavior by modifying the `install-config.yaml` file to reference the location of GCP Marketplace offer.
 
 .Prerequisites
 
-* You have the {product-title} installation program and the pull secret for your cluster.
+* You have an existing `install-config.yaml` file.
 
 .Procedure
 
-. Generate the installation manifests by running the following command:
+. Edit the `compute.platform.gcp.osImage` parameters to specify the location of the GCP Marketplace image:
+** Set the `project` parameter to `redhat-marketplace-public`.
+** Set the `name` parameter to one of the following offerings:
 +
-[source,terminal]
-----
-$ openshift-install create manifests --dir <installation_dir>
-----
+{product-title}:: `redhat-coreos-ocp-413-x86-64-202305021736`
+{opp}:: `redhat-coreos-opp-413-x86-64-202305021736`
+{oke}:: `redhat-coreos-oke-413-x86-64-202305021736`
+. Save the file and reference it when deploying the cluster.
 
-. Locate the following files:
-
-** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-0.yaml`
-** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-1.yaml`
-** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-2.yaml`
-
-. In each file, edit the `.spec.template.spec.providerSpec.value.disks[0].image` property to reference the offer to use:
-+
-{product-title}:: `projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-413-x86-64-202305021736`
-{opp}:: `projects/redhat-marketplace-public/global/images/redhat-coreos-opp-413-x86-64-202305021736`
-{oke}:: `projects/redhat-marketplace-public/global/images/redhat-coreos-oke-413-x86-64-202305021736`
-
-.Example compute machine set with the GCP Marketplace image
+.Sample `install-config.yaml` file that specifies a GCP Marketplace image for compute machines
 [source,yaml]
 ----
-deletionProtection: false
-disks:
-- autoDelete: true
-  boot: true
-  image: projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145
-  labels: null
-  sizeGb: 128
-  type: pd-ssd
-kind: GCPMachineProviderSpec
-machineType: n2-standard-4
+apiVersion: v1
+baseDomain: example.com
+controlPlane:
+# ...
+compute:
+  platform:
+    gcp:
+      osImage:
+        project: redhat-marketplace-public
+        name: redhat-coreos-ocp-413-x86-64-202305021736
+# ...
 ----


### PR DESCRIPTION
Version(s):
4.13

Issue:
This PR addresses [osdocs-7519](https://issues.redhat.com/browse/OSDOCS-7519).

Link to docs preview:

- [Additional Google Cloud Platform (GCP) configuration parameters](https://63767--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-configuration-parameters-additional-gcp_installing-gcp-customizations)
- [Sample customized install-config.yaml file for GCP](https://63767--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-gcp-config-yaml_installing-gcp-customizations)
- [Using the GCP Marketplace offering](https://63767--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-gcp-marketplace_installing-gcp-customizations)

QE review:
- [x] QE has approved this change.

Additional information:
This feature was originally planed for 4.14 and was documented by https://github.com/openshift/openshift-docs/pull/60348. However, per [CORS-2445](https://issues.redhat.com/browse/CORS-2445), there is a request to have this backported to 4.13.
