### PR TITLE
OSDOCS-7517: Using ZTP manifests with agent

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -36,6 +36,15 @@ If you do not want to make additional configurations, proceed to xref:../../inst
 // Partitioning the disk
 include::modules/installation-user-infra-machines-advanced.adoc[leveloffset=+3]
 
+// Optional: Using ZTP manifests
+include::modules/installing-ocp-agent-ZTP.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#sample-ztp-custom-resources_installing-with-agent-based-installer[Sample {ztp} custom resources].
+
+* See xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-deploying-far-edge-clusters-at-scale[Challenges of the network far edge] to learn more about {ztp-first}.
+
 // Creating and booting the agent image
 include::modules/installing-ocp-agent-boot.adoc[leveloffset=+2]
 

--- a/modules/installing-ocp-agent-ZTP.adoc
+++ b/modules/installing-ocp-agent-ZTP.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * installing-with-agent/installing-with-agent.adoc
+
+:_content-type: PROCEDURE
+[id="installing-ocp-agent-ztp_{context}"]
+= Optional: Using ZTP manifests
+
+You can use {ztp-first} manifests to configure your installation beyond the options available through the `install-config.yaml` and `agent-config.yaml` files.
+
+[NOTE]
+====
+{ztp} manifests can be generated with or without configuring the `install-config.yaml` and `agent-config.yaml` files beforehand.
+If you chose to configure the `install-config.yaml` and `agent-config.yaml` files, the configurations will be imported to the ZTP cluster manifests when they are generated.
+====
+
+.Prerequisites
+
+* You have placed the `openshift-install` binary in a directory that is on your `PATH`.
+
+* Optional: You have created and configured the `install-config.yaml` and `agent-config.yaml` files.
+
+.Procedure
+
+. Use the following command to generate ZTP cluster manifests:
++
+[source,terminal]
+----
+$ openshift-install agent create cluster-manifests --dir <installation_directory>
+----
++
+[IMPORTANT]
+====
+If you have created the `install-config.yaml` and `agent-config.yaml` files, those files are deleted and replaced by the cluster manifests generated through this command.
+
+Any configurations made to the `install-config.yaml` and `agent-config.yaml` files are imported to the ZTP cluster manifests when you run the `openshift-install agent create cluster-manifests` command.
+====
+
+. Navigate to the `cluster-manifests` directory:
++
+[source,terminal]
+----
+$ cd <installation_directory>/cluster-manifests
+----
+
+. Configure the manifest files in the `cluster-manifests` directory.
+For sample files, see the "Sample GitOps ZTP custom resources" section.
+
+. Disconnected clusters: If you did not define mirror configuration in the `install-config.yaml` file before generating the ZTP manifests, perform the following steps:
+
+.. Navigate to the `mirror` directory:
++
+[source,terminal]
+----
+$ cd ../mirror
+----
+
+.. Configure the manifest files in the `mirror` directory.


### PR DESCRIPTION
[OSDOCS-7517](https://issues.redhat.com/browse/OSDOCS-7517) 

Versions: 4.14+

This PR better documents how to perform an Agent-based Installation using ZTP manifests. The manifests have been [advertised in the docs](https://docs.openshift.com/container-platform/4.14/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.html#:~:text=Optional%3A%20ZTP%20manifests) and [samples are provided](https://docs.openshift.com/container-platform/4.14/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html#sample-ztp-custom-resources_installing-with-agent-based-installer), but a formal procedure would also be useful to users.

This can also be backported to 4.13 once the procedure is finalized.

QE review:
- [x] QE has approved this change.

Preview: [Optional: Using ZTP manifests](https://63873--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-ztp_installing-with-agent-based-installer)
