### PR TITLE
[SRVCOM-2463, SRVCOM-2486, SRVCOM-2462, SRVKE-1490] Serverless release notes 1.30

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,14 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-30-0.adoc[leveloffset=+1]
+// 1.30.0 additional resources
+[role="_additional-resources"]
+.Additional resources
+* xref:../knative-serving/config-applications/overriding-config-serving.adoc#knative-serving-CR-system-deployments[Overriding system deployment configurations]
+
+
+// OCP + OSD + ROSA
 include::modules/serverless-rn-1-29-1.adoc[leveloffset=+1]
 // 1.29.1 additional resources
 [role="_additional-resources"]

--- a/modules/serverless-deprecated-removed-features.adoc
+++ b/modules/serverless-deprecated-removed-features.adoc
@@ -10,33 +10,18 @@ Some features that were Generally Available (GA) or a Technology Preview (TP) in
 
 For the most recent list of major functionality deprecated and removed within {ServerlessProductName}, refer to the following table:
 
-// OCP + OSD table
-
-.Deprecated and removed features tracker for {ocp-product-title} and {dedicated-product-title}
-[cols="3,1,1,1,1,1",options="header"]
+.Deprecated and removed features tracker
+[cols="3,1,1,1,1,1,1",options="header"]
 |====
-|Feature |1.21|1.22 to 1.26|1.27|1.28|1.29
+|Feature |1.21|1.22 to 1.26|1.27|1.28|1.29|1.30
 
-|`KafkaBinding` API
-|Deprecated
-|Removed
-|Removed
-|Removed
-|Removed
-
-|`kn func emit` (`kn func invoke` in 1.21+)
-|Removed
-|Removed
-|Removed
-|Removed
-|Removed
-
-|Serving and Eventing `v1alpha1` API
+|`NamespacedKafka` annotation
+|-
+|-
+|-
 |-
 |-
 |Deprecated
-|Deprecated
-|Removed
 
 |`enable-secret-informer-filtering` annotation
 |-
