### PR TITLE
OSDOCS#7742: Adds notes for MS 4.13.13 release

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -264,3 +264,12 @@ Issued: 2023-09-12
 {product-title} release 4.13.12 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5013[RHBA-2023:5013] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5011[RHBA-2023:5011] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-13-dp"]
+=== RHBA-2023:5157 - {product-title} 4.13.13 bug fix and security update
+
+Issued: 2023-09-19
+
+{product-title} release 4.13.13 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5157[RHBA-2023:5157] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5155[RHSA-2023:5155] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
OSDOCS#7742: Adds notes for MS 4.13.13 release

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-7742

Link to docs preview:
https://64838--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-13-dp

QE review:
- [ ] QE has approved this change.
No QE needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
