### PR TITLE
CMP-2101: SPO 0.8.0 release notes

### DIFF
--- a/security/security_profiles_operator/spo-release-notes.adoc
+++ b/security/security_profiles_operator/spo-release-notes.adoc
@@ -12,6 +12,18 @@ These release notes track the development of the Security Profiles Operator in {
 
 For an overview of the Security Profiles Operator, see xref:../../security/security_profiles_operator/spo-overview.adoc#[Security Profiles Operator Overview].
 
+[id="spo-release-notes-0-8-0"]
+== Security Profiles Operator 0.8.0
+
+The following advisory is available for the Security Profiles Operator 0.8.0:
+
+* link:https://access.redhat.com/errata/RHBA-2023:4689[RHBA-2023:4689 - OpenShift Security Profiles Operator bug fix update]
+
+[id="spo-0-8-0-bug-fixes"]
+=== Bug fixes
+
+* Previously, while trying to install Security Profiles Operator in a disconnected cluster, the secure hashes provided were incorrect due to a SHA relabeling issue. With this update, the SHAs provided work consistently with disconnected environments. (link:https://issues.redhat.com/browse/OCPBUGS-14404[*OCPBUGS-14404*])
+
 [id="spo-release-notes-0-7-1"]
 == Security Profiles Operator 0.7.1
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/CMP-2101

Link to docs preview (VPN required):
[Security Profiles Operator 0.8.0](https://file.rdu.redhat.com/antaylor/CMP-2101/security/security_profiles_operator/spo-release-notes.html#spo-release-notes-0-8-0)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
The errata link provided in this PR **will not work** until the errata is published. This PR will be merged after the release is final.
