### PR TITLE
OSDOCS#7318: Updating multi-arch compute machines bare metal docs for GA

### DIFF
--- a/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc
+++ b/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
 :context: creating-multi-arch-compute-nodes-bare-metal
 [id="creating-multi-arch-compute-nodes-bare-metal"]
-= Creating a cluster with multi-architecture compute machine on bare metal (Technology Preview)
+= Creating a cluster with multi-architecture compute machine on bare metal
 include::_attributes/common-attributes.adoc[]
 
 toc::[]
@@ -11,9 +11,6 @@ To create a cluster with multi-architecture compute machines on bare metal, you 
 Before you can add 64-bit ARM nodes to your bare metal cluster, you must upgrade your cluster to one that uses the multi-architecture payload. For more information on migrating to the multi-architecture payload, see xref:../../updating/updating_a_cluster/migrating-to-multi-payload.adoc#migrating-to-multi-payload[Migrating to a cluster with multi-architecture compute machines].
 
 The following procedures explain how to create a {op-system} compute machine using an ISO image or network PXE booting. This will allow you to add ARM64 nodes to your bare metal cluster and deploy a cluster with multi-architecture compute machines.
-
-:Featurename: Clusters with multi-architecture compute machines on bare metal user-provisioned installations
-include::snippets/technology-preview.adoc[leveloffset=+1]
 
 include::modules/multi-architecture-verifying-cluster-compatibility.adoc[leveloffset=+1]
 


### PR DESCRIPTION
**Version(s):** 4.14+ 
**Issue:** [OSDOCS-7318](https://issues.redhat.com//browse/OSDOCS-7318)

**Description:** Removes tech preview labels for bare metal GA in 4.14

**Link to docs preview:**
[Creating a cluster with multi-architecture compute machine on bare metal ](https://64536--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-bare-metal)

**QE review:**
- [x] QE approved