### PR TITLE
OBSDOCS-433: fix-wrong-annotation-for-thanosrulerconfig-4.13

### DIFF
--- a/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -579,7 +579,7 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 |nodeSelector|map[string]string|Defines the nodes on which the Pods are scheduled.
 
-|resources|*v1.ResourceRequirements|Defines resource requests and limits for the Alertmanager container.
+|resources|*v1.ResourceRequirements|Defines resource requests and limits for the Thanos Ruler container.
 
 |retention|string|Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `15d`.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-433
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63823--docspreview.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator#description-23
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @juzhao 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Fixes an error in the ThanosRulerConfig info in the CMO config reference for OCP 4.13.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
