### PR TITLE
CNV-20183- new content temporary token VNC

### DIFF
--- a/modules/virt-temporary-token-VNC.adoc
+++ b/modules/virt-temporary-token-VNC.adoc
@@ -1,0 +1,69 @@
+// Module included in the following assemblies:
+//
+// * virt/virtual_machines/virt-accessing-vm-consoles.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="virt-temporary-token-VNC_{context}"]
+= Generating a temporary token for the VNC console
+
+Generate a temporary authentication bearer token for the Kubernetes API to access the VNC of a virtual machine (VM).
+
+[NOTE]
+====
+Kubernetes also supports authentication using client certificates, instead of a bearer token, by modifying the curl command.
+====
+
+.Prerequisites
+
+* A running virtual machine with {VirtProductName} 4.14 or later and xref:../../virt/about-virt/virt-architecture#virt-about-ssp-operator_virt-architecture[`ssp-operator`] 4.14 or later
+
+.Procedure
+
+. Enable the feature gate in the HyperConverged (`HCO`) custom resource (CR):
++
+[source,terminal,subs="attributes+"]
+----
+$ oc patch hyperconverged kubevirt-hyperconverged -n {CNVNamespace} --type json -p '[{"op": "replace", "path": "/spec/featureGates/deployVmConsoleProxy", "value": true}]'
+# ...
+----
+
+. Generate a token by running the following command:
++
+[source,terminal]
+----
+$ curl --header "Authorization: Bearer ${TOKEN}" \
+     "https://api.<cluster_fqdn>/apis/token.kubevirt.io/v1alpha1/namespaces/<namespace>/virtualmachines/<vm_name>/vnc?duration=<duration>" <1>
+----
+<1> Duration can be in hours and minutes, with a minimum duration of 10 minutes. Example: `5h30m`. The token is valid for 10 minutes by default if this parameter is not set.
++
+Sample output:
++
+[source,terminal]
+----
+{ "token": "eyJhb..." }
+----
+
+. Optional: Use the token provided in the output to create a variable:
++
+[source,terminal]
+----
+$ export VNC_TOKEN="<token>"
+----
+
+You can now use the token to access the VNC console of a VM.
+
+.Verification
+
+.  Log in to the cluster by running the following command:
++
+[source,terminal]
+----
+$ oc login --token ${VNC_TOKEN}
+----
+
+.  Use `virtctl` to test access to the VNC console of the VM by running the following command:
++
+[source,terminal]
+----
+$ virtctl vnc <vm_name> -n <namespace>
+----

--- a/virt/virtual_machines/virt-accessing-vm-consoles.adoc
+++ b/virt/virtual_machines/virt-accessing-vm-consoles.adoc
@@ -23,6 +23,10 @@ include::modules/virt-connecting-to-vm-console-web.adoc[leveloffset=+2]
 include::modules/virt-connecting-vm-virtctl.adoc[leveloffset=+2]
 :!vnc-console:
 
+:context: vnc-console
+include::modules/virt-temporary-token-VNC.adoc[leveloffset=+2]
+:!vnc-console:
+
 [id="serial-console_virt-accessing-vm-consoles"]
 == Connecting to the serial console
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-20183](https://issues.redhat.com//browse/CNV-20183)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64453--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/virt-accessing-vm-consoles#virt-temporary-token-VNC_vnc-console
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
