### PR TITLE
OSSM-2423: [DOC] must-gather tool needs to be more specific

### DIFF
--- a/modules/ossm-about-collecting-ossm-data.adoc
+++ b/modules/ossm-about-collecting-ossm-data.adoc
@@ -16,7 +16,7 @@ You can use the `oc adm must-gather` CLI command to collect information about yo
 
 * The {product-title} CLI (`oc`) installed.
 
-.Precedure
+.Procedure
 
 . To collect {SMProductName} data with `must-gather`, you must specify the {SMProductName} image.
 +
@@ -31,3 +31,12 @@ $ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-mus
 ----
 $ oc adm must-gather --image=registry.redhat.io/openshift-service-mesh/istio-must-gather-rhel8:2.4 gather <namespace>
 ----
++
+This creates a local directory that contains the following items: 
+
+* The Istio Operator namespace and its child objects
+* All control plane namespaces and their children objects
+* All namespaces and their children objects that belong to any service mesh
+* All Istio custom resource definitions (CRD)
+* All Istio CRD objectsm such as VirtualServices in a given namespace
+* All Istio webhooks


### PR DESCRIPTION
[OSSM-2423](https://issues.redhat.com//browse/OSSM-2423): [DOC] must-gather tool needs to be more specific about gather for specific namespace

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSSM-2423

Link to docs preview:
https://64534--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-troubleshooting-istio#ossm-about-collecting-ossm-data_troubleshooting-ossm

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
