### PR TITLE
OCPBUGS#11516: Noted that custom rules are ignored if the audit log p…

### DIFF
--- a/modules/nodes-nodes-audit-config-about.adoc
+++ b/modules/nodes-nodes-audit-config-about.adoc
@@ -25,7 +25,7 @@ Audit log profiles define how to log requests that come to the OpenShift API ser
 |In addition to logging metadata for all requests, logs request bodies for  every read and write request to the API servers (`get`, `list`, `create`, `update`, `patch`). This profile has the most resource overhead. ^[1]^
 
 |`None`
-|No requests are logged; even OAuth access token requests and OAuth authorize token requests are not logged.
+|No requests are logged; even OAuth access token requests and OAuth authorize token requests are not logged. Custom rules are ignored when this profile is set.
 
 [WARNING]
 ====

--- a/modules/nodes-nodes-audit-policy-custom.adoc
+++ b/modules/nodes-nodes-audit-policy-custom.adoc
@@ -10,6 +10,11 @@ You can configure an audit log policy that defines custom rules. You can specify
 
 These custom rules take precedence over the top-level profile field. The custom rules are evaluated from top to bottom, and the first that matches is applied.
 
+[IMPORTANT]
+====
+Custom rules are ignored if the top-level profile field is set to `None`.
+====
+
 .Prerequisites
 
 * You have access to the cluster as a user with the `cluster-admin` role.
@@ -41,11 +46,11 @@ spec:
     profile: Default                    <2>
 ----
 <1> Add one or more groups and specify the profile to use for that group. These custom rules take precedence over the top-level profile field. The custom rules are evaluated from top to bottom, and the first that matches is applied.
-<2> Set to `Default`, `WriteRequestBodies`, `AllRequestBodies`, or `None`. If you do not set this top-level `audit.profile` field, it defaults to the `Default` profile.
+<2> Set to `Default`, `WriteRequestBodies`, or `AllRequestBodies`. If you do not set this top-level profile field, it defaults to the `Default` profile.
 +
 [WARNING]
 ====
-It is not recommended to disable audit logging by using the `None` profile unless you are fully aware of the risks of not logging data that can be beneficial when troubleshooting issues. If you disable audit logging and a support situation arises, you might need to enable audit logging and reproduce the issue in order to troubleshoot properly.
+Do not set the top-level profile field to `None` if you want to use custom rules. Custom rules are ignored if the top-level profile field is set to `None`.
 ====
 
 . Save the file to apply the changes.


### PR DESCRIPTION
…rofile is set to None

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-11516

Link to docs preview:
* https://64307--docspreview.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config#about-audit-log-profiles_audit-log-policy-config
* https://64307--docspreview.netlify.app/openshift-enterprise/latest/security/audit-log-policy-config#configuring-audit-policy-custom_audit-log-policy-config

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
