### PR TITLE
OSDOCS-7650: release note MicroShift network changes

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -125,7 +125,19 @@ This routing rule matches the Kubernetes service IP address range and forwards t
 [id="microshift-4-14-networking-changes"]
 === Networking changes
 
-Networking changes to {product-title} {product-version} include IP address assignment changes, gateway changes, and other refinements.
+Networking updates to {product-title} {product-version} include traffic flow pattern, gateway, and custom configuration changes.
+
+[discrete]
+[id="microshift-4-14-traffic-flow-change"]
+==== North-south traffic flow changed
+
+The external gateway bridge and the physical device on the host are no longer connected. The north-south traffic between the network service and the OVN external switch flows from the host kernel to {product-title} through the external gateway bridge. See the xref:../microshift_networking/microshift-networking.adoc#microshift-description-connections-network-topology_microshift-networking[MicroShift networking] documentation for more information.
+
+[discrete]
+[id="microshift-4-14-network-config-flags-deprecated"]
+==== Network configuration flags are deprecated
+
+The gateway bridge flag, 'gatewayInterface', and the OVS flag, `disableOVSInit`, in the networking configuration file, `/etc/microshift/ovn.yaml`, are deprecated with this release. See the xref:../microshift_networking/microshift-networking.adoc#microshift-config-OVN-K_microshift-networking[MicroShift OVN-K configuration] documentation for more information.
 
 [discrete]
 [id="microshift-4-14-cidr-removal"]


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7650

Link to docs preview:
https://64205--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-notable-technical-changes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
