### PR TITLE
OSDOCS-7625: add GA and update release notes 4.14

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -12,12 +12,16 @@ toc::[]
 
 [id="microshift-4-14-about-this-release"]
 == About this release
+// TODO: Update with the relevant information closer to release.
+{product-title} (link:https://access.redhat.com/errata/RHSA-2023:XXXX[RHSA-2023:XXXX]) is now Generally Available. This release uses link:https://github.com/kubernetes/kubernetes/blob/master/CHANGELOG/CHANGELOG-1.27.md[Kubernetes 1.27] with CRI-O runtime. New features, changes, and known issues that pertain to {product-title} {product-version} are included in this topic.
 
-//The Red Hat build of {product-title} is Technology Preview only. Features and known issues that pertain to {product-title} {ocp-version} are included in this topic. This Technology Preview software is not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using {product-title} in production. Technology Preview provides early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+You can deploy {product-title} clusters to either on-premise, cloud, or disconnected environments.
 
-//For more information about the support scope of Red Hat Technology Preview features, read link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+// Double check OP system versions
+{product-title} {product-version} is supported on {op-system-ostree-first} and {op-system-base-full} 9.2.
 
-//need messaging and link here
+//TODO: update link after GA; KCS article will not be live until then
+//For lifecycle information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
 [id="microshift-4-14-new-features-and-enhancements"]
 == New features and enhancements
@@ -25,9 +29,9 @@ toc::[]
 This release adds improvements related to the following components and concepts.
 
 //L3 major categories with features in each as L4s, for example:
-[id="microshift-4-14-rhel-edge"]
-=== {op-system-ostree-first} {op-system-version}
-* {product-title} runs on {op-system-ostree} version {op-system-version} or later.
+[id="microshift-4-14-rhel"]
+=== {op-system-base-full} {op-system-version}
+* {product-title} runs on {op-system-base-full} version 9.2.
 
 // Some details of the next note are adapted from https://kubernetes.io/blog/2022/08/31/cgroupv2-ga-1-25/
 * {product-title} uses crun and Control Group v2 (cgroup v2). {OCP} {ocp-version} defaults to Control Group v1. The divergence of control group versions is not anticipated to have a noticeable behavior difference on most workloads. If workloads rely on the cgroup file system layout, they may need to be updated to be compatible with cgroup v2.
@@ -35,6 +39,14 @@ This release adds improvements related to the following components and concepts.
 ** If you run third-party monitoring and security agents that depend on the cgroup file system, update the agents to versions that support cgroup v2.
 ** If you run cAdvisor as a standalone DaemonSet for monitoring pods and containers, update it to v0.43.0 or later.
 ** If you deploy Java applications with the JDK, ensure you are using JDK 11.0.16 and later or JDK 15 and later, which fully support cgroup v2.
+
+[id="microshift-4-14-updates-supported"]
+=== Updates are supported on {product-version} and later
+With this release, updates for both minor releases and patch releases are supported.
+
+* {product-title} offers in-place updates on {op-system-ostree} systems with automatic system rollback capabilities and automatic back up and restore functions.
+* Updates of the RPMs on a non-OSTree system such as {op-system} are also supported.
+* Updates from preview versions such as {product-title} 4.13 and earlier are not supported.
 
 //[id="microshift-4-14-new-feat-based-on-{op-system-ostree}"]
 //==== Placeholder for new feat bases on RHEL Edge
@@ -73,7 +85,7 @@ This release adds improvements related to the following components and concepts.
 //[id="microshift-4-14-lvms-system-requirements"]
 //==== LVMS system requirements
 
-//[id="microshift-4-13-deprecated-removed-features"]
+//[id="microshift-4-14-deprecated-removed-features"]
 //== Deprecated and removed features
 
 //[id="microshift-4-14-bug-fixes"]


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7625

Link to docs preview:
https://64195--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-about-this-release
https://64195--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-updates-supported

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
