### PR TITLE
Updated the section for uninstalling Pipeline Operator.

### DIFF
--- a/cicd/pipelines/uninstalling-pipelines.adoc
+++ b/cicd/pipelines/uninstalling-pipelines.adoc
@@ -9,7 +9,7 @@ toc::[]
 Cluster administrators can uninstall the {pipelines-title} Operator by performing the following steps:
 
 . Delete the Custom Resources (CRs) that were added by default when you installed the {pipelines-title} Operator.
-. Delete the CRs of the optional components, such as {tekton-chains}, that are dependent on the Operator.
+. Delete the CRs of the optional components such as {tekton-hub} that depend on the Operator.
 +
 [CAUTION]
 ====

--- a/modules/op-deleting-the-pipelines-component-and-custom-resources.adoc
+++ b/modules/op-deleting-the-pipelines-component-and-custom-resources.adoc
@@ -28,5 +28,5 @@ Deleting the CRs will delete the {pipelines-title} components, and all the tasks
 
 [IMPORTANT]
 ====
-Repeat the procedure to find and remove CRs of optional components such as {tekton-chains}, before uninstalling the Operator. If you uninstall the Operator without removing the CRs of optional components, you cannot remove them later.
+Repeat the procedure to find and remove CRs of optional components such as {tekton-hub} before uninstalling the Operator. If you uninstall the Operator without removing the CRs of optional components, you cannot remove them later.
 ====


### PR DESCRIPTION
Jira issue : [RHDEVDOCS-5609](https://issues.redhat.com/browse/RHDEVDOCS-5609)

Aligned team: DevTools

OCP Version(s): 4.10 and later

Docs preview: [64067--docspreview](https://64067--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/uninstalling-pipelines)

SME review: @piyush-garg 

QE review: @ppitonak 

Peer review: @Srivaralakshmi 