### PR TITLE
OSDOCS#7547: Restructuring ACME related modules.

### DIFF
--- a/modules/cert-manager-acme-dns01-ambient-aws.adoc
+++ b/modules/cert-manager-acme-dns01-ambient-aws.adoc
@@ -15,39 +15,6 @@ You can use {cert-manager-operator} to set up an ACME issuer to solve DNS-01 cha
 
 .Procedure
 
-. Optional: Override the nameserver settings for the DNS-01 self check.
-+
-This step is required only when the target public-hosted zone overlaps with the cluster's default private-hosted zone.
-
-.. Edit the `CertManager` resource by running the following command:
-+
-[source,terminal]
-----
-$ oc edit certmanager cluster
-----
-
-.. Add a `spec.controllerConfig` section with the following override arguments:
-+
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1alpha1
-kind: CertManager
-metadata:
-  name: cluster
-  ...
-spec:
-  ...
-  controllerConfig:                                <1>
-    overrideArgs:
-      - '--dns01-recursive-nameservers-only'       <2>
-      - '--dns01-recursive-nameservers=1.1.1.1:53' <3>
-----
-<1> Add the `spec.controllerConfig` section.
-<2> Specify to only use recursive nameservers instead of checking the authoritative nameservers associated with that domain.
-<3> Provide a comma-separated list of `<host>:<port>` nameservers to query for the DNS-01 self check. You must use a `1.1.1.1:53` value to avoid the public and private zones overlapping.
-
-.. Save the file to apply the changes.
-
 . Optional: Create a namespace for the issuer:
 +
 [source,terminal]
@@ -102,38 +69,6 @@ spec:
 $ oc create -f issuer.yaml
 ----
 
-. Create a certificate:
-
-.. Create a YAML file that defines the `Certificate` object:
-+
-.Example `certificate.yaml` file
-[source,yaml]
-----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: <tls_cert>              <1>
-  namespace: <issuer_namespace> <2>
-spec:
-  isCA: false
-  commonName: '<common_name>'    <3>
-  secretName: <tls-cert>        <4>
-  dnsNames:
-  - '<domain_name>'              <5>
-  issuerRef:
-    name: <letsencrypt_staging>    <6>
-    kind: Issuer
-----
-<1> Provide a name for the certificate.
-<2> Specify the namespace that you created for the issuer.
-<3> Replace `<common_name>` with your common name (CN).
-<4> Specify the name of the secret to create that will contain the certificate.
-<5> Replace `<domain_name>` with your domain name.
-<6> Specify the name of the issuer that you created.
-
-.. Create the `Certificate` object by running the following command:
-+
-[source,terminal]
-----
-$ oc create -f certificate.yaml
-----
+[role="_additional-resources"]
+== Additional resources
+* For information about the override procedure and creating the certificate, see xref:../cert_manager_operator/cert-manager-operator-issuer-acme#cert-manager-acme-dns01-explicit-aws_cert-manager-operator-issuer-acme[Configuring an ACME issuer by using explicit credentials for AWS Route53].

--- a/modules/cert-manager-acme-dns01-ambient-gcp.adoc
+++ b/modules/cert-manager-acme-dns01-ambient-gcp.adoc
@@ -15,46 +15,6 @@ You can use the {cert-manager-operator} to set up an ACME issuer to solve DNS-01
 
 .Procedure
 
-. Optional: Override the nameserver settings for the DNS-01 self check.
-+
-This step is required only when the target public-hosted zone overlaps with the cluster's default private-hosted zone.
-
-.. Edit the `CertManager` resource by running the following command:
-+
-[source,terminal]
-----
-$ oc edit certmanager cluster
-----
-
-.. Add a `spec.controllerConfig` section with the following override arguments:
-+
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1alpha1
-kind: CertManager
-metadata:
-  name: cluster
-  ...
-spec:
-  ...
-  controllerConfig:                                <1>
-    overrideArgs:
-      - '--dns01-recursive-nameservers-only'       <2>
-      - '--dns01-recursive-nameservers=1.1.1.1:53' <3>
-----
-<1> Add the `spec.controllerConfig` section.
-<2> Specify to only use recursive nameservers instead of checking the authoritative nameservers associated with that domain.
-<3> Provide a comma-separated list of `<host>:<port>` nameservers to query for the DNS-01 self check. You must use a `1.1.1.1:53` value to avoid the public and private zones overlapping.
-
-.. Save the file to apply the changes.
-
-. Optional: Create a namespace for the issuer:
-+
-[source,terminal]
-----
-$ oc new-project <issuer_namespace>
-----
-
 . Modify the `CertManager` resource to add the `--issuer-ambient-credentials` argument:
 +
 [source,terminal]
