### PR TITLE
OSDOCS#6367:Installing specific Operator version in web console

### DIFF
--- a/modules/olm-installing-specific-version-web-console.adoc
+++ b/modules/olm-installing-specific-version-web-console.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * operators/admin/olm-adding-operators-to-cluster.adoc
+
+:_content-type: PROCEDURE
+[id="olm-installing-specific-version-web-console_{context}"]
+= Installing a specific version of an Operator in the web console
+
+You can install a specific version of an Operator by using the OperatorHub in the web console. You are able to browse the various versions of an operator across any channels it might have, view the metadata for that channel and version, and select the exact version you want to install.
+
+.Prerequisites
+
+* You must have administrator privileges.
+
+.Procedure
+
+. From the web console, click *Operators* → *OperatorHub*.
+
+. Select an Operator you want to install.
+
+. From the selected Operator, you can select a *Channel* and *Version* from the lists.
++
+[NOTE]
+====
+The version selection defaults to the latest version for the channel selected. If the latest version for the channel is selected, the Automatic approval strategy is enabled by default. Otherwise Manual approval is required when not installing the latest version for the selected channel.
+
+Manual approval applies to all operators installed in a namespace.
+
+Installing an Operator with manual approval causes all Operators installed within the namespace to function with the Manual approval strategy and all Operators are updated together. Install Operators into separate namespaces for updating independently.
+====
+
+. Click *Install*
+
+.Verification
+
+* When the operator is installed, the metadata indicates which channel and version are installed.
++
+[NOTE]
+====
+The channel and version dropdown menus are still available for viewing other version metadata in this catalog context.
+====

--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -48,6 +48,8 @@ include::modules/olm-installing-specific-version-cli.adoc[leveloffset=+1]
 * xref:../../operators/admin/olm-upgrading-operators.adoc#olm-approving-pending-upgrade_olm-upgrading-operators[Manually approving a pending Operator update]
 * xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-global-namespaces_olm-adding-operators-to-a-cluster[Installing global Operators in custom namespaces]
 
+include::modules/olm-installing-specific-version-web-console.adoc[leveloffset=+1]
+
 include::modules/olm-preparing-multitenant-operators.adoc[leveloffset=+1]
 .Next steps
 


### PR DESCRIPTION
OSDOCS#6367:Installing specific Operator version in web console

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6367

Link to docs preview:
https://64953--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-adding-operators-to-cluster#olm-installing-specific-version-web-console_olm-adding-operators-to-a-cluster

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
