### PR TITLE
OCPBUGS#17754: Updated cocode snippet installation-cis-ibm-cloud.adoc

### DIFF
--- a/modules/installation-cis-ibm-cloud.adoc
+++ b/modules/installation-cis-ibm-cloud.adoc
@@ -46,7 +46,7 @@ $ ibmcloud cis instance-create <instance_name> standard <1>
 +
 [source,terminal]
 ----
-$ ibmcloud cis instance-set <instance_crn> <1>
+$ ibmcloud cis instance-set <instance_name> <1>
 ----
 <1> The instance cloud resource name.
 


### PR DESCRIPTION
[OCPBUGS-17754](https://issues.redhat.com/browse/OCPBUGS-17754)

Version(s):
4.14 through to 4.10

Link to docs preview:
[Using IBM Cloud Internet Services for DNS resolution](https://64303--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud_public/installing-ibm-cloud-account#installation-cis-ibm-cloud_installing-ibm-cloud-account)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
