### PR TITLE
OSDOCS-7644

### DIFF
--- a/modules/rosa-policy-identity-access-management.adoc
+++ b/modules/rosa-policy-identity-access-management.adoc
@@ -50,6 +50,17 @@ Red Hat personnel do not access AWS accounts in the course of routine {product-t
 
 SREs generate a short-lived AWS access token for a reserved role using the AWS Security Token Service (STS). Access to the STS token is audit-logged and traceable back to individual users. Both STS and non-STS clusters use the AWS STS service for SRE access. For non-STS clusters, the `BYOCAdminAccess` role has the `AdministratorAccess` IAM policy attached, and this role is used for administration. For STS clusters, the `ManagedOpenShift-Support-Role` has the `ManagedOpenShift-Support-Access` policy attached, and this role is used for administration.
 
+[id="rosa-sre-sts-view-aws-account_{context}"]
+== SRE STS view of AWS accounts
+
+When SRE is on VPN through two-factor authentication, Red Hat Support and SRE can assume the `ManagedOpenShift-Support-Role` in your AWS Account. `ManagedOpenShift-Support-Role` has all the permissions necessary for SRE to troubleshoot AWS resources. Upon assumption of the `ManagedOpenShift-Support-Role`, SRE uses a AWS Security Token Service (STS) to perform troubleshooting actions in your account. SRE can perform multiple actions which include:
+
+* Viewing CloudTrail logs
+* Shutting down a faulty EC2 Instance
+* Creating EC2 snapshots
+
+For a full list of permissions, see sts_support_permission_policy.json in the link:https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html[About IAM resources for ROSA clusters that use STS] user guide.
+
 [id="rosa-policy-rh-access_{context}"]
 == Red Hat support access
 Members of the Red Hat Customer Experience and Engagement (CEE) team typically have read-only access to parts of the cluster. Specifically, CEE has limited access to the core and product namespaces and does not have access to the customer namespaces.

--- a/osd_architecture/osd_policy/osd-sre-access.adoc
+++ b/osd_architecture/osd_policy/osd-sre-access.adoc
@@ -1,5 +1,7 @@
+////
 :_content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: osd-sre-access
 [id="osd-sre-access"]
 = SRE and service account access
+////

--- a/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
@@ -1,5 +1,9 @@
+////
 :_content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-sre-access
 [id="rosa-sre-access"]
 = SRE and service account access
+
+include::modules/rosa-policy-identity-access-management.adoc[leveloffset=+1]
+////


### PR DESCRIPTION
[OSDOCS-7644](https://issues.redhat.com/browse/OSDOCS-7644): [Doc] SRE STS AWS view

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OSDOCS-7644](https://issues.redhat.com/browse/OSDOCS-7644)
Preview pages: [ROSA build preview](https://64405--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix#rosa-sre-sts-view-aws-account_rosa-policy-responsibility-matrix)
SME review **completed**: @paulczar and @jaybeeunix
QE review: **NA**
Peer review **completed**: @bmcelvee

**Note**: We are including only ROSA content and not OSD content as part of Acceptance Criteria for this Jira. For more information, please see [slack thread](https://redhat-internal.slack.com/archives/C05Q2MLFB0X/p1694093293402269?thread_ts=1694003063.601879&cid=C05Q2MLFB0X).

