### PR TITLE
[OSDOCS-7196]: Removing step about manual rollout

### DIFF
--- a/modules/etcd-tuning-parameters.adoc
+++ b/modules/etcd-tuning-parameters.adoc
@@ -85,19 +85,6 @@ $ oc describe etcd/cluster | grep "Control Plane Hardware Speed"
 Control Plane Hardware Speed:  ""
 ----
 
-. Force an etcd rollout, which restarts all etcd pods one at a time to pick up the new values, by entering the following command:
-+
-[source,terminal]
-----
-$ oc patch etcd/cluster --type=merge -p '{"spec": {"forceRedeploymentReason": "hardwareSpeedChange-'"$( date --rfc-3339=ns )"'"}}'
-----
-+
-.Example output
-[source,terminal]
-----
-etcd.operator.openshift.io/cluster patched
-----
-
 . Wait for etcd pods to roll out:
 +
 [source,terminal]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7196
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64595--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/recommended-performance-scale-practices/recommended-etcd-practices#etcd-changing-hardware-speed-tolerance_recommended-etcd-practices
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR removes the step about forcing an etcd rollout, as the rollout should happen automatically.
Related PR: https://github.com/openshift/openshift-docs/pull/63875
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
