### PR TITLE
CNV-28780: RBAC roles for storage

### DIFF
--- a/modules/virt-default-cluster-roles.adoc
+++ b/modules/virt-default-cluster-roles.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * virt/virt-additional-security-privileges-controller-and-launcher.adoc
+// * virt/about_virt/virt-security-policies.adoc
 
 :_content-type: REFERENCE
 [id="default-cluster-roles-for-virt_{context}"]

--- a/modules/virt-storage-rbac-roles.adoc
+++ b/modules/virt-storage-rbac-roles.adoc
@@ -1,0 +1,240 @@
+// Module included in the following assemblies:
+//
+// * virt/about_virt/virt-security-policies.adoc
+
+:_content-type: REFERENCE
+[id="virt-storage-rbac-roles_{context}"]
+= RBAC roles for storage features in {VirtProductName}
+
+The following permissions are granted to the Containerized Data Importer (CDI), including the `cdi-operator` and `cdi-controller` service accounts.
+
+[id="cluster-wide-rbac-roles-cdi"]
+== Cluster-wide RBAC roles
+
+.Aggregated cluster roles for the `cdi.kubevirt.io` API group
+[cols="1,2,1",options="header"]
+|===
+| CDI cluster role
+| Resources  
+| Verbs
+
+.2+.^| `cdi.kubevirt.io:admin`
+.^| `datavolumes`, `uploadtokenrequests`  
+.^| `*` (all)
+
+.^| `datavolumes/source`
+.^| `create`
+
+.2+.^| `cdi.kubevirt.io:edit`
+.^| `datavolumes`, `uploadtokenrequests`  
+.^| `*`
+
+.^| `datavolumes/source`
+.^| `create`
+
+.2+.^| `cdi.kubevirt.io:view`
+.^| `cdiconfigs`, `dataimportcrons`, `datasources`, `datavolumes`, `objecttransfers`, `storageprofiles`, `volumeimportsources`, `volumeuploadsources`, `volumeclonesources` 
+.^| `get`, `list`, `watch`
+
+.^| `datavolumes/source`
+.^| `create`
+
+.^| `cdi.kubevirt.io:config-reader`
+.^| `cdiconfigs`, `storageprofiles`
+.^| `get`, `list`, `watch`
+|===
+
+.Cluster-wide roles for the `cdi-operator` service account
+[cols="1,1,2",options="header"]
+|===
+| API group
+| Resources
+| Verbs
+
+.^| `rbac.authorization.k8s.io`
+.^| `clusterrolebindings`, `clusterroles`
+.^| `get`, `list`, `watch`, `create`, `update`, `delete`
+
+.^| `security.openshift.io`
+.^| `securitycontextconstraints`
+.^| `get`, `list`, `watch`, `update`, `create`
+
+.^| `apiextensions.k8s.io`
+.^| `customresourcedefinitions`, `customresourcedefinitions/status`
+.^| `get`, `list`, `watch`, `create`, `update`, `delete`
+
+.^| `cdi.kubevirt.io`
+.^| `*`
+.^| `*`
+
+.^| `upload.cdi.kubevirt.io`
+.^| `*`
+.^| `*`
+
+.^| `admissionregistration.k8s.io`
+.^| `validatingwebhookconfigurations`, `mutatingwebhookconfigurations`
+.^| `create`, `list`, `watch`
+
+.^| `admissionregistration.k8s.io`
+.^| `validatingwebhookconfigurations`
+
+Allow list: `cdi-api-dataimportcron-validate, cdi-api-populator-validate, cdi-api-datavolume-validate, cdi-api-validate, objecttransfer-api-validate`
+.^| `get`, `update`, `delete`
+
+.^| `admissionregistration.k8s.io`
+.^| `mutatingwebhookconfigurations`
+
+Allow list: `cdi-api-datavolume-mutate`
+.^| `get`, `update`, `delete`
+
+.^| `apiregistration.k8s.io`
+.^| `apiservices`
+.^| `get`, `list`, `watch`, `create`, `update`, `delete`
+|===
+
+.Cluster-wide roles for the `cdi-controller` service account
+[cols="1,1,2",options="header"]
+|===
+| API group
+| Resources
+| Verbs
+
+.^| `""` (core)
+.^| `events`
+.^| `create`, `patch`
+
+.^| `""` (core)
+.^| `persistentvolumeclaims`
+.^| `get`, `list`, `watch`, `create`, `update`, `delete`, `deletecollection`, `patch`
+
+.^| `""` (core)
+.^| `persistentvolumes`
+.^| `get`, `list`, `watch`, `update`
+
+.^| `""` (core)
+.^| `persistentvolumeclaims/finalizers`, `pods/finalizers`
+.^| `update`
+
+.^| `""` (core)
+.^| `pods`, `services`
+.^| `get`, `list`, `watch`, `create`, `delete`
+
+.^| `""` (core)
+.^| `configmaps`
+.^| `get`, `create`
+
+.^| `storage.k8s.io`
+.^| `storageclasses`, `csidrivers`
+.^| `get`, `list`, `watch`
+
+.^| `config.openshift.io`
+.^| `proxies`
+.^| `get`, `list`, `watch`
+
+.^| `cdi.kubevirt.io`
+.^| `*`
+.^| `*`
+
+.^| `snapshot.storage.k8s.io`
+.^| `volumesnapshots`, `volumesnapshotclasses`, `volumesnapshotcontents`
+.^| `get`, `list`, `watch`, `create`, `delete`
+
+.^| `snapshot.storage.k8s.io`
+.^| `volumesnapshots`
+.^| `update`, `deletecollection`
+
+.^| `apiextensions.k8s.io`
+.^| `customresourcedefinitions`
+.^| `get`, `list`, `watch`
+
+.^| `scheduling.k8s.io`
+.^| `priorityclasses`
+.^| `get`, `list`, `watch`
+
+.^| `image.openshift.io`
+.^| `imagestreams`
+.^| `get`, `list`, `watch`
+
+.^| `""` (core)
+.^| `secrets`
+.^| `create`
+
+.^| `kubevirt.io`
+.^| `virtualmachines/finalizers`
+.^| `update`
+|===
+
+[id="namespaced-rbac-roles-cdi"]
+== Namespaced RBAC roles
+
+.Namespaced roles for the `cdi-operator` service account
+[cols="1,1,2",options="header"]
+|===
+| API group
+| Resources
+| Verbs
+
+.^| `rbac.authorization.k8s.io`
+.^| `rolebindings`, `roles`
+.^| `get`, `list`, `watch`, `create`, `update`, `delete`
+
+.^| `""` (core)
+.^| `serviceaccounts`, `configmaps`, `events`, `secrets`, `services`
+.^| `get`, `list`, `watch`, `create`, `update`, `patch`, `delete`
+
+.^| `apps`
+.^| `deployments`, `deployments/finalizers`
+.^| `get`, `list`, `watch`, `create`, `update`, `delete`
+
+.^| `route.openshift.io`
+.^| `routes`, `routes/custom-host`
+.^| `get`, `list`, `watch`, `create`, `update`
+
+.^| `config.openshift.io`
+.^| `proxies`
+.^| `get`, `list`, `watch`
+
+.^| `monitoring.coreos.com`
+.^| `servicemonitors`, `prometheusrules`
+.^| `get`, `list`, `watch`, `create`, `delete`, `update`, `patch`
+
+.^| `coordination.k8s.io`
+.^| `leases`
+.^| `get`, `create`, `update`
+|===
+
+.Namespaced roles for the `cdi-controller` service account
+[cols="1,1,2",options="header"]
+|===
+| API group
+| Resources
+| Verbs
+
+.^| `""` (core)
+.^| `configmaps`
+.^| `get`, `list`, `watch`, `create`, `update`, `delete`
+
+.^| `""` (core)
+.^| `secrets`
+.^| `get`, `list`, `watch`
+
+.^| `batch`
+.^| `cronjobs`
+.^| `get`, `list`, `watch`, `create`, `update`, `delete`
+
+.^| `batch`
+.^| `jobs`
+.^| `create`, `delete`, `list`, `watch`
+
+.^| `coordination.k8s.io`
+.^| `leases`
+.^| `get`, `create`, `update`
+
+.^| `networking.k8s.io`
+.^| `ingresses`
+.^| `get`, `list`, `watch`
+
+.^| `route.openshift.io`
+.^| `routes`
+.^| `get`, `list`, `watch`
+|===

