### PR TITLE
[RHACS] Updated version number for 4.2 release

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -53,10 +53,10 @@ endif::[]
 :osp: Red Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.1.2
+:rhacs-version: 4.2.0
 :ocp-supported-version: 4.10
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
-:product-version: 4.1
+:product-version: 4.2
 :product-title-short: RHACS
 :product-title-managed: Red Hat Advanced Cluster Security Cloud Service
 :product-title-managed-short: RHACS Cloud Service


### PR DESCRIPTION
Updated version number for 4.2 release.

Cherry pick into `rhacs-docs-4.2`