### PR TITLE
GitOps 1.9.2 release notes documentation.

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,8 +23,12 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-9-2.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-9-1.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-9-0.adoc[leveloffset=+1]
+
 // 1.25.0 additional resources, OCP docs
 ifdef::openshift-enterprise[]
 [role="_additional-resources"]

--- a/modules/gitops-release-notes-1-9-2.adoc
+++ b/modules/gitops-release-notes-1-9-2.adoc
@@ -1,0 +1,37 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-9-2_{context}"]
+= Release notes for {gitops-title} 1.9.2
+
+{gitops-title} 1.9.2 is now available on {product-title} 4.12 and 4.13.
+
+[id="errata-updates-1-9-2_{context}"]
+== Errata updates
+
+[id="rhsa-2023-5029-gitops-1-9-2-security-update-advisory_{context}"]
+=== RHSA-2023:5029 - {gitops-title} 1.9.2 security update advisory
+
+Issued: 2023-09-08
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2023:5029[RHSA-2023:5029]
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----
+
+[id="fixed-issues-1-9-2_{context}"]
+== Fixed issues
+
+The following issue has been resolved in the current release:
+
+* Before this update, an old Redis image version was used when deploying the {gitops-title} Operator, which resulted in vulnerabilities. This update fixes the vulnerabilities on Redis by upgrading it to the latest version of the `registry.redhat.io/rhel-8/redis-6` image. link:https://issues.redhat.com/browse/GITOPS-3069[GITOPS-3069]
+


### PR DESCRIPTION
Jira issue : [RHDEVDOCS-5613](https://issues.redhat.com/browse/RHDEVDOCS-5613)

Aligned team: DevTools 
OCP Version(s): 4.12 and to 4.13

Docs preview: [64185--docspreview](https://64185--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes#gitops-release-notes-1-9-2_gitops-release-notes)

SME review: @reginapizza 

QE review: @varshab1210 

Peer review: @Srivaralakshmi 