### PR TITLE
OSDOCS-7855: Add MOBB tutorial template

### DIFF
--- a/rosa_tutorials/rosa-mobb-template-tutorial.adoc
+++ b/rosa_tutorials/rosa-mobb-template-tutorial.adoc
@@ -1,0 +1,68 @@
+:_content-type: ASSEMBLY
+[id=“rosa-mobb-<topic>-tutorial”]
+= Tutorial: <Topic>
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-mobb-<topic>-tutorial
+
+toc::[]
+
+//Mobb content metadata
+//Brought into ROSA product docs 2023-09-18
+//---
+//date: '2021-06-10'
+//title: ROSA Prerequisites
+//weight: 1
+//tags: ["AWS", "ROSA", "Quickstarts"]
+//authors:
+//  - <author>
+//---
+
+include::snippets/mobb-support-statement.adoc[leveloffset=+1]
+
+Introductory text.
+
+== <Heading 2>
+
+Paragraph text.
+
+image::<example-image>.png[<example image text>]
+
+[NOTE]
+====
+Images need to be added to the images folder to build in the content.
+====
+
+=== <Heading 3>
+
+.Prerequisites <formatting>
+
+Here is the link formatting: 
+
+* link:<redhat.com>[External or hard link]
+* xref:../rosa_architecture/rosa-getting-support.adoc#rosa-getting-support[Sample cross reference]
+
+
+.Procedure <formatting>
+
+. <numbered step formatting>
++
+* <bullet formatting: use a bullet for single-step processes or non-numbered processes> 
++
+[source,terminal]
+----
+$ <sample-code-block>
+----
++
+[NOTE] 
+====
+<sample note formatting; you can use the following admonitions> 
+
+* NOTE
+* TIP
+* IMPORTANT
+* CAUTION
+* WARNING
+====
+
+
+


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7855

Link to docs preview:
This file will not build in the product documentation. 

QE review:
No QE review required. This is just adds a template. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
