### PR TITLE
OBSDOCS-106: Remove outdated configmap refs

### DIFF
--- a/logging/cluster-logging-external.adoc
+++ b/logging/cluster-logging-external.adoc
@@ -18,16 +18,6 @@ To send audit logs to the default internal Elasticsearch log store, use the Clus
 
 When you forward logs externally, the {logging} creates or modifies a Fluentd config map to send logs using your desired protocols. You are responsible for configuring the protocol on the external log aggregator.
 
-[IMPORTANT]
-====
-You cannot use the config map methods and the Cluster Log Forwarder in the same cluster.
-====
-
-// The following include statements pull in the module files that comprise
-// the assembly. Include any combination of concept, procedure, or reference
-// modules required to cover the user story. You can also include other
-// assemblies.
-
 include::modules/cluster-logging-collector-log-forwarding-about.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-forwarding-separate-indices.adoc[leveloffset=+1]

--- a/modules/cluster-logging-collector-log-forward-fluentd.adoc
+++ b/modules/cluster-logging-collector-log-forward-fluentd.adoc
@@ -6,11 +6,6 @@ You can use the Fluentd *forward* protocol to send a copy of your logs to an ext
 
 To configure log forwarding using the *forward* protocol, you must create a `ClusterLogForwarder` custom resource (CR) with one or more outputs to the Fluentd servers, and pipelines that use those outputs. The Fluentd output can use a TCP (insecure) or TLS (secure TCP) connection.
 
-[NOTE]
-====
-Alternately, you can use a config map to forward logs using the *forward* protocols. However, this method is deprecated in {product-title} and will be removed in a future release.
-====
-
 .Prerequisites
 
 * You must have a logging server that is configured to receive the logging data using the specified protocol or format.

--- a/modules/cluster-logging-collector-log-forward-syslog.adoc
+++ b/modules/cluster-logging-collector-log-forward-syslog.adoc
@@ -6,12 +6,6 @@ You can use the *syslog* link:https://tools.ietf.org/html/rfc3164[RFC3164] or li
 
 To configure log forwarding using the *syslog* protocol, you must create a `ClusterLogForwarder` custom resource (CR) with one or more outputs to the syslog servers, and pipelines that use those outputs. The syslog output can use a UDP, TCP, or TLS connection.
 
-//SME-Feedback-Req: Is the below note accurate?
-[NOTE]
-====
-Alternately, you can use a config map to forward logs using the *syslog* RFC3164 protocols. However, this method is deprecated in {product-title} and will be removed in a future release.
-====
-
 .Prerequisites
 
 * You must have a logging server that is configured to receive the logging data using the specified protocol or format.


### PR DESCRIPTION
Version(s):
4.10+

Issue:
https://issues.redhat.com/browse/OBSDOCS-106

Link to docs preview:
https://64340--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-external

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
