### PR TITLE
OCPBUGS#15261: fix issue with callout rendering on the customer portal

### DIFF
--- a/modules/ipi-install-configuring-the-install-config-file.adoc
+++ b/modules/ipi-install-configuring-the-install-config-file.adoc
@@ -56,25 +56,25 @@ platform:
       - name: <openshift_master_1>
         role: master
         bmc:
-          address: ipmi://<out_of_band_ip> <4>
+          address: ipmi://<out_of_band_ip>
           username: <user>
           password: <password>
         bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
-         deviceName: "<installation_disk_drive_path>" <5>
+         deviceName: "<installation_disk_drive_path>"
       - name: <openshift_master_2>
         role: master
         bmc:
-          address: ipmi://<out_of_band_ip> <4>
+          address: ipmi://<out_of_band_ip>
           username: <user>
           password: <password>
         bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
-         deviceName: "<installation_disk_drive_path>" <5>
+         deviceName: "<installation_disk_drive_path>"
       - name: <openshift_worker_0>
         role: worker
         bmc:
-          address: ipmi://<out_of_band_ip> <4>
+          address: ipmi://<out_of_band_ip>
           username: <user>
           password: <password>
         bootMACAddress: <NIC1_mac_address>
@@ -86,7 +86,7 @@ platform:
           password: <password>
         bootMACAddress: <NIC1_mac_address>
         rootDeviceHints:
-         deviceName: "<installation_disk_drive_path>" <5>
+         deviceName: "<installation_disk_drive_path>"
 pullSecret: '<pull_secret>'
 sshKey: '<ssh_pub_key>'
 ----


### PR DESCRIPTION
[OCPBUGS#15261]: This PR updates callout numbering to fix issue with rendering on the customer portal.

Version(s):
4.11+
(At the time of merging the PR 4.10 was EOL so only merging 4.11+)

Issue:
https://issues.redhat.com/browse/OCPBUGS-15261

Link to docs preview:
- d.o.c preview: https://64614--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow#configuring-the-install-config-file_ipi-install-installation-workflow 

- Customer portal preview: (Sorry, not sure how to share a customer portal build preview. I generated HTML  locally and sharing a screen cap for the problem area)
  **Before**
![image](https://github.com/openshift/openshift-docs/assets/74918891/7d3b9e08-8da8-42f1-98ff-2c055d94cd5e)

**After**
 ![image](https://github.com/openshift/openshift-docs/assets/74918891/d1d6904e-8d0b-4c4b-926c-8061c357dcf1)

QE review: N/A since this is a [formatting-only](https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/doc_guidelines.adoc#verification-of-your-content) change