### PR TITLE
OSDOCS#7721: Custom RHCOS image for control plane and compute machines

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1207,18 +1207,13 @@ Additional GCP configuration parameters are described in the following table:
 |The name of the existing VPC that you want to deploy your cluster to.
 |String.
 
+|`platform.gcp.projectID`
+|The name of the GCP project where the installation program installs the cluster.
+|String.
+
 |`platform.gcp.region`
 |The name of the GCP region that hosts your cluster.
 |Any valid region name, such as `us-central1`.
-
-|`platform.gcp.type`
-|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type].
-|The GCP machine type.
-
-|`platform.gcp.zones`
-|The availability zones where the installation program creates machines for the specified MachinePool.
-|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
-link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
 |`platform.gcp.controlPlaneSubnet`
 |The name of the existing subnet in your VPC that you want to deploy your control plane machines to.
@@ -1236,13 +1231,30 @@ The `licenses` parameter is a deprecated field and nested virtualization is enab
 ====
 |Any license available with the link:https://cloud.google.com/compute/docs/reference/rest/v1/licenses/list[license API], such as the license to enable link:https://cloud.google.com/compute/docs/instances/nested-virtualization/overview[nested virtualization]. You cannot use this parameter with a mechanism that generates pre-built images. Using a license URL forces the installer to copy the source image before use.
 
-|`platform.gcp.osDisk.diskSizeGB`
+|`platform.gcp.defaultMachinePlatform.osDisk.diskSizeGB`
 |The size of the disk in gigabytes (GB).
 |Any size between 16 GB and 65536 GB.
 
-|`platform.gcp.osDisk.diskType`
+|`platform.gcp.defaultMachinePlatform.osDisk.diskType`
 |The type of disk.
 |Either the default `pd-ssd` or the `pd-standard` disk type. The control plane nodes must be the `pd-ssd` disk type. The worker nodes can be either type.
+
+|`platform.gcp.defaultMachinePlatform.osImage.project`
+|Optional. By default, the installation program downloads and installs the {op-system} image that is used to boot control plane and compute machines. You can override the default behavior by specifying the location of a custom {op-system} image for the installation program to use for both types of machines.
+|String. The name of GCP project where the image is located.
+
+|`platform.gcp.defaultMachinePlatform.osImage.name`
+|The name of the custom {op-system} image for the installation program to use to boot control plane and compute machines. If you use `platform.gcp.defaultMachinePlatform.osImage.project`, this field is required.
+|String. The name of the RHCOS image.
+
+|`platform.gcp.defaultMachinePlatform.type`
+|The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type].
+|The GCP machine type.
+
+|`platform.gcp.defaultMachinePlatform.zones`
+|The availability zones where the installation program creates machines for the specified MachinePool.
+|A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
+link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
 |`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.name`
 |The name of the customer managed encryption key to be used for control plane machine disk encryption.
@@ -1259,6 +1271,14 @@ The `licenses` parameter is a deprecated field and nested virtualization is enab
 |`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.projectID`
 |For control plane machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
 |The GCP project ID.
+
+|`controlPlane.platform.gcp.osImage.project`
+|Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by specifying the location of a custom {op-system} image for the installation program to use for control plane machines only.
+|String. The name of GCP project where the image is located.
+
+|`controlPlane.platform.gcp.osImage.name`
+|The name of the custom {op-system} image for the installation program to use to boot control plane machines. If you use `controlPlane.platform.gcp.osImage.project`, this field is required.
+|String. The name of the {op-system} image.
 
 ////
 `controlPlane.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
@@ -1284,6 +1304,14 @@ The GCP Compute Engine System service account email, like `<service_account_name
 |`compute.platform.gcp.osDisk.encryptionKey.kmsKey.projectID`
 |For compute machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
 |The GCP project ID.
+
+|`compute.platform.gcp.osImage.project`
+|Optional. By default, the installation program downloads and installs the {op-system} image that is used to boot compute machines. You can override the default behavior by specifying the location of a custom {op-system} image for the installation program to use for compute machines only.
+|String. The name of GCP project where the image is located.
+
+|`compute.platform.gcp.osImage.name`
+|The name of the custom {op-system} image for the installation program to use to boot compute machines. If you use `compute.platform.gcp.osImage.project`, this field is required.
+|String. The name of the {op-system} image.
 
 ////
 `compute.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
@@ -1776,7 +1804,7 @@ If defined, the parameters `compute.platform.alibabacloud` and `controlPlane.pla
 |String.
 
 |`platform.alibabacloud.defaultMachinePlatform.instanceType`
-|For both compute machines and control plane machines, the ECS instance type used to create the ECS instance. Example: `ecs.g6.xlarge` 
+|For both compute machines and control plane machines, the ECS instance type used to create the ECS instance. Example: `ecs.g6.xlarge`
 |String.
 
 |`platform.alibabacloud.defaultMachinePlatform.systemDiskCategory`

--- a/modules/installation-gcp-config-yaml.adoc
+++ b/modules/installation-gcp-config-yaml.adoc
@@ -55,6 +55,9 @@ controlPlane: <2> <3>
             keyRing: test-machine-keys
             location: global
             projectID: project-id
+        osImage: <6>
+          project: example-project-name
+          name: example-image-name
   replicas: 3
 compute: <2> <3>
 - hyperthreading: Enabled <4>
@@ -74,6 +77,9 @@ compute: <2> <3>
             keyRing: test-machine-keys
             location: global
             projectID: project-id
+        osImage: <6>
+          project: example-project-name
+          name: example-image-name
   replicas: 3
 metadata:
   name: test-cluster <1>
@@ -100,36 +106,31 @@ platform:
   gcp:
     projectID: openshift-production <1>
     region: us-central1 <1>
+    defaultMachinePlatform:
+      osImage: <6>
+        project: example-project-name
+        name: example-image-name
 ifdef::vpc,restricted[]
-    network: existing_vpc <6>
-    controlPlaneSubnet: control_plane_subnet <7>
-    computeSubnet: compute_subnet <8>
+    network: existing_vpc <7>
+    controlPlaneSubnet: control_plane_subnet <8>
+    computeSubnet: compute_subnet <9>
 endif::vpc,restricted[]
 ifndef::restricted[]
 pullSecret: '{"auths": ...}' <1>
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <9>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <10>
 endif::restricted[]
 ifndef::vpc,restricted[]
 ifndef::openshift-origin[]
-fips: false <6>
-sshKey: ssh-ed25519 AAAA... <7>
+fips: false <7>
+sshKey: ssh-ed25519 AAAA... <8>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <6>
+sshKey: ssh-ed25519 AAAA... <7>
 endif::openshift-origin[]
 endif::vpc,restricted[]
 ifdef::vpc[]
-ifndef::openshift-origin[]
-fips: false <9>
-sshKey: ssh-ed25519 AAAA... <10>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-sshKey: ssh-ed25519 AAAA... <9>
-endif::openshift-origin[]
-endif::vpc[]
-ifdef::restricted[]
 ifndef::openshift-origin[]
 fips: false <10>
 sshKey: ssh-ed25519 AAAA... <11>
@@ -137,22 +138,31 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 sshKey: ssh-ed25519 AAAA... <10>
 endif::openshift-origin[]
+endif::vpc[]
+ifdef::restricted[]
+ifndef::openshift-origin[]
+fips: false <11>
+sshKey: ssh-ed25519 AAAA... <12>
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+sshKey: ssh-ed25519 AAAA... <11>
+endif::openshift-origin[]
 endif::restricted[]
 ifdef::private[]
 ifndef::openshift-origin[]
