### PR TITLE
OSDOCS-7630: Documented the 4.13.11 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3134,3 +3134,24 @@ The latency tuning logic monitors the veth NIC creation events and starts config
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-13-11"]
+=== RHBA-2023:4905 - {product-title} 4.13.11 bug fix
+
+Issued: 2023-09-05
+
+{product-title} release 4.13.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4905[RHBA-2023:4905] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.11 --pullspecs
+----
+
+[id="ocp-4-13-11-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-7630](https://issues.redhat.com/browse/OSDOCS-7630)

Version(s):
4.13

Link to docs preview:
* [4.13.11 z-stream notes](https://64262--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-11)

QE review:
- [x] QE approval is not required for z-stream release notes. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
