### PR TITLE
[OSDOCS-6086]: OLM-managed Operators can use AWS STS (CCO docs)

### DIFF
--- a/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
@@ -50,6 +50,15 @@ include::modules/cco-short-term-creds-format-aws.adoc[leveloffset=+2]
 //AWS component secret permissions requirements
 include::modules/cco-short-term-creds-component-permissions-aws.adoc[leveloffset=+2]
 
+//OLM-managed Operator support for authentication with AWS STS
+include::modules/cco-short-term-creds-aws-olm.adoc[leveloffset=+2]
+
+////
+[role="_additional-resources"]
+.Additional resources
+* xr\ef:../../operators/operator_sdk/osdk-token-auth.html#osdk-aws-sts_osdk-token-auth[CCO-based workflow for OLM-managed Operators with AWS STS]
+////
+
 [id="cco-short-term-creds-gcp_{context}"]
 == GCP Workload Identity
 

--- a/modules/cco-short-term-creds-aws-olm.adoc
+++ b/modules/cco-short-term-creds-aws-olm.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc
+
+:_content-type: CONCEPT
+[id="cco-short-term-creds-aws-olm_{context}"]
+= OLM-managed Operator support for authentication with AWS STS
+
+In addition to {product-title} cluster components, some Operators managed by the Operator Lifecycle Manager (OLM) on AWS clusters can use manual mode with STS. These Operators authenticate with limited-privilege, short-term credentials that are managed outside the cluster. To determine if an Operator supports authentication with AWS STS, see the Operator description in OperatorHub.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-6086](https://issues.redhat.com//browse/OSDOCS-6086)

Link to docs preview:
[OLM-managed Operator support for authentication with AWS STS](https://63954--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-short-term-creds#cco-short-term-creds-aws-olm_cco-short-term-creds)

QE review:
- [x] QE has approved this change.

Additional information: