### PR TITLE
OSDOCS#6402: GCP on with multi-arch compute machines support

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -536,6 +536,8 @@ Topics:
     File: creating-multi-arch-compute-nodes-azure
   - Name: Creating a cluster with multi-architecture compute machines on AWS
     File: creating-multi-arch-compute-nodes-aws
+  - Name: Creating a cluster with multi-architecture compute machines on GCP
+    File: creating-multi-arch-compute-nodes-gcp
   - Name: Creating a cluster with multi-architecture compute machines on bare metal
     File: creating-multi-arch-compute-nodes-bare-metal
   - Name: Creating a cluster with multi-architecture compute machines on IBM Z and IBM LinuxONE with z/VM

--- a/modules/multi-architecture-modify-machine-set-gcp.adoc
+++ b/modules/multi-architecture-modify-machine-set-gcp.adoc
@@ -1,0 +1,149 @@
+//Module included in the following assembly
+//
+//post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc
+
+:_content-type: PROCEDURE
+[id="multi-architecture-modify-machine-set-gcp_{context}"]
+= Adding an ARM64 compute machine set to your GCP cluster 
+
+To configure a cluster with multi-architecture compute machines, you must create a GCP ARM64 compute machine set. This adds ARM64 compute nodes to your cluster.
+
+.Prerequisites 
+
+* You installed the {oc-first}. 
+* You used the installation program to create an AMD64 single-architecture AWS cluster with the multi-architecture installer binary.
+
+.Procedure
+* Create and modify a compute machine set, this controls the ARM64 compute nodes in your cluster:
++
+[source,terminal]
+----
+$ oc create -f gcp-arm64-machine-set-0.yaml
+----
++
+--
+.Sample GCP YAML compute machine set to deploy an ARM64 compute node
+[source,yaml]
+----
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+metadata:
+  labels:
+    machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
+  name: <infrastructure_id>-w-a
+  namespace: openshift-machine-api
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        machine.openshift.io/cluster-api-cluster: <infrastructure_id>
+        machine.openshift.io/cluster-api-machine-role: <role> <2>
+        machine.openshift.io/cluster-api-machine-type: <role>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-w-a
+    spec:
+      metadata:
+        labels:
+          node-role.kubernetes.io/<role>: ""
+      providerSpec:
+        value:
+          apiVersion: gcpprovider.openshift.io/v1beta1
+          canIPForward: false
+          credentialsSecret:
+            name: gcp-cloud-credentials
+          deletionProtection: false
+          disks:
+          - autoDelete: true
+            boot: true
+            image: <path_to_image> <3>
+            labels: null
+            sizeGb: 128
+            type: pd-ssd
+          gcpMetadata: <4>
+          - key: <custom_metadata_key>
+            value: <custom_metadata_value>
+          kind: GCPMachineProviderSpec
+          machineType: n1-standard-4 <5>
+          metadata:
+            creationTimestamp: null
+          networkInterfaces:
+          - network: <infrastructure_id>-network
+            subnetwork: <infrastructure_id>-worker-subnet
+          projectID: <project_name> <6>
+          region: us-central1 <7>
+          serviceAccounts:
+          - email: <infrastructure_id>-w@<project_name>.iam.gserviceaccount.com
+            scopes:
+            - https://www.googleapis.com/auth/cloud-platform
+          tags:
+            - <infrastructure_id>-worker
+          userDataSecret:
+            name: worker-user-data
+          zone: us-central1-a
+----
+<1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. You can obtain the infrastructure ID by running the following command:
++
+[source,terminal]
+----
+$ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
+----
+<2> Specify the role node label to add.
+<3> Specify the path to the image that is used in current compute machine sets. You need the project and image name for your path to image. 
++
+To access the project and image name, run the following command: 
++ 
+[source,terminal]
+----
+$ oc get configmap/coreos-bootimages \ 
+  -n openshift-machine-config-operator \ 
+  -o jsonpath='{.data.stream}' | jq \ 
+  -r '.architectures.aarch64.images.gcp'
+----
++
+.Example output 
+[source,terminal]
+----
+  "gcp": {
+    "release": "415.92.202309142014-0",
+    "project": "rhcos-cloud",
+    "name": "rhcos-415-92-202309142014-0-gcp-aarch64"
+  }
+----
+Use the `project` and `name` parameters from the output to create the path to image field in your machine set. The path to the image should follow the following format:
++
+[source,terminal]
+----
+$ projects/<project>/global/images/<image_name>
+----
+<4> Optional: Specify custom metadata in the form of a `key:value` pair. For example use cases, see the GCP documentation for link:https://cloud.google.com/compute/docs/metadata/setting-custom-metadata[setting custom metadata].
+<5> Specify an ARM64 supported machine type. For more information, refer to _Tested instance types for GCP on 64-bit ARM infrastructures_ in "Additional resources".
+<6> Specify the name of the GCP project that you use for your cluster.
+<7> Specify the region, for example, `us-central1`. Ensure that the zone you select offers 64-bit ARM machines.
+--
+
+.Verification 
+. View the list of compute machine sets by entering the following command:
++
+[source,terminal]
+----
+$ oc get machineset -n openshift-machine-api
+----
+You can then see your created ARM64 machine set. 
++
+.Example output
+[source,terminal]
+----
+NAME                                                DESIRED  CURRENT  READY  AVAILABLE  AGE
+<infrastructure_id>-gcp-arm64-machine-set-0                   2        2      2          2  10m
+----
+. You can check that the nodes are ready and scheduable with the following command:
++
+[source,terminal]
+---- 
+$ oc get nodes
+----

