### PR TITLE
OCPBUGS#13393: Updated GCP Confidential VMs known issue in RN doc

### DIFF
--- a/modules/installation-gcp-enabling-confidential-vms.adoc
+++ b/modules/installation-gcp-enabling-confidential-vms.adoc
@@ -20,7 +20,7 @@ include::snippets/technology-preview.adoc[]
 
 [IMPORTANT]
 ====
-Due to a known issue, you cannot use persistent volume storage on a cluster with Confidential VMs. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-7582[OCPBUGS-7582].
+Due to a known issue in {product-title} 4.13.3 and earlier versions, you cannot use persistent volume storage on a cluster with Confidential VMs on Google Cloud Platform (GCP). This issue was resolved in {product-title} 4.13.4. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-11768[OCPBUGS-11768].
 ====
 
 .Prerequisites

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -172,7 +172,7 @@ In {product-title} {product-version}, you can use Confidential VMs when installi
 
 [IMPORTANT]
 ====
-Due to a known issue, you cannot use persistent volume storage on a cluster with Confidential VMs. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-7582[OCPBUGS-7582].
+Due to a known issue in {product-title} 4.13.3 and earlier versions, you cannot use persistent volume storage on a cluster with Confidential VMs on Google Cloud Platform (GCP). This issue was resolved in {product-title} 4.13.4. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-11768[OCPBUGS-11768].
 ====
 
 [id="ocp-4-13-installation-aws-local-zones"]
@@ -2999,6 +2999,10 @@ You can view the container images in this release by running the following comma
 $ oc adm release info 4.13.4 --pullspecs
 ----
 
+[id="ocp-4-13-4-bug-fixes"]
+==== Bug fixes
+* Previously, you could not use persistent volume storage on a cluster with Confidential virtual machines (VMs) on Google Cloud Platform (GCP). This issue persists with {product-title} 4.13.3 and earlier versions. From {product-title} 4.13.4 and later versions, you can now use persistent volume storage on a cluster with Confidential VMs on GCP. (link:https://issues.redhat.com/browse/OCPBUGS-11768[*OCPBUGS-11768*])
+
 [id="ocp-4-13-4-updating"]
 ==== Updating
 
@@ -3022,7 +3026,7 @@ $ oc adm release info 4.13.5 --pullspecs
 
 [id="ocp-4-13-5-bug-fixes"]
 ==== Bug fixes
-* Previosly, the Gateway API feature did not provide DNS records with a trailing dot for the Gateway domain. This caused the status of the DNS record to never become available on the GCP platform. With this update, the DNS records for Gateway API Gateways are properly provisioned and the Gateway API feature works on GCP because the gateway service dns controller now adds a trailing dot if it is missing in the domain. (link:https://issues.redhat.com/browse/OCPBUGS-15434[*OCPBUGS-15434*])
+* Previously, the Gateway API feature did not provide DNS records with a trailing dot for the Gateway domain. This caused the status of the DNS record to never become available on the GCP platform. With this update, the DNS records for Gateway API Gateways are properly provisioned and the Gateway API feature works on GCP because the gateway service dns controller now adds a trailing dot if it is missing in the domain. (link:https://issues.redhat.com/browse/OCPBUGS-15434[*OCPBUGS-15434*])
 
 * Previously, if you used the *Pipelines* page of the *Developer* console to add a repository, and you entered a GitLab or Bitbucket Pipelines as Code repository URL as the *Git Repo URL*, the created `Repository` resource was invalid. This was caused by a missing schema issue in the `git_provider.url` spec, which is now fixed. (link:https://issues.redhat.com/browse/OCPBUGS-15410[*OCPBUGS-15410*])
 


### PR DESCRIPTION
[OCPBUGS-13393](https://issues.redhat.com/browse/OCPBUGS-13393)

Version(s):
4.13

Link to docs preview:
* [Installing a cluster on GCP using Confidential VMs](https://64472--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-installation-gcp-confidential-vms)
* [OpenShift Container Platform 4.13.4 bug fix and security update](https://64472--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-4)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
