### PR TITLE
OSDOCS#7562: Scheduling workloads on multi-arch clusters

### DIFF
--- a/modules/multi-architecture-scheduling-examples.adoc
+++ b/modules/multi-architecture-scheduling-examples.adoc
@@ -1,0 +1,139 @@
+// Module included in the following assembly 
+//
+//post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc
+
+:_content-type: CONCEPT
+[id="multi-architecture-scheduling-examples_{context}"]
+
+= Sample multi-architecture node workload deployments 
+
+Before you schedule workloads on a cluster with compute nodes of different architectures, consider the following use cases:
+
+Using node affinity to schedule workloads on a node:: You can allow a workload to be scheduled on only a set of nodes with architectures supported by its images, you can set the `spec.affinity.nodeAffinity` field in your pod's template specification.
++
+.Example deployment with the `nodeAffinity` set to certain architectures 
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata: # ...
+spec:
+   # ...
+  template:
+     # ...
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values: <1>
+                - amd64
+                - arm64
+----
+<1> Specify the supported architectures. Valid values include `amd64`,`arm64`, or both values.
+
+Tainting every node for a specific architecture:: You can taint a node to avoid workloads that are not compatible with its architecture to be scheduled on that node. In the case where your cluster is using a `MachineSet` object, you can add parameters to the `.spec.template.spec.taints` field to avoid workloads being scheduled on nodes with non-supported architectures.
+
+* Before you can taint a node, you must scale down the `MachineSet` object or remove available machines. You can scale down the machine set by using one of following commands: 
++
+[source,terminal]
+----
+$ oc scale --replicas=0 machineset <machineset> -n openshift-machine-api
+----
++
+Or: 
++
+[source,terminal]
+----
+$ oc edit machineset <machineset> -n openshift-machine-api
+----
+For more information on scaling machine sets, see "Modifying a compute machine set".
+
++
+--
+.Example `MachineSet` with a taint set
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata: # ...
+spec:
+  # ...
+  template:
+    # ...
+    spec:
+      # ...
+      taints:
+      - effect: NoSchedule         
+        key: multi-arch.openshift.io/arch                
+        value: arm64
+----
+You can also set a taint on a specific node by running the following command: 
+[source,terminal]
+----
+$ oc adm taint nodes <node-name> multi-arch.openshift.io/arch=arm64:NoSchedule
+----
+--
+
+Creating a default toleration:: You can annotate a namespace so all of the workloads get the same default toleration by running the following command:
++
+[source,terminal]
+----
+$ oc annotate namespace my-namespace \
+  'scheduler.alpha.kubernetes.io/defaultTolerations'='[{"operator": "Exists", "effect": "NoSchedule", "key": "multi-arch.openshift.io/arch"}]'
+----
+
+Tolerating architecture taints in workloads:: On a node with a defined taint, workloads will not be scheduled on that node. However, you can allow them to be scheduled by setting a toleration in the pod's specification.
++
+.Example deployment with a toleration 
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata: # ...
+spec:
+  # ...
+  template:
+    # ...
+    spec:
+      tolerations:
+      - key: "multi-arch.openshift.io/arch"
+        value: "arm64"
+        operator: "Equal"
+        effect: "NoSchedule"
+----
++
+This example deployment can also be allowed on nodes with the `multi-arch.openshift.io/arch=arm64` taint specified.
+
+Using node affinity with taints and tolerations:: When a scheduler computes the set of nodes to schedule a pod, tolerations can broaden the set while node affinity restricts the set. If you set a taint to the nodes of a specific architecture, the following example toleration is required for scheduling pods.
++
+.Example deployment with a node affinity and toleration set. 
+[source,yaml]
+----
+apiVersion: apps/v1
+kind: Deployment
+metadata: # ...
+spec:
+  # ...
+  template:
+    # ...
+    spec:
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+            - matchExpressions:
+              - key: kubernetes.io/arch
+                operator: In
+                values:
+                - amd64
+                - arm64
+      tolerations:
+      - key: "multi-arch.openshift.io/arch"
+        value: "arm64"
+        operator: "Equal"
+        effect: "NoSchedule"
+---- 

--- a/modules/multi-architecture-scheduling-overview.adoc
+++ b/modules/multi-architecture-scheduling-overview.adoc
@@ -1,0 +1,13 @@
+// module included in the following assembly 
+//
+//post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc
+
+:_content-type: CONCEPT
+[id="multi-architecture-scheduling-overview_{context}"]
+= Scheduling workloads on clusters with multi-architecture compute machines 
+
+Before deploying a workload onto a cluster with compute nodes of different architectures, you must configure your compute node scheduling process so the pods in your cluster are correctly assigned. 
+
+You can schedule workloads onto multi-architecture nodes for your cluster in several ways. For example, you can use a node affinity or a node selector to select the node you want the pod to schedule onto. You can also use scheduling mechanisms, like taints and tolderations, when using node affinity or node selector to correctly schedule workloads. 
+
+

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing.adoc
@@ -2,7 +2,26 @@
 :context: multi-architecture-compute-managing
 [id="multi-architecture-compute-managing"]
 = Managing your cluster with multi-architecture compute machines
+include::_attributes/common-attributes.adoc[]
 
-toc::[] 
+toc::[]
+
+== Scheduling workloads on clusters with multi-architecture compute machines
+
+Deploying a workload on a cluster with compute nodes of different architectures requires attention and monitoring of your cluster. There might be further actions you need to take in order to successfully place pods in the nodes of your cluster.
+
+For more detailed information on node affinity, scheduling, taints and tolerlations, see the following documentatinon: 
+
+* xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations[Controlling pod placement using node taints].
+
+* xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity[Controlling pod placement on nodes using node affinity]
+
+* xref:../../nodes/scheduling/nodes-scheduler-about.adoc#nodes-scheduler-about[Controlling pod placement using the scheduler]
+
+include::modules/multi-architecture-scheduling-examples.adoc[leveloffset=+2]
+
+.Additional resources
+
+* xref:../../machine_management/modifying-machineset.adoc#machineset-modifying_modifying-machineset[Modifying a compute machine set]
 
 include::modules/multi-architecture-import-imagestreams.adoc[leveloffset=+1]


### PR DESCRIPTION
**Version:** 4.14+ 

**Issue:** [OSDOCS-7562](https://issues.redhat.com//browse/OSDOCS-7562)

**Link to docs preview:**

[Managing your cluster with multi-architecture compute machines -> Scheduling workloads on clusters with multi-architecture compute machines 
](https://63915--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-compute-managing)
**QE review:**
- [x] QE has approved this change.