@@ -99,33 +59,6 @@ spec:
 $ oc create -f issuer.yaml
 ----
 
-. Create a certificate:
-
-.. Create a YAML file that defines the `Certificate` object:
-+
-.Example `certificate.yaml` file
-[source,yaml]
-----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: <tls_cert> <1>
-  namespace: <issuer_namespace>
-spec:
-  secretName: <tls_cert> <2>
-  issuerRef:
-    name: <acme-dns01-clouddns_issuer> <3>
-  dnsNames:
-  - '<domain_name>' <4>
-----
-<1> Provide a name for the certificate.
-<2> Specify the name of the secret to create that will contain the certificate.
-<3> Specify the name of the issuer that you created.
-<4> Replace `<domain_name>` with your domain name.
-
-.. Create the `Certificate` object by running the following command:
-+
-[source,terminal]
-----
-$ oc create -f certificate.yaml
-----
+[role="_additional-resources"]
+== Additional resources
+* For information about the override procedure and creating the certificate, see xref:../cert_manager_operator/cert-manager-operator-issuer-acme#cert-manager-acme-dns01-explicit-aws_cert-manager-operator-issuer-acme[Configuring an ACME issuer by using explicit credentials for AWS Route53].

--- a/modules/cert-manager-acme-dns01-explicit-aws.adoc
+++ b/modules/cert-manager-acme-dns01-explicit-aws.adoc
@@ -22,6 +22,11 @@ You can use Amazon Route 53 with explicit credentials in an {product-title} clus
 . Optional: Override the nameserver settings for the DNS-01 self check.
 +
 This step is required only when the target public-hosted zone overlaps with the cluster's default private-hosted zone.
++
+[IMPORTANT]
+====
+The override procedure is applicable for all DNS-01 self-checks.
+====
 
 .. Edit the `CertManager` resource by running the following command:
 +
@@ -115,6 +120,11 @@ $ oc create -f issuer.yaml
 ----
 
 . Create a certificate:
++
+[NOTE]
+====
+This procedure applicable for all DNS-01 self-checks.
+====
 
 .. Create a YAML file that defines the `Certificate` object:
 +

--- a/modules/cert-manager-acme-dns01-explicit-azure.adoc
+++ b/modules/cert-manager-acme-dns01-explicit-azure.adoc
@@ -19,46 +19,6 @@ You can follow this procedure for an {product-title} cluster that is not running
 
 .Procedure
 
-. Optional: Override the nameserver settings for the DNS-01 self check.
-+
-This step is required only when the target public-hosted zone overlaps with the cluster's default private-hosted zone.
-
-.. Edit the `CertManager` resource by running the following command:
-+
-[source,terminal]
-----
-$ oc edit certmanager cluster
-----
-
-.. Add a `spec.controllerConfig` section with the following override arguments:
-+
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1alpha1
-kind: CertManager
-metadata:
-  name: cluster
-  ...
-spec:
-  ...
-  controllerConfig:                                <1>
-    overrideArgs:
-      - '--dns01-recursive-nameservers-only'       <2>
-      - '--dns01-recursive-nameservers=1.1.1.1:53' <3>
-----
-<1> Add the `spec.controllerConfig` section.
-<2> Specify to only use recursive nameservers instead of checking the authoritative nameservers associated with that domain.
-<3> Provide a comma-separated list of `<host>:<port>` nameservers to query for the DNS-01 self check. You must use a `1.1.1.1:53` value to avoid the public and private zones overlapping.
-
-.. Save the file to apply the changes.
-
-. Optional: Create a namespace for the issuer:
-+
-[source,terminal]
-----
-$ oc new-project my-issuer-namespace
-----
-
 . Create a secret to store your Azure credentials in by running the following command:
 +
 [source,terminal]
@@ -120,34 +80,6 @@ spec:
 $ oc create -f issuer.yaml
 ----
 
