### PR TITLE
OSDOCS-7118 GCP confidential VMs moving to GA

### DIFF
--- a/modules/installation-gcp-enabling-confidential-vms.adoc
+++ b/modules/installation-gcp-enabling-confidential-vms.adoc
@@ -15,14 +15,6 @@
 
 You can use Confidential VMs when installing your cluster. Confidential VMs encrypt data while it is being processed. For more information, see Google's documentation on link:https://cloud.google.com/confidential-computing[Confidential Computing]. You can enable Confidential VMs and Shielded VMs at the same time, although they are not dependent on each other.
 
-:FeatureName: Confidential Computing
-include::snippets/technology-preview.adoc[]
-
-[IMPORTANT]
-====
-Due to a known issue, you cannot use persistent volume storage on a cluster with Confidential VMs. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-7582[OCPBUGS-7582].
-====
-
 .Prerequisites
 * You have created an `install-config.yaml` file.
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7118

Link to docs preview:
https://64086--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-gcp-enabling-confidential-vms_installing-gcp-customizations

QE review:
- [x] QE has approved this change.