### PR TITLE
Updates cluster capabilities docs with optional IR disablement

### DIFF
--- a/installing/cluster-capabilities.adoc
+++ b/installing/cluster-capabilities.adoc
@@ -80,6 +80,12 @@ include::modules/cluster-samples-operator.adoc[leveloffset=+2]
 .Additional resources
 * xref:../openshift_images/configuring-samples-operator.adoc#configuring-samples-operator[Configuring the Cluster Samples Operator]
 
+include::modules/cluster-image-registry-operator.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../registry/configuring-registry-operator.adoc#configuring-registry-operator[Image Registry Operator in {product-title}]
+
 [role="_additional-resources"]
 [id="additional-resources_{context}"]
 == Additional resources

--- a/modules/cluster-image-registry-operator.adoc
+++ b/modules/cluster-image-registry-operator.adoc
@@ -1,12 +1,27 @@
 // Module included in the following assemblies:
 //
 // * operators/operator-reference.adoc
+// * installing/cluster-capabilities.adoc
+
+// operators/operator-reference.adoc
+ifeval::["{context}" == "cluster-operators-ref"]
+:operator-ref:
+endif::[]
+
+// installing/cluster-capabilities.adoc
+ifeval::["{context}" == "cluster-capabilities"]
+:cluster-caps:
+endif::[]
 
 [id="cluster-image-registry-operator_{context}"]
 = Cluster Image Registry Operator
 
 [discrete]
 == Purpose
+
+ifdef::cluster-caps[]
+The Cluster Image Registry Operator provides features for the `ImageRegistry` capability.
+endif::[]
 
 The Cluster Image Registry Operator manages a singleton instance of the {product-registry}. It manages all configuration of the registry, including creating storage.
 
@@ -15,6 +30,10 @@ On initial start up, the Operator creates a default `image-registry` resource in
 If insufficient information is available to define a complete `image-registry` resource, then an incomplete resource is defined and the Operator updates the resource status with information about what is missing.
 
 The Cluster Image Registry Operator runs in the `openshift-image-registry` namespace and it also manages the registry instance in that location. All configuration and workload resources for the registry reside in that namespace.
+
+ifdef::cluster-caps[]
+If you disable the `ImageRegistry` capability, you can reduce the overall resource footprint of {product-title} in Telco environments. Depending on your deployment, you can disable this component if you do not need it.
+endif::[]
 
 [discrete]
 == Project

--- a/snippets/capabilities-table.adoc
+++ b/snippets/capabilities-table.adoc
@@ -19,6 +19,9 @@ The following table describes the `baselineCapabilitySet` values.
 |`v4.13`
 |Specify this option when you want to enable the default capabilities for {product-title} 4.13. By specifying `v4.13`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.13 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot` and `NodeTuning`.
 
+|`v4.14`
+|Specify this option when you want to enable the default capabilities for {product-title} 4.14. By specifying `v4.14`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.14 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, and `ImageRegistry`.
+
 // TODO: Add `Build` and `DeploymentConfig` to the list for 4.14.
 
 |`None`


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-7702

Link to docs preview:
https://64481--docspreview.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities

Operators Overview (to show no changes made with ifevals): https://64481--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-image-registry-operator_cluster-operators-ref

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
