### PR TITLE
OCPBUG#13751: Replaced useage with usage in "viewing health information" section

### DIFF
--- a/modules/network-observability-viewing-alerts.adoc
+++ b/modules/network-observability-viewing-alerts.adoc
@@ -6,7 +6,7 @@
 [id="network-observability-alert-dashboard_{context}"]
 = Viewing health information
 
-You can access metrics about health and resource useage of the Network Observability Operator from the *Dashboards* page in the web console. A health alert banner that directs you to the dashboard can appear on the *Network Traffic* and *Home* pages in the event that an alert is triggered. Alerts are generated in the following cases:
+You can access metrics about health and resource usage of the Network Observability Operator from the *Dashboards* page in the web console. A health alert banner that directs you to the dashboard can appear on the *Network Traffic* and *Home* pages in the event that an alert is triggered. Alerts are generated in the following cases:
 
 * The *NetObservLokiError* alert occurs if the `flowlogs-pipeline` workload is dropping flows because of Loki errors, such as if the Loki ingestion rate limit has been reached.
 * The *NetObservNoFlows* alert occurs if no flows are ingested for a certain amount of time..Prerequisites


### PR DESCRIPTION
Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUS-13751](https://issues.redhat.com/browse/OCPBUGS-13751)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview](https://63871--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/network-observability-operator-monitoring#network-observability-alert-dashboard_network_observability)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Does not need QE review. Minor update
- [ ] QE review not necessary.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
