### PR TITLE
[WIP] OSSM-3473 [DOC] Document which SMCP versions are supported by latest operator version

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -43,6 +43,14 @@ This release adds improvements related to the following components and concepts.
 |===
 //COMPONENTS ABOVE MAY NEED TO BE UPDATED FOR 2.4.3
 
+=== Supported {SMProductName} Operator versions for 2.4.3
+
+{SMProductName} supports the installation of these OSSM control plane versions: 
+
+* 2.4.3
+* 2.3.7
+* 2.2.10
+
 === {SMProductName} operator to ARM-based clusters
 :FeatureName: {SMProductName} operator to ARM based clusters
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
[DOC] [OSSM-3473](https://issues.redhat.com//browse/OSSM-3473) Document which SMCP versions are supported by latest operator version

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-3473

Link to docs preview:
https://64971--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
To help users understand what versions of the OpenShift Service Mesh operator are supported with each release, a new section has been added that lists supported versions, starting with release 2.4.3.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
