### PR TITLE
RHDEVDOCS-5511: Authenticating build images

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -13,5 +13,7 @@ Topics:
   File: configuring-openshift-builds
 - Name: Configuring build runs
   File: configuring-build-runs
+- Name: Authenticating build images
+  File: authenticating-build-images
 - Name: Uninstalling OpenShift Builds
   File: uninstalling-openshift-builds

--- a/builds/authenticating-build-images.adoc
+++ b/builds/authenticating-build-images.adoc
@@ -1,0 +1,34 @@
+:_content-type: ASSEMBLY
+[id="authenticating-build-images"]
+= Authenticating build images 
+include::_attributes/common-attributes.adoc[]
+:context: authenticating-build-images
+
+toc::[]
+
+
+You might need to define authentication when building images. For example, authentication is needed when you push images to a private registry or pull source code from a Git repository. At the time of authentication, you can use your user name and password or secrets, which store the required sensitive data.
+
+For authentication during an image build, you can configure basic or SSH authentication along with secrets in your `Build` custom resource (CR).
+
+
+
+include::modules/ob-build-secret-annotation.adoc[leveloffset=+1]
+
+include::modules/ob-authentication-to-git-repositories.adoc[leveloffset=+1]
+
+include::modules/ob-basic-authentication.adoc[leveloffset=+2]
+
+include::modules/ob-ssh-authentication.adoc[leveloffset=+2]
+
+include::modules/ob-usage-of-git-secret.adoc[leveloffset=+2]
+
+include::modules/ob-authentication-to-container-registries.adoc[leveloffset=+1]
+
+include::modules/ob-role-based-access-control.adoc[leveloffset=+1]
+
+
+
+
+// [role="_additional-resources"]
+// == Additional resources

--- a/modules/ob-authentication-to-container-registries.adoc
+++ b/modules/ob-authentication-to-container-registries.adoc
@@ -1,0 +1,47 @@
+// This module is included in the following assembly:
+//
+// builds/authenticating-build-images.adoc
+
+:_content-type: PROCEDURE
+[id="ob-authentication-to-container-registries_{context}"]
+= Authentication to container registries
+
+To push images to a private container registry, you must define a secret in the respective namespace and then reference it in your `Build` custom resource (CR).
+
+
+.Procedure
+. Run the following command to generate a secret:
++
+[source,terminal]
+----
+$ oc --namespace <namespace> create secret docker-registry <container_registry_secret_name> \
+  --docker-server=<registry_host> \ <1>
+  --docker-username=<username> \ <2>
+  --docker-password=<password> \ <3>
+  --docker-email=<email_address>
+---- 
+<1> The `<registry_host>` value denotes the URL in this format `\https://<registry_server>/<registry_host>`.
+<2> The `<username>` value is the user ID.
+<3> The `<password>` value can be your container registry password or an access token.
+
+. Run the following command to annotate the secret:
++
+[source,terminal]
+----
+$ oc --namespace <namespace> annotate secrets <container_registry_secret_name> build.shipwright.io/referenced.secret='true'
+---- 
+
+. Set the value of the `spec.output.pushSecret` field to the secret name in your `Build` CR:
++
+[source,yaml]
+----
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: buildah-golang-build
+  # ...
+  output:
+    image: <path_to_image> 
+    pushSecret: <container_registry_secret_name>
+----
+

--- a/modules/ob-authentication-to-git-repositories.adoc
+++ b/modules/ob-authentication-to-git-repositories.adoc
@@ -1,0 +1,15 @@
+// This module is included in the following assembly:
+//
+// builds/authenticating-build-images.adoc
+
+:_content-type: CONCEPT
+[id="ob-authentication-to-git-repositories_{context}"]
+= Authentication to Git repositories
+
+You can define the following types of authentication for a Git repository:
+
+* Basic authentication
+* Secure Shell (SSH) authentication
+
+You can also configure Git secrets with both types of authentication in your `Build` CR.
+

--- a/modules/ob-basic-authentication.adoc
+++ b/modules/ob-basic-authentication.adoc
@@ -1,0 +1,25 @@
+// This module is included in the following assembly:
+//
+// builds/authenticating-build-images.adoc
+
+:_content-type: REFERENCE
+[id="ob-basic-authentication_{context}"]
+= Basic authentication
+
+With basic authentication, you must configure the user name and password of the Git repository. The following example shows the usage of basic authentication for Git:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-git-basic-auth
+  annotations:
+    build.shipwright.io/referenced.secret: "true"
+type: kubernetes.io/basic-auth <1>
+stringData: <2>
+  username: <cleartext_username>
+  password: <cleartext_password>
+----
+<1> The type of the Kubernetes secret.
+<2> The field to store your user name and password in clear text.

