### PR TITLE
OSDOCS-6384: Adds monitoring release note

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -207,6 +207,11 @@ With this release, the `MaxUnavailableStatefulSet` featureset configuration para
 [id="ocp-4-14-monitoring"]
 === Monitoring
 
+[id="client-cert-key-service-monitor"]
+==== Client Certification and key path to a ServiceMonitor in the {product-title} console
+
+With this release, if the `kube-apiserver` is not available or unable to be reached, a local authentication and authorization path for scraper targets is available in the console Operator and console configuration. This is to avoid sending valid `kube-apiserver` credentials to everyone who can create a `ServiceMonitor`.
+
 [id="ocp-4-14-scalability-and-performance"]
 === Scalability and performance
 


### PR DESCRIPTION
[OSDOCS-6384](https://issues.redhat.com//browse/OSDOCS-6384): Adds monitoring release note

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6384

Link to docs preview:
https://63958--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-monitoring

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This note might go better in the monitoring section as opposed to the console section. Do we need further docs other than a release note?
