### PR TITLE
Support removal of OpenShift Default Registry RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -601,6 +601,11 @@ Kubernetes 1.27 removed the following deprecated API, so you must migrate manife
 
 |===
 
+[id="ocp-4-14-openshift-default-registry"]
+==== Removal of the OPENSHIFT_DEFAULT_REGISTRY 
+
+{product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups. 
+
 [id="ocp-4-14-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7709

Link to docs preview:
https://64546--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-openshift-default-registry

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
