### PR TITLE
OSDOCS-7727: FIO 1.3.2 release notes

### DIFF
--- a/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
+++ b/security/file_integrity_operator/file-integrity-operator-release-notes.adoc
@@ -15,6 +15,15 @@ For an overview of the File Integrity Operator, see xref:../../security/file_int
 
 To access the latest release, see xref:../../security/file_integrity_operator/file-integrity-operator-updating.adoc#olm-preparing-upgrade_file-integrity-operator-updating[Updating the File Integrity Operator].
 
+[id="file-integrity-operator-release-notes-1-3-2"]
+== OpenShift File Integrity Operator 1.3.2
+
+The following advisory is available for the OpenShift File Integrity Operator 1.3.2:
+
+* link:https://access.redhat.com/errata/RHBA-2023:5107[RHBA-2023:5107 OpenShift File Integrity Operator Bug Fix Update]
+
+This update addresses a CVE in an underlying dependency.
+
 [id="file-integrity-operator-release-notes-1-3-1"]
 == OpenShift File Integrity Operator 1.3.1
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-7727
https://issues.redhat.com/browse/CMP-2152

Link to docs preview (VPN required):
[OpenShift File Integrity Operator 1.3.2](https://file.rdu.redhat.com/antaylor/OSDOCS-7727/security/file_integrity_operator/file-integrity-operator-release-notes.html#file-integrity-operator-release-notes-1-3-2)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
**NOTE:** The link to the errata **WILL NOT WORK** until the errata is published at a later date and prior to the merge of this PR. 
