### PR TITLE
OSDOCS-4438: Deploy Microshift with mirror registry

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -434,8 +434,10 @@ Topics:
   File: microshift-operators
 - Name: Greenboot workload health check scripts
   File: microshift-greenboot-workload-scripts
-- Name: Pod security authentication and authorization  
+- Name: Pod security authentication and authorization
   File: microshift-authentication
+- Name: Mirror registry deployment
+  File: microshift-deploy-with-mirror-registry
 ---
 Name: Backup and restore
 Dir: microshift_backup_and_restore

--- a/microshift_running_apps/microshift-deploy-with-mirror-registry.adoc
+++ b/microshift_running_apps/microshift-deploy-with-mirror-registry.adoc
@@ -1,0 +1,29 @@
+:_content-type: ASSEMBLY
+[id="microshift-deploy-with-mirror-registry"]
+= {product-title} deployment with a mirror registry
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-deployment-mirror
+
+toc::[]
+
+You can use a custom container registry when you deploy {product-title} in an air-gapped network. Running your cluster in a restricted network without direct internet connectivity is possible by installing the cluster from a mirrored set of container images in a private registry.
+
+include::modules/microshift-mirror-container-images.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://docs.openshift.com/container-platform/{ocp-version}/installing/disconnected_install/installing-mirroring-creating-registry.html[Creating a mirror registry with mirror registry for Red Hat OpenShift]
+
+include::modules/microshift-get-mirror-reg-container-image-list.adoc[leveloffset=+1]
+
+include::modules/microshift-mirroring-prereqs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://access.redhat.com/documentation/en-us/openshift_container_platform/{ocp-version}/html/installing/disconnected-installation-mirroring#installation-adding-registry-pull-secret_installing-mirroring-disconnected[Configuring credentials that allow images to be mirrored]
+
+include::modules/microshift-downloading-container-images.adoc[leveloffset=+1]
+
+include::modules/microshift-uploading-images-to-mirror.adoc[leveloffset=+1]
+
+include::modules/microshift-configuring-hosts-for-mirror.adoc[leveloffset=+1]

--- a/modules/microshift-configuring-hosts-for-mirror.adoc
+++ b/modules/microshift-configuring-hosts-for-mirror.adoc
@@ -1,0 +1,79 @@
+// Module included in the following assemblies:
+//
+// * microshift/running_applications/microshift-deploy-with-mirror-registry.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-configuring-hosts-for-mirror_{context}"]
+= Configuring hosts for mirror registry access
+
+To configure a {product-title} host to use a mirror registry, you must give the {product-title} host access to the registry by creating a configuration file that maps the Red Hat registry host names to the mirror.
+
+.Prerequisites
+* Your mirror host has access to the internet.
+* The mirror host can access the mirror registry.
+* You configured the mirror registry for use in your restricted network.
+* You downloaded the pull secret and modified it to include authentication to your mirror repository.
+
+.Procedure
+. Log into your {product-title} host.
+
+. Enable the SSL certificate trust on any host accessing the mirror registry by completing the following steps:
+
+.. Copy the `rootCA.pem` file from the mirror registry, for example, `<registry_path>/quay-rootCA`, to the {product-title} host at the `/etc/pki/ca-trust/source/anchors` directory.
+.. Enable the certificate in the system-wide trust store configuration by running the following command:
++
+[source,terminal]
+----
+$ sudo update-ca-trust
+----
+
+. Create the `/etc/containers/registries.conf.d/999-microshift-mirror.conf` configuration file that maps the Red Hat registry host names to the mirror registry:
++
+.Example mirror configuration file
+[source,terminal]
+----
+[[registry]]
+    prefix = ""
+    location = "<registry_host>:<port>" <1>
+    mirror-by-digest-only = true
+    insecure = false
+
+[[registry]]
+    prefix = ""
+    location = "quay.io"
+    mirror-by-digest-only = true
+[[registry.mirror]]
+    location = "<registry_host>:<port>"
+    insecure = false
+
+[[registry]]
+    prefix = ""
+    location = "registry.redhat.io"
+    mirror-by-digest-only = true
+[[registry.mirror]]
+    location = "<registry_host>:<port>"
+    insecure = false
+
+[[registry]]
+    prefix = ""
+    location = "registry.access.redhat.com"
+    mirror-by-digest-only = true
+[[registry.mirror]]
+    location = "<registry_host>:<port>"
+    insecure = false
+----
+<1> Replace `<registry_host>:<port>` with the host name and port of your mirror registry server, for example, `<microshift-quay:8443>`.
+
+. Enable the {product-title} service by running the following command:
++
+[source,terminal]
+----
+$ sudo systemctl enable microshift
+----
+
+. Reboot the host by running the following command:
++
+[source,terminal]
+----
+$ sudo reboot
+----

