### PR TITLE
Update OMR docs to 1.3.8

### DIFF
--- a/modules/mirror-registry-release-notes.adoc
+++ b/modules/mirror-registry-release-notes.adoc
@@ -11,6 +11,17 @@ These release notes track the development of the _mirror registry for Red Hat Op
 
 For an overview of the _mirror registry for Red Hat OpenShift_, see xref:../../installing/disconnected_install/installing-mirroring-creating-registry.adoc#mirror-registry-flags_installing-mirroring-creating-registry[Creating a mirror registry with mirror registry for Red Hat OpenShift].
 
+[id="mirror-registry-for-openshift-1-3-8"]
+== Mirror registry for Red Hat OpenShift 1.3.8
+
+Issued: 2023-08-16
+
+_Mirror registry for Red Hat OpenShift_ is now available with Red Hat Quay 3.8.11.
+
+The following advisory is available for the _mirror registry for Red Hat OpenShift_:
+
+* link:https://access.redhat.com/errata/RHBA-2023:4622[RHBA-2023:4622 - mirror registry for Red Hat OpenShift 1.3.8]
+
 [id="mirror-registry-for-openshift-1-3-7"]
 == Mirror registry for Red Hat OpenShift 1.3.7
 


### PR DESCRIPTION
Adds OMR 1.3.8 docs and advisory link. 

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSDOCS-7548

Link to docs preview:
https://63787--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-creating-registry#mirror-registry-for-openshift-1-3-8

QE not needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
