### PR TITLE
OSDOCS#7527: Adding namespaces that are always set to privileged PSA to release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -150,6 +150,17 @@ With this release, you can now require your workloads to use a specific security
 
 For more information, see xref:../authentication/managing-security-context-constraints.adoc#security-context-constraints-requiring_configuring-internal-oauth[Configuring a workload to require a specific SCC].
 
+[id="ocp-4-14-auth-psa-privileged-namespaces"]
+==== Pod security admission privileged namespaces
+
+With this release, the following system namespaces are always set to the `privileged` pod security admission profile:
+
+* `default`
+* `kube-public`
+* `kube-system`
+
+For more information, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#psa-privileged-namespaces_understanding-and-managing-pod-security-admission[Privileged namespaces].
+
 [id="ocp-4-14-networking"]
 === Networking
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OSDOCS-7527

Link to docs preview:
https://64229--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-auth-psa-privileged-namespaces

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->


**Depends on #64227 for the xref to work**