### PR TITLE
OCPBUGS 18601 fixing typo for spec definition path

### DIFF
--- a/snippets/performance-profile-workload-partitioning.adoc
+++ b/snippets/performance-profile-workload-partitioning.adoc
@@ -33,7 +33,7 @@ a|* Set the number of huge pages (`count`)
 |`spec.realTimeKernel`
 |Set `enabled` to `true` to use the realtime kernel.
 
-|`spec.realTimeKernel.workloadHints`
-|Use `WorkloadHints` to define the set of top level flags for different type of workloads.
+|`spec.workloadHints`
+|Use `workloadHints` to define the set of top level flags for different type of workloads.
 The example configuration configures the cluster for low latency and high performance.
 |====


### PR DESCRIPTION
[OCPBUGS-18601]: spec.realTimeKernel.workloadHints should be spec.workloadHints

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13, 4.14, main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-18601
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64679--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/enabling-workload-partitioning
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
