### PR TITLE
OSDOCS-7602: Documented the 4.12.31 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4002,3 +4002,23 @@ $ oc adm release info 4.12.30 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+
+[id="ocp-4-12-31"]
+=== RHBA-2023:4756 - {product-title} 4.12.31 bug fix update
+
+Issued: 2023-08-31
+
+{product-title} release 4.12.31 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4756[RHBA-2023:4756] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4759[RHBA-2023:4759] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.31 --pullspecs
+----
+
+[id="ocp-4-12-31-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-7602](https://issues.redhat.com/browse/OSDOCS-7602)

Version(s):
4.12

Link to docs preview:
[4.12.31 notes](https://63977--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-31)

QE review:
- [x] QE approval is not required for z-stream updates.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
