### PR TITLE
[OSDOCS-3987] OCP content port to ROSA and OSD: Images

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -331,6 +331,59 @@ Topics:
     File: setting-up-trusted-ca
     Distros: openshift-dedicated
 ---
+Name: Images
+Dir: openshift_images
+Distros: openshift-dedicated
+Topics:
+- Name: Overview of images
+  File: index
+# replaced Configuring the Cluster Samples Operator name, cannot configure the operator
+- Name: Overview of the Cluster Samples Operator
+  File: configuring-samples-operator
+  Distros: openshift-dedicated
+- Name: Using the Cluster Samples Operator with an alternate registry
+  File: samples-operator-alt-registry
+  Distros: openshift-dedicated
+- Name: Creating images
+  File: create-images
+- Name: Managing images
+  Dir: managing_images
+  Topics:
+  - Name: Managing images overview
+    File: managing-images-overview
+  - Name: Tagging images
+    File: tagging-images
+  - Name: Image pull policy
+    File: image-pull-policy
+  - Name: Using image pull secrets
+    File: using-image-pull-secrets
+- Name: Managing image streams
+  File: image-streams-manage
+  Distros: openshift-dedicated
+- Name: Using image streams with Kubernetes resources
+  File: using-imagestreams-with-kube-resources
+  Distros: openshift-dedicated
+- Name: Triggering updates on image stream changes
+  File: triggering-updates-on-imagestream-changes
+  Distros: openshift-dedicated
+- Name: Image configuration resources
+  File: image-configuration
+  Distros: openshift-dedicated
+- Name: Using templates
+  File: using-templates
+- Name: Using Ruby on Rails
+  File: templates-using-ruby-on-rails
+- Name: Using images
+  Dir: using_images
+  Distros: openshift-dedicated
+  Topics:
+  - Name: Using images overview
+    File: using-images-overview
+  - Name: Source-to-image
+    File: using-s21-images
+  - Name: Customizing source-to-image images
+    File: customizing-s2i-images
+---
 Name: Add-on services
 Dir: adding_service_cluster
 Distros: openshift-dedicated

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -485,6 +485,59 @@ Topics:
     File: setting-up-trusted-ca
     Distros: openshift-rosa
 ---
+Name: Images
+Dir: openshift_images
+Distros: openshift-rosa
+Topics:
+- Name: Overview of images
+  File: index
+# replaced Configuring the Cluster Samples Operator name, cannot configure the operator
+- Name: Overview of the Cluster Samples Operator
+  File: configuring-samples-operator
+  Distros: openshift-rosa
+- Name: Using the Cluster Samples Operator with an alternate registry
+  File: samples-operator-alt-registry
+  Distros: openshift-rosa
+- Name: Creating images
+  File: create-images
+- Name: Managing images
+  Dir: managing_images
+  Topics:
+  - Name: Managing images overview
+    File: managing-images-overview
+  - Name: Tagging images
+    File: tagging-images
+  - Name: Image pull policy
+    File: image-pull-policy
+  - Name: Using image pull secrets
+    File: using-image-pull-secrets
+- Name: Managing image streams
+  File: image-streams-manage
+  Distros: openshift-rosa
+- Name: Using image streams with Kubernetes resources
+  File: using-imagestreams-with-kube-resources
+  Distros: openshift-rosa
+- Name: Triggering updates on image stream changes
+  File: triggering-updates-on-imagestream-changes
+  Distros: openshift-rosa
+- Name: Image configuration resources
+  File: image-configuration
+  Distros: openshift-rosa
+- Name: Using templates
+  File: using-templates
+- Name: Using Ruby on Rails
+  File: templates-using-ruby-on-rails
+- Name: Using images
+  Dir: using_images
+  Distros: openshift-rosa
+  Topics:
+  - Name: Using images overview
+    File: using-images-overview
+  - Name: Source-to-image
+    File: using-s21-images
+  - Name: Customizing source-to-image images
+    File: customizing-s2i-images
+---
   Name: Add-on services
   Dir: adding_service_cluster
   Distros: openshift-rosa

