### PR TITLE
OSDOCS6989: Changed content in OpenStack: Deploy control plane nodes via MachineSet

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-about.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-about.adoc
@@ -25,7 +25,7 @@ The Control Plane Machine Set Operator has the following limitations:
 
 * The Operator requires the Machine API Operator to be operational and is therefore not supported on clusters with manually provisioned machines. When installing a {product-title} cluster with manually provisioned machines for a platform that creates an active generated `ControlPlaneMachineSet` custom resource (CR), you must remove the Kubernetes manifest files that define the control plane machine set as instructed in the installation process.
 
-* Only Amazon Web Services (AWS), Google Cloud Platform (GCP), {ibmpowerProductName} Virtual Server, Microsoft Azure, Nutanix, and VMware vSphere clusters are supported.
+* Only Amazon Web Services (AWS), Google Cloud Platform (GCP), {ibmpowerProductName} Virtual Server, Microsoft Azure, Nutanix, VMware vSphere, and {rh-openstack-first} clusters are supported.
 
 * Only clusters with three control plane machines are supported.
 

--- a/machine_management/control_plane_machine_management/cpmso-configuration.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-configuration.adoc
@@ -33,6 +33,8 @@ The `<platform_provider_spec>` and `<platform_failure_domains>` sections of the 
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[Sample YAML snippets for configuring VMware vSphere clusters]
 
+* xref:../../machine_management/control_plane_machine_management/cpmso-configuration#cpmso-sample-yaml-openstack_cpmso-configuration[Sample YAML snippets for configuring {rh-openstack-first} clusters]
+
 [id="cpmso-sample-yaml-aws_{context}"]
 == Sample YAML for configuring Amazon Web Services clusters
 
@@ -94,3 +96,14 @@ Some sections of the control plane machine set CR are provider-specific. The fol
 
 //Sample VMware vSphere provider specification
 include::modules/cpmso-yaml-provider-spec-vsphere.adoc[leveloffset=+2]
+
+[id="cpmso-sample-yaml-openstack_{context}"]
+== Sample YAML for configuring {rh-openstack-first} clusters
+
+Some sections of the control plane machine set CR are provider-specific. The following example YAML snippets show provider specification and failure domain configurations for an {rh-openstack} cluster.
+
+//Sample OpenStack provider specification
+include::modules/cpmso-yaml-provider-spec-openstack.adoc[leveloffset=+2]
+
+//Sample OpenStack failure domain configuration
+include::modules/cpmso-yaml-failure-domain-openstack.adoc[leveloffset=+2]

--- a/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-getting-started.adoc
@@ -52,12 +52,17 @@ The status of the control plane machine set after installation depends on your c
 |
 |
 |X
+
+|{rh-openstack-first}
+|X ^[3]^
+|X
+|
 |====
 [.small]
 --
 1. AWS clusters that are upgraded from version 4.11 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
 2. GCP and Azure clusters that are upgraded from version 4.12 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
-3. Nutanix clusters that are upgraded from version 4.13 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
+3. Nutanix and {rh-openstack} clusters that are upgraded from version 4.13 or earlier require xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-activating_cpmso-getting-started[CR activation].
 --
 
 //Checking the control plane machine set custom resource state
@@ -82,3 +87,4 @@ include::modules/cpmso-creating-cr.adoc[leveloffset=+1]
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Sample YAML for configuring Microsoft Azure clusters]
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-nutanix_cpmso-configuration[Sample YAML for configuring Nutanix clusters]
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[Sample YAML for configuring VMware vSphere clusters]
+* xref:../../machine_management/control_plane_machine_management/cpmso-configuration#cpmso-sample-yaml-openstack_cpmso-configuration[Sample YAML for configuring {rh-openStack-first} clusters]

--- a/machine_management/control_plane_machine_management/cpmso-resiliency.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-resiliency.adoc
@@ -23,6 +23,8 @@ include::modules/cpmso-failure-domains-provider.adoc[leveloffset=+2]
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-yaml-failure-domain-azure_cpmso-configuration[Sample Microsoft Azure failure domain configuration]
 
