### PR TITLE
[enterprise-4.11] OCPBUGS-18432: Updated TuneD bootloader supportability note

### DIFF
--- a/modules/configuring-huge-pages.adoc
+++ b/modules/configuring-huge-pages.adoc
@@ -94,9 +94,9 @@ $ oc get node <node_using_hugepages> -o jsonpath="{.status.allocatable.hugepages
 ----
 
 ifndef::openshift-origin[]
-[WARNING]
+[NOTE]
 ====
-The TuneD bootloader plugin is currently supported on {op-system-first} 8.x worker nodes. For {op-system-base-full} 7.x worker nodes, the TuneD bootloader plugin is currently not supported.
+The TuneD bootloader plugin only supports {op-system-first} worker nodes.
 ====
 endif::openshift-origin[]
 

--- a/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
+++ b/modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc
@@ -34,9 +34,9 @@ that is not supported. The following TuneD plugins are currently not supported:
 * systemd
 
 
-[WARNING]
+[NOTE]
 ====
-The TuneD bootloader plugin is currently supported on {op-system-first} 8.x worker nodes. For {op-system-base-full} 7.x worker nodes, the TuneD bootloader plugin is currently not supported.
+The TuneD bootloader plugin only supports {op-system-first} worker nodes.
 ====
 
 .Additional references


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/64221