### PR TITLE
OSDOCS#6504: IBM Power VS - move install config parameters out of ass…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -432,6 +432,8 @@ Topics:
     File: installing-restricted-networks-ibm-power-vs
   - Name: Uninstalling a cluster on IBM Power Virtual Server
     File: uninstalling-cluster-ibm-power-vs
+  - Name: Installation configuration parameters for IBM Power Virtual Server
+    File: installation-config-parameters-ibm-power-vs
 - Name: Installing on OpenStack
   Dir: installing_openstack
   Distros: openshift-origin,openshift-enterprise

--- a/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs.adoc
@@ -1,0 +1,12 @@
+:_content-type: ASSEMBLY
+[id="installation-config-parameters-ibm-power-vs"]
+= Installation configuration parameters for {ibmpowerProductName} Virtual Server
+include::_attributes/common-attributes.adoc[]
+:context: installation-config-parameters-ibm-power-vs
+:platform: {ibmpowerProductName} Virtual Server
+
+toc::[]
+
+Before you deploy an {product-title} on {ibmpowerProductName} Virtual Server, you provide parameters to customize your cluster and the platform that hosts it. When you create the `install-config.yaml` file, you provide values for the required parameters through the command line. You can then modify the `install-config.yaml` file to customize your cluster further.
+
+include::modules/installation-configuration-parameters.adoc[leveloffset=+1]

--- a/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
@@ -30,7 +30,9 @@ include::modules/installation-ibm-cloud-export-variables.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
-include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs#installation-config-parameters-ibm-power-vs[Installation configuration parameters for {ibmpowerProductName} Virtual Server]
 
 include::modules/installation-ibm-power-vs-config-yaml.adoc[leveloffset=+2]
 

--- a/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
@@ -36,7 +36,9 @@ include::modules/installation-ibm-cloud-export-variables.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
-include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs#installation-config-parameters-ibm-power-vs[Installation configuration parameters for {ibmpowerProductName} Virtual Server]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 

--- a/installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
+++ b/installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
@@ -32,7 +32,9 @@ include::modules/installation-ibm-cloud-export-variables.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
-include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs#installation-config-parameters-ibm-power-vs[Installation configuration parameters for {ibmpowerProductName} Virtual Server]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 

--- a/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
@@ -41,7 +41,9 @@ include::modules/installation-ibm-cloud-export-variables.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
-include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs#installation-config-parameters-ibm-power-vs[Installation configuration parameters for {ibmpowerProductName} Virtual Server]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -14,10 +14,6 @@
 // * installing/installing_azure/installing-azure-network-customizations.adoc
 // * installing/installing_azure/installing-azure-private.adoc
 // * installing/installing_azure/installing-azure-vnet.adoc
-// * installing/installing_ibm_powervs/installing-ibm-power-vs-customizations.adoc
-// * installing/installing_ibm_powervs/installing-ibm-power-vs-private-cluster.adoc
-// * installing/installing_ibm_powervs/installing-restricted-networks-ibm-power-vs.adoc
-// * installing/installing_ibm_powervs/installing-ibm-powervs-vpc.adoc
 // * installing/installing_openstack/installing-openstack-installer-custom.adoc
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -26,15 +22,6 @@
 // * installing/installing_openstack/installing-openstack-user-sr-iov-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-user-sr-iov.adoc
 // * installing/installing_openstack/installing-openstack-user.adoc
-// * installing/installing_vmc/installing-restricted-networks-vmc.adoc
-// * installing/installing_vmc/installing-vmc-customizations.adoc
-// * installing/installing_vmc/installing-vmc-network-customizations.adoc
-// * installing/installing_vmc/installing-vmc-user-infra.adoc
-// * installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
-// * installing/installing_vmc/installing-restricted-networks-vmc-user-infra.adoc
-// * installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc
-// * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 // * installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
 // * installing/installing-restricted-networks-nutanix-installer-provisioned.adoc
 // * installing/installing_vsphere/installation-config-parameters-vsphere.adoc
@@ -46,6 +33,7 @@
 // * installing/installing_bare_metal/installation-config-parameters-bare-metal.adoc
 // * installing/installing_ibm_cloud_public/installation-config-parameters-ibm-cloud-vps.adoc
 // * installing/installing_alibaba/installation-config-parameters-alibaba.adoc
+// * installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs.adoc
 
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
@@ -115,45 +103,9 @@ ifeval::["{context}" == "installing-openstack-user-sr-iov-kuryr"]
 :osp:
 :osp-kuryr:
 endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
-:vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vmc-customizations"]
-:vmc:
-endif::[]
-ifeval::["{context}" == "installing-vmc-network-customizations"]
-:vmc:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vmc"]
-:vmc:
-endif::[]
-ifeval::["{context}" == "installing-vmc-user-infra"]
-:vmc:
-endif::[]
-ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
-:vmc:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
-:vmc:
-endif::[]
 ifeval::["{context}" == "installing-openstack-installer-restricted"]
 :osp:
 :osp-custom:
-endif::[]
-ifeval::["{context}" == "installing-ibm-power-vs-customizations"]
-:ibm-power-vs:
-endif::[]
-ifeval::["{context}" == "installing-ibm-power-vs-private-cluster"]
-:ibm-power-vs:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-ibm-power-vs"]
-:ibm-power-vs:
-endif::[]
-ifeval::["{context}" == "installing-ibm-powervs-vpc"]
-:ibm-power-vs:
 endif::[]
 ifeval::["{context}" == "installing-nutanix-installer-provisioned"]
 :nutanix:
@@ -188,55 +140,53 @@ endif::[]
 ifeval::["{context}" == "installation-config-parameters-alibaba"]
 :alibaba-cloud:
 endif::[]
