### PR TITLE
OSDOCS#6911: Dual-stack configuration for OpenStack

### DIFF
--- a/installing/installing_openstack/installing-openstack-installer-custom.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-custom.adoc
@@ -52,6 +52,12 @@ After you deploy your cluster, you can attach pods to additional networks. For m
 ====
 
 include::modules/installation-osp-config-yaml.adoc[leveloffset=+2]
+
+
+//Dual-stack networking
+include::modules/install-osp-dualstack.adoc[leveloffset=+2]
+include::modules/install-osp-deploy-dualstack.adoc[leveloffset=+3]
+
 include::modules/installation-osp-external-lb-config.adoc[leveloffset=+2]
 // include::modules/installation-osp-setting-worker-affinity.adoc[leveloffset=+1]
 include::modules/ssh-agent-using.adoc[leveloffset=+1]

--- a/modules/install-osp-deploy-dualstack.adoc
+++ b/modules/install-osp-deploy-dualstack.adoc
@@ -1,0 +1,85 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_openstack/installing-openstack-installer-custom.adoc
+:_content-type: PROCEDURE
+[id="install-osp-deploy-dualstack_{context}"]
+= Deploying the dual-stack cluster
+
+.Procedure
+
+. Create a network with IPv4 and IPv6 subnets. The available address modes for `ipv6-ra-mode` and `ipv6-address-mode` fields are: `stateful`, `stateless` and `slaac`.
++
+[NOTE]
+====
+The dualstack network MTU must accommodate both the minimum MTU for IPv6, which is 1280, and the OVN-Kubernetes encapsulation overhead, which is 100.
+====
++
+[NOTE]
+====
+DHCP must be enabled on the subnets.
+====
+
+. Create the API and Ingress VIPs ports.
+
+. Add the IPv6 subnet to the router to enable router advertisements. If you are using a provider network, you can enable router advertisements by adding the network as an external gateway, which also enables external connectivity.
+
+
+. To configure IPv4 and IPv6 address endpoints for cluster nodes, edit the `install-config.yaml` file. The following is an example of an `install-config.yaml` file.
+
+.Example `install-config.yaml`
+
+[source, yaml]
+----
+apiVersion: v1
+baseDomain: mydomain.test
+featureSet: TechPreviewNoUpgrade <1>
+compute:
+- name: worker
+  platform:
+    openstack:
+      type: m1.xlarge
+  replicas: 3
+controlPlane:
+  name: master
+  platform:
+    openstack:
+      type: m1.xlarge
+  replicas: 3
+metadata:
+  name: mycluster
+networking:
+  machineNetwork: <2>
+  - cidr: "192.168.25.0/24"
+  - cidr: "fd2e:6f44:5dd8:c956::/64"
+  clusterNetwork: <2>
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  - cidr: fd01::/48
+    hostPrefix: 64
+  serviceNetwork: <2>
+  - 172.30.0.0/16
+  - fd02::/112
+platform:
+  openstack:
+    ingressVIPs: ['192.168.25.79', 'fd2e:6f44:5dd8:c956:f816:3eff:fef1:1bad'] <3>
+    apiVIPs: ['192.168.25.199', 'fd2e:6f44:5dd8:c956:f816:3eff:fe78:cf36'] <4>
+    controlPlanePort: <5>
+      fixedIPs: <6>
+      - subnet: <7>
+          name: subnet-v4
+          id: subnet-v4-id
+      - subnet: <7>
+          name: subnet-v6
+          id: subnet-v6-id
+      network: <7>
+        name: dualstack
+        id: network-id
+----
+
+<1> Dual-stack clusters are supported only with the `TechPreviewNoUpgrade` value.
+<2> You must specify an IP address range in the `cidr` field for both IPv4 and IPv6 address families.
+<3> Specify the virtual IP (VIP) address endpoints for the Ingress VIP services to provide an interface to the cluster.
+<4> Specify the virtual IP (VIP) address endpoints for the API VIP services to provide an interface to the cluster.
+<5> Specify the dual-stack network details that are used by all the nodes across the cluster.
+<6> The CIDR of any subnet specified in this field must match the CIDRs listed on `networks.machineNetwork`.
+<7> You can specify a value for either `name` or `id`, or both.

--- a/modules/install-osp-dualstack.adoc
+++ b/modules/install-osp-dualstack.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_openstack/installing-openstack-installer-custom.adoc
+:_content-type: CONCEPT
+[id="install-osp-dualstack_{context}"]
+= Optional: Configuring a cluster with dual-stack networking
+
+:FeatureName: Dual-stack configuration for OpenStack
+include::snippets/technology-preview.adoc[]
+
+You can create a dual-stack cluster on {rh-openstack}. However, the dual-stack configuration is enabled only if you are using an {rh-openstack} network with IPv4 and IPv6 subnets.
+
+[NOTE]
+====
+{rh-openstack} does not support the following configurations:
+
+* Conversion of an IPv4 single-stack cluster to a dual-stack cluster network.
+
+* IPv6 as the primary address family for dual-stack cluster network.
+====
+


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OSDOCS-6911

Link to docs preview: https://63935--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom#optional-configuring-a-cluster-with-dual-stack-networking

QE review:
- [ ] QE has approved this change.  NA (Tech preview)
- [x] SME has approved this change. @MaysaMacedo 