### PR TITLE
MetalLB updating the pod affinity example OCPBUGS-17959

### DIFF
--- a/modules/nw-metallb-operator-setting-pod-priority-affinity.adoc
+++ b/modules/nw-metallb-operator-setting-pod-priority-affinity.adoc
@@ -5,9 +5,9 @@
 [id="nw-metallb-operator-setting-pod-priority-affinity_{context}"]
 = Configuring pod priority and pod affinity in a MetalLB deployment
 
-You can optionally assign pod priority and pod affinity rules to `controller` and `speaker` pods by configuring the `MetalLB` custom resource. The pod priority indicates the relative importance of a pod on a node and schedules the pod based on this priority. Set a high priority on your `controller` or `speaker` pod to ensure scheduling priority over other pods on the node. 
+You can optionally assign pod priority and pod affinity rules to `controller` and `speaker` pods by configuring the `MetalLB` custom resource. The pod priority indicates the relative importance of a pod on a node and schedules the pod based on this priority. Set a high priority on your `controller` or `speaker` pod to ensure scheduling priority over other pods on the node.
 
-Pod affinity manages relationships among pods. Assign pod affinity to the `controller` or `speaker` pods to control on what node the scheduler places the pod in the context of pod relationships. For example, you can allow pods with logically related workloads on the same node, or ensure pods with conflicting workloads are on separate nodes. 
+Pod affinity manages relationships among pods. Assign pod affinity to the `controller` or `speaker` pods to control on what node the scheduler places the pod in the context of pod relationships. For example, you can use pod affinity rules to ensure that certain pods are located on the same node or nodes, which can help improve network communication and reduce latency between those components.
 
 .Prerequisites
 
@@ -15,8 +15,10 @@ Pod affinity manages relationships among pods. Assign pod affinity to the `contr
 
 * You have installed the MetalLB Operator.
 
+* You have started the MetalLB Operator on your cluster.
+
 .Procedure
-. Create a `PriorityClass` custom resource, such as `myPriorityClass.yaml`, to configure the priority level. This example uses a high-priority class:
+. Create a `PriorityClass` custom resource, such as `myPriorityClass.yaml`, to configure the priority level. This example defines a `PriorityClass` named `high-priority` with a value of `1000000`. Pods that are assigned this priority class are considered higher priority during scheduling compared to pods with lower priority classes:
 +
 [source,yaml]
 ----
@@ -34,7 +36,7 @@ value: 1000000
 $ oc apply -f myPriorityClass.yaml
 ----
 
-. Create a `MetalLB` custom resource, such as `MetalLBPodConfig.yaml`, to specify the `priorityClassName` and `podAffinity` values: 
+. Create a `MetalLB` custom resource, such as `MetalLBPodConfig.yaml`, to specify the `priorityClassName` and `podAffinity` values:
 +
 [source,yaml]
 ----
@@ -46,12 +48,17 @@ metadata:
 spec:
   logLevel: debug
   controllerConfig:
-    priorityClassName: high-priority
-    runtimeClassName: myclass
+    priorityClassName: high-priority <1>
+    affinity:
+      podAffinity: <2>
+        requiredDuringSchedulingIgnoredDuringExecution:
+        - labelSelector:
+            matchLabels:
+             app: metallb
+          topologyKey: kubernetes.io/hostname
   speakerConfig:
     priorityClassName: high-priority
-    runtimeClassName: myclass
-  affinity:
+    affinity:
       podAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:
         - labelSelector:
@@ -59,6 +66,9 @@ spec:
              app: metallb
           topologyKey: kubernetes.io/hostname
 ----
++
+<1> Specifies the priority class for the MetalLB controller pods. In this case, it is set to `high-priority`.
+<2> Specifies that you are configuring pod affinity rules. These rules dictate how pods are scheduled in relation to other pods or nodes. This configuration instructs the scheduler to schedule pods that have the label `app: metallb` onto nodes that share the same hostname. This helps to co-locate MetalLB-related pods on the same nodes, potentially optimizing network communication, latency, and resource usage between these pods.
 
 . Apply the `MetalLB` custom resource configuration:
 +
@@ -68,16 +78,27 @@ $ oc apply -f MetalLBPodConfig.yaml
 ----
 
 .Verification
-* To view the priority class that you assigned to pods in a namespace, run the following command, replacing `<namespace>` with your target namespace:
+* To view the priority class that you assigned to pods in the `metallb-system` namespace, run the following command:
 +
 [source,bash]
 ----
-$ oc get pods -n <namespace> -o custom-columns=NAME:.metadata.name,PRIORITY:.spec.priorityClassName
+$ oc get pods -n metallb-system -o custom-columns=NAME:.metadata.name,PRIORITY:.spec.priorityClassName
+----
++
+.Example output
++
+[source,terminal]
+----
+NAME                                                 PRIORITY
+controller-584f5c8cd8-5zbvg                          high-priority
+metallb-operator-controller-manager-9c8d9985-szkqg   <none>
+metallb-operator-webhook-server-c895594d4-shjgx      <none>
+speaker-dddf7                                        high-priority
 ----
 
-* To verify that the scheduler placed pods according to pod affinity rules, view the metadata for the pod's node by running the following command, replacing `<namespace>` with your target namespace:
+* To verify that the scheduler placed pods according to pod affinity rules, view the metadata for the pod's node or nodes by running the following command:
 +
 [source,bash]
 ----
-$ oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name -n <namespace>
+$ oc get pod -o=custom-columns=NODE:.spec.nodeName,NAME:.metadata.name -n metallb-system
 ----

--- a/modules/nw-metallb-operator-setting-runtimeclass.adoc
+++ b/modules/nw-metallb-operator-setting-runtimeclass.adoc
@@ -5,7 +5,7 @@
 [id="nw-metallb-operator-setting-runtimeclass_{context}"]
 = Configuring a container runtime class in a MetalLB deployment
 
-You can optionally assign a container runtime class to `controller` and `speaker` pods by configuring the `MetalLB` custom resource. For example, for Windows workloads, you can assign a Windows runtime class to the pod, which uses this runtime class for all containers in the pod.  
+You can optionally assign a container runtime class to `controller` and `speaker` pods by configuring the MetalLB custom resource. For example, for Windows workloads, you can assign a Windows runtime class to the pod, which uses this runtime class for all containers in the pod.
 
 .Prerequisites
 
@@ -21,7 +21,7 @@ You can optionally assign a container runtime class to `controller` and `speaker
 apiVersion: node.k8s.io/v1
 kind: RuntimeClass
 metadata:
