### PR TITLE
OSDOCS#7528: Release note for PSA sync being disabled if PSA labels a…

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -223,6 +223,13 @@ With this release, the following system namespaces are always set to the `privil
 
 For more information, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#psa-privileged-namespaces_understanding-and-managing-pod-security-admission[Privileged namespaces].
 
+[id="ocp-4-14-auth-psa-disable-sync-modified"]
+==== Pod security admission synchronization disabled on modified namespaces
+
+With this release, if a user manually modifies a pod security admission label from the automatically labeled value on a label-synchronized namespace, synchronization is disabled for that label. Users can enable synchronization again, if necessary.
+
+For more information, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-sync-exclusions_understanding-and-managing-pod-security-admission[Pod security admission synchronization namespace exclusions].
+
 [id="ocp-4-14-networking"]
 === Networking
 
@@ -300,7 +307,7 @@ For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-no
 [id="ocp-414-broadcom-bcm57504-support"]
 ==== Support for Broadcom BCM57504 is now GA
 
-Support for the Broadcom BCM57504 network interface controller is now available for the SR-IOV Network Operator. 
+Support for the Broadcom BCM57504 network interface controller is now available for the SR-IOV Network Operator.
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
 
@@ -321,7 +328,7 @@ With this release, the logical volume manager (LVM) cluster custom resource (CR)
 === Registry
 
 [id="ocp-4-14-optional-image-registry-operator"]
-==== Optional Image Registry Operator 
+==== Optional Image Registry Operator
 
 With this release, the Image Registry Operator is now an optional component. This feature helps reduce the overall resources footprint of {product-title} in Telco environments when the Image Registry Operator is not needed.
 


### PR DESCRIPTION
…re modified

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7528

Link to docs preview:
https://64419--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-auth-psa-disable-sync-modified

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->


**The xref won't jump to the proper section until PR #64343 is merged.**