### PR TITLE
OSDOCS-7626: adds release note backup and restore MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -39,6 +39,10 @@ This release adds improvements related to the following components and concepts.
 //[id="microshift-4-14-new-feat-based-on-{op-system-ostree}"]
 //==== Placeholder for new feat bases on RHEL Edge
 
+[id="microshift-backup-and-restore"]
+=== Backup and restore
+The capability to back up and restore the {product-title} database is now available. You can manually back up and restore data on all supported systems at any time. See the xref:../microshift_backup_and_restore/microshift-backup-and-restore.adoc#microshift-backup-and-restore[Backing up and restoring {product-title} data] documentation for more information.
+
 //[id="microshift-4-14-installation"]
 //=== Installation
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7626

Link to docs preview:
https://64237--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-backup-and-restore

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
