### PR TITLE
ROX-19203: Add info for product usage page

### DIFF
--- a/modules/viewing-product-usage.adoc
+++ b/modules/viewing-product-usage.adoc
@@ -1,0 +1,45 @@
+// Module included in the following assemblies:
+//
+// * operating/use-system-health-dashboard.adoc
+:_content-type: PROCEDURE
+[id="viewing-product-usage_{context}"]
+= Viewing product usage data
+
+[role="_abstract"]
+{product-title-short} provides product usage data for the number of secured Kubernetes nodes and CPU units for secured clusters based on metrics collected from {product-title-short} sensors. This information can be useful to estimate {product-title-short} consumption data for reporting.
+
+For more information on how CPU units are defined in Kubernetes, see link:https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/#meaning-of-cpu[CPU resource units].
+
+[NOTE]
+====
+{ocp} provides its own usage reports; this information is intended for use with self-managed Kubernetes systems.
+====
+
+{product-title-short} provides the following usage data in the web portal and API:
+
+* Currently secured CPU units: The number of Kubernetes CPU units used by your {product-title-short} secured clusters, as of the latest metrics collection.
+* Currently secured node count: The number of Kubernetes nodes secured by {product-title-short}, as of the latest metrics collection.
+* Maximum secured CPU units: The maximum number of CPU units used by your {product-title-short} secured clusters, as measured hourly and aggregated for the time period defined by the *Start date* and *End date*.
+* Maximum secured node count: The maximum number of Kubernetes nodes secured by {product-title-short}, as measured hourly and aggregated for the time period defined by the *Start date* and *End date*.
+* CPU units observation date: The date on which the maximum secured CPU units data was collected.
+* Node count observation date: The date on which the maximum secured node count data was collected.
+
+The sensors collect data every 5 minutes, so there can be a short delay in displaying the current data. To view historical data, you must configure the *Start date* and *End date* and download the data file. The date range is inclusive and depends on your time zone.
+
+The presented maximum values are computed based on hourly maximums for the requested period. The hourly maximums are available for download in CSV format.
+
+[NOTE]
+====
+The data shown is not sent to Red Hat or displayed as Prometheus metrics.
+====
+
+.Procedure
+
+. In the {product-title-short} portal, navigate to *Platform Configuration* -> *System Health*.
+. Click *Show product usage*.
+. In the *Start date* and *End date* fields, choose the dates for which you want to display data. This range is inclusive and depends on your time zone.
+. Optional: To download the detailed data, click *Download CSV*.
+
+You can also obtain this data by using the `ProductUsageService` API object. For more information, navigate to *Help* -> *API reference* in the {product-title-short} portal.
+
+

--- a/operating/use-system-health-dashboard.adoc
+++ b/operating/use-system-health-dashboard.adoc
@@ -16,6 +16,8 @@ The system health dashboard is only available on {product-title} 3.0.53 and newe
 
 include::modules/system-health-dashboard-details.adoc[leveloffset=+1]
 
+include::modules/viewing-product-usage.adoc[leveloffset=+1]
+
 include::modules/generate-diagnostic-bundle-using-acs-portal.adoc[leveloffset=+1]
 
 [role="_additional-resources"]


### PR DESCRIPTION
Version(s):

4.2+

[Issue](https://issues.redhat.com/browse/ROX-19203)

[Link to docs preview
](https://file.rdu.redhat.com/kcarmich/ROX-19203-product-usage/operating/use-system-health-dashboard.html#viewing-product-usage_use-system-health-dashboard)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
