### PR TITLE
TELCODOCS-1278: First draft

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -62,11 +62,33 @@ include::modules/kmm-adding-the-keys-for-secureboot.adoc[leveloffset=+1]
 include::modules/kmm-checking-the-keys.adoc[leveloffset=+2]
 include::modules/kmm-signing-a-prebuilt-driver-container.adoc[leveloffset=+1]
 include::modules/kmm-building-and-signing-a-moduleloader-container-image.adoc[leveloffset=+1]
+[role="_additional-resources"]
 .Additional resources
 For information on creating a service account, see link:https://docs.openshift.com/container-platform/4.12/authentication/understanding-and-creating-service-accounts.html#service-accounts-managing_understanding-service-accounts[Creating service accounts].
 
 // Added for TELCODOCS-1277
 include::modules/kmm-customizing-upgrades-for-kernel-modules.adoc[leveloffset=+1]
+
+// Added for TELCODOCS-1278
+include::modules/kmm-day1-kernel-module-loading.adoc[leveloffset=+1]
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.openshift.com/container-platform/4.13/post_installation_configuration/machine-configuration-tasks.html#machine-config-operator_post-install-machine-configuration-tasks[Machine Config Operator]
+
+include::modules/kmm-day1-supported-use-cases.adoc[leveloffset=+2]
+include::modules/kmm-day1-oot-kernel-module-loading-flow.adoc[leveloffset=+2]
+include::modules/kmm-day1-kernel-module-image.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.openshift.com/container-platform/4.13/hardware_enablement/psap-driver-toolkit.html[Driver Toolkit]
+
+include::modules/kmm-day1-in-tree-module-replacement.adoc[leveloffset=+2]
+include::modules/kmm-day1-mco-yaml-creation.adoc[leveloffset=+2]
+include::modules/kmm-day1-machineconfigpool.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://www.redhat.com/en/blog/openshift-container-platform-4-how-does-machine-config-pool-work[About MachineConfigPool]
 
 include::modules/kmm-debugging-and-troubleshooting.adoc[leveloffset=+1]
 

--- a/modules/kmm-day1-in-tree-module-replacement.adoc
+++ b/modules/kmm-day1-in-tree-module-replacement.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-day1-in-tree-module-replacement_{context}"]
+= In-tree module replacement
+
+The Day 1 functionality always tries to replace the in-tree kernel module with the OOT version. If the in-tree kernel module is not loaded, the flow is not affected; the service proceeds and loads the OOT kernel module.

--- a/modules/kmm-day1-kernel-module-image.adoc
+++ b/modules/kmm-day1-kernel-module-image.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-day1-kernel-module-image_{context}"]
+= The kernel module image
+
+The Day 1 functionality uses the same DTK based image leveraged by Day 2 KMM builds. The out-of-tree kernel module should be located under `/opt/lib/modules/${kernelVersion}`.

--- a/modules/kmm-day1-kernel-module-loading.adoc
+++ b/modules/kmm-day1-kernel-module-loading.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-day1-kernel-module-loading_{context}"]
+= Day 1 kernel module loading
+
+Kernel Module Management (KMM) is typically a Day 2 Operator. Kernel modules are loaded only after the complete initialization of a Linux (RHCOS) server. However, in some scenarios the kernel module must be loaded at an earlier stage. Day 1 functionality allows you to use the Machine Config Operator (MCO) to load kernel modules during the Linux `systemd` initialization stage.

--- a/modules/kmm-day1-machineconfigpool.adoc
+++ b/modules/kmm-day1-machineconfigpool.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-day1-machineconfigpool_{context}"]
+= The MachineConfigPool
+
+The `MachineConfigPool` identifies a collection of nodes that are affected by the applied MCO.
+
+[source,yaml]
+----
+kind: MachineConfigPool
+metadata:
+  name: sfc
+spec:
+  machineConfigSelector: <1>
+    matchExpressions:
+      - {key: machineconfiguration.openshift.io/role, operator: In, values: [worker, sfc]}
+  nodeSelector: <2>
+    matchLabels:
+      node-role.kubernetes.io/sfc: ""
+  paused: false
+  maxUnavailable: 1
+----
+<1> Matches the labels in the MachineConfig.
+<2> Matches the labels on the node.
+
+There are predefined `MachineConfigPools` in the OCP cluster:
+
+* `worker`: Targets all worker nodes in the cluster
+
+* `master`: Targets all master nodes in the cluster
+
+Define the following `MachineConfig` to target the master `MachineConfigPool`:
+
+[source,yaml]
+----
+metadata:
+  labels:
+    machineconfiguration.opensfhit.io/role: master
+----
+
+
+Define the following `MachineConfig` to target the worker `MachineConfigPool`:
+
+[source,yaml]
+----
+metadata:
+  labels:
+    machineconfiguration.opensfhit.io/role: worker
+----

