### PR TITLE
OCPBUGS-17409 Adding link to KB article 

### DIFF
--- a/modules/nw-sriov-configuring-operator.adoc
+++ b/modules/nw-sriov-configuring-operator.adoc
@@ -110,8 +110,10 @@ Admission Controller application. It provides the following capabilities:
 
 By default the SR-IOV Network Operator Admission Controller webhook is enabled by the Operator and runs as a daemon set on all control plane nodes.
 
-NOTE: Use caution when disabling the SR-IOV Network Operator Admission Controller webhook. You can disable the webhook under specific circumstances, such as troubleshooting, or if you want to use unsupported devices.
-
+[NOTE]
+====
+Use caution when disabling the SR-IOV Network Operator Admission Controller webhook. You can disable the webhook under specific circumstances, such as troubleshooting, or if you want to use unsupported devices. For information about configuring unsupported devices, see link:https://access.redhat.com/articles/7010183[Configuring the SR-IOV Network Operator to use an unsupported NIC].
+====
 
 The following is an example of the Operator Admission Controller webhook pods running in a cluster with three control plane nodes:
 


### PR DESCRIPTION
[OCPBUGS-17409]: 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10,4.11,4.12,4.13,4.14, and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-17409
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64297--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-operator.html#about-sr-iov-operator-admission-control-webhook_configuring-sriov-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