-publish: Internal <11>
+publish: Internal <12>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-publish: Internal <10>
+publish: Internal <11>
 endif::openshift-origin[]
 endif::private[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <12>
+additionalTrustBundle: | <13>
     -----BEGIN CERTIFICATE-----
     <MY_TRUSTED_CA_CERT>
     -----END CERTIFICATE-----
-imageContentSources: <13>
+imageContentSources: <14>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -161,11 +171,11 @@ imageContentSources: <13>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <11>
+additionalTrustBundle: | <12>
   -----BEGIN CERTIFICATE-----
   <MY_TRUSTED_CA_CERT>
   -----END CERTIFICATE-----
-imageContentSources: <12>
+imageContentSources: <13>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -185,29 +195,16 @@ endif::restricted[]
 If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Use larger machine types, such as `n1-standard-8`, for your machines if you disable simultaneous multithreading.
 ====
 <5> Optional: The custom encryption key section to encrypt both virtual machines and persistent volumes. Your default compute service account must have the permissions granted to use your KMS key and have the correct IAM role assigned. The default service account name follows the `service-<project_number>@compute-system.iam.gserviceaccount.com` pattern. For more information on granting the correct permissions for your service account, see "Machine management" -> "Creating machine sets" -> "Creating a machine set on GCP".
+<6> Optional: A custom {op-system-first} image for the installation program to use to boot control plane and compute machines. The `project` and `name` parameters under `platform.gcp.defaultMachinePlatform.osImage` apply to both control plane and compute machines. If the `project` and `name` parameters under `controlPlane.platform.gcp.osImage` or `compute.platform.gcp.osImage` are set, they override the `platform.gcp.defaultMachinePlatform.osImage` parameters.
 ifdef::vpc,restricted[]
-<6> Specify the name of an existing VPC.
-<7> Specify the name of the existing subnet to deploy the control plane machines to. The subnet must belong to the VPC that you specified.
-<8> Specify the name of the existing subnet to deploy the compute machines to. The subnet must belong to the VPC that you specified.
+<7> Specify the name of an existing VPC.
+<8> Specify the name of the existing subnet to deploy the control plane machines to. The subnet must belong to the VPC that you specified.
+<9> Specify the name of the existing subnet to deploy the compute machines to. The subnet must belong to the VPC that you specified.
 endif::vpc,restricted[]
 ifdef::restricted[]
-<9> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
+<10> For `<local_registry>`, specify the registry domain name, and optionally the port, that your mirror registry uses to serve content. For example, `registry.example.com` or `registry.example.com:5000`. For `<credentials>`, specify the base64-encoded user name and password for your mirror registry.
 endif::restricted[]
 ifdef::vpc[]
-ifndef::openshift-origin[]
-<9> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
-+
-[IMPORTANT]
-====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
-====
-<10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
-<9> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
-endif::openshift-origin[]
-endif::vpc[]
-ifdef::restricted[]
 ifndef::openshift-origin[]
 <10> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
@@ -220,19 +217,33 @@ endif::openshift-origin[]
 ifdef::openshift-origin[]
 <10> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
-endif::restricted[]
-ifndef::vpc,restricted[]
+endif::vpc[]
+ifdef::restricted[]
 ifndef::openshift-origin[]
-<6> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<11> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
 To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
 ====
-<7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<12> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<6> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+<11> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+endif::openshift-origin[]
+endif::restricted[]
+ifndef::vpc,restricted[]
+ifndef::openshift-origin[]
+<7> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
++
+[IMPORTANT]
+====
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode]. The use of FIPS validated or Modules In Process cryptographic libraries is only supported on {product-title} deployments on the `x86_64` architecture.
+====
+<8> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<7> You can optionally provide the `sshKey` value that you use to access the machines in your cluster.
 endif::openshift-origin[]
 endif::vpc,restricted[]
 +
@@ -242,20 +253,20 @@ For production {product-title} clusters on which you want to perform installatio
 ====
 ifdef::private[]
 ifndef::openshift-origin[]
-<11> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<12> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<10> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
+<11> How to publish the user-facing endpoints of your cluster. Set `publish` to `Internal` to deploy a private cluster, which cannot be accessed from the internet. The default value is `External`.
 endif::openshift-origin[]
 endif::private[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<12> Provide the contents of the certificate file that you used for your mirror registry.
-<13> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<13> Provide the contents of the certificate file that you used for your mirror registry.
+<14> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<11> Provide the contents of the certificate file that you used for your mirror registry.
-<12> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<12> Provide the contents of the certificate file that you used for your mirror registry.
+<13> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]
 

