### PR TITLE
OSDOCS#4440: Adding a CA bundle

### DIFF
--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -23,6 +23,18 @@ include::modules/microshift-adding-repos-to-image-builder.adoc[leveloffset=+1]
 
 include::modules/microshift-adding-service-to-blueprint.adoc[leveloffset=+1]
 
+include::modules/microshift-ca-adding-bundle.adoc[leveloffset=+1]
+
+include::modules/microshift-ca-adding-bundle-ostree.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+[id="additional-resources_microshift-add-cert-bundle"]
+.Additional resources
+
+* xref:../microshift_install/microshift-embed-in-rpm-ostree.adoc#microshift-creating-ostree-iso_microshift-embed-in-rpm-ostree[Creating the {op-system-ostree} image]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/7/html/security_guide/sec-shared-system-certificates[Using Shared System Certificates in{op-system-base-full} 7]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/composing_a_customized_rhel_system_image/creating-system-images-with-composer-command-line-interface_composing-a-customized-rhel-system-image#image-customizations_creating-system-images-with-composer-command-line-interface[Creating system images using the image builder command-line interface {op-system-base-full} 8]
+
 include::modules/microshift-creating-ostree-iso.adoc[leveloffset=+1]
 
 include::modules/microshift-add-blueprint-build-iso.adoc[leveloffset=+1]
@@ -32,7 +44,7 @@ include::modules/microshift-download-iso-prep-for-use.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images[Creating a RHEL for Edge Container blueprint using image builder CLI]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images[Creating a {op-system-ostree} Container blueprint using image builder CLI]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/composing_installing_and_managing_rhel_for_edge_images/composing-a-rhel-for-edge-image-using-image-builder-command-line_composing-installing-managing-rhel-for-edge-images#image-customizations_composing-a-rhel-for-edge-image-using-image-builder-command-line[Supported image customizations]
 * link:https://www.osbuild.org/guides/image-builder-on-premises/building-ostree-images.html#building-ostree-image[Building ostree images]
 * link:https://www.osbuild.org/guides/image-builder-on-premises/blueprint-reference.html[Blueprint reference]

--- a/modules/microshift-ca-adding-bundle-ostree.adoc
+++ b/modules/microshift-ca-adding-bundle-ostree.adoc
@@ -1,0 +1,62 @@
+//Module included in the following assemblies:
+//
+//* microshift_install/microshift-embed-in-rpm-ostree.adoc
+
+
+:_content-type: PROCEDURE
+[id="microshift-ca-adding-bundle-ostree_{context}"]
+= Adding a certificate authority bundle to an ostree image
+You can include additional trusted certificate authorities (CAs) to the {op-system-ostree-first} `rpm-ostree` image by adding them to the blueprint that you use to create the image. Using the following procedure sets up additional CAs to be trusted by the operating system when pulling images from an image registry.
+
+[NOTE]
+====
+This procedure requires you to configure the CA bundle customizations in the blueprint, and then add steps to your kickstart file to enable the bundle. In the following steps, `data` is the key, and `<value>` represents the PEM-encoded certificate.
+====
+
+.Prerequisites
+
+* You have root user access to your build host.
+* Your build host meets the Image Builder system requirements.
+* You have installed and set up Image Builder and the `composer-cli` tool.
+
+.Procedure
+
+. Add the following custom values to your blueprint to add a directory.
+
+.. Add instructions to your blueprint on the host where the image is built to create the directory, for example, `/etc/pki/ca-trust/source/anchors/` for your certificate bundles.
++
+[source,terminal]
+----
+[[customizations.directories]]
+path = "/etc/pki/ca-trust/source/anchors"
+----
+
+.. After the image has booted, create the certificate bundles, for example, `/etc/pki/ca-trust/source/anchors/cert1.pem`:
++
+[source,terminal]
+----
+[[customizations.files]]
+path = "/etc/pki/ca-trust/source/anchors/cert1.pem"
+data = "<value>"
+----
+
+. To enable the certificate bundle in the system-wide trust store configuration, use the `update-ca-trust` command on the host where the image you are using has booted, for example:
++
+[source,terminal]
+----
+$ sudo update-ca-trust
+----
+
+[NOTE]
+====
+The `update-ca-trust` command might be included in the `%post` section of a kickstart file used for MicroShift host installation so that all the necessary certificate trust is enabled on the first boot. You must configure the CA bundle customizations in the blueprint before adding steps to your kickstart file to enable the bundle.
+
+[source,terminal]
+----
+%post
+# Update certificate trust storage in case new certificates were
+# installed at /etc/pki/ca-trust/source/anchors directory
+update-ca-trust
+%end
+----
+====

--- a/modules/microshift-ca-adding-bundle.adoc
+++ b/modules/microshift-ca-adding-bundle.adoc
@@ -1,0 +1,9 @@
+//Module included in the following assemblies:
+//
+//* microshift_install/microshift-embed-in-rpm-ostree.adoc
+
+:_content-type: CONCEPT
+[id="microshift-ca-adding-bundle_{context}"]
+= Adding a certificate authority bundle
+
+{product-title} uses the host trust bundle when clients evaluate server certificates. You can also use a customized security certificate chain to improve the compatibility of your endpoint certificates with clients specific to your deployments. To do this, you can add a certificate authority (CA) bundle with root and intermediate certificates to the {op-system-ostree-first} system-wide trust store.


### PR DESCRIPTION
OSDOCS#4440: Adding a CA bundle

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-4440

Link to docs preview:
https://64649--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree#microshift-ca-adding-bundle_microshift-embed-in-rpm-ostree

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Received lgtm in slack
