### PR TITLE
[OSDOCS-7122]: GCP Confidential Compute is GA (RNs)

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -82,6 +82,10 @@ Deploying a three-node cluster is supported on Nutanix as of {product-title} {pr
 
 For more information, see xref:../installing/installing_nutanix/installing-nutanix-three-node.adoc#installing-nutanix-three-node[Installing a three-node cluster on Nutanix].
 
+[id="ocp-4-14-installation-gcp-confidential-vms"]
+==== Installing a cluster on GCP using Confidential VMs is generally available
+In {product-title} {product-version}, using Confidential VMs when installing your cluster is generally available. For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-enabling-confidential-vms_installing-gcp-customizations[Enabling Confidential VMs].
+
 [id="ocp-4-14-dc-build-apis-disabled"]
 ==== DeploymentConfig and Build APIs can now be disabled
 
@@ -885,7 +889,7 @@ In the following tables, features are marked with the following statuses:
 |GCP Confidential VMs
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
 |====
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-7122](https://issues.redhat.com//browse/OSDOCS-7122)

Link to docs preview:
[Installing a cluster on GCP using Confidential VMs is generally available](https://63959--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-installation-gcp-confidential-vms)

QE review:
- [x] QE has approved this change.

Additional information: