### PR TITLE
proxy-authorization headers leak fix

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 ./aura.tar.gz
 lxml~=4.9.1
 pyyaml~=6.0
-requests~=2.27.1
+requests>=2.31.0


### PR DESCRIPTION
For patching a security issue: Unintended leak of Proxy-Authorization header in requests 
This only affect proxied requests when credentials are supplied in the URL user information component (e.g. https://username:password@proxy:8080), which is not applicable to our use.

