### PR TITLE
OSDOCS-3562: Add SRE access assembly for OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -50,6 +50,8 @@ Topics:
       File: policy-responsibility-matrix
     - Name: Understanding process and security for OpenShift Dedicated
       File: policy-process-security
+#  - Name: SRE and service account access
+#    File: osd-sre-access
     - Name: About availability for OpenShift Dedicated
       File: policy-understand-availability
     - Name: Update life cycle

--- a/osd_architecture/osd-sre-access.adoc
+++ b/osd_architecture/osd-sre-access.adoc
@@ -1,0 +1,5 @@
+:_content-type: ASSEMBLY
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: osd-sre-access
+[id="osd-sre-access"]
+= SRE and service account access


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-3562

Link to docs preview:
Assembly is not visible: https://64392--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-process-security

QE review:
No QE review required.

Additional information:
This PR is putting in place an assembly where multiple writers can contribute content for a critical documentation request. The assembly is commented out and will not build in the documentation until all pieces have been added and reviewed. This PR does not require QE or SME review because it contains no technical information. 

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
