### PR TITLE
[enterprise-4.13] OSDOCS-6913: Added documentation for creating a cluster admin when creating a cluster

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -224,20 +224,23 @@ I: Interactive mode enabled.
 Any optional fields can be left empty and a default will be selected.
 ? Cluster name: <cluster_name>
 Deploy cluster with Hosted Control Plane (optional): No
-? OpenShift version: 4.13.4 <1>
-? Configure the use of IMDSv2 for ec2 instances optional/required (optional): <2>
-I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role for the Installer role <3>
+? Create cluster admin user: Yes <1>
+? Username: user-admin <1>
+? Password: [? for help] *************** <1>
+? OpenShift version: 4.13.4 <2>
+? Configure the use of IMDSv2 for ec2 instances optional/required (optional): <3>
+I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role for the Installer role <4>
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role for the ControlPlane role
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role for the Worker role
 I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for the Support role
 ? External ID (optional):
-? Operator roles prefix: <cluster_name>-<random_string> <4>
-? Multiple availability zones (optional): No <5>
+? Operator roles prefix: <cluster_name>-<random_string> <5>
+? Multiple availability zones (optional): No <6>
 ? AWS region: us-east-1
 ? PrivateLink cluster (optional): No
 ? Install into an existing VPC (optional): No
 ? Select availability zones (optional): No
-? Enable Customer Managed key (optional): No <6>
+? Enable Customer Managed key (optional): No <7>
 ? Compute nodes instance type (optional):
 ? Enable autoscaling (optional): No
 ? Compute nodes: 2
@@ -245,32 +248,33 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for th
 ? Service CIDR: 172.30.0.0/16
 ? Pod CIDR: 10.128.0.0/14
 ? Host prefix: 23
-? Encrypt etcd data (optional): No <7>
+? Encrypt etcd data (optional): No <8>
 ? Disable Workload monitoring (optional): No
 I: Creating cluster '<cluster_name>'
 I: To create this cluster again in the future, you can run:
-   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <8>
+   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <9>
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
 I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
 ...
 ----
-<1> When creating the cluster, the listed `OpenShift version` options include the major, minor, and patch versions, for example `4.13.4`.
-<2> Optional: Specify 'optional' to configure all EC2 instances to use both v1 and v2 endpoints of EC2 Instance Metadata Service (IMDS). This is the default value. Specify 'required' to configure all EC2 instances to use IMDSv2 only.
+<1> When creating your cluster, you can create a local administrator user for your cluster. Selecting `Yes` then prompts you to create a user name and password for the cluster admin. The user name must not contain `/`, `:`, or `%`. The password must be at least 14 characters (ASCII-standard) without whitespaces. This process automatically configures an htpasswd identity provider.
+<2> When creating the cluster, the listed `OpenShift version` options include the major, minor, and patch versions, for example `4.13.4`.
+<3> Optional: Specify 'optional' to configure all EC2 instances to use both v1 and v2 endpoints of EC2 Instance Metadata Service (IMDS). This is the default value. Specify 'required' to configure all EC2 instances to use IMDSv2 only.
 +
 [IMPORTANT]
 ====
 The Instance Metadata Service settings cannot be changed after your cluster is created.
 ====
-<3> If you have more than one set of account roles in your AWS account for your cluster version, an interactive list of options is provided.
-<4> By default, the cluster-specific Operator role names are prefixed with the cluster name and random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _Defining an Operator IAM role prefix_.
+<4> If you have more than one set of account roles for your cluster version in your AWS account, an interactive list of options is provided.
+<5> By default, the cluster-specific Operator role names are prefixed with the cluster name and a random 4-digit hash. You can optionally specify a custom prefix to replace `<cluster_name>-<hash>` in the role names. The prefix is applied when you create the cluster-specific Operator IAM roles. For information about the prefix, see _Defining an Operator IAM role prefix_.
 +
 [NOTE]
 ====
 If you specified custom ARN paths when you created the associated account-wide roles, the custom path is automatically detected. The custom path is applied to the cluster-specific Operator roles when you create them in a later step.
 ====
-<5> Optional: Multiple availability zones are recommended for production workloads. The default is a single availability zone.
-<6> Optional: Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN to in the preceding step.
+<6> Optional: Multiple availability zones are recommended for production workloads. The default is a single availability zone.
+<7> Optional: Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN in the preceding step.
 +
 [IMPORTANT]
 ====
@@ -279,14 +283,14 @@ Only persistent volumes (PVs) created from the default storage class are encrypt
 PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
 ====
 
-<7> Optional: Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted, but not the keys.
+<8> Optional: Only enable this option if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted but not the keys.
 +
 [IMPORTANT]
 ====
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Red Hat recommends that you enable etcd encryption only if you specifically require it for your use case.
 ====
 +
-<8> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
+<9> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
 --
 +
 As an alternative to using the `--interactive` mode, you can specify the customization options directly when you run the `rosa create cluster` command. Run the `rosa create cluster --help` command to view a list of available CLI options, or see _create cluster_ in _Managing objects with the ROSA CLI_.

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -19,6 +19,16 @@ The following table describes the interactive cluster creation mode options:
 |`Cluster name`
 |Enter a name for your cluster, for example `my-rosa-cluster`.
 
+|`Deploy cluster with Hosted Control Plane (optional)`
+|Enable the use of Hosted Control Planes.
+[IMPORTANT]
+====
+The ROSA with Hosted Control Planes functionality is currently offered as a Technology Preview. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete.
+====
+
+|`Create cluster admin user`
+|Create a cluster administrator user when you create your cluster using the htpasswd identity provider. The username must not contain `/`, `:`, or `%`. The password must be at least 14 characters (ASCII-standard) without whitespaces.
+
 |`Deploy cluster using AWS STS`
 |Create an OpenShift cluster that uses the AWS Security Token Service (STS) to allocate temporary, limited-privilege credentials for component-specific AWS Identity and Access Management (IAM) roles. The service enables cluster components to make AWS API calls using secure cloud resource management practices. The default is `Yes`.
 
@@ -37,6 +47,12 @@ The following table describes the interactive cluster creation mode options:
 |`Operator roles prefix`
 |Enter a prefix to assign to the cluster-specific Operator IAM roles. The default is the name of the cluster and a 4-digit random string, for example `my-rosa-cluster-a0b1`.
 
+|`Deploy cluster using pre registered OIDC Configuration ID`
+|Specify if you want to use a pre-configured OIDC configuration or if you want to create a new OIDC configuration as part of the cluster creation process.
+
+|`Tags (optional)`
+|Specify a tag that is used on all resources created by ROSA in AWS. Tags are comma separated, for example: "key value, foo bar".
+
 |`Multiple availability zones (optional)`
 |Deploy the cluster to multiple availability zones in the AWS region. The default is `No`, which results in a cluster being deployed to a single availability zone. If you deploy a cluster into multiple availability zones, the AWS region must have at least 3 availability zones. Multiple availability zones are recommended for production workloads.
 
@@ -45,6 +61,15 @@ The following table describes the interactive cluster creation mode options:
 
 |`PrivateLink cluster (optional)`
 |Create a cluster using AWS PrivateLink. This option provides private connectivity between Virtual Private Clouds (VPCs), AWS services, and your on-premise networks, without exposing your traffic to the public internet. To provide support, Red Hat Site Reliability Engineering (SRE) can connect to the cluster by using AWS PrivateLink Virtual Private Cloud (VPC) endpoints. This option cannot be changed after a cluster is created. The default is `No`.
+
+|`Machine CIDR`
+|Specify the IP address range for machines (cluster nodes), which must encompass all CIDR address ranges for your VPC subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. The default is `10.0.0.0/16`. This range must not conflict with any connected networks.
+
+|`Service CIDR`
+|Specify the IP address range for services. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `172.30.0.0/16`. It is recommended that the address ranges are the same between clusters.
+
+|`Pod CIDR`
+|Specify the IP address range for pods. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `10.128.0.0/14`. It is recommended that they are the same between clusters.
 
 |`Install into an existing VPC (optional)`
 |Install a cluster into an existing AWS VPC. To use this option, your VPC must have 2 subnets for each availability zone that you are installing the cluster into. The default is `No`.
