### PR TITLE
[OSDOCS-7765]: Remove note about default machine pools. 

### DIFF
--- a/modules/rosa-sdpolicy-am-compute.adoc
+++ b/modules/rosa-sdpolicy-am-compute.adoc
@@ -8,14 +8,9 @@
 
 Single availability zone clusters require a minimum of 3 control plane nodes, 2 infrastructure nodes, and 2 worker nodes deployed to a single availability zone.
 
-Multiple availability zone clusters require a minimum of 3 control plane nodes. 3 infrastructure nodes, and 3 worker nodes. Additional nodes must be purchased in multiples of three to maintain proper node distribution.
+Multiple availability zone clusters require a minimum of 3 control plane nodes, 3 infrastructure nodes, and 3 worker nodes. Additional nodes must be purchased in multiples of three to maintain proper node distribution.
 
 All {product-title} clusters support a maximum of 180 worker nodes.
-
-[NOTE]
-====
-After the cluster is installed, the `Default` machine pool cannot be deleted, and its node type or size cannot be changed.
-====
 
 Control plane and infrastructure nodes are deployed and managed by Red Hat. Shutting down the underlying infrastructure through the cloud provider console is unsupported and can lead to data loss. There are at least 3 control plane nodes that handle etcd- and API-related workloads. There are at least 2 infrastructure nodes that handle metrics, routing, the web console, and other workloads. You must not run any workloads on the control and infrastructure nodes. Any workloads you intend to run must be deployed on worker nodes. See the Red Hat Operator support section below for more information about Red Hat workloads that must be deployed on worker nodes.
 

--- a/modules/sdpolicy-am-compute.adoc
+++ b/modules/sdpolicy-am-compute.adoc
@@ -11,11 +11,6 @@ Multiple availability zone clusters require a minimum of 3 worker nodes for Cust
 
 Worker nodes must all be the same type and size within a single {product-title} cluster.
 
-[NOTE]
-====
-The default machine pool node type and size cannot be changed after the cluster has been created.
-====
-
 Control plane and infrastructure nodes are also provided by Red Hat. There are at least 3 control plane nodes that handle etcd and API-related workloads. There are at least 2 infrastructure nodes that handle metrics, routing, the web console, and other workloads. You must not run any workloads on the control plane and infrastructure nodes. Any workloads you intend to run must be deployed on worker nodes. See the Red Hat Operator support section below for more information about Red Hat workloads that must be deployed on worker nodes.
 
 [NOTE]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-7765
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
OSD: https://64850--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition#instance-types_osd-service-definition
ROSA: https://64850--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition#rosa-sdpolicy-instance-types_rosa-service-definition
QE review: 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
