### PR TITLE
ROX-19513: fix cut and paste error and leading zero issue

### DIFF
--- a/modules/default-requirements-secured-cluster-services.adoc
+++ b/modules/default-requirements-secured-cluster-services.adoc
@@ -20,7 +20,7 @@ Sensor monitors your Kubernetes and {ocp} clusters. These services currently dep
 [discrete]
 == Memory and CPU requirements
 
-The following table lists the minimum memory and storage values required to install and run Central.
+The following table lists the minimum memory and storage values required to install and run sensor on secured clusters.
 
 |===
 | Sensor | CPU | Memory
@@ -48,11 +48,11 @@ By default, the admission control service runs 3 replicas. The following table l
 | Admission controller | CPU | Memory
 
 | *Request*
-| .05 cores
+| 0.05 cores
 | 100 MiB
 
 | *Limit*
-| .5 cores
+| 0.5 cores
 | 500 MiB
 |===
 
@@ -97,16 +97,16 @@ By default, the admission control service runs 3 replicas. The following table l
 
 .2+| *Collector Container*
 | *Request*
-| .05 cores
+| 0.05 cores
 | 320 MiB
 
 | *Limit*
-| .75 cores
+| 0.75 cores
 | 1000 MiB
 
 .2+| *Compliance Container*
 | *Request*
-| .01 cores
+| 0.01 cores
 | 10 MiB
 
 | *Limit*
@@ -115,7 +115,7 @@ By default, the admission control service runs 3 replicas. The following table l
 
 .2+| *Node-Inventory Container*
 | *Request*
-| .01 cores
+| 0.01 cores
 | 10 MiB
 
 | *Limit*
@@ -124,7 +124,7 @@ By default, the admission control service runs 3 replicas. The following table l
 
 .2+| *Total*
 | *Request*
-| .07 cores
+| 0.07 cores
 | 340 MiB
 
 | *Limit*


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.2`
- Cherry pick to `rhacs-docs-4.1`

[Issue](https://issues.redhat.com/browse/ROX-19513)

[Link to docs preview
](https://64206--docspreview.netlify.app/openshift-acs/latest/installing/acs-default-requirements#acs-general-requirements_acs-default-requirements)

QE review: (**N/A**, bug fix)
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Eng confirmed that this was a cut and paste error.

