### PR TITLE
OSDOCS#7545: Release Notes for root volume types

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -91,6 +91,10 @@ The `DeploymentConfig` and `Build` APIs are now optional cluster capabilities. Y
 
 For more information, see xref:../installing/cluster-capabilities.adoc#cluster-capabilities[Cluster capabilities].
 
+[id="ocp-4-14-rootvolume-types-openstack-available"]
+==== Root volume types parameter for {rh-openstack} is now available
+You can now specify one or more root volume types in {rh-openstack}, by using the `rootVolume.types` parameter. This parameter is available for both control plane and compute machines.
+
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration
 
@@ -460,6 +464,15 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 
+|`compute.platform.openstack.rootVolume.type` for {rh-openstack}
+|General Availability
+|General Availability
+|Deprecated
+
+|`controlPlane.platform.openstack.rootVolume.type` for {rh-openstack}
+|General Availability
+|General Availability
+|Deprecated
 |====
 [.small]
 --
@@ -571,7 +584,6 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 |Deprecated
-
 |====
 
 //[discrete]


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OSDOCS-7545 

Link to docs preview:

Added: https://64212--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-rootvolume-types-openstack-available
Deprecated: https://64212--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-deprecated-removed-features

QE review:
- [x] QE has approved this change. @itzikb-redhat 