### PR TITLE
fixes xref error

### DIFF
--- a/storage/persistent_storage/persistent_storage_local/troubleshooting-local-persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/troubleshooting-local-persistent-storage-using-lvms.adoc
@@ -18,7 +18,7 @@ include::modules/lvms-troubleshooting-recovering-from-node-failure.adoc[leveloff
 [id="additional-resources-forced-cleanup-1"]
 .Additional resources
 
-* xref:troubleshooting-local-persistent-storage-using-lvms.adoc#performing-a-forced-cleanup_troubleshooting-local-persistent-storage-using-lvms[Performing a forced cleanup]
+* xref:../../../troubleshooting-local-persistent-storage-using-lvms.adoc#performing-a-forced-cleanup_troubleshooting-local-persistent-storage-using-lvms[Performing a forced cleanup]
 
 include::modules/lvms-troubleshooting-recovering-from-disk-failure.adoc[leveloffset=+1]
 
@@ -26,6 +26,6 @@ include::modules/lvms-troubleshooting-recovering-from-disk-failure.adoc[leveloff
 [id="additional-resources-forced-cleanup-2"]
 .Additional resources
 
-* xref:troubleshooting-local-persistent-storage-using-lvms.adoc#performing-a-forced-cleanup_troubleshooting-local-persistent-storage-using-lvms[Performing a forced cleanup]
+* xref:../../../troubleshooting-local-persistent-storage-using-lvms.adoc#performing-a-forced-cleanup_troubleshooting-local-persistent-storage-using-lvms[Performing a forced cleanup]
 
 include::modules/lvms-troubleshooting-performing-a-forced-cleanup.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixes an xref error inadvertently introduced in https://github.com/openshift/openshift-docs/pull/63394

merge to main, CP to 4.12+

build_for_portal.py currently fails with:
```
Processing storage
Traceback (most recent call last):
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 1178, in <module>
    main()
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 1142, in main
    reformat_for_drupal(info)
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 458, in reformat_for_drupal
    copy_files(book, book_src_dir, src_dir, dest_dir, info)
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 501, in copy_files
    iter_tree(node, info["distro"], dir_callback, topic_callback)
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 236, in iter_tree
    iter_tree(
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 236, in iter_tree
    iter_tree(
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 236, in iter_tree
    iter_tree(
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 247, in iter_tree
    topic_callback(node, parent_dir, depth)
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 499, in topic_callback
    copy_file(info, book_src_dir, src_file, dest_dir, dest_file)
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 529, in copy_file
    content = scrub_file(info, book_src_dir, src_file, tag=tag, cwd=cwd)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 699, in scrub_file
    content = fix_links(content, info, book_src_dir, src_file, tag=tag, cwd=cwd)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 728, in fix_links
    content = _fix_links(content, book_src_dir, src_file, info, cwd=cwd)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/aireilly/openshift-docs/build_for_portal.py", line 762, in _fix_links
    book_dir_name = external_link.group(1)
                    ^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'group'
```
