### PR TITLE
[OSDOCS-6598] Added information on what role is required for OADP installation on ROSA STS

### DIFF
--- a/modules/oadp-installing-oadp-rosa-sts.adoc
+++ b/modules/oadp-installing-oadp-rosa-sts.adoc
@@ -34,6 +34,13 @@ web_identity_token_file = /var/run/secrets/openshift/serviceaccount/token
 EOF
 ----
 
+.. Create a namespace for OADP:
++
+[source,terminal]
+----
+$ oc create namespace openshift-adp
+----
+
 .. Create the OpenShift secret:
 +
 [source,terminal]
@@ -93,16 +100,16 @@ spec:
       defaultPlugins:
       - openshift
       - aws
-      restic:
-        enable: false
+    restic:
+      enable: false
   snapshotLocations:
-  - velero:
-      config:
-        credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials <1>
-        enableSharedConfig: "true" <2>
-        profile: default <3>
-        region: ${REGION} <4>
-      provider: aws
+    - velero:
+        config:
+          credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials <1>
+          enableSharedConfig: "true" <2>
+          profile: default <3>
+          region: ${REGION} <4>
+        provider: aws
 EOF
 ----
 

--- a/modules/oadp-preparing-aws-credentials.adoc
+++ b/modules/oadp-preparing-aws-credentials.adoc
@@ -19,11 +19,11 @@ Change the cluster name to match your ROSA cluster, and ensure you are logged in
 [source,terminal]
 ----
 $ export CLUSTER_NAME=my-cluster <1>
-export ROSA_CLUSTER_ID-$(rosa describe cluster -c ${CLUSTER_NAME} --output json | jq -r .id)
+export ROSA_CLUSTER_ID=$(rosa describe cluster -c ${CLUSTER_NAME} --output json | jq -r .id)
 export REGION=$(rosa describe cluster -c ${CLUSTER_NAME} --output json | jq -r .region.id)
 export OIDC_ENDPOINT=$(oc get authentication.config.openshift.io cluster -o jsonpath='{.spec.serviceAccountIssuer}' | sed 's|^https://||')
-export AWS_ACCOUNT_ID='aws sts get-caller-identity --query Account --output text'
-export CLUSTER_VERSION='rosa describe cluster -c ${CLUSTER_NAME} -o json | jq -r .version.raw_id | but -f -2 -d '.' '
+export AWS_ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+export CLUSTER_VERSION=$(rosa describe cluster -c ${CLUSTER_NAME} -o json | jq -r .version.raw_id | cut -f -2 -d '.')
 export ROLE_NAME="${CLUSTER_NAME}-openshift-oadp-aws-cloud-credentials"
 export SCRATCH="/tmp/${CLUSTER_NAME}/oadp"
 mkdir -p ${SCRATCH}
@@ -39,7 +39,7 @@ ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
 +
 [source,terminal]
 ----
-$ POLICY_ARN=$(aws iam list-policies --query "Policies[?PolicyName=='RosaOadpVer1'].{ARN:Arn}" -- output text) <1>
+$ POLICY_ARN=$(aws iam list-policies --query "Policies[?PolicyName=='RosaOadpVer1'].{ARN:Arn}" --output text) <1>
 ----
 +
 <1> Replace `RosaOadp` with your policy name.
@@ -61,10 +61,10 @@ cat << EOF > ${SCRATCH}/policy.json <1>
   {
     "Effect": "Allow",
     "Action": [
-      "s3:CreateBucket",$ echo ${POLICY_ARN}
-      "s3:DeleteBucket",cd openshift-docs
-      "s3:PutBucketTegging",
-      "s3:GetBucketTegging",
+      "s3:CreateBucket",
+      "s3:DeleteBucket",
+      "s3:PutBucketTagging",
+      "s3:GetBucketTagging",
       "s3:PutEncryptionConfiguration",
       "s3:GetEncryptionConfiguration",
       "s3:PutLifecycleConfiguration",
@@ -73,10 +73,10 @@ cat << EOF > ${SCRATCH}/policy.json <1>
       "s3:ListBucket",
       "s3:GetObject",
       "s3:PutObject",
-      "s3:DeleteOgject",
-      "s3:ListBucketMultipartUpLoads",
-      "s3:AbortMultipartUpLoads",
-      "s3:ListMultipartUpLoadParts",
+      "s3:DeleteObject",
+      "s3:ListBucketMultipartUploads",
+      "s3:AbortMultipartUploads",
+      "s3:ListMultipartUploadParts",
       "s3:DescribeSnapshots",
       "ec2:DescribeVolumes",
       "ec2:DescribeVolumeAttribute",
@@ -85,15 +85,16 @@ cat << EOF > ${SCRATCH}/policy.json <1>
       "ec2:CreateTags",
       "ec2:CreateVolume",
       "ec2:CreateSnapshot",
-      "ec2:DeleteSnapshot",
-    ]
+      "ec2:DeleteSnapshot"
+    ],
     "Resource": "*"
   }
  ]}
 EOF
-POLICY_ARN=$(aws iam create-policy --policy-mane "RosaOadpVer1" \
+
+POLICY_ARN=$(aws iam create-policy --policy-name "RosaOadpVer1" \
 --policy-document file:///${SCRATCH}/policy.json --query Policy.Arn \
---tags Key=rosa_openshift_version,Value=${CLUSTER_VERSION} Key-rosa_role_prefix,Value=ManagedOpenShift Key=operator_namespace,Value=openshift-oadp Key=operator_name,Value=openshift-oadp \
+--tags Key=rosa_openshift_version,Value=${CLUSTER_VERSION} Key=rosa_role_prefix,Value=ManagedOpenShift Key=operator_namespace,Value=openshift-oadp Key=operator_name,Value=openshift-oadp \
 --output text)
 fi
 ----
@@ -116,7 +117,7 @@ $ echo ${POLICY_ARN}
 ----
 $ cat <<EOF > ${SCRATCH}/trust-policy.json
 {
-    "Version": :2012-10-17",
+    "Version":2012-10-17",
     "Statement": [{
       "Effect": "Allow",
       "Principal": {
@@ -127,7 +128,7 @@ $ cat <<EOF > ${SCRATCH}/trust-policy.json
         "StringEquals": {
           "${OIDC_ENDPOINT}:sub": [
             "system:serviceaccount:openshift-adp:openshift-adp-controller-manager",
-            "system:serviceaccount:openshift-adp:velero:]
+            "system:serviceaccount:openshift-adp:velero"]
         }
       }
     }]
@@ -142,11 +143,11 @@ EOF
 $ ROLE_ARN=$(aws iam create-role --role-name \
   "${ROLE_NAME}" \
   --assume-role-policy-document file://${SCRATCH}/trust-policy.json \
-  --tags Key+rosa_cluster_id,Value=${ROSA_CLUSTER_ID}
-Key=rosa_openshift_verson,Value=${CLUSTER_VERSION}
+  --tags Key=rosa_cluster_id,Value=${ROSA_CLUSTER_ID}
+Key=rosa_openshift_version,Value=${CLUSTER_VERSION}
 Key=rosa_role_prefix,Value=ManagedOpenShift
 Key=operator_namespace,Value=openshift-adp
-Key=operator_name,Value-openshift-oadp \
+Key=operator_name,Value=openshift-oadp \
    --query Role.Arn --output text)
 ----
 


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-6598

Link to docs preview:
https://64045--docspreview.netlify.app/openshift-rosa/latest/rosa_backing_up_and_restoring_applications/backing-up-applications

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

