### PR TITLE
OSDOCS 7476: Adding Build and DeploymentConfig to the list of optiona…

### DIFF
--- a/installing/cluster-capabilities.adoc
+++ b/installing/cluster-capabilities.adoc
@@ -36,6 +36,9 @@ include::modules/cluster-bare-metal-operator.adoc[leveloffset=+2]
 * xref:../installing/installing_bare_metal/preparing-to-install-on-bare-metal.adoc#preparing-to-install-on-bare-metal[Preparing for bare metal cluster installation]
 * xref:../post_installation_configuration/bare-metal-configuration.adoc#post-install-bare-metal-configuration[Bare metal configuration]
 
+// Build capability
+include::modules/build-config-capability.adoc[leveloffset=+2]
+
 include::modules/cluster-storage-operator.adoc[leveloffset=+2]
 
 include::modules/console-operator.adoc[leveloffset=+2]
@@ -49,6 +52,9 @@ include::modules/cluster-csi-snapshot-controller-operator.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 * xref:../storage/container_storage_interface/persistent-storage-csi-snapshots.adoc#persistent-storage-csi-snapshots[CSI volume snapshots]
+
+// DeploymentConfig capability
+include::modules/deployment-config-capability.adoc[leveloffset=+2]
 
 include::modules/insights-operator.adoc[leveloffset=+2]
 

--- a/modules/build-config-capability.adoc
+++ b/modules/build-config-capability.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// *  installing/cluster-capabilities.adoc
+
+:_content-type: REFERENCE
+[id="build-config-capability_{context}"]
+= Build capability
+
+[discrete]
+== Purpose
+
+The `Build` capability enables the `Build` API. The `Build` API manages the lifecycle of `Build` and `BuildConfig` objects.
+
+[IMPORTANT]
+====
+If the `Build` capability is disabled, the cluster cannot use `Build` or `BuildConfig` resources. Disable the capability only if `Build` and `BuildConfig` resources are not required in the cluster.
+====

--- a/modules/deployment-config-capability.adoc
+++ b/modules/deployment-config-capability.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// *  installing/cluster-capabilities.adoc
+
+:_content-type: REFERENCE
+[id="deployment-config-capability_{context}"]
+= DeploymentConfig capability
+
+[discrete]
+== Purpose
+
+The `DeploymentConfig` capability enables and manages the `DeploymentConfig` API.
+
+[IMPORTANT]
+====
+If the `DeploymentConfig` capability is disabled, the cluster cannot use `DeploymentConfig` resources. Disable the capability only if `DeploymentConfig` resources are not required in the cluster.
+====

--- a/snippets/capabilities-table.adoc
+++ b/snippets/capabilities-table.adoc
@@ -14,10 +14,12 @@ The following table describes the `baselineCapabilitySet` values.
 |Specify when you want the capabilities recommended in {product-title} 4.11 and not automatically enable capabilities, which might be introduced in later versions. The capabilities recommended in {product-title} 4.11 are `baremetal`, `marketplace`, and `openshift-samples`.
 
 |`v4.12`
-|Specify when you want the capabilities recommended in {product-title} 4.12 and not automatically enable capabilities, which might be introduced in later versions. The capabilities recommended in {product-title} 4.12 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage` and `CSISnapshot`. 
+|Specify when you want the capabilities recommended in {product-title} 4.12 and not automatically enable capabilities, which might be introduced in later versions. The capabilities recommended in {product-title} 4.12 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage` and `CSISnapshot`.
 
 |`v4.13`
-|Specify when you want the capabilities recommended in {product-title} 4.13 and not automatically enable capabilities, which might be introduced in later versions. The capabilities recommended in {product-title} 4.12 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot` and `NodeTuning`. 
+|Specify when you want the capabilities recommended in {product-title} 4.13 and not automatically enable capabilities, which might be introduced in later versions. The capabilities recommended in {product-title} 4.13 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot` and `NodeTuning`.
+
+// TODO: Add `Build` and `DeploymentConfig` to the list for 4.14.
 
 |`None`
 |Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via `additionalEnabledCapabilities`.


### PR DESCRIPTION
…l capabilities

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7476

Link to docs preview:
https://63812--docspreview.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
