### PR TITLE
OCPBUGS#18100-New: Revert optional step in vSphere docs

### DIFF
--- a/modules/installation-vsphere-machines.adoc
+++ b/modules/installation-vsphere-machines.adoc
@@ -141,20 +141,20 @@ Ensure that all virtual machine names across a vSphere installation are unique.
 
 .. On the *Select a compute resource* tab, select the name of a host in your datacenter.
 +
-.. On the *Select clone options*, select
-*Customize this virtual machine's hardware*.
+.. On the *Select clone options* tab, select *Customize this virtual machine's hardware*.
 
-.. Optional: On the *Customize hardware* tab, click *VM Options* -> *Advanced*.
+.. On the *Customize hardware* tab, click *Advanced Parameters*.
 +
 [IMPORTANT]
 ====
 The following configuration suggestions are for example purposes only. As a cluster administrator, you must configure resources according to the resource demands placed on your cluster. To best manage cluster resources, consider creating a resource pool from the cluster's root resource pool.
 ====
 +
-*** Override default DHCP networking in vSphere. To enable static IP networking:
+*** Optional: Override default DHCP networking in vSphere. To enable static IP networking:
 +
 **** Set your static IP configuration:
 +
+.Example command
 [source,terminal]
 ----
 $ export IPCFG="ip=<ip>::<gateway>:<netmask>:<hostname>:<iface>:none nameserver=srv1 [nameserver=srv2 [nameserver=srv3 [...]]]"
@@ -166,8 +166,17 @@ $ export IPCFG="ip=<ip>::<gateway>:<netmask>:<hostname>:<iface>:none nameserver=
 $ export IPCFG="ip=192.168.100.101::192.168.100.254:255.255.255.0:::none nameserver=8.8.8.8"
 ----
 +
-*** Click *Edit Configuration*, and on the *Configuration Parameters* window, search the list of available parameters for steal clock accounting (`stealclock.enable`). Set the parameter to the value of `TRUE`. Enabling steal clock accounting can help with troubleshooting cluster issues.
-*** Click *Add Configuration Params*. Define the following parameter names and values:
+**** Set the `guestinfo.afterburn.initrd.network-kargs` property before you boot a VM from an OVA in vSphere:
++
+.Example command
+[source,terminal]
+----
+$ govc vm.change -vm "<vm_name>" -e "guestinfo.afterburn.initrd.network-kargs=${IPCFG}"
+----
++
+*** Add the following configuration parameter names and values by specifying data in the *Attribute* and *Values* fields. Ensure that you select the *Add* button for each parameter that you create.
+**** `guestinfo.ignition.config.data`: Locate the base-64 encoded files that you created previously in this procedure, and paste the contents of the base64-encoded Ignition config file for this machine type.
+**** `guestinfo.ignition.config.data.encoding`: Specify `base64`.
 **** `disk.EnableUUID`: Specify `TRUE`.
 **** `stealclock.enable`: If this parameter was not defined, add it and specify `TRUE`.
 **** Create a child resource pool from the cluster's root resource pool. Perform resource allocation in this child resource pool.
@@ -175,7 +184,8 @@ $ export IPCFG="ip=192.168.100.101::192.168.100.254:255.255.255.0:::none nameser
 .. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the
 machine type.
 
-.. Complete the configuration and power on the VM.
+.. Complete the remaining configuration steps. On clicking the *Finish* button, you have completed the cloning operation.  
+.. From the *Virtual Machines* tab, right-click on your VM and then select *Power* -> *Power On*.
 
 .. Check the console output to verify that Ignition ran.
 +
@@ -185,7 +195,10 @@ machine type.
 Ignition: ran on 2022/03/14 14:48:33 UTC (this boot)
 Ignition: user-provided config was applied
 ----
-. Create the rest of the machines for your cluster by following the preceding steps for each machine.
+
+.Next steps
+
+* Create the rest of the machines for your cluster by following the preceding steps for each machine.
 +
 [IMPORTANT]
 ====

