### PR TITLE
TELCODOCS-1324: CP to 4.13

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2758,9 +2758,6 @@ Topics:
   File: cnf-performing-platform-verification-latency-tests
 - Name: Improving cluster stability in high latency environments using worker latency profiles
   File: scaling-worker-latency-profiles
-- Name: Topology Aware Lifecycle Manager for cluster updates
-  File: cnf-talm-for-cluster-upgrades
-  Distros: openshift-origin,openshift-enterprise
 - Name: Creating a performance profile
   File: cnf-create-performance-profiles
   Distros: openshift-origin,openshift-enterprise
@@ -2793,6 +2790,9 @@ Topics:
     - Name: Advanced managed cluster configuration with PolicyGenTemplate resources
       File: ztp-advanced-policy-config
     - Name: Updating managed clusters with the Topology Aware Lifecycle Manager
+      File: cnf-talm-for-cluster-upgrades
+      Distros: openshift-origin,openshift-enterprise
+    - Name: Updating managed clusters in a disconnected environment with the Topology Aware Lifecycle Manager
       File: ztp-talm-updating-managed-policies
     - Name: Updating GitOps ZTP
       File: ztp-updating-gitops

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1273,7 +1273,7 @@ Now, during container image pre-caching, {cgu-operator} compares the available h
 
 * A new `excludePrecachePatterns` field in the `ConfigMap` CR is available that controls which pre-cache images {cgu-operator} downloads to the cluster host before an update.
 
-For more information see xref:../scalability_and_performance/cnf-talm-for-cluster-upgrades.adoc#talo-precache-feature-image-filter_cnf-topology-aware-lifecycle-manager[Using the container image pre-cache filter].
+For more information see xref:../scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades.adoc#talo-precache-feature-image-filter_cnf-topology-aware-lifecycle-manager[Using the container image pre-cache filter].
 
 [id="ocp-4-13-ran-http-transport"]
 ==== HTTP transport replaces AMQP for PTP and bare-metal events (Technology Preview)

--- a/scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades.adoc
+++ b/scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="cnf-talm-for-cluster-updates"]
-= {cgu-operator-full} for cluster updates
+= Updating managed clusters with the {cgu-operator-full}
 include::_attributes/common-attributes.adoc[]
 :context: cnf-topology-aware-lifecycle-manager
 
