### PR TITLE
[enterprise-4.11] Manual Cherrypick: OBSDOCS-475 - Logging 5.6.11 & 5.5.16 Release Notes-4.11

### DIFF
--- a/logging/cluster-logging-release-notes.adoc
+++ b/logging/cluster-logging-release-notes.adoc
@@ -19,11 +19,15 @@ include::modules/logging-rn-5.7.3.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.7.2.adoc[leveloffset=+1]
 
+include::modules/logging-rn-5.6.11.adoc[leveloffset=+1]
+
+include::modules/logging-rn-5.6.9.adoc[leveloffset=+1]
+
+include::modules/logging-rn-5.6.8.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.6.7.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.6.adoc[leveloffset=+1]
-
-include::modules/logging-rn-5.6.8.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-rn-5.6.5.adoc[leveloffset=+1]
 
@@ -36,6 +40,10 @@ include::modules/cluster-logging-rn-5.6.2.adoc[leveloffset=+1]
 include::modules/cluster-logging-rn-5.6.1.adoc[leveloffset=+1]
 
 include::modules/cluster-logging-rn-5.6.adoc[leveloffset=+1]
+
+include::modules/logging-rn-5.5.16.adoc[leveloffset=+1]
+
+include::modules/logging-rn-5.5.14.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.5.13.adoc[leveloffset=+1]
 

--- a/logging/v5_5/logging-5-5-release-notes.adoc
+++ b/logging/v5_5/logging-5-5-release-notes.adoc
@@ -8,6 +8,12 @@ toc::[]
 
 include::snippets/logging-compatibility-snip.adoc[]
 
+include::modules/logging-rn-5.5.16.adoc[leveloffset=+1]
+
+include::modules/logging-rn-5.5.14.adoc[leveloffset=+1]
+
+include::modules/logging-rn-5.5.13.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.5.11.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.5.10.adoc[leveloffset=+1]

--- a/logging/v5_6/logging-5-6-release-notes.adoc
+++ b/logging/v5_6/logging-5-6-release-notes.adoc
@@ -9,6 +9,10 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-rn-5.6.11.adoc[leveloffset=+1]
+
+include::modules/logging-rn-5.6.9.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.6.8.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.7.adoc[leveloffset=+1]

