### PR TITLE
OCPBUGS#9939: agent-config typo

### DIFF
--- a/modules/agent-install-networking.adoc
+++ b/modules/agent-install-networking.adoc
@@ -14,7 +14,7 @@ In addition to static IP addresses, you can apply any network configuration that
 
 == DHCP
 
-.Preferred method: `install-config.yaml` and `agent.config.yaml`
+.Preferred method: `install-config.yaml` and `agent-config.yaml`
 
 You must specify the value for the `rendezvousIP` field. The `networkConfig` fields can be left blank:
 
@@ -32,7 +32,7 @@ rendezvousIP: 192.168.111.80 <1>
 
 == Static networking
 
-.. Preferred method: `install-config.yaml` and `agent.config.yaml`
+.. Preferred method: `install-config.yaml` and `agent-config.yaml`
 
 +
 .Sample agent-config.yaml.file

--- a/modules/agent-installer-configuring-fips-compliance.adoc
+++ b/modules/agent-installer-configuring-fips-compliance.adoc
@@ -10,7 +10,7 @@
 
 During a cluster deployment, the Federal Information Processing Standards (FIPS) change is applied when the Red Hat Enterprise Linux CoreOS (RHCOS) machines are deployed in your cluster. For Red Hat Enterprise Linux (RHEL) machines, you must enable FIPS mode when you install the operating system on the machines that you plan to use as worker machines.
 
-You can enable FIPS mode through the preferred method of `install-config.yaml` and `agent.config.yaml`:
+You can enable FIPS mode through the preferred method of `install-config.yaml` and `agent-config.yaml`:
 
 . You must set value of the `fips` field to `True` in the `install-config.yaml` file:
 +


### PR DESCRIPTION
[OCPBUGS-9939](https://issues.redhat.com/browse/OCPBUGS-9939)

Versions: 4.12+

This PR fixes a typo where `agent-config.yaml` was misspelled as `agent.config.yaml`

No QE needed.

Preview:

- [Configuring FIPS through the Agent-based Installer](https://63880--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#agent-installer-configuring-fips-compliance_preparing-to-install-with-agent-based-installer)
- [About networking](https://63880--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#agent-install-networking_preparing-to-install-with-agent-based-installer)