--- a/modules/multi-architecture-verifying-cluster-compatibility.adoc
+++ b/modules/multi-architecture-verifying-cluster-compatibility.adoc
@@ -1,6 +1,11 @@
 // Module included in the following assemblies:
 
-// * post_installation_configuration/multi-architecture-configuration.adoc
+// * post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws.adoc
+// * post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-azure.adoc
+// * post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc
+// * post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc
+// * post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.adoc
+// * post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc
 
 :_content-type: PROCEDURE
 [id="multi-architecture-verifying-cluster-compatibility_{context}"]

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc
@@ -1,0 +1,22 @@
+:_content-type: ASSEMBLY
+:context: creating-multi-arch-compute-nodes-gcp
+[id="creating-multi-arch-compute-nodes-gcp"]
+= Creating a cluster with multi-architecture compute machines on GCP
+include::_attributes/common-attributes.adoc[]
+
+toc::[]
+
+To create a Google Cloud Platform (GCP) cluster with multi-architecture compute machines, you must first create a single-architecture GCP installer-provisioned cluster with the multi-architecture installer binary. For more information on AWS installations, refer to xref:../../installing/installing_gcp/installing-gcp-customizations.adoc[Installing a cluster on GCP with customizations]. You can then add ARM64 compute machines sets to your GCP cluster.
+
+[NOTE]
+====
+Secure booting is currently not supported on ARM64 machines for GCP 
+====
+
+include::modules/multi-architecture-verifying-cluster-compatibility.adoc[leveloffset=+1]
+
+include::modules/multi-architecture-modify-machine-set-gcp.adoc[leveloffset=+1]
+
+.Additional resources
+
+* xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-tested-machine-types-arm_installing-gcp-customizations[Tested instance types for GCP on 64-bit ARM infrastructures]

--- a/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc
@@ -28,8 +28,15 @@ To create a cluster with multi-architecture compute machines for various platfor
 
 * xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws.adoc#creating-multi-arch-compute-nodes-aws[Creating a cluster with multi-architecture compute machines on AWS]
 
+* xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp.adoc#creating-multi-arch-compute-nodes-gcp[Creating a cluster with multi-architecture compute machines on GCP]
+
 * xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc#creating-multi-arch-compute-nodes-bare-metal[Creating a cluster with multi-architecture compute machines on bare metal]
 
 * xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z.adoc#creating-multi-arch-compute-nodes-ibm-z[Creating a cluster with multi-architecture compute machines on {ibmzProductName} and {linuxoneProductName} with z/VM]
 
 * xref:../../post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-ibm-z-kvm.adoc#creating-multi-arch-compute-nodes-ibm-z-kvm[Creating a cluster with multi-architecture compute machines on {ibmzProductName} and {linuxoneProductName} with {op-system-base} KVM]
+
+[IMPORTANT]
+====
+Autoscaling from zero is currently not supported on Google Cloud Platform (GCP). 
+====


### PR DESCRIPTION
**Version(s):** 4.14+
**Issue:** [OSDOCS-6402](https://issues.redhat.com//browse/OSDOCS-6402)

**Link to docs preview:**

[Creating a cluster with multi-architecture compute machine on GCP](https://63991--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-gcp#multi-architecture-modify-machine-set-gcp_creating-multi-arch-compute-nodes-gcp)

**QE review:**
- [x] QE has approved this change.
