### PR TITLE
OSDOCS-7722-11: Updated wording for minimalism in stock RN text 4.11

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2587,7 +2587,7 @@ With this update, xref:../networking/hardware_networks/using-pod-level-bonding.a
 [id="ocp-4-11-1-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-2"]
 === RHBA-2022:6143 - {product-title} 4.11.2 bug fix update
@@ -2606,7 +2606,7 @@ $ oc adm release info 4.11.2 --pullspecs
 [id="ocp-4-11-2-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-3"]
 === RHSA-2022:6287 - {product-title} 4.11.3 bug fix update and security update
@@ -2633,7 +2633,7 @@ Beginning with {product-title} 4.11.3, users no longer need to set the Root FS i
 [id="ocp-4-11-3-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-4"]
 === RHBA-2022:6376 - {product-title} 4.11.4 bug fix update
@@ -2652,7 +2652,7 @@ $ oc adm release info 4.11.4 --pullspecs
 [id="ocp-4-11-4-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-5"]
 === RHSA-2022:6536 - {product-title} 4.11.5 bug fix and security update
@@ -2681,7 +2681,7 @@ $ oc adm release info 4.11.5 --pullspecs
 [id="ocp-4-11-5-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-6"]
 === RHBA-2022:6659 - {product-title} 4.11.6 bug fix update
@@ -2912,7 +2912,7 @@ $ oc annotate pod dns-default target.workload.openshift.io/management='{"effect"
 [id="ocp-4-11-6-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-7"]
 === RHSA-2022:6732 - {product-title} 4.11.7 bug fix update
@@ -2931,7 +2931,7 @@ $ oc adm release info 4.11.7 --pullspecs
 [id="ocp-4-11-7-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-8"]
 === RHBA-2022:6809 - {product-title} 4.11.8 bug fix update
@@ -2955,7 +2955,7 @@ $ oc adm release info 4.11.8 --pullspecs
 [id="ocp-4-11-8-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-9"]
 === RHBA-2022:6897 - {product-title} 4.11.9 bug fix update
@@ -2974,7 +2974,7 @@ $ oc adm release info 4.11.9 --pullspecs
 [id="ocp-4-11-9-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-12"]
 === RHSA-2022:7201 - {product-title} 4.11.12 bug fix and security update
@@ -3005,7 +3005,7 @@ For more information, see xref:../authentication/bound-service-account-tokens.ad
 [id="ocp-4-11-12-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-13"]
 === RHBA-2022:7201 - {product-title} 4.11.13 bug fix update
@@ -3029,7 +3029,7 @@ $ oc adm release info 4.11.13 --pullspecs
 [id="ocp-4-11-13-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-16"]
 === RHSA-2022:8535 - {product-title} 4.11.16 bug fix and security update
@@ -3057,7 +3057,7 @@ $ oc adm release info 4.11.16 --pullspecs
 [id="ocp-4-11-16-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-17"]
 === RHBA-2022:8627 - {product-title} 4.11.17 bug fix and security update
@@ -3076,7 +3076,7 @@ $ oc adm release info 4.11.17 --pullspecs
 [id="ocp-4-11-17-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-18"]
 === RHBA-2022:8698 - {product-title} 4.11.18 bug fix update
@@ -3112,7 +3112,7 @@ $ oc adm release info 4.11.18 --pullspecs
 [id="ocp-4-11-18-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-20"]
 === RHSA-2022:8893 - {product-title} 4.11.20 bug fix and security update
@@ -3141,7 +3141,7 @@ $ oc adm release info 4.11.20 --pullspecs
 [id="ocp-4-11-20-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-21"]
 === RHSA-2022:9107 - {product-title} 4.11.21 bug fix and security update
@@ -3169,7 +3169,7 @@ $ oc adm release info 4.11.21 --pullspecs
 [id="ocp-4-11-21-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-22"]
 === RHBA-2023:0027 - {product-title} 4.11.22 bug fix update
@@ -3209,7 +3209,7 @@ This is due to a CoreOS limitation in the number of seccomp profiles that can be
 [id="ocp-4-11-22-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-24"]
 === RHSA-2023:0069 - {product-title} 4.11.24 bug fix and security update
@@ -3228,7 +3228,7 @@ $ oc adm release info 4.11.24 --pullspecs
 [id="ocp-4-11-24-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-25"]
 === RHSA-2023:0245 - {product-title} 4.11.25 bug fix and security update
@@ -3247,7 +3247,7 @@ $ oc adm release info 4.11.25 --pullspecs
 [id="ocp-4-11-25-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-26"]
 === RHSA-2023:0565 - {product-title} 4.11.26 bug fix and security update
@@ -3278,7 +3278,7 @@ $ oc adm release info 4.11.26 --pullspecs
 [id="ocp-4-11-26-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-27"]
 === RHSA-2023:0651 - {product-title} 4.11.27 bug fix and security update
@@ -3302,7 +3302,7 @@ $ oc adm release info 4.11.27 --pullspecs
 [id="ocp-4-11-27-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-28"]
 === RHSA-2023:0774 - {product-title} 4.11.28 bug fix and security update
