### PR TITLE
OSDOCS-3562: Added SRE topics to topic maps.

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -50,8 +50,8 @@ Topics:
       File: policy-responsibility-matrix
     - Name: Understanding process and security for OpenShift Dedicated
       File: policy-process-security
-#    - Name: SRE and service account access
-#      File: osd-sre-access
+    - Name: SRE and service account access
+      File: osd-sre-access
     - Name: About availability for OpenShift Dedicated
       File: policy-understand-availability
     - Name: Update life cycle

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -67,8 +67,8 @@ Topics:
     File: rosa-life-cycle
   - Name: Understanding security for ROSA
     File: rosa-policy-process-security
-#  - Name: SRE and service account access
-#    File: rosa-sre-access
+  - Name: SRE and service account access
+    File: rosa-sre-access
 - Name: About IAM resources for ROSA with STS
   File: rosa-sts-about-iam-resources
 - Name: OpenID Connect Overview

--- a/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
@@ -7,6 +7,7 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 Red Hat site reliability engineering (SRE) access to ROSA clusters is outlined through identity and access management.
 
 include::modules/rosa-policy-identity-access-management.adoc[leveloffset=+1]
+include::modules/sre-cluster-access.adoc[leveloffset=+1]
 include::modules/rosa-sre-access-privatelink-vpc.adoc[leveloffset=+1]
 include::modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:

[OSDOCS-7641](https://issues.redhat.com/browse/OSDOCS-7641)

Link to docs preview:
- [OSD](https://64499--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-sre-access)
- [ROSA](https://64499--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-sre-access)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added the SRE topics to the topic map.