### PR TITLE
[OSDOCS-6138]: Azure AD Workload ID installation RNs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -80,6 +80,15 @@ In {product-title} {product-version}, you can install a cluster that uses a NAT 
 ==== Installing a cluster on Google Cloud Platform (GCP) using pd-balanced disk type
 In {product-title} {product-version}, you can install a cluster on GCP using the `pd-balanced` disk type. This disk type is only available for compute nodes and cannot be used for control plane nodes. For more information, see xref:../installing/installing_gcp/installation-config-parameters-gcp.adoc#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp[Additional GCP configuration parameters].
 
+[id="ocp-4-14-azure-ad-workload-id"]
+==== Installing a cluster with Azure AD Workload Identity
+
+During installation, you can now configure a Microsoft Azure cluster to use Azure AD Workload Identity. With Azure AD Workload Identity, cluster components use short-term security credentials that are managed outside the cluster.
+
+For more information about the short-term credentials implementation for {product-title} clusters on Azure, see xref:../authentication/managing_cloud_provider_credentials/cco-short-term-creds.adoc#cco-short-term-creds-azure_cco-short-term-creds[Azure AD Workload Identity].
+
+To learn how to configure this credentials management strategy during installation, see xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-with-short-term-creds_installing-azure-customizations[Configuring an Azure cluster to use short-term credentials].
+
 [id="ocp-4-14-user-defined-tags-azure"]
 ==== User-defined tags for Microsoft Azure is now generally available
 
@@ -1217,7 +1226,7 @@ With this update, when creating a `DNSRecord` custom resource (CR) for a gateway
 
 * Previously, a Cluster Network Operator controller monitored a broader set of resources than necessary, which resulted in its reconciler being triggered too often. Consequently, this increased the loads on both the Cluster Network Operator and the `kube-apiserver`.
 +
-With this update, the Cluster Network Operator `allowlist` controller monitors its `cni-sysctl-allowlist` config map for changes. As a result, rather than being triggered when any config map is changed, the `allowlist` controller reconciler is only triggered when changes are made to the `cni-sysctl-allowlist` config map or the `default-cni-sysctl-allowlist` config map. As a result, Cluter Network Operator API requests and config map requests are reduced. (link:https://issues.redhat.com/browse/OCPBUGS-11565[*OCPBUGS-11565*]). 
+With this update, the Cluster Network Operator `allowlist` controller monitors its `cni-sysctl-allowlist` config map for changes. As a result, rather than being triggered when any config map is changed, the `allowlist` controller reconciler is only triggered when changes are made to the `cni-sysctl-allowlist` config map or the `default-cni-sysctl-allowlist` config map. As a result, Cluter Network Operator API requests and config map requests are reduced. (link:https://issues.redhat.com/browse/OCPBUGS-11565[*OCPBUGS-11565*]).
 
 * `segfault` failures that were related to HaProxy have been resolved. Users should no longer receive these errors. (link:https://issues.redhat.com/browse/OCPBUGS-11595[*OCPBUGS-11595*])
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-6138](https://issues.redhat.com//browse/OSDOCS-6138)

Link to docs preview:
[Installing a cluster with Azure AD Workload Identity](https://64960--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-azure-ad-workload-id)

QE review:
- [ ] QE has approved this change.

Additional information: