### PR TITLE
OSDOCS-6862: Add support for external IPsec endpoints

### DIFF
--- a/modules/nw-ovn-ipsec-enable.adoc
+++ b/modules/nw-ovn-ipsec-enable.adoc
@@ -4,14 +4,14 @@
 
 :_content-type: PROCEDURE
 [id="nw-ovn-ipsec-enable_{context}"]
-= Enabling IPsec encryption
+= Enabling pod-to-pod IPsec encryption
 
-As a cluster administrator, you can enable IPsec encryption after cluster installation.
+As a cluster administrator, you can enable pod-to-pod IPsec encryption after cluster installation.
 
 .Prerequisites
 
-* Install the OpenShift CLI (`oc`).
-* Log in to the cluster with a user with `cluster-admin` privileges.
+* Install the {oc-first}.
+* You are logged in to the cluster as a user with `cluster-admin` privileges.
 * You have reduced the size of your cluster MTU by `46` bytes to allow for the overhead of the IPsec ESP header.
 
 .Procedure

--- a/modules/nw-ovn-ipsec-north-south-enable.adoc
+++ b/modules/nw-ovn-ipsec-north-south-enable.adoc
@@ -1,0 +1,143 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
+
+:_content-type: PROCEDURE
+[id="nw-ovn-ipsec-north-south-enable_{context}"]
+= Enabling IPsec encryption for external IPsec endpoints
+
+// This procedure requests installing Butane to prepare the machine config
+
+As a cluster administrator, you can enable IPsec encryption between the cluster and external IPsec endpoints. Because this procedure uses Butane to create machine configs, you must have the `butane` command installed.
+
+[NOTE]
+====
+After you apply the machine config, the Machine Config Operator reboots affected nodes in your cluster to rollout the new machine config.
+====
+
+.Prerequisites
+
+* Install the {oc-first}.
+* You are logged in to the cluster as a user with `cluster-admin` privileges.
+* You have reduced the size of your cluster MTU by `46` bytes to allow for the overhead of the IPsec ESP header.
+* You have installed the `butane` utility.
+* You have an existing PKCS#12 certificate for the IPsec endpoint and a CA cert in PEM format.
+
+.Procedure
+
+As a cluster administrator, you can enable IPsec support for external IPsec endpoints.
+
+. Create an IPsec configuration file named `ipsec-endpoint-config.conf`. The configuration is consumed in the next step. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/securing_networks/configuring-a-vpn-with-ipsec_securing-networks#configuring-a-vpn-with-ipsec_securing-networks[Libreswan as an IPsec VPN implementation].
+
+. Provide the following certificate files to add to the Network Security Services (NSS) database on each host. These files are imported as part of the Butane configuration in subsequent steps.
++
+--
+* `left_server.p12`: The certificate bundle for the IPsec endpoints
+* `ca.pem`: The certificate authority that you signed your certificates with
+--
+
+. Create a machine config to apply the IPsec configuration to your cluster by using the following two steps:
+
+.. To add the IPsec configuration, create Butane config files for the control plane and worker nodes with the following contents:
++
+[source,terminal,subs="attributes+"]
+----
+$ for role in master worker; do
+  cat >> "99-ipsec-$\{role}-endpoint-config.bu" <<-EOF
+  variant: openshift
+  version: {product-version}.0
+  metadata:
+    name: 99-$\{role}-import-certs-enable-svc-os-ext
+    labels:
+      machineconfiguration.openshift.io/role: $role
+  openshift:
+    extensions:
+      - ipsec
+  systemd:
+    units:
+    - name: ipsec-import.service
+      enabled: true
+      contents: |
+        [Unit]
+        Description=Import external certs into ipsec NSS
+        Before=ipsec.service
+      
+        [Service]
+        Type=oneshot
+        ExecStart=/usr/local/bin/ipsec-addcert.sh
+        RemainAfterExit=false
+        StandardOutput=journal
+
+        [Install]
+        WantedBy=multi-user.target
+    - name: ipsecenabler.service
+      enabled: true
+      contents: |
+        [Service]
+        Type=oneshot
+        ExecStart=systemctl enable --now ipsec.service
+
+        [Install]
+        WantedBy=multi-user.target
+  storage:
+    files:
+    - path: /etc/pki/certs/ca.pem
+      mode: 0400
+      overwrite: true
+      contents:
+        local: ca.pem
+    - path: /etc/pki/certs/left_server.p12
+      mode: 0400
+      overwrite: true
+      contents:
+        local: left_server.p12
+    - path: /usr/local/bin/ipsec-addcert.sh
+      mode: 0740
+      overwrite: true
+      contents:
+        inline: |
+          #!/bin/bash -e
+          echo "importing cert to NSS"
+          certutil -A -n "CA" -t "CT,C,C" -d /var/lib/ipsec/nss/ -i /etc/pki/certs/ca.pem
+          pk12util -W "" -i /etc/pki/certs/left_server.p12 -d /var/lib/ipsec/nss/
+          certutil -M -n "left_server" -t "u,u,u" -d /var/lib/ipsec/nss/
+EOF
+done
+----
+
+.. To transform the Butane files that you created in the previous step into machine configs, enter the following command:
++
+[source,terminal]
+----
+$ for role in master worker; do
+  butane 99-ipsec-${role}-endpoint-config.bu -o ./99-ipsec-$role-endpoint-config.yaml
+done
+----
+
+. To apply the machine configs to your cluster, enter the following command:
++
+[source,terminal]
+----
+$ for role in master worker; do
+  oc apply -f 99-ipsec-${role}-endpoint-config.yaml
+done
+----
++
+[IMPORTANT]
+====
+As the Machine Config Operator (MCO) updates machines in each machine config pool, it reboots each node one by one. You must wait until all the nodes are updated before external IPsec connectivity is available.
+====
+
+. Check the machine config pool status by entering the following command:
++
+[source,terminal]
+----
+$ oc get mcp
+----
++
+A successfully updated node has the following status: `UPDATED=true`, `UPDATING=false`, `DEGRADED=false`.
++
+[NOTE]
+====
+By default, the MCO updates one machine per pool at a time, causing the total time the migration takes to increase with the size of the cluster.
+====

