### PR TITLE
OBSDOCS-213: Loki reliability hardening reference docs

### DIFF
--- a/logging/cluster-logging-loki.adoc
+++ b/logging/cluster-logging-loki.adoc
@@ -13,13 +13,26 @@ Loki is a horizontally scalable, highly available, multi-tenant log aggregation 
 include::modules/loki-deployment-sizing.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-loki-deploy.adoc[leveloffset=+1]
+
 ////
 include::modules/logging-loki-restart-hardening.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 * link:https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets[Pod disruption budgets Kubernetes documentation]
+
+include::modules/logging-loki-reliability-hardening.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podantiaffinity-v1-core[`PodAntiAffinity` v1 core Kubernetes documentation]
+* link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity[Assigning Pods to Nodes Kubernetes documentation]
+
+ifdef::openshift-enterprise[]
+* xref:../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
+endif::[]
 ////
+
 include::modules/logging-loki-retention.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-forwarding-lokistack.adoc[leveloffset=+1]
@@ -29,8 +42,9 @@ include::modules/loki-rate-limit-errors.adoc[leveloffset=+2]
 [role="_additional-resources"]
 [id="additional-resources_cluster-logging-loki"]
 == Additional Resources
-* link:https://grafana.com/docs/loki/latest/logql/[Loki Query Language (LogQL) Documentation]
-* link:https://loki-operator.dev/docs/howto_connect_grafana.md/[Grafana Dashboard Documentation]
-* link:https://loki-operator.dev/docs/object_storage.md/[Loki Object Storage Documentation]
-* link:https://loki-operator.dev/docs/api.md/#loki-grafana-com-v1-IngestionLimitSpec[Loki Operator `IngestionLimitSpec` Documentation]
-* link:https://grafana.com/docs/loki/latest/operations/storage/schema/#changing-the-schema[Loki Storage Schema Documentation]
+* link:https://grafana.com/docs/loki/latest/get-started/components/[Loki components documentation]
+* link:https://grafana.com/docs/loki/latest/logql/[Loki Query Language (LogQL) documentation]
+* link:https://loki-operator.dev/docs/howto_connect_grafana.md/[Grafana Dashboard documentation]
+* link:https://loki-operator.dev/docs/object_storage.md/[Loki Object Storage documentation]
+* link:https://loki-operator.dev/docs/api.md/#loki-grafana-com-v1-IngestionLimitSpec[Loki Operator `IngestionLimitSpec` documentation]
+* link:https://grafana.com/docs/loki/latest/operations/storage/schema/#changing-the-schema[Loki Storage Schema documentation]

--- a/modules/logging-loki-reliability-hardening.adoc
+++ b/modules/logging-loki-reliability-hardening.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * logging/cluster-logging-loki.adoc
+
+:_content-type: CONCEPT
+[id="logging-loki-reliability-hardening_{context}"]
+= Configuring Loki to tolerate node failure
+
+In the {logging} 5.8 and later versions, the Loki Operator supports setting pod anti-affinity rules to request that pods of the same component are scheduled on different available nodes in the cluster.
+
+include::snippets/about-pod-affinity.adoc[]
+
+The Operator sets default, preferred `podAntiAffinity` rules for all Loki components, which includes the `compactor`, `distributor`, `gateway`, `indexGateway`, `ingester`, `querier`, `queryFrontend`, and `ruler` components.
+
+You can override the preferred `podAntiAffinity` settings for Loki components by configuring required settings in the `requiredDuringSchedulingIgnoredDuringExecution` field:
+
+.Example user settings for the ingester component
+[source,yaml]
+----
+apiVersion: loki.grafana.com/v1
+kind: LokiStack
+metadata:
+  name: logging-loki
+  namespace: openshift-logging
+spec:
+# ...
+  template:
+    ingester:
+      podAntiAffinity:
+      # ...
+        requiredDuringSchedulingIgnoredDuringExecution: <1>
+        - labelSelector:
+            matchLabels: <2>
+              app.kubernetes.io/component: ingester
+          topologyKey: kubernetes.io/hostname
+# ...
+----
+<1> The stanza to define a required rule.
+<2> The key-value pair (label) that must be matched to apply the rule.

--- a/modules/nodes-scheduler-node-affinity-about.adoc
+++ b/modules/nodes-scheduler-node-affinity-about.adoc
@@ -99,4 +99,3 @@ If you are using node affinity and node selectors in the same pod configuration,
 
 * If you specify multiple `matchExpressions` associated with `nodeSelectorTerms`, then the pod can be scheduled onto a node only if all `matchExpressions` are satisfied.
 ====
-

--- a/nodes/scheduling/nodes-scheduler-pod-affinity.adoc
+++ b/nodes/scheduling/nodes-scheduler-pod-affinity.adoc
@@ -6,19 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
-
-Affinity is a property of pods that controls the nodes on which they prefer to be scheduled. Anti-affinity is a property of pods
-that prevents a pod from being scheduled on a node.
-
-In {product-title} _pod affinity_ and _pod anti-affinity_ allow you to constrain which nodes your pod is eligible to be scheduled on based on the key/value labels on other pods.
-
-
-
-// The following include statements pull in the module files that comprise
-// the assembly. Include any combination of concept, procedure, or reference
-// modules required to cover the user story. You can also include other
-// assemblies.
+include::snippets/about-pod-affinity.adoc[]
 
 include::modules/nodes-scheduler-pod-affinity-about.adoc[leveloffset=+1]
 

--- a/snippets/about-pod-affinity.adoc
+++ b/snippets/about-pod-affinity.adoc
@@ -1,0 +1,11 @@
+// Snippets included in the following assemblies and modules:
+//
+// * /nodes/scheduling/nodes-scheduler-pod-affinity.adoc
+// * /modules/logging-loki-reliability-hardening.adoc
+
+:_content-type: SNIPPET
+
+Affinity is a property of pods that controls the nodes on which they prefer to be scheduled. Anti-affinity is a property of pods
+that prevents a pod from being scheduled on a node.
+
+In {product-title}, _pod affinity_ and _pod anti-affinity_ allow you to constrain which nodes your pod is eligible to be scheduled on based on the key-value labels on other pods.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-213

Link to docs preview:
- https://64845--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki#logging-loki-reliability-hardening_cluster-logging-loki
- https://64845--docspreview.netlify.app/openshift-enterprise/latest/nodes/scheduling/nodes-scheduler-pod-affinity (no content change, moved to snippet only)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
