### PR TITLE
[OSDOCS-7734]: Fix link to ROSA CLI in ROSA docs

### DIFF
--- a/modules/rosa-installing.adoc
+++ b/modules/rosa-installing.adoc
@@ -19,7 +19,7 @@ Install and configure the {product-title} (ROSA) CLI, `rosa`. You can also insta
 .Procedure
 
 . Install `rosa`, the {product-title} command-line interface (CLI).
-.. Download the link:https://access.redhat.com/products/red-hat-openshift-service-aws/[latest release] of the ROSA CLI for your operating system.
+.. Download the link:https://console.redhat.com/openshift/downloads[latest release] of the ROSA CLI for your operating system.
 .. Optional: Rename the executable file you downloaded to `rosa`. This documentation uses `rosa` to refer to the executable file.
 .. Optional: Add `rosa` to your path.
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-7734
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://64677--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-installing-rosa#rosa-installing-and-configuring-the-rosa-cli_rosa-installing-cli
QE review:
- [ ] QE has approved this change. N/A
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/1b2c0b2f-bd8a-42a7-b193-ba469900a413)
