### PR TITLE
Expand CO docs to not claim compliance based on usage

### DIFF
--- a/security/compliance_operator/compliance-operator-supported-profiles.adoc
+++ b/security/compliance_operator/compliance-operator-supported-profiles.adoc
@@ -4,7 +4,8 @@
 include::_attributes/common-attributes.adoc[]
 :context: compliance-operator-supported-profiles
 
-There are several profiles available as part of the Compliance Operator (CO) installation.
+There are several profiles available as part of the Compliance Operator (CO) installation. While you can use the following profiles to assess gaps in a cluster, usage alone does not infer or guarantee compliance with a particular profile.
+
 
 [IMPORTANT]
 ====


### PR DESCRIPTION
Even though the Compliance Operator comes with multiple profiles, usage of these profiles alone doesn't automatically imply compliance with a particular profile.

This can be confusing to readers, and we can clarify that expectation by highlighting it in the supported profiles documentation.

Version(s):

All supported versions (4.10 - 4.14).

Issue:


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Adding @sheriff-rh for awareness.