### PR TITLE
 OSDOCS 7678: Included missing policy info and instructions for ROSA Shared VPC

### DIFF
--- a/modules/rosa-sharing-vpc-creation-and-sharing.adoc
+++ b/modules/rosa-sharing-vpc-creation-and-sharing.adoc
@@ -10,35 +10,99 @@ You can share subnets within a configured VPC with another AWS user account if t
 
 .Procedure
 
-. From the AWS account that centrally manages your VPC, create or modify a VPC to your specifications in the link:https://us-east-1.console.aws.amazon.com/vpc/[VPC section of the AWS console]. This AWS account will be the *VPC-owning AWS account*. 
-. In the link:https://us-east-1.console.aws.amazon.com/iamv2/[Identity and Access Management (IAM) section of the AWS console], create a custom trust policy role for the shared VPC permissions. This role needs to have the following permissions:
-  * A trust policy to assume roles:
+. From the AWS account that centrally manages your VPC, create or modify a VPC to your specifications in the link:https://us-east-1.console.aws.amazon.com/vpc/[VPC section of the AWS console]. This AWS account will be the *VPC-owning AWS account*.
++
+. Create a custom policy file to allow for necessary Shared VPC permissions that uses the name `SharedVPCPolicy`:
 +
 [source,terminal]
 ----
+$ cat <<EOF > /tmp/shared-vpc-policy.json
 {
-  "Version": "2012-10-17",
-  "Statement": [
-    {
-	  "Sid": "Statement1",
-	  "Effect": "Allow",
-	  "Principal": {
-	  	"AWS": "arn:aws:iam::<Account-ID>:root"
-	  }, <1>
-	  "Action": "sts:AssumeRole"
-	}
-  ]
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "route53:ChangeResourceRecordSets",
+                "route53:ListHostedZones",
+                "route53:ListHostedZonesByName",
+                "route53:ListResourceRecordSets",
+                "route53:ChangeTagsForResource",
+                "route53:GetAccountLimit",
+                "route53:GetChange",
+                "route53:GetHostedZone",
+                "route53:ListTagsForResource",
+                "route53:UpdateHostedZoneComment",
+                "tag:GetResources",
+                "tag:UntagResources"
+            ],
+            "Resource": "*"
+        }
+    ]
 }
+EOF
+----
++
+. Create the policy in AWS:
++
+[source,terminal]
+----
+$ aws iam create-policy \
+    --policy-name SharedVPCPolicy \
+    --policy-document file:///tmp/shared-vpc-policy.json
+----
++
+You will attach this policy to a role necessary for the shared VPC permissions.
++
+. Create a custom trust policy file that grants permission to assume roles:
++
+[source,terminal]
+----
+$ cat <<EOF > /tmp/shared-vpc-role.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Principal": {
+                "AWS": "arn:aws:iam::<Account-ID>:root"  <1>
+            },
+            "Action": "sts:AssumeRole"
+        }
+    ]
+}
+EOF
 ----
 +
 --
-<1> The following principals are be added later in this process after the *cluster-creating AWS account* user has created these roles. On creation, you must create a root user placeholder by using the *cluster-creator's AWS Account* ID as `arn:aws:iam::{Account}:root`.
+<1> The principal will be scoped down later in this process after the *cluster-creating AWS account* user has created the necessary cluster roles. On creation, you must create a root user placeholder by using the *cluster-creator's AWS Account* ID as `arn:aws:iam::{Account}:root`.
 --
-    * The `ResourceGroupandTagEditorFullAccess` permissions policy
-    * The `Route53minimalPermissions` permissions policy
 +
-After you create this IAM role, provide the created role's ARN to the cluster creator.
-
+. Create the IAM role:
++
+[source,terminal]
+----
+$ aws iam create-role --role-name <role_name> \  <1>
+    --assume-role-policy-document file:///tmp/trust-policy.json
+----
++
+--
+<1> Replace _<role_name>_ with the name of the role you want to create.
+--
++
+. Attach the custom `SharedVPCPolicy` permissions policy:
++
+[source, terminal]
+----
+$ aws iam attach-role-policy --role-name <role_name> --policy-arn \  <1>
+    arn:aws:iam::<AWS_account_ID>:policy/SharedVPCPolicy  <2>
+----
++
+--
+<1> Replace _<role_name>_ with the name of the role you created.
+<2> Replace _<AWS_account_ID>_ with the *VPC-owning AWS account* ID.
+--
++
 . In the link:https://us-east-1.console.aws.amazon.com/ram/[Resource Access Manager of the AWS console], create a Resource Share that shares the previously created public and private subnets to the *cluster-creating AWS account* ID.
 
 After you create the Resource Share, notify the *cluster-creating AWS account* user to reserve an `openshiftapps.com` DNS domain and create Operator roles to continue configuration.


### PR DESCRIPTION
IMPORTANT This PR is replacing https://github.com/openshift/openshift-docs/pull/64483 due to incorrect squashing of commits. Have incorporated all reviewer feedback so far.

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7678

Link to docs preview:

[Configuring a VPC to share within your AWS organization](https://64578--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config)

SME review:
- [x] SME has approved this change.

Peer review:
- [x] Peer reviewer has approved this change.
 
QE review:
- [ ] QE has approved this change.
