### PR TITLE
Begins work for non-OVN managed networks on egress IPs

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -149,6 +149,57 @@ On Azure, the following capacity limits exist for IP address assignment:
 
 For more information, see link:https://docs.microsoft.com/en-us/azure/azure-resource-manager/management/azure-subscription-service-limits?toc=/azure/virtual-network/toc.json#networking-limits[Networking limits].
 
+[id="nw-egress-ips-multi-nic-considerations_{context}"]
+== Considerations for using an egress IP on additional network interfaces
+
+:FeatureName: Using an egress IP on additional network interfaces
+include::snippets/technology-preview.adoc[]
+
+In {product-title}, egress IPs provide administrators a way to control network traffic. Egress IPs can be used with the `br-ex`, or primary, network interface, which is a Linux bridge interface associated with Open vSwitch, or they can be used with additional network interfaces. 
+
+You can inspect your network interface type by running the following command:
+
+[source,terminal]
+----
+$ ip -details link show
+----
+
+The primary network interface is assigned a node IP address which also contains a subnet mask. Information for this node IP address can be retrieved from the Kubernetes node object for each node within your cluster by inspecting the `k8s.ovn.org/node-primary-ifaddr` annotation. In an IPv4 cluster, this annotation is similar to the following example: `"k8s.ovn.org/node-primary-ifaddr: {"ipv4":"192.168.111.23/24"}"`.
+
+If the egress IP is not within the subnet of the primary network interface subnet, you can use an egress IP on another Linux network interface that is not of the primary network interface type. By doing so, {product-title} administrators are provided with a greater level of control over networking aspects such as routing, addressing, segmentation, and security policies. This feature provides users with the option to route workload traffic over specific network interfaces for purposes such as traffic segmentation or meeting specialized requirements.
+
+If the egress IP is not within the subnet of the primary network interface, then the selection of another network interface for egress traffic might occur if they are present on a node. 
+
+You can determine which other network interfaces might support egress IPs by inspecting the `k8s.ovn.org/host-cidrs` Kubernetes node annotation. This annotation contains the addresses and subnet mask found for the primary network interface. It also contains additional network interface addresses and subnet mask information. These addresses and subnet masks are assigned to network interfaces that use the link:https://networklessons.com/cisco/ccna-200-301/longest-prefix-match-routing[longest prefix match routing] mechanism to determine which network interface supports the egress IP. 
+
+[NOTE]
+====
+OVN-Kubernetes provides a mechanism to control and direct outbound network traffic from specific namespaces and pods. This ensures that it exits the cluster through a particular network interface and with a specific egress IP address.
+====
+
+[discrete]
+[id="nw-egress-ips-multi-nic-requirements_{context}"]
+=== Requirements for assigning an egress IP to a network interface that is not the primary network interface
+
+For users who want an egress IP and traffic to be routed over a particular interface that is not the primary network interface, the following conditions must be met:
+
+* {product-title} is installed on a bare metal cluster. This feature is disabled within cloud or hypervisor environments.
+
+* Your {product-title} pods are not configured as host-networked.
+
+* If a network interface is removed or if the IP address and subnet mask which allows the egress IP to be hosted on the interface is removed, then the egress IP is reconfigured. Consequently, it could be assigned to another node and interface.
+
+* The Egress IP must be IPv4. IPv6 is currently unsupported.
+
+* IP forwarding must be enabled for the network interface. To enable IP forwarding, you can set `ipForwarding: Global` in your `config.yaml` file, for example:
++
+[source,yaml]
+----
+# ...
+ipForwarding: Global
+# ...
+----
+
 ifdef::openshift-sdn[]
 [id="nw-egress-ips-limitations_{context}"]
 == Limitations


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-6183

Link to docs preview:
https://63879--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn#nw-egress-ips-multi-nic-considerations_configuring-egress-ips-ovn

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
