### PR TITLE
OSDOCS 6451: Release notes for deprecating DeploymentConfig

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -533,8 +533,30 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
+[discrete]
+=== Workloads deprecated and removed features
+
+.Workloads deprecated and removed tracker
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.12 |4.13 |4.14
+
+|`DeploymentConfig` objects
+|General Availability
+|General Availability
+|Deprecated
+
+|====
+
 [id="ocp-4-14-deprecated-features"]
 === Deprecated features
+
+[id="ocp-4-14-deployment-config-deprecated"]
+=== DeploymentConfig resources are now deprecated
+
+As of {product-title} 4.14, `DeploymentConfig` objects are deprecated. `DeploymentConfig` objects are still supported, but are not recommended for new installations. Only security-related and critical issues will be fixed.
+
+Instead, use `Deployment` objects or another alternative to provide declarative updates for pods.
 
 [id="ocp-4-14-removed-features"]
 === Removed features


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OSDOCS-6451

Link to docs preview:
* https://64000--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-deployment-config-deprecated
* https://64000--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-deprecated-removed-features (Workloads deprecated and removed tracker table) 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
