### PR TITLE
OCPBUGS#18560: Added important vSphere note about AD username integra…

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -429,6 +429,14 @@ ifdef::vsphere[]
 .. Specify the user name and password for the vCenter account that has the required permissions to create the cluster.
 +
 The installation program connects to your vCenter instance.
++
+[IMPORTANT]
+====
+Some VMware vCenter Single Sign-On (SSO) environments with Active Directory (AD) integration might primarily require you to use the traditional login method, which requires the `<domain>\` construct.
+
+To ensure that vCenter account permission checks complete properly, consider using the User Principal Name (UPN) login method, such as `<username>@<fully_qualified_domainname>`.
+====
+
 .. Select the data center in your vCenter instance to connect to.
 .. Select the default vCenter datastore to use.
 +


### PR DESCRIPTION
[OCPBUGS-18560](https://issues.redhat.com/browse/OCPBUGS-18560)

Version(s):
4.14 through to 4.10

Link to docs preview:
[Deploying the cluster: step 2d](https://64480--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned#installation-launching-installer_installing-vsphere-installer-provisioned)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
