### PR TITLE
OSDOCS-7212: Machine configs are processed in order of their name

### DIFF
--- a/modules/machine-config-overview.adoc
+++ b/modules/machine-config-overview.adoc
@@ -9,6 +9,8 @@
 
 The Machine Config Operator (MCO) manages updates to systemd, CRI-O and Kubelet, the kernel, Network Manager and other system features. It also offers a `MachineConfig` CRD that can write configuration files onto the host (see link:https://github.com/openshift/machine-config-operator#machine-config-operator[machine-config-operator]). Understanding what MCO does and how it interacts with other components is critical to making advanced, system-level changes to an {product-title} cluster. Here are some things you should know about MCO, machine configs, and how they are used:
 
+* Machine configs are processed alphabetically, in lexicographically increasing order, of their name. The render controller uses the first machine config in the list as the base and appends the rest to the base machine config.
+
 * A machine config can make a specific change to a file or service on the operating system of each system representing a pool of {product-title} nodes.
 
 * MCO applies changes to operating systems in pools of machines. All {product-title} clusters start with worker and control plane node pools. By adding more role labels, you can configure custom pools of nodes. For example, you can set up a custom pool of worker nodes that includes particular hardware features needed by an application. However, examples in this section focus on changes to the default pool types.
@@ -50,7 +52,7 @@ The kinds of components that MCO can change include:
 +
 [IMPORTANT]
 ====
-* Changing SSH keys by using a machine config is supported only for the `core` user. 
+* Changing SSH keys by using a machine config is supported only for the `core` user.
 * Adding new users by using a machine config is not supported.
 ====
 * **kernelArguments**: Add arguments to the kernel command line when {product-title} nodes boot.


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-7212

Link to docs preview:
https://64537--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks#machine-config-overview-post-install-machine-configuration-tasks