### PR TITLE
RHDEVDOCS-5358 Add versions, history, JIRA bug link got GitOps

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -47,6 +47,8 @@
 
     unsupported_versions_serverless = [];
 
+    unsupported_versions_gitops = [];
+
     unsupported_versions_origin = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "3.11", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"];
 
   %>
@@ -94,6 +96,16 @@
         <span>
           <div class="alert alert-danger" role="alert" id="support-alert">
             <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/serverless/latest/about/about-serverless.html" style="color: #545454 !important" class="link-primary">latest Serverless docs</a>.
+          </div>
+        </span>
+
+      <% end %>
+
+      <% if ((unsupported_versions_gitops.include? version) && (distro_key == "openshift-gitops")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/gitops/latest/gitops-release-notes.html" style="color: #545454 !important" class="link-primary">latest GitOps docs</a>.
           </div>
         </span>
 
@@ -176,6 +188,14 @@
               <option value="1.29">1.29</option>
               <option value="1.28">1.28</option>
             </select>
+        <% elsif (distro_key == "openshift-gitops") %>
+            <a href="https://docs.openshift.com/gitops/<%= version %>/gitops-release-notes.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.9">1.9</option>
+              <option value="1.8">1.8</option>
+            </select>            
         <% elsif (distro_key == "openshift-origin") %>
               <a href="https://docs.okd.io/<%= version %>/welcome/index.html">
             <%= distro %>
@@ -208,7 +228,7 @@
       <li class="hidden-xs active">
         <%= breadcrumb_topic %>
       </li>
-      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs"  && distro_key != "openshift-serverless") %>
+      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs"  && distro_key != "openshift-serverless"  && distro_key != "openshift-gitops") %>
       <span text-align="right" style="float: right !important">
         <a href="https://github.com/openshift/openshift-docs/commits/<%=
         ((distro_key == "openshift-enterprise") ? "enterprise-#{version}"
@@ -272,6 +292,23 @@
           <% end %>
         </span>
       <% end %>
+      <% elsif (distro_key == "openshift-gitops") %>
+        <span text-align="right" style="float: right !important">
+          <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-gitops") ? "gitops-docs-#{version}" : "gitops-docs" %>/<%= repo_path %>">
+            <span class="material-icons-outlined" title="Page history">history
+            </span>
+          </a>
+          <% unless (unsupported_versions_gitops.include? version) %>
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12317820&issuetype=1&components=12342156&priority=4&summary=<%= "[gitops-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+              <span class="material-icons-outlined" title="Open an issue">bug_report
+              </span>
+            </a>
+            <a href="javascript: void(0);" onclick="window.print()">
+              <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
+            </a>
+          <% end %>
+        </span>
+      <% end %>      
     </ol>
     <div class="row row-offcanvas row-offcanvas-left">
       <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas hide-for-print">
@@ -351,7 +388,8 @@
     'openshift-aro' : ['docs_aro', version],
     'openshift-rosa' : ['docs_rosa'],
     'openshift-acs' : ['docs_acs', version],
-    'openshift-serverless' : ['docs_serverless', version]
+    'openshift-serverless' : ['docs_serverless', version],
+    'openshift-gitops' : ['docs_gitops', version]
   };
 
   // only OSD v3 docs have the version variable specified


### PR DESCRIPTION
Version(s):
Main only

Issue:
[RHDEVDOCS-5358](https://issues.redhat.com//browse/RHDEVDOCS-5358)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->


Additional information:
Adds support for GitOps standalone
