### PR TITLE
Fixing missing FIPS admonitions for 4.12 GCP

### DIFF
--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -220,7 +220,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64`, `ppc64le`, and `s390x` architectures.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64`, `ppc64le`, and `s390x` architectures.
 ====
 <13> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
@@ -234,7 +234,7 @@ ifndef::openshift-origin[]
 +
 [IMPORTANT]
 ====
-The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64`, `ppc64le`, and `s390x` architectures.
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64`, `ppc64le`, and `s390x` architectures.
 ====
 <9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]


### PR DESCRIPTION
Adding 2 missing FIPS admonitions to GCP 4.12 docs. Previously, the content was only added inside a conditional for the GCP existing VPC assembly. This update adds the content to all GCP assemblies.

Version(s):
4.12

Link to docs preview:
[GCP install with customizations](https://bscott-rh.github.io/openshift-docs/fixing-fips-4.12-gcp-preview/installing/installing_gcp/installing-gcp-customizations.html#installation-gcp-config-yaml_installing-gcp-customizations)
[GCP install with network customizations](https://bscott-rh.github.io/openshift-docs/fixing-fips-4.12-gcp-preview/installing/installing_gcp/installing-gcp-network-customizations.html#installation-gcp-config-yaml_installing-gcp-network-customizations)
[GCP install on restricted network](https://bscott-rh.github.io/openshift-docs/fixing-fips-4.12-gcp-preview/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.html#installation-gcp-config-yaml_installing-restricted-networks-gcp-installer-provisioned)
[private GCP install](https://bscott-rh.github.io/openshift-docs/fixing-fips-4.12-gcp-preview/installing/installing_gcp/installing-gcp-private.html#installation-gcp-config-yaml_installing-gcp-private)

Received Slack approval from Kirsten Newcomer. Will be processing another 4.12 PR to update additional FIPS language after this PR.