### PR TITLE
OCPBUGS-11918: New table defining profile extensions

### DIFF
--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -157,4 +157,43 @@ The Compliance Operator provides the following compliance profiles:
 |===
 [.small]
 1. To locate the CIS {product-title} v4 Benchmark, go to  link:https://www.cisecurity.org/benchmark/kubernetes[CIS Benchmarks] and click *Download Latest CIS Benchmark*, where you can then register to download the benchmark.
-2. Node profiles must be used with the relevant Platform profile. For more information, see xref:../../security/compliance_operator/compliance-operator-understanding.adoc#compliance_profile_typesunderstanding-compliance[Compliance Operator profile types].
+2. Node profiles must be used with the relevant Platform profile. For more information, see _Compliance Operator profile types_.
+
+[id="compliance-extended-profiles_{context}"]
+== About extended compliance profiles
+
+Some compliance profiles have controls that require following industry best practices, resulting in some profiles extending others. Combining the Center for Internet Security (CIS) best practices with National Institute of Standards and Technology (NIST) security frameworks establishes a path to a secure and compliant environment.
+
+For example, the NIST High-Impact and Moderate-Impact profiles extend the CIS profile to achieve compliance. As a result, extended compliance profiles eliminate the need to run both profiles in a single cluster.
+
+.Profile extensions
+[cols="50%,50%", options="header"]
+
+|===
+|Profile
+|Extends
+
+|ocp4-pci-dss
+|ocp4-cis
+
+|ocp4-pci-dss-node
+|ocp4-cis-node
+
+|ocp4-high
+|ocp4-cis
+
+|ocp4-high-node
+|ocp4-cis-node
+
+|ocp4-moderate
+|ocp4-cis
+
+|ocp4-moderate-node
+|ocp4-cis-node
+
+|ocp4-nerc-cip
+|ocp4-moderate
+
+|ocp4-nerc-cip-node
+|ocp4-moderate-node
+|===


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-11918

Link to docs preview (VPN required):
[About extended compliance profiles](https://file.rdu.redhat.com/antaylor/OCPBUGS-11918/security/compliance_operator/compliance-operator-supported-profiles.html#compliance-extended-profiles_compliance-operator-supported-profiles)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added an additional conceptual information section to a module to describe how some compliance profiles are an extension of others. Based on information available in [upstream code](https://github.com/ComplianceAsCode/content/blob/master/products/ocp4/profiles/moderate.profile#L43).
