### PR TITLE
adding the missing matchLabels

### DIFF
--- a/modules/olm-operatorgroups-target-namespace.adoc
+++ b/modules/olm-operatorgroups-target-namespace.adoc
@@ -30,7 +30,8 @@ metadata:
   namespace: my-namespace
 spec:
   selector:
-    cool.io/prod: "true"
+    matchLabels:
+      cool.io/prod: "true"
 ----
 
 [IMPORTANT]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
A label cannot appear directly below the selector, this will result in the field being pruned and watching all namespaces.  The label needs to appear under matchLabels instead..

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): appears at least starting with the 4.5 docs
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