+* xref:../../machine_management/control_plane_machine_management/cpmso-configuration#cpmso-yaml-failure-domain-openstack_cpmso-configuration[Sample {rh-openstack} failure domain configuration]
+
 //Balancing control plane machines
 include::modules/cpmso-failure-domains-balancing.adoc[leveloffset=+2]
 

--- a/machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
@@ -29,3 +29,9 @@ include::modules/cpmso-ts-mhc-etcd-degraded.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../backup_and_restore/control_plane_backup_and_restore/disaster_recovery/scenario-2-restoring-cluster-state.adoc#dr-restoring-cluster-state[Restoring to a previous cluster state]
+
+//Configuring OpenStack without Availability Zones
+include::modules/cpmso-openstack-without-az-config.adoc[leveloffset=+1]
+
+//Configuring OpenStack with Availability Zones
+include::modules/cpmso-openstack-with-az-config.adoc[leveloffset=+1]

--- a/machine_management/control_plane_machine_management/cpmso-using.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-using.adoc
@@ -109,6 +109,7 @@ include::modules/machineset-gcp-confidential-vm.adoc[leveloffset=+2]
 
 //Configuring Shielded VM options by using machine sets
 include::modules/machineset-gcp-shielded-vms.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 * link:https://cloud.google.com/compute/shielded-vm/docs/shielded-vm[What is Shielded VM?]
@@ -118,3 +119,11 @@ include::modules/machineset-gcp-shielded-vms.adoc[leveloffset=+2]
 
 //Enabling customer-managed encryption keys for a machine set
 include::modules/machineset-gcp-enabling-customer-managed-encryption.adoc[leveloffset=+2]
+
+[id="cpmso-supported-features-openstack_{context}"]
+== Updating the configuration for {rh-openstack} control plane machines
+
+You can enable {rh-openstack-first} features on control plane machines by changing the configuration of your control plane machine set. When you save an update to the control plane machine set, the Control Plane Machine Set Operator updates the control plane machines according to your configured update strategy.
+
+//Changing the OpenStack Nova Flavor by using a control plane machine set
+include::modules/cpms-changing-openstack-flavor-type.adoc[leveloffset=+2]

--- a/modules/cpms-changing-openstack-flavor-type.adoc
+++ b/modules/cpms-changing-openstack-flavor-type.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+// * machine_management/control_plane_machine_management/cpmso-using.adoc
+
+ifeval::["{context}" == "recommended-control-plane-practices"]
+:scale-host:
+endif::[]
+ifeval::["{context}" == "cpmso-using"]
+:cpmso-using:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="cpms-changing-openstack-flavor-type_{context}"]
+= Changing the {rh-openstack} Nova Flavor by using a control plane machine set
+
+In {rh-openstack}, flavors define the compute, memory, and storage capacity of nova computing instances. An {rh-openstack} Nova flavor is a virtual hardware template. 
+
+You can change the {rh-openstack-first} Nova flavor that your control plane machines use by updating the specification in the control plane machine set custom resource (CR).
+
+.Prerequisites
+
+* Your {rh-openstack} cluster uses a control plane machine set.
+
+.Procedure
+
+ifdef::scale-host[]
+. Edit your control plane machine set CR by running the following command:
++
+[source,terminal]
+----
+$ oc --namespace openshift-machine-api edit controlplanemachineset.machine.openshift.io cluster
+----
+endif::scale-host[]
+
+. Edit the following line under the `providerSpec` field:
++
+[source,yaml]
+----
+providerSpec:
+  value:
+    ...
+    flavor: <1>
+----
+<1> Specify a larger {rh-openstack}  flavor type with the same base as the previous selection. For example, you can change `m6i.xlarge` to `m6i.2xlarge` or `m6i.4xlarge`.
+
+. Save your changes.
+
+ifdef::scale-host[]
+** For clusters that use the default `RollingUpdate` update strategy, the Operator automatically propagates the changes to your control plane configuration.
+
+** For clusters that are configured to use the `OnDelete` update strategy, you must replace your control plane machines manually.
+endif::scale-host[]
+
+ifeval::["{context}" == "recommended-control-plane-practices"]
+:!scale-host:
+endif::[]
+ifeval::["{context}" == "cpmso-using"]
+:!cpmso-using:
+endif::[]

