### PR TITLE
OCPBUGS-17088: Baremetal IPI install doc is missing required port access information

### DIFF
--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -10,6 +10,39 @@ Installer-provisioned installation of {product-title} involves several network r
 
 image::210_OpenShift_Baremetal_IPI_Deployment_updates_0122_2.png[Installer-provisioned networking]
 
+[id="network-requirements-ensuring-required-ports-are-open_{context}"]
+== Ensuring required ports are open
+
+Certain ports must be open between cluster nodes for installer-provisioned installations to complete successfully. In certain situations, such as using separate subnets for far edge worker nodes, you must ensure that the nodes in these subnets can communicate with nodes in the other subnets on the following required ports.
+
+.Required ports
+[options="header"]
+|====
+|Port|Description
+
+|`67`,`68` | When using a provisioning network, cluster nodes access the `dnsmasq` DHCP server over their provisioning network interfaces using ports `67` and `68`.
+
+| `69` | When using a provisioning network, cluster nodes communicate with the TFTP server on port `69` using their provisioning network interfaces. The TFTP server runs on the bootstrap VM. The bootstrap VM runs on the provisioner node.
+
+| `80` | When not using the image caching option or when using virtual media, the provisioner node must have port `80` open on the `baremetal` machine network interface to stream the {op-system-first} image from the provisioner node to the cluster nodes.
+
+| `123` | The cluster nodes must access the NTP server on port `123` using the `baremetal` machine network.
+
+|`5050`| The Ironic Inspector API runs on the control plane nodes and listens on port `5050`. The Inspector API is responsible for hardware introspection, which collects information about the hardware characteristics of the bare metal nodes.
+
+|`6180`| When deploying with virtual media and not using TLS, the provisioner node and the control plane nodes must have port `6180` open on the `baremetal` machine network interface so that the baseboard management controller (BMC) of the worker nodes can access the {op-system} image. Starting with {product-title} 4.13, the default HTTP port is `6180`.
+
+|`6183`| When deploying with virtual media and using TLS, the provisioner node and the control plane nodes must have port `6183` open on the `baremetal` machine network interface so that the BMC of the worker nodes can access the {op-system} image.
+
+|`6385`| The Ironic API server runs initially on the bootstrap VM and later on the control plane nodes and listens on port `6385`. The Ironic API allows clients to interact with Ironic for bare metal node provisioning and management, including operations like enrolling new nodes, managing their power state, deploying images, and cleaning the hardware.
+
+|`8080`| When using image caching without TLS, port `8080` must be open on the provisioner node and accessible by the BMC interfaces of the cluster nodes.
+
+|`8083`| When using the image caching option with TLS, port `8083` must be open on the provisioner node and accessible by the BMC interfaces of the cluster nodes.
+
+|`9999`| By default, the Ironic Python Agent (IPA) listens on TCP port `9999` for API calls from the Ironic conductor service. This port is used for communication between the bare metal node where IPA is running and the Ironic conductor service.
+
+|====
 
 [id="network-requirements-increase-mtu_{context}"]
 == Increase the network MTU
@@ -111,7 +144,7 @@ For the `baremetal` network, a network administrator must reserve a number of IP
 [IMPORTANT]
 .Reserving IP addresses so they become static IP addresses
 ====
-Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To configure static IP addresses with NMState, see "(Optional) Configuring host network interfaces" in the "Setting up the environment for an OpenShift installation" section.
+Some administrators prefer to use static IP addresses so that each node's IP address remains constant in the absence of a DHCP server. To configure static IP addresses with NMState, see "(Optional) Configuring node network interfaces" in the "Setting up the environment for an OpenShift installation" section.
 ====
 
 [IMPORTANT]
@@ -161,4 +194,4 @@ You can reconfigure the control plane nodes to act as NTP servers on disconnecte
 [id='network-requirements-out-of-band_{context}']
 == Port access for the out-of-band management IP address
 
-The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the provisioner during installation, the out-of-band management IP address must be granted access to port `6180` on the bootstrap host and on the {product-title} control plane hosts. TLS port `6183` is required for virtual media installation, for example, via Redfish.
+The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the provisioner node during installation, the out-of-band management IP address must be granted access to port `6180` on the provisioner node and on the {product-title} control plane nodes. TLS port `6183` is required for virtual media installation, for example, by using Redfish.


### PR DESCRIPTION
Added a section for required open ports.

Fixes: OCPBUGS-17088 and [TELCODOCS-1389](https://issues.redhat.com//browse/TELCODOCS-1389)

See https://issues.redhat.com/browse/OCPBUGS-17088  and https://issues.redhat.com/browse/TELCODOCS-1389 for additional details.

Preview URL: http://184.23.213.161:8080/OCPBUGS-17088/installing/installing_bare_metal_ipi/ipi-install-prerequisites.html#network-requirements-ensuring-required-ports-are-open_ipi-install-prerequisites

For release(s): 4.14, 4.13
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
