### PR TITLE
OCPBUGS#19016: Operator groups can overwrite cluster roles

### DIFF
--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -96,6 +96,10 @@ spec:
   targetNamespaces:
   - <namespace>
 ----
++
+--
+include::snippets/operator-group-unique-name.adoc[]
+--
 
 .. Create the `OperatorGroup` object:
 +

--- a/modules/olm-installing-specific-version-cli.adoc
+++ b/modules/olm-installing-specific-version-cli.adoc
@@ -165,6 +165,10 @@ spec:
   targetNamespaces:
   - <namespace>
 ----
++
+--
+include::snippets/operator-group-unique-name.adoc[]
+--
 
 .. Create the `OperatorGroup` object:
 +

--- a/modules/olm-operatorgroups-rbac.adoc
+++ b/modules/olm-operatorgroups-rbac.adoc
@@ -21,6 +21,8 @@ When an Operator group is created, three cluster roles are generated. Each conta
 |`olm.opgroup.permissions/aggregate-to-view: <operatorgroup_name>`
 |===
 
+include::snippets/operator-group-unique-name.adoc[]
+
 The following RBAC resources are generated when a CSV becomes an active member of an Operator group, as long as the CSV is watching all namespaces with the `AllNamespaces` install mode and is not in a failed state with reason `InterOperatorGroupOwnerConflict`:
 
 * Cluster roles for each API resource from a CRD

--- a/modules/olm-operatorgroups-static.adoc
+++ b/modules/olm-operatorgroups-static.adoc
@@ -24,3 +24,5 @@ spec:
     matchLabels:
       something.cool.io/cluster-monitoring: "true"
 ----
+
+include::snippets/operator-group-unique-name.adoc[]

--- a/modules/olm-operatorgroups-target-namespace.adoc
+++ b/modules/olm-operatorgroups-target-namespace.adoc
@@ -19,6 +19,8 @@ spec:
   - my-namespace
 ----
 
+include::snippets/operator-group-unique-name.adoc[]
+
 You can alternatively specify a namespace using a label selector with the `spec.selector` parameter:
 
 [source,yaml]

--- a/modules/olm-policy-scoping-operator-install.adoc
+++ b/modules/olm-policy-scoping-operator-install.adoc
@@ -93,6 +93,10 @@ EOF
 ----
 +
 Any Operator installed in the designated namespace is tied to this Operator group and therefore to the service account specified.
++
+--
+include::snippets/operator-group-unique-name.adoc[]
+--
 
 . Create a `Subscription` object in the designated namespace to install an Operator:
 +

--- a/snippets/operator-group-unique-name.adoc
+++ b/snippets/operator-group-unique-name.adoc
@@ -1,5 +1,11 @@
 // Text snippet included in the following assemblies:
 //
+// * modules/olm-installing-from-operatorhub-using-cli.adoc
+// * modules/olm-installing-specific-version-cli.adoc
+// * modules/olm-operatorgroups-rbac.adoc
+// * modules/olm-operatorgroups-static.adoc
+// * modules/olm-operatorgroups-target-namespace.adoc
+// * modules/olm-policy-scoping-operator-install.adoc
 
 :_mod-docs-content-type: SNIPPET
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11-4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [OCPBUGS-19016](https://issues.redhat.com/browse/OCPBUGS-19016)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:

* `modules/olm-installing-from-operatorhub-using-cli.adoc`
** [User tasks](https://64754--docspreview.netlify.app/openshift-enterprise/latest/operators/user/olm-installing-operators-in-namespace#olm-installing-operator-from-operatorhub-using-cli_olm-installing-operators-in-namespace)
  * [Admin tasks](https://64754--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster#olm-installing-operator-from-operatorhub-using-cli_olm-adding-operators-to-a-cluster)
  *  [Post-installation](https://64754--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/preparing-for-users#olm-installing-operator-from-operatorhub-using-cli_post-install-preparing-for-users)
* `modules/olm-installing-specific-version-cli.adoc`
  * [User tasks](https://64754--docspreview.netlify.app/openshift-enterprise/latest/operators/user/olm-installing-operators-in-namespace#olm-installing-specific-version-cli_olm-installing-operators-in-namespace)
  * [Admin tasks](https://64754--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster#olm-installing-specific-version-cli_olm-adding-operators-to-a-cluster)
* `modules/olm-operatorgroups-rbac.adoc`
  * [Understanding Operators > OLM > Undestanding Operator groups](https://64754--docspreview.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-operatorgroups#olm-operatorgroups-rbac_olm-understanding-operatorgroups)
* `modules/olm-operatorgroups-static.adoc`
  * [Understanding Operators > OLM > Undestanding Operator groups](https://64754--docspreview.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-operatorgroups#olm-operatorgroups-static_olm-understanding-operatorgroups)
* `modules/olm-operatorgroups-target-namespace.adoc`
  * [Understanding Operators > OLM > Undestanding Operator groups](https://64754--docspreview.netlify.app/openshift-enterprise/latest/operators/understanding/olm/olm-understanding-operatorgroups#olm-operatorgroups-target-namespace_olm-understanding-operatorgroups)
* `modules/olm-policy-scoping-operator-install.adoc`
  * [Admin tasks > Allowing non-admins to install Operators > Scoping Operator installations](https://64754--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-creating-policy#olm-policy-scoping-operator-install_olm-creating-policy)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
