### PR TITLE
[OSDOCS-6831]: Minor update to etcd recovery docs for hosted control planes

### DIFF
--- a/modules/hosted-cluster-etcd-status.adoc
+++ b/modules/hosted-cluster-etcd-status.adoc
@@ -14,7 +14,7 @@ To check the status of your hosted cluster, complete the following steps.
 +
 [source,terminal]
 ----
-$ oc rsh etcd-0
+$ oc rsh -n <control_plane_namespace> -c etcd etcd-0
 ----
 
 . Set up the etcdctl environment by entering the following commands:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6831
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64590--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-backup-restore-dr#hosted-cluster-etcd-status_hcp-backup-restore-dr
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
