### PR TITLE
OSDOCS-5202-RN: Documented the 4.14 vSphere static IP addresses relea…

### DIFF
--- a/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
+++ b/modules/installation-vsphere-installer-infra-static-ip-nodes.adoc
@@ -1,3 +1,11 @@
+////
+Module included in the following assemblies:
+* xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc[Installing a cluster on vSphere]
+* xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc[Installing a cluster on vSphere with customizations]
+* xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc[Installing a cluster on vSphere with network customizations]
+* xref:../installing/installing_vsphere/installing-restricted-networks-vsphere.adoc[Installing a cluster on vSphere in a restricted network]
+////
+
 :_content-type: CONCEPT
 [discrete]
 [id="installation-vsphere-installer-infra-static-ip-nodes_{context}"]

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -99,6 +99,18 @@ For more information, see xref:../installing/cluster-capabilities.adoc#cluster-c
 ==== Root volume types parameter for {rh-openstack} is now available
 You can now specify one or more root volume types in {rh-openstack}, by using the `rootVolume.types` parameter. This parameter is available for both control plane and compute machines.
 
+[id="ocp-4-14-static-ip-addresses-vsphere-nodes"]
+==== Static IP addresses for vSphere nodes
+You can provision bootstrap, control plane, and compute nodes with static IP addresses in environments where Dynamic Host Configuration Protocol (DHCP) does not exist.
+
+:FeatureName: Static IP addresses for vSphere nodes
+include::snippets/technology-preview.adoc[]
+
+After you deployed your cluster to run nodes with static IP addresses, you can scale a machine to use one of these static IP addresses. Additionally, you can use a machine set to configure a machine to use one of the configured static IP addresses.
+
+For more information, see the "Static IP addresses for vSphere nodes" section in the xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc[Installing a cluster on vSphere] document.
+
+
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
[OSDOCS-7859](https://issues.redhat.com/browse/OSDOCS-7859)

Version(s):
4.14

Link to docs preview:
[Static IP addresses for vSphere nodes](https://65014--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-static-ip-addresses-vsphere-nodes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