+ifeval::["{context}" == "installation-config-parameters-ibm-power-vs"]
+:ibm-power-vs:
+endif::[]
 
 
 :_content-type: CONCEPT
 [id="installation-configuration-parameters_{context}"]
-ifndef::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud[]
+ifndef::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 = Installation configuration parameters
-endif::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud[]
+endif::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 
 // Managing headings is required as part of the effort for https://issues.redhat.com/browse/OSDOCS-6493.
 // This accommodates the existing IA of the installation assemblies, while the improvement is implemented.
 // As part of the updates for the last provider, the conditions can be removed and the following heading can be used.
-ifdef::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud[]
+ifdef::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 = Available installation configuration parameters for {platform}
-endif::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud[]
+endif::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 
 // If install-config.yaml is generated by openshift-install
 // The addition of providers beyond bare,ibm-power,ibm-z,ash is necessary as part of the effort for https://issues.redhat.com/browse/OSDOCS-6493
 // This accommodates the existing IA of the installation assemblies, while the improvement is implemented.
 // As part of the updates for the last provider, content between lines 277-292 can be completely removed.
-ifndef::bare,ibm-power,ibm-z,ash,vsphere,gcp,ibm-cloud,alibaba-cloud[]
+ifndef::bare,ibm-power,ibm-z,ash,vsphere,gcp,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 Before you deploy an {product-title} cluster, you provide parameter values to describe your account on the cloud platform that hosts your cluster and optionally customize your cluster's platform. When you create the `install-config.yaml` installation configuration file, you provide values for the required parameters through the command line. If you customize your cluster, you can modify the `install-config.yaml` file to provide more details about the platform.
-endif::bare,ibm-power,ibm-z,ash,vsphere,gcp,ibm-cloud,alibaba-cloud[]
-
-// If the user manually creates install-config.yaml
-ifdef::ibm-power-vs[]
-Before you deploy an {product-title} cluster, you provide a customized `install-config.yaml` installation configuration file that describes the details for your environment.
-endif::ibm-power-vs[]
+endif::bare,ibm-power,ibm-z,ash,vsphere,gcp,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 
 // A condition for this note is required as part of the effort for https://issues.redhat.com/browse/OSDOCS-6493.
 // This accommodates the existing content for installation assemblies, while the improvement is implemented.
 // As part of the updates for the last provider, this note can be removed from the module.
-ifndef::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud[]
+ifndef::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 [NOTE]
 ====
 After installation, you cannot modify these parameters in the `install-config.yaml` file.
 ====
-endif::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud[]
+endif::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 
 // This condition is required as part of the effort for https://issues.redhat.com/browse/OSDOCS-6493.
 // As part of the update for each provider, this content applies to the net new provider-specific installation configuration parameter assembly.
 // As part of the updates for the last provider, the conditions can be completely removed.
-ifdef::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud[]
+ifdef::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 The following tables specify the required, optional, and {platform}-specific installation configuration parameters that you can set as part of the installation process.
 
 [NOTE]
 ====
 After installation, you cannot modify these parameters in the `install-config.yaml` file.
 ====
-endif::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud[]
+endif::vsphere,gcp,ibm-z,ibm-power,ash,bare,ibm-cloud,alibaba-cloud,ibm-power-vs[]
 
 [id="installation-configuration-parameters-required_{context}"]
 == Required configuration parameters
@@ -2165,36 +2115,9 @@ ifeval::["{context}" == "installing-openstack-user-sr-iov-kuryr"]
 :!osp:
 :!osp-kuryr:
 endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
-:!vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vmc-customizations"]
-:!vmc:
-endif::[]
-ifeval::["{context}" == "installing-vmc-network-customizations"]
-:!vmc:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-vmc"]
-:!vmc:
-endif::[]
 ifeval::["{context}" == "installing-openstack-installer-restricted"]
 :!osp:
 :!osp-custom:
-endif::[]
-ifeval::["{context}" == "installing-ibm-power-vs-customizations"]
-:!ibm-power-vs:
-endif::[]
-ifeval::["{context}" == "installing-ibm-power-vs-private-cluster"]
-:!ibm-power-vs:
-endif::[]
-ifeval::["{context}" == "installing-restricted-networks-ibm-power-vs"]
-:!ibm-power-vs:
-endif::[]
-ifeval::["{context}" == "installing-ibm-powervs-vpc"]
-:!ibm-power-vs:
 endif::[]
 ifeval::["{context}" == "installing-nutanix-installer-provisioned"]
 :!nutanix:
@@ -2228,5 +2151,8 @@ ifeval::["{context}" == "installation-config-parameters-ibm-cloud-vpc"]
 endif::[]
 ifeval::["{context}" == "installation-config-parameters-alibaba"]
 :!alibaba-cloud:
+endif::[]
+ifeval::["{context}" == "installation-config-parameters-ibm-power-vs"]
+:!ibm-power-vs:
 endif::[]
 :!platform:


### PR DESCRIPTION
Version(s):
4.14+

Issue:

This PR addresses [osdocs-6504](https://issues.redhat.com/browse/OSDOCS-6504).

Link to docs preview:

- [Installation configuration parameters for IBM Power Virtual Server](https://64103--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs)
  New assembly at book level.
- Installing a cluster on IBM Power Virtual Server with customizations > [Creating the installation configuration file](https://64103--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-power-vs-customizations#installation-initializing_installing-ibm-power-vs-customizations)
Note the absence of Installation configuration parameters following this topic. In lieu of the module, a cross reference is provided for the new assembly.

It is worth noting that the latter is an example of the change that this PR introduces. This change has been applied to all Alibaba installation assemblies.

QE review:
- [N/A] QE has approved this change.
Given that this update is a reorg only, QE approval is not required. See conversation at https://github.com/openshift/openshift-docs/pull/61165#pullrequestreview-1493117699
