### PR TITLE
OSDOCS#5491: Creating authentication docs for MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -155,6 +155,8 @@ Topics:
   File: microshift-operators
 - Name: Greenboot workload health check scripts
   File: microshift-greenboot-workload-scripts
+- Name: Pod security authentication and authorization  
+  File: microshift-authentication
 ---
 Name: Troubleshooting
 Dir: microshift_troubleshooting

--- a/microshift_running_apps/microshift-authentication.adoc
+++ b/microshift_running_apps/microshift-authentication.adoc
@@ -1,0 +1,15 @@
+:_content-type: ASSEMBLY
+[id="authentication-with-microshift"]
+= Pod security authentication and authorization on {product-title}
+include::_attributes/attributes-microshift.adoc[]
+:context: authentication-microshift
+
+== Understanding and managing pod security admission 
+
+Pod security admission is an implementation of the link:https://kubernetes.io/docs/concepts/security/pod-security-standards/[Kubernetes pod security standards]. Use pod security admission to restrict the behavior of pods.
+
+include::modules/microshift-security-context-constraints.adoc[leveloffset=+1]
+
+include::modules/microshift-viewing-security-context.adoc[leveloffset=+2]
+
+include::modules/microshift-security-context-constraints-opting.adoc[leveloffset=+1]

--- a/modules/microshift-security-context-constraints-opting.adoc
+++ b/modules/microshift-security-context-constraints-opting.adoc
@@ -1,0 +1,49 @@
+// Module included in the following assemblies:
+//
+// * microshift_running_apps/microshift-authentication.adoc
+
+:_content-type: PROCEDURE 
+[id="microshift-security-context-constraints-opting_{context}"]
+= Controlling pod security admission synchronization
+
+You can enable or disable automatic pod security admission synchronization for most namespaces.
+
+[IMPORTANT]
+====
+Namespaces that are defined as part of the cluster payload have pod security admission synchronization disabled permanently. These namespaces include:
+
+* `default`
+* `kube-node-lease`
+* `kube-system`
+* `kube-public`
+* `openshift`
+* All system-created namespaces that are prefixed with `openshift-`, except for `openshift-operators`
+By default, all namespaces that have an `openshift-` prefix are not synchronized. You can enable synchronization for any user-created [x-]`openshift-*` namespaces. You cannot enable synchronization for any system-created [x-]`openshift-*` namespaces, except for `openshift-operators`. 
+
+If an Operator is installed in a user-created `openshift-*` namespace, synchronization is turned on by default after a cluster service version (CSV) is created in the namespace. The synchronized label inherits the permissions of the service accounts in the namespace.
+====
+
+.Procedure
+
+* For each namespace that you want to configure, set a value for the `security.openshift.io/scc.podSecurityLabelSync` label:
+** To disable pod security admission label synchronization in a namespace, set the value of the `security.openshift.io/scc.podSecurityLabelSync` label to `false`.
++
+Run the following command:
++
+[source,terminal]
+----
+$ oc label namespace <namespace> security.openshift.io/scc.podSecurityLabelSync=false
+----
+** To enable pod security admission label synchronization in a namespace, set the value of the `security.openshift.io/scc.podSecurityLabelSync` label to `true`.
++
+Run the following command:
++
+[source,terminal]
+----
+$ oc label namespace <namespace> security.openshift.io/scc.podSecurityLabelSync=true
+----
+
+[NOTE]
+====
+You can use the --overwrite flag to reverse the effects of the pod security label synchronization in a namespace.
+====

--- a/modules/microshift-security-context-constraints.adoc
+++ b/modules/microshift-security-context-constraints.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * microshift_running_apps/microshift-authentication.adoc
+
+:_content-type: CONCEPT
+[id="microshift-security-context-constraints_{context}"]
+
+= Security context constraint synchronization with pod security standards
+
+{product-title} includes link:https://kubernetes.io/docs/concepts/security/pod-security-admission[Kubernetes pod security admission]. Globally, the `restricted` profile is enforced by default for {product-title}.
+
+In addition to the global pod security admission control configuration, a controller exists that applies pod security admission control `warn` and `audit` labels to namespaces according to the security context constraint (SCC) permissions of the service accounts that are in a given namespace.
+
+[IMPORTANT]
+====
+Namespaces that are defined as part of the cluster payload have pod security admission synchronization disabled permanently. You can enable pod security admission synchronization on other namespaces as necessary. If an Operator is installed in a user-created `openshift-*` namespace, synchronization is turned on by default after a cluster service version (CSV) is created in the namespace. 
+====
+
+The controller examines `ServiceAccount` object permissions to use security context constraints in each namespace. Security context constraints (SCCs) are mapped to pod security profiles based on their field values; the controller uses these translated profiles. Pod security admission `warn` and `audit` labels are set to the most privileged pod security profile found in the namespace to prevent warnings and audit logging as pods are created.
+
+Namespace labeling is based on consideration of namespace-local service account privileges.
+
+Applying pods directly might use the SCC privileges of the user who runs the pod. However, user privileges are not considered during automatic labeling.

--- a/modules/microshift-viewing-security-context.adoc
+++ b/modules/microshift-viewing-security-context.adoc
@@ -1,0 +1,23 @@
+// Module included in the following assemblies:
+//
+// * microshift_running_apps/microshift-authentication.adoc
+
+:_content-type: PROCEDURE 
+[id="microshift-viewing-security-context_{context}"]
+= Viewing security context constraints in a namespace 
+
+MicroShift allows you to access the security context constraints (SCC) permissions in a given namespace.
+
+.Prerequisites 
+
+* You have installed the OpenShift CLI (`oc`)
+
+.Procedure
+
+* To view the security context constraints in your namespace, run the following command: 
++
+[source,terminal]
+----
+oc get --show-labels namespace <namespace>
+----
+


### PR DESCRIPTION
**Versions:** 4.14+ 
**Issue:** [OSDOCS-5494](https://issues.redhat.com//browse/OSDOCS-5494) 

**Description:** This PR adds a new section to the MicroShift docs for pod security and authenication

**Previews:** 

- [Pod security authentication and authorization on MicroShift](https://64230--docspreview.netlify.app/microshift/latest/microshift_running_apps/microshift-authentication)

**QE review** 
- [x] QE approval
