### PR TITLE
TELCODOCS-1535-ocp-4.10: Updated correct YAML file for pod deployment

### DIFF
--- a/modules/sandboxed-containers-deploying-workloads-with-kata-runtime-cli.adoc
+++ b/modules/sandboxed-containers-deploying-workloads-with-kata-runtime-cli.adoc
@@ -28,40 +28,32 @@ To deploy a pod-templated workload in a sandboxed container, you must add `kata`
 ** `Deployment` objects
 ** `DeploymentConfig` objects
 
-.Example for Pod objects
+.Example for `Pod` objects
 [source,yaml]
 ----
-  apiVersion: v1
-  kind: Pod
-  metadata:
-   name: mypod
-  spec:
-    runtimeClassName: kata
-----
-
-.Example for Deployment objects
-[source,yaml]
-----
-  apiVersion: apps/v1
-  kind: Deployment
-  metadata:
-    name: mypod
-    labels:
-      app: mypod
-  spec:
-    replicas: 3
-    selector:
-      matchLabels:
-        app: mypod
-    template:
-      metadata:
-        labels:
-          app: mypod
-      spec:
-        runtimeClassName: kata
-        containers:
-        - name: mypod
-          image: myImage
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-openshift
+  labels:
+    app: hello-openshift
+spec:
+  runtimeClassName: kata
+  containers:
+    - name: hello-openshift
+      image: quay.io/openshift/origin-hello-openshift
+      ports:
+        - containerPort: 8888
+      securityContext:
+        privileged: false
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1001
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
 ----
 
 {product-title} creates the workload and begins scheduling it.

--- a/modules/sandboxed-containers-deploying-workloads-with-kata-runtime-web.adoc
+++ b/modules/sandboxed-containers-deploying-workloads-with-kata-runtime-web.adoc
@@ -26,51 +26,32 @@ To deploy a pod-templated workload in a sandboxed container, you must manually a
 . In the YAML file for the workload, in the *spec* field where the container is listed, add `runtimeClassName: kata`.
 
 +
-.Example for Pod
+.Example for `Pod` object
 [source,yaml]
 ----
-    apiVersion: v1
-    kind: Pod
-    metadata:
-      name: example
-      labels:
-        app: httpd
-      namespace: openshift-sandboxed-containers-operator
-    spec:
-      runtimeClassName: kata
-      containers:
-        - name: httpd
-          image: 'image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest'
-          ports:
-            - containerPort: 8080
-----
-
-+
-.Example for Deployment
-[source,yaml]
-----
-    apiVersion: apps/v1
-    kind: Deployment
-    metadata:
-      name: example
-      namespace: openshift-sandboxed-containers-operator
-    spec:
-      selector:
-        matchLabels:
-          app: httpd
-      replicas: 3
-      template:
-        metadata:
-          labels:
-            app: httpd
-        spec:
-          runtimeClassName: kata
-          containers:
-            - name: httpd
-              image: >-
-                image-registry.openshift-image-registry.svc:5000/openshift/httpd:latest
-              ports:
-                - containerPort: 8080
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hello-openshift
+  labels:
+    app: hello-openshift
+spec:
+  runtimeClassName: kata
+  containers:
+    - name: hello-openshift
+      image: quay.io/openshift/origin-hello-openshift
+      ports:
+        - containerPort: 8888
+      securityContext:
+        privileged: false
+        allowPrivilegeEscalation: false
+        runAsNonRoot: true
+        runAsUser: 1001
+        capabilities:
+          drop:
+            - ALL
+        seccompProfile:
+          type: RuntimeDefault
 ----
 
 . Click *Save*.


### PR DESCRIPTION
Version(s):
4.10

Issue:
https://issues.redhat.com/browse/TELCODOCS-1535

Link to docs preview:

- https://64266--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads#sandboxed-containers-deploying-workloads-with-kata-runtime-web_deploying-sandboxed-containers
- https://64266--docspreview.netlify.app/openshift-enterprise/latest/sandboxed_containers/deploying-sandboxed-container-workloads#sandboxed-containers-deploying-workloads-with-kata-runtime-cli_deploying-sandboxed-containers

QE review:
- [x] QE has approved this change.