--- a/modules/images-configuration-allowed.adoc
+++ b/modules/images-configuration-allowed.adoc
@@ -18,7 +18,12 @@ When the `allowedRegistries` parameter is defined, all registries, including the
 
 .Procedure
 
-. Edit the `image.config.openshift.io/cluster` CR:
+ifndef::openshift-rosa,openshift-dedicated[]
+. Edit the `image.config.openshift.io/cluster` custom resource:
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Edit the `image.config.openshift.io/cluster` custom resource:
+endif::openshift-rosa,openshift-dedicated[]
 +
 [source,terminal]
 ----
@@ -61,7 +66,9 @@ Either the `allowedRegistries` parameter or the `blockedRegistries` parameter ca
 +
 The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, the allowed registries list is used to update the image signature policy in the `/host/etc/containers/policy.json` file on each node.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 . To check that the registries have been added to the policy file, use the following command on a node:
+// cannot create resource "namespaces"
 +
 [source,terminal]
 ----
@@ -157,6 +164,7 @@ The following policy indicates that only images from the example.com, quay.io, a
 }
 ----
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 [NOTE]
 ====

--- a/modules/images-configuration-blocked.adoc
+++ b/modules/images-configuration-blocked.adoc
@@ -18,7 +18,12 @@ To prevent pod failure, do not add the `registry.redhat.io` and `quay.io` regist
 
 .Procedure
 
-. Edit the `image.config.openshift.io/cluster` CR:
+ifndef::openshift-rosa,openshift-dedicated[]
+. Edit the `image.config.openshift.io/cluster` custom resource:
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Edit the `image.config.openshift.io/cluster` custom resource:
+endif::openshift-rosa,openshift-dedicated[]
 +
 [source,terminal]
 ----
@@ -58,7 +63,9 @@ Either the `blockedRegistries` registry or the `allowedRegistries` registry can 
 +
 The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` resource for any changes to the registries. When the MCO detects a change, it drains the nodes, applies the change, and uncordons the nodes. After the nodes return to the `Ready` state, changes to the blocked registries appear in the `/etc/containers/registries.conf` file on each node.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 . To check that the registries have been added to the policy file, use the following command on a node:
+// cannot create resource "namespaces"
 +
 [source,terminal]
 ----
@@ -77,3 +84,4 @@ unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
   location = "untrusted.com"
   blocked = true
 ----
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/images-configuration-cas.adoc
+++ b/modules/images-configuration-cas.adoc
@@ -40,7 +40,7 @@ data:
 
 You can configure additional CAs with the following procedure.
 
-. To configure an additional CA:
+* To configure an additional CA:
 +
 [source,terminal]
 ----

--- a/modules/images-configuration-insecure.adoc
+++ b/modules/images-configuration-insecure.adoc
@@ -18,7 +18,12 @@ Insecure external registries should be avoided to reduce possible security risks
 
 .Procedure
 
-. Edit the `image.config.openshift.io/cluster` CR:
+ifndef::openshift-rosa,openshift-dedicated[]
+. Edit the `image.config.openshift.io/cluster` custom resource:
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Edit the `image.config.openshift.io/cluster` custom resource:
+endif::openshift-rosa,openshift-dedicated[]
 +
 [source,terminal]
 ----
@@ -66,7 +71,9 @@ When the `allowedRegistries` parameter is defined, all registries, including the
 +
 The Machine Config Operator (MCO) watches the `image.config.openshift.io/cluster` CR for any changes to the registries, then drains and uncordons the nodes when it detects changes. After the nodes return to the `Ready` state, changes to the insecure and blocked registries appear in the `/etc/containers/registries.conf` file on each node.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 . To check that the registries have been added to the policy file, use the following command on a node:
+// cannot create resource "namespaces"
 +
 [source,terminal]
 ----
@@ -85,3 +92,4 @@ unqualified-search-registries = ["registry.access.redhat.com", "docker.io"]
   location = "insecure.com"
   insecure = true
 ----
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/images-configuration-registry-mirror-convert.adoc
+++ b/modules/images-configuration-registry-mirror-convert.adoc
@@ -16,7 +16,12 @@ For more information about `ImageDigestMirrorSet` or `ImageTagMirrorSet` objects
 
 .Prerequisites
 
-* Ensure that you have access to the cluster as a user with the `cluster-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* Access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 * Ensure that you have `ImageContentSourcePolicy` objects on your cluster.
 

