### PR TITLE
add grub password procedure

### DIFF
--- a/modules/rhcos-setting-grub-password-day-2.adoc
+++ b/modules/rhcos-setting-grub-password-day-2.adoc
@@ -1,0 +1,169 @@
+// Module included in the follow assemblies:
+//
+// * post_installation_configuration/machine-configuration-tasks.adoc
+
+:_content-type: PROCEDURE
+[id="rhcos-setting-grub-password-day-2_{context}"]
+= Setting a GRUB password on {op-system}
+
+:FeatureName: GRUB password management
+include::snippets/technology-preview.adoc[]
+
+On clusters installed with {product-title} 4.14 and above, you can set up a password to prevent unauthorized users from accessing the GRUB command line, modify kernel command-line arguments, or boot non-default OSTree deployments.
+
+.Prerequisites
+
+* You have a running {product-title} cluster.
+* You are logged in as a cluster administrator.
+* You installed the OpenShift CLI (`oc`).
+* You installed the `butane` utility.
+* You installed the `grub2-tools-minimal` package.
+
+.Procedure
+
+. Create a password hash for GRUB using the `grub2-mkpasswd-pbkdf2` command line tool:
++
+[source,terminal]
+----
+$ grub2-mkpasswd-pbkdf2
+Enter password:
+Reenter password:
+PBKDF2 hash of your password is
+grub.pbkdf2.sha512.10000.5AE6255...
+----
++
+[NOTE]
+====
+It is recommended to rotate your GRUB password regularly and perform the following steps with both the updated password and the date it was updated.
+====
+
+. Create a script that validates your configurations and sets the GRUB config for the root user with the newly created password:
++
+.rhcos_set_grub_password.sh
+[source,bash]
+----
+#!/bin/bash
+set -euo pipefail
+
+STAMPFILE="/var/lib/.grub_password_<date_changed>"
+GRUBPASSWORD="grub.pbkdf2.sha512.10000.58E6255..."
+
+main () {
+
+  # Validate GRUB config
+  if [[ $(grep -c 'source $prefix/user.cfg' '/boot/grub2/grub.cfg') != 1 ]]; then
+    echo "Invalid GRUB config: Missing user.cfg"
+    return 1
+  fi
+
+  # Validate ostree repo config
+  if [[ $(grep -c 'bls-append-except-default=grub_users=""' '/sysroot/ostree/repo/config') != 1 ]]; then
+    echo "Invalid ostree repo config: Missing bls-append-except-default"
+    return 1
+  fi
+
+  # Remount /boot as RW
+  mount -o remount,rw /boot
+
+  # Write config
+  echo -e "set superusers=\"root\"\npassword_pbkdf2 root ${GRUBPASSWORD}" > /boot/grub2/user.cfg
+  chmod 400 /boot/grub2/user.cfg
+
+  # Write stamp file
+  touch "${STAMPFILE}"
+
+}
+
+main "${@}"
+----
+
+. Create a systemd service unit that launches the script on boot:
++
+.rhcos-set-grub-password.service
+[source,text]
+----
+[Unit]
+Description=Set GRUB password
+ConditionPathExists=!/var/lib/.grub_password_<date_changed>
+RequiresMountsFor=/boot
+Before=machine-config-daemon-firstboot.service kubelet.service
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+MountFlags=slave
+ExecStart=/usr/local/bin/rhcos_set_grub_password.sh
+
+[Install]
+WantedBy=multi-user.target
+----
+
+. Create a Butane config that includes the files from the previous steps:
++
+.40-worker-grub-password.bu
+[source,yaml,subs=attributes+]
+----
+variant: openshift
+version: {product-version}.0
+metadata:
+  name: 99-worker-grub-password
+  labels:
+    machineconfiguration.openshift.io/role: worker
+storage:
+  files:
+    - path: /usr/local/bin/rhcos_set_grub_password.sh
+      mode: 0700
+      overwrite: true
+      contents:
+        inline: |
+          ... <1>
+
+systemd:
+  units:
+    - name: rhcos-set-grub-password.service
+      enabled: true
+      contents:
+          ... <2>
+----
+<1> The contents of the file `rhcos_set_grub_password.sh`.
+<2> The contents of the file `rhcos-set-grub-password.service`.
+
+. Generate a `MachineConfig` object, `40-worker-grub-password.yaml`, that contains the configuration you want to deliver to the nodes:
++
+[source,terminal]
+----
+$ butane 40-worker-grub-password.bu -o 40-worker-grub-password.yaml
+----
+
+. Apply the machine config:
++
+[source,terminal]
+----
+$ oc apply -f 40-worker-grub-password.yaml
+----
++
+The controller detects the new `MachineConfig` object and generated a new `rendered-worker-<hash>` version.
+
+. Monitor the status of the rollout of the new rendered configuration to each node:
++
+[source,terminal]
+----
+$ oc describe machineconfigpool/worker
+----
++
+Once the password is set after a node reboot, you can remove the machine config.
+
+.Verification
+* You can verify that the password is set by trying to boot a rollback entry in the GRUB boot menu or by looking at the contents of the `/boot/grub2/user.cfg` file:
++
+[source,terminal]
+----
+# cat /boot/grub2/user.cfg
+----
++
+.Expected output
+[source,terminal]
+----
+set superusers="root"
+password_pbkdf2 root grub.pbkdf2.sha512.10000.5AE6255...
+----

--- a/post_installation_configuration/machine-configuration-tasks.adoc
+++ b/post_installation_configuration/machine-configuration-tasks.adoc
@@ -67,6 +67,7 @@ include::modules/rhcos-load-firmware-blobs.adoc[leveloffset=+2]
 * xref:../installing/install_config/installing-customizing.adoc#installation-special-config-butane_installing-customizing[Creating machine configs with Butane]
 
 include::modules/core-user-password.adoc[leveloffset=+2]
+include::modules/rhcos-setting-grub-password-day-2.adoc[leveloffset=+2]
 
 [id="configuring-machines-with-custom-resources"]
 == Configuring MCO-related custom resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7736
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64558--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/machine-configuration-tasks#rhcos-setting-grub-password-day-2_post-install-machine-configuration-tasks
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
