### PR TITLE
OCPBUGS-18161: Updated contentImage location for ComplianceSuite files

### DIFF
--- a/modules/compliance-crd-advanced-compliance-scan.adoc
+++ b/modules/compliance-crd-advanced-compliance-scan.adoc
@@ -18,7 +18,7 @@ spec:
   scanType: Node <1>
   profile: xccdf_org.ssgproject.content_profile_moderate <2>
   content: ssg-ocp4-ds.xml
-  contentImage: quay.io/complianceascode/ocp4:latest <3>
+  contentImage: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:45dc... <3>
   rule: "xccdf_org.ssgproject.content_rule_no_netrc_files" <4>
   nodeSelector: <5>
     node-role.kubernetes.io/worker: ""

--- a/modules/compliance-crd-compliance-suite.adoc
+++ b/modules/compliance-crd-compliance-suite.adoc
@@ -24,7 +24,7 @@ spec:
       scanType: Node
       profile: xccdf_org.ssgproject.content_profile_moderate
       content: ssg-rhcos4-ds.xml
-      contentImage: quay.io/complianceascode/ocp4:latest
+      contentImage: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:45dc...
       rule: "xccdf_org.ssgproject.content_rule_no_netrc_files"
       nodeSelector:
         node-role.kubernetes.io/worker: ""

--- a/modules/compliance-objects.adoc
+++ b/modules/compliance-objects.adoc
@@ -28,7 +28,7 @@ spec:
     - name: workers-scan
       profile: xccdf_org.ssgproject.content_profile_moderate
       content: ssg-rhcos4-ds.xml
-      contentImage: quay.io/complianceascode/ocp4:latest
+      contentImage: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:45dc...
       debug: true
       rule: xccdf_org.ssgproject.content_rule_no_direct_root_logins
       nodeSelector:

--- a/modules/compliance-raw-tailored.adoc
+++ b/modules/compliance-raw-tailored.adoc
@@ -33,7 +33,7 @@ spec:
     - name: workers-scan
       profile: xccdf_org.ssgproject.content_profile_moderate
       content: ssg-rhcos4-ds.xml
-      contentImage: quay.io/complianceascode/ocp4:latest
+      contentImage: registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:45dc...
       debug: true
   tailoringConfigMap:
       name: nist-moderate-modified


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-18161

Link to docs preview (VPN required):
[Using the ComplianceSuite and ComplianceScan objects directly](https://file.rdu.redhat.com/antaylor/OCPBUGS-18161/security/compliance_operator/compliance-operator-advanced.html#compliance-objects_compliance-advanced)
[Using raw tailored profiles](https://file.rdu.redhat.com/antaylor/OCPBUGS-18161/security/compliance_operator/compliance-operator-advanced.html#compliance-raw-tailored_compliance-advanced)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Addressed the locations mentioned in the bug as well as an additional location in the docs.