### PR TITLE
ROX-19079: remove tech preview references for CORE_BPF collection

### DIFF
--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -172,7 +172,6 @@ The default value is `EBPF`.
 Red Hat recommends using `EBPF` for data collection.
 If you select `NoCollection`, Collector does not report any information about the network activity and the process executions.
 Available options are `NoCollection`, `EBPF`, and `CORE_BPF`.
-The `CORE_BPF` collection method is a Technology Preview feature only.
 
 | `perNode.collector.imageFlavor`
 | The image type to use for Collector. You can specify it as `Regular` or `Slim`.

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -70,7 +70,6 @@
 
 | `collector.collectionMethod`
 | Either `EBPF`, `CORE_BPF`, or `NO_COLLECTION`.
-The `CORE_BPF` collection method is a Technology Preview feature only.
 
 | `collector.imagePullPolicy`
 | Image pull policy for the Collector container.


### PR DESCRIPTION
Version(s):
RHACS 4.2

Issue:
https://issues.redhat.com/browse/ROX-19079

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Cherry-pick into `rhacs-docs-4.2`
