### PR TITLE
Add release note for IPsec north-south traffic encryption

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -765,6 +765,13 @@ With this release, you can access the NMstate Operator and resources such as the
 
 IPsec is now supported on the IBM Cloud platform for clusters that use the OVN-Kubernetes network plugin, which is the default in {product-title} 4.14. For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#configuring-ipsec-ovn[Configuring IPsec encryption].
 
+[id="ocp-4-14-networking-ovn-kubernetes-ipsec-support-for-external-traffic"]
+==== OVN-Kubernetes network plugin support for IPsec encryption of external traffic (Technology Preview)
+
+{product-title} now supports encryption of external traffic, also known as north-south traffic. IPsec already supports encryption of network traffic between pods, known as east-west traffic. You can use both features in conjunction to provide full in-transit encryption for {product-title} clusters. This is available as a Technology Preview feature.
+
+To use this feature, you need to define an IPsec configuration tuned for your network infrastructure. For more information, refer to xref:../networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc#nw-ovn-ipsec-north-south-enable_configuring-ipsec-ovn[Enabling IPsec encryption for external IPsec endpoints].
+
 [id="ocp-4-14-single-stack-support-nmstate"]
 ==== Single-stack IPv6 support for Kubernetes NMstate
 With this release, you can use Kubernetes NMState Operator in single-stack IPv6 clusters.
@@ -2232,6 +2239,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Admin Network Policy (`AdminNetworkPolicy`)
+|Not Available
+|Not Available
+|Technology Preview
+
+|IPsec external traffic (north-south)
 |Not Available
 |Not Available
 |Technology Preview


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-6862

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64835--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-networking-ovn-kubernetes-ipsec-support-for-external-traffic
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
