### PR TITLE
OSDOCS-6922: Infrastructure Node Utilization Update

### DIFF
--- a/modules/sd-planning-considerations.adoc
+++ b/modules/sd-planning-considerations.adoc
@@ -70,10 +70,10 @@ The maximum number of compute nodes on ROSA is 180.
 
 .Rules for infrastructure node resizing alerts
 
-Resizing alerts are triggered for the infrastructure nodes in a cluster when either of the following scenarios are true: 
+Resizing alerts are triggered for the infrastructure nodes in a cluster when it has high-sustained CPU or memory utilization. This high-sustained utilization status is: 
 
-* Each infrastructure node has less than 16GiB RAM or less than 5 CPUs, and there are more than 25 and less than 101 compute nodes.
-* Each infrastructure node has less than 32GiB RAM or less than 9 CPUs, and there are more than 100 compute nodes.
+* Infrastructure nodes sustain over 50% utilization on average in a classic ROSA cluster with a single availability zone using 2 infrastructure nodes.
+* Infrastructure nodes sustain over 66% utilization on average in a classic ROSA cluster with multiple availability zones using 3 infrastructure nodes.
 +
 [NOTE]
 ====
@@ -85,6 +85,8 @@ ifdef::openshift-dedicated[]
 {product-title} 
 endif::[]
 is 180.
+
+The resizing alerts only appear after sustained periods of high utilization. Short usage spikes, such as a node temporarily going down causing the other node to scale up, do not trigger these alerts.
 ====
 
 The SRE team might scale the control plane and infrastructure nodes for additional reasons, for example to manage an increase in resource consumption on the nodes.


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSD-15310](https://issues.redhat.com/browse/OSD-15310)

Link to docs preview:
* [Node scaling after installation](https://63960--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-limits-scalability.html#node-scaling-after-installation_rosa-limits-scalability) in Limits and Scalability
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/8e3c074f-4d52-4c41-8561-a759f0432a45)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Updated the infrastructure node scaling to specify high-sustained utilization.