--- a/modules/machine-vsphere-machines.adoc
+++ b/modules/machine-vsphere-machines.adoc
@@ -15,6 +15,8 @@ endif::[]
 
 You can add more compute machines to a user-provisioned {product-title} cluster on VMware vSphere.
 
+After your vSphere template deploys in your {product-title} cluster, you can deploy a virtual machine (VM) for a machine in that cluster.
+
 ifdef::three-node-cluster[]
 [NOTE]
 ====
@@ -29,26 +31,38 @@ endif::three-node-cluster[]
 
 .Procedure
 
-. After the template deploys, deploy a VM for a machine in the cluster.
-.. Right-click the template's name and click *Clone* -> *Clone to Virtual Machine*.
-.. On the *Select a name and folder* tab, specify a name for the VM. You might include the machine type in the name, such as `compute-1`.
+. Right-click the template's name and click *Clone* -> *Clone to Virtual Machine*.
+
+. On the *Select a name and folder* tab, specify a name for the VM. You might include the machine type in the name, such as `compute-1`.
 +
 [NOTE]
 ====
 Ensure that all virtual machine names across a vSphere installation are unique.
 ====
-.. On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
-.. On the *Select a compute resource* tab, select the name of a host in your datacenter.
-.. On the *Select clone options*, select *Customize this virtual machine's hardware*.
-.. On the *Customize hardware* tab, click *VM Options* -> *Advanced*.
-*** Click *Edit Configuration*, and on the *Configuration Parameters* window, click *Add Configuration Params*. Define the following parameter names and values:
-**** `guestinfo.ignition.config.data`: Paste the contents of the base64-encoded compute Ignition config file for this machine type.
-**** `guestinfo.ignition.config.data.encoding`: Specify `base64`.
-**** `disk.EnableUUID`: Specify `TRUE`.
-.. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the machine type. Also, make sure to select the correct network under *Add network adapter* if there are multiple networks available.
-.. Complete the configuration and power on the VM.
 
-. Continue to create more compute machines for your cluster.
+. On the *Select a name and folder* tab, select the name of the folder that you created for the cluster.
+
+. On the *Select a compute resource* tab, select the name of a host in your datacenter.
+
+. On the *Select storage* tab, select storage for your configuration and disk files.
+
+. On the *Select clone options* tab, select *Customize this virtual machine's hardware*.
+
+. On the *Customize hardware* tab, click *Advanced Parameters*.
+** Add the following configuration parameter names and values by specifying data in the *Attribute* and *Values* fields. Ensure that you select the *Add* button for each parameter that you create.
+*** `guestinfo.ignition.config.data`: Paste the contents of the base64-encoded compute Ignition config file for this machine type.
+*** `guestinfo.ignition.config.data.encoding`: Specify `base64`.
+*** `disk.EnableUUID`: Specify `TRUE`.
+
+. In the *Virtual Hardware* panel of the *Customize hardware* tab, modify the specified values as required. Ensure that the amount of RAM, CPU, and disk storage meets the minimum requirements for the machine type. If many networks exist, select *Add New Device* > *Network Adapter*, and then enter your network information in the fields provided by the *New Network* menu item.
+
+. Complete the remaining configuration steps. On clicking the *Finish* button, you have completed the cloning operation.  
+
+. From the *Virtual Machines* tab, right-click on your VM and then select *Power* -> *Power On*.
+
+.Next steps
+
+* Continue to create more compute machines for your cluster.
 
 ifeval::["{context}" == "installing-vsphere"]
 :!three-node-cluster:


### PR DESCRIPTION
[OCPBUGS-18100](https://issues.redhat.com/browse/OCPBUGS-18100)

Version(s):
4.14 through to 4.10

Link to docs preview:
* [Installing RHCOS and starting the OpenShift Container Platform bootstrap process](https://64010--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere#installation-vsphere-machines_installing-vsphere)
* [Adding more compute machines to a cluster in vSphere](https://64010--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere#machine-vsphere-machines_installing-vsphere)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
