### PR TITLE
[OSDOCS-7105]: GCP Confidential Compute is GA

### DIFF
--- a/modules/machineset-gcp-confidential-vm.adoc
+++ b/modules/machineset-gcp-confidential-vm.adoc
@@ -13,10 +13,12 @@ endif::[]
 
 By editing the machine set YAML file, you can configure the Confidential VM options that a machine set uses for machines that it deploys.
 
-For more information about Confidential Compute features, functionality, and compatibility, see the GCP Compute Engine documentation about link:https://cloud.google.com/compute/confidential-vm/docs/about-cvm[Confidential VM].
+For more information about Confidential VM features, functions, and compatibility, see the GCP Compute Engine documentation about link:https://cloud.google.com/confidential-computing/confidential-vm/docs/about-cvm#confidential-vm[Confidential VM].
 
-:FeatureName: Confidential Computing
-include::snippets/technology-preview.adoc[]
+[IMPORTANT]
+====
+{product-title} {product-version} does not support some Confidential Compute features, such as Confidential VMs with AMD Secure Encrypted Virtualization Secure Nested Paging (SEV-SNP).
+====
 
 .Procedure
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-7105](https://issues.redhat.com//browse/OSDOCS-7105)

Link to docs preview:
[Configuring Confidential VM by using machine sets](https://63957--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-gcp-confidential-vm_creating-machineset-gcp)

QE review:
- [x] QE has approved this change.

Additional information: