### PR TITLE
OBSDOCS-433: fix-wrong-annotation-for-thanosrulerconfig-4.12

### DIFF
--- a/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
+++ b/monitoring/config-map-reference-for-the-cluster-monitoring-operator.adoc
@@ -1,7 +1,7 @@
-// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the 
-// source code for the Cluster Monitoring Operator. Any changes made to this 
-// file will be overwritten when the content is re-generated. If you wish to 
-// make edits, read the docgen utility instructions in the source code for the 
+// DO NOT EDIT THE CONTENT IN THIS FILE. It is automatically generated from the
+// source code for the Cluster Monitoring Operator. Any changes made to this
+// file will be overwritten when the content is re-generated. If you wish to
+// make edits, read the docgen utility instructions in the source code for the
 // CMO.
 :_content-type: REFERENCE
 [id="config-map-reference-for-the-cluster-monitoring-operator"]
@@ -16,19 +16,19 @@ toc::[]
 
 [role="_abstract"]
 Parts of {product-title} cluster monitoring are configurable.
-The API is accessible by setting parameters defined in various config maps. 
+The API is accessible by setting parameters defined in various config maps.
 
-* To configure monitoring components, edit the `ConfigMap` object named `cluster-monitoring-config` in the `openshift-monitoring` namespace. 
+* To configure monitoring components, edit the `ConfigMap` object named `cluster-monitoring-config` in the `openshift-monitoring` namespace.
 These configurations are defined by link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration].
-* To configure monitoring components that monitor user-defined projects, edit the `ConfigMap` object named `user-workload-monitoring-config` in the `openshift-user-workload-monitoring` namespace. 
+* To configure monitoring components that monitor user-defined projects, edit the `ConfigMap` object named `user-workload-monitoring-config` in the `openshift-user-workload-monitoring` namespace.
 These configurations are defined by link:#userworkloadconfiguration[UserWorkloadConfiguration].
 
 The configuration file is always defined under the `config.yaml` key in the config map data.
 
 [NOTE]
 ====
-* Not all configuration parameters are exposed. 
-* Configuring cluster monitoring is optional. 
+* Not all configuration parameters are exposed.
+* Configuring cluster monitoring is optional.
 * If a configuration does not exist or is empty, default values are used.
 * If the configuration is invalid YAML data, the Cluster Monitoring Operator stops reconciling the resources and reports `Degraded=True` in the status conditions of the Operator.
 ====
@@ -48,7 +48,7 @@ link:#thanosrulerconfig[ThanosRulerConfig]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |apiVersion|string|Defines the API version of Alertmanager. Possible values are `v1` or `v2`. The default is `v2`.
 
 |bearerToken|*v1.SecretKeySelector|Defines the secret key reference containing the bearer token to use when authenticating to Alertmanager.
@@ -75,7 +75,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |enabled|*bool|A Boolean flag that enables or disables the main Alertmanager instance in the `openshift-monitoring` namespace. The default value is `true`.
 
 |enableUserAlertmanagerConfig|bool|A Boolean flag that enables or disables user-defined namespaces to be selected for `AlertmanagerConfig` lookups. This setting only applies if the user workload monitoring instance of Alertmanager is not enabled. The default value is `false`.
@@ -104,7 +104,7 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |enabled|bool|A Boolean flag that enables or disables a dedicated instance of Alertmanager for user-defined alerts in the `openshift-user-workload-monitoring` namespace. The default value is `false`.
 
 |enableAlertmanagerConfig|bool|A Boolean flag to enable or disable user-defined namespaces to be selected for `AlertmanagerConfig` lookup. The default value is `false`.
@@ -129,7 +129,7 @@ The `ClusterMonitoringConfiguration` resource defines settings that customize th
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |alertmanagerMain|*link:#alertmanagermainconfig[AlertmanagerMainConfig]|`AlertmanagerMainConfig` defines settings for the Alertmanager component in the `openshift-monitoring` namespace.
 
 |enableUserWorkload|*bool|`UserWorkloadEnabled` is a Boolean flag that enables monitoring for user-defined projects.
@@ -160,7 +160,7 @@ Appears in: link:#k8sprometheusadapter[K8sPrometheusAdapter]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |enabled|bool|When `enabled` is set to `true`, the Cluster Monitoring Operator (CMO) deploys a dedicated Service Monitor that exposes the kubelet `/metrics/resource` endpoint. This Service Monitor sets `honorTimestamps: true` and only keeps metrics that are relevant for the pod resource queries of Prometheus Adapter. Additionally, Prometheus Adapter is configured to use these dedicated metrics. Overall, this feature improves the consistency of Prometheus Adapter-based CPU usage measurements used by, for example, the `oc adm top pod` command or the Horizontal Pod Autoscaler.
 
 |===
