### PR TITLE
OCPBUGS#18190: Added missing DNS records for vSphere IPI docs

### DIFF
--- a/modules/installation-vsphere-installer-infra-requirements.adoc
+++ b/modules/installation-vsphere-installer-infra-requirements.adoc
@@ -464,7 +464,7 @@ endif::vsphere[]
 [discrete]
 [id="installation-vsphere-installer-infra-requirements-dns-records_{context}"]
 === DNS records
-You must create DNS records for two static IP addresses in the appropriate DNS server for the vCenter instance that hosts your {product-title} cluster. In each record, `<cluster_name>` is the cluster name and `<base_domain>` is the cluster base domain that you specify when you install the cluster. A complete DNS record takes the form: `<component>.<cluster_name>.<base_domain>.`.
+You must create DNS records for certain static IP addresses in the appropriate DNS server for the vCenter instance that hosts your {product-title} cluster. In each record, `<cluster_name>` is the cluster name and `<base_domain>` is the cluster base domain that you specify when you install the cluster. A complete DNS record takes the form: `<component>.<cluster_name>.<base_domain>.`.
 
 .Required DNS records
 [cols="1a,5a,3a",options="header"]
@@ -486,6 +486,12 @@ external to the cluster and from all the nodes within the cluster.
 machines that run the Ingress router pods, which are the worker nodes by
 default. This record must be resolvable by both clients external to the cluster
 and from all the nodes within the cluster.
+
+|Kubernetes API
+|`api-int.<cluster_name>.<base_domain>.`
+a|For an {product-title} cluster that supports Windows nodes: A DNS A/AAAA or CNAME record, and a DNS PTR record, to internally identify the API load balancer. These records must be resolvable from all the Windows nodes within the cluster.
+
+*Important*: The API server must be able to resolve the Windows worker nodes by the hostnames that are recorded in Kubernetes. If the API server cannot resolve the node names, then proxied API calls can fail, and you cannot retrieve logs from pods.
 |===
 
 ifeval::["{context}" == "installing-restricted-networks-installer-provisioned-vsphere"]


### PR DESCRIPTION
[OCPBUGS-18190](https://issues.redhat.com/browse/OCPBUGS-18190)

Version(s):
4.14 through to 4.10

Link to docs preview:
* [DNS records](https://64270--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-vsphere-installer-infra-requirements_installing-vsphere-installer-provisioned-network-customizations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
