### PR TITLE
OSDOCS-7698: Documented the 4.11.49 z-stream releases

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3728,3 +3728,22 @@ $ oc adm release info 4.11.48 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+
+[id="ocp-4-11-49"]
+=== RHSA-2023:5001 {product-title} 4.11.49 bug fix update
+
+Issued: 2023-09-13
+
+{product-title} release 4.11.49, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:5001[RHSA-2023:5001] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5003[RHBA-2023:5003] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.49 --pullspecs
+----
+
+[id="ocp-4-11-49-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.


### PR DESCRIPTION
[OSDOCS-7698](https://issues.redhat.com/browse/OSDOCS-7698)

Version(s):
4.11

Link to docs preview:
* [4.11.49 z-stream release notes](https://64586--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-49)

QE review:
- [ ] QE approval is not required for z-stream release notes.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
