### PR TITLE
OSDOCS-3562: SRE and service account access for ROSA and OSD

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -50,8 +50,8 @@ Topics:
       File: policy-responsibility-matrix
     - Name: Understanding process and security for OpenShift Dedicated
       File: policy-process-security
-#    - Name: SRE and service account access
-#      File: osd-sre-access
+    - Name: SRE and service account access
+      File: osd-sre-access
     - Name: About availability for OpenShift Dedicated
       File: policy-understand-availability
     - Name: Update life cycle

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -67,8 +67,8 @@ Topics:
     File: rosa-life-cycle
   - Name: Understanding security for ROSA
     File: rosa-policy-process-security
-#  - Name: SRE and service account access
-#    File: rosa-sre-access
+  - Name: SRE and service account access
+    File: rosa-sre-access
 - Name: About IAM resources for ROSA with STS
   File: rosa-sts-about-iam-resources
 - Name: OpenID Connect Overview

--- a/modules/rosa-policy-identity-access-management.adoc
+++ b/modules/rosa-policy-identity-access-management.adoc
@@ -57,7 +57,6 @@ When SREs are on a VPN through two-factor authentication, they and Red Hat Suppo
 
 * Viewing CloudTrail logs
 * Shutting down a faulty EC2 Instance
-* Creating EC2 snapshots
 
 All activities performed by SREs arrive from Red Hat IP addresses and are logged to CloudTrail to allow you to audit and review all activity. This role is only used in cases where access to AWS services is required to assist you. The majority of permissions are read-only. However, a select few permissions have more access, including the ability to reboot an instance or spin up a new instance. SRE access is limited to the policy permissions attached to the `ManagedOpenShift-Support-Role`.
 

--- a/osd_architecture/osd_policy/osd-sre-access.adoc
+++ b/osd_architecture/osd_policy/osd-sre-access.adoc
@@ -5,5 +5,8 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 = SRE and service account access
 
 toc::[]
-include::modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc[leveloffset=+1]
+
+include::modules/policy-identity-access-management.adoc[leveloffset=+1]
 include::modules/sre-cluster-access.adoc[leveloffset=+1]
+include::modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc[leveloffset=+1]
+

--- a/osd_architecture/osd_policy/policy-process-security.adoc
+++ b/osd_architecture/osd_policy/policy-process-security.adoc
@@ -9,6 +9,10 @@ toc::[]
 
 include::modules/policy-incident.adoc[leveloffset=+1]
 include::modules/policy-change-management.adoc[leveloffset=+1]
-include::modules/policy-identity-access-management.adoc[leveloffset=+1]
 include::modules/policy-security-regulation-compliance.adoc[leveloffset=+1]
 include::modules/policy-disaster-recovery.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* For more information about Red Hat site reliability engineering (SRE) teams access, see xref:../../osd_architecture/osd_policy/osd-sre-access.adoc#policy-identity-access-management_osd-sre-access[Identity and access management].

--- a/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-policy-responsibility-matrix.adoc
@@ -13,7 +13,6 @@ include::modules/rosa-policy-shared-responsibility.adoc[leveloffset=+1]
 
 include::modules/rosa-policy-incident.adoc[leveloffset=+1]
 include::modules/rosa-policy-change-management.adoc[leveloffset=+1]
-include::modules/rosa-policy-identity-access-management.adoc[leveloffset=+1]
 include::modules/rosa-policy-security-and-compliance.adoc[leveloffset=+1]
 include::modules/rosa-policy-disaster-recovery.adoc[leveloffset=+1]
 
@@ -23,3 +22,8 @@ include::modules/rosa-policy-disaster-recovery.adoc[leveloffset=+1]
 * xref:../../rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc#rosa-nodes-machinepools-about[About machine pools]
 
 include::modules/rosa-policy-customer-responsibility.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+== Additional resources
+
+* For more information about Red Hat site reliability engineering (SRE) teams access, see xref:../../rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc#rosa-policy-identity-access-management_rosa-sre-access[Identity and access management].


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-3562

Link to docs preview:
ROSA: https://64510--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-sre-access
OSD: https://64510--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-sre-access 

QE review:
No QE review required. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
