### PR TITLE
OSDOCS#7584:Adds notes for MS 4.13.10 release

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -237,3 +237,12 @@ Issued: 2023-08-16
 {product-title} release 4.13.9, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4605[RHBA-2023:4605] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4603[RHSA-2023:4603] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-10-dp"]
+=== RHBA-2023:4733 - {product-title} 4.13.10 bug fix and security update
+
+Issued: 2023-08-30
+
+{product-title} release 4.13.10, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4733[RHBA-2023:4733] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:4731[RHSA-2023:4731] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Adds notes for MS 4.13.10 release

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-7584

Link to docs preview:
https://64060--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-10-dp

QE review:
- [ ] QE has approved this change.
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
