### PR TITLE
CNV-30799 adding comment to cloning vms between namespaces

### DIFF
--- a/virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc
+++ b/virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc
@@ -19,6 +19,9 @@ to the destination namespace.
 * Only a user with the xref:../../../authentication/using-rbac.adoc#default-roles_using-rbac[`cluster-admin`]
 role can create cluster roles.
 
+[NOTE]
+If you are a non-admin user that is an administrator for both the source and target namespaces, you can create a `Role` instead of a `ClusterRole` where appropriate. 
+
 include::modules/virt-about-datavolumes.adoc[leveloffset=+1]
 
 include::modules/virt-creating-rbac-cloning-dvs.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Adding comment regarding role vs clusterrole to cloning vms between namespaces

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):  enterprise-4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:  https://issues.redhat.com/browse/CNV-30799
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
