### PR TITLE
CNV-22900: Document shared block volumes 

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3952,6 +3952,8 @@ Topics:
       File: virt-hot-plugging-virtual-disks
     - Name: Expanding VM disks
       File: virt-expanding-vm-disks
+    - Name: Configuring shared volumes
+      File: virt-configuring-shared-volumes-for-vms
 - Name: Networking
   Dir: vm_networking
   Topics:

--- a/modules/virt-configuring-disk-sharing-lun.adoc
+++ b/modules/virt-configuring-disk-sharing-lun.adoc
@@ -1,0 +1,59 @@
+// Module included in the following assemblies:
+//
+// * * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+
+:_content-type: PROCEDURE
+[id="virt-configuring-disk-sharing-lun_{context}"]
+= Configuring disk sharing by using LUN
+
+You can configure a LUN-backed virtual machine disk to be shared among multiple virtual machines by enabling SCSI persistent reservation. Enabling the shared option allows you to use advanced SCSI commands, such as those required for a Windows failover clustering implementation, against the underlying storage. Any disk to be shared must be in block mode.
+
+A disk of type `LUN` exposes the volume as a LUN device to the VM. This allows the VM to execute arbitrary iSCSI command passthrough on the disk.
+
+You reserve a LUN through the SCSI persistent reserve options to protect data on the VM from outside access. To enable the reservation, you configure the feature gate option. You then activate the option on the LUN disk to issue SCSI device-specific input and output controls (IOCTLs) that the VM requires.
+
+.Prerequisites
+
+* The volume access mode must be `ReadWriteMany` (RWX) if the VMs that are sharing disks are running on different nodes.
++
+If the VMs that are sharing disks are running on the same node, `ReadWriteOnce` (RWO) volume access mode is sufficient.
+* The storage provider must support a Container Storage Interface (CSI) driver that uses the SCSI protocol.
+* If you are a cluster administrator and intend to configure disk sharing by using LUN, you must enable the cluster's feature gate on the `HyperConverged` custom resource (CR).
+
+.Procedure
+
+. Edit or create the `VirtualMachine` manifest for your VM to set the required values, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-0
+spec:
+  template:
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: sata
+            name: rootdisk
+          - errorPolicy: report
+            lun: <1>
+              bus: scsi
+              reservation: true <2>
+            name: na-shared
+            serial: shared1234
+      volumes:
+      - dataVolume:
+          name: vm-0
+        name: rootdisk
+      - name: na-shared
+        persistentVolumeClaim:
+          claimName: pvc-na-share
+----
+<1> Identifies a LUN disk.
+<2> Identifies that the persistent reservation is enabled.
+
+. Save the `VirtualMachine` manifest file to apply your changes.

--- a/modules/virt-configuring-vm-disk-sharing.adoc
+++ b/modules/virt-configuring-vm-disk-sharing.adoc
@@ -1,0 +1,54 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+
+:_content-type: PROCEDURE
+[id="virt-configuring-vm-disk-sharing{context}"]
+= Configuring disk sharing by using virtual machine disks
+
+You can configure block volumes so that multiple virtual machines (VMs) can share storage.
+
+The application running on the guest operating system determines the storage option you must configure for the VM. A disk of type `disk` exposes the volume as an ordinary disk to the VM.
+
+.Prerequisites
+
+* The volume access mode must be `ReadWriteMany` (RWX) if the VMs that are sharing disks are running on different nodes.
++
+If the VMs that are sharing disks are running on the same node, `ReadWriteOnce` (RWO) volume access mode is sufficient.
+
+* The storage provider must support the required Container Storage Interface (CSI) driver.
+
+.Procedure
+
+. Create the `VirtualMachine` manifest for your VM to set the required values, as shown in the following example:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: <vm_name>
+spec:
+  template:
+# ...
+    spec:
+      domain:
+        devices:
+          disks:
+          - disk:
+              bus: virtio
+            name: rootdisk
+            disk1: disk_one <1>
+          - disk:
+              bus: virtio
+            name: cloudinitdisk
+            disk2: disk_two
+            shareable: true <2>
+          interfaces:
+          - masquerade: {}
+            name: default
+----
+<1> Identifies a device as a disk.
+<2> Identifies a shared disk.
+
+. Save the `VirtualMachine` manifest file to apply your changes.

--- a/modules/virt-enabling-persistentreservation-feature-gate.adoc
+++ b/modules/virt-enabling-persistentreservation-feature-gate.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+//
+// * * virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+
+:_content-type: PROCEDURE
+[id="virt-enabling-persistentreservation-feature-gate_{context}"]
+= Enabling the PersistentReservation feature gate
+
+You can enable the SCSI `persistentReservation` feature gate and allow a LUN-backed block mode virtual machine (VM) disk to be shared among multiple virtual machines.
+
+The `persistentReservation` feature gate is disabled by default.
+
+.Prerequisites
+
+* Cluster administrator privileges are required.
+* The volume access mode `ReadWriteMany` (RWX) is required if the VMs that are sharing disks are running on different nodes. If the VMs that are sharing disks are running on the same node, the `ReadWriteOnce` (RWO) volume access mode is sufficient.
+* The storage provider must support a Container Storage Interface (CSI) driver that uses the SCSI protocol.
+
+.Procedure
+
+. Enable the `persistentReservation` feature gate by running the following command:
++
+[source,terminal,subs="attributes+"]
+----
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} \
+  --type json -p '[{"op":"replace","path":"/spec/featureGates/persistentReservation", "value": true}]'
+----

--- a/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
+++ b/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms.adoc
@@ -1,0 +1,24 @@
+:_content-type: ASSEMBLY
+[id="virt-configuring-shared-volumes-for-vms"]
+= Configuring shared volumes for virtual machines
+include::_attributes/common-attributes.adoc[]
+:context: virt-configuring-shared-volumes-for-vms
+toc::[]
+
+You can configure shared disks to allow multiple virtual machines (VMs) to share the same underlying storage. A shared disk's volume must be block mode.
+
+You configure disk sharing by exposing the storage as either of these types:
+
+* An ordinary virtual machine disk
+* A logical unit number (LUN) device with an iSCSi connection and raw device mapping, as required for Windows Failover Clustering for shared volumes
+
+include::modules/virt-configuring-vm-disk-sharing.adoc[leveloffset=+1]
+
+include::modules/virt-configuring-disk-sharing-lun.adoc[leveloffset=+1]
+
+include::modules/virt-enabling-persistentreservation-feature-gate.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://www.qemu.org/docs/master/interop/pr-helper.html[Persistent reservation helper protocol]
+* link:https://learn.microsoft.com/en-us/windows-server/failover-clustering/failover-clustering-overview[Failover Clustering in Windows Server and Azure Stack HCI]


### PR DESCRIPTION
Version(s): 4.15

Issue: [CNV-22900](https://issues.redhat.com/browse/CNV-22900)

[Configuring shared volumes for virtual machines](https://64333--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms)
[Configuring disk sharing by using virtual machine disks ](https://64333--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms#virt-configuring-vm-disk-sharingvirt-configuring-shared-volumes-for-vms)
[Configuring disk sharing by using LUN](https://64333--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms#virt-configuring-disk-sharing-lun_virt-configuring-shared-volumes-for-vms)
[Enabling the PersistentReservation feature gate](https://64333--ocpdocs-pr.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virtual_disks/virt-configuring-shared-volumes-for-vms#virt-enabling-persistentreservation-feature-gate_virt-configuring-shared-volumes-for-vms)





QE review: Done

**Note:** I removed the files that we are no longer using in this PR.

