### PR TITLE
Addition of missing cloud providers

### DIFF
--- a/machine_management/index.adoc
+++ b/machine_management/index.adoc
@@ -31,11 +31,21 @@ As a cluster administrator, you can perform the following actions:
 
 * Create a compute machine set for the following cloud providers:
 
+** xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#creating-machineset-alibaba[Alibaba]
+
 ** xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#creating-machineset-aws[AWS]
+
+** xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#creating-machineset-azure-stack-hub[Azure Stack Hub]
 
 ** xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#creating-machineset-azure[Azure]
 
 ** xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#creating-machineset-gcp[GCP]
+
+** xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#creating-machineset-ibm-cloud[IBM Cloud]
+
+** xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#creating-machineset-ibm-power-vs[IBM Power Virtual Server]
+
+** xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#creating-machineset-nutanix[Nutanix]
 
 ** xref:../machine_management/creating_machinesets/creating-machineset-osp.adoc#creating-machineset-osp[{rh-openstack}]
 


### PR DESCRIPTION
Adding the missing cloud provider links to compute machine set in docs.

Version:
```
main
```

Issue:
[#64725 ](https://github.com/openshift/openshift-docs/issues/64725l)

Link to docs preview:
[preview](https://github.com/7h3-3mp7y-m4n/openshift-docs/blob/main/machine_management/index.adoc)

QE review:
- [ ] QE has approved this change.
