### PR TITLE
OCPBUGS-18432: Updated TuneD bootloader supportability note

### DIFF
--- a/modules/configuring-huge-pages.adoc
+++ b/modules/configuring-huge-pages.adoc
@@ -92,9 +92,9 @@ $ oc get node <node_using_hugepages> -o jsonpath="{.status.allocatable.hugepages
 ----
 
 ifndef::openshift-origin[]
-[WARNING]
+[NOTE]
 ====
-The TuneD bootloader plugin is currently supported on {op-system-first} 8.x worker nodes. For {op-system-base-full} 7.x worker nodes, the TuneD bootloader plugin is currently not supported.
+The TuneD bootloader plugin only supports {op-system-first} worker nodes.
 ====
 endif::openshift-origin[]
 

--- a/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
+++ b/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
@@ -34,9 +34,9 @@ that is not supported. The following TuneD plugins are currently not supported:
 * systemd
 
 
-[WARNING]
+[NOTE]
 ====
-The TuneD bootloader plugin is currently supported on {op-system-first} 8.x worker nodes. For {op-system-base-full} 7.x worker nodes, the TuneD bootloader plugin is currently not supported.
+The TuneD bootloader plugin only supports {op-system-first} worker nodes.
 ====
 
 .Additional references


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-18432

Link to docs preview (VPN required):
[Supported TuneD daemon plugins](https://file.rdu.redhat.com/antaylor/OCPBUGS-18432/scalability_and_performance/using-node-tuning-operator.html#supported-tuned-daemon-plug-ins_node-tuning-operator)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Corrected a note and adjusted it from a WARNING to a NOTE block in two places. 