### PR TITLE
[MULTIARCH-3728] Docs update - Control Plane Machine Set support for IBM PowerVS

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-about.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-about.adoc
@@ -25,7 +25,7 @@ The Control Plane Machine Set Operator has the following limitations:
 
 * The Operator requires the Machine API Operator to be operational and is therefore not supported on clusters with manually provisioned machines. When installing a {product-title} cluster with manually provisioned machines for a platform that creates an active generated `ControlPlaneMachineSet` custom resource (CR), you must remove the Kubernetes manifest files that define the control plane machine set as instructed in the installation process.
 
-* Only Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, Nutanix, and VMware vSphere clusters are supported.
+* Only Amazon Web Services (AWS), Google Cloud Platform (GCP), {ibmpowerProductName} Virtual Server, Microsoft Azure, Nutanix, and VMware vSphere clusters are supported.
 
 * Only clusters with three control plane machines are supported.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/MULTIARCH-3728
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64064--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-about#cpmso-limitations_cpmso-about
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
