### PR TITLE
[OSDOCS-1138] OCP content port to ROSA and OSD: Admission Controller

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -56,6 +56,10 @@ Topics:
       File: policy-understand-availability
     - Name: Update life cycle
       File: osd-life-cycle
+# Created a new assembly in ROSA/OSD. In OCP, the assembly is in a book that is not in ROSA/OSD
+- Name: About admission plugins
+  File: osd-admission-plug-ins
+  Distros: openshift-dedicated
 ---
 #Name: Tutorials
 #Dir: cloud_experts_tutorials

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -69,6 +69,10 @@ Topics:
     File: rosa-policy-process-security
   - Name: SRE and service account access
     File: rosa-sre-access
+# Created a new assembly in ROSA/OSD. In OCP, the assembly is in a book that is not in ROSA/OSD
+- Name: About admission plugins
+  File: rosa-admission-plug-ins
+  Distros: openshift-rosa
 - Name: About IAM resources for ROSA with STS
   File: rosa-sts-about-iam-resources
 - Name: OpenID Connect Overview

--- a/modules/admission-plug-ins-default.adoc
+++ b/modules/admission-plug-ins-default.adoc
@@ -5,7 +5,9 @@
 [id="admission-plug-ins-default_{context}"]
 = Default admission plugins
 
+ifndef::openshift-rosa,openshift-dedicated[]
 //Future xref - A set of default admission plugins is enabled in {product-title} {product-version}. These default plugins contribute to fundamental control plane functionality, such as ingress policy, xref:../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-resource-override_nodes-cluster-overcommit[cluster resource limit override] and quota policy.
+endif::openshift-rosa,openshift-dedicated[]
 Default validating and admission plugins are enabled in {product-title} {product-version}. These default plugins contribute to fundamental control plane functionality, such as ingress policy, cluster resource limit override and quota policy. 
 
 include::snippets/default-projects.adoc[]

--- a/modules/admission-webhooks-about.adoc
+++ b/modules/admission-webhooks-about.adoc
@@ -9,10 +9,26 @@ In addition to {product-title} default admission plugins, dynamic admission can 
 
 There are two types of webhook admission plugins in {product-title}:
 
+ifndef::openshift-rosa,openshift-dedicated[]
 //Future xref - * During the admission process, xref:../architecture/admission-plug-ins.adoc#mutating-admission-plug-in[the mutating admission plugin] can perform tasks, such as injecting affinity labels.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa[]
+//Future xref - * During the admission process, xref:../rosa_architecture/rosa-admission-plug-ins.adoc#mutating-admission-plug-in[the mutating admission plugin] can perform tasks, such as injecting affinity labels.
+endif::openshift-rosa[]
+ifdef::openshift-dedicated[]
+//Future xref - * During the admission process, xref:../osd_architecture/osd-admission-plug-ins.adoc#mutating-admission-plug-in[the mutating admission plugin] can perform tasks, such as injecting affinity labels.
+endif::openshift-dedicated[]
 * During the admission process, the _mutating admission plugin_ can perform tasks, such as injecting affinity labels.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 //Future xref - * At the end of the admission process, xref:../architecture/admission-plug-ins.adoc#validating-admission-plug-in[the validating admission plugin] makes sure an object is configured properly, for example ensuring affinity labels are as expected. If the validation passes, {product-title} schedules the object as configured.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa[]
+//Future xref - * At the end of the admission process, xref:../rosa_architecture/rosa-admission-plug-ins.html#validating-admission-plug-in_admission-plug-ins[the validating admission plugin] makes sure an object is configured properly, for example ensuring affinity labels are as expected. If the validation passes, {product-title} schedules the object as configured.
+endif::openshift-rosa[]
+ifdef::openshift-dedicated[]
+//Future xref - * At the end of the admission process, xref:../osd_architecture/osd-admission-plug-ins.html#validating-admission-plug-in_admission-plug-ins[the validating admission plugin] makes sure an object is configured properly, for example ensuring affinity labels are as expected. If the validation passes, {product-title} schedules the object as configured.
+endif::openshift-dedicated[]
 * At the end of the admission process, the _validating admission plugin_ can be used to make sure an object is configured properly, for example ensuring affinity labels are as expected. If the validation passes, {product-title} schedules the object as configured.
 
 When an API request comes in, mutating or validating admission plugins use the list of external webhooks in the configuration and call them in parallel:
