### PR TITLE
[HCCDOC-1094] Insights DataGather

### DIFF
--- a/modules/disabling-insights-operator-gather.adoc
+++ b/modules/disabling-insights-operator-gather.adoc
@@ -12,6 +12,11 @@ You can disable the Insights Operator gather operations. Disabling the gather op
 :FeatureName: The `InsightsDataGather` custom resource 
 include::snippets/technology-preview.adoc[] 
 
+[NOTE]
+====
+If you enable Technology Preview in your cluster, the Insights Operator runs gather operations in individual pods. This is part of the Technology Preview feature set for the Insights Operator and supports the new data gathering features.
+====
+
 .Prerequisites
 
 * You are logged in to the {product-title} web console as a user with `cluster-admin` role.

--- a/modules/running-insights-operator-gather-cli.adoc
+++ b/modules/running-insights-operator-gather-cli.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+
+:_content-type: PROCEDURE
+[id="running-insights-operator-gather-openshift-cli_{context}"]
+= Running an Insights Operator gather operation using the OpenShift CLI
+You can run an Insights Operator gather operation using the {product-title} command line interface. 
+
+.Prerequisites
+
+* You are logged in to {product-title} as a user with the `cluster-admin` role.
+
+.Procedure
+* Enter the following command to run the gather operation: 
++
+[source,terminal]
+----
+$ oc apply -f <your_datagather_definition>.yaml 
+----
++
+Replace `<your_datagather_definition>.yaml` with a configuration file using the following parameters:
++
+[source,yaml]
+----
+apiVersion: insights.openshift.io/v1alpha1
+kind: DataGather
+metadata:
+  name: <your_data_gather> <1>
+spec:
+ gatherers: <2>
+   - name: workloads 
+     state: Disabled
+----
++
+--
+<1> Replace the `<your_data_gather>` with a unique name for your gather operation.
+<2> Enter individual gather operations to disable under the `gatherers` parameter. This example disables the `workloads` data gather operation and will run the remainder of the default operations. To run the complete list of default gather operations, leave the `spec` parameter empty. You can find the complete list of gather operations in the Insights Operator documentation. 
+--
+
+.Verification
+
+* Check that your new gather operation is prefixed with your chosen name under the list of pods in the `openshift-insights` project. Upon completion, the Insights Operator automatically uploads the data to Red Hat for processing.
+

--- a/modules/running-insights-operator-gather-web-console.adoc
+++ b/modules/running-insights-operator-gather-web-console.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * support/remote_health_monitoring/using-insights-operator.adoc
+
+
+:_content-type: PROCEDURE
+
+[id="running-insights-operator-gather-web-console_{context}"]
+= Running an Insights Operator gather operation using the web console
+You can run an Insights Operator gather operation using the {product-title} web console.
+
+.Prerequisites
+
+* You are logged in to the {product-title} web console as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Navigate to *Administration* -> *CustomResourceDefinitions*.
+. On the *CustomResourceDefinitions* page, use the *Search by name* field to find the *DataGather* resource definition and click it.
+. On the *CustomResourceDefinition details* page, click the *Instances* tab.
+. Click *Create DataGather*.
+. To create a new `DataGather` operation, edit the configuration file:
++
+[source,yaml]
+----
+apiVersion: insights.openshift.io/v1alpha1
+kind: DataGather
+metadata:
+  name: <your_data_gather> <1>
+spec:
+ gatherers: <2>
+   - name: workloads 
+     state: Disabled
+----
++
+--
+<1> Replace the `<your_data_gather>` with a unique name for your gather operation.
+<2> Enter individual gather operations to disable under the `gatherers` parameter. This example disables the `workloads` data gather operation and will run the remainder of the default operations. To run the complete list of default gather operations, leave the `spec` parameter empty. You can find the complete list of gather operations in the Insights Operator documentation. 
+--
++
+. Click *Save*.
+
+.Verification
+
+. Navigate to *Workloads* -> *Pods*.
+. On the Pods page, select the *Project* pulldown menu, and then turn on Show default projects.
+. Select the `openshift-insights` project from the *Project* pulldown menu. 
+. Check that your new gather operation is prefixed with your chosen name under the list of pods in the `openshift-insights` project. Upon completion, the Insights Operator automatically uploads the data to Red Hat for processing.

--- a/support/remote_health_monitoring/using-insights-operator.adoc
+++ b/support/remote_health_monitoring/using-insights-operator.adoc
@@ -23,4 +23,18 @@ include::modules/disabling-insights-operator-alerts.adoc[leveloffset=+1]
 include::modules/insights-operator-downloading-archive.adoc[leveloffset=+1]
 include::modules/insights-operator-gather-duration.adoc[leveloffset=+1]
 include::modules/disabling-insights-operator-gather.adoc[leveloffset=+1]
+[id="running-insights-operator-gather_using-insights-operator"]
+== Running an Insights Operator gather operation
+
+You can run Insights Operator data gather operations on demand. The following procedures describe how to run the default list of gather operations using the OpenShift web console or CLI. You can customize the on demand gather function to exclude any gather operations you choose. Disabling gather operations from the default list degrades Insights Advisor's ability to offer effective recommendations for your cluster. If you have previously disabled Insights Operator gather operations in your cluster, this procedure will override those parameters.  
+
+:FeatureName: The `DataGather` custom resource 
+include::snippets/technology-preview.adoc[] 
+
+[NOTE]
+====
+If you enable Technology Preview in your cluster, the Insights Operator runs gather operations in individual pods. This is part of the Technology Preview feature set for the Insights Operator and supports the new data gathering features.
+====
+include::modules/running-insights-operator-gather-web-console.adoc[leveloffset=+2]
+include::modules/running-insights-operator-gather-cli.adoc[leveloffset=+2]
 include::modules/insights-operator-configuring.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
enterprise-4.14+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/HCCDOC-1094
linked issue: https://issues.redhat.com/browse/HCCDOC-903 

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://63976--docspreview.netlify.app/openshift-enterprise/latest/support/remote_health_monitoring/using-insights-operator#running-insights-operator-gather_using-insights-operator
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds a new procedure for manually creating a DataGather operation. This is TP in 4.14+