@@ -175,7 +175,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |audit|*Audit|Defines the audit configuration used by the Prometheus Adapter instance. Possible profile values are: `metadata`, `request`, `requestresponse`, and `none`. The default value is `metadata`.
 
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
@@ -196,7 +196,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
@@ -213,7 +213,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
@@ -230,7 +230,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |additionalAlertmanagerConfigs|[]link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]|Configures additional Alertmanager instances that receive alerts from the Prometheus component. By default, no additional Alertmanager instances are configured.
 
 |enforcedBodySizeLimit|string|Enforces a body size limit for Prometheus scraped metrics. If a scraped target's body response is larger than the limit, the scrape will fail. The following values are valid: an empty value to specify no limit, a numeric value in Prometheus size format (such as `64MB`), or the string `automatic`, which indicates that the limit will be automatically calculated based on cluster capacity. The default value is empty, which indicates no limit.
@@ -270,7 +270,7 @@ link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |logLevel|string|Defines the log level settings for Prometheus Operator. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
 
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
@@ -289,7 +289,7 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |additionalAlertmanagerConfigs|[]link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]|Configures additional Alertmanager instances that receive alerts from the Prometheus component. By default, no additional Alertmanager instances are configured.
 
 |enforcedLabelLimit|*uint64|Specifies a per-scrape limit on the number of labels accepted for a sample. If the number of labels exceeds this limit after metric relabeling, the entire scrape is treated as failed. The default value is `0`, which means that no limit is set.
@@ -338,7 +338,7 @@ link:#prometheusrestrictedconfig[PrometheusRestrictedConfig]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |authorization|*monv1.SafeAuthorization|Defines the authorization settings for remote write storage.
 
 |basicAuth|*monv1.BasicAuth|Defines basic authentication settings for the remote write endpoint URL.
@@ -383,7 +383,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |nodeSelector|map[string]string|Defines the nodes on which the pods are scheduled.
 
 |tolerations|[]v1.Toleration|Defines tolerations for the pods.
@@ -400,7 +400,7 @@ Appears in: link:#clustermonitoringconfiguration[ClusterMonitoringConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |enableRequestLogging|bool|A Boolean flag that enables or disables request logging. The default value is `false`.
 
 |logLevel|string|Defines the log level setting for Thanos Querier. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
@@ -423,14 +423,14 @@ Appears in: link:#userworkloadconfiguration[UserWorkloadConfiguration]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |additionalAlertmanagerConfigs|[]link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]|Configures how the Thanos Ruler component communicates with additional Alertmanager instances. The default value is `nil`.
 
 |logLevel|string|Defines the log level setting for Thanos Ruler. The possible values are `error`, `warn`, `info`, and `debug`. The default value is `info`.
 
 |nodeSelector|map[string]string|Defines the nodes on which the Pods are scheduled.
 
-|resources|*v1.ResourceRequirements|Defines resource requests and limits for the Alertmanager container.
+|resources|*v1.ResourceRequirements|Defines resource requests and limits for the Thanos Ruler container.
 
 |retention|string|Defines the duration for which Prometheus retains data. This definition must be specified using the following regular expression pattern: `[0-9]+(ms\|s\|m\|h\|d\|w\|y)` (ms = milliseconds, s= seconds,m = minutes, h = hours, d = days, w = weeks, y = years). The default value is `15d`.
 
@@ -455,7 +455,7 @@ Appears in: link:#additionalalertmanagerconfig[AdditionalAlertmanagerConfig]
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |ca|*v1.SecretKeySelector|Defines the secret key reference containing the Certificate Authority (CA) to use for the remote host.
 
 |cert|*v1.SecretKeySelector|Defines the secret key reference containing the public certificate to use for the remote host.
@@ -476,7 +476,7 @@ The `UserWorkloadConfiguration` resource defines the settings responsible for us
 
 [options="header"]
 |===
-| Property | Type | Description 
+| Property | Type | Description
 |alertmanager|*link:#alertmanageruserworkloadconfig[AlertmanagerUserWorkloadConfig]|Defines the settings for the Alertmanager component in user workload monitoring.
 
 |prometheus|*link:#prometheusrestrictedconfig[PrometheusRestrictedConfig]|Defines the settings for the Prometheus component in user workload monitoring.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-433
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63825--docspreview.netlify.app/openshift-enterprise/latest/monitoring/config-map-reference-for-the-cluster-monitoring-operator#description-15
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @juzhao 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Fixes an error in the ThanosRulerConfig info in the CMO config reference for OCP 4.12. Also removes some extraneous trailing spaces.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
