### PR TITLE
OCPBUGS#7913: 4.13 yaml fix

### DIFF
--- a/modules/installing-ocp-agent-boot.adoc
+++ b/modules/installing-ocp-agent-boot.adoc
@@ -34,9 +34,9 @@ This is the preferred method for the Agent-based installation. Using {ztp} manif
 
 . Create the `install-config.yaml` file:
 +
-[source,yaml]
+[source,terminal]
 ----
-cat << EOF > ./my-cluster/install-config.yaml
+$ cat << EOF > ./my-cluster/install-config.yaml
 apiVersion: v1
 baseDomain: test.example.com
 compute:
@@ -114,43 +114,43 @@ platform:
 
 . Create the `agent-config.yaml` file:
 +
-[source,yaml]
+[source,terminal]
 ----
-  cat > agent-config.yaml << EOF
-  apiVersion: v1alpha1
-  kind: AgentConfig
-  metadata:
-    name: sno-cluster
-  rendezvousIP: 192.168.111.80 <1>
-  hosts: <2>
-    - hostname: master-0 <3>
+$ cat > agent-config.yaml << EOF
+apiVersion: v1alpha1
+kind: AgentConfig
+metadata:
+  name: sno-cluster
+rendezvousIP: 192.168.111.80 <1>
+hosts: <2>
+  - hostname: master-0 <3>
+    interfaces:
+      - name: eno1
+        macAddress: 00:ef:44:21:e6:a5
+    rootDeviceHints: <4>
+      deviceName: /dev/sdb
+    networkConfig: <5>
       interfaces:
         - name: eno1
-          macAddress: 00:ef:44:21:e6:a5
-      rootDeviceHints: <4>
-        deviceName: /dev/sdb
-      networkConfig: <5>
-        interfaces:
-          - name: eno1
-            type: ethernet
-            state: up
-            mac-address: 00:ef:44:21:e6:a5
-            ipv4:
-              enabled: true
-              address:
-                - ip: 192.168.111.80
-                  prefix-length: 23
-              dhcp: false
-        dns-resolver:
-          config:
-            server:
-              - 192.168.111.1
-        routes:
-          config:
-            - destination: 0.0.0.0/0
-              next-hop-address: 192.168.111.2
-              next-hop-interface: eno1
-              table-id: 254
+          type: ethernet
+          state: up
+          mac-address: 00:ef:44:21:e6:a5
+          ipv4:
+            enabled: true
+            address:
+              - ip: 192.168.111.80
+                prefix-length: 23
+            dhcp: false
+      dns-resolver:
+        config:
+          server:
+            - 192.168.111.1
+      routes:
+        config:
+          - destination: 0.0.0.0/0
+            next-hop-address: 192.168.111.2
+            next-hop-interface: eno1
+            table-id: 254
   EOF
 ----
 +


### PR DESCRIPTION
[OCPBUGS-7913](https://issues.redhat.com/browse/OCPBUGS-7913)

Version: 4.13 only

This PR removes two leading spaces in a yaml file within the agent installer docs which should not be there.

QE review:
- [x] QE has approved this change.

Preview: [Creating and booting the agent image](https://63869--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-boot_installing-with-agent-based-installer)