### PR TITLE
Follow-up for 4.14 typo

### DIFF
--- a/modules/nw-egress-service-ovn.adoc
+++ b/modules/nw-egress-service-ovn.adoc
@@ -41,7 +41,7 @@ spec:
 $ oc apply -f ip-addr-pool.yaml
 ----
 
-. Create `Service` and `EgressService` CRs. 
+. Create `Service` and `EgressService` CRs: 
 
 .. Create a file, such as `service-egress-service.yaml`, with content like the following example:
 +
@@ -109,7 +109,6 @@ spec:
   - matchLabels:
       egress-service.k8s.ovn.org/example-namespace-example-service: "" <1>
 ----
-
 <1> In this example, the `EgressService` CR configures the source IP address for egress traffic to use the load-balancer service IP address. Therefore, you must specify the load-balancer node for return traffic to use the same return path for the traffic originating from the pod.
 
 .Verification


### PR DESCRIPTION
Fixing two minor typos caught in merge-review feedback here: https://github.com/openshift/openshift-docs/pull/61548#pullrequestreview-1618350553

Version(s):
4.14+

Link to docs preview:
https://64591--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services#nw-egress-service-ovn_configuring-egress-traffic-loadbalancer-services