### PR TITLE
RHDEVDOCS-5358 fix version dropdown for gitops

### DIFF
--- a/_javascripts/page-loader.js
+++ b/_javascripts/page-loader.js
@@ -52,6 +52,11 @@ function versionSelector(list) {
     newLink = "https://docs.openshift.com/serverless/" +
       newVersion +
       fileRequested;
+  } else if (['1.8', '1.9'].contains(newVersion)) {
+    // check and handle links for GitOps versions
+    newLink = "https://docs.openshift.com/gitops/" +
+      newVersion +
+      fileRequested;
   } else {
     //if distro key is openshift enterprise
     if (dk == "openshift-enterprise") {
@@ -84,6 +89,8 @@ function versionSelector(list) {
             window.location = "https://google.com/search?q=site:https://docs.openshift.com/acs/" + newVersion + " " + document.title;}
           else if (['1.28', '1.29'].contains(newVersion)) {
             window.location = "https://google.com/search?q=site:https://docs.openshift.com/serverless/" + newVersion + " " + document.title;}
+          else if (['1.8', '1.9'].contains(newVersion)) {
+            window.location = "https://google.com/search?q=site:https://docs.openshift.com/gitops/" + newVersion + " " + document.title;}            
           else {
             if (dk == "openshift-enterprise"){
               window.location = "https://google.com/search?q=site:https://docs.openshift.com/enterprise/" + newVersion + " " + document.title;


### PR DESCRIPTION

Version(s):
main and 4.1

Issue:
[RHDEVDOCS-5358](https://issues.redhat.com//browse/RHDEVDOCS-5358)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->


