### PR TITLE
OSDOCS#7638: Added rootvolume.zones parameter mandatory note

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -870,6 +870,10 @@ Additional {rh-openstack} configuration parameters are described in the followin
 |For compute machines, the root volume's type. This property is deprecated and is replaced by `compute.platform.openstack.rootVolume.types`.
 |String, for example, `performance`. ^[2]^
 
+|`compute.platform.openstack.rootVolume.zones`
+|For compute machines, the Cinder availability zone to install root volumes on. If you do not set a value for this parameter, the installation program selects the default availability zone. This parameter is mandatory when `compute.platform.openstack.zones` is defined.
+|A list of strings, for example `["zone-1", "zone-2"]`.
+
 |`controlPlane.platform.openstack.rootVolume.size`
 |For control plane machines, the size in gigabytes of the root volume. If you do not set this value, machines use ephemeral storage.
 |Integer, for example `30`.
@@ -881,6 +885,10 @@ Additional {rh-openstack} configuration parameters are described in the followin
 |`controlPlane.platform.openstack.rootVolume.type`
 |For control plane machines, the root volume's type. This property is deprecated and is replaced by `compute.platform.openstack.rootVolume.types`.
 |String, for example, `performance`. ^[2]^
+
+|`controlPlane.platform.openstack.rootVolume.zones`
+|For control plane machines, the Cinder availability zone to install root volumes on. If you do not set this value, the installation program selects the default availability zone. This parameter is mandatory when `controlPlane.platform.openstack.zones` is defined.
+|A list of strings, for example `["zone-1", "zone-2"]`.
 
 |`platform.openstack.cloud`
 |The name of the {rh-openstack} cloud to use from the list of clouds in the
@@ -928,10 +936,6 @@ Optional {rh-openstack} configuration parameters are described in the following 
 On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
 
-|`compute.platform.openstack.rootVolume.zones`
-|For compute machines, the availability zone to install root volumes on. If you do not set a value for this parameter, the installation program selects the default availability zone.
-|A list of strings, for example `["zone-1", "zone-2"]`.
-
 |`compute.platform.openstack.serverGroupPolicy`
 |Server group policy to apply to the group that will contain the compute machines in the pool. You cannot change server group policies or affiliations after creation. Supported options include `anti-affinity`, `soft-affinity`, and `soft-anti-affinity`. The default value is `soft-anti-affinity`.
 
@@ -955,10 +959,6 @@ Additional networks that are attached to a control plane machine are also attach
 
 On clusters that use Kuryr, {rh-openstack} Octavia does not support availability zones. Load balancers and, if you are using the Amphora provider driver, {product-title} services that rely on Amphora VMs, are not created according to the value of this property.
 |A list of strings. For example, `["zone-1", "zone-2"]`.
-
-|`controlPlane.platform.openstack.rootVolume.zones`
-|For control plane machines,  the availability zone to install root volumes on. If you do not set this value, the installation program selects the default availability zone.
-|A list of strings, for example `["zone-1", "zone-2"]`.
 
 |`controlPlane.platform.openstack.serverGroupPolicy`
 |Server group policy to apply to the group that will contain the control plane machines in the pool. You cannot change server group policies or affiliations after creation. Supported options include `anti-affinity`, `soft-affinity`, and `soft-anti-affinity`. The default value is `soft-anti-affinity`.


### PR DESCRIPTION
Version(s):4.14

Issue: https://issues.redhat.com/browse/OSDOCS-7638

Link to docs preview:
https://64512--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_openstack/installing-openstack-installer-custom#installation-configuration-parameters-additional-osp_installing-openstack-installer-custom

QE review:
- [x] QE has approved this change. @itzikb-redhat 
- [x] SME has approved this change. @EmilienM 