@@ -64,26 +89,21 @@ The following table describes the interactive cluster creation mode options:
 |`Compute nodes`
 |Specify the number of compute nodes to provision into each availability zone. Clusters deployed in a single availability zone require at least 2 nodes. Clusters deployed in multiple zones must have at least 3 nodes. The maximum number of worker nodes is 180 nodes. The default value is `2`.
 
-|`Machine CIDR`
-|Specify the IP address range for machines (cluster nodes), which must encompass all CIDR address ranges for your VPC subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. The default is `10.0.0.0/16`. This range must not conflict with any connected networks.
-
-|`Service CIDR`
-|Specify the IP address range for services. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `172.30.0.0/16`. It is recommended that they are the same between clusters.
-
-|`Pod CIDR`
-|Specify the IP address range for pods. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `10.128.0.0/14`. It is recommended that they are the same between clusters.
+|`Default machine pool labels (optional)`
+|Specify the labels for the default machine pool. The label format should be a comma-separated list of key-value pairs. This list will overwrite any modifications made to node labels on an ongoing basis.
 
 |`Host prefix`
 |Specify the subnet prefix length assigned to pods scheduled to individual machines. The host prefix determines the pod IP address pool for each machine. For example, if the host prefix is set to `/23`, each machine is assigned a `/23` subnet from the pod CIDR address range. The default is `/23`, allowing 512 cluster nodes and 512 pods per node, both of which are beyond our supported maximums. For information on the supported maximums, see the Additional resources section below.
 
-// |`fips (optional)`
-// |Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with RHCOS instead.
-////
+|`Machine pool root disk size (GiB or TiB)`
+|Specify the size of the machine pool root disk. This value must include a unit suffix like GiB or TiB, for example the default value of `300GiB`.
+
+|`Enable FIPS support (optional)`
+|Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with RHCOS instead.
 [IMPORTANT]
 ====
 The use of FIPS Validated / Modules in Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-////
 
 |`Encrypt etcd data (optional)`
 |In {product-title}, the control plane storage is encrypted at rest by default and this includes encryption of the etcd volumes. You can additionally enable the `Encrypt etcd data` option to encrypt the key values for some resources in etcd, but not the keys.
@@ -95,5 +115,17 @@ By enabling etcd encryption for the key values in etcd, you will incur a perform
 
 |`Disable workload monitoring (optional)`
 |Disable monitoring for user-defined projects. Monitoring for user-defined projects is enabled by default.
+
+|`Route Selector for ingress (optional)`
+|Specify the route selector for your ingress. The format should be a comma-separated list of `key=value`. If you do not specify a label, all routes will be exposed on both routers. For legacy ingress support, these labels are inclusion labels; otherwise, they are treated as exclusion label.
+
+|`Excluded namespaces for ingress (optional)`
+|Specify the excluded namespaces for your ingress. The format should be a comma-separated list `value1, value2...`. If you do not specify any values, all namespaces will be exposed.
+
+|`Wildcard Policy (optional, choose 'Skip' to skip selection. The default value will be supplied.)`
+|Choose the wildcard policy for your ingress. The options are `WildcardsDisallowed` and `WildcardsAllowed`. Default is `WildcardsDisallowed`.
+
+|`Namespace Ownership Policy (optional, choose 'Skip' to skip selection. The default value will be supplied.)`
+|Choose the namespace ownership policy for your ingress. The options are `Strict` and `InterNamespaceAllowed`. The default is `Strict`.
 
 |===

--- a/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
+++ b/modules/rosa-sts-overview-of-the-default-cluster-specifications.adoc
@@ -38,6 +38,7 @@ endif::rosa-standalone[]
 
 |Accounts and roles
 |* Default IAM role prefix: `ManagedOpenShift`
+* No cluster admin role created
 
 |Cluster settings
 |* Default cluster version: Latest


### PR DESCRIPTION
Manual cherry-pick of #63506  for `enterprise-4.13` 