### PR TITLE
OSDOCS#6990: Add CPMS variable root volume types

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -911,17 +911,25 @@ Additional {rh-openstack} configuration parameters are described in the followin
 |For compute machines, the size in gigabytes of the root volume. If you do not set this value, machines use ephemeral storage.
 |Integer, for example `30`.
 
+|`compute.platform.openstack.rootVolume.types`
+|For compute machines, the root volume types.
+|A list of strings, for example, {`performance-host1`, `performance-host2`, `performance-host3`}. ^[1]^
+
 |`compute.platform.openstack.rootVolume.type`
-|For compute machines, the root volume's type.
-|String, for example `performance`.
+|For compute machines, the root volume's type. This property is deprecated and is replaced by `compute.platform.openstack.rootVolume.types`.
+|String, for example, `performance`. ^[2]^
 
 |`controlPlane.platform.openstack.rootVolume.size`
 |For control plane machines, the size in gigabytes of the root volume. If you do not set this value, machines use ephemeral storage.
 |Integer, for example `30`.
 
+|`controlPlane.platform.openstack.rootVolume.types`
+|For control plane machines, the root volume types.
+|A list of strings, for example, {`performance-host1`, `performance-host2`, `performance-host3`}. ^[1]^
+
 |`controlPlane.platform.openstack.rootVolume.type`
-|For control plane machines, the root volume's type.
-|String, for example `performance`.
+|For control plane machines, the root volume's type. This property is deprecated and is replaced by `compute.platform.openstack.rootVolume.types`.
+|String, for example, `performance`. ^[2]^
 
 |`platform.openstack.cloud`
 |The name of the {rh-openstack} cloud to use from the list of clouds in the
@@ -939,6 +947,11 @@ This property is deprecated. To use a flavor as the default for all machine pool
 
 |String, for example `m1.xlarge`.
 |====
+
+. If the machine pool defines `zones`, the count of types can either be a single item or match the number of items in `zones`. For example, the count of types cannot be 2 if there are 3 items in `zones`.
+
+. If you have any existing reference to this property, the installer populates the corresponding value in the `controlPlane.platform.openstack.rootVolume.types` field.
+
 
 [id="installation-configuration-parameters-optional-osp_{context}"]
 == Optional {rh-openstack} configuration parameters


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OSDOCS-6990

Link to docs preview: https://63861--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom#installation-configuration-parameters-additional-osp_installing-openstack-installer-custom

QE review:
- [x] QE has approved this change. @itzikb-redhat
- [x] SME has approved this change. @EmilienM / @pierreprinetti 
