### PR TITLE
OCPBUGS-18774 - add oc patch command to mirror ztp image to  local re…

### DIFF
--- a/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
+++ b/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
@@ -47,6 +47,23 @@ $ oc patch argocd openshift-gitops \
 -n openshift-gitops --type=merge \ 
 --patch-file out/argocd/deployment/argocd-openshift-gitops-patch.json
 ----
++
+[NOTE]
+====
+For a disconnected environment, amend the `out/argocd/deployment/argocd-openshift-gitops-patch.json` file with the `ztp-site-generate` image mirrored in your local registry. Run the following command:
+[source,terminal]
+----
+$ oc patch argocd openshift-gitops -n openshift-gitops --type='json' \
+-p='[{"op": "replace", "path": "/spec/repo/initContainers/0/image", \
+"value": "<local_registry>/<ztp_site_generate_image_ref>"}]'
+----
+where:
+--
+<local_registry>:: Is the URL of the disconnected registry, for example, `my.local.registry:5000`
+<ztp-site-generate-image-ref>:: Is the path to the mirrored `ztp-site-generate` image in the local registry, for example `openshift4-ztp-site-generate:custom`.
+--
+
+====
 
 . Apply the pipeline configuration to your hub cluster by using the following command:
 +


### PR DESCRIPTION
OCPBUGS-18774 - add `oc patch` command to mirror ztp image to local registry

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-18774
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64714--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-configuring-hub-cluster-with-argocd_ztp-preparing-the-hub-cluster
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
