### PR TITLE
OCPBUGS#18029: Changed example from baremetal to vsphere

### DIFF
--- a/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-dual-stack-network.adoc
@@ -3,6 +3,10 @@
 // ipi-install-configuration-files.adoc
 // installing-vsphere-installer-provisioned-network-customizations.adoc
 
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:vsphere:
+endif::[]
+
 :_content-type: PROCEDURE
 [id='modifying-install-config-for-dual-stack-network_{context}']
 = Optional: Deploying with dual-stack networking
@@ -26,6 +30,21 @@ serviceNetwork:
 
 To provide an interface to the cluster for applications that use IPv4 and IPv6 addresses, configure IPv4 and IPv6 virtual IP (VIP) address endpoints for the Ingress VIP and API VIP services. To configure IPv4 and IPv6 address endpoints, edit the `apiVIPs` and `ingressVIPs` configuration settings in the `install-config.yaml` file . The `apiVIPs` and `ingressVIPs` configuration settings use a list format. The order of the list indicates the primary and secondary VIP address for each service.
 
+ifdef::vsphere[]
+[source,yaml]
+----
+platform:
+  vsphere:
+    apiVIPs:
+      - <api_ipv4>
+      - <api_ipv6>
+    ingressVIPs:
+      - <wildcard_ipv4>
+      - <wildcard_ipv6>
+----
+endif::[]
+
+ifndef::vsphere[]
 [source,yaml]
 ----
 platform:
@@ -37,6 +56,7 @@ platform:
       - <wildcard_ipv4>
       - <wildcard_ipv6>
 ----
+endif::[]
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s): 4.13+

Issue: https://issues.redhat.com/browse/OCPBUGS-18029

Link to docs preview: 
**vSphere**: https://63900--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#modifying-install-config-for-dual-stack-network_installing-vsphere-installer-provisioned-network-customizations

**Bare Metal**:https://63900--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow

QE review:
- [x] QE has approved this change. @rbbratta