### PR TITLE
OSDOCS-6269: updates command line arguments to examine nbdb and sbdb with OVN-K I/C and running network-tools

### DIFF
--- a/modules/nw-ovn-kubernetes-examine-nb-database-contents-ref.adoc
+++ b/modules/nw-ovn-kubernetes-examine-nb-database-contents-ref.adoc
@@ -8,13 +8,19 @@
 
 The following table describes the command line arguments that can be used with `ovn-nbctl` to examine the contents of the northbound database.
 
+
+[NOTE]
+====
+Open a remote shell in the pod you want to view the contents of and then run the `ovn-nbctl` commands.
+====
+
 .Command line arguments to examine northbound database contents
 [cols="30%,70%",options="header"]
 |===
 |Argument |Description
 
 |`ovn-nbctl show`
-|An overview of the northbound database contents.
+|An overview of the northbound database contents as seen from a specific node.
 
 |`ovn-nbctl show <switch_or_router>`
 |Show the details associated with the specified switch or router.

--- a/modules/nw-ovn-kubernetes-examine-sb-database-contents-ref.adoc
+++ b/modules/nw-ovn-kubernetes-examine-sb-database-contents-ref.adoc
@@ -8,13 +8,18 @@
 
 The following table describes the command line arguments that can be used with `ovn-sbctl` to examine the contents of the southbound database.
 
+[NOTE]
+====
+Open a remote shell in the pod you wish to view the contents of and then run the `ovn-sbctl` commands.
+====
+
 .Command line arguments to examine southbound database contents
 [cols="30%,70%",options="header"]
 |===
 |Argument |Description
 
 |`ovn-sbctl show`
-|Overview of the southbound database contents.
+|An overview of the southbound database contents as seen from a specific node.
 
 |`ovn-sbctl list Port_Binding <port>`
 |List the contents of southbound database for a the specified port .

