### PR TITLE
OCPBUGS-14034

### DIFF
--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -370,6 +370,9 @@ a|--cluster <cluster_name>\|<cluster_id>
 
 |--username-claims
 |The list (string) of claims to use as the preferred username when provisioning a user.
+
+|--groups-claims
+|The list (string) of claims to use as the groups names.
 |===
 
 .Optional arguments inherited from parent commands


### PR DESCRIPTION
[OCPBUGS-14034](https://issues.redhat.com/browse/OCPBUGS-14034): [DOCS] Missing groups-claims parameter in the ROSA documentation

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.12+ (As per Jira, the Affects Version/s: 4.12, 4.13)
JIRA issues: [OCPBUGS-14034](https://issues.redhat.com/browse/OCPBUGS-14034)
Preview pages: [Click to see the build preview in your browser](https://64955--docspreview.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-create-idp_rosa-managing-objects-cli)
SME review **completed**: @arendej
QE review **completed**: @yuwang-RH
Peer review **completed**: @mburke5678