### PR TITLE
SRVCOM-2432 add support for serverless 1.30

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -293,6 +293,9 @@ openshift-serverless:
     serverless-docs-1.29:
       name: '1.29'
       dir: serverless/1.29
+    serverless-docs-1.30:
+      name: '1.30'
+      dir: serverless/1.30      
 openshift-gitops:
   name: Red Hat OpenShift GitOps
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION

Version(s):
main only

Issue:
[SRVCOM-2432](https://issues.redhat.com//browse/SRVCOM-2432)

