### PR TITLE
GH #64763 : added the missing urls for PatternFly new version

### DIFF
--- a/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
+++ b/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
@@ -41,9 +41,9 @@ conster Header: React.FC = () => {
 * Avoid selectors that could affect markup outside of your plugins components, such as element selectors. These are not APIs and are subject to change. Using them might break your plugin. Avoid selectors like element selectors that could affect markup outside of your plugins components.
 
 [discrete]
-== PatternFly 4 guidelines
+== PatternFly guidelines
 When creating your plugin, follow these guidelines for using PatternFly:
 
-* Use link:https://www.patternfly.org/v4/[PatternFly4] components and PatternFly CSS variables. Core PatternFly components are available through the SDK. Using PatternFly components and variables help your plugin look consistent in future console versions.
-* Make your plugin accessible by following link:https://www.patternfly.org/v4/accessibility/accessibility-fundamentals/[PatternFly's accessibility fundamentals].
+* Use link:https://www.patternfly.org/components/all-components/[PatternFly] components and PatternFly CSS variables. Core PatternFly components are available through the SDK. Using PatternFly components and variables help your plugin look consistent in future console versions.
+* Make your plugin accessible by following link:https://www.patternfly.org/accessibility/accessibility-fundamentals/[PatternFly's accessibility fundamentals].
 * Avoid using other CSS libraries such as Bootstrap or Tailwind. They can conflict with PatternFly and will not match the console look and feel.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): uncertain
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://github.com/openshift/openshift-docs/issues/64763
https://issues.redhat.com/browse/OCPBUGS-17838
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://github.com/volantxs/openshift-docs/blob/missing_url/web_console/dynamic-plugin/overview-dynamic-plugin.adoc
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

updated all the suggested changes regarding missing/old links for PatternFly in the required file
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for a review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
