### PR TITLE
[OSDOCS-7732]: AWS placement groups support RNs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -275,6 +275,13 @@ With this release, control plane machine sets are supported for Nutanix clusters
 
 For more information, see xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with the Control Plane Machine Set Operator].
 
+[id="ocp-4-14-mapi-aws-placement-groups"]
+==== Support for assigning AWS machines to placement groups
+
+With this release, you can configure a machine set to deploy machines within an existing AWS placement group. You can use this feature with Elastic Fabric Adapter (EFA) instances to improve network performance for machines within the specified placement group.
+
+You can use this feature with xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-aws-existing-placement-group_creating-machineset-aws[compute] and xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#machineset-aws-existing-placement-group_cpmso-using[control plane] machine sets.
+
 [id="ocp-4-14-nodes"]
 === Nodes
 
@@ -670,9 +677,9 @@ Kubernetes 1.27 removed the following deprecated API, so you must migrate manife
 |===
 
 [id="ocp-4-14-openshift-default-registry"]
-==== Removal of the OPENSHIFT_DEFAULT_REGISTRY 
+==== Removal of the OPENSHIFT_DEFAULT_REGISTRY
 
-{product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups. 
+{product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups.
 
 [id="ocp-4-14-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6752](https://issues.redhat.com//browse/OSDOCS-6752) > [OSDOCS-7732](https://issues.redhat.com//browse/OSDOCS-7732)

Link to docs preview:
[Support for assigning AWS machines to placement groups](https://64657--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-mapi-aws-placement-groups)

QE review:
- [x] QE has approved this change.

Additional information: