### PR TITLE
TRACING-3479: Add documentation for Prometheus Receiver to OpenTelemetry Collector.

### DIFF
--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -211,6 +211,36 @@ The Jaeger receiver ingests data in Jaeger formats.
 <4> The Jaeger Thrift Binary endpoint. If omitted, the default `+0.0.0.0:6832+` is used.
 <5> The TLS server side configuration. See the OTLP receiver configuration section for more details.
 
+[id="prometheus-receiver_{context}"]
+==== Prometheus Receiver
+
+The Prometheus receiver scrapes metrics endpoints..
+
+* Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
+* Supported signals: metrics
+
+.OpenTelemetry Collector custom resource with an enabled Prometheus receiver
+[source,yaml]
+----
+  config: |
+    receivers:
+        prometheus:
+          config:
+            scrape_configs: <1>
+              - job_name: 'my-app'  <2>
+                scrape_interval: 5s <3>
+                static_configs:
+                  - targets: ['my-app.example.svc.cluster.local:8888'] <4>
+    service:
+      pipelines:
+        metrics:
+          receivers: [prometheus]
+----
+<1> Scrape configurations using Prometheus format.
+<2> Prometheus job name.
+<3> Interval to scrape the metrics data.
+<4> Targets where the metrics are exposed. This example scrapes the metrics from an application called "my-app" in the "example" Project.
+
 [id="zipkin-receiver_{context}"]
 ==== Zipkin Receiver
 


### PR DESCRIPTION
Version(s):
All OCP supported versions.

Issue:
https://issues.redhat.com/browse/TRACING-3479

Link to docs preview:


QE review:
- [ ] QE has approved this change.

Additional information:
This documentation is for RHOSDT 3.0.
@max-cx 