### PR TITLE
OSDOCS-7771: Migrate Creating a Public/Private BYO VPC for ROSA tutorial to ROSA product documentation

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -84,6 +84,8 @@ Distros: openshift-rosa
 Topics:
 - Name: ROSA prerequisites
   File: rosa-mobb-prerequisites-tutorial
+- Name: Creating a Public/Private BYO VPC for ROSA
+  File: rosa-mobb-byo-vpc-tutorial
 ---
 Name: Getting started
 Dir: rosa_getting_started

--- a/rosa_tutorials/rosa-mobb-byo-vpc-tutorial.adoc
+++ b/rosa_tutorials/rosa-mobb-byo-vpc-tutorial.adoc
@@ -1,0 +1,56 @@
+:_content-type: ASSEMBLY
+[id="rosa-mobb-byo-vpc-tutorial"]
+= Tutorial: Creating a Public/Private BYO VPC for ROSA
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-mobb-byo-vpc-tutorial
+
+//Mobb content metadata
+//Brought into ROSA product docs 2023-09-19
+//---
+//date: '2021-06-14'
+//title: Creating a Public/Private BYO VPC for ROSA
+//tags: ["AWS", "ROSA"]
+//authors:
+//  - Connor Wooley
+//---
+
+include::snippets/mobb-support-statement.adoc[leveloffset=+1]
+
+This is Terraform example to create a single AZ VPC in which to deploy a single AZ ROSA cluster. 
+
+[IMPORTANT]
+====
+This is intended to be used as a guide to get started quickly, not to be used in production.
+====
+
+== Prerequisites
+
+* link:https://www.terraform.io/downloads.html[Terraform]
+
+== Deploy
+
+. Download the following repo:
++
+[source,terminal]
+----
+$ git clone https://github.com/rh-mobb/documentation.git
+$ cd documentation/docs/rosa/byo-vpc
+----
++
+. Modify `main.tf as` needed, then run:
++
+[source,terminal]
+----
+$ terraform init
+$ terraform plan
+$ terraform apply
+----
+
+== Cleanup
+
+* To destroy resources, run:
++
+[source,terminal]
+----
+$ terraform destroy
+----


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7771

Link to docs preview:
https://64921--docspreview.netlify.app/openshift-rosa/latest/rosa_tutorials/rosa-mobb-byo-vpc-tutorial

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
