### PR TITLE
docs: It's supported to change files via Ignition

### DIFF
--- a/installing/install_config/installing-customizing.adoc
+++ b/installing/install_config/installing-customizing.adoc
@@ -6,10 +6,12 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Although directly making changes to {product-title} nodes is discouraged,
-there are times when it is necessary to implement a
-required low-level security, redundancy, networking, or performance feature.
-Direct changes to {product-title} nodes can be done by:
+{product-title} supports both cluster-wide and per-machine configuration via Ignition,
+which allows arbitrary partitioning and file content changes to the operating system.
+In general, if a configuration file is documented in {op-system-base-full}, then modifying
+it via Ignition is supported.
+
+There are two ways to deploy machine config changes:
 
 * Creating machine configs that are included in manifest files
 to start up a cluster during `openshift-install`.
@@ -17,8 +19,10 @@ to start up a cluster during `openshift-install`.
 * Creating machine configs that are passed to running
 {product-title} nodes via the Machine Config Operator.
 
-* Creating an Ignition config that is passed to `coreos-installer`
-when installing bare-metal nodes.
+Additionally, modifying the reference config, such as
+the Ignition config that is passed to `coreos-installer` when installing bare-metal nodes
+allows per-machine configuration. These changes are currently not visible
+to the Machine Config Operator.
 
 The following sections describe features that you might want to
 configure on your nodes in this way.


### PR DESCRIPTION
We keep weaseling on this and we keep having to answer questions like "can I modify iscsi.conf".  I tried to stub out a "reasonableness" here by saying if it's documented how to use it in dnf-based RHEL, we support it in RHCOS via Ignition as a baseline.  That's not 100% true, but it's close enough to start with.
