### PR TITLE
OSDOCS-6528: Created documentation for creating a shared VPC

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -437,6 +437,8 @@ Topics:
     File: route-configuration
   - Name: Secured routes
     File: secured-routes
+- Name: Configuring a shared virtual private cloud for ROSA clusters
+  File: rosa-shared-vpc-config
 ---
 Name: Application development
 Dir: applications

--- a/modules/rosa-sharing-vpc-cluster-creation.adoc
+++ b/modules/rosa-sharing-vpc-cluster-creation.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * networking/rosa-shared-vpc-config.adoc
+:_content-type: PROCEDURE
+[id="rosa-sharing-vpc-cluster-creation_{context}"]
+= Creating your cluster in a shared VPC
+To create a cluster in a shared VPC, complete the following step. 
+
+[NOTE]
+====
+Installing a cluster in a shared VPC is supported only for OpenShift 4.13.9 and later.
+====
+
+.Procedure
+* In a terminal, the *cluster-creating AWS account* user enters the following command to create the cluster in the shared VPC:
+
+[source,terminal]
+----
+rosa create cluster --cluster-name <cluster_name> --sts --operator-roles-prefix <prefix> --oidc-config-id <oidc_config_id> --region us-east-1 --subnet-ids <subnet_ids> --private-hosted-zone-id <hosted_zone_ID> --shared-vpc-role-arn <vpc-role-arn> --base-domain <dns-domain>
+----
+
+[IMPORTANT]
+====
+After you delete a shared-VPC cluster, three DNS records will not be removed from the private hosted zone. If you make any subsequent install attempts by using the same values, installation errors will occur.
+
+This issue might also manifest when shared-VPC networking prerequisites are not correctly configured. See this article for more information link:https://access.redhat.com/articles/7031016[on this limitation].
+====

--- a/modules/rosa-sharing-vpc-creation-and-sharing.adoc
+++ b/modules/rosa-sharing-vpc-creation-and-sharing.adoc
@@ -1,0 +1,44 @@
+// Module included in the following assemblies:
+//
+// * networking/rosa-shared-vpc-config.adoc
+
+:_content-type: PROCEDURE
+[id="rosa-sharing-vpc-creation-and-sharing_{context}"]
+= Configuring a VPC to share within your AWS organization
+
+You can share subnets within a configured VPC with another AWS user account if that account is within your current AWS organization.
+
+.Procedure
+
+. From the AWS account that centrally manages your VPC, create or modify a VPC to your specifications in the link:https://us-east-1.console.aws.amazon.com/vpc/[VPC section of the AWS console]. This AWS account will be the *VPC-owning AWS account*. 
+. In the link:https://us-east-1.console.aws.amazon.com/iamv2/[Identity and Access Management (IAM) section of the AWS console], create a custom trust policy role for the shared VPC permissions. This role needs to have the following permissions:
+  * A trust policy to assume roles:
++
+[source,terminal]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+	  "Sid": "Statement1",
+	  "Effect": "Allow",
+	  "Principal": {
+	  	"AWS": "arn:aws:iam::<Account-ID>:root"
+	  }, <1>
+	  "Action": "sts:AssumeRole"
+	}
+  ]
+}
+----
++
+--
+<1> The following principals are be added later in this process after the *cluster-creating AWS account* user has created these roles. On creation, you must create a root user placeholder by using the *cluster-creator's AWS Account* ID as `arn:aws:iam::{Account}:root`.
+--
+    * The `ResourceGroupandTagEditorFullAccess` permissions policy
+    * The `Route53minimalPermissions` permissions policy
++
+After you create this IAM role, provide the created role's ARN to the cluster creator.
+
+. In the link:https://us-east-1.console.aws.amazon.com/ram/[Resource Access Manager of the AWS console], create a Resource Share that shares the previously created public and private subnets to the *cluster-creating AWS account* ID.
+
+After you create the Resource Share, notify the *cluster-creating AWS account* user to reserve an `openshiftapps.com` DNS domain and create Operator roles to continue configuration.

