### PR TITLE
TELCODOCS-1404: CatalogSource CR depracation note and DefaultCatSrc CR update

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -572,6 +572,11 @@ As of {product-title} 4.14, `DeploymentConfig` objects are deprecated. `Deployme
 
 Instead, use `Deployment` objects or another alternative to provide declarative updates for pods.
 
+[id="ocp-4-14-ztp-talm-defaultcatsrc-update"]
+=== Operator-specific CatalogSource CRs used in {gitops-shortname} ZTP are deprecated
+
+From {product-title} {product-version}, you must only use the `DefaultCatSrc.yaml` `CatalogSource` CR when updating Operators with {cgu-operator-first}. All other `CatalogSource` CRs are deprecated and are planned to be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. For more information about `DefaultCatSrc` CR, see xref:../scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc#talo-operator-update_ztp-talm[Performing an Operator update].
+
 [id="ocp-4-14-removed-features"]
 === Removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1404
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64291--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-ztp-talm-defaultcatsrc-update
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
