### PR TITLE
OADP-2130: Restructure of the OADP Introduction

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -43,6 +43,7 @@ endif::openshift-origin[]
 :hybrid-console: Red Hat Hybrid Cloud Console
 :hybrid-console-second: Hybrid Cloud Console
 :oadp-first: OpenShift API for Data Protection (OADP)
+:oadp-full: OpenShift API for Data Protection
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-registry: OpenShift image registry
 :rh-storage-first: Red Hat OpenShift Data Foundation
@@ -60,7 +61,7 @@ endif::openshift-origin[]
 :secondary-scheduler-operator: Secondary Scheduler Operator
 // Backup and restore
 :velero-domain: velero.io
-:velero-version: 1.9
+:velero-version: 1.11
 :launch: image:app-launcher.png[title="Application Launcher"]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers

--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2794,9 +2794,11 @@ Topics:
   File: graceful-cluster-shutdown
 - Name: Restarting a cluster gracefully
   File: graceful-cluster-restart
-- Name: Application backup and restore
+- Name: OADP Application backup and restore
   Dir: application_backup_and_restore
   Topics:
+  - Name: Introduction to OpenShift API for Data Protection
+    File: oadp-intro         
   - Name: OADP release notes
     File: oadp-release-notes
   - Name: OADP features and plugins

--- a/backup_and_restore/application_backup_and_restore/oadp-intro.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-intro.adoc
@@ -1,0 +1,34 @@
+:_content-type: ASSEMBLY
+[id="oadp-introduction"]
+= Introduction to {oadp-full}
+include::_attributes/common-attributes.adoc[]
+:context: oadp-api
+:namespace: openshift-adp
+:local-product: OADP
+
+toc::[]
+
+The {oadp-first} product safeguards customer applications on {product-title}. It offers comprehensive disaster recovery protection, covering {product-title} applications, application-related cluster resources, persistent volumes, and internal images. OADP is also capable of backing up both containerized applications and virtual machines (VMs). 
+
+However, OADP does not serve as a disaster recovery solution for xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[etcd] or OpenShift Operators. 
+
+
+[id="oadp-apis_{context}"]
+= {oadp-full} APIs
+
+{oadp-first} provides APIs that enable multiple approaches to customizing backups and preventing the inclusion of unnecessary or inappropriate resources. 
+
+OADP provides the following APIs:
+
+* xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc#backing-up-applications[Backup]
+* xref:../../backup_and_restore/application_backup_and_restore/backing_up_and_restoring/restoring-applications.adoc#restoring-applications[Restore]
+* Schedule
+* BackupStorageLocation
+* VolumeSnapshotLocation
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backup-etcd[Backing up etcd]
+// once finished re-work come back and add doc links to the APIs
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[OADP-2130](https://issues.redhat.com/browse/OADP-2130)

Doc Improvements - Restructure of OADP documentation

This PR is a focused on including an introduction section and improving the structure of the documentation as the taxonomy was problematic. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.


Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
Enterprise 4.11 → branch/enterprise-4.11
Enterprise 4.12 → branch/enterprise-4.12
Enterprise 4.13 → branch/enterprise-4.13
Enterprise 4.14 → branch/enterprise-4.14
Enterprise 4.15 → branch/enterprise-4.15

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OADP-2130

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[OADP Introduction](https://64198--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-intro)

QE review:
- [ X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
