### PR TITLE
OSDOCS-7699: adds release note to MicroShift 4.13

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -255,3 +255,12 @@ Issued: 2023-09-05
 {product-title} release 4.13.11 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:4907[RHBA-2023:4907] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:4905[RHBA-2023:4905] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-12-dp"]
+=== RHBA-2023:5013 - {product-title} 4.13.12 bug fix update
+
+Issued: 2023-09-12
+
+{product-title} release 4.13.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5013[RHBA-2023:5013] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5011[RHBA-2023:5011] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-7699

Link to docs preview:
https://64527--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-12-dp

QE review:
- N/A, no bug fixes

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
