### PR TITLE
OCPBUGS-16363: Added a procedure for Hypershift management plane conf…

### DIFF
--- a/modules/compliance-operator-hcp-mgmt-config.adoc
+++ b/modules/compliance-operator-hcp-mgmt-config.adoc
@@ -1,0 +1,72 @@
+// Module included in the following assemblies:
+//
+// * security/compliance_operator/compliance-scans.adoc
+
+:_content-type: PROCEDURE
+[id="co-hcp-mgmt-config_{context}"]
+= Configuring the Hosted control planes management cluster
+
+If you are hosting your own Hosted control plane or Hypershift environment and want to scan a Hosted Cluster from the management cluster, you will need to set the name and prefix namespace for the target Hosted Cluster. You can achieve this by creating a `TailoredProfile`.
+
+[IMPORTANT]
+====
+This procedure only applies to users managing their own Hosted control planes environment.
+====
+
+[NOTE]
+====
+Only `ocp4-cis` and `ocp4-pci-dss` profiles are supported in Hosted control planes management clusters.
+====
+
+.Prerequisites
+
+* The Compliance Operator is installed in the management cluster.
+
+.Procedure
+
+. Obtain the `name` and `namespace` of the hosted cluster to be scanned by running the following command:
++
+[source,terminal]
+----
+$ oc get hostedcluster -A
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE       NAME                   VERSION   KUBECONFIG                              PROGRESS    AVAILABLE   PROGRESSING   MESSAGE
+local-cluster   79136a1bdb84b3c13217   4.13.5    79136a1bdb84b3c13217-admin-kubeconfig   Completed   True        False         The hosted control plane is available
+----
+
+. In the management cluster, create a `TailoredProfile` extending the scan Profile and define the name and namespace of the Hosted Cluster to be scanned:
++
+.Example `management-tailoredprofile.yaml`
+[source,yaml]
+----
+apiVersion: compliance.openshift.io/v1alpha1
+kind: TailoredProfile
+metadata:
+  name: hypershift-cisk57aw88gry
+  namespace: openshift-compliance
+spec:
+  description: This profile test required rules
+  extends: ocp4-cis <1>
+  title: Management namespace profile
+  setValues:
+  - name: ocp4-hypershift-cluster
+    rationale: This value is used for HyperShift version detection
+    value: 79136a1bdb84b3c13217 <2>
+  - name: ocp4-hypershift-namespace-prefix
+    rationale: This value is used for HyperShift control plane namespace detection
+    value: local-cluster <3>
+----
+<1> Variable. Only `ocp4-cis` and `ocp4-pci-dss` profiles are supported in Hosted control planes management clusters.
+<2> The `value` is the `NAME` from the output in the previous step.
+<3> The `value` is the `NAMESPACE` from the output in the previous step.
+
+. Create the `TailoredProfile`:
++
+[source,terminal]
+----
+$ oc create -n openshift-compliance -f mgmt-tp.yaml
+----

--- a/security/compliance_operator/compliance-scans.adoc
+++ b/security/compliance_operator/compliance-scans.adoc
@@ -26,6 +26,8 @@ include::modules/running-compliance-scans-worker-node.adoc[leveloffset=+1]
 
 include::modules/compliance-scansetting-cr.adoc[leveloffset=+1]
 
+include::modules/compliance-operator-hcp-mgmt-config.adoc[leveloffset=+1]
+
 include::modules/compliance-applying-resource-requests-and-limits.adoc[leveloffset=+1]
 
 include::modules/compliance-scheduling-pods-with-resource-requests.adoc[leveloffset=+1]


### PR DESCRIPTION
…iguration

Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OCPBUGS-16363

Link to docs preview (VPN required):
[Configuring the Hosted control planes management cluster](https://file.rdu.redhat.com/antaylor/OCPBUGS-16363/security/compliance_operator/compliance-scans.html#co-hcp-mgmt-config_compliance-operator-scans)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None