### PR TITLE
Removed tech preview prereq missed when promoted to GA

### DIFF
--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -103,15 +103,6 @@ spec:
 	set to a positive number, it must be at least 8192.
 <6> Optional: Specifies the container runtime to deploy to new containers. The default is `runc`.
 
-.Prerequisite
-
-* To enable crun, you must enable the `TechPreviewNoUpgrade` feature set.
-+
-[NOTE]
-====
-Enabling the `TechPreviewNoUpgrade` feature set cannot be undone and prevents minor version updates. These feature sets are not recommended on production clusters.
-====
-
 .Procedure
 
 To change CRI-O settings using the `ContainerRuntimeConfig` CR:


### PR DESCRIPTION
Per [a Slack convo](https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1692873336529079), I missed removing a prereq to configure the TechPreviewNoUpgrade feature set when [crun graduated to GA](https://github.com/openshift/openshift-docs/pull/56585/commits/34b386d750bf65d806374ecc0ec7380f5562f304#diff-4eafb95f95fa2b74cac3229c8ce2b5d4ecdb7adf31a7be62bd4af93913c67731R108). 

Preview:
[Creating a ContainerRuntimeConfig CR to edit CRI-O parameters](https://63896--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks#create-a-containerruntimeconfig_post-install-machine-configuration-tasks) -- Removed Prerequisite section before the procedure.