### PR TITLE
Update nw-networkpolicy-about.adoc

### DIFF
--- a/modules/nw-networkpolicy-about.adoc
+++ b/modules/nw-networkpolicy-about.adoc
@@ -144,7 +144,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          policy-group.network.openshift.io/ingress:""<1>
+          policy-group.network.openshift.io/ingress: ""<1>
   podSelector: {}
   policyTypes:
   - Ingress
@@ -168,7 +168,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          policy-group.network.openshift.io/host-network:""
+          policy-group.network.openshift.io/host-network: ""
   podSelector: {}
   policyTypes:
   - Ingress

--- a/modules/nw-networkpolicy-deny-all-allowed.adoc
+++ b/modules/nw-networkpolicy-deny-all-allowed.adoc
@@ -68,8 +68,8 @@ endif::multi[]
 ----
 ifdef::multi[]
 <1> `namespace: default` deploys this policy to the `default` namespace.
-<2> `podSelector:` is empty, this means it matches all the pods. Therefore, the policy applies to all pods in the default namespace.
-<3> `network_name`: specifies the name of a network attachment definition.
+<2> `network_name`: specifies the name of a network attachment definition.
+<3> `podSelector:` is empty, this means it matches all the pods. Therefore, the policy applies to all pods in the default namespace.
 <4> There are no `ingress` rules specified. This causes incoming traffic to be dropped to all pods.
 endif::multi[]
 ifndef::multi[]


### PR DESCRIPTION
Customer is using the OCP document and trying to create the network policy using the example network policies mentioned in the below  documentation. 

https://docs.openshift.com/container-platform/4.13/networking/network_policy/about-network-policy.html#nw-networkpolicy-allow-from-router_about-network-policy

https://docs.openshift.com/container-platform/4.13/networking/network_policy/about-network-policy.html#nw-networkpolicy-allow-from-hostnetwork_about-network-policy

While copy and pasting the example policy from the documentation, the policy creation was failed with the below error,

`Error from server (BadRequest): error when creating "host.yaml": NetworkPolicy in version "v1" cannot be handled as a NetworkPolicy: json: cannot unmarshal string into Go struct field LabelSelector.spec.ingress.from.namespaceSelector.matchLabels of type map[string]string`

There was a indentation error in spec.ingress.from.namespaceSelector.matchLabels 

policy-group.network.openshift.io/ingress:""
policy-group.network.openshift.io/host-network:""

**Before the change:**
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-from-router
spec:
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          policy-group.network.openshift.io/ingress:""
  podSelector: {}
  policyTypes:
  - Ingress
```
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-from-hostnetwork
spec:
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          policy-group.network.openshift.io/host-network:""
  podSelector: {}
  policyTypes:
  - Ingress
```
**After the change:**
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-from-router
spec:
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          policy-group.network.openshift.io/ingress: ""
  podSelector: {}
  policyTypes:
  - Ingress
```
```
apiVersion: networking.k8s.io/v1
kind: NetworkPolicy
metadata:
  name: allow-from-hostnetwork
spec:
  ingress:
  - from:
    - namespaceSelector:
        matchLabels:
          policy-group.network.openshift.io/host-network: ""
  podSelector: {}
  policyTypes:
  - Ingress
```
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13

Issue: Typos in the example network policy

Link to docs preview: https://docs.openshift.com/container-platform/4.13/networking/network_policy/about-network-policy.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