--- a/modules/images-configuration-registry-mirror.adoc
+++ b/modules/images-configuration-registry-mirror.adoc
@@ -57,7 +57,12 @@ If your cluster uses an `ImageDigestMirrorSet` or `ImageTagMirrorSet` object to 
 The following procedure creates a postinstallation mirror configuration, where you create an `ImageDigestMirrorSet` object.
 
 .Prerequisites
-* Ensure that you have access to the cluster as a user with the `cluster-admin` role.
+ifndef::openshift-rosa,openshift-dedicated[]
+* Access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 
 * Ensure that there are no `ImageContentSourcePolicy` objects on your cluster. For example, you can use the following command:
 +

--- a/modules/images-configuration-shortname.adoc
+++ b/modules/images-configuration-shortname.adoc
@@ -37,7 +37,12 @@ The `containerRuntimeSearchRegistries` parameter works only with the Podman and 
 
 .Procedure
 
+ifndef::openshift-rosa,openshift-dedicated[]
 . Edit the `image.config.openshift.io/cluster` custom resource:
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Edit the `image.config.openshift.io/cluster` custom resource:
+endif::openshift-rosa,openshift-dedicated[]
 +
 [source,terminal]
 ----
@@ -90,6 +95,7 @@ status:
 When the `allowedRegistries` parameter is defined, all registries, including the `registry.redhat.io` and `quay.io` registries and the default {product-registry}, are blocked unless explicitly listed. If you use this parameter, to prevent pod failure, add all registries including the `registry.redhat.io` and `quay.io` registries and the `internalRegistryHostname` to the `allowedRegistries` list, as they are required by payload images within your environment. For disconnected clusters, mirror registries should also be added.
 ====
 
+ifndef::openshift-rosa,openshift-dedicated[]
 . To check that the registries have been added, when a node returns to the `Ready` state, use the following command on the node:
 +
 [source,terminal]
@@ -102,4 +108,4 @@ $ cat /host/etc/containers/registries.conf.d/01-image-searchRegistries.conf
 ----
 unqualified-search-registries = ['reg1.io', 'reg2.io', 'reg3.io']
 ----
-
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/images-samples-operator-deprecated-image-stream.adoc
+++ b/modules/images-samples-operator-deprecated-image-stream.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * openshift_images/configuring-samples-operator.adoc
+// * openshift_images/configuring-samples-operator.adoc
 
 
 :_mod-docs-content-type: PROCEDURE

--- a/modules/installation-adding-registry-pull-secret.adoc
+++ b/modules/installation-adding-registry-pull-secret.adoc
@@ -43,8 +43,12 @@ This process requires that you have write access to a container image registry o
 endif::restricted[]
 
 .Prerequisites
-
+ifndef::openshift-rosa,openshift-dedicated[]
 * You configured a mirror registry to use in your disconnected environment.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You configured a mirror registry to use.
+endif::openshift-rosa,openshift-dedicated[]
 ifdef::restricted[]
 * You identified an image repository location on your mirror registry to mirror images into.
 * You provisioned a mirror registry account that allows images to be uploaded to that image repository.

