### PR TITLE
OSDOCS-7856: Migrated AWS Secrets Manager

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -100,6 +100,8 @@ Topics:
   File: cloud-experts-configure-custom-tls-ciphers
 - Name: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
   File: cloud-experts-entra-id-idp
+- Name: Using AWS Secrets Manager CSI on ROSA with STS
+  File: cloud-experts-aws-secret-manager  
 ---
 Name: Getting started
 Dir: rosa_getting_started

--- a/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
+++ b/cloud_experts_tutorials/cloud-experts-aws-secret-manager.adoc
@@ -1,0 +1,340 @@
+:_content-type: ASSEMBLY
+[id="cloud-experts-aws-secret-manager"] 
+= Tutorial: Using AWS Secrets Manager CSI on ROSA with STS
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: cloud-experts-aws-secret-manager
+
+toc::[]
+
+//Mobb content metadata
+//Brought into ROSA product docs 2023-09-18
+// ---
+// date: '2023-05-25'
+// title: Using AWS Secrets Manager CSI on Red Hat OpenShift on AWS with STS
+// tags: ["AWS", "ROSA"]
+// authors:
+//   - Paul Czarkowski
+//   - Chris Kang
+// ---
+
+The AWS Secrets and Configuration Provider (ASCP) provides a way to expose AWS Secrets as Kubernetes storage volumes. With the ASCP, you can store and manage your secrets in Secrets Manager and then retrieve them through your workloads running on ROSA.
+
+This is made even easier and more secure through the use of AWS STS and Kubernetes PodIdentity.
+
+[id="cloud-experts-aws-secret-manager-prerequisites"]
+== Prerequisites
+
+* A ROSA cluster deployed with STS
+* Helm 3
+* aws CLI
+* oc CLI
+* jq
+
+[id="cloud-experts-aws-secret-manager-preparing-environment"]
+== Preparing Environment
+
+. Validate that your cluster has STS:
++
+[source,terminal]
+----
+$ oc get authentication.config.openshift.io cluster -o json \
+  | jq .spec.serviceAccountIssuer
+----
++
+You should see something like the following, if not you should not proceed, instead look to the link:https://docs.openshift.com/rosa/rosa_getting_started_sts/rosa_creating_a_cluster_with_sts/rosa-sts-creating-a-cluster-quickly.html[Red Hat documentation on creating an STS cluster].
++
+[source,terminal]
+----
+"https://xxxxx.cloudfront.net/xxxxx"
+----
+
+. Set SecurityContextConstraints to allow the CSI driver to run:
++
+[source,terminal]
+----
+$ oc new-project csi-secrets-store
+$ oc adm policy add-scc-to-user privileged \
+    system:serviceaccount:csi-secrets-store:secrets-store-csi-driver
+$ oc adm policy add-scc-to-user privileged \
+    system:serviceaccount:csi-secrets-store:csi-secrets-store-provider-aws
+----
+
+. Create some environment variables to refer to later:
++
+[source,terminal]
+----
+$ export REGION=$(oc get infrastructure cluster -o=jsonpath="{.status.platformStatus.aws.region}")
+$ export OIDC_ENDPOINT=$(oc get authentication.config.openshift.io cluster \
+   -o jsonpath='{.spec.serviceAccountIssuer}' | sed  's|^https://||')
+$ export AWS_ACCOUNT_ID=`aws sts get-caller-identity --query Account --output text`
+$ export AWS_PAGER=""
+----
+
+[id="cloud-experts-aws-secret-manager-deply-aws-secrets"]
+== Deploy the AWS Secrets and Configuration Provider
+
+. Use Helm to register the secrets store CSI driver:
++
+[source,terminal]
+----
+$ helm repo add secrets-store-csi-driver \
+    https://kubernetes-sigs.github.io/secrets-store-csi-driver/charts
+----
+
+. Update your Helm repositories:
++
+[source,terminal]
+----
+$ helm repo update
+----
+
+. Install the secrets store CSI driver:
++
+[source,terminal]
+----
+$ helm upgrade --install -n csi-secrets-store \
+    csi-secrets-store-driver secrets-store-csi-driver/secrets-store-csi-driver
+----
+
+. Deploy the AWS provider:
++
+[source,terminal]
+----
+$ oc -n csi-secrets-store apply -f \
+    https://raw.githubusercontent.com/rh-mobb/documentation/main/content/misc/secrets-store-csi/aws-provider-installer.yaml
+----
+
+. Check that both Daemonsets are running:
++
+[source,terminal]
+----
+$ oc -n csi-secrets-store get ds \
+    csi-secrets-store-provider-aws \
+    csi-secrets-store-driver-secrets-store-csi-driver
+----
+
+. Label the Secrets Store CSI Driver to allow use with the restricted pod security profile:
++
+[source,terminal]
+----
+$ oc label csidriver.storage.k8s.io/secrets-store.csi.k8s.io security.openshift.io/csi-ephemeral-volume-profile=restricted
+----
+
+[id="cloud-experts-aws-secret-manager-create-iam-polices"]
+== Creating a Secret and IAM Access Policies
+
+. Create a secret in Secrets Manager:
++
+[source,terminal]
+----
+$ SECRET_ARN=$(aws --region "$REGION" secretsmanager create-secret \
+    --name MySecret --secret-string \
+    '{"username":"shadowman", "password":"hunter2"}' \
+    --query ARN --output text)
+$ echo $SECRET_ARN
+----
+
+. Create an IAM Access Policy document:
++
+[source,terminal]
+----
+$ cat << EOF > policy.json
+{
+   "Version": "2012-10-17",
+   "Statement": [{
+      "Effect": "Allow",
+      "Action": [
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
+      ],
+      "Resource": ["$SECRET_ARN"]
+      }]
+}
+EOF
+----
+
+. Create an IAM Access Policy:
++
+[source,terminal]
+----
+$ POLICY_ARN=$(aws --region "$REGION" --query Policy.Arn \
+--output text iam create-policy \
+--policy-name openshift-access-to-mysecret-policy \
+--policy-document file://policy.json)
+$ echo $POLICY_ARN
+----
+
+. Create an IAM Role trust policy document:
++
+[NOTE]
+====
+The trust policy is locked down to the default service account of a namespace you will create later.
+====
++
+[source,terminal]
+----
+$ cat <<EOF > trust-policy.json
+{
+   "Version": "2012-10-17",
+   "Statement": [
+   {
+   "Effect": "Allow",
+   "Condition": {
+     "StringEquals" : {
+       "${OIDC_ENDPOINT}:sub": ["system:serviceaccount:my-application:default"]
+      }
+    },
+    "Principal": {
+       "Federated": "arn:aws:iam::$AWS_ACCOUNT_ID:oidc-provider/${OIDC_ENDPOINT}"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity"
+    }
+    ]
+}
+EOF
+----
+
+. Create an IAM role:
++
+[source,terminal]
+----
+$ ROLE_ARN=$(aws iam create-role --role-name openshift-access-to-mysecret \
+--assume-role-policy-document file://trust-policy.json \
+--query Role.Arn --output text)
+$ echo $ROLE_ARN
+----
+
+. Attach the role to the policy:
++
+[source,terminal]
+----
+$ aws iam attach-role-policy --role-name openshift-access-to-mysecret \
+    --policy-arn $POLICY_ARN
+----
+
+[id="cloud-experts-aws-secret-manager-creating-application"]
+== Create an Application to use this secret
+
+. Create an OpenShift project:
++
+[source,terminal]
+----
+$ oc new-project my-application
+----
+
+. Annotate the default service account to use the STS Role:
++
+[source,terminal]
+----
+$ oc annotate -n my-application serviceaccount default \
+    eks.amazonaws.com/role-arn=$ROLE_ARN
+----
+
+. Create a secret provider class to access our secret:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+apiVersion: secrets-store.csi.x-k8s.io/v1
+kind: SecretProviderClass
+metadata:
+  name: my-application-aws-secrets
+spec:
+  provider: aws
+  parameters:
+    objects: |
+      - objectName: "MySecret"
+        objectType: "secretsmanager"
+EOF
+----
+
+. Create a Deployment using our secret:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+apiVersion: v1
+kind: Pod
+metadata:
+  name: my-application
+  labels:
+    app: my-application
+spec:
+  volumes:
+  - name: secrets-store-inline
+    csi:
+      driver: secrets-store.csi.k8s.io
+      readOnly: true
+      volumeAttributes:
+        secretProviderClass: "my-application-aws-secrets"
+  containers:
+  - name: my-application-deployment
+    image: k8s.gcr.io/e2e-test-images/busybox:1.29
+    command:
+      - "/bin/sleep"
+      - "10000"
+    volumeMounts:
+    - name: secrets-store-inline
+      mountPath: "/mnt/secrets-store"
+      readOnly: true
+EOF
+----
+
+. Verify the Pod has the secret mounted:
++
+[source,terminal]
+----
+$ oc exec -it my-application -- cat /mnt/secrets-store/MySecret
+----
+
+[id="cloud-experts-aws-secret-manager-cleanup"]
+== Clean up
+
+. Delete the application:
++
+[source,terminal]
+----
+$ oc delete project my-application
+----
+
+. Delete the secrets store csi driver:
++
+[source,terminal]
+----
+$ helm delete -n csi-secrets-store csi-secrets-store-driver
+----
+
+. Delete Security Context Constraints:
++
+[source,terminal]
+----
+$ oc adm policy remove-scc-from-user privileged \
+    system:serviceaccount:csi-secrets-store:secrets-store-csi-driver
+$ oc adm policy remove-scc-from-user privileged \
+    system:serviceaccount:csi-secrets-store:csi-secrets-store-provider-aws
+----
+
+. Delete the AWS provider:
++
+[source,terminal]
+----
+$ oc -n csi-secrets-store delete -f \
+https://raw.githubusercontent.com/rh-mobb/documentation/main/content/misc/secrets-store-csi/aws-provider-installer.yaml
+----
+
+. Delete AWS Roles and Policies:
++
+[source,terminal]
+----
+$ aws iam detach-role-policy --role-name openshift-access-to-mysecret \
+    --policy-arn $POLICY_ARN
+$ aws iam delete-role --role-name openshift-access-to-mysecret
+$ aws iam delete-policy --policy-arn $POLICY_ARN
+----
+
+. Delete the Secrets Manager secret:
++
+[source,terminal]
+----
+$ aws secretsmanager --region $REGION delete-secret --secret-id $SECRET_ARN
+----


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-7856](https://issues.redhat.com/browse/OSDOCS-7856)

Link to docs preview:
- [Using AWS Secrets Manager CSI on Red Hat OpenShift on AWS with STS](https://65003--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-aws-secret-manager)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Migrated the "Using AWS Secrets Manager CSI on Red Hat OpenShift on AWS with STS" topic from the MOBB docs to ROSA docs.