### PR TITLE
[OSDOCS-6752]: AWS placement groups support

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-using.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-using.adoc
@@ -36,6 +36,9 @@ include::modules/private-clusters-setting-api-private.adoc[leveloffset=+2]
 //Selecting a larger Amazon Web Services instance type for control plane machines
 include::modules/cpms-changing-aws-instance-type.adoc[leveloffset=+2]
 
+//Assigning machines to placement groups by using machine sets
+include::modules/machineset-aws-existing-placement-group.adoc[leveloffset=+2]
+
 //Machine sets that enable the Amazon EC2 Instance Metadata Service
 include::modules/machineset-imds-options.adoc[leveloffset=+2]
 

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -17,6 +17,9 @@ include::modules/machineset-yaml-aws.adoc[leveloffset=+1]
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
 
+//Assigning machines to placement groups by using machine sets
+include::modules/machineset-aws-existing-placement-group.adoc[leveloffset=+1]
+
 //Machine sets that enable the Amazon EC2 Instance Metadata Service
 include::modules/machineset-imds-options.adoc[leveloffset=+1]
 

--- a/modules/machineset-aws-existing-placement-group.adoc
+++ b/modules/machineset-aws-existing-placement-group.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating-machinesets/creating-machineset-aws.adoc
+// * machine_management/control_plane_machine_management/cpmso-using.adoc
+
+ifeval::["{context}" == "cpmso-using"]
+:cpmso:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="machineset-aws-existing-placement-group_{context}"]
+= Assigning machines to placement groups for Elastic Fabric Adapter instances by using machine sets
+
+You can configure a machine set to deploy machines on link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html[Elastic Fabric Adapter] (EFA) instances within an existing AWS placement group.
+
+EFA instances do not require placement groups, and you can use placement groups for purposes other than configuring an EFA. This example uses both to demonstrate a configuration that can improve network performance for machines within the specified placement group.
+
+.Prerequisites
+
+* You created a placement group in the AWS console.
++
+[NOTE]
+====
+Ensure that the link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html#limitations-placement-groups[rules and limitations] for the type of placement group that you create are compatible with your intended use case.
+ifdef::cpmso[]
+The control plane machine set spreads the control plane machines across multiple failure domains when possible. To use placement groups for the control plane, you must use a placement group type that can span multiple Availability Zones.
+endif::cpmso[]
+====
+
+.Procedure
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Edit the following lines under the `providerSpec` field:
++
+[source,yaml]
+----
+ifndef::cpmso[]
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+endif::cpmso[]
+ifdef::cpmso[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+endif::cpmso[]
+# ...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          instanceType: <supported_instance_type> # <1>
+          networkInterfaceType: EFA # <2>
+          placement:
+            availabilityZone: <zone> # <3>
+            region: <region> # <4>
+          placementGroupName: <placement_group> # <5>
+# ...
+----
+<1> Specify an instance type that link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/efa.html#efa-instance-types[supports EFAs].
+<2> Specify the `EFA` network interface type.
+<3> Specify the zone, for example, `us-east-1a`.
+<4> Specify the region, for example, `us-east-1`.
+<5> Specify the name of the existing AWS placement group to deploy machines in.
+
+.Verification
+
+* In the AWS console, find a machine that the machine set created and verify the following in the machine properties:
+
+** The placement group field has the value that you specified for the `placementGroupName` parameter in the machine set.
+
+** The interface type field indicates that it uses an EFA.
+
+ifeval::["{context}" == "cpmso-using"]
+:!cpmso:
+endif::[]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-6752](https://issues.redhat.com//browse/OSDOCS-6752)

Link to docs preview:
* [Assigning machines to placement groups by using machine sets](https://63815--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-aws-existing-placement-group_creating-machineset-aws) (compute)
* [Assigning machines to placement groups by using machine sets](https://63815--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-using#machineset-aws-existing-placement-group_cpmso-using) (control plane) 

QE review
- [x] QE has approved this change.

Additional information:

