### PR TITLE
CNV-32032: Release note deprecated feature

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -120,6 +120,9 @@ Deprecated features are included in the current release and supported. However, 
 
 //CNV-29048 Release note: DEPRECATED FEATURE (Metrics backlog 4.14)
 
+//CNV-32032 Release note: DEPRECATED FEATURE (Windows 2012R2 templates deprecated)
+* Support for Windows Server 2012R2 templates is deprecated. 
+
 
 [id="virt-4-14-removed"]
 === Removed features

--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -121,7 +121,7 @@ Deprecated features are included in the current release and supported. However, 
 //CNV-29048 Release note: DEPRECATED FEATURE (Metrics backlog 4.14)
 
 //CNV-32032 Release note: DEPRECATED FEATURE (Windows 2012R2 templates deprecated)
-* Support for Windows Server 2012R2 templates is deprecated. 
+* Support for Windows Server 2012 R2 templates is deprecated. 
 
 
 [id="virt-4-14-removed"]


### PR DESCRIPTION
Version(s): 4.14


Issue: [CNV-32032](https://issues.redhat.com/browse/CNV-32032)


Link to docs preview: [Release note: Deprecated feature Windows 2012 R2 templates](https://63947--docspreview.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes#virt-4-14-deprecated)


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