--- a/virt/about_virt/virt-security-policies.adoc
+++ b/virt/about_virt/virt-security-policies.adoc
@@ -16,23 +16,26 @@ Learn about {VirtProductName} security and authorization.
 
 include::modules/virt-about-workload-security.adoc[leveloffset=+1]
 
-include::modules/virt-additional-scc-for-kubevirt-controller.adoc[leveloffset=+1]
+include::modules/virt-automatic-certificates-renewal.adoc[leveloffset=+1]
 
 [id="authorization_virt-security-policies"]
 == Authorization
 
-{VirtProductName} uses xref:../../authentication/using-rbac.adoc#using-rbac[role-based access control] (RBAC) for authorization. For example, an administrator can create an RBAC role that provides the permissions required to launch a virtual machine. The administrator can then restrict access to that feature by binding the role to specific users.
+{VirtProductName} uses xref:../../authentication/using-rbac.adoc#using-rbac[role-based access control] (RBAC) to define permissions for human users and service accounts. The permissions defined for service accounts control the actions that {VirtProductName} components can perform. 
+
+You can also use RBAC roles to manage user access to virtualization features. For example, an administrator can create an RBAC role that provides the permissions required to launch a virtual machine. The administrator can then restrict access by binding the role to specific users.
 
 include::modules/virt-default-cluster-roles.adoc[leveloffset=+2]
 
-[discrete]
+include::modules/virt-storage-rbac-roles.adoc[leveloffset=+2]
+
+include::modules/virt-additional-scc-for-kubevirt-controller.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
-[id="additional-resources_authorization"]
+[id="additional-resources_{context}"]
 == Additional resources
 * xref:../../authentication/managing-security-context-constraints.adoc#security-context-constraints-about_configuring-internal-oauth[Managing security context constraints]
 * xref:../../authentication/using-rbac.adoc#using-rbac[Using RBAC to define and apply permissions]
 * xref:../../authentication/using-rbac.adoc#creating-cluster-role_using-rbac[Creating a cluster role]
 * xref:../../authentication/using-rbac.adoc#cluster-role-binding-commands_using-rbac[Cluster role binding commands]
 * xref:../../virt/virtual_machines/cloning_vms/virt-enabling-user-permissions-to-clone-datavolumes.adoc#virt-enabling-user-permissions-to-clone-datavolumes[Enabling user permissions to clone data volumes across namespaces]
-
-include::modules/virt-automatic-certificates-renewal.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-28780](https://issues.redhat.com//browse/CNV-28780)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: 
- [Security policies assembly (top)](https://64489--docspreview.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-security-policies)
- [New module for storage RBAC roles](https://64489--docspreview.netlify.app/openshift-enterprise/latest/virt/about_virt/virt-security-policies#virt-storage-rbac-roles_virt-security-policies)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
- The API reference formatting is intentional because this is referring to items in `resources`, not API object `Kind` values 
- I am also reorganizing this assembly in an attempt to make it flow more logically
- Restoring assembly-level additional resources section now that there are multiple RBAC-related modules
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
