### PR TITLE
OCPBUGS-12930-link-fix

### DIFF
--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -201,5 +201,5 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
 * If necessary, you can xref:../../authentication/managing_cloud_provider_credentials/cco-mode-mint.adoc#manually-removing-cloud-creds_cco-mode-mint[remove cloud provider credentials].

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -216,4 +216,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -77,4 +77,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -140,4 +140,4 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -128,4 +128,4 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z-kvm.adoc
@@ -128,4 +128,4 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -137,4 +137,4 @@ include::modules/installation-complete-user-infra.adoc[leveloffset=+1]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#available_cluster_customizations[Customize your cluster].
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]

--- a/installing/installing_openstack/installing-openstack-installer-restricted.adoc
+++ b/installing/installing_openstack/installing-openstack-installer-restricted.adoc
@@ -71,7 +71,7 @@ include::modules/cluster-telemetry.adoc[leveloffset=+1]
 * If the mirror registry that you used to install your cluster has a trusted CA, add it to the cluster by xref:../../openshift_images/image-configuration.adoc#images-configuration-cas_image-configuration[configuring additional trust stores].
 * If necessary, you can
 xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
 * xref:../../post_installation_configuration/cluster-tasks.adoc#post-install-must-gather-disconnected[Configure image streams] for the Cluster Samples Operator and the `must-gather` tool.
 * Learn how to xref:../../operators/admin/olm-restricted-networks.adoc#olm-restricted-networks[use Operator Lifecycle Manager (OLM) on restricted networks].
 * If you did not configure {rh-openstack} to accept application traffic over floating IP addresses, xref:../../post_installation_configuration/network-configuration.adoc#installation-osp-configuring-api-floating-ip_post-install-network-configuration[configure {rh-openstack} access with floating IP addresses].

--- a/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere.adoc
@@ -96,5 +96,5 @@ include::modules/nw-configuring-external-load-balancer.adoc[leveloffset=+1]
 
 * xref:../../installing/install_config/installing-customizing.adoc#installing-customizing[Customize your cluster].
 * If necessary, you can xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#opting-out-remote-health-reporting_opting-out-remote-health-reporting[opt out of remote health reporting].
-* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.html#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
+* If necessary, see xref:../../support/remote_health_monitoring/opting-out-of-remote-health-reporting.adoc#insights-operator-register-disconnected-cluster_opting-out-remote-health-reporting[Registering your disconnected cluster]
 * xref:../../registry/configuring_registry_storage/configuring-registry-storage-vsphere.adoc#configuring-registry-storage-vsphere[Set up your registry and configure registry storage].


### PR DESCRIPTION
Cherry Picked from 6f19289b3f26bdcf168dd66e083d3a66a5fc3fca [OCPBUGS-12930-link-fix](https://github.com/openshift/openshift-docs/pull/64296)

File removed as one belongs in 4.13 + . See https://github.com/openshift/openshift-docs/pull/47558 . The other file (installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc) belongs to https://github.com/openshift/openshift-docs/pull/54259.