### PR TITLE
PR for SRVOCF-544: Update the tekton links in Building and deploying a function on the cluster section for 1.30

### DIFF
--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -24,14 +24,14 @@ You can use the Knative (`kn`) CLI to initiate a function project build and then
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.29.0/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.30/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
 ----
 
 .. Create the `kn func` deploy Tekton task to be able to deploy the function in the pipeline:
 +
 [source,terminal]
 ----
-$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.29.0/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
+$ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.30/pkg/pipelines/resources/tekton/task/func-deploy/0.1/func-deploy.yaml
 ----
 
 . Create a function:


### PR DESCRIPTION
**Dedicated JIRA:** https://issues.redhat.com/browse/SRVOCF-544

**Description:** In the **Building and deploying a function on the cluster** section, updated the links present in step no. 1 (a&b) for 1.30.

**Doc preview:** [Building and deploying a function on the cluster](https://64156--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-on-cluster-builds#serverless-functions-creating-on-cluster-builds_serverless-functions-on-cluster-builds)