### PR TITLE
SRVCOM-2432 add 1.30 to version dropdown for serverless

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -186,6 +186,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.30">1.30</option>
               <option value="1.29">1.29</option>
               <option value="1.28">1.28</option>
             </select>

--- a/_templates/_search.html.erb
+++ b/_templates/_search.html.erb
@@ -8,6 +8,8 @@
 <%= render("_templates/_search_enterprise.html.erb", :version => version) %>
 <% elsif distro_key == 'openshift-telco' %>
 <%= render("_templates/_search_telco.html.erb", :version => version) %>
+<% elsif distro_key == 'openshift-serverless' %>
+<%= render("_templates/_search_serverless.html.erb", :version => version) %>
 <% else %>
 <%= render("_templates/_search_other.html") %>
 <% end %>

--- a/_templates/_search_serverless.html.erb
+++ b/_templates/_search_serverless.html.erb
@@ -1,0 +1,21 @@
+<div id="hc-search">
+  <input id="hc-search-input" type="text">
+  <button id="hc-search-btn">Search</button>
+</div>
+
+<div id="hc-search-modal">
+  <div id="hc-modal-content">
+    <span id="hc-modal-close">&times;</span>
+    <div id="hc-search-results-wrapper">
+      <div id="hc-search-results"></div>
+      <div id="hc-search-progress-indicator" class="text-center search-progress-indicator"><i class="fa fa-circle-o-notch fa-spin" style="font-size:42px"></i></div>
+      <div class="text-center">
+        <button id="hc-search-more-btn">Show more results</button>
+      </div>
+    </div>
+  </div>
+</div>
+
+<script>
+  hcSearchCategory("docs_serverless", "<%= version %>");
+</script>


### PR DESCRIPTION
Version(s):
main only

Issue:
SRVCOM 2432

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->


Updates for version drop down, to support serverless 1.30
