### PR TITLE
OCPBUGS#3154 BoundServiceAccountToken has 365d validation period even…

### DIFF
--- a/modules/bound-sa-tokens-configuring.adoc
+++ b/modules/bound-sa-tokens-configuring.adoc
@@ -122,8 +122,13 @@ spec:
 ----
 <1> A reference to an existing service account.
 <2> The path relative to the mount point of the file to project the token into.
-<3> Optionally set the expiration of the service account token, in seconds. The default is 3600 seconds (1 hour) and must be at least 600 seconds (10 minutes). The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours.
+<3> Optionally set the expiration of the service account token, in seconds. The default is 3600 seconds (1 hour) and must be at least 600 seconds (10 minutes). The kubelet will start trying to rotate the token if the token is older than 80 percent of its time to live or if the token is older than 24 hours. 
 <4> Optionally set the intended audience of the token. The recipient of a token should verify that the recipient identity matches the audience claim of the token, and should otherwise reject the token. The audience defaults to the identifier of the API server.
++
+[NOTE]
+====
+In order to prevent unexpected failure, {product-title} overrides the `expirationSeconds` value to be one year from the initial token generation with the `--service-account-extend-token-expiration` default of `true`. You cannot change this setting.
+====
 
 .. Create the pod:
 +


### PR DESCRIPTION
… if it has expirationSeconds: 3607

Version(s):
4.11+

Issue:
[OCPBUGS-3154](https://issues.redhat.com/browse/OCPBUGS-3154)

Link to docs preview:
[Preview](https://63921--docspreview.netlify.app/openshift-enterprise/latest/authentication/bound-service-account-tokens#bound-sa-tokens-configuring_bound-service-account-tokens)

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
