### PR TITLE
[enterprise-4.14] CNV-26426: Release note: Deprecate TTO

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -140,6 +140,7 @@ The SVVP Certification applies to:
 Deprecated features are included in the current release and supported. However, they will be removed in a future release and are not recommended for new deployments.
 
 //CNV-26426 [DOCS] Release note: Deprecate TTO
+* The `tekton-tasks-operator` is deprecated and Tekton tasks and example pipelines are now deployed by the `ssp-operator`.
 
 //CNV-29048 Release note: DEPRECATED FEATURE (Metrics backlog 4.14)
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/CNV-26426

Link to docs preview:
https://64962--docspreview.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes#virt-4-14-deprecated

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
