### PR TITLE
PR for SRVKE-1419: Document Eventing mTLS with Service Mesh

### DIFF
--- a/eventing/event-sources/serverless-custom-event-sources.adoc
+++ b/eventing/event-sources/serverless-custom-event-sources.adoc
@@ -22,6 +22,12 @@ include::modules/specifying-sink-flag-kn.adoc[leveloffset=+3]
 include::modules/serverless-sinkbinding-odc.adoc[leveloffset=+2]
 // Reference
 include::modules/serverless-sinkbinding-reference.adoc[leveloffset=+2]
+// OSSM
+include::modules/serverless-sinkbinding-ossm.adoc[leveloffset=+2]
+
+.Additional resources
+
+* xref:../../integrations/serverless-ossm-setup.adoc#serverless-ossm-setup_serverless-ossm-setup[Integrating{SMProductShortName} with {ServerlessProductName}]
 
 [id="serverless-custom-event-sources-containersource"]
 == Container source
@@ -36,3 +42,9 @@ include::modules/serverless-kn-containersource.adoc[leveloffset=+2]
 include::modules/serverless-odc-create-containersource.adoc[leveloffset=+2]
 // Reference
 include::modules/serverless-containersource-reference.adoc[leveloffset=+2]
+// OSSM
+include::modules/serverless-containersource-ossm.adoc[leveloffset=+2]
+
+.Additional resources
+
+* xref:../../integrations/serverless-ossm-setup.adoc#serverless-ossm-setup_serverless-ossm-setup[Integrating{SMProductShortName} with {ServerlessProductName}]

--- a/modules/serverless-containersource-ossm.adoc
+++ b/modules/serverless-containersource-ossm.adoc
@@ -1,0 +1,127 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-containersource-ossm_{context}"]
+= Integrating {SMProductShortName} with ContainerSource
+
+.Prerequisites
+
+// TODO link to ../serverless/integrations/serverless-ossm-setup.adoc#serverless-ossm-setup_serverless-ossm-setup
+
+* You have integrated {SMProductShortName} with {ServerlessProductName}.
+
+.Procedure
+
+. Create a `Service` in a namespace that is a member of the `ServiceMeshMemberRoll`.
++
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: event-display
+  namespace: <namespace> <1>
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true" <2>
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      containers:
+      - image: quay.io/openshift-knative/knative-eventing-sources-event-display:latest
+----
+<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
+<2> Injects {SMProductShortName} sidecars into the Knative service pods.
+
+. Apply the `Service` resource.
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Create a `ContainerSource` in a namespace that is a member of the `ServiceMeshMemberRoll` and sink set to the `event-display`.
++
+[source,yaml]
+----
+apiVersion: sources.knative.dev/v1
+kind: ContainerSource
+metadata:
+  name: test-heartbeats
+  namespace: <namespace> <1>
+spec:
+  template:
+    metadata: <2>
+      annotations:
+        sidecar.istio.io/inject: "true"
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      containers:
+        - image: quay.io/openshift-knative/heartbeats:latest
+          name: heartbeats
+          args:
+            - --period=1s
+          env:
+            - name: POD_NAME
+              value: "example-pod"
+            - name: POD_NAMESPACE
+              value: "event-test"
+  sink:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display
+----
+<1> A namespace is part of the `ServiceMeshMemberRoll`.
+<2> Enables {SMProductShortName} integration with a `ContainerSource`
+
+. Apply the `ContainerSource` resource.
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+.Verification
+
+To verify that the events were sent to the Knative event sink, look at the message dumper function logs.
+
+. Enter the following command:
++
+[source,terminal]
+----
+$ oc get pods
+----
+
+. Enter the following command:
++
+[source,terminal]
+----
+$ oc logs $(oc get pod -o name | grep event-display) -c user-container
+----
++
+.Example output
+[source,terminal]
+----
+☁️  cloudevents.Event
+Validation: valid
+Context Attributes,
+  specversion: 1.0
+  type: dev.knative.eventing.samples.heartbeat
+  source: https://knative.dev/eventing/test/heartbeats/#event-test/mypod
+  id: 2b72d7bf-c38f-4a98-a433-608fbcdd2596
+  time: 2019-10-18T15:23:20.809775386Z
+  contenttype: application/json
+Extensions,
+  beats: true
+  heart: yes
+  the: 42
+Data,
+  {
+    "id": 1,
+    "label": ""
+  }
+----

--- a/modules/serverless-ossm-setup.adoc
+++ b/modules/serverless-ossm-setup.adoc
@@ -39,13 +39,14 @@ metadata:
 spec:
   members: <1>
     - knative-serving
+    - knative-eventing
     - <namespace>
 ----
 <1> A list of namespaces to be integrated with {SMProductShortName}.
 +
 [IMPORTANT]
 ====
-This list of namespaces must include the `knative-serving` namespace.
+This list of namespaces must include the `knative-serving` and `knative-eventing` namespaces.
 ====
 
 . Apply the `ServiceMeshMemberRoll` resource:
@@ -176,6 +177,172 @@ spec:
 ----
 $ oc apply -f <filename>
 ----
+
+. Install Knative Eventing by creating the following `KnativeEventing` custom resource definition (CRD), which also enables the Istio integration:
++
+[source,yaml]
+----
+apiVersion: operator.knative.dev/v1beta1
+kind: KnativeEventing
+metadata:
+  name: knative-eventing
+  namespace: knative-eventing 
+spec:
+  config:
+    features:
+      istio: enabled <1>
+  workloads:
+  - name: pingsource-mt-adapter
+    annotations:
+      "sidecar.istio.io/inject": "true" <2>
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+  - name: imc-dispatcher
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+  - name: mt-broker-ingress
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+  - name: mt-broker-filter
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+----
+<1> Enables Eventing istio controller to create a `DestinationRule` for each InMemoryChannel or KafkaChannel service.
+<2> Enables sidecar injection for Knative Eventing pods.
+
+:FeatureName: The Knative Eventing integration with {SMProductShortName}
+include::snippets/technology-preview.adoc[leveloffset=+4]
+
+. Apply the `KnativeEventing` resource:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Install Knative Kafka by creating the following `KnativeKafka` custom resource definition (CRD), which also enables the Istio integration:
++
+[source,yaml]
+----
+apiVersion: operator.serverless.openshift.io/v1alpha1
+kind: KnativeKafka
+metadata:
+  name: knative-kafka
+  namespace: knative-eventing
+spec:
+  channel:
+    enabled: true
+    bootstrapServers: <bootstrap_servers> <1>
+  source:
+    enabled: true
+  broker:
+    enabled: true
+    defaultConfig:
+      bootstrapServers: <bootstrap_servers> <1>
+      numPartitions: <num_partitions>
+      replicationFactor: <replication_factor>
+  sink:
+    enabled: true
+  workloads: <2>
+  - name: kafka-controller
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+  - name: kafka-broker-receiver
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+  - name: kafka-broker-dispatcher
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+  - name: kafka-channel-receiver
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+  - name: kafka-channel-dispatcher
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+  - name: kafka-source-dispatcher
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+  - name: kafka-sink-receiver
+    annotations:
+      "sidecar.istio.io/inject": "true"
+      "sidecar.istio.io/rewriteAppHTTPProbers": "true"
+----
+<1> The Apache Kafka cluster URL, for example: `my-cluster-kafka-bootstrap.kafka:9092`.
+<2> Enables sidecar injection for Knative Kafka pods.
+
+:FeatureName: The Knative Eventing integration with {SMProductShortName}
+include::snippets/technology-preview.adoc[leveloffset=+4]
+
+. Apply the `KnativeKafka` resource:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Install `ServiceEntry` to make {SMProductName} aware of the communication between `KnativeKafka` components and an Apache Kafka cluster:
++
+[source,yaml]
+----
+apiVersion: networking.istio.io/v1alpha3
+kind: ServiceEntry
+metadata:
+  name: kafka-cluster
+  namespace: knative-eventing
+spec:
+  hosts: <1>
+    - <bootstrap_servers_without_port>
+  exportTo:
+    - "."
+  ports: <2>
+    - number: 9092
+      name: tcp-plain
+      protocol: TCP
+    - number: 9093
+      name: tcp-tls
+      protocol: TCP
+    - number: 9094
+      name: tcp-sasl-tls
+      protocol: TCP
+    - number: 9095
+      name: tcp-sasl-plain
+      protocol: TCP
+    - number: 9096
+      name: tcp-noauth
+      protocol: TCP
+  location: MESH_EXTERNAL
+  resolution: NONE
+----
+<1> The list of Apache Kafka cluster hosts, for example: `my-cluster-kafka-bootstrap.kafka`.
+<2> Apache Kafka cluster listeners ports.
+
++
+[NOTE]
+====
+The listed ports in `spec.ports` are example TCP ports and depend on how the Apache Kafka cluster is configured.
+====
+
+. Apply the `ServiceEntry` resource:
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
++
+[IMPORTANT]
+====
+Ensure that addresses are set in the ServiceEntry. If the addresses are not set, all the traffic on the port defined in the ServiceEntry is matched regardless of the host.
+====
+
+.Verification
 
 . Create a Knative Service that has sidecar injection enabled and uses a pass-through route:
 +

--- a/modules/serverless-sinkbinding-ossm.adoc
+++ b/modules/serverless-sinkbinding-ossm.adoc
@@ -1,0 +1,168 @@
+// Module included in the following assemblies:
+//
+// * /serverless/eventing/event-sources/serverless-custom-event-sources.adoc
+
+:_content-type: PROCEDURE
+[id="serverless-sinkbinding-ossm_{context}"]
+= Integrating {SMProductShortName} with SinkBinding
+
+.Prerequisites
+
+* You have integrated {SMProductShortName} with {ServerlessProductName}.
+
+.Procedure
+
+. Create a `Service` in a namespace that is a member of the `ServiceMeshMemberRoll`.
++
+[source,yaml]
+----
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: event-display
+  namespace: <namespace> <1>
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "true" <2>
+        sidecar.istio.io/rewriteAppHTTPProbers: "true"
+    spec:
+      containers:
+      - image: quay.io/openshift-knative/knative-eventing-sources-event-display:latest
+----
+<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
+<2> Injects {SMProductShortName} sidecars into the Knative service pods.
+
+. Apply the `Service` resource.
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Create a `SinkBinding`.
++
+[source,yaml]
+----
+apiVersion: sources.knative.dev/v1
+kind: SinkBinding
+metadata:
+  name: bind-heartbeat
+  namespace: <namespace> <1>
+spec:
+  subject:
+    apiVersion: batch/v1
+    kind: Job <2>
+    selector:
+      matchLabels:
+        app: heartbeat-cron
+
+  sink:
+    ref:
+      apiVersion: serving.knative.dev/v1
+      kind: Service
+      name: event-display
+----
+<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
+<2> In this example, any Job with the label `app: heartbeat-cron` is bound to the event sink.
+
+. Apply the `SinkBinding` resource.
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+. Create a `CronJob`:
++
+[source,yaml]
+----
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: heartbeat-cron
+  namespace: <namespace> <1>
+spec:
+  # Run every minute
+  schedule: "* * * * *"
+  jobTemplate:
+    metadata:
+      labels:
+        app: heartbeat-cron
+        bindings.knative.dev/include: "true"
+    spec:
+      template:
+        metadata:
+          annotations:
+            sidecar.istio.io/inject: "true" <2>
+            sidecar.istio.io/rewriteAppHTTPProbers: "true"
+        spec:
+          restartPolicy: Never
+          containers:
+            - name: single-heartbeat
+              image: quay.io/openshift-knative/heartbeats:latest
+              args:
+                - --period=1
+              env:
+                - name: ONE_SHOT
+                  value: "true"
+                - name: POD_NAME
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.name
+                - name: POD_NAMESPACE
+                  valueFrom:
+                    fieldRef:
+                      fieldPath: metadata.namespace
+----
+<1> A namespace that is a member of the `ServiceMeshMemberRoll`.
+<2> Injects {SMProductShortName} sidecars into the `CronJob` pods.
+
+. Apply the `CronJob` resource.
++
+[source,terminal]
+----
+$ oc apply -f <filename>
+----
+
+.Verification
+
+To verify that the events were sent to the Knative event sink, look at the message dumper function logs.
+
+. Enter the following command:
++
+[source,terminal]
+----
+$ oc get pods
+----
+
+. Enter the following command:
++
+[source,terminal]
+----
+$ oc logs $(oc get pod -o name | grep event-display) -c user-container
+----
++
+.Example output
+[source,terminal]
+----
+☁️  cloudevents.Event
+Validation: valid
+Context Attributes,
+  specversion: 1.0
+  type: dev.knative.eventing.samples.heartbeat
+  source: https://knative.dev/eventing/test/heartbeats/#event-test/mypod
+  id: 2b72d7bf-c38f-4a98-a433-608fbcdd2596
+  time: 2019-10-18T15:23:20.809775386Z
+  contenttype: application/json
+Extensions,
+  beats: true
+  heart: yes
+  the: 42
+Data,
+  {
+    "id": 1,
+    "label": ""
+  }
+----


### PR DESCRIPTION
**Affected versions for cherry-picking:** Serverless 1.29+

**Dedicated JIRA:** https://issues.redhat.com/browse/SRVKE-1419

**Description:** 
Eventing --> Event sources --> **Custom event sources**
- Integrating Service Mesh with SinkBinding
- Integrating Service Mesh with ContainerSource

**Doc preview:**

Added two new sections under Eventing --> Event sources --> **Custom event sources**
- [Integrating Service Mesh with SinkBinding](https://64130--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-custom-event-sources#serverless-sinkbinding-ossm_serverless-custom-event-sources)
- [Integrating Service Mesh with ContainerSource](https://64130--docspreview.netlify.app/openshift-serverless/latest/eventing/event-sources/serverless-custom-event-sources#serverless-containersource-ossm_serverless-custom-event-sources)

In Integrations --> Integrating Service Mesh with OpenShift Serverless --> Check Step no 7 

- [Integrating Service Mesh with OpenShift Serverless](https://64130--docspreview.netlify.app/openshift-serverless/latest/integrations/serverless-ossm-setup#serverless-ossm-setup_serverless-ossm-setup)

**Reviewers:** 
SME Review: @pierDipi 
QE Review: @maschmid 
Peer Review: @lpettyjo
