### PR TITLE
RHDEVDOCS_5358 add gitops distro to main build

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -293,3 +293,16 @@ openshift-serverless:
     serverless-docs-1.29:
       name: '1.29'
       dir: serverless/1.29
+openshift-gitops:
+  name: Red Hat OpenShift GitOps
+  author: OpenShift documentation team <openshift-docs@redhat.com>
+  site: commercial
+  site_name: Documentation
+  site_url: https://docs.openshift.com/
+  branches:
+    gitops-docs-1.8:
+      name: '1.8'
+      dir: gitops/1.8
+    gitops-docs-1.9:
+      name: '1.9'
+      dir: gitops/1.9


### PR DESCRIPTION

Version(s):
main only

Issue:
[RHDEVDOCS-5358](https://issues.redhat.com//browse/RHDEVDOCS-5358)

Link to docs preview:
N/A

Additional information:
Try building standalone GitOps content on d.o.c