@@ -27,7 +27,7 @@ include::modules/cnf-topology-aware-lifecycle-manager-policies-concept.adoc[leve
 [role="_additional-resources"]
 .Additional resources
 
-For more information about the `PolicyGenTemplate` CRD, see xref:../scalability_and_performance/ztp_far_edge/ztp-configuring-managed-clusters-policies.adoc#ztp-the-policygentemplate_ztp-configuring-managed-clusters-policies[About the PolicyGenTemplate CRD].
+For more information about the `PolicyGenTemplate` CRD, see xref:ztp-configuring-managed-clusters-policies.adoc#ztp-the-policygentemplate_ztp-configuring-managed-clusters-policies[About the PolicyGenTemplate CRD].
 
 include::modules/cnf-topology-aware-lifecycle-manager-apply-policies.adoc[leveloffset=+2]
 
@@ -48,8 +48,8 @@ include::modules/cnf-topology-aware-lifecycle-manager-troubleshooting.adoc[level
 [role="_additional-resources"]
 .Additional resources
 
-* For information about troubleshooting, see xref:../support/troubleshooting/troubleshooting-operator-issues.adoc[OpenShift Container Platform Troubleshooting Operator Issues].
+* For information about troubleshooting, see xref:../../support/troubleshooting/troubleshooting-operator-issues.adoc[OpenShift Container Platform Troubleshooting Operator Issues].
 
-* For more information about using {cgu-operator-full} in the ZTP workflow, see xref:../scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc#ztp-topology-aware-lifecycle-manager[Updating managed policies with {cgu-operator-full}].
+* For more information about using {cgu-operator-full} in the ZTP workflow, see xref:ztp-talm-updating-managed-policies.adoc#ztp-topology-aware-lifecycle-manager[Updating managed policies with {cgu-operator-full}].
 
-* For more information about the `PolicyGenTemplate` CRD, see xref:../scalability_and_performance/ztp_far_edge/ztp-configuring-managed-clusters-policies.adoc#ztp-the-policygentemplate_ztp-configuring-managed-clusters-policies[About the PolicyGenTemplate CRD]
+* For more information about the `PolicyGenTemplate` CRD, see xref:ztp-configuring-managed-clusters-policies.adoc#ztp-the-policygentemplate_ztp-configuring-managed-clusters-policies[About the PolicyGenTemplate CRD]

--- a/scalability_and_performance/ztp_far_edge/ztp-configuring-managed-clusters-policies.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-configuring-managed-clusters-policies.adoc
@@ -48,6 +48,6 @@ include::modules/ztp-restarting-policies-reconciliation.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For information about using {cgu-operator-first} to construct your own `ClusterGroupUpgrade` CR, see xref:../../scalability_and_performance/cnf-talm-for-cluster-upgrades.adoc#talo-about-cgu-crs_cnf-topology-aware-lifecycle-manager[About the ClusterGroupUpgrade CR].
+* For information about using {cgu-operator-first} to construct your own `ClusterGroupUpgrade` CR, see xref:cnf-talm-for-cluster-upgrades.adoc#talo-about-cgu-crs_cnf-topology-aware-lifecycle-manager[About the ClusterGroupUpgrade CR].
 
 include::modules/ztp-definition-of-done-for-ztp-installations.adoc[leveloffset=+1]

--- a/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
@@ -17,7 +17,7 @@ include::modules/ztp-acm-installing-disconnected-rhacm.adoc[leveloffset=+1]
 
 * xref:../../cicd/gitops/installing-openshift-gitops.adoc#getting-started-with-openshift-gitops[Installing OpenShift GitOps]
 
-* xref:../../scalability_and_performance/cnf-talm-for-cluster-upgrades.adoc#installing-topology-aware-lifecycle-manager-using-cli_cnf-topology-aware-lifecycle-manager[Installing {cgu-operator}]
+* xref:cnf-talm-for-cluster-upgrades.adoc#installing-topology-aware-lifecycle-manager-using-cli_cnf-topology-aware-lifecycle-manager[Installing {cgu-operator}]
 
 * xref:../../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="ztp-topology-aware-lifecycle-manager"]
-= Updating managed clusters with the {cgu-operator-full}
+= Updating managed clusters in a disconnected environment with the {cgu-operator-full}
 include::_attributes/common-attributes.adoc[]
 :context: ztp-talm
 
@@ -13,7 +13,7 @@ You can use the {cgu-operator-first} to manage the software lifecycle of {produc
 [role="_additional-resources"]
 .Additional resources
 
-* For more information about the {cgu-operator-full}, see xref:../../scalability_and_performance/cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full}].
+* For more information about the {cgu-operator-full}, see xref:cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full}].
 
 include::modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-updating-gitops.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-updating-gitops.adoc
@@ -30,6 +30,6 @@ include::modules/ztp-roll-out-the-configuration-changes.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* For information about the {cgu-operator-first}, see xref:../../scalability_and_performance/cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full} configuration].
+* For information about the {cgu-operator-first}, see xref:cnf-talm-for-cluster-upgrades.adoc#cnf-about-topology-aware-lifecycle-manager-config_cnf-topology-aware-lifecycle-manager[About the {cgu-operator-full} configuration].
 
 * For information about creating `ClusterGroupUpgrade` CRs, see xref:../../scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc#talo-precache-autocreated-cgu-for-ztp_ztp-talm[About the auto-created ClusterGroupUpgrade CR for ZTP].


### PR DESCRIPTION
[TELCODOCS-1324](https://issues.redhat.com//browse/TELCODOCS-1324): CP for https://github.com/openshift/openshift-docs/pull/64174

Version(s):
4.13

Link to docs preview:
- https://64271--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades
- https://64271--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-scalability-and-performance-talm-updates
