### PR TITLE
OSDOCS-7068: Conceptual info for cgroup v2 as new 4.14  default

### DIFF
--- a/nodes/clusters/nodes-cluster-cgroups-2.adoc
+++ b/nodes/clusters/nodes-cluster-cgroups-2.adoc
@@ -6,9 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-By default, {product-title} uses  link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1.html[Linux control group version 1] (cgroup v1) in your cluster. You can switch to link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2), if needed, by editing the `node.config` object. Enabling cgroup v2 in {product-title} disables all cgroup version 1 controllers and hierarchies in your cluster. 
+By default, {product-title} uses link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v2.html[Linux control group version 2] (cgroup v2) in your cluster. You can switch to link:https://www.kernel.org/doc/html/latest/admin-guide/cgroup-v1/index.html[Linux control group version 1] (cgroup v1), if needed, by editing the `node.config` object. Enabling cgroup v1 in {product-title} disables all cgroup version 2 controllers and hierarchies in your cluster. 
 
-cgroup v2 is the next version of the Linux cgroup API. cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information], and enhanced resource management and isolation. 
+cgroup v2 offers several improvements over cgroup v1, including a unified hierarchy, safer sub-tree delegation, new features (such as link:https://www.kernel.org/doc/html/latest/accounting/psi.html[Pressure Stall Information]), and enhanced resource management and isolation. 
 
 // The following include statements pull in the module files that comprise
 // the assembly. Include any combination of concept, procedure, or reference


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS-7068](https://issues.redhat.com//browse/OSDOCS-7068)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://63876--docspreview.netlify.app/openshift-enterprise/latest/nodes/clusters/nodes-cluster-cgroups-2#nodes-clusters-cgroups-2
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Prior to 4.14, cgroup v1 has been the default Linux cgroup API. Beginning with 4.14, cgroup v2 will be the default.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
