### PR TITLE
CNV-27495: new virtctl manifest commands

### DIFF
--- a/modules/virt-virtctl-commands.adoc
+++ b/modules/virt-virtctl-commands.adoc
@@ -144,7 +144,7 @@ If a port number is not specified, the proxy runs on a random port.
 [id='vm-volume-export-commands_{context}']
 == VM export commands
 
-You use `virtctl vmexport` commands to create, download, or delete a volume exported from a VM, VM snapshot, or persistent volume claim (PVC).
+Use `virtctl vmexport` commands to create, download, or delete a volume exported from a VM, VM snapshot, or persistent volume claim (PVC). Certain manifests also contain a header secret, which grants access to the endpoint to import a disk image in a format that {VirtProductName} can use.
 
 .VM export commands
 [width="100%",cols="1a,2a",options="header"]
@@ -174,6 +174,24 @@ Optional:
 
 |`virtctl vmexport download <vmexport_name> --<vm\|snapshot\|pvc>=<object_name> --output=<output_file> --volume=<volume_name>`
 |Create a `VirtualMachineExport` CR and then download the volume defined in the CR.
+
+|`virtctl vmexport download export --manifest`
+|Retrieve the manifest for an existing export. The manifest does not include the header secret.
+
+|`virtctl vmexport download export --manifest --vm=example`
+|Create a VM export for a VM example, and retrieve the manifest. The manifest does not include the header secret.
+
+|`virtctl vmexport download export --manifest --snap=example`
+|Create a VM export for a VM snapshot example, and retrieve the manifest. The manifest does not include the header secret.
+
+|`virtctl vmexport download export --manifest --include-secret`
+|Retrieve the manifest for an existing export. The manifest includes the header secret.
+
+|`virtctl vmexport download export --manifest --manifest-output-format=json`
+|Retrieve the manifest for an existing export in json format. The manifest does not include the header secret.
+
+|`virtctl vmexport download export --manifest --include-secret --output=manifest.yaml`
+|Retrieve the manifest for an existing export. The manifest includes the header secret and writes it to the file specified.
 |===
 
 [id='vm-memory-dump-commands_{context}']


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-27495](https://issues.redhat.com//browse/CNV-27495)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63770--docspreview.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools#vm-volume-export-commands_virt-using-the-cli-tools
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
