### PR TITLE
[No Jira] Re-include a module deleted by accident

### DIFF
--- a/functions/serverless-functions-creating.adoc
+++ b/functions/serverless-functions-creating.adoc
@@ -9,3 +9,4 @@ toc::[]
 Before you can build and deploy a function, you must create it. You can create functions using the Knative (`kn`) CLI.
 
 include::modules/serverless-create-func-kn.adoc[leveloffset=+1]
+include::modules/odc-creating-functions.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
`serverless-1.30`+

Issue:
No Jira

Link to docs preview:
https://64713--docspreview.netlify.app/openshift-serverless/latest/functions/serverless-functions-creating

QE review:
Not needed.