### PR TITLE
[enterprise-4.10] Ocpbugs 14777 410

### DIFF
--- a/modules/virt-prerequisites-mediated-devices.adoc
+++ b/modules/virt-prerequisites-mediated-devices.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: CONCEPT
 [id="prerequisites_{context}"]
-== Prerequisites
+= Prerequisites
 
 * If your hardware vendor provides drivers, you installed them on the nodes where you want to create mediated devices.
 ** If you use NVIDIA cards, you link:https://access.redhat.com/solutions/6738411[installed the NVIDIA GRID driver].

--- a/modules/virt-virtual-gpus-config-overview.adoc
+++ b/modules/virt-virtual-gpus-config-overview.adoc
@@ -57,8 +57,8 @@ For example, the name file for the `nvidia-231` type contains the selector strin
 +
 [source,terminal]
 ----
-$ oc get $NODE -o json  \
-| jq '.status.allocatable | \
-with_entries(select(.key | startswith("nvidia.com/"))) | \
-with_entries(select(.value != "0"))'
+$ oc get $NODE -o json \
+  | jq '.status.allocatable \
+    | with_entries(select(.key | startswith("nvidia.com/"))) \
+    | with_entries(select(.value != "0"))'
 ----


### PR DESCRIPTION
[OCPBUGS-14777]: Fixing indention associated with "The resourceName should match that allocated on the node" needs fixed

Cherry Picked from https://github.com/openshift/openshift-docs/commit/7e094c64bedcd84169bf67aaa9e3916d269a80ac xref: https://github.com/openshift/openshift-docs/pull/63308

Version(s):
4.10

Issue:
https://issues.redhat.com/browse/OCPBUGS-14777

Link to docs preview:
https://63308--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/advanced_vm_management/virt-configuring-mediated-devices.html#configuration-overview_virt-configuring-mediated-devices

Additional information: All approvals tracked in https://github.com/openshift/openshift-docs/pull/63308. This PR fixes https://github.com/openshift/openshift-docs/pull/63524