-  name: myclass 
+  name: myclass
 handler: myconfiguration
 ----
 
@@ -32,7 +32,7 @@ handler: myconfiguration
 $ oc apply -f myRuntimeClass.yaml
 ----
 
-. Create a `MetalLB` custom resource, such as `MetalLBRuntime.yaml`, to specify the `runtimeClassName` value: 
+. Create a `MetalLB` custom resource, such as `MetalLBRuntime.yaml`, to specify the `runtimeClassName` value:
 +
 [source,yaml]
 ----
@@ -47,12 +47,12 @@ spec:
     runtimeClassName: myclass
     annotations: <1>
       controller: demo
-  speakerConfig: 
+  speakerConfig:
     runtimeClassName: myclass
     annotations: <1>
       speaker: demo
 ----
-<1> This example uses `annotations` to add metadata such as build release information or GitHub pull request information. You can populate annotations with characters not permitted in labels. However, you cannot use annotations to identify or select objects. 
+<1> This example uses `annotations` to add metadata such as build release information or GitHub pull request information. You can populate annotations with characters that are not permitted in labels. However, you cannot use annotations to identify or select objects.
 
 . Apply the `MetalLB` custom resource configuration:
 +

--- a/networking/metallb/metallb-operator-install.adoc
+++ b/networking/metallb/metallb-operator-install.adoc
@@ -26,14 +26,16 @@ include::modules/nw-metallb-operator-deployment-specifications-for-metallb.adoc[
 // Deployment specs to limit speaker pods to specific nodes
 include::modules/nw-metallb-operator-limit-speaker-to-nodes.adoc[leveloffset=+2]
 
-// Deployment specs to set pod priority and pod ffinity
+// Deployment specs to set RuntimeClass
+include::modules/nw-metallb-operator-setting-runtimeclass.adoc[leveloffset=+2]
+
+// Deployment specs to set pod priority and pod affinity
 include::modules/nw-metallb-operator-setting-pod-priority-affinity.adoc[leveloffset=+2]
 
 // Deployment specs to set pod CPU limits
 include::modules/nw-metallb-operator-setting-pod-CPU-limits.adoc[leveloffset=+2]
 
-// Deployment specs to set RuntimeClass
-include::modules/nw-metallb-operator-setting-runtimeclass.adoc[leveloffset=+2]
+
 
 [role="_additional-resources"]
 [id="additional-resources_metallb-operator-install"]


### PR DESCRIPTION
[OCPBUGS-17959]: Updating the pod affinity example
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14, 4.13, 4.12 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-17959
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://63849--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-operator-install.html#nw-metallb-operator-setting-pod-priority-affinity_metallb-operator-install
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
