### PR TITLE
OSDOCS-5403: MicroShift 4.12.30 release note

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -311,3 +311,12 @@ Issued: 2023-08-16
 {product-title} release 4.12.29 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4610[RHBA-2023:4610] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4608[RHBA-2023:4608] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-30-dp"]
+=== RHBA-2023:4673 - {product-title} 4.12.30 bug fix update
+
+Issued: 2023-08-23
+
+{product-title} release 4.12.30 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4673[RHBA-2023:4673] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4671[RHBA-2023:4671] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
**Issue:** [OSDOCS-5403](https://issues.redhat.com/browse/OSDOCS-5413)
For
**For version:** 4.12


Link to docs preview:
[MicroShift Release notes -> RHBA-2023:4673 - MicroShift 4.12.30 bug fix update ](https://63816--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes#microshift-4-12-30-dp)

QE review: 

- [ ] QE has approved this change