### PR TITLE
 [enterprise-4.14] OCPBUGS#3646: service account is used to admit the…

### DIFF
--- a/modules/security-context-constraints-about.adoc
+++ b/modules/security-context-constraints-about.adoc
@@ -381,6 +381,11 @@ user identity and groups that the user belongs to. Additionally, if the pod
 specifies a service account, the set of allowable SCCs includes any constraints
 accessible to the service account.
 
+[NOTE]
+====
+When you create a workload resource, such as deployment, only the service account is used to find the SCCs and admit the pods when they are created.
+====
+
 Admission uses the following approach to create the final security context for
 the pod:
 


### PR DESCRIPTION
Version(s): 4.14 only
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-3646
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://64956--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints.html#admission_configuring-internal-oauth
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: QE approval is in this original PR - https://github.com/openshift/openshift-docs/pull/56483
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Created this cherry-pick PR based on the last comment on the bug. This is the original PR - https://github.com/openshift/openshift-docs/pull/56483
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
