### PR TITLE
[enterprise-4.11] GitOps 1.8.5 release notes documantion.

### DIFF
--- a/cicd/gitops/gitops-release-notes.adoc
+++ b/cicd/gitops/gitops-release-notes.adoc
@@ -23,6 +23,9 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+
+include::modules/gitops-release-notes-1-8-5.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-8-4.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-8-3.adoc[leveloffset=+1]

--- a/modules/gitops-release-notes-1-8-5.adoc
+++ b/modules/gitops-release-notes-1-8-5.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assembly:
+//
+// * gitops/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+
+[id="gitops-release-notes-1-8-5_{context}"]
+= Release notes for {gitops-title} 1.8.5
+
+{gitops-title} 1.8.5 is now available on {product-title} 4.10, 4.11, 4.12, and 4.13.
+
+[id="errata-updates-1-8-5_{context}"]
+== Errata updates
+
+[id="rhsa-2023-5030-gitops-1-8-5-security-update-advisory_{context}"]
+=== RHSA-2023:5030 - {gitops-title} 1.8.5 security update advisory
+
+Issued: 2023-09-08
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2023:5030[RHSA-2023:5030]
+
+If you have installed the {gitops-title} Operator, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-operators
+----
+


### PR DESCRIPTION
Cherry Picked from #64187 xref: https://github.com/openshift/openshift-docs/pull/64187

[64663--docspreview](https://64663--docspreview.netlify.app/openshift-enterprise/latest/cicd/gitops/gitops-release-notes#gitops-release-notes-1-8-5_gitops-release-notes)