-. Create a certificate:
-
-.. Create a YAML file that defines the `Certificate` object:
-+
-.Example `certificate.yaml` file
-[source,yaml]
-----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: <tls_cert> <1>
-  namespace: <issuer-namespace> <2>
-spec:
-  secretName: <tls_cert> <3>
-  issuerRef:
-    name: <acme-dns01-azuredns-issuer> <4>
-  dnsNames:
-  - '<domain_name>' <5>
-----
-<1> Provide a name for the certificate.
-<2> Replace `<issuer_namespace>` with your issuer namespace.
-<3> Specify the name of the secret to create that will contain the certificate.
-<4> Specify the name of the issuer that you created.
-<5> Replace `<domain_name>` with your domain name.
-
-.. Create the `Certificate` object by running the following command:
-+
-[source,terminal]
-----
-$ oc create -f certificate.yaml
-----
+[role="_additional-resources"]
+== Additional resources
+* For information about the override procedure and creating the certificate, see xref:../cert_manager_operator/cert-manager-operator-issuer-acme#cert-manager-acme-dns01-explicit-aws_cert-manager-operator-issuer-acme[Configuring an ACME issuer by using explicit credentials for AWS Route53].

--- a/modules/cert-manager-acme-dns01-explicit-gcp.adoc
+++ b/modules/cert-manager-acme-dns01-explicit-gcp.adoc
@@ -19,46 +19,6 @@ You can use Google CloudDNS with explicit credentials in an {product-title} clus
 
 .Procedure
 
-. Optional: Override the nameserver settings for the DNS-01 self check.
-+
-This step is required only when the target public-hosted zone overlaps with the cluster's default private-hosted zone.
-
-.. Edit the `CertManager` resource by running the following command:
-+
-[source,terminal]
-----
-$ oc edit certmanager cluster
-----
-
-.. Add a `spec.controllerConfig` section with the following override arguments:
-+
-[source,yaml]
-----
-apiVersion: operator.openshift.io/v1alpha1
-kind: CertManager
-metadata:
-  name: cluster
-  ...
-spec:
-  ...
-  controllerConfig:                                <1>
-    overrideArgs:
-      - '--dns01-recursive-nameservers-only'       <2>
-      - '--dns01-recursive-nameservers=1.1.1.1:53' <3>
-----
-<1> Add the `spec.controllerConfig` section.
-<2> Specify to only use recursive nameservers instead of checking the authoritative nameservers associated with that domain.
-<3> Provide a comma-separated list of `<host>:<port>` nameservers to query for the DNS-01 self check. You must use a `1.1.1.1:53` value to avoid the public and private zones overlapping.
-
-.. Save the file to apply the changes.
-
-. Optional: Create a namespace for the issuer:
-+
-[source,terminal]
-----
-$ oc new-project my-issuer-namespace
-----
-
 . Create a secret to store your GCP credentials by running the following command:
 +
 [source,terminal]
@@ -107,34 +67,6 @@ spec:
 $ oc create -f issuer.yaml
 ----
 
-. Create a certificate:
-
-.. Create a YAML file that defines the `Certificate` object:
-+
-.Example `certificate.yaml` file
-[source,yaml]
-----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: <tls_cert> <1>
-  namespace: <issuer-namespace> <2>
-spec:
-  secretName: <tls_cert> <3>
-  issuerRef:
-    name: issuer-acme-dns01-clouddns <4>
-  dnsNames:
-  - '<domain_name>' <5>
-----
-<1> Provide a name for the certificate.
-<2> Replace `<issuer_namespace>` with your issuer namespace.
-<3> Specify the name of the secret to create that will contain the certificate.
-<4> Specify the name of the issuer that you created.
-<5> Replace `<domain_name>` with your domain name.
-
-.. Create the `Certificate` object by running the following command:
-+
-[source,terminal]
-----
-$ oc create -f certificate.yaml
-----
+[role="_additional-resources"]
+== Additional resources
+* For information about the override procedure and creating the certificate, see xref:../cert_manager_operator/cert-manager-operator-issuer-acme#cert-manager-acme-dns01-explicit-aws_cert-manager-operator-issuer-acme[Configuring an ACME issuer by using explicit credentials for AWS Route53].


### PR DESCRIPTION
Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS 7547](https://issues.redhat.com/browse/OSDOCS-7547)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Doc Preview](https://63966--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-issuer-acme#cert-manager-acme-dns01-explicit-aws_cert-manager-operator-issuer-acme)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
