### PR TITLE
Updates for the Code blocks, command syntax, and example output section of the Doc guidelines

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -996,16 +996,17 @@ You can use backticks or other markup in the title for a block, such as a code b
 
 === Code blocks, command syntax, and example output
 
-Code blocks are generally used to show examples of command syntax, example
-screen output, and configuration files.
+Code blocks are generally used to show examples of command syntax, example screen output, and configuration files.
 
-The main distinction between showing command syntax and a command example is
-that a command syntax shows readers how to use the command without real values.
-An example command, however, shows the command with actual values with an
-example output of that command, where applicable.
+//redundant with 1080
+The main distinction between showing command syntax and a command example is that a command syntax shows readers how to use the command without real values. An example command, however, shows the command with actual values with an example output of that command, where applicable.
 
+[[use-source-terminal]]
+==== Source tags for terminal commands and output
+* Use `[source,terminal]` for `oc` commands or any terminal commands to enable syntax highlighting. If you are also showing a code block for the output of the command, use `[source,terminal]` for that code block as well. Separate a command and its related example output into individual code blocks. See <<single-command-per-code-block>>.
++
 For example:
-
++
 ....
 In the following example, the `oc get` operation returns a complete list of services that are currently defined:
 
@@ -1023,7 +1024,7 @@ kubernetes-ro       component=apiserver,provider=kubernetes   <none>            
 docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
 ----
 ....
-
++
 This renders as:
 
 > In the following example, the `oc get` operation returns a complete list of services that are currently defined:
@@ -1040,26 +1041,86 @@ This renders as:
 > docker-registry     <none>                                    name=registrypod    172.30.17.158       5001
 > ----
 
-The following guidelines go into more detail about specific requirements and
-recommendations when using code blocks:
+* Any `[source]` metadata must go on the line directly before the code block. Also, do not insert a space in between the `[source]` tag and the metadata.
+//Context: https://github.com/openshift/openshift-docs/pull/64373
++
+For example:
++
+....
 
-* If a step in a procedure is to run a command, make sure that the step
-text includes an explicit instruction to "run" or "enter" the command. In most cases,
-use one of the following patterns to introduce the code block:
+[source,terminal]
+----
+$ oc get se
+----
+
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: Scheduler
+metadata:
+  name: cluster
+# ...
+spec:
+  defaultNodeSelector: node-role.kubernetes.io/app=
+# ...
+----
+....
+
+* For Bash "here" documents use `[source,terminal]`, such as the following example:
++
+....
+[source,terminal]
+----
+$ cat <<EOF| oc create -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: mlistener
+  labels:
+    app: multicast-verify
+EOF
+----
+....
++
+[NOTE]
+====
+For bash scripts, use `[source,bash]`. For example:
+[source,bash]
+----
+#!/bin/bash
+
+# optional argument handling
+if [[ "$1" == "config" ]]
+then
+    echo $KUBECONFIG
+    exit 0
+fi
+
+echo "I am a plugin named kubectl-test"
+----
+====
+
+The following guidelines go into more detail about specific requirements and recommendations when using code blocks:
+
+[[step-with-command]]
+==== Procedure step that introduces a command
+If a step in a procedure is to run a command, make sure that the step text includes an explicit instruction to "run" or "enter" the command. In most cases, use one of the following patterns to introduce the code block:
 
 ** <Step description> by running the following command:
 ** <Step description> by entering the following command:
 ** <Step description>, run the following command:
 ** <Step description>, enter the following command:
 
-* Do NOT use any markup in code blocks; code blocks generally do not accept any markup.
+[[no-markup-codeblock]]
+==== No markup in code blocks
+Do NOT use any markup in code blocks; code blocks generally do not accept any markup.
 
-* For all code blocks, you must include an empty line above a code block (unless
-that line is introducing block metadata, such as `[source,terminal]` for syntax
-highlighting).
-+
+[[empty-line-before-codeblock]]
+==== Empty line before code blocks
+For all code blocks, you must include an empty line above a code block (unless that line is introducing block metadata, such as `[source,terminal]` for syntax highlighting).
+
 Acceptable:
