### PR TITLE
OSDOCS#3051: Adding us-iso-west-1 as supported AWS region

### DIFF
--- a/modules/installation-aws-regions.adoc
+++ b/modules/installation-aws-regions.adoc
@@ -60,6 +60,7 @@ The following AWS secret regions are supported:
 
 * `us-isob-east-1` Secret Commercial Cloud Services (SC2S)
 * `us-iso-east-1` Commercial Cloud Services (C2S)
+* `us-`iso-west-1` C2S
 
 [id="installation-aws-china_{context}"]
 == AWS China regions


### PR DESCRIPTION
Version(s):
4.14+

Issue:
This PR addresses [osdocs-3051](https://issues.redhat.com/browse/OSDOCS-3051).

Link to docs preview:

AWS SC2S and C2S secret regions

QE review:
- [ ] QE has approved this change.
