### PR TITLE
OSDOCS-5239-RN: Documented the 4.14 quickly cluster install AWS LZ re…

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -114,6 +114,12 @@ For more information, see the "Static IP addresses for vSphere nodes" section in
 ==== Additional validation for the Bare Metal Host CR
 
 The Bare Metal Host Custom Resource (CR) now contains the `ValidatingWebhooks` parameter. With this parameter, the Bare Metal Operator now catches any configuration errors before accepting the CR, and returns a message with the configuration errors to the user.
+[id="ocp-4-14-quickly-install-cluster-aws-local-zones"]
+==== Install a cluster quickly in AWS Local Zones
+For {product-title} {product-version}, you can quickly install a cluster on Amazon Web Services (AWS) to extend compute nodes to Local Zone locations. After you add zone names to the installation configuration file, the installation program fully automates the creation of required resources, network and compute, on each Local Zone.
+
+For more information, see xref:../installing/installing_aws/installing-aws-localzone.adoc#installation-cluster-quickly-extend-workers_installing-aws-localzone[Intall a cluster quickly in AWS Local Zones].
+
 
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration


### PR DESCRIPTION
[OSDOCS-5239](https://issues.redhat.com/browse/OSDOCS-5239)

Version(s):
4.14

Link to docs preview:
[Install a cluster quickly in AWS Local Zones](https://65012--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-quickly-install-cluster-aws-local-zones)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