-+
+
 ....
 Lorem ipsum
 
@@ -1067,43 +1128,36 @@ Lorem ipsum
 $ lorem.sh
 ----
 ....
-+
+
 Not acceptable:
-+
+
 ....
 Lorem ipsum
 ----
 $ lorem.sh
 ----
 ....
-+
+
 Without the line spaces, the content is likely to be not parsed correctly.
 
-* Use `[source,terminal]` for `oc` commands or any terminal commands to enable
-syntax highlighting. Any `[source]` metadata must go on the line directly before
-the code block. For example:
-+
-....
-[source,terminal]
-----
-$ oc get nodes
-----
-....
-+
-If you are also showing a code block for the output of the command, use
-`[source,terminal]` for that code block as well.
-
-* Use source tags for the programming language used in the code block to enable
-syntax highlighting. For example:
+[[source-tags-for-programming-language]]
+==== Source tags for programming languages
+Use source tags for the programming language used in the code block to enable syntax highlighting. For example:
 
 ** `[source,yaml]`
 ** `[source,go]`
 ** `[source,javascript]`
 ** `[source,jsx]`
+** `[source,bash]`
 
-* Do not use more than one command per code block. For example, the following must
-be split up into three separate code blocks:
-+
+[[single-command-per-code-block]]
+==== Single command per code block
+Do not use more than one command per code block.
+
+When commands are bunched together, the copy to clipboard functionality might not break the lines up correctly. Using single command per code block makes it copy-and-paste friendly.
+
+For example, the following must be split up into three separate code blocks:
+
 ....
 To create templates you can modify, run the following commands:
 
@@ -1123,58 +1177,17 @@ $ oc adm create-error-template > errors.html
 ----
 ....
 
-* If your command contains multiple lines and uses callout annotations, you must comment out the callout(s) in the codeblock, as shown in the following example:
-+
-....
-To scale based on the percent of CPU utilization, create a `HorizontalPodAutoscaler` object for an existing object:
+[[command-syntax-replaceable-values]]
+==== Command syntax for replaceable values
+To mark up command syntax, use the code block and wrap any replaceable values in angle brackets (`<>`) with the required command parameter, using underscores (`_`) between words as necessary for legibility.
 
-[source,terminal]
-----
-$ oc autoscale <object_type>/<name> \// <1>
-  --min <number> \// <2>
-  --max <number> \// <3>
-  --cpu-percent=<percent> <4>
-----
-<1> Specify the type and name of the object to autoscale.
-<2> Optional: Specify the minimum number of replicas when scaling down.
-<3> Specify the maximum number of replicas when scaling up.
-<4> Specify the target average CPU utilization over all the pods, represented as a percent of requested CPU.
-....
-
-* Separate a command and its related example output into individual code blocks.
-This allows the command to be easily copied using the button on
-+++docs.openshift.com+++.
-+
-In addition, prepend the code block for the output with the title `.Example output`
-to make it consistently clear across the docs when this is being represented. A
-lead-in sentence explaining the example output is optional. For example:
-+
-....
-Use the `oc new-project` command to create a new project:
-
-[source,terminal]
-----
-$ oc new-project my-project
-----
-
-The output verifies that a new project was created:
-
-.Example output
-[source,terminal]
-----
-Now using project "my-project" on server "https://openshift.example.com:6443".
-----
-....
-
-* To mark up command syntax, use the code block and wrap any replaceable values in angle brackets (`<>`) with the required command parameter, using underscores (`_`) between words as necessary for legibility.
-+
 [IMPORTANT]
 ====
 Do not italicize user-replaced values. This guideline is an exception to the link:https://redhat-documentation.github.io/supplementary-style-guide/#user-replaced-values[_Red Hat supplementary style guide for product documentation_].
 ====
-+
+
 For example:
-+
+
 ....
 To view a list of objects for the specified object type, enter the following command:
 
