### PR TITLE
OSDOCS-3562: Add SRE access assembly

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -67,6 +67,8 @@ Topics:
     File: rosa-life-cycle
   - Name: Understanding process and security for ROSA
     File: rosa-policy-process-security
+#  - Name: SRE and service account access
+#    File: rosa-sre-access
 - Name: About IAM resources for ROSA with STS
   File: rosa-sts-about-iam-resources
 - Name: OpenID Connect Overview

--- a/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
@@ -1,0 +1,5 @@
+:_content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-sre-access
+[id="rosa-sre-access"]
+= SRE and service account access


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-3562

Link to docs preview:
Assembly is not visible: https://64207--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-understand-availability

QE review:
No QE review required.

Additional information:
This PR is putting in place an assembly where multiple writers can contribute content for a critical documentation request. The assembly is commented out and will not build in the documentation until all pieces have been added and reviewed. This PR does not require QE or SME review because it contains no technical information. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