--- a/modules/nw-ovn-ipsec-traffic.adoc
+++ b/modules/nw-ovn-ipsec-traffic.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: CONCEPT
 [id="nw-ovn-ipsec-traffic_{context}"]
-= Types of network traffic flows encrypted by IPsec
+= Types of network traffic flows encrypted by pod-to-pod IPsec
 
 With IPsec enabled, only the following network traffic flows between pods are encrypted:
 
@@ -20,30 +20,3 @@ The following traffic flows are not encrypted:
 The encrypted and unencrypted flows are illustrated in the following diagram:
 
 image::nw-ipsec-encryption.png[IPsec encrypted and unencrypted traffic flows]
-
-== Network connectivity requirements when IPsec is enabled
-
-You must configure the network connectivity between machines to allow {product-title} cluster
-components to communicate. Each machine must be able to resolve the hostnames
-of all other machines in the cluster.
-
-.Ports used for all-machine to all-machine communications
-[cols="2a,2a,5a",options="header"]
-|===
-
-|Protocol
-|Port
-|Description
-
-.2+|UDP
-|`500`
-|IPsec IKE packets
-
-|`4500`
-|IPsec NAT-T packets
-
-|ESP
-|N/A
-|IPsec Encapsulating Security Payload (ESP)
-
-|===

--- a/modules/nw-own-ipsec-required-ports.adoc
+++ b/modules/nw-own-ipsec-required-ports.adoc
@@ -1,0 +1,30 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/about-ipsec-ovn.adoc
+
+:_content-type: CONCEPT
+[id="network-connectivity-requirements-ipsec_{context}"]
+= Network connectivity requirements when IPsec is enabled
+
+You must configure the network connectivity between machines to allow {product-title} cluster components to communicate. Each machine must be able to resolve the hostnames of all other machines in the cluster.
+
+.Ports used for all-machine to all-machine communications
+[cols="2a,2a,5a",options="header"]
+|===
+
+|Protocol
+|Port
+|Description
+
+.2+|UDP
+|`500`
+|IPsec IKE packets
+
+|`4500`
+|IPsec NAT-T packets
+
+|ESP
+|N/A
+|IPsec Encapsulating Security Payload (ESP)
+
+|===