@@ -44,20 +29,13 @@ For the most recent list of major functionality deprecated and removed within {S
 |-
 |Deprecated
 |Deprecated
+|Deprecated
 
-|====
-
-
-// ROSA table
-
-.Deprecated and removed features tracker for {rosa-product-title}
-[cols="3,1,1,1,1",options="header"]
-|====
-|Feature |1.23 to 1.26|1.27|1.28|1.29
-
-|`KafkaBinding` API
-|Removed
-|Removed
+|Serving and Eventing `v1alpha1` API
+|-
+|-
+|Deprecated
+|Deprecated
 |Removed
 |Removed
 
@@ -66,12 +44,15 @@ For the most recent list of major functionality deprecated and removed within {S
 |Removed
 |Removed
 |Removed
+|Removed
+|Removed
 
-|Serving and Eventing `v1alpha1` API
-|-
+|`KafkaBinding` API
 |Deprecated
-|Deprecated
+|Removed
+|Removed
+|Removed
+|Removed
 |Removed
 
 |====
-

--- a/modules/serverless-rn-1-30-0.adoc
+++ b/modules/serverless-rn-1-30-0.adoc
@@ -1,0 +1,97 @@
+// Module included in the following assemblies
+//
+// * about/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-30-0_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.30
+
+{ServerlessProductName} 1.30 is now available. New features, changes, and known issues that relate to {ServerlessProductName} on {product-title} are included in this topic.
+
+[IMPORTANT]
+====
+{ocp-product-title} 4.13 is based on {op-system-base-full} 9.2. {op-system-base} 9.2 has not been submitted for Federal Information Processing Standards (FIPS) validation. Although Red Hat cannot commit to a specific timeframe, we expect to obtain FIPS validation for {op-system-base} 9.0 and {op-system-base} 9.2 modules, and later even minor releases of {op-system-base} 9.x. Information on updates will be available in the link:https://access.redhat.com/articles/2918071[Compliance Activities and Government Standards Knowledgebase article].
+====
+
+[id="new-features-1-30-0_{context}"]
+== New features
+
+* {ServerlessProductName} now uses Knative Serving 1.9.
+* {ServerlessProductName} now uses Knative Eventing 1.9.
+* {ServerlessProductName} now uses Kourier 1.9.
+* {ServerlessProductName} now uses Knative (`kn`) CLI 1.9.
+* {ServerlessProductName} now uses Knative for Apache Kafka 1.9.
+* The `kn func` CLI plug-in now uses `func` 1.10.1.
+
+* {ServerlessProductName} now runs on HyperShift-hosted clusters.
+
+* {ServerlessProductName} now runs on single-node OpenShift.
+
+* Developer Experience around {ServerlessProductName} is now available through OpenShift Toolkit, an OpenShift IDE Extension for the Visual Studio Code (VSCode). The extension can be installed from the VSCode Extension Tab and VSCode Marketplace. See the link:https://marketplace.visualstudio.com/items?itemName=redhat.vscode-openshift-connector[Marketplace page for the Visual Studio Code OpenShift Toolkit extension].
+
+
+* {FunctionsProductName} nows supports {pipelines-title} versions 1.10 and 1.11. Older versions of {pipelines-title} are no longer compatible with {FunctionsProductName}.
+
+* Serverless Logic is now available as a Technology Preview (TP) feature.
++
+See link:https://openshift-knative.github.io/docs/docs/latest/serverless-logic/about.html[the Serverless Logic documentation] for details.
+
+* Beginning with {ServerlessProductName} 1.30.0, the following runtime environments are supported on {ibmzProductName} using the s2i builder:
++
+** NodeJS
+** Python
+** TypeScript
+** Quarkus
+
+* Eventing integration with {SMProductName} is now available as a Technology Preview (TP) feature.
++
+The integration includes the following:
++
+** `PingSource`
+** `ApiServerSource`
+** Knative Source for Apache Kafka
+** Knative Broker for Apache Kafka
+** Knative Sink for Apache Kafka
+** `ContainerSource`
+** `SinkBinding`
+** `InMemoryChannel`
+** `KafkaChannel`
+** Channel-based Knative Broker
+
+* Pipelines-as-code for {FunctionsProductName} is now available as a Technology Preview (TP).
+
+* You can now configure the burst and queries per second (QPS) values for `net-kourier`.
+
+* {FunctionsProductName} users now have the ability to override the `readiness` and `liveness` probe values in the `func.yaml` file for individual Quarkus functions.
++
+See "Functions development reference guide" for guidance on Quarkus, TypeScript, and Node.js functions.
+
+* Beginning with {ServerlessProductName} 1.30.0, Kourier controller and gateway manifests have the following limits and requests by default:
+** requests:
+*** cpu: 200m
+*** memory: 200Mi
+** limits:
+*** cpu: 500m
+*** memory: 500Mi
++
+See the "Overriding Knative Serving system deployment configurations" section of {ServerlessProductName} documentation.
+
+* The `NamespacedKafka` annotation, which was a Technology Preview (TP) feature, is now deprecated in favor of the standard Kafka broker with no data plane isolation.
+
+[id="fixed-issues-1-30_{context}"]
+== Fixed issues
+
+* Previously, the `3scale-kourier-gateway` pod was sending thousands of `net-kourier-controller` DNS queries daily. New queries were being sent for each `NXDOMAIN` reply. This continued until the correct DNS query was produced.
++
+The query now has the `net-kourier-controller.knative-serving-ingress.svc.<cluster domain>.` fully-qualified domain name (FQDN) by default, which solves the problem.
+
+[id="known-issues-1-30-0_{context}"]
+== Known issues
+
+* Building and deploying a function using Podman version 4.6 fails with the `invalid pull policy "1"` error.
++
+To work around this issue, use Podman version 4.5.
+
+* Function deployment using Pipelines-as-code is not supported on {ibmzProductName} and {ibmpowerProductName}.
+
+* Packbuilder is not supported on {ibmzProductName} and {ibmpowerProductName}.

--- a/modules/serverless-tech-preview-features.adoc
+++ b/modules/serverless-tech-preview-features.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * serverless/serverless-release-notes.adoc
+// * about/serverless-release-notes.adoc
 
 :_content-type: REFERENCE
 [id="serverless-tech-preview-features_{context}"]
@@ -10,48 +10,47 @@ Features which are Generally Available (GA) are fully supported and are suitable
 
 The following table provides information about which {ServerlessProductName} features are GA and which are TP:
 
-// OCP + OSD table
-.Generally Available and Technology Preview features tracker for {ocp-product-title} and {dedicated-product-title}
+.Generally Available and Technology Preview features tracker
 [cols="2,1,1,1",options="header"]
 |====
-|Feature |1.27|1.28|1.29
+|Feature |1.28|1.29|1.30
 
-|`multi-container support`
+|Overriding `liveness` and `readiness` in functions
+|-
+|-
+|GA
+
+|Eventing integration with {SMProductName}
+|-
 |-
 |TP
+
+|`kn func`
+|GA
+|GA
 |GA
 
-|Namespace-scoped brokers
+|Quarkus functions
+|GA
+|GA
+|GA
+
+|Node.js functions
+|GA
+|GA
+|GA
+
+|TypeScript functions
+|GA
+|GA
+|GA
+
+|Python functions
 |TP
 |TP
 |TP
 
-|TLS for internal traffic
-|TP
-|TP
-|TP
-
-|PVC support for Knative services
-|GA
-|GA
-|GA
-
-|Init containers support for Knative services
-|GA
-|GA
-|GA
-
-|Kafka sink
-|GA
-|GA
-|GA
-
-|Kafka broker
-|GA
-|GA
-|GA
-
-|HTTPS redirection
+|Service Mesh mTLS
 |GA
 |GA
 |GA
@@ -61,99 +60,45 @@ The following table provides information about which {ServerlessProductName} fea
 |GA
 |GA
 
-|Service Mesh mTLS
+|HTTPS redirection
 |GA
 |GA
 |GA
 
-|Python functions
-|-
+|Kafka broker
+|GA
+|GA
+|GA
+
+|Kafka sink
+|GA
+|GA
+|GA
+
+|Init containers support for Knative services
+|GA
+|GA
+|GA
+
+|PVC support for Knative services
+|GA
+|GA
+|GA
+
+|TLS for internal traffic
 |TP
 |TP
-
-|TypeScript functions
 |TP
-|GA
-|GA
 
-|Node.js functions
+|Namespace-scoped brokers
 |TP
-|GA
-|GA
+|TP
+|TP
 
-|Quarkus functions
-|GA
-|GA
-|GA
-
-|`kn func`
-|GA
+|`multi-container support`
+|TP
 |GA
 |GA
 
 |====
 
-
-// // ROSA table
-
-// .Generally Available and Technology Preview features tracker for {rosa-product-title}
-// [cols="2,1,1,1",options="header"]
-// |====
-// |Feature |1.27|1.28|1.29
-
-// |`multi-container support`
-// |-
-// |TP
-// |GA
-
-// |Namespace-scoped brokers
-// |TP
-// |TP
-// |TP
-
-// |TLS for internal traffic
-// |TP
-// |TP
-// |TP
-
-// |PVC support for Knative services
-// |GA
-// |GA
-// |GA
-
-// |Init containers support for Knative services
-// |GA
-// |GA
-// |GA
-
-// |Kafka sink
-// |TP
-// |TP
-// |TP
-
-// |Kafka broker
-// |GA
-// |GA
-// |GA
-
-// |HTTPS redirection
-// |GA
-// |GA
-// |GA
-
-// |`emptyDir` volumes
-// |GA
-// |GA
-// |GA
-
-// |Service Mesh mTLS
-// |GA
-// |GA
-// |GA
-
-// |`kn func`
-// |GA
-// |GA
-// |GA
-
-// |====


### PR DESCRIPTION
Version(s):
`serverless-docs-1.30`+

Issue:
https://issues.redhat.com/browse/SRVCOM-2463
https://issues.redhat.com/browse/SRVCOM-2486
https://issues.redhat.com/browse/SRVCOM-2462
https://issues.redhat.com/browse/SRVKE-1490

Link to docs preview:
* GA/TP features table: https://64019--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes#serverless-tech-preview-features_serverless-release-notes
* Deprecated/removed features table: https://64019--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes#serverless-deprecated-removed-features_serverless-release-notes
* Serverless 1.30 release notes: https://64019--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes#serverless-rn-1-30-0_serverless-release-notes

QE review:
- [ ] QE has approved this change.