### PR TITLE
OCPBUGS#11899: Updated Creating the Kubernetes manifest and Ignition …

### DIFF
--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -150,26 +150,6 @@ $ ./openshift-install create manifests --dir <installation_directory> <1>
 <1> For `<installation_directory>`, specify the installation directory that
 contains the `install-config.yaml` file you created.
 
-ifdef::aws,azure,ash,gcp[]
-. Remove the Kubernetes manifest files that define the control plane machines:
-+
-[source,terminal]
-----
-$ rm -f <installation_directory>/openshift/99_openshift-cluster-api_master-machines-*.yaml
-----
-+
-By removing these files, you prevent the cluster from automatically generating control plane machines.
-endif::aws,azure,ash,gcp[]
-
-ifdef::aws,ash,azure,gcp[]
-. Remove the Kubernetes manifest files that define the control plane machine set:
-+
-[source,terminal]
-----
-$ rm -f <installation_directory>/openshift/99_openshift-machine-api_master-control-plane-machine-set.yaml
-----
-endif::aws,ash,azure,gcp[]
-
 ifdef::gcp[]
 ifndef::user-infra-vpc[]
 . Optional: If you do not want the cluster to provision compute machines, remove
@@ -411,7 +391,11 @@ stringData:
   azure_resourcegroup: ${resource_group}
   azure_region: ${azure_region}
 ----
+endif::ash[]
 
+ifdef::ash,aws[]
+.. To find `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation, run the following `grep` command.
++
 [IMPORTANT]
 ====
 The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-set: TechPreviewNoUpgrade` annotation.
@@ -420,8 +404,6 @@ The release image includes `CredentialsRequest` objects for Technology Preview f
 
 * If you are using any of these features, you must create secrets for the corresponding objects.
 ====
-
-*** To find `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation, run the following command:
 +
 [source,terminal]
 ----
@@ -434,7 +416,9 @@ $ grep "release.openshift.io/feature-set" *
 0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-set: TechPreviewNoUpgrade
 ----
 // Right now, only the CAPI Operator is an issue, but it might make sense to update `0000_30_capi-operator_00_credentials-request.yaml` to `<tech_preview_credentials_request>.yaml` for the future.
+endif::ash,aws[]
 
+ifdef::ash[]
 .. Create a `cco-configmap.yaml` file in the manifests directory with the Cloud Credential Operator (CCO) disabled:
 +
 .Sample `ConfigMap` object


### PR DESCRIPTION
[OCPBUGS-11899](https://issues.redhat.com/browse/OCPBUGS-11899)

Version(s):
4.14 through to 4.12

Link to docs preview:
* [Creating the Kubernetes manifest and Ignition config files (AWS)](https://64285--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws#installation-user-infra-generate-k8s-manifest-ignition_installing-restricted-networks-aws)
* [Creating the Kubernetes manifest and Ignition config files (Azure)](https://64285--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#installation-user-infra-generate-k8s-manifest-ignition_installing-azure-user-infra)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
