### PR TITLE
OCPBUGS#17814-New: Removed administerXpn statement from GCP docs

### DIFF
--- a/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
+++ b/modules/minimum-required-permissions-ipi-gcp-xpn.adoc
@@ -7,9 +7,14 @@
 
 When you are installing a cluster to a link:https://cloud.google.com/vpc/docs/shared-vpc[shared VPC], you must configure the service account for both the host project and the service project. If you are not installing to a shared VPC, you can skip this section.
 
-You must apply the minimum roles required for a standard installation as listed above, to the service project. Note that custom roles, and therefore fine-grained permissions, cannot be used in shared VPC installations because GCP does not support adding the required permission `compute.organizations.administerXpn` to custom roles.
+You must apply the minimum roles required for a standard installation as listed above, to the service project.
 
-In addition, the host project must apply one of the following configurations to the service account:
+[IMPORTANT]
+====
+You can use granular permissions for a Cloud Credential Operator that operates in either manual or mint credentials mode. You cannot use granular permissions in passthrough credentials mode.
+====
+
+Ensure that the host project applies one of the following configurations to the service account:
 
 .Required permissions for creating firewalls in the host project
 [%collapsible]


### PR DESCRIPTION
[OCPBUGS-17814](https://issues.redhat.com/browse/OCPBUGS-17814)

Version(s):
4.13 + 

Link to docs preview:
[Required GCP permissions for shared VPC installations](https://64012--ocpdocs-pr.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account.html#minimum-required-permissions-ipi-gcp-xpn)

- [x] SME has approved this change.
- [x] QE has approved this change.

Additional information:
* https://github.com/openshift/openshift-docs/pull/73841
