### PR TITLE
OCPBUGS 18108 updating image to http://registry.access.redhat.com/rhel:latest

### DIFF
--- a/modules/cnf-scheduling-numa-aware-workloads.adoc
+++ b/modules/cnf-scheduling-numa-aware-workloads.adoc
@@ -67,7 +67,7 @@ spec:
             memory: "100Mi"
             cpu: "10"
       - name: ctnr2
-        image: gcr.io/google_containers/pause-amd64:3.0
+        image: registry.access.redhat.com/rhel:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "-c"]
         args: [ "while true; do sleep 1h; done;" ]
@@ -129,7 +129,7 @@ Events:
 Deployments that request more resources than is available for scheduling will fail with a `MinimumReplicasUnavailable` error. The deployment succeeds when the required resources become available. Pods remain in the `Pending` state until the required resources are available.
 ====
 
-. Verify that the expected allocated resources are listed for the node. 
+. Verify that the expected allocated resources are listed for the node.
 
 .. Identify the node that is running the deployment pod by running the following command, replacing <namespace> with the namespace you specified in the `Deployment` CR:
 +


### PR DESCRIPTION
[OCPBUGS-18108]: Replace image: gcr.io/google_containers/pause-amd64:3.0 with registry.access.redhat.com/rhel:latest in file scalability_and_performance/cnf-numa-aware-scheduling.adoc

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10 > 4.14 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-18108
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64168--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-scheduling-numa-aware-workloads_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
