### PR TITLE
OSDOCS-6661: Updates to MicroShift manifests

### DIFF
--- a/microshift_running_apps/microshift-applications.adoc
+++ b/microshift_running_apps/microshift-applications.adoc
@@ -10,4 +10,6 @@ You can use the `kustomize` configuration management tool to deploy applications
 
 include::modules/microshift-manifests-overview.adoc[leveloffset=+1]
 
+include::modules/microshift-manifests-override-paths.adoc[leveloffset=+1]
+
 include::modules/microshift-applying-manifests-example.adoc[leveloffset=+1]

--- a/microshift_running_apps/microshift-greenboot-workload-scripts.adoc
+++ b/microshift_running_apps/microshift-greenboot-workload-scripts.adoc
@@ -22,4 +22,4 @@ include::modules/microshift-greenboot-testing-workload-script.adoc[leveloffset=+
 [role="_additional-resources"]
 .Additional resources
 * xref:../microshift_install/microshift-greenboot.adoc#microshift-greenboot[The greenboot health check]
-* xref:../microshift_running_apps/microshift-applications.adoc#microshift-manifests-example_applications-microshift[Auto applying manifests]
+* xref:../microshift_running_apps/microshift-applications.adoc#microshift-applying-manifests-example_applications-microshift[Auto applying manifests]

--- a/microshift_running_apps/microshift-operators.adoc
+++ b/microshift_running_apps/microshift-operators.adoc
@@ -15,8 +15,4 @@ Operators offer a more localized configuration experience and integrate with Kub
 [id="how-to-install-operators_{context}"]
 == How to install Operators in {product-title}
 
-To minimize the footprint of {product-title}, Operators are installed directly with manifests instead of using the Operator Lifecycle Manager (OLM). The following examples provide instructions on how you can use the `kustomize` configuration management tool with {product-title} to deploy an application. Use the same steps to install Operators with manifests.
-
-include::modules/microshift-manifests-overview.adoc[leveloffset=+2]
-
-include::modules/microshift-applying-manifests-example.adoc[leveloffset=+2]
+To minimize the footprint of {product-title}, Operators are installed directly with manifests instead of using the Operator Lifecycle Manager (OLM). You can use the `kustomize` configuration management tool with {product-title} to deploy an application. Use the same steps to install Operators with manifests. Read xref:../microshift_running_apps/microshift-applications.adoc#microshift-manifests-overview_applications-microshift[Application deployment with {product-title}] for more information about manifests.

--- a/modules/microshift-applying-manifests-example.adoc
+++ b/modules/microshift-applying-manifests-example.adoc
@@ -1,9 +1,9 @@
 // Module included in the following assemblies:
 //
-// * microshift/running_applications/microshift-operators.adoc
+// * microshift/running_applications/microshift-applications.adoc
 
 :_content-type: PROCEDURE
-[id="microshift-manifests-example_{context}"]
+[id="microshift-applying-manifests-example_{context}"]
 = Using manifests example
 This example demonstrates automatic deployment of a BusyBox container using `kustomize` manifests in the `/etc/microshift/manifests` directory.
 
@@ -29,7 +29,6 @@ $ sudo mkdir -p ${MANIFEST_DIR}
 [source,terminal]
 ----
 $ sudo tee ${MANIFEST_DIR}/busybox.yaml &>/dev/null <<EOF
-
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -39,6 +38,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: busybox-deployment
+  namespace:busybox
 spec:
   selector:
     matchLabels:
@@ -64,7 +64,6 @@ EOF
 [source,terminal]
 ----
 $ sudo tee ${MANIFEST_DIR}/kustomization.yaml &>/dev/null <<EOF
----
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: busybox
@@ -72,7 +71,7 @@ resources:
   - busybox.yaml
 images:
   - name: BUSYBOX_IMAGE
-    newName: registry.k8s.io/busybox
+    newName: busybox:1.35
 EOF
 ----
 

--- a/modules/microshift-manifests-override-paths.adoc
+++ b/modules/microshift-manifests-override-paths.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assemblies:
+//
+// * microshift//running_applications/microshift-applications.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-manifests-override-paths_{context}"]
+= Override the list of manifest paths
+You can override the list of default manifest paths by using a new single path, or by using a new glob pattern for multiple files. Use the following procedure to customize your manifest paths.
+
+.Procedure
+
+. Override the list of default paths by inserting your own values and running one of the following commands:
+
+.. Set `manifests.kustomizePaths` to `<++"++/opt/alternate/path++"++>` in the configuration file for a single path.
+
+.. Set `kustomizePaths` to `,++"++/opt/alternative/path.d/++*"++.` in the configuration file for a glob pattern.
++
+[source,terminal]
+----
+manifests:
+    kustomizePaths:
+        - <location> <1>
+----
+<1> Set each location entry to an exact path by using `++"++/opt/alternate/path++"++` or a glob pattern by using `++"++/opt/alternative/path.d/++*"++`.
+
+. To disable loading manifests, set the configuration option to an empty list.
++
+[source,terminal]
+----
+manifests:
+    kustomizePaths: []
+----
++
+[NOTE]
+====
+The configuration file overrides the defaults entirely. If the `kustomizePaths` value is set, only the values in the configuration file are used. Setting the value to an empty list disables manifest loading.
+====

--- a/modules/microshift-manifests-overview.adoc
+++ b/modules/microshift-manifests-overview.adoc
@@ -1,12 +1,14 @@
 // Module included in the following assemblies:
 //
-// * microshift/using-config-tools.adoc
+// * microshift//running_applications/microshift-applications.adoc
 
 :_content-type: CONCEPT
 [id="microshift-manifests-overview_{context}"]
 = How manifests work with kustomize
 
-The `kustomize` configuration management tool is integrated with {product-title}. At every start, {product-title} searches the `/etc/microshift/manifests` and `/usr/lib/microshift/` manifest directories for a `kustomization.yaml` file. If it finds one, {product-title} automatically runs the equivalent of the `kubectl apply -k` command to apply the identified manifests to the cluster.
+The `kustomize` configuration management tool is integrated with {product-title}. At every start, {product-title} searches the `/etc/microshift/manifests`, `/etc/microshift/manifests.d/++*++`, `/usr/lib/microshift/`, and `/usr/lib/microshift/manifests.d/++*++` manifest directories for a `kustomization.yaml`, `kustomization.yml`, or `Kustomization` file. If it finds one, {product-title} automatically runs the equivalent of the `kubectl apply -k` command to apply the identified manifests to the cluster.
+
+Loading from multiple directories allows you to manage {product-title} workloads with more flexibility. Different workloads can be independent of each other.
 
 [cols="2",options="header"]
 |===
@@ -16,6 +18,12 @@ The `kustomize` configuration management tool is integrated with {product-title}
 |`/etc/microshift/manifests`
 |Read-write location for configuration management systems or development.
 
+|`/etc/microshift/manifests.d/*`
+|Read-write location for configuration management systems or development.
+
 |`/usr/lib/microshift/manifests`
+|Read-only location for embedding configuration manifests on OSTree-based systems.
+
+|`/usr/lib/microshift/manifestsd./*`
 |Read-only location for embedding configuration manifests on OSTree-based systems.
 |===


### PR DESCRIPTION
[OSDOCS-6661](https://issues.redhat.com//browse/OSDOCS-6661): Updates to MicroShift manifests

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6661

Link to docs preview:
https://63830--docspreview.netlify.app/microshift/latest/microshift_running_apps/microshift-applications

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
