### PR TITLE
OCPBUGS-18653: OpenStack: Remove mentions of OSP 16.1

### DIFF
--- a/modules/installation-osp-setting-cloud-provider-options.adoc
+++ b/modules/installation-osp-setting-cloud-provider-options.adoc
@@ -47,7 +47,7 @@ monitor-max-retries = 1 <6>
 ----
 <1> This property sets the Octavia provider that your load balancer uses. It accepts `"ovn"` or `"amphora"` as values. If you choose to use OVN, you must also set `lb-method` to `SOURCE_IP_PORT`.
 <2> This property is required if you want to use multiple external networks with your cluster. The cloud provider creates floating IP addresses on the network that is specified here.
-<3> This property controls whether the cloud provider creates health monitors for Octavia load balancers. Set the value to `True` to create health monitors. As of {rh-openstack} 16.1 and 16.2, this feature is only available for the Amphora provider.
+<3> This property controls whether the cloud provider creates health monitors for Octavia load balancers. Set the value to `True` to create health monitors. As of {rh-openstack} 16.2, this feature is only available for the Amphora provider.
 <4> This property sets the frequency with which endpoints are monitored. The value must be in the `time.ParseDuration()` format. This property is required if the value of the `create-monitor` property is `True`.
 <5> This property sets the time that monitoring requests are open before timing out. The value must be in the `time.ParseDuration()` format. This property is required if the value of the `create-monitor` property is `True`.
 <6> This property defines how many successful monitoring requests are required before a load balancer is marked as online. The value must be an integer. This property is required if the value of the `create-monitor` property is `True`.
@@ -60,7 +60,7 @@ Prior to saving your changes, verify that the file is structured correctly. Clus
 +
 [IMPORTANT]
 ====
-You must set the value of the `create-monitor` property to `True` if you use services that have the value of the `.spec.externalTrafficPolicy` property set to `Local`. The OVN Octavia provider in {rh-openstack} 16.1 and 16.2 does not support health monitors. Therefore, services that have `ETP` parameter values set to `Local` might not respond when the `lb-provider` value is set to `"ovn"`.
+You must set the value of the `create-monitor` property to `True` if you use services that have the value of the `.spec.externalTrafficPolicy` property set to `Local`. The OVN Octavia provider in {rh-openstack} 16.2 does not support health monitors. Therefore, services that have `ETP` parameter values set to `Local` might not respond when the `lb-provider` value is set to `"ovn"`.
 ====
 +
 [IMPORTANT]

--- a/modules/nw-ingress-controller-configuration-parameters.adoc
+++ b/modules/nw-ingress-controller-configuration-parameters.adoc
@@ -70,7 +70,7 @@ spec:
 +
 [NOTE]
 ====
-On {rh-openstack-first}, the `LoadBalancerService` endpoint publishing strategy is only supported if a cloud provider is configured to create health monitors. For {rh-openstack} 16.1 and 16.2, this strategy is only possible if you use the Amphora Octavia provider.
+On {rh-openstack-first}, the `LoadBalancerService` endpoint publishing strategy is only supported if a cloud provider is configured to create health monitors. For {rh-openstack} 16.2, this strategy is only possible if you use the Amphora Octavia provider.
 
 For more information, see the "Setting cloud provider options" section of the {rh-openstack} installation documentation.
 ====

--- a/modules/nw-osp-loadbalancer-etp-local.adoc
+++ b/modules/nw-osp-loadbalancer-etp-local.adoc
@@ -9,6 +9,6 @@ You can set the external traffic policy (ETP) parameter, `.spec.externalTrafficP
 
 Having the `ETP` option set to `Local` requires that health monitors be created for the load balancer. Without health monitors, traffic can be routed to a node that doesn't have a functional endpoint, which causes the connection to drop. To force Cloud Provider OpenStack to create health monitors, you must set the value of the `create-monitor` option in the cloud provider configuration to `true`.
 
-In {rh-openstack} 16.1 and 16.2, the OVN Octavia provider does not support health monitors. Therefore, setting the ETP to local is unsupported.
+In {rh-openstack} 16.2, the OVN Octavia provider does not support health monitors. Therefore, setting the ETP to local is unsupported.
 
-In {rh-openstack} 16.1 and 16.2, the Amphora Octavia provider does not support HTTP monitors on UDP pools. As a result, UDP load balancer services have `UDP-CONNECT` monitors created instead. Due to implementation details, this configuration only functions properly with the OVN-Kubernetes CNI plugin. When the OpenShift SDN CNI plugin is used, the UDP services alive nodes are detected unreliably.
+In {rh-openstack} 16.2, the Amphora Octavia provider does not support HTTP monitors on UDP pools. As a result, UDP load balancer services have `UDP-CONNECT` monitors created instead. Due to implementation details, this configuration only functions properly with the OVN-Kubernetes CNI plugin. When the OpenShift SDN CNI plugin is used, the UDP services alive nodes are detected unreliably.

--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -13,7 +13,7 @@ In {product-title} {product-version}, you can install a cluster that uses instal
 * Google Cloud Platform (GCP)
 * Microsoft Azure
 * Microsoft Azure Stack Hub
-* {rh-openstack-first} versions 16.1 and 16.2
+* {rh-openstack-first}
 ** The latest {product-title} release supports both the latest {rh-openstack} long-life release and intermediate release. For complete {rh-openstack} release compatibility, see the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 * IBM Cloud VPC
 * Nutanix
@@ -37,7 +37,8 @@ In {product-title} {product-version}, you can install a cluster that uses user-p
 * Azure
 * Azure Stack Hub
 * GCP
-* {rh-openstack} versions 16.1 and 16.2
+* {rh-openstack}
+** The latest {product-title} release supports both the latest {rh-openstack} long-life release and intermediate release. For complete {rh-openstack} release compatibility, see the link:https://access.redhat.com/articles/4679401[{product-title} on {rh-openstack} support matrix].
 * VMware vSphere
 * VMware Cloud on AWS
 * Bare metal


### PR DESCRIPTION
OSP 16.1 is not supported since OCP 4.12. This commit removes mentions of it and removes explicit listing of OSP versions from the Supported Platforms page that was confusing. Instead, just the link to the compatibility matrix [1] is left.

[1] https://access.redhat.com/articles/4679401

Version(s):
4.14, 4.13, 4.12

Issue:
[OCPBUGS-18653
](https://issues.redhat.com/browse/OCPBUGS-18653)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