@@ -25,8 +41,10 @@ When an API request comes in, mutating or validating admission plugins use the l
 
 * If an error is encountered when calling a webhook, the request is either denied or the webhook is ignored depending on the error policy set. If the error policy is set to `Ignore`, the request is unconditionally accepted in the event of a failure. If the policy is set to `Fail`, failed requests are denied. Using `Ignore` can result in unpredictable behavior for all clients.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 //Future xrefs - Communication between the webhook admission plugin and the webhook server must use TLS. Generate a certificate authority (CA) certificate and use the certificate to sign the server certificate that is used by your webhook server. The PEM-encoded CA certificate is supplied to the webhook admission plugin using a mechanism, such as xref:../security/certificates/service-serving-certificate.adoc#service-serving-certificate[service serving certificate secrets].
 Communication between the webhook admission plugin and the webhook server must use TLS. Generate a CA certificate and use the certificate to sign the server certificate that is used by your webhook admission server. The PEM-encoded CA certificate is supplied to the webhook admission plugin using a mechanism, such as service serving certificate secrets.
+endif::openshift-rosa,openshift-dedicated[]
 
 The following diagram illustrates the sequential admission chain process within which multiple webhook servers are called.
 
@@ -41,9 +59,11 @@ Some common webhook admission plugin use cases include:
 * Namespace reservation.
 //Future xrefs - * :../networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[Limiting custom network resources managed by the SR-IOV network device plugin].
 * Limiting custom network resources managed by the SR-IOV network device plugin.
+ifndef::openshift-rosa,openshift-dedicated[]
 //Future xref - * xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations_dedicating_nodes-scheduler-taints-tolerations[Defining tolerations that enable taints to qualify which pods should be scheduled on a node].
 * Defining tolerations that enable taints to qualify which pods should be scheduled on a node.
 //Future xref - * xref:../nodes/pods/nodes-pods-priority.adoc#admin-guide-priority-preemption-names_nodes-pods-priority[Pod priority class validation].
+endif::openshift-rosa,openshift-dedicated[]
 * Pod priority class validation.
 
 [NOTE]

--- a/osd_architecture/osd-admission-plug-ins.adoc
+++ b/osd_architecture/osd-admission-plug-ins.adoc
@@ -1,0 +1,38 @@
+:_content-type: ASSEMBLY
+[id="osd-admission-plug-ins"]
+= Admission plugins
+include::_attributes/common-attributes.adoc[]
+:context: admission-plug-ins
+
+toc::[]
+
+
+Admission plugins are used to help regulate how {product-title} functions. 
+
+// Concept modules
+include::modules/admission-plug-ins-about.adoc[leveloffset=+1]
+
+include::modules/admission-plug-ins-default.adoc[leveloffset=+1]
+
+include::modules/admission-webhooks-about.adoc[leveloffset=+1]
+
+include::modules/admission-webhook-types.adoc[leveloffset=+1]
+
+// user (groups=["dedicated-admins" "system:authenticated:oauth" "system:authenticated"]) is attempting to grant RBAC permissions not currently held, clusterroles.rbac.authorization.k8s.io "system:openshift:online:my-webhook-server" not found, cannot get resource "rolebindings", cannot create resource "apiservices", cannot create resource "validatingwebhookconfigurations" 
+ifndef::openshift-rosa,openshift-dedicated[]
+// Procedure module
+include::modules/configuring-dynamic-admission.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
+
+[role="_additional-resources"]
+[id="admission-plug-ins-additional-resources"]
+== Additional resources
+
+ifndef::openshift-rosa,openshift-dedicated[]
+* xref: /networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[Limiting custom network resources managed by the SR-IOV network device plugin]
+endif::openshift-rosa,openshift-dedicated[]
+
+* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations_dedicating_nodes-scheduler-taints-tolerations[Defining tolerations that enable taints to qualify which pods should be scheduled on a node]
+
+* xref:../nodes/pods/nodes-pods-priority.adoc#admin-guide-priority-preemption-names_nodes-pods-priority[Pod priority class validation]
+


### PR DESCRIPTION
This PR ports the Admission Controller assembly from OCP to the OSD and ROSA books using single-sourcing.

Version(s):

enterprise-4.13
enterprise-4.14

Previews:
**PEER REVIEW:** The relevant changes are nearly/entirely that I created a new _Admission plugins_ assembly for ROSA and OSD each, which is a direct copy of the OSD version. I hid the _Configuring dynamic admission_ module and the _Limiting custom network resources managed by the SR-IOV network device plugin_ additional ref.  The link text is changed to the heading title in a [separate PR](https://github.com/openshift/openshift-docs/pull/65099). I also hid a number of _Future xref_, which are commented out in the original modules, so no there should be no difference in the ROSA/OSD version.

OCP: [Admission plugins](https://64604--docspreview.netlify.app/openshift-enterprise/latest/architecture/admission-plug-ins)
ROSA: [Admission plugins](https://64604--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa-admission-plug-ins) 
OSD: [Admission plugins](https://64604--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd-admission-plug-ins) 

Issue: https://issues.redhat.com/browse/OSDOCS-1138
