### PR TITLE
ROX-18667: Update policy criteria for add and drop changes and new criteria

### DIFF
--- a/modules/policy-criteria.adoc
+++ b/modules/policy-criteria.adoc
@@ -81,6 +81,33 @@ AND, OR
 
 6+| *Section: Image contents*
 
+| CVE is fixable
+| This criterion results in a violation only if the image in the deployment you are evaluating has a fixable CVE.
+| Fixable
+| Boolean
+| ✕
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Days Since CVE Was First Discovered In Image
+| This criterion results in a violation only if it has been more than a specified number of days since {product-title-short} discovered the CVE in a specific image.
+| Days Since CVE Was First Discovered In Image
+| Integer
+| ✕
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
+| Days Since CVE Was First Discovered In System
+| This criterion results in a violation only if it has been more than a specified number of days since {product-title-short} discovered the CVE across all deployed images in all clusters that {product-title-short} monitors.
+| Days Since CVE Was First Discovered In System
+| Integer
+| ✕
+| *Build*, +
+*Deploy*, +
+*Runtime* (when used with a Runtime criterion)
+
 | Image age
 | The minimum number of days from image creation date.
 | Image Age
@@ -343,12 +370,13 @@ LOCALHOST
 
 
 | Drop Capabilities
-| Linux capabilities that must be dropped from the container.
-For example `CAP_SETUID` or `CAP_NET_RAW`.
+| Linux capabilities that must be dropped from the container. Provides alerts when the specified capabilities are not dropped.
+For example, if configured with `SYS_ADMIN` AND `SYS_BOOT`, and the deployment drops only _one_ or _neither_ of these two capabilities, the alert occurs.
 | Drop Capabilities +
 
 | One of: +
 
+ALL +
 AUDIT_CONTROL +
 AUDIT_READ +
 AUDIT_WRITE +
@@ -387,16 +415,53 @@ SYS_TIME +
 SYS_TTY_CONFIG +
 SYSLOG +
 WAKE_ALARM +
-| AND, OR
+| AND
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 
 
 | Add Capabilities
-| Linux capabilities that must not be added to the container, for instance the ability to send raw packets or override file permissions.
+| Linux capabilities that must not be added to the container, such as the ability to send raw packets or override file permissions. Provides alerts when the specified capabilities are added. For example, if configured with `NET_ADMIN` or `NET_RAW`, and the deployment manifest YAML file includes at least one of these two capabilities, the alert occurs.
 | Add Capabilities
-| (same as Drop Capabilities)
-| AND, OR
+|
+AUDIT_CONTROL +
+AUDIT_READ +
+AUDIT_WRITE +
+BLOCK_SUSPEND +
+CHOWN +
+DAC_OVERRIDE +
+DAC_READ_SEARCH +
+FOWNER +
+FSETID +
+IPC_LOCK +
+IPC_OWNER +
+KILL +
+LEASE +
+LINUX_IMMUTABLE +
+MAC_ADMIN +
+MAC_OVERRIDE +
+MKNOD +
+NET_ADMIN +
+NET_BIND_SERVICE +
+NET_BROADCAST +
+NET_RAW +
+SETGID +
+SETFCAP +
+SETPCAP +
+SETUID +
+SYS_ADMIN +
+SYS_BOOT +
+SYS_CHROOT +
+SYS_MODULE +
+SYS_PACCT +
+SYS_PTRACE +
+SYS_RAWIO +
+SYS_RESOURCE +
+SYS_TIME +
+SYS_TTY_CONFIG +
+SYSLOG +
+WAKE_ALARM +
+| OR
 | *Deploy*, +
 *Runtime* (when used with a Runtime criterion)
 


### PR DESCRIPTION
Version(s):
- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.2`

[Issue](https://issues.redhat.com/browse/ROX-18667)

[Link to docs preview
](https://63778--docspreview.netlify.app/openshift-acs/latest/operating/manage-security-policies#policy-criteria_manage-security-policies)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Change to back end was made in 4.1; change to GUI will be in 4.2. Since this chapter deals mostly with GUI, I don't think this should be cherry picked to 4.1.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