--- a/modules/installation-gcp-marketplace.adoc
+++ b/modules/installation-gcp-marketplace.adoc
@@ -4,45 +4,39 @@
 
 :_content-type: PROCEDURE
 [id="installation-gcp-marketplace_{context}"]
-= Using a GCP Marketplace image
-If you want to deploy an {product-title} cluster using a GCP Marketplace image, you must create the manifests and edit the compute machine set definitions to specify the GCP Marketplace image.
+= Using the GCP Marketplace offering
+
+Using the GCP Marketplace offering lets you deploy an {product-title} cluster, which is billed on pay-per-use basis (hourly, per core) through GCP, while still being supported directly by Red{nbsp}Hat.
+
+By default, the installation program downloads and installs the {op-system-first} image that is used to deploy compute machines. To deploy an {product-title} cluster using an {op-system} image from the GCP Marketplace, override the default behavior by modifying the `install-config.yaml` file to reference the location of GCP Marketplace offer.
 
 .Prerequisites
 
-* You have the {product-title} installation program and the pull secret for your cluster.
+* You have an existing `install-config.yaml` file.
 
 .Procedure
 
-. Generate the installation manifests by running the following command:
+. Edit the `compute.platform.gcp.osImage` parameters to specify the location of the GCP Marketplace image:
+** Set the `project` parameter to `redhat-marketplace-public`.
+** Set the `name` parameter to one of the following offerings:
 +
-[source,terminal]
-----
-$ openshift-install create manifests --dir <installation_dir>
-----
+{product-title}:: `redhat-coreos-ocp-48-x86-64-202210040145`
+{opp}:: `redhat-coreos-opp-48-x86-64-202206140145`
+{oke}:: `redhat-coreos-oke-48-x86-64-202206140145`
+. Save the file and reference it when deploying the cluster.
 
-. Locate the following files:
-
-** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-0.yaml`
-** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-1.yaml`
-** `<installation_dir>/openshift/99_openshift-cluster-api_worker-machineset-2.yaml`
-
-. In each file, edit the `.spec.template.spec.providerSpec.value.disks[0].image` property to reference the offer to use:
-+
-{product-title}:: `projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145`
-{opp}:: `projects/redhat-marketplace-public/global/images/redhat-coreos-opp-48-x86-64-202206140145`
-{oke}:: `projects/redhat-marketplace-public/global/images/redhat-coreos-oke-48-x86-64-202206140145`
-
-.Example compute machine set with the GCP Marketplace image
+.Sample `install-config.yaml` file that specifies a GCP Marketplace image for compute machines
 [source,yaml]
 ----
-deletionProtection: false
-disks:
-- autoDelete: true
-  boot: true
-  image: projects/redhat-marketplace-public/global/images/redhat-coreos-ocp-48-x86-64-202210040145
-  labels: null
-  sizeGb: 128
-  type: pd-ssd
-kind: GCPMachineProviderSpec
-machineType: n2-standard-4
+apiVersion: v1
+baseDomain: example.com
+controlPlane:
+# ...
+compute:
+  platform:
+    gcp:
+      osImage:
+        project: redhat-marketplace-public
+        name: redhat-coreos-ocp-48-x86-64-202210040145
+# ...
 ----


### PR DESCRIPTION
Version(s):
4.11

Issue:
This PR addresses [osdocs-7721](https://issues.redhat.com/browse/OSDOCS-7721).

Link to docs preview:

- [Additional Google Cloud Platform (GCP) configuration parameters](https://64620--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-configuration-parameters-additional-gcp_installing-gcp-customizations)
- [Sample customized install-config.yaml file for GCP](https://64620--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-gcp-config-yaml_installing-gcp-customizations)
- [Using the GCP Marketplace offering](https://64620--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-gcp-marketplace_installing-gcp-customizations)

QE review:
- [x] QE has approved this change.

Additional information:
This feature was originally planed for 4.14 and was documented by https://github.com/openshift/openshift-docs/pull/60348. However, per [CORS-2445](https://issues.redhat.com/browse/CORS-2445), there is a request to have this backported to 4.11.
