### PR TITLE
TELCODOCS-950: subsequent update to RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -152,7 +152,7 @@ Ingress Node Firewall Operator was made a technology preview in {product-title} 
 ==== Dynamic use of non-reserved CPUs for OVS
 
 With this release, the Open vSwitch (OVS) networking stack can dynamically use non-reserved CPUs.
-This dynamic use of non-reserved CPUs occurs by default in performance-tuned clusters with a CPU manager policy set to `static`.
+This dynamic use of non-reserved CPUs occurs by default in nodes in a machine config pool that has a performance profile applied to it.
 The dynamic use of available, non-reserved CPUs maximizes compute resources for OVS and minimizes network latency for workloads during periods of high demand.
 OVS remains unable to dynamically use isolated CPUs assigned to containers in `Guaranteed` QoS pods. This separation avoids disruption to critical application workloads.
 


### PR DESCRIPTION
[TELCODOCS-950](https://issues.redhat.com//browse/TELCODOCS-950): After intitial merge in #60655, one final tweak to make it clear a PP must be applied. 

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-950

Link to docs preview:
https://64088--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-networking-kernal-network-pinning

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

