### PR TITLE
CNV-31146: bug fix for uninstalling virt

### DIFF
--- a/modules/virt-deleting-virt-cli.adoc
+++ b/modules/virt-deleting-virt-cli.adoc
@@ -37,6 +37,13 @@ $ oc delete subscription kubevirt-hyperconverged -n openshift-cnv
 $ oc delete csv -n openshift-cnv -l operators.coreos.com/kubevirt-hyperconverged.openshift-cnv
 ----
 
+. Delete the {VirtProductName} namespace:
++
+[source,terminal]
+----
+$ oc delete namespace openshift-cnv
+----
+
 . List the {VirtProductName} custom resource definitions (CRDs) by running the `oc delete crd` command with the `dry-run` option:
 +
 [source,terminal]

--- a/modules/virt-installing-virt-operator.adoc
+++ b/modules/virt-installing-virt-operator.adoc
@@ -17,9 +17,9 @@ You can deploy the {VirtProductName} Operator by using the {product-title} web c
 
 . From the *Administrator* perspective, click *Operators* -> *OperatorHub*.
 
-. In the *Filter by keyword* field, type *{CNVOperatorDisplayName}*.
+. In the *Filter by keyword* field, type *Virtualization*.
 
-. Select the *{CNVOperatorDisplayName}* tile.
+. Select the *{CNVOperatorDisplayName}* tile with the *Red Hat* source label.
 
 . Read the information about the Operator and click *Install*.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-31146](https://issues.redhat.com//browse/CNV-31146)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64780--docspreview.netlify.app/openshift-enterprise/latest/virt/install/uninstalling-virt#virt-deleting-virt-cli_uninstalling-virt
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
