### PR TITLE
OSDOCS-7685

### DIFF
--- a/modules/osd-persistent-storage-csi-efs-sts.adoc
+++ b/modules/osd-persistent-storage-csi-efs-sts.adoc
@@ -112,10 +112,10 @@ $ rosa describe cluster \
 +
 [source,terminal]
 ----
-$ aws iam create-role \
+ROLE_ARN=$(aws iam create-role \
   --role-name "<your_cluster_name>-aws-efs-csi-operator" \
   --assume-role-policy-document file://<your_trust_file_name>.json \
-  --query "Role.Arn" --output text
+  --query "Role.Arn" --output text); echo $ROLE_ARN
 ----
 +
 Save the output. You will use it in the next steps.
@@ -124,27 +124,22 @@ Save the output. You will use it in the next steps.
 +
 [source,terminal]
 ----
-$ aws iam create-policy \
+POLICY_ARN=$(aws iam create-policy \
   --policy-name "<your_rosa_cluster_name>-rosa-efs-csi" \
   --policy-document file://<your_policy_file_name>.json \
-  --query 'Policy.Arn' --output text) || \
-  POLICY=$(aws iam list-policies \
-  --query 'Policies[?PolicyName==`rosa-efs-csi`].Arn' \
-  --output text
+  --query 'Policy.Arn' --output text); echo $POLICY_ARN
 ----
 +
-Save the output. You will use it in the next steps.
 
 .. Attach the IAM policy to the IAM role:
 +
 [source,terminal]
 ----
 $ aws iam attach-role-policy \
-     --role-name "<your_rosa_cluster_name>-aws-efs-csi-operator" \
-     --policy-arn <policy_ARN> <1>
+  --role-name "<your_rosa_cluster_name>-aws-efs-csi-operator" \
+  --policy-arn $POLICY_ARN
 ----
 +
-<1> Replace `policy_ARN` with the output you saved while creating the policy.
 
 . Create a `Secret` YAML file for the driver operator:
 +


### PR DESCRIPTION
[OSDOCS-7685](https://issues.redhat.com/browse/OSDOCS-7685): ROSA & AWS EFS CSI Driver Operator: Doc correction - Missing brackets

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OSDOCS-7685](https://issues.redhat.com/browse/OSDOCS-7685)
Preview pages: [Click to see the build preview in your browser](https://64612--docspreview.netlify.app/openshift-rosa/latest/storage/container_storage_interface/osd-persistent-storage-aws-efs-csi#efs-sts_osd-persistent-storage-aws-efs-csi)
SME review **completed**: Gianfranco Mollo
QE review **completed**:  @duanwei33 and @ropatil010 
Peer review **completed**: @lahinson

Note: We have SME approval in [Jira comment](https://issues.redhat.com/browse/OSDOCS-7685?focusedId=22997003&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-22997003).