### PR TITLE
TELCODOCS-1410: Recommend creating new catalog source for Operator image

### DIFF
--- a/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
+++ b/modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc
@@ -1,0 +1,68 @@
+// Module included in the following assemblies:
+//
+// * scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+
+:_content-type: PROCEDURE
+[id="cnf-topology-aware-lifecycle-manager-operator-troubleshooting_{context}"]
+= Troubleshooting missed Operator updates due to out-of-date policy compliance states
+
+In some scenarios, {cgu-operator-first} might miss Operator updates due to an out-of-date policy compliance state.
+
+After a catalog source update, it takes time for the Operator Lifecycle Manager (OLM) to update the subscription status. The status of the subscription policy might continue to show as compliant while {cgu-operator} decides whether remediation is needed. As a result, the Operator specified in the subscription policy does not get upgraded.
+
+To avoid this scenario, add another catalog source configuration to the `PolicyGenTemplate` and specify this configuration in the subscription for any Operators that require an update.
+
+.Procedure
+
+. Add a catalog source configuration in the `PolicyGenTemplate` resource:
++
+[source,yaml]
+----
+- fileName: DefaultCatsrc.yaml
+      remediationAction: inform
+      policyName: "operator-catsrc-policy"
+      metadata:
+        name: redhat-operators
+      spec:
+        displayName: Red Hat Operators Catalog
+        image: registry.example.com:5000/olm/redhat-operators:v{product-version}
+        updateStrategy:
+          registryPoll:
+            interval: 1h
+      status:
+        connectionState:
+            lastObservedState: READY
+- fileName: DefaultCatsrc.yaml
+      remediationAction: inform
+      policyName: "operator-catsrc-policy"
+      metadata:
+        name: redhat-operators-v2 <1>
+      spec:
+        displayName: Red Hat Operators Catalog v2 <2>
+        image: registry.example.com:5000/olredhat-operators:<version> <3>
+        updateStrategy:
+          registryPoll:
+            interval: 1h
+      status:
+        connectionState:
+            lastObservedState: READY
+----
+<1> Update the name for the new configuration.
+<2> Update the display name for the new configuration.
+<3> Update the index image URL. This `fileName.spec.image` field overrides any configuration in the `DefaultCatsrc.yaml` file.
+
+. Update the `Subscription` resource to point to the new configuration for Operators that require an update:
++
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: operator-subscription
+  namespace: operator-namspace
+# ...
+spec:
+  source: redhat-operators-v2 <1>
+# ...
+----
+<1> Enter the name of the additional catalog source configuration that you defined in the `PolicyGenTemplate` resource.

--- a/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
@@ -44,6 +44,10 @@ include::modules/cnf-topology-aware-lifecycle-manager-operator-update.adoc[level
 
 * For more information about updating {ztp}, see xref:../../scalability_and_performance/ztp_far_edge/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}].
 
+* xref:../../scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc#cnf-topology-aware-lifecycle-manager-operator-troubleshooting_ztp-talm[Troubleshooting missed Operator updates due to out-of-date policy compliance states].
+
+include::modules/cnf-topology-aware-lifecycle-manager-operator-troubleshooting.adoc[leveloffset=+3]
+
 include::modules/cnf-topology-aware-lifecycle-manager-operator-and-platform-update.adoc[leveloffset=+2]
 
 include::modules/cnf-topology-aware-lifecycle-manager-pao-update.adoc[leveloffset=+2]


### PR DESCRIPTION
[TELCODOCS-1410](https://issues.redhat.com//browse/TELCODOCS-1410): This seems to be an edge case where, despite the mitigation of using:
```
  status:
        connectionState:
            lastObservedState: READY 
````
... there can still be an issue with upgrading Operators in the cluster. In this edge case, it is recommended to create an additional catalog source configuration in the `PolicyGenTemplate` resource. This is like a workaround for a workaround... so it seemed overkill to create a new section. And it was awkward changing the existing procedure for to suit an edge case. So I put in a note. Hopefully this bug will go away in the future and this note can be removed. :man_shrugging:  

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1410

Link to docs preview:
https://file.emea.redhat.com/rohennes/TELCODOCS-1410-catsrc/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.html#cnf-topology-aware-lifecycle-manager-operator-troubleshooting_ztp-talm

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