--- a/modules/cpmso-creating-cr.adoc
+++ b/modules/cpmso-creating-cr.adoc
@@ -65,7 +65,7 @@ $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 Before you activate the CR, you must ensure that its configuration is correct for your cluster requirements.
 ====
 <3> Specify the update strategy for the cluster. Valid values are `OnDelete` and `RollingUpdate`. The default value is `RollingUpdate`. For more information about update strategies, see "Updating the control plane configuration".
-<4> Specify your cloud provider platform name. Valid values are `AWS`, `Azure`, `GCP`, `Nutanix`, and `VSphere`.
+<4> Specify your cloud provider platform name. Valid values are `AWS`, `Azure`, `GCP`, `Nutanix`, `VSphere`, and `{rh-openstack}`.
 <5> Add the `<platform_failure_domains>` configuration for the cluster. The format and values of this section are provider-specific. For more information, see the sample failure domain configuration for your cloud provider.
 +
 [NOTE]

--- a/modules/cpmso-failure-domains-provider.adoc
+++ b/modules/cpmso-failure-domains-provider.adoc
@@ -33,6 +33,10 @@ The control plane machine set concept of a failure domain is analogous to existi
 |VMware vSphere
 |
 |Not applicable
+
+|{rh-openStack-first}
+|X
+|link:https://docs.openstack.org/nova/latest/admin/availability-zones.html[{rh-openStack} Compute Availability Zones] and link:https://docs.openstack.org/cinder/latest/admin/availability-zone-type.html[{rh-openStack} Block Storage Availability Zones]
 |====
 [.small]
 --

--- a/modules/cpmso-openstack-with-az-config.adoc
+++ b/modules/cpmso-openstack-with-az-config.adoc
@@ -1,0 +1,77 @@
+// Module included in the following assemblies:
+//
+// * machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
+
+:_content-type: PROCEDURE
+[id="cpmso-openstack-with-az-config_{context}"]
+= Configuring {rh-openstack} with availability zones
+
+If you upgrade a cluster on {rh-openstack-first} from version 4.13 to 4.14 that uses root volumes with Availability Zones (AZs), you must manually configure machine plane machine resources to use control plane machine sets.
+
+If you are starting with the {product-title} cluster, version 4.14, this process is done automatically. If you are  upgrading and if the masters are deployed on multiple AZs, follow the steps.
+
+For the clusters deployed before the {product-title} version 4.14, the Installer correctly sets the same server group for all the masters, regardless of the number of AZs. Two of the three masters have an invalid `ServerGroup` in their Machine `ProviderSpec`.
+
+[NOTE]
+====
+Manually editing control plane machine resources does not update the control plane instances. However, it is necessary in order for the `cluster-control-plane-machine-set-operator` to correctly generate a `ControlPlaneMachineSet` (CPMS) for your cluster.
+====
+
+. Update the `ProviderSpec` for both `master-1` and `master-2` by setting the property `serverGroupName` of `spec.providerSpec` to the value of `master-0` `spec.providerSpec.serverGroupName`:
++
+[source,terminal]
+----
+$ oc edit machine/<cluster_id>-master-1 -n openshift-machine-api
+<make edits>
+$ oc edit machine/<cluster_id>-master-2 -n openshift-machine-api
+<make edits>
+----
++
+[source,yaml]
+----
+providerSpec:
+  value:
+    apiVersion: machine.openshift.io/v1alpha1
+    availabilityZone: az0
+      cloudName: openstack
+    cloudsSecret:
+      name: openstack-cloud-credentials
+      namespace: openshift-machine-api
+    flavor: m1.xlarge
+    image: rhcos-4.14
+    kind: OpenstackProviderSpec
+    metadata:
+      creationTimestamp: null
+    networks:    
+    - filter: {}
+      subnets:  
+      - filter:
+          name: refarch-lv7q9-nodes
+          tags: openshiftClusterID=refarch-lv7q9
+    securityGroups:
+    - filter: {}
+      name: refarch-lv7q9-master
+    serverGroupName: refarch-lv7q9-master-az0 <1>
+    serverMetadata:
+      Name: refarch-lv7q9-master
+      openshiftClusterID: refarch-lv7q9
+    tags:
+    - openshiftClusterID=refarch-lv7q9
+    trunk: true
+    userDataSecret:
+      name: master-user-data
+----
+<1> Change the value.
+
+. In case you updated your control plane machine resources after install, follow these steps. 
+* In your {rh-openstack} cluster, find the AZ of the root volumes for your control plane machines and set it in the `availabilityZone` property of all the control plane machines.
+
+After all the three control plane Machine resources have the same correct ServerGroupName, your control plane is ready to be managed by the cluster CPMS Operator. The Operator will generate a CPMS for you.
+
+. You can review the generated CPMS and set it to `Active` when it is ready:
++
+[source,terminal]
+----
+$ oc describe controlplanemachineset.machine.openshift.io/cluster --namespace openshift-machine-api
+$ oc edit controlplanemachineset.machine.openshift.io/cluster --namespace openshift-machine-api
+----