--- a/modules/microshift-downloading-container-images.adoc
+++ b/modules/microshift-downloading-container-images.adoc
@@ -1,0 +1,65 @@
+// Module included in the following assemblies:
+//
+// * microshift/running_applications/microshift-deploy-with-mirror-registry.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-downloading-container-images_{context}"]
+= Downloading container images
+
+After you have located the container list and completed the mirroring prerequisites, download the container images to a host with internet access.
+
+.Prerequisites
+
+* You are logged into a host with access to the internet.
+* You have ensured that the `.pull-secret-mirror.json` file and `microshift-containers` directory contents are available locally.
+
+.Procedure
+
+. Install the `skopeo` tool used for copying the container images by running the following command:
++
+[source,terminal]
+----
+$ sudo dnf install -y skopeo
+----
+
+. Set the environment variable that points to the pull secret file:
++
+[source,terminal]
+----
+$ PULL_SECRET_FILE=~/.pull-secret-mirror.json
+----
+
+. Set the environment variable that points to the list of container images:
++
+[source,terminal]
+----
+$ IMAGE_LIST_FILE=~/microshift-container-refs.txt
+----
+
+. Set the environment variable that points to the destination directory for storing the downloaded data:
++
+[source,terminal]
+----
+$ IMAGE_LOCAL_DIR=~/microshift-containers
+----
+
+. Run the following script to download the container images to the `${IMAGE_LOCAL_DIR}` directory:
++
+[source,terminal]
+----
+while read -r src_img ; do
+   # Remove the source registry prefix
+   dst_img=$(echo "${src_img}" | cut -d '/' -f 2-)
+
+   # Run the image download command
+   echo "Downloading '${src_img}' to '${IMAGE_LOCAL_DIR}'"
+   mkdir -p "${IMAGE_LOCAL_DIR}/${dst_img}"
+   skopeo copy --all --quiet \
+      --preserve-digests \
+      --authfile "${PULL_SECRET_FILE}" \
+      docker://"${src_img}" dir://"${IMAGE_LOCAL_DIR}/${dst_img}"
+
+done < "${IMAGE_LIST_FILE}"
+----
+
+. Transfer the image set to the target environment, such as air-gapped site. Then you can upload the image set into the mirror registry.

--- a/modules/microshift-get-mirror-reg-container-image-list.adoc
+++ b/modules/microshift-get-mirror-reg-container-image-list.adoc
@@ -1,0 +1,60 @@
+// Module included in the following assemblies:
+//
+// * microshift/running_applications/microshift-deploy-with-mirror-registry.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-get-mirror-reg-container-image-list_{context}"]
+= Getting the {product-title} mirror registry container image list
+
+To use a mirror registry, you must know which container image references are used by a specific version of {product-title}. These references are provided in the `release-<arch>.json` files that are part of the `microshift-release-info` RPM package.
+
+.Prerequisites
+
+* You have installed jq.
+
+.Procedure
+
+. Access the list of container image references by using one of the following methods:
+
+** If the package is installed on the {product-title} host, get the location of the files by running the following command:
++
+[source,terminal]
+----
+$ rpm -ql microshift-release-info
+----
++
+.Example output
+[source,text]
+----
+/usr/share/microshift/release/release-x86_64.json
+----
+
+** If the package is not installed on a {product-title} host, download and unpack the RPM package without installing it by running the following command:
++
+[source,terminal]
+----
+$ rpm2cpio microshift-release-info*.noarch.rpm | cpio -idmv
+----
++
+.Example output
+[source,text]
+----
+/usr/share/microshift/release/release-x86_64.json
+----
+
+. Extract the list of container images into the `microshift-container-refs.txt` file by running the following commands:
++
+[source,terminal]
+----
+$ RELEASE_FILE=/usr/share/microshift/release/release-$(uname -m).json
+----
++
+[source,terminal]
+----
+$ jq -r '.images | .[]' ${RELEASE_FILE} > microshift-container-refs.txt
+----
+
+[NOTE]
+====
+After the `microshift-container-refs.txt` file is created with the {product-title} container image list, you can append the file with other user-specific image references before running the mirroring procedure.
+====

--- a/modules/microshift-mirror-container-images.adoc
+++ b/modules/microshift-mirror-container-images.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+//
+// * microshift/running_applications/microshift-deploy-with-mirror-registry.adoc
+
+:_content-type: CONCEPT
+[id="microshift-mirror-container-images_{context}"]
+= Mirror container images into an existing registry
+
+Using a custom air-gapped container registry, or mirror, is necessary with certain user environments and workload requirements. Mirroring allows for the transfer of container images and updates to air-gapped environments where they can be installed on a {product-title} instance.
+
+To create an air-gapped mirror registry for {product-title} containers, you must complete the following steps:
+
+* Get the container image list to be mirrored.
+* Configure the mirroring prerequisites.
+* Download images on a host with the internet access.
+* Copy the downloaded image directory to an air-gapped site.
+* Upload images to a mirror registry in an air-gapped site.
+* Configure your {product-title} hosts to use the mirror registry.

--- a/modules/microshift-mirroring-prereqs.adoc
+++ b/modules/microshift-mirroring-prereqs.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * microshift/running_applications/microshift-deploy-with-mirror-registry.adoc
+
+:_content-type: CONCEPT
+[id="microshift-configuring-mirroring-prereqs_{context}"]
+= Configuring mirroring prerequisites
+
+You must create a container image registry credentials file that allows the mirroring of images from your internet-connected mirror host to your air-gapped mirror. Follow the instructions in the "Configuring credentials that allow images to be mirrored" link provided in the "Additional resources" section. These instructions guide you to create a `~/.pull-secret-mirror.json` file on the mirror registry host that includes the user credentials for accessing the mirror.
+
+[id="microshift-example-mirror-pull-secret-entry_{context}"]
+== Example mirror registry pull secret entry
+
+For example, the following section is added to the pull secret file for the `microshift_quay:8443` mirror registry using `microshift:microshift` as username and password.
+
+.Example mirror registry section for pull secret file
+[source,terminal]
+----
+"<microshift_quay:8443>": { <1>
+    "auth": "<microshift_auth>", <2>
+    "email": "<microshift_quay@example.com>" <3>
+},
+----
+<1> Replace the `<registry_host>:<port>` value `microshift_quay:8443` with the host name and port of your mirror registry server.
+<2> Replace the `<microshift_auth>` value with the user password.
+<3> Replace the `</microshift_quay@example.com>` value with the user email.

--- a/modules/microshift-upload-cont2-mirror-script.adoc
+++ b/modules/microshift-upload-cont2-mirror-script.adoc
@@ -1,0 +1,27 @@
+[source,sh]
+----
+# Use timestamp and counter as a tag on the target images to avoid
+# their overwrite by the 'latest' automatic tagging
+image_tag=mirror-$(date +%y%m%d%H%M%S)
+image_cnt=1
+
+pushd "${IMAGE_LOCAL_DIR}" >/dev/null
+while read -r src_manifest ; do
+   # Remove the manifest.json file name
+   src_img=$(dirname "${src_manifest}")
+   # Add the target registry prefix and remove SHA
+   dst_img="${TARGET_REGISTRY}/${src_img}"
+   dst_img=$(echo "${dst_img}" | awk -F'@' '{print $1}')
+
+   # Run the image upload command
+   echo "Uploading '${src_img}' to '${dst_img}'"
+   skopeo copy --all --quiet \
+      --preserve-digests \
+      --authfile "${IMAGE_PULL_FILE}" \
+      dir://"${IMAGE_LOCAL_DIR}/${src_img}" docker://"${dst_img}:${image_tag}-${image_cnt}"
+   # Increment the counter
+   (( image_cnt += 1 ))
+
+done < <(find . -type f -name manifest.json -printf '%P\n')
+popd >/dev/null
+----

--- a/modules/microshift-uploading-images-to-mirror.adoc
+++ b/modules/microshift-uploading-images-to-mirror.adoc
@@ -1,0 +1,76 @@
+// Module included in the following assemblies:
+//
+// * microshift/running_applications/microshift-deploy-with-mirror-registry.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-uploading-container-images-to-mirror_{context}"]
+= Uploading container images to a mirror registry
+
+To use your container images at an air-gapped site, upload them to the mirror registry using the following procedure.
+
+.Prerequisites
+
+* You are logged into a host with access to `microshift-quay`.
+* The `.pull-secret-mirror.json` file is available locally.
+* The `microshift-containers` directory contents are available locally.
+
+.Procedure
+
+. Install the `skopeo` tool used for copying the container images by running the following command:
++
+[source,terminal]
+----
+$ sudo dnf install -y skopeo
+----
+
+. Set the environment variables pointing to the pull secret file:
++
+[source,terminal]
+----
+$ IMAGE_PULL_FILE=~/.pull-secret-mirror.json
+----
+
+. Set the environment variables pointing to the local container image directory:
++
+[source,terminal]
+----
+$ IMAGE_LOCAL_DIR=~/microshift-containers
+----
+
+. Set the environment variables pointing to the mirror registry URL for uploading the container images:
++
+[source,terminal]
+----
+$ TARGET_REGISTRY=<registry_host>:<port> <1>
+----
+<1> Replace `<registry_host>:<port>` with the host name and port of your mirror registry server.
+
+. Run the following script to upload the container images to the `${TARGET_REGISTRY}` mirror registry:
++
+[source,terminal]
+----
+image_tag=mirror-$(date +%y%m%d%H%M%S)
+image_cnt=1
+   # Uses timestamp and counter as a tag on the target images to avoid
+   # their overwrite by the 'latest' automatic tagging
+
+pushd "${IMAGE_LOCAL_DIR}" >/dev/null
+while read -r src_manifest ; do
+   # Remove the manifest.json file name
+   src_img=$(dirname "${src_manifest}")
+   # Add the target registry prefix and remove SHA
+   dst_img="${TARGET_REGISTRY}/${src_img}"
+   dst_img=$(echo "${dst_img}" | awk -F'@' '{print $1}')
+
+   # Run the image upload command
+   echo "Uploading '${src_img}' to '${dst_img}'"
+   skopeo copy --all --quiet \
+      --preserve-digests \
+      --authfile "${IMAGE_PULL_FILE}" \
+      dir://"${IMAGE_LOCAL_DIR}/${src_img}" docker://"${dst_img}:${image_tag}-${image_cnt}"
+   # Increment the counter
+   (( image_cnt += 1 ))
+
+done < <(find . -type f -name manifest.json -printf '%P\n')
+popd >/dev/null
+----

--- a/snippets/microshift-upload-cont2-mirror-script.adoc
+++ b/snippets/microshift-upload-cont2-mirror-script.adoc
@@ -1,0 +1,27 @@
+[source,terminal]
+----
+image_tag=mirror-$(date +%y%m%d%H%M%S)
+image_cnt=1
+   # Uses timestamp and counter as a tag on the target images to avoid
+   # their overwrite by the 'latest' automatic tagging
+
+pushd "${IMAGE_LOCAL_DIR}" >/dev/null
+while read -r src_manifest ; do
+   # Remove the manifest.json file name
+   src_img=$(dirname "${src_manifest}")
+   # Add the target registry prefix and remove SHA
+   dst_img="${TARGET_REGISTRY}/${src_img}"
+   dst_img=$(echo "${dst_img}" | awk -F'@' '{print $1}')
+
+   # Run the image upload command
+   echo "Uploading '${src_img}' to '${dst_img}'"
+   skopeo copy --all --quiet \
+      --preserve-digests \
+      --authfile "${IMAGE_PULL_FILE}" \
+      dir://"${IMAGE_LOCAL_DIR}/${src_img}" docker://"${dst_img}:${image_tag}-${image_cnt}"
+   # Increment the counter
+   (( image_cnt += 1 ))
+
+done < <(find . -type f -name manifest.json -printf '%P\n')
+popd >/dev/null
+----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-4438

Link to docs preview:
https://64852--docspreview.netlify.app/microshift/latest/microshift_running_apps/microshift-deploy-with-mirror-registry

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

SME approved in Slack.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
