### PR TITLE
The multus annotations with JSON should be a JSON list

### DIFF
--- a/modules/nw-multus-advanced-annotations.adoc
+++ b/modules/nw-multus-advanced-annotations.adoc
@@ -55,14 +55,14 @@ kind: Pod
 metadata:
   name: example-pod
   annotations:
-    k8s.v1.cni.cncf.io/networks: '
+    k8s.v1.cni.cncf.io/networks: '[
     {
       "name": "net1"
     },
     {
       "name": "net2", <1>
       "default-route": ["192.0.2.1"] <2>
-    }'
+    }]'
 spec:
   containers:
   - name: example-pod


### PR DESCRIPTION
This fixes a subtle JSON error in the JSON formatted errors, it should be a JSON list of objects