### PR TITLE
Adjust validate script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,9 @@ jobs:
         - gem install asciidoctor asciidoctor-diagram rouge
         - pip3 install pyyaml aura.tar.gz
       script:
-        # Fail if Asciidoctor encounters errors. Pass otherwise. Run only if there are modified AsciiDoc files
-        - if ! [[ -z $(git diff --name-only HEAD~1 HEAD --diff-filter=d '*.adoc' ':(exclude)_unused_topics/*') ]]; then chmod +x ./scripts/check-asciidoctor-build.sh && ./scripts/check-asciidoctor-build.sh; fi
+        # Fail if Asciidoctor encounters errors. Pass otherwise.
+        - chmod +x ./scripts/check-asciidoctor-build.sh
+        - ./scripts/check-asciidoctor-build.sh || travis_terminate 1
 
     - stage: build
       if: branch IN (main, enterprise-4.13, enterprise-4.14)


### PR DESCRIPTION
Fixes .travis.yml logic and validate script logic. Update build to use [travis_terminate](https://medium.com/@manjula.cse/how-to-stop-the-execution-of-travis-pipeline-if-script-exits-with-an-error-f0e5a43206bf) to exit 1 from the script when changes cause assemblies to fail validation. Lone modules are ignored.
)

* [Build when lone orphan AsciiDoc modules are added (Updated)](https://app.travis-ci.com/github/openshift/openshift-docs/jobs/608885427) ✅
* [Build when included AsciiDoc is modified and in error (Updated)](https://app.travis-ci.com/github/openshift/openshift-docs/jobs/608884634) ❌
* [Build when included AsciiDoc is modified and not in error](https://app.travis-ci.com/github/openshift/openshift-docs/jobs/608801959) ✅
* [Build when no AsciiDoc is modified (Updated)](https://app.travis-ci.com/github/openshift/openshift-docs/jobs/608884886) ✅

Merge to main, CP to enterprise 4.10+