### PR TITLE
OSDOCS-7658: Increase the  maximum number of CRDs

### DIFF
--- a/modules/openshift-cluster-maximums-major-releases.adoc
+++ b/modules/openshift-cluster-maximums-major-releases.adoc
@@ -62,7 +62,7 @@ Red Hat does not provide direct guidance on sizing your {product-title} cluster.
 | 12,000
 
 | Number of custom resource definitions (CRD)
-| 512 ^[8]^
+| 1,024 ^[8]^
 
 |===
 [.small]
@@ -74,7 +74,7 @@ Red Hat does not provide direct guidance on sizing your {product-title} cluster.
 5. When there are a large number of active projects, etcd might suffer from poor performance if the keyspace grows excessively large and exceeds the space quota. Periodic maintenance of etcd, including defragmentation, is highly recommended to free etcd storage.
 6. There are several control loops in the system that must iterate over all objects in a given namespace as a reaction to some changes in state. Having a large number of objects of a given type in a single namespace can make those loops expensive and slow down processing given state changes. The limit assumes that the system has enough CPU, memory, and disk to satisfy the application requirements.
 7. Each service port and each service back-end has a corresponding entry in `iptables`. The number of back-ends of a given service impact the size of the `Endpoints` objects, which impacts the size of data that is being sent all over the system.
-8. {product-title} has a limit of 512 total custom resource definitions (CRD), including those installed by {product-title}, products integrating with {product-title} and user-created CRDs. If there are more than 512 CRDs created, then there is a possibility that `oc` command requests might be throttled.
+8. Tested on a cluster with 29 servers: 3 control planes, 2 infrastructure nodes, and 24 worker nodes. The cluster had 500 namespaces. {product-title} has a limit of 1,024 total custom resource definitions (CRD), including those installed by {product-title}, products integrating with {product-title} and user-created CRDs. If there are more than 1,024 CRDs created, then there is a possibility that `oc` command requests might be throttled.
 --
 
 [id="cluster-maximums-major-releases-example-scenario_{context}"]


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-7658

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

[OpenShift Container Platform tested cluster maximums for major releases](https://64239--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/planning-your-environment-according-to-object-maximums#cluster-maximums-major-releases_object-limits)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