--- a/modules/logging-rn-5.5.14.adoc
+++ b/modules/logging-rn-5.5.14.adoc
@@ -1,0 +1,15 @@
+// Module included in the following assemblies:
+// cluster-logging-release-notes.adoc
+// logging-5-5-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-5-14_{context}"]
+= Logging 5.5.14
+This release includes link:https://access.redhat.com/errata/RHBA-2023:4343[OpenShift Logging Bug Fix Release 5.5.14].
+
+[id="openshift-logging-5-5-14-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, the Vector collector occasionally panicked with the following error message in its log: `thread 'vector-worker' panicked at 'all branches are disabled and there is no else branch', src/kubernetes/reflector.rs:26:9`. With this update, the error does not show in the Vector collector. (link:https://issues.redhat.com/browse/LOG-4279[LOG-4279])
+
+[id="openshift-logging-5-5-14-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-2828[CVE-2023-2828]

--- a/modules/logging-rn-5.5.16.adoc
+++ b/modules/logging-rn-5.5.16.adoc
@@ -1,0 +1,17 @@
+// Module included in the following assemblies:
+// cluster-logging-release-notes.adoc
+// logging-5-5-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-5-16_{context}"]
+= Logging 5.5.16
+This release includes link:https://access.redhat.com/errata/RHSA-2023:5096[OpenShift Logging Bug Fix Release 5.5.16].
+
+[id="openshift-logging-5-5-16-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, the LokiStack gateway cached authorized requests very broadly. As a result, this caused wrong authorization results. With this update, LokiStack gateway caches on a more fine-grained basis which resolves this issue. (link:https://issues.redhat.com/browse/LOG-4434[LOG-4434])
+
+[id="openshift-logging-5-5-16-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-3899[CVE-2023-3899]
+* link:https://access.redhat.com/security/cve/CVE-2023-32360[CVE-2023-32360]
+* link:https://access.redhat.com/security/cve/CVE-2023-34969[CVE-2023-34969]

--- a/modules/logging-rn-5.6.11.adoc
+++ b/modules/logging-rn-5.6.11.adoc
@@ -1,0 +1,18 @@
+// Module included in the following assemblies:
+// cluster-logging-release-notes.adoc
+// logging-5-6-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-6-11_{context}"]
+= Logging 5.6.11
+This release includes link:https://access.redhat.com/errata/RHSA-2023:5095[OpenShift Logging Bug Fix Release 5.6.11].
+
+[id="openshift-logging-5-6-11-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, the LokiStack gateway cached authorized requests very broadly. As a result, this caused wrong authorization results. With this update, LokiStack gateway caches on a more fine-grained basis which resolves this issue. (link:https://issues.redhat.com/browse/LOG-4435[LOG-4435])
+
+
+[id="openshift-logging-5-6-11-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-3899[CVE-2023-3899]
+* link:https://access.redhat.com/security/cve/CVE-2023-32360[CVE-2023-32360]
+* link:https://access.redhat.com/security/cve/CVE-2023-34969[CVE-2023-34969]

--- a/modules/logging-rn-5.6.9.adoc
+++ b/modules/logging-rn-5.6.9.adoc
@@ -1,0 +1,27 @@
+// Module included in the following assemblies:
+// cluster-logging-release-notes.adoc
+// logging-5-6-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-6-9_{context}"]
+= Logging 5.6.9
+This release includes link:https://access.redhat.com/errata/RHBA-2023:4342[OpenShift Logging Bug Fix Release 5.6.9].
+
+[id="openshift-logging-5-6-9-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, when multiple roles were used to authenticate using STS with AWS Cloudwatch forwarding, a recent update caused the credentials to be non-unique. With this update, multiple combinations of STS roles and static credentials can once again be used to authenticate with AWS Cloudwatch. (link:https://issues.redhat.com/browse/LOG-4084[LOG-4084])
+
+* Before this update, the Vector collector occasionally panicked with the following error message in its log: `thread 'vector-worker' panicked at 'all branches are disabled and there is no else branch', src/kubernetes/reflector.rs:26:9`. With this update, the error has been resolved. (link:https://issues.redhat.com/browse/LOG-4276[LOG-4276])
+
+* Before this update, Loki filtered label values for active streams but did not remove duplicates, making Grafana's Label Browser unusable. With this update, Loki filters out duplicate label values for active streams, resolving the issue. (link:https://issues.redhat.com/browse/LOG-4390[LOG-4390])
+
+
+[id="openshift-logging-5-6-9-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2020-24736[CVE-2020-24736]
+* link:https://access.redhat.com/security/cve/CVE-2022-48281[CVE-2022-48281]
+* link:https://access.redhat.com/security/cve/CVE-2023-1667[CVE-2023-1667]
+* link:https://access.redhat.com/security/cve/CVE-2023-2283[CVE-2023-2283]
+* link:https://access.redhat.com/security/cve/CVE-2023-24329[CVE-2023-24329]
+* link:https://access.redhat.com/security/cve/CVE-2023-26604[CVE-2023-26604]
+* link:https://access.redhat.com/security/cve/CVE-2023-28466[CVE-2023-28466]
+* link:https://access.redhat.com/security/cve/CVE-2023-32233[CVE-2023-32233]


### PR DESCRIPTION
This is a manual cherry-pick of https://github.com/openshift/openshift-docs/pull/64617

Fix version: 4.11

Note: Added files for 5.5.14 & 5.6.9 as they were missing

Doc preview: https://64983--docspreview.netlify.app/openshift-enterprise/latest/logging/v5_6/logging-5-6-release-notes

cherry picked from: f5ac41ade0474ad93a4bbba082ae626999449c46