### PR TITLE
OCPBUGS#16269: Reinstate correct numbering order for the procedure

### DIFF
--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -110,13 +110,12 @@ Failure to meet these requirements for the `rootDeviceHints` parameter might res
 ironic-inspector inspection failed: No disks satisfied root device hints
 ----
 ====
---
 
 [NOTE]
 ====
 Before {product-title} 4.12, the cluster installation program only accepted an IPv4 address or and IPv6 address for the `apiVIP` and `ingressVIP` configuration settings. In {product-title} 4.12 and later, these configuration settings are deprecated. Instead, use a list format in the `apiVIPs` and `ingressVIPs` configuration settings to specify IPv4 addresses, IPv6 addresses or both IP address formats.
 ====
-
+--
 . Create a directory to store the cluster configuration:
 +
 [source,terminal]


### PR DESCRIPTION
[OCPBUGS#16269]: This PR reinstates correct numbering order for the configuring install-config.yaml procedure

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-16269

Link to docs preview:
https://file.rdu.redhat.com/avbhatt/obug-16269/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.html#configuring-the-install-config-file_ipi-install-installation-workflow

QE review: N/A since this is a [formatting-only](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content) change
 