### PR TITLE
CNV-18089: OVN-Kubernetes secondary networks

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3791,6 +3791,8 @@ Topics:
     File: virt-connecting-vm-to-sriov
   - Name: Using DPDK with SR-IOV
     File: virt-using-dpdk-with-sriov
+  - Name: Connecting a VM to an OVN-Kubernetes secondary network
+    File: virt-connecting-vm-to-ovn-secondary-network
   - Name: Hot plugging secondary network interfaces
     File: virt-hot-plugging-network-interfaces
   - Name: Connecting a VM to a service mesh

--- a/modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc
+++ b/modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc
@@ -1,0 +1,57 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc              
+
+:_content-type: PROCEDURE                                             
+[id="virt-attaching-vm-to-ovn-secondary-nw-cli_{context}"]                                   
+= Attaching a virtual machine to an OVN-Kubernetes secondary network using the CLI
+
+You can connect a virtual machine (VM) to the OVN-Kubernetes secondary network by including the network details in the VM configuration.
+
+.Prerequisites
+* You have access to the cluster as a user with `cluster-admin` privileges.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+. Edit the `VirtualMachine` manifest to add the OVN-Kubernetes secondary network interface details, as in the following example:
++
+[source,yaml]
+----
+apiVersion: kubevirt.io/v1
+kind: VirtualMachine
+metadata:
+  name: vm-server
+spec:
+  running: true
+  template:
+    spec:
+      domain:
+        devices:
+          interfaces:
+          - name: default
+            masquerade: {}
+          - name: secondary <1>
+            bridge: {}
+        resources:
+          requests:
+            memory: 1024Mi
+      networks:
+      - name: default
+        pod: {}
+      - name: secondary  <2>
+        multus:
+          networkName: l2-network <3>
+# ...
+----
+<1> The name of the OVN-Kubernetes secondary interface.
+<2> The name of the network. This must match the value of the `spec.template.spec.domain.devices.interfaces.name` field.
+<3> The name of the `NetworkAttachmentDefinition` object.
+
+. Apply the `VirtualMachine` manifest:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+
+. Optional: If you edited a running virtual machine, you must restart it for the changes to take effect.

--- a/modules/virt-creating-layer2-nad-cli.adoc
+++ b/modules/virt-creating-layer2-nad-cli.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc              
+
+:_content-type: PROCEDURE                                             
+[id="virt-creating-layer2-nad-cli_{context}"]                                   
+= Creating a NAD for flat layer 2 topology using the CLI
+
+You can create a network attachment definition (NAD) which describes how to attach a pod to the layer 2 overlay network.
+
+.Prerequisites
+* You have access to the cluster as a user with `cluster-admin` privileges.
+* You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Create a `NetworkAttachmentDefinition` object:
++
+[source,yaml]
+----
+apiVersion: k8s.cni.cncf.io/v1
+kind: NetworkAttachmentDefinition
+metadata:
+  name: l2-network
+  namespace: my-namespace
+spec:
+  config: |2
+    {
+            "cniVersion": "0.3.1", <1>
+            "name": "my-namespace-l2-network", <2>
+            "type": "ovn-k8s-cni-overlay", <3>
+            "topology":"layer2", <4>
+            "mtu": 1300, <5>
+            "netAttachDefName": "my-namespace/l2-network" <6>
+    }
+----
+<1> The CNI specification version. The required value is `0.3.1`.
+<2> The name of the network. This attribute is not namespaced. For example, you can have a network named `l2-network` referenced from two different `NetworkAttachmentDefinition` objects that exist in two different namespaces. This feature is useful to connect VMs in different namespaces.
+<3> The name of the CNI plug-in to be configured. The required value is `ovn-k8s-cni-overlay`.
+<4> The topological configuration for the network. The required value is `layer2`.
+<5> Optional: The maximum transmission unit (MTU) value. The default value is automatically set by the kernel.
+<6> The value of the `namespace` and `name` fields in the `metadata` stanza of the `NetworkAttachmentDefinition` object.
++
+[NOTE]
+====
+The above example configures a cluster-wide overlay without a subnet defined. This means that the logical switch implementing the network only provides layer 2 communication. You must configure an IP address when you create the virtual machine by either setting a static IP address or by deploying a DHCP server on the network for a dynamic IP address.
+====
+
+. Apply the manifest:
++
+[source,terminal]
+----
+$ oc apply -f <filename>.yaml
+----
+

--- a/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
+++ b/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc
@@ -1,0 +1,40 @@
+:_content-type: ASSEMBLY                                        
+[id="virt-connecting-vm-to-ovn-secondary-network"]                            
+= Connecting a virtual machine to an OVN-Kubernetes secondary network                                                
+include::_attributes/common-attributes.adoc[]                   
+:context: virt-connecting-vm-to-ovn-secondary-network                        
+                                                                
+toc::[]   
+
+You can connect a virtual machine (VM) to an OVN-Kubernetes secondary network. The OVN-Kubernetes Container Network Interface (CNI) plug-in uses the Geneve (Generic Network Virtualization Encapsulation) protocol to create an overlay network between nodes. 
+
+{VirtProductName} currently supports the flat layer 2 topology. This topology connects workloads by a cluster-wide logical switch. You can use this overlay network to connect VMs on different nodes, without having to configure any additional physical networking infrastructure.
+
+To configure an OVN-Kubernetes secondary network and attach a VM to that network, perform the following steps:
+
+. Create a network attachment definition (NAD) by using the web console or the xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-creating-layer2-nad-cli_virt-connecting-vm-to-ovn-secondary-network[CLI].
+
+. Add information about the secondary network interface to the VM specification by using the web console or the xref:../../virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network.adoc#virt-attaching-vm-to-ovn-secondary-nw-cli_virt-connecting-vm-to-ovn-secondary-network[CLI].
+
+
+[id="creating-ovn-layer2-nad"]
+== Creating an OVN-Kubernetes NAD
+
+You can create an OVN-Kubernetes flat layer 2 network attachment definition (NAD) by using the {product-title} web console or the CLI.
+
+
+include::modules/virt-creating-layer2-nad-cli.adoc[leveloffset=+2]
+
+
+[id="attaching-vm-to-ovn-secondary-nw"]
+== Attaching a virtual machine to the OVN-Kubernetes secondary network
+
+You can attach a virtual machine (VM) to the OVN-Kubernetes secondary network interface by using the {product-title} web console or the CLI.
+
+include::modules/virt-attaching-vm-to-ovn-secondary-nw-cli.adoc[leveloffset=+2]
+
+
+[role="_additional-resources"]
+[id="additional-resources_virt-connecting-vm-to-ovn-secondary-network"]
+== Additional resources
+* xref:../../networking/multiple_networks/configuring-additional-network.adoc#configuration-ovnk-additional-networks_configuring-additional-network[Configuration for an OVN-Kubernetes additional network]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-18089](https://issues.redhat.com//browse/CNV-18089)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64435--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-connecting-vm-to-ovn-secondary-network
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
