### PR TITLE
OSDOCS#7832: Migrate sts cluster logging addon workaround from MOBB to ROSA

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -78,12 +78,14 @@ Topics:
 # - Name: Training for ROSA
 #   File: rosa-training
 ---
-Name: Tutorials 
-Dir: rosa_tutorials 
+Name: Tutorials
+Dir: rosa_tutorials
 Distros: openshift-rosa
 Topics:
 - Name: ROSA prerequisites
   File: rosa-mobb-prerequisites-tutorial
+- Name: Workaround to fix the issue with the logging-addon on ROSA STS Clusters
+  File: rosa-mobb-sts-cluster-logging-addon
 ---
 Name: Getting started
 Dir: rosa_getting_started

--- a/rosa_tutorials/rosa-mobb-sts-cluster-logging-addon.adoc
+++ b/rosa_tutorials/rosa-mobb-sts-cluster-logging-addon.adoc
@@ -1,0 +1,139 @@
+:_content-type: ASSEMBLY
+[id="rosa-mobb-sts-cluster-logging-addon"]
+= Tutorial: Workaround to fix the issue with the logging-addon on ROSA STS Clusters
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-mobb-sts-cluster-logging-addon
+
+toc::[]
+
+// ---
+// date: '2021-11-02'
+// title: Work Around to fix the issue with the logging-addon on ROSA STS Clusters
+// tags: ["AWS", "ROSA", "STS"]
+// authors:
+//   - Connor Wooley
+// ---
+
+include::snippets/mobb-support-statement.adoc[leveloffset=+1]
+
+Currently, the logging-addon is not working on ROSA STS clusters.
+This is due to permissions missing from the Operator itself.
+
+The following procedure is a workaround to provide credentials to the addon.
+
+[NOTE]
+====
+Please see the official link:https://access.redhat.com/solutions/6485391[Red Hat KCS] for more information.
+====
+
+.Prerequisites
+
+* An STS-based ROSA Cluster
+
+.Procedure
+
+. Uninstall the logging-addon from the cluster:
++
+[source,terminal]
+----
+$ rosa uninstall addon -c <mycluster> cluster-logging-operator -y
+----
+
+. Create an IAM Trust Policy document:
++
+[source,terminal]
+----
+$ cat << EOF > /tmp/trust-policy.json
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Effect": "Allow",
+            "Action": [
+                "logs:CreateLogGroup",
+                "logs:CreateLogStream",
+                "logs:DescribeLogGroups",
+                "logs:DescribeLogStreams",
+                "logs:PutLogEvents",
+                "logs:GetLogEvents",
+                "logs:PutRetentionPolicy",
+                "logs:GetLogRecord"
+            ],
+            "Resource": "arn:aws:logs:*:*:*"
+        }
+    ]
+}
+EOF
+----
+
+. Create the IAM Policy:
++
+[source,terminal]
+----
+$ POLICY_ARN=$(aws iam create-policy --policy-name "RosaCloudWatchAddon" --policy-document file:///tmp/trust-policy.json --query Policy.Arn --output text)
+$ echo $POLICY_ARN
+----
+
+. Create a service account:
++
+[source,terminal]
+----
+$ aws iam create-user --user-name RosaCloudWatchAddon  \
+  --query User.Arn --output text
+----
+
+. Attach the policy to the user:
++
+[source,terminal]
+----
+$ aws iam attach-user-policy --user-name RosaCloudWatchAddon \
+  --policy-arn ${POLICY_ARN}
+----
+
+. Create an access key and save the output (Paste the `AccessKeyId` and `SecretAccessKey` into `values.yaml`):
++
+[source,terminal]
+----
+$ aws iam create-access-key --user-name RosaCloudWatchAddon
+----
++
+[source,terminal]
+----
+$ export AWS_ID=<from above>
+$ export AWS_KEY=<from above>
+----
+
+. Create a secret for the addon to use:
++
+[source,terminal]
+----
+$ cat << EOF | kubectl apply -f -
+apiVersion: v1
+kind: Secret
+metadata:
+ name: instance
+ namespace: openshift-logging
+stringData:
+  aws_access_key_id: ${AWS_ID}
+  aws_secret_access_key: ${AWS_KEY}
+EOF
+----
+
+. Install the logging-addon from the cluster:
++
+[source,terminal]
+----
+$ rosa install addon -c <mycluster> cluster-logging-operator -y
+----
+
+. Accept the defaults (or change them as appropriate):
++
+[source,terminal]
+----
+? Use AWS CloudWatch: Yes
+? Collect Applications logs: Yes
+? Collect Infrastructure logs: Yes
+? Collect Audit logs (optional): No
+? CloudWatch region (optional):
+I: Add-on 'cluster-logging-operator' is now installing. To check the status run 'rosa list addons -c mycluster'
+----


### PR DESCRIPTION
Version(s): 4.13+

Issue:
[OSDOCS-7832](https://issues.redhat.com/browse/OSDOCS-7832)

Link to docs preview: [Workaround to fix the issue with the logging-addon on ROSA STS Clusters](https://64931--docspreview.netlify.app/openshift-rosa/latest/rosa_tutorials/rosa-mobb-sts-cluster-logging-addon)

QE review:
- [ ] QE has approved this change.
