### PR TITLE
OSDOCS-7605: add release note MicroShift 4.12.31

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -320,3 +320,12 @@ Issued: 2023-08-23
 {product-title} release 4.12.30 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4673[RHBA-2023:4673] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4671[RHBA-2023:4671] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-31-dp"]
+=== RHBA-2023:4758 - {product-title} 4.12.31 bug fix update
+
+Issued: 2023-08-31
+
+{product-title} release 4.12.31 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4673[RHBA-2023:4758] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4671[RHBA-2023:4756] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-7605

Link to docs preview:
https://63993--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes#microshift-4-12-31-dp 

QE review:
- N/A placeholder bug only 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
