### PR TITLE
[WIP] OBSDOCS-480: Add-alertmanager-auth-sample-code

### DIFF
--- a/modules/monitoring-example-alertmanager-webhook-authentication-settings.adoc
+++ b/modules/monitoring-example-alertmanager-webhook-authentication-settings.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+// * monitoring/configuring-the-monitoring-stack.adoc
+
+:_content-type: REFERENCE
+[id="example-alertmanager-webhook-authentication-settings_{context}"]
+= Example Alertmanager webhook authentication settings
+
+These examples show settings that configure Alertmanager in the `openshift-monitoring` namespace to authenticate with a webhook endpoint by using an API token that is configured in a `Secret` object.
+
+The following sample YAML shows a `Secret` object with authentication credentials to be referenced in the Alertmanager config map settings for the Cluster Monitoring Operator (CMO):
+
+[source,yaml]
+----
+apiVersion: v1
+kind: Secret
+data: 
+  api_token: m8VjfmV2Cg== <1>
+metadata: 
+  name: alertmanager-credentials <2>
+  namespace: openshift-monitoring
+----
+<1> Replace this value with the API token used to authenticate to your webhook endpoint.
+<2> The name of the secret to be referenced in the CMO config map settings. 
+
+The following sample YAML shows CMO config map settings for Alertmanager.
+These settings reference the authentication credentials contained in the previous `Secret` object, which is mounted as a volume in the `alertmanager` container for the Alertmanager pods:
+
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cluster-monitoring-config
+  namespace: openshift-monitoring
+data:
+  config.yaml: |
+    alertmanagerMain:
+      enabled: true
+      secrets:
+      - alertmanager-credentials <1> 
+      receivers:
+        - name: webhook
+        webhook_configs: 
+        - url: 'https://webhook.example.com/' <2>
+          http_config: 
+            authorization: 
+              type: apikey
+              credentials_file: /etc/alertmanager/secrets/alertmanager-credentials/api_token <3>
+----
+<1> The name of the configured Kubernetes `Secret` object.
+<2> The URL of the webhook endpoint.
+<3> The path to the authentication `api_token` value in the `Secret` object, which has been mounted as a volume in the `alertmanager` container for the Alertmanager pods.

--- a/observability/monitoring/managing-alerts.adoc
+++ b/observability/monitoring/managing-alerts.adoc
@@ -98,6 +98,8 @@ include::modules/monitoring-creating-alert-routing-for-user-defined-projects.ado
 // Applying a custom Alertmanager configuration
 ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/monitoring-applying-custom-alertmanager-configuration.adoc[leveloffset=+1]
+// Example Alertmanager webhook authentication settings
+include::modules/monitoring-example-alertmanager-webhook-authentication-settings.adoc[leveloffset=2]
 endif::openshift-dedicated,openshift-rosa[]
 
 // Applying a custom configuration to Alertmanager for user-defined alert routing
@@ -111,7 +113,6 @@ include::modules/monitoring-applying-a-custom-configuration-to-alertmanager-for-
 * See link:https://prometheus.io/docs/alerting/configuration/[Alertmanager configuration] for configuring alerting through different alert receivers.
 ifndef::openshift-rosa,openshift-dedicated[]
 * See xref:../../observability/monitoring/enabling-alert-routing-for-user-defined-projects.adoc#enabling-alert-routing-for-user-defined-projects[Enabling alert routing for user-defined projects] to learn how to enable a dedicated instance of Alertmanager for user-defined alert routing.
-
 
 == Next steps
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-480
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64933--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts#example-alertmanager-webhook-authentication-settings_managing-alerts
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @juzhao 
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR adds sample YAML code to show webhook authentication settings for Alertmanager using a Kubernetes `Secret` object.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
