### PR TITLE
[enterprise-4.11] OSDOCS#4515: Adding xref to Optimizing storage

### DIFF
--- a/installing/installing_aws/installing-aws-china.adoc
+++ b/installing/installing_aws/installing-aws-china.adoc
@@ -45,6 +45,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -43,6 +43,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]

--- a/installing/installing_aws/installing-aws-government-region.adoc
+++ b/installing/installing_aws/installing-aws-government-region.adoc
@@ -45,6 +45,12 @@ include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -45,6 +45,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-aws-private.adoc
+++ b/installing/installing_aws/installing-aws-private.adoc
@@ -40,6 +40,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-aws-user-infra.adoc
+++ b/installing/installing_aws/installing-aws-user-infra.adoc
@@ -46,6 +46,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]

--- a/installing/installing_aws/installing-aws-vpc.adoc
+++ b/installing/installing_aws/installing-aws-vpc.adoc
@@ -36,6 +36,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]
 

--- a/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -51,6 +51,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -64,6 +64,12 @@ of the required machines.
 This section describes the requirements for deploying {product-title} on user-provisioned infrastructure.
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 include::modules/installation-aws-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-aws-arm-tested-machine-types.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -34,6 +34,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-government-region.adoc
+++ b/installing/installing_azure/installing-azure-government-region.adoc
@@ -42,6 +42,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -37,6 +37,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-private.adoc
+++ b/installing/installing_azure/installing-azure-private.adoc
@@ -37,6 +37,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-user-infra.adoc
+++ b/installing/installing_azure/installing-azure-user-infra.adoc
@@ -76,6 +76,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-marketplace-subscribe.adoc[leveloffset=+1]

--- a/installing/installing_azure/installing-azure-vnet.adoc
+++ b/installing/installing_azure/installing-azure-vnet.adoc
@@ -31,6 +31,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]

--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -38,6 +38,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/csr-management.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_bare_metal/installing-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal.adoc
@@ -46,6 +46,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/csr-management.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -50,6 +50,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/csr-management.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -31,6 +31,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -38,6 +38,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -35,6 +35,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra-vpc.adoc
@@ -60,6 +60,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]
 

--- a/installing/installing_gcp/installing-gcp-user-infra.adoc
+++ b/installing/installing_gcp/installing-gcp-user-infra.adoc
@@ -43,6 +43,12 @@ include::modules/installation-gcp-limits.adoc[leveloffset=+2]
 include::modules/installation-gcp-service-account.adoc[leveloffset=+2]
 include::modules/installation-gcp-permissions.adoc[leveloffset=+2]
 include::modules/minimum-required-permissions-upi-gcp.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-gcp-regions.adoc[leveloffset=+2]
 include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -31,6 +31,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -43,6 +43,11 @@ include::modules/installation-configuration-parameters.adoc[leveloffset=+2]
 
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-gcp-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-using-gcp-custom-machine-types.adoc[leveloffset=+2]

--- a/installing/installing_gcp/installing-restricted-networks-gcp.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp.adoc
@@ -50,6 +50,12 @@ include::modules/installation-gcp-limits.adoc[leveloffset=+2]
 include::modules/installation-gcp-service-account.adoc[leveloffset=+2]
 include::modules/installation-gcp-permissions.adoc[leveloffset=+2]
 include::modules/minimum-required-permissions-upi-gcp.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/installation-gcp-regions.adoc[leveloffset=+2]
 include::modules/installation-gcp-install-cli.adoc[leveloffset=+2]
 

--- a/installing/installing_ibm_power/installing-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-ibm-power.adoc
@@ -40,6 +40,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/minimum-ibm-power-system-requirements.adoc[leveloffset=+2]
 include::modules/recommended-ibm-power-system-requirements.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]

--- a/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
+++ b/installing/installing_ibm_power/installing-restricted-networks-ibm-power.adoc
@@ -48,6 +48,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/minimum-ibm-power-system-requirements.adoc[leveloffset=+2]
 include::modules/recommended-ibm-power-system-requirements.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]

--- a/installing/installing_ibm_z/installing-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-ibm-z.adoc
@@ -46,6 +46,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/minimum-ibm-z-system-requirements.adoc[leveloffset=+2]
 include::modules/preferred-ibm-z-system-requirements.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]

--- a/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
+++ b/installing/installing_ibm_z/installing-restricted-networks-ibm-z.adoc
@@ -54,6 +54,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/minimum-ibm-z-system-requirements.adoc[leveloffset=+2]
 include::modules/preferred-ibm-z-system-requirements.adoc[leveloffset=+2]
 include::modules/csr-management.adoc[leveloffset=+2]

--- a/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
+++ b/installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
@@ -61,6 +61,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]

--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -53,6 +53,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]

--- a/installing/installing_vsphere/installing-vsphere.adoc
+++ b/installing/installing_vsphere/installing-vsphere.adoc
@@ -52,6 +52,12 @@ This section describes the requirements for deploying {product-title} on user-pr
 
 include::modules/installation-machine-requirements.adoc[leveloffset=+2]
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../scalability_and_performance/optimizing-storage.adoc#optimizing-storage[Optimizing storage]
+
 include::modules/csr-management.adoc[leveloffset=+2]
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]


### PR DESCRIPTION
Version(s):
4.11

Issue:
This PR addresses [osdocs-4515](https://issues.redhat.com/browse/OSDOCS-4515).

Link to docs preview:
[Minimum resource requirements for cluster installation](https://64863--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#installation-minimum-resource-requirements_installing-aws-customizations)
See **Additional resources** directly following module.

Worth noting that the same link appears in 33 assemblies. Providing this one link to demonstrate that the link resolves correctly.

QE review:
- [N/A] QE has approved this change.
QE approval is not required. Adding a link to the Optimizing storage content per the request of @sjstout as part of the Closed Loop initiative. No content has been added/updated

Additional information:

This change has been implemented in 4.12+ in https://github.com/openshift/openshift-docs/pull/64785. However, the merge conflicts were so numerous when attempting to CP back to 4.11 using a commit ID, that I decided it would be faster to open a separate PR for 4.11 and add the link manually.
