### PR TITLE
Adding new OCP Telco distro infrastructure

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -224,6 +224,16 @@ openshift-dpu:
     enterprise-4.10:
       name: '4.10'
       dir: container-platform-dpu/4.10
+openshift-telco:
+  name: OpenShift Container Platform for Telco
+  author: OpenShift Documentation Project <openshift-docs@redhat.com>
+  site: commercial
+  site_name: Documentation
+  site_url: https://docs.openshift.com/
+  branches:
+    enterprise-4.14:
+      name: '4.14'
+      dir: container-platform-telco/4.14
 openshift-acs:
   name: Red Hat Advanced Cluster Security for Kubernetes
   author: OpenShift documentation team <openshift-docs@redhat.com>

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -11,6 +11,7 @@
   <meta content="width=device-width, initial-scale=1.0" name="viewport">
   <%= (distro_key == "openshift-webscale") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
   <%= (distro_key == "openshift-dpu") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
+  <%= (distro_key == "openshift-telco") ? '<meta name="robots" content="noindex,nofollow">' : '' %>
   <%= ((["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7"].include?(version)) && distro_key == "openshift-enterprise") ? '<meta name="googlebot" content="noindex">' : '' %>
   <title><%= [topic_title, subgroup_title].compact.join(' - ') %> | <%= group_title %> | <%= distro %> <%= version %></title>
   <link href="https://assets.openshift.net/content/subdomain.css" rel="stylesheet" type="text/css"/>
@@ -195,7 +196,14 @@
             <select id="version-selector" onchange="versionSelector(this);">
               <option value="1.9">1.9</option>
               <option value="1.8">1.8</option>
-            </select>            
+            </select>
+        <% elsif (distro_key == "openshift-telco") %>
+            <a href="https://docs.openshift.com/container-platform-telco/<%= version %>/welcome/index.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="4.14">4.14</option>
+            </select>
         <% elsif (distro_key == "openshift-origin") %>
               <a href="https://docs.okd.io/<%= version %>/welcome/index.html">
             <%= distro %>
@@ -234,6 +242,7 @@
         ((distro_key == "openshift-enterprise") ? "enterprise-#{version}"
           : (distro_key == "openshift-aro") ? "aro-work"
           : (distro_key=="openshift-dedicated" ) ? "dedicated-4"
+          : (distro_key == "openshift-telco") ? "enterprise-#{version}"
           : "main" ) %>/<%= repo_path %>"><span class="material-icons-outlined" title="Page history">history</span></a>
         <%
           unless (unsupported_versions.include? version)
@@ -245,6 +254,7 @@
           : (distro_key=="openshift-aro" ) ? "[aro-#{version}]+Issue+in+file+#{repo_path}"
           : (distro_key=="openshift-online" ) ? "[online-#{version}]+Issue+in+file+#{repo_path}"
           : (distro_key=="openshift-rosa" ) ? "[rosa-#{version}]+Issue+in+file+#{repo_path}"
+          : (distro_key=="openshift-telco" ) ? "[enterprise-#{version}]+Issue+in+file+#{repo_path}"
           : "Issue+in+file+#{repo_path}" ) %>">
           <span class="material-icons-outlined" title="Open an issue">bug_report</span>
         </a>
@@ -307,7 +317,7 @@
             </a>
           <% end %>
         </span>
-      <% end %>      
+      <% end %>
     </ol>
     <div class="row row-offcanvas row-offcanvas-left">
       <div class="col-xs-8 col-sm-3 col-md-3 sidebar sidebar-offcanvas hide-for-print">
@@ -384,6 +394,7 @@
     'openshift-dedicated': ['docs_dedicated_v4'],
     'openshift-online': ['docs_online', version],
     'openshift-enterprise': ['docs_cp', version],
+    'openshift-telco': ['docs_telco', version],
     'openshift-aro' : ['docs_aro', version],
     'openshift-rosa' : ['docs_rosa'],
     'openshift-acs' : ['docs_acs', version],

--- a/_templates/_search.html.erb
+++ b/_templates/_search.html.erb
@@ -6,6 +6,8 @@
 <%= render("_templates/_search_online.html") %>
 <% elsif distro_key == 'openshift-enterprise' %>
 <%= render("_templates/_search_enterprise.html.erb", :version => version) %>
+<% elsif distro_key == 'openshift-telco' %>
+<%= render("_templates/_search_telco.html.erb", :version => version) %>
 <% else %>
 <%= render("_templates/_search_other.html") %>
 <% end %>

--- a/_templates/_search_telco.html.erb
+++ b/_templates/_search_telco.html.erb
@@ -1,0 +1,21 @@
+<div id="hc-search">
+  <input id="hc-search-input" type="text">
+  <button id="hc-search-btn">Search</button>
+</div>
+
+<div id="hc-search-modal">
+  <div id="hc-modal-content">
+    <span id="hc-modal-close">&times;</span>
+    <div id="hc-search-results-wrapper">
+      <div id="hc-search-results"></div>
+      <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+      <div class="text-center">
+        <button id="hc-search-more-btn">Show more results</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  hcSearchCategory("docs_telco", "<%= version %>");
+</script>


### PR DESCRIPTION
Telco docs team requires a new openshift-telco distro to deliver Core and RAN 4.14 reference design specs behind a password-protected site.

The purpose of this distro is to allow password-protected access to restricted OCP Telco content.

Merge to main only.

Version(s):
main