--- a/modules/kmm-day1-mco-yaml-creation.adoc
+++ b/modules/kmm-day1-mco-yaml-creation.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-day1-mco-yaml-creation_{context}"]
+= MCO yaml creation
+
+KMM provides an API to create an MCO YAML manifest for the Day 1 functionality:
+
+[source,console]
+----
+ProduceMachineConfig(machineConfigName, machineConfigPoolRef, kernelModuleImage, kernelModuleName string) (string, error)
+----
+
+The returned output is a string representation of the MCO YAML manifest to be applied. It is up to the customer to apply this YAML.
+
+The parameters are:
+
+`machineConfigName`:: The name of the MCO YAML manifest. This parameter is set as the `name` parameter of the metadata of the MCO YAML manifest.
+
+`machineConfigPoolRef`:: The `MachineConfigPool` name used to identify the targeted nodes.
+
+`kernelModuleImage`:: The name of the container image that includes the OOT kernel module.
+
+`kernelModuleName`:: The name of the OOT kernel module. This parameter is used both to unload the in-tree kernel module (if loaded into the kernel) and to load the OOT kernel module.
+
+The API is located under `pkg/mcproducer` package of the KMM source code. The KMM operator does not need to be running to use the Day 1 functionality. You only need to import the `pkg/mcproducer` package into their operator/utility code, call the API, and apply the produced MCO YAML to the cluster.

--- a/modules/kmm-day1-oot-kernel-module-loading-flow.adoc
+++ b/modules/kmm-day1-oot-kernel-module-loading-flow.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: PROCEDURE
+[id="kmm-day1-oot-kernel-module-loading-flow_{context}"]
+= OOT kernel module loading flow
+
+The loading of the out-of-tree (OOT) kernel module leverages the Machine Config Operator (MCO). The flow sequence is as follows:
+
+.Procedure
+
+. Apply a `MachineConfig` resource to the existing running cluster. In order to identify the necessary nodes that need to be updated,
+you must create an appropriate `MachineConfigPool` resource.
+
+. MCO applies the reboots node by node. On any rebooted node, two new `systemd` services are deployed: `pull` service and `load` service.
+
+. The `load` service is configured to run prior to the `NetworkConfiguration` service. The service tries to pull a predefined kernel module image and then, using that image, to unload an in-tree module and load an OOT kernel module.
+
+. The `pull` service is configured to run after NetworkManager service. The service checks if the preconfigured kernel module image is located on the node's filesystem. If it is, the service exists normally, and the server continues with the boot process. If not, it pulls the image onto the node and reboots the node afterwards.

--- a/modules/kmm-day1-supported-use-cases.adoc
+++ b/modules/kmm-day1-supported-use-cases.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-day1-supported-use-cases_{context}"]
+= Day 1 supported use cases
+
+The Day 1 functionality supports a limited number of use cases. The main use case is to allow loading out-of-tree (OOT) kernel modules prior to NetworkManager service initialization. It does not support loading kernel module at the `initramfs` stage.
+
+The following are the conditions needed for Day 1 functionality:
+
+* The kernel module is not loaded in the kernel.
+
+* The in-tree kernel module is loaded into the kernel, but can be unloaded and replaced by the OOT kernel module. This means that the in-tree module is not referenced by any other kernel modules.
+
+* In order for Day 1 functionlity to work, the node must have a functional network interface, that is, an in-tree kernel driver for that interface. The OOT kernel module can be a network driver that will replace the functional network driver.


### PR DESCRIPTION
D/S Docs: [MGMT-13870](https://issues.redhat.com//browse/MGMT-13870) Orderly kmod upgrades

Version: 4.13+

Jira: Document Day 1 support through KMM

Version(s): KMMO 1.1

Link to docs preview: https://64449--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management#kmm-day1-kernel-module-loading_kernel-module-management-operator

SME review: @yevgeny-shnaidman, @qbarrand
QE review: @cdvultur

