### PR TITLE
SRVCOM-2705: Showcase image leftovers

### DIFF
--- a/modules/serverless-containersource-ossm.adoc
+++ b/modules/serverless-containersource-ossm.adoc
@@ -31,7 +31,7 @@ spec:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
-      - image: quay.io/openshift-knative/knative-eventing-sources-event-display:latest
+      - image: quay.io/openshift-knative/showcase
 ----
 <1> A namespace that is a member of the `ServiceMeshMemberRoll`.
 <2> Injects {SMProductShortName} sidecars into the Knative service pods.

--- a/modules/serverless-sinkbinding-ossm.adoc
+++ b/modules/serverless-sinkbinding-ossm.adoc
@@ -29,7 +29,7 @@ spec:
         sidecar.istio.io/rewriteAppHTTPProbers: "true"
     spec:
       containers:
-      - image: quay.io/openshift-knative/knative-eventing-sources-event-display:latest
+      - image: quay.io/openshift-knative/showcase
 ----
 <1> A namespace that is a member of the `ServiceMeshMemberRoll`.
 <2> Injects {SMProductShortName} sidecars into the Knative service pods.


### PR DESCRIPTION
Version(s): Serverless 1.29+

Issue: https://issues.redhat.com/browse/SRVCOM-2705

Link to docs preview: https://64976--docspreview.netlify.app

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
