### PR TITLE
[DO NOT MERGE] test

### DIFF
--- a/scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 [id="recommended-control-plane-practices"]
-= Recommended control plane practices
 include::_attributes/common-attributes.adoc[]
+= Recommended control plane practices {sno}
 :context: recommended-control-plane-practices
 
 toc::[]

--- a/scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="recommended-infrastructure-practices"]
-= Recommended infrastructure practices
+= Recommended infrastructure practices {sno}
 include::_attributes/common-attributes.adoc[]
 :context: recommended-infrastructure-practices
 


### PR DESCRIPTION
An attribute variable doesn't render in a title in the redhat portal in following scenario

- It's the first assembly in a section
- The include attributes directive is below the title

![image](https://github.com/openshift/openshift-docs/assets/104497497/35981823-52d1-4700-8914-df485642e3f5)

Subsequent assemblies in a section do not have this issue as whatever processing is done consumes the attributes from a previous assembly and therefore variables will resolve.

To fix the above issue, place the include attributes directive above the title of the first assembly in a section:
![image](https://github.com/openshift/openshift-docs/assets/104497497/5fe8c35b-47ef-49cf-8d5d-65f9f673d5e0)

The issue doesn't effect docs.openshift, it only effects access.redhat.

This is recommended fix for such edge cases:
````
:_content-type: ASSEMBLY
[id="recommended-control-plane-practices"]
include::_attributes/common-attributes.adoc[]
= Recommended control plane practices {sno}
:context: recommended-control-plane-practices
````

Placing the include above the ID I suspect is valid but asciidoctor.js in VS Code's AsciiDoc extension reports an error message. As a lot of us use VS Code, it's probably best to keep the include under the ID. 