--- a/modules/cpmso-openstack-without-az-config.adoc
+++ b/modules/cpmso-openstack-without-az-config.adoc
@@ -1,0 +1,74 @@
+// Module included in the following assemblies:
+//
+// * machine_management/control_plane_machine_management/cpmso-troubleshooting.adoc
+
+:_content-type: PROCEDURE
+[id="cpmso-openstack-ts-az-config_{context}"]
+= Configuring {rh-openstack} clusters without availability zones
+
+If you upgrade a cluster on {rh-openstack-first} from version 4.13 to 4.14 that uses root volumes with availability zones, you must manually configure machine plane machine resources to use control plane machine sets.
+
+If you are starting with the {product-title} cluster, version 4.14, this process is done automatically. If you are  upgrading, follow the steps.
+
+This makes the root volume availability zone to be taken from the compute availability zone, which is not available in cinder. The control plane machine cannot be created. 
+
+For the clusters deployed before the {product-title} version 4.14, you need to manually update the control plane machine resources, so that they are updated on the instances.
+
+[NOTE]
+====
+Manually editing control plane machine resources does not update the control plane instances. However, it is necessary in order for the `cluster-control-plane-machine-set-operator` to correctly generate a `ControlPlaneMachineSet` (CPMS) for your cluster.
+====
+
+. Update the `ProviderSpec`, for all the control plane machines matching the environment, and set the property `rootVolume.availabilityZone` of `spec.providerSpec` to the value of the actual volume AZ (example with `master-0`):
++
+[source,terminal]
+----
+$ oc edit machine/<cluster_id>-master-0 -n openshift-machine-api
+<make edits>
+----
++
+[source,yaml]
+----
+providerSpec:
+  value:
+    apiVersion: machine.openshift.io/v1alpha1
+    availabilityZone: az0
+      cloudName: openstack
+    cloudsSecret:
+      name: openstack-cloud-credentials
+      namespace: openshift-machine-api
+    flavor: m1.xlarge
+    image: rhcos-4.14
+    kind: OpenstackProviderSpec
+    metadata:
+      creationTimestamp: null
+    networks:    
+    - filter: {}
+      subnets:  
+      - filter:
+          name: refarch-lv7q9-nodes
+          tags: openshiftClusterID=refarch-lv7q9
+    rootVolume:
+        availabilityZone: nova <1>
+        diskSize: 30
+        sourceUUID: rhcos-4.12
+        volumeType: fast-0
+    securityGroups:
+    - filter: {}
+      name: refarch-lv7q9-master
+    serverGroupName: refarch-lv7q9-master
+    serverMetadata:
+      Name: refarch-lv7q9-master
+      openshiftClusterID: refarch-lv7q9
+    tags:
+    - openshiftClusterID=refarch-lv7q9
+    trunk: true
+    userDataSecret:
+      name: master-user-data
+----
+<1> Add the zone name.
+
+. In case you updated your control plane machine resources after install, follow these steps. 
+* In your {rh-openstack} cluster, find the AZ of the root volumes for your control plane machines and set it in the `availabilityZone` property of all the control plane machines.
+
+After all of the control plane machines have a root volume availability zone, your control plane is ready to be managed by the Cluster Control Plane Machine Set Operator. The Operator will generate a control plane machine set for you.

