### PR TITLE
TELCODOCS-1252: D/S and R/N: OCPVE-297 Enable ext4 PVs on LVMS

### DIFF
--- a/modules/lvms-adding-a-storage-class.adoc
+++ b/modules/lvms-adding-a-storage-class.adoc
@@ -1,0 +1,55 @@
+// This module is included in the following assemblies: 
+//
+// storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+
+:_content-type: PROCEDURE
+[id="adding-a-storage-class_{context}"]
+= Adding a storage class
+
+You can add a storage class to an {product-title} cluster. A storage class describes a class of storage in the cluster and how the cluster dynamically provisions the persistent volumes (PVs) when the user specifies the storage class. A storage class describes the type of device classes, the quality-of-service level, the filesystem type, and other details. 
+
+.Procedure
+
+. Create a YAML file:
++
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: lvm-storageclass
+parameters:
+  csi.storage.k8s.io/fstype: ext4
+  topolvm.io/device-class: vg1
+provisioner: topolvm.io
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
+----
++
+Save the file by using a name similar to the storage class name. For example, `lvm-storageclass.yaml`.
+
+. Apply the YAML file by using the `oc` command:
++
+[source,terminal]
+----
+$ oc apply -f <file_name> <1>
+----
+<1> Replace `<file_name>` with the name of the YAML file. For example, `lvm-storageclass.yaml`.
++
+The cluster will create the storage class. 
+
+. Verify that the cluster created the storage class by using the following command:
++
+[source,terminal]
+----
+$ oc get storageclass <name> <1>
+----
+<1> Replace `<name>` with the name of the storage class. For example, `lvm-storageclass`.
++
+.Example output
+[source,terminal,options="nowrap",role="white-space-pre"]
+----
+NAME              PROVISIONER  RECLAIMPOLICY  VOLUMEBINDINGMODE     ALLOWVOLUMEEXPANSION  AGE
+lvm-storageclass  topolvm.io   Delete         WaitForFirstConsumer  true                  1s
+----

--- a/modules/lvms-creating-logical-volume-manager-cluster.adoc
+++ b/modules/lvms-creating-logical-volume-manager-cluster.adoc
@@ -48,7 +48,8 @@ spec:
   storage:
     deviceClasses:  <1>
       - name: vg1
-        default: true <2>
+        fstype: ext4 <2>
+        default: true <3>
         deviceSelector:
           paths:
           - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
@@ -57,7 +58,7 @@ spec:
           name: thin-pool-1
           sizePercent: 90
           overprovisionRatio: 10
-        nodeSelector: <3>
+        nodeSelector: <4>
           nodeSelectorTerms:
             - matchExpressions:
               - key: app
@@ -68,9 +69,10 @@ spec:
 <1> To create multiple device storage classes in the cluster, create a YAML array under `deviceClasses` for each required storage class.
 Configure the local device paths of the disks as an array of values in the `deviceSelector` field.
 When configuring multiple device classes, you must specify the device path for each device.
-<2> Mandatory: The `LVMCluster` resource must contain a single default storage class. Set `default: false` for secondary device storage classes.
+<2> Set `fstype` to `ext4` or `xfs`. By default, it is set to `xfs` if the setting is not specified.
+<3> Mandatory: The `LVMCluster` resource must contain a single default storage class. Set `default: false` for secondary device storage classes.
 If you are upgrading the `LVMCluster` resource from a previous version, you must specify a single default device class.
-<3> Optional: To control what worker nodes the `LVMCluster` CR is applied to, specify a set of node selector labels.
+<4> Optional: To control what worker nodes the `LVMCluster` CR is applied to, specify a set of node selector labels.
 The specified labels must be present on the node in order for the `LVMCluster` to be scheduled on that node.
 
 .. Create the `LVMCluster` CR:

--- a/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
+++ b/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc
@@ -68,6 +68,9 @@ include::modules/lvms-creating-logical-volume-manager-cluster.adoc[leveloffset=+
 
 * xref:../../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-reference-file_logical-volume-manager-storage[{lvms} reference YAML file]
 
+//Adding a storage class
+include::modules/lvms-adding-a-storage-class.adoc[leveloffset=+1]
+
 //Provisioning
 include::modules/lvms-provisioning-storage-using-logical-volume-manager-operator.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Added the fstype parameter to the CR.

Fixes: [TELCODOCS-1252](https://issues.redhat.com//browse/TELCODOCS-1252)

See https://issues.redhat.com/browse/TELCODOCS-1252 for additional details.

Preview URL: http://184.23.213.161:8080/TELCODOCS-1252/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-creating-lvms-cluster_logical-volume-manager-storage

http://184.23.213.161:8080/TELCODOCS-1252/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#adding-a-storage-class_logical-volume-manager-storage

For release(s): 4.14
QE Review: 

- [ ] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
