### PR TITLE
Temp: Add back uppercase PVC file name

### DIFF
--- a/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-PVC.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-cloning-vm-disk-into-new-block-storage-PVC.adoc
@@ -1,0 +1,40 @@
+:_content-type: ASSEMBLY
+[id="virt-cloning-vm-disk-into-new-block-storage-pvc"]
+= Cloning a virtual machine disk into a new block storage persistent volume claim
+include::_attributes/common-attributes.adoc[]
+:context: virt-cloning-vm-disk-into-new-block-storage-pvc
+
+toc::[]
+
+You can clone the persistent volume claim (PVC) of a virtual machine disk into
+a new block PVC by referencing the source PVC in your clone target data volume configuration
+file.
+
+[WARNING]
+====
+Cloning operations between different volume modes are supported, such as cloning from a persistent volume (PV) with `volumeMode: Block` to a PV with `volumeMode: Filesystem`.
+
+However, you can only clone between different volume modes if they are of the `contentType: kubevirt`.
+====
+
+[TIP]
+====
+When you enable preallocation globally, or for a single data volume, the Containerized Data Importer (CDI) preallocates disk space during cloning. Preallocation enhances write performance. For more information, see xref:../../../virt/virtual_machines/virtual_disks/virt-using-preallocation-for-datavolumes.adoc#virt-using-preallocation-for-datavolumes[Using preallocation for data volumes].
+====
+
+== Prerequisites
+
+* Users need xref:../../../virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[additional permissions] to clone the PVC of a virtual machine disk into another namespace.
+
+:blockstorage:
+include::modules/virt-about-datavolumes.adoc[leveloffset=+1]
+
+include::modules/virt-about-block-pvs.adoc[leveloffset=+1]
+
+include::modules/virt-creating-local-block-pv.adoc[leveloffset=+1]
+
+include::modules/virt-cloning-pvc-of-vm-disk-into-new-datavolume.adoc[leveloffset=+1]
+
+include::modules/virt-cdi-supported-operations-matrix.adoc[leveloffset=+1]
+
+:blockstorage!:


### PR DESCRIPTION
Add uppercase PVC file back to `main` (and cherrypick to 4.14) to satisfy some case-sensitivity issues some repo contributors are seeing.