--- a/modules/cpmso-yaml-failure-domain-openstack.adoc
+++ b/modules/cpmso-yaml-failure-domain-openstack.adoc
@@ -1,0 +1,24 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-configuration.adoc
+
+:_content-type: REFERENCE
+[id="cpmso-yaml-failure-domain-openstack_{context}"]
+= Sample {rh-openStack} failure domain configuration
+
+The control plane machine set concept of a failure domain is analogous to existing {rh-openstack-first} concept of an link:https://docs.openstack.org/cinder/latest/admin/availability-zone-type.html[_Availability Zone (AZ)_]. The `ControlPlaneMachineSet` CR spreads control plane machines across multiple failure domains when possible. 
+
+When configuring {rh-openstack} failure domains in the control plane machine set, you must specify the availability zone name and the subnet to use. 
+
+.Sample OpenStack failure domain values
+[source,yaml]
+----
+failureDomains:
+  openstack:
+  - placement:
+      availabilityZone: az0 <1>
+      rootVolume:
+          availabilityZone: az0
+          volumeType: tripleo
+----
+<1> Specifies an {rh-openstack} availability zone for the first failure domain.

--- a/modules/cpmso-yaml-provider-spec-openstack.adoc
+++ b/modules/cpmso-yaml-provider-spec-openstack.adoc
@@ -1,0 +1,48 @@
+// Module included in the following assemblies:
+//
+// * machine_management/cpmso-configuration.adoc
+
+:_content-type: REFERENCE
+[id="cpmso-yaml-provider-spec-openstack_{context}"]
+= Sample {rh-openstack} provider specification
+
+When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane machine custom resource (CR) that is created by the installation program.
+
+.Sample OpenStack `providerSpec` values
+[source,yaml]
+----
+providerSpec:
+  value:
+    apiVersion: machine.openshift.io/v1alpha1
+    cloudName: openstack
+    cloudsSecret:
+      name: openstack-cloud-credentials <1>
+      namespace: openshift-machine-api
+    flavor: m1.xlarge <2>
+    image: ocp1-2g2xs-rhcos
+    kind: OpenstackProviderSpec <3>
+    metadata:
+      creationTimestamp: null
+    networks:
+    - filter: {}
+      subnets:
+      - filter:
+          name: ocp1-2g2xs-nodes
+          tags: openshiftClusterID=ocp1-2g2xs
+    securityGroups:
+    - filter: {}
+      name: ocp1-2g2xs-master <4>
+    serverGroupName: ocp1-2g2xs-master
+    serverMetadata:
+      Name: ocp1-2g2xs-master
+      openshiftClusterID: ocp1-2g2xs
+    tags:
+    - openshiftClusterID=ocp1-2g2xs
+    trunk: true
+    userDataSecret:
+      name: master-user-data
+----
+<1> Specifies the secret name for the cluster. Do not change this value.
+<2> Specifies the {rh-openstack} flavor type for the control plane.
+<3> Specifies the {rh-openstack} cloud provider platform type. Do not change this value.
+<4> Specifies the control plane machines security group.


### PR DESCRIPTION
Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OSDOCS6989](https://issues.redhat.com/browse/OSDOCS-6989)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
- [Limitations](https://64454--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-about#cpmso-limitations_cpmso-about)
- [Supported cloud providers](https://64454--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-getting-started#cpmso-platform-matrix_cpmso-getting-started)
- [Creating a control plane machine set custom resource ](https://64454--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-getting-started#cpmso-creating-cr_cpmso-getting-started)
- [Sample Yaml for configuring OpenStack clusters](https://64454--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-configuration#cpmso-sample-yaml-openstack_cpmso-configuration)
- [Enabling OpenStack features for control plane machines](https://64454--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-using#cpmso-supported-features-openstack_cpmso-using)
- [Changing he OpenStack Nova Flavor by using a control plane machine set](https://64454--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-using#cpms-changing-openstack-flavor-type_cpmso-using)
- [Failure domain  platform support and configuration](https://64454--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-resiliency#cpmso-failure-domains-provider_cpmso-resiliency)
- [Configuring OpenStack without availability zones](https://64454--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-troubleshooting#cpmso-openstack-ts-az-config_cpmso-troubleshooting)
- [Configuring OpenStack with availability zones](https://64454--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-troubleshooting#cpmso-openstack-with-az-config_cpmso-troubleshooting)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