--- a/modules/ob-build-secret-annotation.adoc
+++ b/modules/ob-build-secret-annotation.adoc
@@ -1,0 +1,27 @@
+// This module is included in the following assembly:
+//
+// builds/authenticating-build-images.adoc
+
+:_content-type: CONCEPT
+[id="ob-build-secret-annotation_{context}"]
+= Build secret annotation
+
+You can add an annotation `build.shipwright.io/referenced.secret: "true"` to a build secret. Based on this annotation, the build controller takes a reconcile action when an event, such as create, update, or delete triggers for the build secret. The following example shows the usage of an annotation with a secret:
+
+[source,yaml]
+----
+apiVersion: v1
+data:
+  .dockerconfigjson: <pull_secret> <1>
+kind: Secret
+metadata:
+  annotations:
+    build.shipwright.io/referenced.secret: "true" <2>
+  name: secret-docker
+type: kubernetes.io/dockerconfigjson
+----
+<1> Base64-encoded pull secret.
+<2> The value of the `build.shipwright.io/referenced.secret` annotation is set to `true`.
+
+This annotation filters secrets which are not referenced in a build instance. For example, if a secret does not have this annotation, the build controller does not reconcile even if the event is triggered for the secret. Reconciling on triggering of events allows the build controller to re-trigger validations on the build configuration, helping you to understand if a dependency is missing.
+

--- a/modules/ob-defining-the-build-specification.adoc
+++ b/modules/ob-defining-the-build-specification.adoc
@@ -25,7 +25,7 @@ spec:
         kind: ClusterBuildStrategy
         name: buildpacks-v3
       output:
-        image: foo/bar:latest
+        image: <path_to_image> 
 ----
 
 [NOTE] 

--- a/modules/ob-role-based-access-control.adoc
+++ b/modules/ob-role-based-access-control.adoc
@@ -1,0 +1,14 @@
+// This module is included in the following assembly:
+//
+// builds/authenticating-build-images.adoc
+
+:_content-type: CONCEPT
+[id="ob-role-based-access-control_{context}"]
+= Role-based access control
+
+The release deployment YAML file includes two cluster-wide roles for using {builds-shortname} objects. The following roles are installed by default:
+
+* `shpwright-build-aggregate-view`: Grants you read access to the {builds-shortname} resources, such as `BuildStrategy`, `ClusterBuildStrategy`, `Build`, and `BuildRun`. This role is aggregated to the Kubernetes `view` role.
+* `shipwright-build-aggregate-edit`: Grants you write access to the {builds-shortname} resources that are configured at namespace level. The build resources include `BuildStrategy`, `Build`, and `BuildRun`. Read access is granted to all `ClusterBuildStrategy` resources. This role is aggregated to the Kubernetes `edit` and `admin` roles.
+
+Only cluster administrators have write access to the `ClusterBuildStrategy` resources. You can change this setting by creating a separate Kubernetes `ClusterRole` role with these permissions and binding the role to appropriate users.

--- a/modules/ob-ssh-authentication.adoc
+++ b/modules/ob-ssh-authentication.adoc
@@ -1,0 +1,28 @@
+// This module is included in the following assembly:
+//
+// builds/authenticating-build-images.adoc
+
+:_content-type: CONCEPT
+[id="ob-ssh-authentication_{context}"]
+= SSH authentication
+
+With SSH authentication, you must configure the Tekton annotations to specify the hostname of the Git repository provider for use. For example, `github.com` for GitHub or `gitlab.com` for GitLab.
+
+The following example shows the usage of SSH authentication for Git:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: secret-git-ssh-auth
+  annotations:
+    build.shipwright.io/referenced.secret: "true"
+type: kubernetes.io/ssh-auth <1>
+data:
+  ssh-privatekey: |   <2>
+    # Insert ssh private key, base64 encoded
+----
+<1> The type of the Kubernetes secret.
+<2> Base64 encoding of the SSH key used to authenticate into Git. You can generate this key by using the `base64 ~/.ssh/id_rsa.pub` command, where `~/.ssh/id_rsa.pub` denotes the default location of the key that is generally used to authenticate to Git.
+ 

--- a/modules/ob-usage-of-git-secret.adoc
+++ b/modules/ob-usage-of-git-secret.adoc
@@ -1,0 +1,40 @@
+// This module is included in the following assembly:
+//
+// builds/authenticating-build-images.adoc
+
+:_content-type: CONCEPT
+[id="ob-usage-of-git-secret_{context}"]
+= Usage of Git secret
+
+After creating a secret in the relevant namespace, you can reference it in your `Build` Custom Resource (CR). You can configure a Git secret with both types of authentication.
+
+The following example shows the usage of a Git secret with SSH authentication type:
+
+[source,yaml]
+----
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: buildah-golang-build
+spec:
+  source:
+    git:
+      url: git@gitlab.com:userjohn/newtaxi.git
+      cloneSecret: secret-git-ssh-auth
+----
+
+The following example shows the usage of a Git secret with basic authentication type:
+
+[source,yaml]
+----
+apiVersion: shipwright.io/v1beta1
+kind: Build
+metadata:
+  name: buildah-golang-build
+spec:
+  source:
+    git:
+      url: https://gitlab.com/userjohn/newtaxi.git
+      cloneSecret: secret-git-basic-auth
+----
+


### PR DESCRIPTION
**Purpose**: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-5511

**Aligned team**: DevTools

**Version for cherrypicking**: build-docs-1.0

**Content for preview**: https://63890--docspreview.netlify.app/openshift-builds/latest/builds/authenticating-build-images

**SME review**:  @apoorvajagtap @jkhelil @coreydaley @divyansh42 

**QE review**:  @jitendar-singh 

**Peer review**: @nalhadef 