### PR TITLE
Updates deprecated links for two Container descrptions

### DIFF
--- a/_unused_topics/nodes-containers-using-about.adoc
+++ b/_unused_topics/nodes-containers-using-about.adoc
@@ -6,7 +6,7 @@
 = Understanding Containers 
 
 The basic units of {product-title} applications are called _containers_.
-link:https://access.redhat.com/articles/1353593[Linux container technologies]
+link:https://www.redhat.com/en/topics/containers#overview[Linux container technologies]
 are lightweight mechanisms for isolating running processes so that they are
 limited to interacting with only their designated resources.
 

--- a/modules/containers-about.adoc
+++ b/modules/containers-about.adoc
@@ -4,7 +4,7 @@
 [id="containers-about_{context}"]
 = Containers
 
-The basic units of {product-title} applications are called containers. link:https://access.redhat.com/articles/1353593[Linux container technologies] are lightweight mechanisms for isolating running processes so that they are limited to interacting with only their designated resources. The word container is defined as a specific running or paused instance of a container image.
+The basic units of {product-title} applications are called containers. link:https://www.redhat.com/en/topics/containers#overview[Linux container technologies] are lightweight mechanisms for isolating running processes so that they are limited to interacting with only their designated resources. The word container is defined as a specific running or paused instance of a container image.
 
 Many application instances can be running in containers on a single host without visibility into each others' processes, files, network, and so on. Typically, each container provides a single service, often called a micro-service, such as a web server or a database, though containers can be used for arbitrary workloads.
 

--- a/nodes/containers/nodes-containers-using.adoc
+++ b/nodes/containers/nodes-containers-using.adoc
@@ -10,7 +10,7 @@ toc::[]
 
 
 The basic units of {product-title} applications are called _containers_.
-Linux container technologies
+link:https://www.redhat.com/en/topics/containers#overview[Linux container technologies]
 are lightweight mechanisms for isolating running processes so that they are
 limited to interacting with only their designated resources.
 


### PR DESCRIPTION
Version(s):
4.10+ 

Issue:
https://issues.redhat.com/browse/OCPBUGS-17705

Link to docs preview:
https://64299--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/#containers-about_overview-of-images

https://64299--docspreview.netlify.app/openshift-enterprise/latest/nodes/containers/nodes-containers-using

QE not needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
