### PR TITLE
[SRVOCF-536] Add steps on configuring pipelines-as-code for a function

### DIFF
--- a/modules/serverless-functions-creating-on-cluster-builds.adoc
+++ b/modules/serverless-functions-creating-on-cluster-builds.adoc
@@ -18,7 +18,7 @@ You can use the Knative (`kn`) CLI to initiate a function project build and then
 
 .Procedure
 
-. In each namespace where you want to run {pipelines-shortname} and deploy a function, you must create the following resources:
+. Create the following resources:
 
 .. Create the `s2i` Tekton task to be able to use Source-to-Image in the pipeline:
 +
@@ -40,23 +40,6 @@ $ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func
 ----
 $ kn func create <function_name> -l <runtime>
 ----
-
-. After you have created a new function project, you must add the project to a Git repository and ensure that the repository is available to the cluster. Information about this Git repository is used to update the `func.yaml` file in the next step.
-
-. Update the configuration in the `func.yaml` file for your function project to enable on-cluster builds for the Git repository:
-+
-[source,yaml]
-----
-...
-git:
-  url: <git_repository_url> <1>
-  revision: main <2>
-  contextDir: <directory_path> <3>
-...
-----
-<1> Required. Specify the Git repository that contains your function's source code.
-<2> Optional. Specify the Git repository revision to be used. This can be a branch, tag, or commit.
-<3> Optional. Specify the function's directory path if the function is not located in the Git repository root folder.
 
 . Implement the business logic of your function. Then, use Git to commit and push the changes.
 
@@ -81,3 +64,27 @@ Please provide credentials for image registry used by Pipeline.
 ----
 
 . To update your function, commit and push new changes by using Git, then run the `kn func deploy --remote` command again.
+
+. Optional. You can configure your function to be built on the cluster after every Git push by using pipelines-as-code:
+
+.. Generate the Tekton `Pipelines` and `PipelineRuns` configuration for your function:
++
+[source,terminal]
+----
+$ kn func config git set
+----
++
+Apart from generating configuration files, this command connects to the cluster and validates that the pipeline is installed. By using the token, it also creates, on behalf of the user, a webhook on the function repository. That webhook triggers the pipeline on the cluster every time changes are pushed to the repository.
++
+You need to have a valid GitHub personal access token with the repository access to use this command.
+
+.. Commit and push the generated `.tekton/pipeline.yaml` and `.tekton/pipeline-run.yaml` files:
++
+[source,terminal]
+----
+$ git add .tekton/pipeline.yaml .tekton/pipeline-run.yaml
+$ git commit -m 'Add the Pipelines and PipelineRuns configuration'
+$ git push
+----
+
+.. After you make a change to your function, commit and push it. The function is rebuilt automatically by using the created pipeline.


### PR DESCRIPTION
Version(s):
`serverless-docs-1.29`+

Issue:
https://issues.redhat.com/browse/SRVOCF-536

Link to docs preview:
https://64455--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-on-cluster-builds#serverless-functions-creating-on-cluster-builds_serverless-functions-on-cluster-builds

QE review:
- [ ] QE has approved this change.