### PR TITLE
ROX18664: Removed TP for the new collection Method

### DIFF
--- a/modules/secured-cluster-configuration-options-operator.adoc
+++ b/modules/secured-cluster-configuration-options-operator.adoc
@@ -172,7 +172,6 @@ The default value is `EBPF`.
 Red Hat recommends using `EBPF` for data collection.
 If you select `NoCollection`, Collector does not report any information about the network activity and the process executions.
 Available options are `NoCollection`, `EBPF`, and `CORE_BPF`.
-The `CORE_BPF` collection method is a Technology Preview feature only.
 
 | `perNode.collector.imageFlavor`
 | The image type to use for Collector. You can specify it as `Regular` or `Slim`.
@@ -192,9 +191,6 @@ If you use the `Slim` image type, you must ensure that your Central instance is 
 | Use this parameter to override the default resource limits for Compliance.
 
 |===
-
-:FeatureName: The `CORE_BPF` collection method
-include::snippets/technology-preview.adoc[]
 
 [id="taint-tolerations-settings_{context}"]
 == Taint Tolerations settings

--- a/modules/secured-cluster-services-config.adoc
+++ b/modules/secured-cluster-services-config.adoc
@@ -70,7 +70,6 @@
 
 | `collector.collectionMethod`
 | Either `EBPF`, `CORE_BPF`, or `NO_COLLECTION`.
-The `CORE_BPF` collection method is a Technology Preview feature only.
 
 | `collector.imagePullPolicy`
 | Image pull policy for the Collector container.
@@ -270,9 +269,6 @@ Otherwise, you must ensure that Central can access the online probe repository h
 | The CPU limit for the Scanner DB container. Use this parameter to override the default value.
 
 |===
-
-:FeatureName: The `CORE_BPF` collection method
-include::snippets/technology-preview.adoc[]
 
 [id="secured-cluster-services-environment-variables_{context}"]
 == Environment variables


### PR DESCRIPTION
Version(s): 4.2+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [ROX-18664](https://issues.redhat.com/browse/ROX-18664)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Preview 1](https://63891--docspreview.netlify.app/openshift-acs/latest/installing/installing_other/install-secured-cluster-other#secured-cluster-services-config_install-secured-cluster-other)- Check the table for collection method.

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review not necessary.

SME review:
- [x] SME has approved the changes. 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Needs to be cherry-picked into rhacs-docs-4.2
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