@@ -1183,9 +1196,9 @@ To view a list of objects for the specified object type, enter the following com
 $ oc get <object_type> <object_id>
 ----
 ....
-+
+
 This renders as:
-+
+
 --
 > To view a list of objects for the specified object type, enter the following command:
 >
@@ -1193,9 +1206,11 @@ This renders as:
 > $ oc get <object_type> <object_id>
 > ----
 --
-+
+
 NOTE: Avoid using full command syntax inline with sentences.
 
+[[resource-names-oc-commands]]
+==== Resource names in oc commands
 * When you specify link:https://kubernetes.io/docs/reference/kubectl/#resource-types[resource names] in `oc` commands, use the full name of the resource type by default. You can use the abbreviation of the resource type name if it improves readability, such as with very long commands, or to be consistent with existing content in the same assembly.
 +
 For example, use `namespaces` instead of `ns` and `poddisruptionbudgets` instead of `pdb`.
@@ -1227,8 +1242,20 @@ The following example shows a more complex use of user-chosen elements and presc
 <resource_group_name>/providers/Microsoft.Compute/diskEncryptionSets/<disk_encryption_set_name>
 ....
 
-* If you must provide additional information on what a line of a code block
-represents, use callouts (`<1>`, `<2>`, etc.) to provide that information.
+[[backslash-for-long-code-line]]
+==== Backslash for long lines of code
+For long lines of code that you want to break up among multiple lines, use a backslash to show the line break. For example:
+
+----
+$ oc get endpoints --all-namespaces --template \
+    '{{ range .items }}{{ .metadata.namespace }}:{{ .metadata.name }} \
+    {{ range .subsets }}{{ range .addresses }}{{ .ip }} \
+    {{ end }}{{ end }}{{ "\n" }}{{ end }}' | awk '/ 172\.30\./ { print $1 }'
+----
+
+[[callouts-in-codeblocks]]
+==== Callouts in code blocks
+* If you must provide additional information on what a line of a code block represents, use callouts (`<1>`, `<2>`, etc.) to provide that information.
 +
 Use this format when embedding callouts into the code block:
 +
@@ -1242,11 +1269,29 @@ code example 2 <2>
 <2> A note about the second example value.
 ....
 
-* If you must provide additional information on what a line of a code block
-represents and the use of callouts is impractical, you can use a description list
-to provide information about the variables in the code block. Using callouts
-might be impractical if a code block contains too many conditional statements to
-easily use numbered callouts or if the same note applies to multiple lines of the codeblock.
+* If your command contains multiple lines and uses callout annotations, you must comment out the callout(s) in the codeblock, as shown in the following example:
++
+
+To scale based on the percent of CPU utilization, create a `HorizontalPodAutoscaler` object for an existing object:
++
+[subs=-callouts]
+....
+[source,terminal]
+----
+$ oc autoscale <object_type>/<name> \// <1>
+  --min <number> \// <2>
+  --max <number> \// <3>
+  --cpu-percent=<percent> <4>
+----
+<1> Specify the type and name of the object to autoscale.
+<2> Optional: Specify the minimum number of replicas when scaling down.
+<3> Specify the maximum number of replicas when scaling up.
+<4> Specify the target average CPU utilization over all the pods, represented as a percent of requested CPU.
+....
+
+* If you must provide additional information on what a line of a code block represents and the use of callouts is impractical, you can use a description list to provide information about the variables in the code block. Using callouts might be impractical if a code block contains too many conditional statements to easily use numbered callouts or if the same note applies to multiple lines of the codeblock.
++
+Be sure to introduce the description list with "where:" and start each variable description with "Specifies."
 +
 ....
 ----
@@ -1260,19 +1305,22 @@ where:
 <variable_2>:: Specifies the explanation of the first variable.
 ....
 +
-Be sure to introduce the description list with "where:" and start each variable
-description with "Specifies."
-
-* For long lines of code that you want to break up among multiple lines, use a
-backslash to show the line break. For example:
+For example:
 +
+....
+[source,terminal]
 ----
