### PR TITLE
adding another reference to the limitation on partial includes

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -382,6 +382,11 @@ When needed, use `.Prerequisites`, `.Next steps`, or `.Additional resources` syn
 == Writing text snippets
 A _text snippet_ is an optional component that lets you reuse content in multiple modules and assemblies. Text snippets are not a substitute for modules but instead are a more granular form of content reuse. While a module is content that a reader can understand on its own (like an article) or as part of a larger body of work (like an assembly), a text snippet is not self-contained and is not intended to be published or cross referenced on its own.
 
+[IMPORTANT]
+====
+Only include entire snippets in an assembly or module. Including link:https://docs.asciidoctor.org/asciidoc/latest/directives/include-lines/[lines by content ranges] can lead to content errors when the included file is subsequently updated and is not permitted.
+====
+
 In the context of modules and assemblies, text snippets do not include headings or anchor IDs. Text snippets also cannot contain xrefs. This type of component is text only. Examples include the following:
 
 * Admonitions that appear in multiple modules.


### PR DESCRIPTION
We added the requirement to include only entire files on https://github.com/openshift/openshift-docs/pull/60078. This PR repeats the requirement in the snippets section of the guidelines.