### PR TITLE
OCPBUGS#18158: Removed Ingress and apiVIPs entries in sample vSphere …

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1562,7 +1562,7 @@ ifdef::vsphere[]
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2,.^4,.^2",options="header"]
+[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
@@ -1570,6 +1570,8 @@ l|platform:
     vsphere
       apiVIPs
 |Virtual IP (VIP) addresses that you configured for control plane API access.
+
+*Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
 
 l|platform
@@ -1617,6 +1619,8 @@ l|platform
     vsphere
       ingressVIPs
 |Virtual IP (VIP) addresses that you configured for cluster Ingress.
+
+*Note:* This parameter applies only to installer-provisioned infrastructure.
 |Multiple IP addresses
 
 l|platform

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -11,6 +11,7 @@ ifdef::openshift-origin[]
 :restricted:
 endif::[]
 
+:_content-type: CONCEPT
 [id="installation-vsphere-config-yaml_{context}"]
 = Sample `install-config.yaml` file for VMware vSphere
 
@@ -42,8 +43,6 @@ networking:
 ---
 platform:
   vsphere:
-    apiVIPs:
-    - 10.0.0.1
     failureDomains: <7>
     - name: <failure_domain_name>
       region: <default_region_name>
@@ -57,8 +56,6 @@ platform:
         resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <10>
         folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <11>
       zone: <default_zone_name>
-    ingressVIPs:
-    - 10.0.0.2
     vcenters:
     - datacenters:
       - <datacenter>


### PR DESCRIPTION
[OCPBUGS-18158](https://issues.redhat.com/browse/OCPBUGS-18158)

Version(s):
4.14 and 4.13

Link to docs preview:
* [Sample install-config.yaml file for VMware vSphere- UPI docs only](https://64295--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere#installation-vsphere-config-yaml_installing-restricted-networks-vsphere)
* [Additional VMware vSphere configuration parameters](https://64295--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-additional-vsphere_installation-config-parameters-vsphere)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
