### PR TITLE
TELCODOCS-1279: First draft

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -24,6 +24,14 @@ include::modules/kmm-security.adoc[leveloffset=+2]
 
 * xref:../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission].
 
+// Added for TELCODOCS-1279
+include::modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://fastbitlab.com/building-a-linux-kernel-module/[Building a linux kernel module]
+
 include::modules/kmm-example-module-cr.adoc[leveloffset=+2]
 include::modules/kmm-creating-moduleloader-image.adoc[leveloffset=+1]
 include::modules/kmm-running-depmod.adoc[leveloffset=+2]

--- a/modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc
+++ b/modules/kmm-replacing-in-tree-modules-with-out-of-tree-modules.adoc
@@ -1,0 +1,43 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-replacing-in-tree-modules-with-out-of-tree-modules_{context}"]
+= Replacing in-tree modules with out-of-tree modules
+
+You can use Kernel Module Management (KMM) to build kernel modules that can be loaded or unloaded into the kernel on demand. These modules extend the functionality of the kernel without the need to reboot the system. Modules can be configured as built-in or dynamically loaded.
+
+Dynamically loaded modules include in-tree modules and out-of-tree (OOT) modules. In-tree modules are internal to the Linux kernel tree, that is, they are already part of the kernel. Out-of-tree modules are external to the Linux kernel tree. They are generally written for development and testing purposes, such as testing the new version of a kernel module that is shipped in-tree, or to deal with incompatibilities.
+
+Some modules loaded by KMM could replace in-tree modules already loaded on the node. To unload an in-tree module before loading your module, set the `.spec.moduleLoader.container.inTreeModuleToRemove` field. The following is an example for module replacement for all kernel mappings:
+
+[source,yaml]
+----
+# ...
+spec:
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: mod_a
+
+      inTreeModuleToRemove: mod_b
+----
+
+In this example, the `moduleLoader` pod uses `inTreeModuleToRemove` to unload the in-tree `mod_b` before loading `mod_a`
+from the `moduleLoader` image.
+When the `moduleLoader`pod is terminated and `mod_a` is unloaded, `mod_b` is not loaded again.
+
+The following is an example for module replacement for specific kernel mappings:
+
+[source,yaml]
+----
+# ...
+spec:
+  moduleLoader:
+    container:
+      kernelMappings:
+        - literal: 6.0.15-300.fc37.x86_64
+          containerImage: some.registry/org/my-kmod:6.0.15-300.fc37.x86_64
+          inTreeModuleToRemove: <module_name>
+----


### PR DESCRIPTION
D/S Docs: [MGMT-13872](https://issues.redhat.com//browse/MGMT-13872) In-tree kernel module replacement with OOT kernel module

Version: 4.13+

Jira: https://issues.redhat.com/browse/TELCODOCS-1279  Document replacing In-tree with OOT kernel module

Version(s): KMMO 1.1

Link to docs preview: https://64784--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management#kmm-replacing-in-tree-modules-with-out-of-tree-modules_kernel-module-management-operator

SME review: @yevgeny-shnaidman, @qbarrand @bthurber 
QE review: @cdvultur