--- a/modules/rosa-sharing-vpc-dns-and-roles.adoc
+++ b/modules/rosa-sharing-vpc-dns-and-roles.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * networking/rosa-shared-vpc-config.adoc
+:_content-type: PROCEDURE
+[id="rosa-sharing-vpc-dns-and-roles_{context}"]
+= Creating your DNS and cluster creation roles
+
+After the *VPC-owning AWS account* user creates a virtual private cloud, subnets, and an IAM role for sharing the VPC resources, the *cluster-creating AWS account* user must reserve an `openshiftapps.com` DNS domain and create Operator roles to communicate back to the *VPC-owning AWS account*.
+
+.Prerequisites
+
+* You have the ARN for the IAM role that is used to share your VPC.
+
+.Procedure
+
+. The cluster creator reserves an `openshiftapps.com` DNS domain with the following command:
++
+[source,terminal]
+----
+$ rosa create dns-domain
+----
++
+The command creates a reserved `openshiftapps.com` DNS domain.
++
+[source,terminal]
+----
+I: DNS domain '14eo.p1.openshiftapps.com' has been created.
+I: To view all DNS domains, run 'rosa list dns-domains'
+----
+. After creating the DNS domain, the *cluster-creating AWS account* user needs to create an OIDC configuration. Review this article for more information link:https://access.redhat.com/articles/7031018[on the ODIC configuration process]. The following command produces the OIDC config ID that you need:
++
+[source,terminal]
+----
+$ rosa create oidc-config
+----
++
+You receive confirmation that the command created an OIDC configuration.
++
+[source,terminal]
+----
+I: To create Operator Roles for this OIDC Configuration, run the following command and remember to replace <user-defined> with a prefix of your choice:
+	rosa create operator-roles --prefix <user-defined> --oidc-config-id 25tu67hq45rto1am3slpf5lq6jargg
+----
+. After the OIDC configuration is created, create the Operator roles by entering the following command:
++
+[source,terminal]
+----
+$ rosa create operator-roles --oidc-config-id <oidc-config-ID> <1>
+    --installer-role-arn <Installer_Role> <2>
+    --shared-vpc-role-arn <Created_VPC_Role_Arn> <3>
+    --prefix <operator-prefix> <4>
+----
++
+--
+<1> Provide the OIDC configuration ID that you created in the previous step.
+<2> Provide the cluster creator's installer ARN that was created as part of the `rosa create account-roles` process.
+<3> Provide the ARN for the role that the *VPC-owning AWS account* created.
+<4> Provide a prefix for the Operator roles.
+--
++
+[NOTE]
+====
+The Installer account role and the shared VPC role must have a one-to-one relationship. If you want to create multiple shared VPC roles, you should create one set of account roles per shared VPC role.
+====
+
+After you create the Operator roles, share the full domain name, which is created with `<intended_cluster_name>.<created_dns_domain>`, your _Ingress Operator Cloud Credentials_ and _Installer_ roles' ARN with the *VPC-owning AWS account* user.
+
+This information resembles these examples:
+
+* ``my-rosa-cluster.14eo.p1.openshiftapps.com``
+* ``arn:aws:iam::111122223333:role/ManagedOpenShift-Installer-Role``
+* ``arn:aws:iam::111122223333:role/my-rosa-cluster-openshift-ingress-operator-cloud-credentials``

--- a/modules/rosa-sharing-vpc-hosted-zones.adoc
+++ b/modules/rosa-sharing-vpc-hosted-zones.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * networking/rosa-shared-vpc-config.adoc
+:_content-type: PROCEDURE
+[id="rosa-sharing-vpc-hosted-zones_{context}"]
+= Updating the shared VPC role and creating hosted zones
+
+After the *cluster-creating AWS account* user provides the DNS domain and the IAM roles, *the VPC-owning AWS account* user must create a private hosted zone and update the trust policy on the IAM role that was created for sharing the VPC.
+
+.Procedure
+
+. The *VPC-owning AWS account* user who owns the VPC must update the VPC sharing IAM role and add the _Installer_ and _Ingress Operator Cloud Credentials_ roles to the principal section of the trust policy.
++
+[source,terminal]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+	  "Sid": "Statement1",
+	  "Effect": "Allow",
+	  "Principal": {
+	  	"AWS": [
+          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-ingress-operator-cloud-credentials",
+          "arn:aws:iam::<Cluster-Creator's-AWS-Account-ID>:role/<prefix>-Installer-Role"
+        ]            
+	  },
+	  "Action": "sts:AssumeRole"
+	}
+  ]
+}
+----
+. After updating the trust policy, the *VPC-owning AWS account* user creates a private hosted zone in the link:https://us-east-1.console.aws.amazon.com/route53/v2/[Route 53 section of the AWS console]. In the hosted zone configuration, the domain name is `<cluster-name>.<dns_domain>`. The private hosted zone must be associated with the created VPC.
+. After the hosted zone is created and associated with the VPC, provide the following to the *cluster-creating AWS account* user:
+* Hosted zone ID
+* AWS region
+* Intended subnet IDs

--- a/networking/rosa-shared-vpc-config.adoc
+++ b/networking/rosa-shared-vpc-config.adoc
@@ -1,0 +1,34 @@
+include::_attributes/attributes-openshift-dedicated.adoc[]
+[id="rosa-shared-vpc-config"]
+= Configuring a shared virtual private cloud for ROSA clusters
+:context: rosa-shared-vpc-config
+
+toc::[]
+
+You can create {product-title} clusters in shared, centrally-managed AWS virtual private clouds (VPCs). This process requires two separate AWS accounts that belong to the same AWS organization. One account functions as the VPC owner while the other account creates the cluster in this VPC.
+
+.Prerequisites
+* You installed the ROSA CLI (`rosa`) 1.2.26 or later.
+* You created all of the required ROSA account roles for creating a cluster.
+* You have an AWS account with the proper permissions to create roles and share resources.
+* You are using an AWS account to create your cluster ("*cluster-creating AWS account*") that is separate from the AWS account that creates your VPC ("*VPC-owning AWS account*").
+* Both AWS accounts belong to the same AWS organization.
+* You enabled resource sharing from the management account for your organization.
+* You have access to the link:https://signin.aws.amazon.com[AWS console].
+
+[NOTE]
+====
+Installing a cluster in a shared VPC is supported only for OpenShift 4.13.9 and later.
+====
+
+include::modules/rosa-sharing-vpc-creation-and-sharing.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_shared-vpc_vpc-creation"]
+[discrete]
+=== Additional resources
+* See the AWS documentation for link:https://docs.aws.amazon.com/ram/latest/userguide/getting-started-sharing.html[sharing your AWS resources].
+
+include::modules/rosa-sharing-vpc-dns-and-roles.adoc[leveloffset=+1]
+include::modules/rosa-sharing-vpc-hosted-zones.adoc[leveloffset=+1]
+include::modules/rosa-sharing-vpc-cluster-creation.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-6528](https://issues.redhat.com/browse/OSDOCS-6528)

Link to docs preview:
* [Configuring a shared virtual private cloud for ROSA clusters](https://63793--docspreview.netlify.app/openshift-rosa/latest/networking/rosa-shared-vpc-config)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a new page for sharing your VPC resources within the same AWS organization.