### PR TITLE
OSSM-3160: [DOC] Service Mesh documentation is missing a hyperlink 

### DIFF
--- a/modules/ossm-control-plane-web.adoc
+++ b/modules/ossm-control-plane-web.adoc
@@ -37,10 +37,8 @@ These steps use `istio-system` as an example, but you can deploy your {SMProduct
 
 . On the *Create ServiceMeshControlPlane* page, accept the default {SMProductShortName} control plane version to take advantage of the features available in the most current version of the product. The version of the control plane determines the features available regardless of the version of the Operator.
 +
-You can configure `ServiceMeshControlPlane` settings later. For more information, see Configuring {SMProductName}.
+.. Click *Create*. The Operator creates pods, services, and {SMProductShortName} control plane components based on your configuration parameters. You can configure `ServiceMeshControlPlane` settings later.
 +
-.. Click *Create*. The Operator creates pods, services, and {SMProductShortName} control plane components based on your configuration parameters.
-
 . To verify the control plane installed correctly, click the *Istio Service Mesh Control Plane* tab.
 +
 .. Click the name of the new control plane.


### PR DESCRIPTION
[OSSM-3160](https://issues.redhat.com//browse/OSSM-3160): [DOC] Service Mesh documentation is missing a hyperlink for Configuring Red Hat OpenShift Service Mesh


Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OSSM-3160 

Link to docs preview:
https://64098--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-create-smcp#ossm-control-plane-deploy-operatorhub_ossm-create-smcp

QE review:
Not required as change does not impact the meaning of the docs.

Additional information:

This updates Step 6a:

6. On the Create ServiceMeshControlPlane page, accept the default Service Mesh control plane version to take advantage of the features available in the most current version of the product. The version of the control plane determines the features available regardless of the version of the Operator.

6a. Click Create. The Operator creates pods, services, and Service Mesh control plane components based on your configuration parameters. You can configure ServiceMeshControlPlane settings later.

The relevant link is already included in the "Additional resources" section so this PR removes the sentence "For more information, see Configuring Red Hat OpenShift Service Mesh."

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
