### PR TITLE
[OSDOCS-6238]: Nutanix CPMS RNs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -184,6 +184,16 @@ With this release, you can access the NMstate Operator and resources such as the
 [id="ocp-4-14-machine-config-operator"]
 === Machine Config Operator
 
+[id="ocp-4-14-machine-api"]
+=== Machine API
+
+[id="ocp-4-14-mapi-cpms-platform-support"]
+==== Support for control plane machine sets on Nutanix clusters
+
+With this release, control plane machine sets are supported for Nutanix clusters.
+
+For more information, see xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with the Control Plane Machine Set Operator].
+
 [id="ocp-4-14-nodes"]
 === Nodes
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6238](https://issues.redhat.com//browse/OSDOCS-6238)

Link to docs preview:
[Support for control plane machine sets on Nutanix clusters](https://63961--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-mapi-cpms-platform-support)

QE review:
- [x] QE has approved this change.

Additional information: