### PR TITLE
OSDOCS-6913: Cleaned up some extra typos

### DIFF
--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -69,7 +69,7 @@ The ROSA with Hosted Control Planes functionality is currently offered as a Tech
 |Specify the IP address range for services. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `172.30.0.0/16`. It is recommended that the address ranges are the same between clusters.
 
 |`Pod CIDR`
-|Specify the IP address range for pods. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `10.128.0.0/14`. It is recommended that they are the same between clusters.
+|Specify the IP address range for pods. The range must be large enough to accommodate your workload. The address block must not overlap with any external service accessed from within the cluster. The default is `10.128.0.0/14`. It is recommended that the address ranges are the same between clusters.
 
 |`Install into an existing VPC (optional)`
 |Install a cluster into an existing AWS VPC. To use this option, your VPC must have 2 subnets for each availability zone that you are installing the cluster into. The default is `No`.
@@ -117,7 +117,7 @@ By enabling etcd encryption for the key values in etcd, you will incur a perform
 |Disable monitoring for user-defined projects. Monitoring for user-defined projects is enabled by default.
 
 |`Route Selector for ingress (optional)`
-|Specify the route selector for your ingress. The format should be a comma-separated list of `key=value`. If you do not specify a label, all routes will be exposed on both routers. For legacy ingress support, these labels are inclusion labels; otherwise, they are treated as exclusion label.
+|Specify the route selector for your ingress. The format should be a comma-separated list of key-value pairs. If you do not specify a label, all routes will be exposed on both routers. For legacy ingress support, these labels are inclusion labels; otherwise, they are treated as exclusion labels.
 
 |`Excluded namespaces for ingress (optional)`
 |Specify the excluded namespaces for your ingress. The format should be a comma-separated list `value1, value2...`. If you do not specify any values, all namespaces will be exposed.


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-6913](https://issues.redhat.com/browse/OSDOCS-6913)

Link to docs preview:
* [Interactive Creation Options](https://63877--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference#rosa-sts-interactive-cluster-creation-mode-options_rosa-sts-interactive-mode-reference)
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/37cc1180-d293-444f-95e1-12b322001bfd)
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/417de826-2f3c-4011-a79a-b44eb48ab359)
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/9431071e-5d22-4fe9-97bd-0898eca71c6e)
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/762e0c27-ddf6-4a44-955a-419c49bc63ba)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Cleaned up some typos from a previous PR.