--- a/modules/nw-ovn-kubernetes-running-network-tools.adoc
+++ b/modules/nw-ovn-kubernetes-running-network-tools.adoc
@@ -16,6 +16,13 @@ Get information about the logical switches and routers by running `network-tools
 
 .Procedure
 
+. Open a remote shell into a pod by running the following command:
++
+[source,terminal]
+----
+$ oc rsh -n openshift-ovn-kubernetes ovnkube-node-2hsbt
+----
+
 . List the routers by running the following command:
 +
 [source,terminal]
@@ -27,13 +34,8 @@ $ ./debug-scripts/network-tools ovn-db-run-command ovn-nbctl lr-list
 +
 [source,terminal]
 ----
-Leader pod is ovnkube-master-vslqm
-5351ddd1-f181-4e77-afc6-b48b0a9df953 (GR_helix13.lab.eng.tlv2.redhat.com)
-ccf9349e-1948-4df8-954e-39fb0c2d4d06 (GR_helix14.lab.eng.tlv2.redhat.com)
-e426b918-75a8-4220-9e76-20b7758f92b7 (GR_hlxcl7-master-0.hlxcl7.lab.eng.tlv2.redhat.com)
-dded77c8-0cc3-4b99-8420-56cd2ae6a840 (GR_hlxcl7-master-1.hlxcl7.lab.eng.tlv2.redhat.com)
-4f6747e6-e7ba-4e0c-8dcd-94c8efa51798 (GR_hlxcl7-master-2.hlxcl7.lab.eng.tlv2.redhat.com)
-52232654-336e-4952-98b9-0b8601e370b4 (ovn_cluster_router)
+944a7b53-7948-4ad2-a494-82b55eeccf87 (GR_ci-ln-54932yb-72292-kd676-worker-c-rzj99)
+84bd4a4c-4b0b-4a47-b0cf-a2c32709fc53 (ovn_cluster_router)
 ----
 
 . List the localnet ports by running the following command:
@@ -48,41 +50,18 @@ ovn-sbctl find Port_Binding type=localnet
 +
 [source,terminal]
 ----
-Leader pod is ovnkube-master-vslqm
-_uuid               : 3de79191-cca8-4c28-be5a-a228f0f9ebfc
+_uuid               : d05298f5-805b-4838-9224-1211afc2f199
 additional_chassis  : []
 additional_encap    : []
 chassis             : []
-datapath            : 3f1a4928-7ff5-471f-9092-fe5f5c67d15c
+datapath            : f3c2c959-743b-4037-854d-26627902597c
 encap               : []
 external_ids        : {}
 gateway_chassis     : []
 ha_chassis_group    : []
-logical_port        : br-ex_helix13.lab.eng.tlv2.redhat.com
+logical_port        : br-ex_ci-ln-54932yb-72292-kd676-worker-c-rzj99
 mac                 : [unknown]
-nat_addresses       : []
-options             : {network_name=physnet}
-parent_port         : []
-port_security       : []
-requested_additional_chassis: []
-requested_chassis   : []
-tag                 : []
-tunnel_key          : 2
-type                : localnet
-up                  : false
-virtual_parent      : []
-
-_uuid               : dbe21daf-9594-4849-b8f0-5efbfa09a455
-additional_chassis  : []
-additional_encap    : []
-chassis             : []
-datapath            : db2a6067-fe7c-4d11-95a7-ff2321329e11
-encap               : []
-external_ids        : {}
-gateway_chassis     : []
-ha_chassis_group    : []
-logical_port        : br-ex_hlxcl7-master-2.hlxcl7.lab.eng.tlv2.redhat.com
-mac                 : [unknown]
+mirror_rules        : []
 nat_addresses       : []
 options             : {network_name=physnet}
 parent_port         : []
@@ -110,20 +89,20 @@ ovn-sbctl find Port_Binding type=l3gateway
 +
 [source,terminal]
 ----
-Leader pod is ovnkube-master-vslqm
-_uuid               : 9314dc80-39e1-4af7-9cc0-ae8a9708ed59
+_uuid               : 5207a1f3-1cf3-42f1-83e9-387bbb06b03c
 additional_chassis  : []
 additional_encap    : []
-chassis             : 336a923d-99e8-4e71-89a6-12564fde5760
-datapath            : db2a6067-fe7c-4d11-95a7-ff2321329e11
+chassis             : ca6eb600-3a10-4372-a83e-e0d957c4cd92
+datapath            : f3c2c959-743b-4037-854d-26627902597c
 encap               : []
 external_ids        : {}
 gateway_chassis     : []
 ha_chassis_group    : []
-logical_port        : etor-GR_hlxcl7-master-2.hlxcl7.lab.eng.tlv2.redhat.com
-mac                 : ["52:54:00:3e:95:d3"]
-nat_addresses       : ["52:54:00:3e:95:d3 10.46.56.77"]
-options             : {l3gateway-chassis="7eb1f1c3-87c2-4f68-8e89-60f5ca810971", peer=rtoe-GR_hlxcl7-master-2.hlxcl7.lab.eng.tlv2.redhat.com}
+logical_port        : etor-GR_ci-ln-54932yb-72292-kd676-worker-c-rzj99
+mac                 : ["42:01:0a:00:80:04"]
+mirror_rules        : []
+nat_addresses       : ["42:01:0a:00:80:04 10.0.128.4"]
+options             : {l3gateway-chassis="84737c36-b383-4c83-92c5-2bd5b3c7e772", peer=rtoe-GR_ci-ln-54932yb-72292-kd676-worker-c-rzj99}
 parent_port         : []
 port_security       : []
 requested_additional_chassis: []
@@ -134,25 +113,26 @@ type                : l3gateway
 up                  : true
 virtual_parent      : []
 
-_uuid               : ad7eb303-b411-4e9f-8d36-d07f1f268e27
+_uuid               : 6088d647-84f2-43f2-b53f-c9d379042679
 additional_chassis  : []
 additional_encap    : []
-chassis             : f41453b8-29c5-4f39-b86b-e82cf344bce4
-datapath            : 082e7a60-d9c7-464b-b6ec-117d3426645a
+chassis             : ca6eb600-3a10-4372-a83e-e0d957c4cd92
+datapath            : dc9cea00-d94a-41b8-bdb0-89d42d13aa2e
 encap               : []
 external_ids        : {}
 gateway_chassis     : []
 ha_chassis_group    : []
-logical_port        : etor-GR_helix14.lab.eng.tlv2.redhat.com
-mac                 : ["34:48:ed:f3:e2:2c"]
-nat_addresses       : ["34:48:ed:f3:e2:2c 10.46.56.14"]
-options             : {l3gateway-chassis="2e8abe3a-cb94-4593-9037-f5f9596325e2", peer=rtoe-GR_helix14.lab.eng.tlv2.redhat.com}
+logical_port        : jtor-GR_ci-ln-54932yb-72292-kd676-worker-c-rzj99
+mac                 : [router]
+mirror_rules        : []
+nat_addresses       : []
+options             : {l3gateway-chassis="84737c36-b383-4c83-92c5-2bd5b3c7e772", peer=rtoj-GR_ci-ln-54932yb-72292-kd676-worker-c-rzj99}
 parent_port         : []
 port_security       : []
 requested_additional_chassis: []
 requested_chassis   : []
 tag                 : []
-tunnel_key          : 1
+tunnel_key          : 2
 type                : l3gateway
 up                  : true
 virtual_parent      : []
@@ -172,52 +152,52 @@ ovn-sbctl find Port_Binding type=patch
 +
 [source,terminal]
 ----
-Leader pod is ovnkube-master-vslqm
-_uuid               : c48b1380-ff26-4965-a644-6bd5b5946c61
+_uuid               : 785fb8b6-ee5a-4792-a415-5b1cb855dac2
 additional_chassis  : []
 additional_encap    : []
 chassis             : []
-datapath            : 72734d65-fae1-4bd9-a1ee-1bf4e085a060
+datapath            : f1ddd1cc-dc0d-43b4-90ca-12651305acec
 encap               : []
 external_ids        : {}
 gateway_chassis     : []
 ha_chassis_group    : []
-logical_port        : jtor-ovn_cluster_router
+logical_port        : stor-ci-ln-54932yb-72292-kd676-worker-c-rzj99
 mac                 : [router]
-nat_addresses       : []
-options             : {peer=rtoj-ovn_cluster_router}
+mirror_rules        : []
+nat_addresses       : ["0a:58:0a:80:02:01 10.128.2.1 is_chassis_resident(\"cr-rtos-ci-ln-54932yb-72292-kd676-worker-c-rzj99\")"]
+options             : {peer=rtos-ci-ln-54932yb-72292-kd676-worker-c-rzj99}
 parent_port         : []
 port_security       : []
 requested_additional_chassis: []
 requested_chassis   : []
 tag                 : []
-tunnel_key          : 4
+tunnel_key          : 1
 type                : patch
 up                  : false
 virtual_parent      : []
 
-_uuid               : 5df51302-f3cd-415b-a059-ac24389938f7
+_uuid               : c01ff587-21a5-40b4-8244-4cd0425e5d9a
 additional_chassis  : []
 additional_encap    : []
 chassis             : []
-datapath            : 0551c90f-e891-4909-8e9e-acc7909e06d0
+datapath            : f6795586-bf92-4f84-9222-efe4ac6a7734
 encap               : []
 external_ids        : {}
 gateway_chassis     : []
 ha_chassis_group    : []
-logical_port        : rtos-hlxcl7-master-1.hlxcl7.lab.eng.tlv2.redhat.com
-mac                 : ["0a:58:0a:82:00:01 10.130.0.1/23"]
+logical_port        : rtoj-ovn_cluster_router
+mac                 : ["0a:58:64:40:00:01 100.64.0.1/16"]
+mirror_rules        : []
 nat_addresses       : []
-options             : {chassis-redirect-port=cr-rtos-hlxcl7-master-1.hlxcl7.lab.eng.tlv2.redhat.com, peer=stor-hlxcl7-master-1.hlxcl7.lab.eng.tlv2.redhat.com}
+options             : {peer=jtor-ovn_cluster_router}
 parent_port         : []
 port_security       : []
 requested_additional_chassis: []
 requested_chassis   : []
 tag                 : []
-tunnel_key          : 4
+tunnel_key          : 1
 type                : patch
 up                  : false
 virtual_parent      : []
-
 [...]
 ----

--- a/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly.adoc
+++ b/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly.adoc
@@ -28,10 +28,8 @@ include::modules/nw-ovn-kubernetes-running-network-tools.adoc[leveloffset=+2]
 [id="additional-resources_ovn-kubernetes-architecture"]
 == Additional resources
 
-* link:https://access.redhat.com/solutions/5660751[How to list OVN database contents with ovn-kubernetes in Red Hat OpenShift Container Platform 4.x?]
 * xref:../../networking/ovn_kubernetes_network_provider/ovn-kubernetes-tracing-using-ovntrace.adoc#ovn-kubernetes-tracing-using-ovntrace[Tracing Openflow with ovnkube-trace]
 * link:https://www.ovn.org/support/dist-docs/ovn-architecture.7.html[OVN architecture]
-* link:https://en.wikipedia.org/wiki/Raft_(algorithm)[Raft (algorithm)]
 * link:https://man7.org/linux/man-pages/man8/ovn-nbctl.8.html[ovn-nbctl linux manual page]
 * link:https://man7.org/linux/man-pages/man8/ovn-sbctl.8.html[ovn-sbctl linux manual page]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com//browse/OSDOCS-6269
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Command line arguments for nbctl](https://64418--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#nw-ovn-kubernetes-examine-nb-database-contents-ref_ovn-kubernetes-architecture)
[Command line arguments for sbctl](https://64418--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#nw-ovn-kubernetes-examine-sb-database-contents-ref_ovn-kubernetes-architecture)
[Running network tools](https://64418--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#nw-ovn-kubernetes-running-network-tools_ovn-kubernetes-architecture)
[Additional resources](https://64418--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#additional-resources_ovn-kubernetes-architecture)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
With #62156 this PR completes the OVN-Kubernetes architecture book.
PTAL @tssurya @anuragthehatter 
https://github.com/openshift/openshift-docs/pull/62156
https://github.com/openshift/openshift-docs/pull/64493
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
