### PR TITLE
[OSDOCS-7196]: Adding TP docs for etcd tuning parameters

### DIFF
--- a/modules/etcd-tuning-parameters.adoc
+++ b/modules/etcd-tuning-parameters.adoc
@@ -1,0 +1,144 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc
+
+:_content-type: PROCEDURE
+[id="etcd-tuning-parameters_{context}"]
+= Setting tuning parameters for etcd
+
+You can set the control plane hardware speed to `"Standard"`, `"Slower"`, or the default, which is `""`.
+
+The default setting allows the system to decide which speed to use. This value enables upgrades from versions where this feature does not exist, as the system can select values from previous versions.
+
+By selecting one of the other values, you are overriding the default. If you see many leader elections due to timeouts or missed heartbeats and your system is set to `""` or `"Standard"`, set the hardware speed to `"Slower"` to make the system more tolerant to the increased latency.
+
+:FeatureName: Tuning etcd latency tolerances
+include::snippets/technology-preview.adoc[]
+
+[id="etcd-changing-hardware-speed-tolerance_{context}"]
+== Changing hardware speed tolerance
+
+To change the hardware speed tolerance for etcd, complete the following steps.
+
+.Procedure
+
+. Check to see what the current value is by entering the following command:
++
+[source, terminal]
+----
+$ oc describe etcd/cluster | grep "Control Plane Hardware Speed"
+----
++
+.Example output
+[source,terminal]
+----
+Control Plane Hardware Speed:  <VALUE>
+----
++
+[NOTE]
+====
+If the output is empty, the field has not been set and should be considered as the default ("").
+====
+
+. Change the value by entering the following command. Replace `<value>` with one of the valid values: `""`, `"Standard"`, or `"Slower"`:
++
+[source,terminal]
+----
+oc patch etcd/cluster --type=merge -p '{"spec": {"controlPlaneHardwareSpeed": "<value>"}}'
+----
++
+The following table indicates the heartbeat interval and leader election timeout for each profile. These values are subject to change.
++
+|===
+| Profile | ETCD_HEARTBEAT_INTERVAL | ETCD_LEADER_ELECTION_TIMEOUT
+| `""` | Varies depending on platform | Varies depending on platform
+| `Standard` | 100 | 1000
+| `Slower` | 500 | 2500
+|===
+
+. Review the output:
++
+.Example output
+[source,terminal]
+----
+etcd.operator.openshift.io/cluster patched
+----
++
+If you enter any value besides the valid values, error output is displayed. For example, if you entered `"Faster"` as the value, the output is as follows:
++
+.Example output
+[source,terminal]
+----
+The Etcd "cluster" is invalid: spec.controlPlaneHardwareSpeed: Unsupported value: "Faster": supported values: "", "Standard", "Slower"
+----
+
+. Verify that the value was changed by entering the following command:
++
+[source, terminal]
+----
+$ oc describe etcd/cluster | grep "Control Plane Hardware Speed"
+----
++
+.Example output
+[source,terminal]
+----
+Control Plane Hardware Speed:  ""
+----
+
+. Force an etcd rollout, which restarts all etcd pods one at a time to pick up the new values, by entering the following command:
++
+[source,terminal]
+----
+$ oc patch etcd/cluster --type=merge -p '{"spec": {"forceRedeploymentReason": "hardwareSpeedChange-'"$( date --rfc-3339=ns )"'"}}'
+----
++
+.Example output
+[source,terminal]
+----
+etcd.operator.openshift.io/cluster patched
+----
+
+. Wait for etcd pods to roll out:
++
+[source,terminal]
+----
+oc get pods -n openshift-etcd -w
+----
++
+The following output shows the expected entries for master-0. Before you continue, wait until all masters show a status of `4/4 Running`.
++
+.Example output
+[source,terminal]
+----
+installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Pending             0          0s
+installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Pending             0          0s
+installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     ContainerCreating   0          0s
+installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     ContainerCreating   0          1s
+installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           1/1     Running             0          2s
+installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Completed           0          34s
+installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Completed           0          36s
+installer-9-ci-ln-qkgs94t-72292-9clnd-master-0           0/1     Completed           0          36s
+etcd-guard-ci-ln-qkgs94t-72292-9clnd-master-0            0/1     Running             0          26m
+etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  4/4     Terminating         0          11m
+etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  4/4     Terminating         0          11m
+etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  0/4     Pending             0          0s
+etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  0/4     Init:1/3            0          1s
+etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  0/4     Init:2/3            0          2s
+etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  0/4     PodInitializing     0          3s
+etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  3/4     Running             0          4s
+etcd-guard-ci-ln-qkgs94t-72292-9clnd-master-0            1/1     Running             0          26m
+etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  3/4     Running             0          20s
+etcd-ci-ln-qkgs94t-72292-9clnd-master-0                  4/4     Running             0          20s
+----
+
+. Enter the following command to review to the values:
++
+[source,terminal]
+----
+$ oc describe -n openshift-etcd pod/<ETCD_PODNAME> | grep -e HEARTBEAT_INTERVAL -e ELECTION_TIMEOUT
+----
++
+[NOTE]
+====
+These values might not have changed from the default.
+====

--- a/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices.adoc
@@ -22,3 +22,5 @@ include::modules/move-etcd-different-disk.adoc[leveloffset=+1]
 * link:https://docs.openshift.com/container-platform/4.11/architecture/architecture-rhcos.html[Red Hat Enterprise Linux CoreOS (RHCOS)]
 
 include::modules/etcd-defrag.adoc[leveloffset=+1]
+
+include::modules/etcd-tuning-parameters.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7196
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63875--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices#etcd-tuning-parameters_recommended-etcd-practices
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: These docs cover a feature that will be Technology Preview for 4.14.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