@@ -3321,7 +3321,7 @@ $ oc adm release info 4.11.28 --pullspecs
 [id="ocp-4-11-28-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 
 [id="ocp-4-11-29"]
@@ -3341,7 +3341,7 @@ $ oc adm release info 4.11.29 --pullspecs
 [id="ocp-4-11-29-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-30"]
 === RHSA-2023:1030 - {product-title} 4.11.30 bug fix and security update
@@ -3365,7 +3365,7 @@ $ oc adm release info 4.11.30 --pullspecs
 [id="ocp-4-11-30-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-31"]
 === RHSA-2023:1158 - {product-title} 4.11.31 bug fix and security update
@@ -3384,7 +3384,7 @@ $ oc adm release info 4.11.31 --pullspecs
 [id="ocp-4-11-31-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-32"]
 === RHBA-2023:1296 - {product-title} 4.11.32 bug fix and security update
@@ -3403,7 +3403,7 @@ $ oc adm release info 4.11.32 --pullspecs
 [id="ocp-4-11-32-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-33"]
 === RHBA-2023:1396 - {product-title} 4.11.33 bug fix
@@ -3422,7 +3422,7 @@ $ oc adm release info 4.11.33 --pullspecs
 [id="ocp-4-11-33-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-34"]
 === RHSA-2023:1504 - {product-title} 4.11.34 bug fix and security update
@@ -3441,7 +3441,7 @@ $ oc adm release info 4.11.34 --pullspecs
 [id="ocp-4-11-34-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-35"]
 === RHBA-2023:1650 - {product-title} 4.11.35 bug fix
@@ -3464,7 +3464,7 @@ $ oc adm release info 4.11.35 --pullspecs
 [id="ocp-4-11-35-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-36"]
 === RHBA-2023:1733 - {product-title} 4.11.36 bug fix
@@ -3502,7 +3502,7 @@ $ oc adm release info 4.11.37 --pullspecs
 [id="ocp-4-11-37-updating"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-38"]
 === RHBA-2023:1863 - {product-title} 4.11.38 bug fix update
@@ -3521,7 +3521,7 @@ $ oc adm release info 4.11.38 --pullspecs
 [id="ocp-4-11-38-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-39"]
 === RHSA-2023:2014 - {product-title} 4.11.39 bug fix and security update
@@ -3544,7 +3544,7 @@ $ oc adm release info 4.11.39 --pullspecs
 [id="ocp-4-11-39-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-40"]
 === RHBA-2023:2694 - {product-title} 4.11.40 bug fix update
@@ -3567,7 +3567,7 @@ $ oc adm release info 4.11.40 --pullspecs
 [id="ocp-4-11-40-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-41"]
 === RHBA-2023:3213 - {product-title} 4.11.41 bug fix update
@@ -3586,7 +3586,7 @@ $ oc adm release info 4.11.41 --pullspecs
 [id="ocp-4-11-41-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-42"]
 === RHSA-2023:3309 - {product-title} 4.11.42 bug fix and security update
@@ -3605,7 +3605,7 @@ $ oc adm release info 4.11.42 --pullspecs
 [id="ocp-4-11-42-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-43"]
 === RHSA-2023:3542 {product-title} 4.11.43 bug fix and security update
@@ -3624,7 +3624,7 @@ $ oc adm release info 4.11.43 --pullspecs
 [id="ocp-4-11-43-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-44"]
 === RHSA-2023:3915 - {product-title} 4.11.44 bug fixes and security update
@@ -3651,7 +3651,7 @@ $ oc adm release info 4.11.44 --pullspecs
 [id="ocp-4-11-44-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-45"]
 === RHSA-2023:4053 {product-title} 4.11.45 bug fix and security update
@@ -3670,7 +3670,7 @@ $ oc adm release info 4.11.45 --pullspecs
 [id="ocp-4-11-45-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-46"]
 === RHSA-2023:4310 {product-title} 4.11.46 bug fix and security update
@@ -3689,7 +3689,7 @@ $ oc adm release info 4.11.46 --pullspecs
 [id="ocp-4-11-46-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-47"]
 === RHBA-2023:4614 {product-title} 4.11.47 bug fix update
@@ -3708,7 +3708,7 @@ $ oc adm release info 4.11.47 --pullspecs
 [id="ocp-4-11-47-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-48"]
 === RHBA-2023:4752 {product-title} 4.11.48 bug fix update
@@ -3727,7 +3727,7 @@ $ oc adm release info 4.11.48 --pullspecs
 [id="ocp-4-11-48-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-49"]
 === RHSA-2023:5001 {product-title} 4.11.49 bug fix update
@@ -3746,4 +3746,4 @@ $ oc adm release info 4.11.49 --pullspecs
 [id="ocp-4-11-49-upgrading"]
 ==== Updating
 
-To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI] for instructions.
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
[OSDOCS-7722](https://issues.redhat.com/browse/OSDOCS-7722)

Version(s):
4.11

Preview:
[Asynchronous errata updates](https://64671--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-asynchronous-errata-updates)

QE review:
- [x] No QE approval required because doc update is regarding as an internal fix.

Additional information:
* Updates stemmed from comments on https://github.com/openshift/openshift-docs/pull/64593
* * Remove "for instructions." as they are redundant words. 