-$ oc get endpoints --all-namespaces --template \
-    '{{ range .items }}{{ .metadata.namespace }}:{{ .metadata.name }} \
-    {{ range .subsets }}{{ range .addresses }}{{ .ip }} \
-    {{ end }}{{ end }}{{ "\n" }}{{ end }}' | awk '/ 172\.30\./ { print $1 }'
+$ oc annotate route <route_name> router.openshift.io/cookie_name="<cookie_name>"
 ----
++
+where:
 
+`<route_name>`:: Specifies the name of the route.
+`<cookie_name>`:: Specifies the name for the cookie.
+....
+
+[[signs-symbols-in-codeblocks]]
+==== Signs and symbols in code blocks
 * If the user must run a command as root, use a number sign (`#`) at the start of the command instead of a dollar sign (`$`). For example:
 +
 ----
@@ -1302,50 +1350,21 @@ Taints:             node-role.kubernetes.io/infra:NoSchedule
 +
 Do not use `[...]`, `<snip>`, or any other variant.
 
-* Do not use `jq` in commands (unless it is truly required), because this requires users to install the `jq` tool. Oftentimes, the same or similar result can be accomplished using `jsonpath` for `oc` commands.
-+
+[[jq-commands]]
+==== Commands with jq
+Do not use `jq` in commands (unless it is truly required), because this requires users to install the `jq` tool. Oftentimes, the same or similar result can be accomplished using `jsonpath` for `oc` commands.
+
 For example, this command that uses `jq`:
-+
+
 ----
 $ oc get clusterversion -o json|jq ".items[0].spec"
 ----
-+
+
 can be updated to use `jsonpath` instead:
-+
+
 ----
 $ oc get clusterversion -o jsonpath='{.items[0].spec}{"\n"}'
 ----
-
-* For Bash "here" documents use `[source,terminal]`, such as the following example:
-+
-....
-[source,terminal]
-----
-$ cat <<EOF| oc create -f -
-apiVersion: v1
-kind: Pod
-metadata:
-  name: mlistener
-  labels:
-    app: multicast-verify
-EOF
-----
-....
-
-* For the output of commands use `[source,text]`, such as with the following example output from the `oc describe <pural> <object>` command:
-+
-....
-[source,text]
-----
-Name:               node1.example.com
-Roles:              worker
-Labels:             kubernetes.io/arch=amd64
-...
-Annotations:        cluster.k8s.io/machine: openshift-machine-api/ahardin-worker-us-east-2a-q5dzc
-...
-CreationTimestamp:  Wed, 13 Feb 2019 11:05:57 -0500
-----
-....
 
 === YAML formatting for Kubernetes and OpenShift API objects
 The following formatting guidelines apply to YAML manifests, but do not apply to the installation configuration YAML specified by `install-config.yaml`.
@@ -1391,7 +1410,7 @@ spec:
       protocol: TCP
 ----
 
-==== Formatting
+==== YAML formatting
 The following conventions govern the layout of YAML for API objects:
 
 - Begin YAML at the beginning of the left margin.


### PR DESCRIPTION
Over the years "Code blocks, command syntax, and example output" section of the Doc guidelines has grown considerably and seeking or citing guidance from this section can take time. 

This PR proposes the following updates: 
- Provide clarity by collating similar items and by removing redundant information
- Improve findability by adding linked sections. (Having link-friendly guidance might help authors and peer reviewers) 

Version(s):
`main`

Issue:
N/A

Link to docs preview:
https://github.com/abhatt-rh/openshift-docs/blob/contribute-codeblocks/contributing_to_docs/doc_guidelines.adoc#code-blocks-command-syntax-and-example-output

QE review: N/A 

Additional information:
This PR also removes hard links from the said section.

Initially, I thought of segregating the information based on its section title. For example, guidance for _codeblocks_, guidance for _commands_ and then guidance for _example outputs_. However, considering the overlap in certain guidance for these three, this approach would have rendered rather ineffective. I am open to suggestions and ideas if we'd like to revisit it.
 