--- a/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
+++ b/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn.adoc
@@ -6,27 +6,62 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-With IPsec enabled, all pod-to-pod network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec _Transport mode_.
+With IPsec enabled, you can encrypt both internal pod-to-pod cluster traffic between nodes and external traffic between pods and IPsec endpoints external to your cluster. All pod-to-pod network traffic between nodes on the OVN-Kubernetes cluster network is encrypted with IPsec _Transport mode_.
 
 IPsec is disabled by default. It can be enabled either during or after installing the cluster. For information about cluster installation, see xref:../../installing/index.adoc#ocp-installation-overview[{product-title} installation overview]. If you need to enable IPsec after cluster installation, you must first resize your cluster MTU to account for the overhead of the IPsec ESP IP header.
 
-The following documentation describes how to enable and disable IPSec after cluster installation.
+[NOTE]
+====
+IPsec on IBM Cloud VPC supports only NAT-T. Using ESP is not supported.
+====
+
+Use the procedures in the following documentation to:
+
+* Enable and disable IPSec after cluster installation
+* Configure support for external IPsec endpoints outside the cluster
+* Verify that IPsec encrypts traffic between pods on different nodes
 
 [id="{context}-prerequisites"]
 == Prerequisites
 
 * You have decreased the size of the cluster MTU by `46` bytes to allow for the additional overhead of the IPsec ESP header. For more information on resizing the MTU that your cluster uses, see xref:../../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the MTU for the cluster network].
 
-include::modules/nw-ovn-ipsec-traffic.adoc[leveloffset=+1]
-include::modules/nw-ovn-ipsec-encryption.adoc[leveloffset=+1]
-include::modules/nw-ovn-ipsec-certificates.adoc[leveloffset=+1]
-include::modules/nw-ovn-ipsec-enable.adoc[leveloffset=+1]
-include::modules/nw-ovn-ipsec-verification.adoc[leveloffset=+1]
-include::modules/nw-ovn-ipsec-disable.adoc[leveloffset=+1]
+include::modules/nw-own-ipsec-required-ports.adoc[leveloffset=+1]
+
+[id="{context}-pod-to-pod-ipsec"]
+== IPsec encryption for pod-to-pod traffic
+
+{product-title} supports IPsec encryption for network traffic between pods.
+
+include::modules/nw-ovn-ipsec-traffic.adoc[leveloffset=+2]
+include::modules/nw-ovn-ipsec-encryption.adoc[leveloffset=+2]
+include::modules/nw-ovn-ipsec-certificates.adoc[leveloffset=+2]
+include::modules/nw-ovn-ipsec-enable.adoc[leveloffset=+2]
+include::modules/nw-ovn-ipsec-verification.adoc[leveloffset=+2]
+include::modules/nw-ovn-ipsec-disable.adoc[leveloffset=+2]
+
+[id="{context}-external-traffic-ipsec"]
+== IPsec encryption for external traffic
+
+{product-title} supports IPsec encryption for traffic to external hosts.
+
+You must supply a custom IPsec configuration, which includes the IPsec configuration file itself and TLS certificates. 
+
+Ensure that the following prohibitions are observed:
+
+* The custom IPsec configuration must not include any connection specifications that might interfere with the cluster's pod-to-pod IPsec configuration.
+* Certificate common names (CN) in the provided certificate bundle must not begin with the `ovs_` prefix, because this naming can collide with pod-to-pod IPsec CN names in the Network Security Services (NSS) database of each node.
+
+// Tech Preview
+:FeatureName: IPsec support for external endpoints
+include::snippets/technology-preview.adoc[]
+
+include::modules/nw-ovn-ipsec-north-south-enable.adoc[leveloffset=+2]
 
 [id="{context}_additional-resources"]
 == Additional resources
 
 * xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[About the OVN-Kubernetes Container Network Interface (CNI) network plugin]
 * xref:../../networking/changing-cluster-network-mtu.adoc#changing-cluster-network-mtu[Changing the MTU for the cluster network]
+* xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-butane-install_installing-customizing[Installing Butane]
 * xref:../../rest_api/operator_apis/network-operator-openshift-io-v1.adoc#network-operator-openshift-io-v1[Network [operator.openshift.io/v1]] API


### PR DESCRIPTION
- https://issues.redhat.com/browse/OSDOCS-6862

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Enabling IPsec encryption for external IPsec endpoints](https://64837--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn#nw-ovn-ipsec-north-south-enable_configuring-ipsec-ovn)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
