### PR TITLE
[MULTIARCH-3446, 3447] oc-mirror add IBM Z and Power architectures

### DIFF
--- a/modules/oc-mirror-imageset-config-params.adoc
+++ b/modules/oc-mirror-imageset-config-params.adoc
@@ -203,6 +203,9 @@ The `targetName` parameter is deprecated. Use the `targetCatalog` parameter inst
 architectures:
   - amd64
   - arm64
+  - multi
+  - ppc64le
+  - s390x
 ----
 
 |`mirror.platform.channels`


### PR DESCRIPTION
Version(s): 4.14+

Issue:
 https://issues.redhat.com/browse/MULTIARCH-3446
and
https://issues.redhat.com/browse/MULTIARCH-3447

Link to docs preview:

https://63938--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected#oc-mirror-imageset-config-params_installing-mirroring-disconnected

@jschintag Pls approve with /lgtm For IBM Z

@alishaIBM Please approve For IBM Power.


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


