### PR TITLE
OSDOCS-7769: Migrated the Cloudwatch logs and STS topic from MOBB docs to ROSA product docs

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -88,6 +88,8 @@ Topics:
   File: rosa-mobb-configure-custom-tls-ciphers
 - Name: Verifying Permissions for a ROSA STS Deployment
   File: rosa-mobb-verify-permissions-sts-deployment
+- Name: Configuring the Cluster Log Forwarder for Cloudwatch logs and STS
+  File: rosa-mobb-cloudwatch-sts
 ---
 Name: Getting started
 Dir: rosa_getting_started

--- a/cloud_experts_tutorials/rosa-mobb-cloudwatch-sts.adoc
+++ b/cloud_experts_tutorials/rosa-mobb-cloudwatch-sts.adoc
@@ -1,0 +1,301 @@
+:_content-type: ASSEMBLY
+[id="rosa-mobb-cloudwatch-sts"]
+= Tutorial: Configuring the Cluster Log Forwarder for Cloudwatch logs and STS
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-mobb-cloudwatch-sts
+
+toc::[]
+
+//Mobb content metadata
+//Brought into ROSA product docs 2023-09-18
+//---
+// date: '2022-08-19'
+// date:
+// title: Configuring the Cluster Log Forwarder for CloudWatch Logs and STS
+// tags: ["AWS", "ROSA"]
+// authors:
+//   - Paul Czarkowski
+//   - Connor Wooley
+// ---
+
+This guide shows how to deploy the Cluster Log Forwarder Operator and configure it to use STS authentication to forward logs to CloudWatch.
+
+[id="rosa-mobb-cloudwatch-sts-prerequisites"]
+== Prerequisites
+
+* A ROSA cluster (configured with STS)
+* The `jq` cli command
+* The `aws` cli command
+
+[id="rosa-mobb-cloudwatch-sts-environmental-setup"]
+== Environment Setup
+
+* Configure the following environment variables:
++
+[NOTE]
+====
+Change the cluster name to match your ROSA cluster and ensure you are logged into the cluster as an Administrator. Ensure all fields are outputted correctly before moving on.
+====
++
+[source,terminal]
+----
+$ export ROSA_CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
+$ export REGION=$(rosa describe cluster -c ${ROSA_CLUSTER_NAME} --output json | jq -r .region.id)
+$ export OIDC_ENDPOINT=$(oc get authentication.config.openshift.io cluster -o json | jq -r .spec.serviceAccountIssuer | sed  's|^https://||')
+$ export AWS_ACCOUNT_ID=`aws sts get-caller-identity --query Account --output text`
+$ export AWS_PAGER=""
+$ export SCRATCH="/tmp/${ROSA_CLUSTER_NAME}/clf-cloudwatch-sts"
+$ mkdir -p ${SCRATCH}
+$ echo "Cluster: ${ROSA_CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
+----
+
+[id="rosa-mobb-cloudwatch-sts-prep-aws"]
+== Prepare AWS Account
+
+. Create an IAM policy for OpenShift Log Forwarding:
++
+[source,terminal]
+----
+$ POLICY_ARN=$(aws iam list-policies --query "Policies[?PolicyName=='RosaCloudWatch'].{ARN:Arn}" --output text)
+$ if [[ -z "${POLICY_ARN}" ]]; then
+cat << EOF > ${SCRATCH}/policy.json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+     {
+           "Effect": "Allow",
+           "Action": [
+              "logs:CreateLogGroup",
+              "logs:CreateLogStream",
+              "logs:DescribeLogGroups",
+              "logs:DescribeLogStreams",
+              "logs:PutLogEvents",
+              "logs:PutRetentionPolicy"
+           ],
+           "Resource": "arn:aws:logs:*:*:*"
+     }
+]
+}
+EOF
+POLICY_ARN=$(aws iam create-policy --policy-name "RosaCloudWatch" \
+--policy-document file:///${SCRATCH}/policy.json --query Policy.Arn --output text)
+fi
+$ echo ${POLICY_ARN}
+----
+
+. Create an IAM role trust policy for the cluster:
++
+[source,terminal]
+----
+$ cat <<EOF > ${SCRATCH}/trust-policy.json
+{
+   "Version": "2012-10-17",
+   "Statement": [{
+     "Effect": "Allow",
+     "Principal": {
+       "Federated": "arn:aws:iam::${AWS_ACCOUNT_ID}:oidc-provider/${OIDC_ENDPOINT}"
+     },
+     "Action": "sts:AssumeRoleWithWebIdentity",
+     "Condition": {
+       "StringEquals": {
+         "${OIDC_ENDPOINT}:sub": "system:serviceaccount:openshift-logging:logcollector"
+       }
+     }
+   }]
+}
+EOF
+$ ROLE_ARN=$(aws iam create-role --role-name "${ROSA_CLUSTER_NAME}-RosaCloudWatch" \
+      --assume-role-policy-document file://${SCRATCH}/trust-policy.json \
+      --query Role.Arn --output text)
+$ echo ${ROLE_ARN}
+----
+
+. Attach the IAM policy to the IAM role:
++
+[source,terminal]
+----
+$ aws iam attach-role-policy --role-name "${ROSA_CLUSTER_NAME}-RosaCloudWatch" \
+   --policy-arn ${POLICY_ARN}
+----
+
+[id="rosa-mobb-cloudwatch-sts-deploy-Os"]
+== Deploy Operators
+
+. Deploy the Cluster Logging Operator:
++
+[source,terminal]
+----
+$  cat << EOF | oc apply -f -
+   apiVersion: operators.coreos.com/v1alpha1
+   kind: Subscription
+   metadata:
+     labels:
+      operators.coreos.com/cluster-logging.openshift-logging: ""
+     name: cluster-logging
+     namespace: openshift-logging
+   spec:
+     channel: stable
+     installPlanApproval: Automatic
+     name: cluster-logging
+     source: redhat-operators
+     sourceNamespace: openshift-marketplace
+EOF
+----
+
+. Create a secret:
++
+[source,terminal]
+----
+$  cat << EOF | oc apply -f -
+  apiVersion: v1
+  kind: Secret
+  metadata:
+    name: cloudwatch-credentials
+    namespace: openshift-logging
+  stringData:
+    role_arn: $ROLE_ARN
+EOF
+----
+
+[id="rosa-mobb-cloudwatch-sts-configure-cluster-logging"]
+== Configure cluster logging
+
+. Create a cluster log forwarding resource:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+  apiVersion: "logging.openshift.io/v1"
+  kind: ClusterLogForwarder
+  metadata:
+    name: instance
+    namespace: openshift-logging
+  spec:
+    outputs:
+      - name: cw
+        type: cloudwatch
+        cloudwatch:
+          groupBy: namespaceName
+          groupPrefix: rosa-${ROSA_CLUSTER_NAME}
+          region: ${REGION}
+        secret:
+          name: cloudwatch-credentials
+    pipelines:
+      - name: to-cloudwatch
+        inputRefs:
+          - infrastructure
+          - audit
+          - application
+        outputRefs:
+          - cw
+EOF
+----
+
+. Create a cluster logging resource:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+  apiVersion: logging.openshift.io/v1
+  kind: ClusterLogging
+  metadata:
+    name: instance
+    namespace: openshift-logging
+  spec:
+    collection:
+      logs:
+         type: vector
+    managementState: Managed
+EOF
+----
+
+[id="rosa-mobb-cloudwatch-sts-check-aws"]
+== Check AWS CloudWatch for logs
+
+* Use the AWS console or CLI to validate that there are log streams from the cluster:
++
+[NOTE]
+====
+If this is a fresh cluster, you may not see a log group for `application` logs as there are no applications running yet.
+====
++
+[source,terminal]
+----
+$ aws logs describe-log-groups --log-group-name-prefix rosa-${ROSA_CLUSTER_NAME}
+----
++
+.Sample output
++
+[source,c]
+----
+{
+  "logGroups": [
+      {
+        "logGroupName": "rosa-xxxx.audit",
+        "creationTime": 1661286368369,
+        "metricFilterCount": 0,
+        "arn": "arn:aws:logs:us-east-2:xxxx:log-group:rosa-xxxx.audit:*",
+        "storedBytes": 0
+      },
+      {
+        "logGroupName": "rosa-xxxx.infrastructure",
+        "creationTime": 1661286369821,
+        "metricFilterCount": 0,
+        "arn": "arn:aws:logs:us-east-2:xxxx:log-group:rosa-xxxx.infrastructure:*",
+        "storedBytes": 0
+      }
+  ]
+}
+----
+
+[id="rosa-mobb-cloudwatch-sts-clean-up"]
+== Clean Up
+
+. Delete the cluster log forwarding resource:
++
+[source,terminal]
+----
+$ oc delete -n openshift-logging clusterlogforwarder instance
+----
+
+. Delete the cluster logging resource:
++
+[source,terminal]
+----
+$ oc delete -n openshift-logging clusterlogging instance
+----
+
+. Detach the IAM policy to the IAM role:
++
+[source,terminal]
+----
+$ aws iam detach-role-policy --role-name "${ROSA_CLUSTER_NAME}-RosaCloudWatch" \
+   --policy-arn "${POLICY_ARN}"
+----
+
+. Delete the IAM role:
++
+[source,terminal]
+----
+$ aws iam delete-role --role-name "${ROSA_CLUSTER_NAME}-RosaCloudWatch"
+----
+
+. Delete the IAM policy:
++
+[NOTE]
+====
+Only run this command if there are no other resources using the policy.
+====
++
+[source,terminal]
+----
+$ aws iam delete-policy --policy-arn "${POLICY_ARN}"
+----
+
+. Delete the CloudWatch Log Groups:
++
+[source,terminal]
+----
+$ aws logs delete-log-group --log-group-name "rosa-${ROSA_CLUSTER_NAME}.audit"
+$ aws logs delete-log-group --log-group-name "rosa-${ROSA_CLUSTER_NAME}.infrastructure"
+----


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-7769](https://issues.redhat.com/browse/OSDOCS-7769)

Link to docs preview:
- [Configuring the Cluster Log Forwarder for Cloudwatch logs and STS](https://64846--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/rosa-mobb-cloudwatch-sts)

QE review:
- [x] QE has approved this change.

Additional information:
Migrated the tutorial for configuring the Cluster Log Forwarder Operator to use Cloudwatch Logs and STS.