### PR TITLE
[OSDOCS-6137]: manual mode support updates

### DIFF
--- a/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
+++ b/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator.adoc
@@ -24,57 +24,68 @@ By setting different values for the `credentialsMode` parameter in the `install-
 * **xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds[Manual mode with short-term credentials for components]**: For some providers, you can use the CCO utility (`ccoctl`) during installation to implement short-term credentials for individual components. These credentials are created and managed outside the {product-title} cluster.
 
 .CCO mode support matrix
-[cols="<.^2,^.^1,^.^1,^.^1"]
+[cols="<.^2,^.^1,^.^1,^.^1,^.^1"]
 |====
-|Cloud provider |Mint |Passthrough |Manual
+|Cloud provider |Mint |Passthrough |Manual with long-term credentials |Manual with short-term credentials
 
 |{alibaba}
 |
 |
-|X
+|X ^[1]^
+|
 
 |Amazon Web Services (AWS)
 |X
 |X
-|X ^[1]^
-
-
-|Microsoft Azure
-|
-|X ^[2]^
 |X
+|X
+
+|Global Microsoft Azure
+|
+|X
+|X
+|X
+
+|Microsoft Azure Stack Hub
+|
+|
+|X
+|
 
 |Google Cloud Platform (GCP)
 |X
 |X
-|X ^[3]^
+|X
+|X
 
 |IBM Cloud
 |
 |
-|X
+|X ^[1]^
+|
 
 |Nutanix
 |
 |
-|X
+|X ^[1]^
+|
 
 |{rh-openstack-first}
 |
 |X
+|
 |
 
 |VMware vSphere
 |
 |X
 |
+|
 
 |====
 [.small]
 --
-1. Short-term credentials with AWS Security Token Service can be configured during installation.
-2. Manual mode with long-term credentials is the only supported CCO configuration for Microsoft Azure Stack Hub.
-3. Short-term credentials with GCP Workload Identity can be configured during installation.
+1. This platform uses the `ccoctl` utility during installation to configure long-term credentials.
 --
 
 [id="cco-determine-mode_{context}"]

--- a/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
+++ b/authentication/managing_cloud_provider_credentials/cco-mode-manual.adoc
@@ -6,23 +6,21 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Manual mode is supported for Alibaba Cloud, Amazon Web Services (AWS), Microsoft Azure, Google Cloud Platform (GCP), IBM Cloud, and Nutanix.
+Manual mode is supported for Alibaba Cloud, Amazon Web Services (AWS), global Microsoft Azure, Microsoft Azure Stack Hub, Google Cloud Platform (GCP), IBM Cloud, and Nutanix.
 
 [id="manual-mode-classic_{context}"]
 == User-managed credentials
 
-In manual mode, a user manages cloud credentials instead of the Cloud Credential Operator (CCO). To use this mode, you must examine the `CredentialsRequest` CRs in the release image for the version of {product-title} that you are running or installing, create corresponding credentials in the underlying cloud provider, and create Kubernetes Secrets in the correct namespaces to satisfy all `CredentialsRequest` CRs for the cluster's cloud provider.
+In manual mode, a user manages cloud credentials instead of the Cloud Credential Operator (CCO). To use this mode, you must examine the `CredentialsRequest` CRs in the release image for the version of {product-title} that you are running or installing, create corresponding credentials in the underlying cloud provider, and create Kubernetes Secrets in the correct namespaces to satisfy all `CredentialsRequest` CRs for the cluster's cloud provider. Some platforms use the CCO utility (`ccoctl`) to facilitate this process during installation and updates.
 
-Using manual mode with long-term credentials allows each cluster component to have only the permissions it requires, without storing an administrator-level credential in the cluster. This mode also does not require connectivity to the AWS public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade.
+Using manual mode with long-term credentials allows each cluster component to have only the permissions it requires, without storing an administrator-level credential in the cluster. This mode also does not require connectivity to services such as the AWS public IAM endpoint. However, you must manually reconcile permissions with new release images for every upgrade.
 
 For information about configuring your cloud provider to use manual mode, see the manual credentials management options for your cloud provider.
 
-[id="manual-mode-sts_{context}"]
-== Manual mode with cloud credentials created and managed outside of the cluster
-
-An AWS or GCP cluster that uses manual mode might be configured to create and manage cloud credentials from outside of the cluster using the AWS Security Token Service (STS) or GCP Workload Identity. With this configuration, the CCO uses short-term credentials for different components.
-
-For more information, see xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds[Manual mode with short-term credentials for components].
+[NOTE]
+====
+An AWS, global Azure, or GCP cluster that uses manual mode might be configured to use short-term credentials for different components. For more information, see xref:../../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds[Manual mode with short-term credentials for components].
+====
 
 [role="_additional-resources"]
 [id="additional-resources_cco-mode-manual"]


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-6137](https://issues.redhat.com//browse/OSDOCS-6137)

Link to docs preview:
* [CCO Modes](https://64848--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/about-cloud-credential-operator#about-cloud-credential-operator-modes_about-cloud-credential-operator)
* [Manual mode with long-term credentials for components](https://64848--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing_cloud_provider_credentials/cco-mode-manual)

QE review:
- [ ] QE has approved this change.

Additional information: