### PR TITLE
OSDOCS#7647: Adds notes for MS 4.12.32 release

### DIFF
--- a/microshift_release_notes/microshift-4-12-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-12-release-notes.adoc
@@ -329,3 +329,12 @@ Issued: 2023-08-31
 {product-title} release 4.12.31 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4673[RHBA-2023:4758] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4671[RHBA-2023:4756] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].
+
+[id="microshift-4-12-32-dp"]
+=== RHBA-2023:4902 - {product-title} 4.12.32 bug fix update
+
+Issued: 2023-09-06
+
+{product-title} release 4.12.32 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4902[RHBA-2023:4902] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4900[RHBA-2023:4900] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel8/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel8].


### PR DESCRIPTION
OSDOCS#7647: Adds notes for MS 4.12.32 release

Version(s):
4.12

Issue:
https://issues.redhat.com/browse/OSDOCS-7647

Link to docs preview:
https://64319--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-12-release-notes#microshift-4-12-32-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
