### PR TITLE
OBSDOCS-214: Documenting Loki restart behavior

### DIFF
--- a/logging/cluster-logging-loki.adoc
+++ b/logging/cluster-logging-loki.adoc
@@ -13,7 +13,13 @@ Loki is a horizontally scalable, highly available, multi-tenant log aggregation 
 include::modules/loki-deployment-sizing.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-loki-deploy.adoc[leveloffset=+1]
+////
+include::modules/logging-loki-restart-hardening.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+* link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets[Pod disruption budgets Kubernetes documentation]
+////
 include::modules/logging-loki-retention.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-forwarding-lokistack.adoc[leveloffset=+1]

--- a/modules/logging-loki-restart-hardening.adoc
+++ b/modules/logging-loki-restart-hardening.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * logging/cluster-logging-loki.adoc
+
+:_content-type: CONCEPT
+[id="logging-loki-restart-hardening_{context}"]
+= LokiStack behavior during cluster restarts
+
+In logging version 5.8 and newer versions, when an {product-title} cluster is restarted, LokiStack ingestion and the query path continue to operate within the available CPU and memory resources available for the node. This means that there is no downtime for the LokiStack during {product-title} cluster updates. This behavior is achieved by using `PodDisruptionBudget` resources. The Loki Operator provisions `PodDisruptionBudget` resources for Loki, which determine the minimum number of pods that must be available per component to ensure normal operations under certain conditions.


### PR DESCRIPTION
Version(s):
4.12+ (logging 5.8)

Issue:
https://issues.redhat.com/browse/OBSDOCS-214

Link to docs preview:
https://64839--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki#logging-loki-restart-hardening_cluster-logging-loki

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
If merging ahead of 5.8 release, new section must be commented out and then uncommented when we go live for release day.
