### PR TITLE
SRVCOM-2550 update redirects for serverless 1.30

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -209,22 +209,22 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12)/serverless/develop/serverless-traffic-management.html /container-platform/$1/serverless/knative-serving/traffic-splitting/traffic-splitting-overview.html [NE,R=302]
 
 
-    # redirect latest to 1.29
+    # redirect latest to 1.30
     RewriteRule ^serverless/?$ /serverless/latest [R=302]
-    RewriteRule ^serverless/latest/?(.*)$ /serverless/1\.29/$1 [NE,R=302]
+    RewriteRule ^serverless/latest/?(.*)$ /serverless/1\.30/$1 [NE,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^serverless/(1\.28|1\.29)/?$ /serverless/$1/about/about-serverless.html [L,R=302]
+    RewriteRule ^serverless/(1\.28|1\.29|1\.30)/?$ /serverless/$1/about/about-serverless.html [L,R=302]
 
     # redirect rel notes
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/serverless-release-notes.html$ /serverless/1.29/about/serverless-release-notes.html [L,R=302]
-    RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.29/about/serverless-release-notes.html [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/serverless-release-notes.html$ /serverless/1.30/about/serverless-release-notes.html [L,R=302]
+    RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.30/about/serverless-release-notes.html [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/?(.*)$ /serverless/1.29/$2  [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
 
     # redirect any links to existing ROSA/Dedicated embedded content to standalone equivalent
-    RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.29/$2  [L,R=302]
+    RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
 
 
     # OSD redirects for new content


### PR DESCRIPTION

Version(s):
main only

Issue:
SRVCOM 2550

Update redirects so that latest points to 1.30