--- a/modules/installation-images-samples-disconnected-mirroring-assist.adoc
+++ b/modules/installation-images-samples-disconnected-mirroring-assist.adoc
@@ -11,11 +11,13 @@ During installation, {product-title} creates a config map named `imagestreamtag-
 
 The format of the key for each entry in the data field in the config map is `<image_stream_name>_<image_stream_tag_name>`.
 
+ifndef::openshift-rosa;openshift-dedicated[]
 During a disconnected installation of {product-title}, the status of the Cluster Samples Operator is set to `Removed`. If you choose to change it to `Managed`, it installs samples.
 [NOTE]
 ====
 The use of samples in a network-restricted or discontinued environment may require access to services external to your network. Some example services include: Github, Maven Central, npm, RubyGems, PyPi and others. There might be additional steps to take that allow the cluster samples operators's objects to reach the services they require.
 ====
+endif::openshift-rosa;openshift-dedicated[]
 
 You can use this config map as a reference for which images need to be mirrored for your image streams to import.
 

--- a/modules/installation-mirror-repository.adoc
+++ b/modules/installation-mirror-repository.adoc
@@ -12,8 +12,13 @@ Mirror the {product-title} image repository to your registry to use during clust
 .Prerequisites
 
 * Your mirror host has access to the internet.
+ifndef::openshift-rosa,openshift-dedicated[]
 * You configured a mirror registry to use in your restricted network and
 can access the certificate and credentials that you configured.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* You configured a mirror registry to use.
+endif::openshift-rosa,openshift-dedicated[]
 ifndef::openshift-origin[]
 * You downloaded the {cluster-manager-url-pull} and modified it to include authentication to your mirror repository.
 endif::[]
@@ -125,6 +130,7 @@ $ REMOVABLE_MEDIA_PATH=<path> <1>
 ----
 <1> Specify the full path, including the initial forward slash (/) character.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 . Mirror the version images to the mirror registry:
 ** If your mirror host does not have internet access, take the following actions:
 ... Connect the removable media to a system that is connected to the internet.
@@ -244,10 +250,62 @@ content.
 
 You must perform this step on a machine with an active internet connection.
 ====
-+
+
 . For clusters using installer-provisioned infrastructure, run the following command:
 +
 [source,terminal]
 ----
 $ openshift-install
 ----
+
+endif::openshift-rosa,openshift-dedicated[]
+
+ifdef::openshift-rosa,openshift-dedicated[]
+. Mirror the version images to the mirror registry:
+
+.. Directly push the release images to the local registry by using following command:
++
+[source,terminal]
+----
+$ oc adm release mirror -a ${LOCAL_SECRET_JSON}  \
+     --from=quay.io/${PRODUCT_REPO}/${RELEASE_NAME}:${OCP_RELEASE}-${ARCHITECTURE} \
+     --to=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY} \
+     --to-release-image=${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}
+----
++
+This command pulls the release information as a digest, and its output includes
+the `imageContentSources` data that you require when you install your cluster.
+
+.. Record the entire `imageContentSources` section from the output of the previous
+command. The information about your mirrors is unique to your mirrored repository, and you must add the `imageContentSources` section to the `install-config.yaml` file during installation.
++
+[NOTE]
+====
+The image name gets patched to Quay.io during the mirroring process, and the podman images will show Quay.io in the registry on the bootstrap virtual machine.
+====
+
+. To create the installation program that is based on the content that you
+mirrored, extract it and pin it to the release by running the following command:
++
+[source,terminal]
+----
+$ oc adm release extract -a ${LOCAL_SECRET_JSON} --command=openshift-install "${LOCAL_REGISTRY}/${LOCAL_REPOSITORY}:${OCP_RELEASE}-${ARCHITECTURE}"
+----
++
+[IMPORTANT]
+====
+To ensure that you use the correct images for the version of {product-title}
+that you selected, you must extract the installation program from the mirrored
+content.
+
+You must perform this step on a machine with an active internet connection.
+====
+
+. For clusters using installer-provisioned infrastructure, run the following command:
++
+[source,terminal]
+----
+$ openshift-install
+----
+endif::openshift-rosa,openshift-dedicated[]
+

--- a/modules/installation-restricted-network-samples.adoc
+++ b/modules/installation-restricted-network-samples.adoc
@@ -35,7 +35,12 @@ The Cluster Samples Operator must be set to `Managed` in a disconnected environm
 ====
 
 .Prerequisites
+ifndef::openshift-rosa,openshift-dedicated[]
 * Access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* Access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-rosa,openshift-dedicated[]
 * Create a pull secret for your mirror registry.
 
 .Procedure

--- a/modules/samples-operator-overview.adoc
+++ b/modules/samples-operator-overview.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * openshift_images/configuring_samples_operator.adoc
+// * openshift_images/configuring-samples-operator.adoc
 
 
 :_mod-docs-content-type: CONCEPT
@@ -52,7 +53,10 @@ Certain circumstances result in the Cluster Samples Operator bootstrapping itsel
 
 * If the Cluster Samples Operator cannot reach link:https://registry.redhat.io[registry.redhat.io] after three minutes on initial startup after a clean installation.
 * If the Cluster Samples Operator detects it is on an IPv6 network.
+// cannot configure the Samples Operator
+ifndef::openshift-rosa,openshift-dedicated[]
 * If the xref:../openshift_images/image-configuration.adoc#images-configuration-parameters_image-configuration[image controller configuration parameters] prevent the creation of image streams by using the default image registry, or by using the image registry specified by the xref:../openshift_images/configuring-samples-operator.adoc#samples-operator-configuration_configuring-samples-operator[`samplesRegistry` setting].
+endif::openshift-rosa,openshift-dedicated[]
 
 [NOTE]
 ====
@@ -72,6 +76,8 @@ However, if the Cluster Samples Operator detects that it is on an IPv6 network a
 IPv6 installations are not currently supported by link:https://registry.redhat.io[registry.redhat.io]. The Cluster Samples Operator pulls most of the sample image streams and images from link:https://registry.redhat.io[registry.redhat.io].
 ====
 
+// Restricted network not supported ROSA/OSD 
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="samples-operator-restricted-network-install"]
 === Restricted network installation
 
@@ -96,6 +102,7 @@ spec:
   - x86_64
   managementState: Removed
 ----
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="samples-operator-retries"]
 == Cluster Samples Operator's tracking and error recovery of image stream imports

--- a/openshift_images/configuring-samples-operator.adoc
+++ b/openshift_images/configuring-samples-operator.adoc
@@ -1,15 +1,29 @@
+ifndef::openshift-rosa,openshift-dedicated[]
 :_mod-docs-content-type: ASSEMBLY
 [id="configuring-samples-operator"]
 = Configuring the Cluster Samples Operator
 include::_attributes/common-attributes.adoc[]
 :context: configuring-samples-operator
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+:_mod-docs-content-type: ASSEMBLY
+[id="configuring-samples-operator"]
+= Overview of the Cluster Samples Operator
+include::_attributes/common-attributes.adoc[]
+:context: configuring-samples-operator
+endif::openshift-rosa,openshift-dedicated[]
 
 toc::[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 The Cluster Samples Operator, which operates in the `openshift` namespace, installs and updates the {op-system-base-full}-based {product-title} image streams and {product-title} templates.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+The Cluster Samples Operator, which operates in the `openshift` namespace, installs and updates the {product-title} image streams and {product-title} templates.
+endif::openshift-rosa,openshift-dedicated[]
 
 [IMPORTANT]
-.Cluster Samples Operator is being downsized
+.Cluster Samples Operator is being downsized  
 ====
 * Starting from {product-title} 4.13, Cluster Samples Operator is downsized. Cluster Samples Operator will stop providing the following updates for non-Source-to-Image (Non-S2I) image streams and templates:
 - new image streams and templates
@@ -41,16 +55,25 @@ include::modules/samples-operator-overview.adoc[leveloffset=+1]
 == Additional resources
 
 * If the Cluster Samples Operator is removed during installation, you can xref:../openshift_images/samples-operator-alt-registry.adoc#samples-operator-alt-registry[use the Cluster Samples Operator with an alternate registry] so content can be imported, and then set the Cluster Samples Operator to `Managed` to get the samples.
+// Restricted network not supported ROSA/OSD 
+ifndef::openshift-rosa,openshift-dedicated[]
 * To ensure the Cluster Samples Operator bootstraps as `Removed` in a restricted network installation with initial network access to defer samples installation until you have decided which samples are desired, follow the instructions for xref:../installing/install_config/installing-customizing.adoc#installing-customizing[customizing nodes] to override the Cluster Samples Operator default configuration and initially come up as `Removed`.
 ** To host samples in your disconnected environment, follow the instructions for xref:../openshift_images/samples-operator-alt-registry.adoc#samples-operator-alt-registry[using the Cluster Samples Operator with an alternate registry].
+endif::openshift-rosa,openshift-dedicated[]
 
+// Restricted network not supported ROSA/OSD 
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/installation-images-samples-disconnected-mirroring-assist.adoc[leveloffset=+2]
 
 See xref:../openshift_images/samples-operator-alt-registry.adoc#installation-restricted-network-samples_samples-operator-alt-registry[Using Cluster Samples Operator image streams with alternate or mirrored registries] for a detailed procedure.
+endif::openshift-rosa,openshift-dedicated[]
 
+// cannot patch resource "configs" in API group "samples.operator.openshift.io"
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/samples-operator-configuration.adoc[leveloffset=+1]
 
 include::modules/samples-operator-crd.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/images-samples-operator-deprecated-image-stream.adoc[leveloffset=+1]
 

--- a/openshift_images/image-configuration.adoc
+++ b/openshift_images/image-configuration.adoc
@@ -16,7 +16,10 @@ include::modules/images-configuration-allowed.adoc[leveloffset=+2]
 
 include::modules/images-configuration-blocked.adoc[leveloffset=+2]
 
+// Managed OpenShift customers may not create ImageContentSourcePolicy
+ifndef::openshift-rosa,openshit-dedicated[]
 include::modules/images-configuration-blocked-payload.adoc[leveloffset=+3]
+endif::openshift-rosa,openshit-dedicated[]
 
 include::modules/images-configuration-insecure.adoc[leveloffset=+2]
 
@@ -26,10 +29,12 @@ include::modules/images-configuration-cas.adoc[leveloffset=+2]
 
 include::modules/images-configuration-registry-mirror.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 
 * For more information about global pull secrets, see xref:../openshift_images/managing_images/using-image-pull-secrets.adoc#images-update-global-pull-secret_using-image-pull-secrets[Updating the global cluster pull secret].
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/images-configuration-registry-mirror-convert.adoc[leveloffset=+2]
 

--- a/openshift_images/image-streams-manage.adoc
+++ b/openshift_images/image-streams-manage.adoc
@@ -13,7 +13,9 @@ include::modules/images-imagestream-configure.adoc[leveloffset=+1]
 include::modules/images-using-imagestream-images.adoc[leveloffset=+1]
 include::modules/images-using-imagestream-tags.adoc[leveloffset=+1]
 include::modules/images-using-imagestream-change-triggers.adoc[leveloffset=+1]
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/images-imagestream-mapping.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
 == Working with image streams
 

--- a/openshift_images/index.adoc
+++ b/openshift_images/index.adoc
@@ -14,7 +14,12 @@ An image stream provides a way of storing different versions of the same basic i
 Those different versions are represented by different tags on the same image name.
 
 include::modules/images-about.adoc[leveloffset=+1]
+ifndef::openshift-rosa,openshift-dedicated[]
 You can xref:../openshift_images/create-images.adoc#creating-images[create], xref:../openshift_images/managing_images/managing-images-overview.adoc#managing-images-overview[manage], and xref:../openshift_images/using_images/using-images-overview.adoc#using-images-overview[use] container images.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+You can xref:../openshift_images/create-images.adoc#creating-images[create] and xref:../openshift_images/managing_images/managing-images-overview.adoc#managing-images-overview[manage] container images.
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/images-image-registry-about.adoc[leveloffset=+1]
 
@@ -44,9 +49,10 @@ You can use the Cluster Samples Operator to manage the sample image streams and 
 
 As a cluster administrator, you can use the Cluster Samples Operator to:
 
+ifndef::openshift-rosa,openshift-dedicated[]
 ** xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configure the Operator].
+endif::openshift-rosa,openshift-dedicated[]
 ** xref:../openshift_images/samples-operator-alt-registry.adoc#samples-operator-alt-registry[Use the Operator with an alternate registry].
-
 
 [id="about-templates"]
 == About templates

--- a/openshift_images/managing_images/using-image-pull-secrets.adoc
+++ b/openshift_images/managing_images/using-image-pull-secrets.adoc
@@ -20,4 +20,7 @@ include::modules/images-allow-pods-to-reference-images-from-secure-registries.ad
 
 include::modules/images-pulling-from-private-registries.adoc[leveloffset=+2]
 
+// cannot get resource "secrets" in API group "" in the namespace "openshift-config" 
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/images-update-global-pull-secret.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]

--- a/openshift_images/samples-operator-alt-registry.adoc
+++ b/openshift_images/samples-operator-alt-registry.adoc
@@ -15,9 +15,11 @@ You must have access to the internet to obtain the necessary container images. I
 
 include::modules/installation-about-mirror-registry.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 .Additional information
 
 For information on viewing the CRI-O logs to view the image source, see xref:../installing/validating-an-installation.adoc#viewing-the-image-pull-source_validating-an-installation[Viewing the image pull source].
+endif::openshift-rosa,openshift-dedicated[]
 
 [id="samples-preparing-bastion"]
 === Preparing the mirror host

--- a/openshift_images/using-templates.adoc
+++ b/openshift_images/using-templates.adoc
@@ -24,9 +24,12 @@ include::modules/templates-cli-generating-list-of-objects.adoc[leveloffset=+2]
 
 include::modules/templates-modifying-uploaded-template.adoc[leveloffset=+1]
 
+// cannot patch resource "templates" 
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/templates-using-instant-app-quickstart.adoc[leveloffset=+1]
 
 include::modules/templates-quickstart.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/templates-writing.adoc[leveloffset=+1]
 

--- a/openshift_images/using_images/using-s21-images.adoc
+++ b/openshift_images/using_images/using-s21-images.adoc
@@ -27,7 +27,7 @@ S2I images are available for you to use directly from the {product-title} web co
 . Choose *All services* under the tile *Developer Catalog*.
 . Select the Type *Builder Images* then can see the available S2I images.
 
-S2I images are also available though the xref:../../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configuring the Cluster Samples Operator].
+S2I images are also available though the xref:../../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Cluster Samples Operator].
 
 include::modules/images-s2i-build-process-overview.adoc[leveloffset=+1]
 
@@ -36,7 +36,9 @@ include::modules/images-s2i-build-process-overview.adoc[leveloffset=+1]
 == Additional resources
 
 * For instructions on using the Cluster Samples Operator, see the xref:../../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configuring the Cluster Samples Operator].
+ifndef::openshift-rosa,openshift-dedicated[]
 * For more information on S2I builds, see the xref:../../cicd/builds/build-strategies.adoc#builds-strategy-s2i-build_build-strategies[builds strategy documentation on S2I builds].
 * For troubleshooting assistance for the S2I process, see xref:../../support/troubleshooting/troubleshooting-s2i.adoc#troubleshooting-s2i[Troubleshooting the Source-to-Image process].
+endif::openshift-rosa,openshift-dedicated[]
 * For an overview of creating images with S2I, see xref:../../openshift_images/create-images.adoc#images-create-s2i_create-images[Creating images from source code with source-to-image].
 * For an overview of testing S2I images, see xref:../../openshift_images/create-images.adoc#images-test-s2i_create-images[About testing S2I images].

--- a/osd_architecture/osd-admission-plug-ins.adoc
+++ b/osd_architecture/osd-admission-plug-ins.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 [id="osd-admission-plug-ins"]
 = Admission plugins
 include::_attributes/common-attributes.adoc[]

--- a/rosa_architecture/rosa-admission-plug-ins.adoc
+++ b/rosa_architecture/rosa-admission-plug-ins.adoc
@@ -1,4 +1,4 @@
-:_content-type: ASSEMBLY
+:_mod-docs-content-type: ASSEMBLY
 [id="rosa-admission-plug-ins"]
 = Admission plugins
 include::_attributes/common-attributes.adoc[]


### PR DESCRIPTION
This PR ports the Support book from OCP to the OSD and ROSA books using single-sourcing.

Version(s):

enterprise-4.13

Previews:
OCP: [Overview of images](https://63895--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/)
ROSA: [Overview of images](https://63895--docspreview.netlify.app/openshift-rosa/latest/openshift_images/)
OSD: [Overview of images](https://63895--docspreview.netlify.app/openshift-dedicated/latest/openshift_images/)

https://issues.redhat.com/browse/OSDOCS-3987