### PR TITLE
[DOCS] OBSDOCS-475 - Logging 5.6.11 & 5.5.16 Release Notes

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -11,6 +11,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-rn-5.6.11.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.6.9.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.8.adoc[leveloffset=+1]
@@ -30,6 +32,8 @@ include::modules/cluster-logging-rn-5.6.2.adoc[leveloffset=+1]
 include::modules/cluster-logging-rn-5.6.1.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-rn-5.6.adoc[leveloffset=+1]
+
+include::modules/logging-rn-5.5.16.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.5.14.adoc[leveloffset=+1]
 

--- a/logging/v5_5/logging-5-5-release-notes.adoc
+++ b/logging/v5_5/logging-5-5-release-notes.adoc
@@ -8,6 +8,8 @@ toc::[]
 
 include::snippets/logging-compatibility-snip.adoc[]
 
+include::modules/logging-rn-5.5.16.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.5.14.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.5.13.adoc[leveloffset=+1]

--- a/logging/v5_6/logging-5-6-release-notes.adoc
+++ b/logging/v5_6/logging-5-6-release-notes.adoc
@@ -9,6 +9,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-rn-5.6.11.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.6.8.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.7.adoc[leveloffset=+1]

--- a/modules/logging-rn-5.5.16.adoc
+++ b/modules/logging-rn-5.5.16.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// cluster-logging-release-notes.adoc
+// logging-5-5-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-5-16_{context}"]
+= Logging 5.5.16
+This release includes link:https://access.redhat.com/errata/RHSA-2023:5096[OpenShift Logging Bug Fix Release 5.5.16].
+
+[id="openshift-logging-5-5-16-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, the LokiStack gateway cached authorized requests very broadly. As a result, this caused wrong authorization results. With this update, LokiStack gateway caches on a more fine-grained basis which resolves this issue. (link:https://issues.redhat.com/browse/LOG-4434[LOG-4434])
+
+[id="openshift-logging-5-5-16-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-3899[CVE-2023-3899]
+* link:https://access.redhat.com/security/cve/CVE-2023-32360[CVE-2023-32360]
+* link:https://access.redhat.com/security/cve/CVE-2023-34969[CVE-2023-34969]

--- a/modules/logging-rn-5.6.11.adoc
+++ b/modules/logging-rn-5.6.11.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+// cluster-logging-release-notes.adoc
+// logging-5-6-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-6-11_{context}"]
+= Logging 5.6.11
+This release includes link:https://access.redhat.com/errata/RHSA-2023:5095[OpenShift Logging Bug Fix Release 5.6.11].
+
+[id="openshift-logging-5-6-11-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, the LokiStack gateway cached authorized requests very broadly. As a result, this caused wrong authorization results. With this update, LokiStack gateway caches on a more fine-grained basis which resolves this issue. (link:https://issues.redhat.com/browse/LOG-4435[LOG-4435])
+
+
+[id="openshift-logging-5-6-11-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-3899[CVE-2023-3899]
+* link:https://access.redhat.com/security/cve/CVE-2023-32360[CVE-2023-32360]
+* link:https://access.redhat.com/security/cve/CVE-2023-34969[CVE-2023-34969]


### PR DESCRIPTION
**Change type:** Doc update; Logging Z-Stream Release Notes - 5.6.11 & 5.5.16
**Doc JIRA:** https://issues.redhat.com/browse/OBSDOCS-475

**Fix Version:** 4.10, 4.11, and 4.12

**Doc Previews:**
For 5.6.11: https://64617--docspreview.netlify.app/openshift-enterprise/latest/logging/v5_6/logging-5-6-release-notes 
For 5.5.16: https://64617--docspreview.netlify.app/openshift-enterprise/latest/logging/v5_5/logging-5-5-release-notes 

**SME Review:** @xperimental 
**QE Review:** @kabirbhartiRH 
**Peer Review:** @agantony 