### PR TITLE
OSDOCS#7533: updating RHEL version numbers

### DIFF
--- a/modules/rhel-compute-updating.adoc
+++ b/modules/rhel-compute-updating.adoc
@@ -52,7 +52,7 @@ By default, the base OS RHEL with "Minimal" installation option enables firewall
 +
 [source,terminal,subs="attributes+"]
 ----
-# subscription-manager repos --disable=rhocp-4.11-for-rhel-8-x86_64-rpms \
+# subscription-manager repos --disable=rhocp-4.13-for-rhel-8-x86_64-rpms \
                              --enable=rhocp-{product-version}-for-rhel-8-x86_64-rpms
 ----
 +
@@ -72,7 +72,7 @@ As of {product-title} 4.11, the Ansible playbooks are provided only for {op-syst
 +
 [source,terminal,subs="attributes+"]
 ----
-# subscription-manager repos --disable=rhocp-4.11-for-rhel-8-x86_64-rpms \
+# subscription-manager repos --disable=rhocp-4.13-for-rhel-8-x86_64-rpms \
                              --enable=rhocp-{product-version}-for-rhel-8-x86_64-rpms
 ----
 


### PR DESCRIPTION
[OSDOCS-7533](https://issues.redhat.com/browse/OSDOCS-7533)

Versions: 4.14+

This PR updates a few RHEL version numbers in the assembly for [Updating a cluster that includes RHEL compute machines](https://docs.openshift.com/container-platform/4.14/updating/updating_a_cluster/updating-cluster-rhel-compute.html)

QE review:
- [x] QE has approved this change.

Preview: [Updating RHEL compute machines in your cluster](https://63867--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-rhel-compute#rhel-compute-updating-minor_updating-cluster-rhel-compute)