### PR TITLE
clarified /etc/passwd requirement when running images for CRI-O compa…

### DIFF
--- a/modules/images-create-guide-openshift.adoc
+++ b/modules/images-create-guide-openshift.adoc
@@ -39,9 +39,9 @@ Because the container user is always a member of the root group, the container u
 
 [WARNING]
 ====
-Care must be taken when altering the directories and file permissions of sensitive areas of a container, which is no different than to a normal system.
+Care must be taken when altering the directories and file permissions of the sensitive areas of a container. If applied to sensitive areas, such as the `/etc/passwd` file, such changes can allow the modification of these files by unintended users, potentially exposing the container or host. CRI-O supports the insertion of arbitrary user IDs into a container's `/etc/passwd` file. As such, changing permissions is never required.
 
-If applied to sensitive areas, such as `/etc/passwd`, this can allow the modification of such files by unintended users potentially exposing the container or host. CRI-O supports the insertion of arbitrary user IDs into the container's `/etc/passwd`, so changing permissions is never required.
+Additionally, the `/etc/passwd` file should not exist in any container image. If it does, the CRI-O container runtime will fail to inject a random UID into the `/etc/passwd` file. In such cases, the container might face challenges in resolving the active UID. Failing to meet this requirement could impact the functionality of certain containerized applications.
 ====
 
 In addition, the processes running in the container must not listen on privileged ports, ports below 1024, since they are not running as a privileged user.


### PR DESCRIPTION
Hello,

I've made updates to the documentation regarding container file permissions, specifically focusing on the `/etc/passwd` file and its interaction with CRI-O container runtime. These changes aim to provide clearer guidance and avoid potential issues with UID resolution in containers.

For more detailed context and discussion on this issue, please refer to the Jira card: [OCPBUGS-15996](https://issues.redhat.com/browse/OCPBUGS-15996).