### PR TITLE
OSDOCS-7601 z-stream release notes for 4.11.48

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3696,7 +3696,7 @@ To update an existing {product-title} 4.11 cluster to this latest release, see x
 
 Issued: 2023-08-16
 
-{product-title} release 4.11.46, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:4614[RHBA-2023:4614] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4616[RHBA-2023:4616] advisory.
+{product-title} release 4.11.47, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:4614[RHBA-2023:4614] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4616[RHBA-2023:4616] advisory.
 
 You can view the container images in this release by running the following command:
 
@@ -3706,6 +3706,25 @@ $ oc adm release info 4.11.47 --pullspecs
 ----
 
 [id="ocp-4-11-47-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-48"]
+=== RHBA-2023:4752 {product-title} 4.11.48 bug fix update
+
+Issued: 2023-08-31
+
+{product-title} release 4.11.48 is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:4752[RHBA-2023:4752] advisory. There is no RPM package in this update.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.48 --pullspecs
+----
+
+[id="ocp-4-11-48-upgrading"]
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-7601](https://issues.redhat.com/browse/OSDOCS-7601)

Link to docs preview:
[Preview](https://63984--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-48)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Expected merge date is Aug. 31. This PR also fixes a typo in the previous RNs.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
