### PR TITLE
OSDOCS#7442: Agent data gathering

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -74,3 +74,7 @@ include::modules/sample-ztp-custom-resources.adoc[leveloffset=+1]
 .Additional resources
 
 * See xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-clusters-at-scale.adoc#ztp-deploying-far-edge-clusters-at-scale[Challenges of the network far edge] to learn more about {ztp-first}.
+
+
+// Gathering log data from a failed Agent-based installation
+include::modules/installing-ocp-agent-gather-log.adoc[leveloffset=+1]

--- a/modules/installing-ocp-agent-ZTP.adoc
+++ b/modules/installing-ocp-agent-ZTP.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing-with-agent/installing-with-agent.adoc
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
 
 :_content-type: PROCEDURE
 [id="installing-ocp-agent-ztp_{context}"]

--- a/modules/installing-ocp-agent-boot.adoc
+++ b/modules/installing-ocp-agent-boot.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing-with-agent/installing-with-agent-based-installer.adoc
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
 
 :_content-type: PROCEDURE
 [id="installing-ocp-agent-boot_{context}"]

--- a/modules/installing-ocp-agent-download.adoc
+++ b/modules/installing-ocp-agent-download.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing-with-agent/installing-with-agent.adoc
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
 
 :_content-type: PROCEDURE
 [id="installing-ocp-agent-retrieve_{context}"]

--- a/modules/installing-ocp-agent-encrypt.adoc
+++ b/modules/installing-ocp-agent-encrypt.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing-with-agent/installing-with-agent-based-installer.adoc
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
 
 :_content-type: PROCEDURE
 [id="installing-ocp-agent-encrypt_{context}"]

--- a/modules/installing-ocp-agent-gather-log.adoc
+++ b/modules/installing-ocp-agent-gather-log.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
+
+:_content-type: PROCEDURE
+[id="installing-ocp-agent-gather-log_{context}"]
+= Gathering log data from a failed Agent-based installation
+
+Use the following procedure to gather log data about a failed Agent-based installation to provide for a support case.
+
+.Procedure
+
+. Run the following command and collect the output:
++
+[source,terminal]
+----
+$ ./openshift-install --dir <install_directory> agent wait-for bootstrap-complete --log-level=debug
+----
++
+.Example error message
+[source,terminal]
+----
+...
+ERROR Bootstrap failed to complete: : bootstrap process timed out: context deadline exceeded
+----
+
+. If the output from the previous command indicates a failure, or if the bootstrap is not progressing, run the following command on node 0 and collect the output:
++
+[source,terminal]
+----
+$ ssh core@<node-ip> sudo /usr/local/bin/agent-gather -O > <local_tmp_path>/agent-gather.tar.xz
+----
++
+[NOTE]
+====
+You only need to gather data from node 0, but gathering this data from every node can be helpful.
+====
+
+. If the bootstrap completes and the cluster nodes reboot, run the following command and collect the output:
++
+[source,terminal]
+----
+$ ./openshift-install --dir <install_directory> agent wait-for install-complete --log-level=debug
+----
+
+. If the output from the previous command indicates a failure, perform the following steps:
+
+.. Export the `kubeconfig` file to your environment by running the following command:
++
+[source,terminal]
+----
+$ export KUBECONFIG=<install_directory>/auth/kubeconfig
+----
+
+.. To gather information for debugging, run the following command:
++
+[source,terminal]
+----
+$ oc adm must-gather
+----
+
+.. Create a compressed file from the `must-gather` directory that was just created in your working directory by running the following command:
++
+[source,terminal]
+----
+$ tar cvaf must-gather.tar.gz <must_gather_directory>
+----
+
+. Excluding the `/auth` subdirectory, attach the installation directory used during the deployment to your support case on the link:https://access.redhat.com[Red Hat Customer Portal].
+
+. Attach all other data gathered from this procedure to your support case.

--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing-with-agent/installing-with-agent-based-installer.adoc
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
 
 :_content-type: PROCEDURE
 [id="installing-ocp-agent-inputs_{context}"]

--- a/modules/installing-ocp-agent-tui.adoc
+++ b/modules/installing-ocp-agent-tui.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing-with-agent/installing-with-agent.adoc
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
 
 :_content-type: PROCEDURE
 [id="installing-ocp-agent-tui_{context}"]

--- a/modules/installing-ocp-agent-verify.adoc
+++ b/modules/installing-ocp-agent-verify.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing-with-agent/installing-with-agent.adoc
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
 
 :_content-type: PROCEDURE
 [id="installing-ocp-agent-verify_{context}"]

--- a/modules/sample-ztp-custom-resources.adoc
+++ b/modules/sample-ztp-custom-resources.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * installing-with-agent/installing-with-agent.adoc
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
 
 :_content-type: CONCEPT
 [id="sample-ztp-custom-resources_{context}"]


### PR DESCRIPTION
[OSDOCS-7442](https://issues.redhat.com/browse/OSDOCS-7442)

Versions: 4.13+

This PR adds instructions for gathering data for a support case when you Agent-based installation has failed.

QE review:
- [x] QE has approved this change.

Preview: [Gathering log data from a failed Agent-based installation](https://64183--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-gather-log_installing-with-agent-based-installer)
