### PR TITLE
[enterprise-4.11] OCPBUGS-9194: CP to 4.11

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -48,6 +48,8 @@ include::modules/ipi-install-configuring-host-network-interfaces-in-the-install-
 
 include::modules/ipi-install-configuring-host-network-interfaces-for-subnets.adoc[leveloffset=+2]
 
+include::modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc[leveloffset=+2]
+
 include::modules/ipi-install-configure-multiple-cluster-nodes.adoc[leveloffset=+2]
 
 include::modules/ipi-install-configuring-managed-secure-boot-in-the-install-config-file.adoc[leveloffset=+2]

--- a/modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc
+++ b/modules/ipi-install-modifying-install-config-for-slaac-dual-stack-network.adoc
@@ -1,0 +1,62 @@
+// This is included in the following assemblies:
+//
+// ipi-install-configuration-files.adoc
+
+:_content-type: PROCEDURE
+[id='ipi-install-modifying-install-config-for-slaac-dual-stack-network_{context}']
+= Optional: Configuring address generation modes for SLAAC in dual-stack networks
+
+For dual-stack clusters that use Stateless Address AutoConfiguration (SLAAC), you must specify a global value for the `ipv6.addr-gen-mode` network setting. You can set this value using NMState to configure the ramdisk and the cluster configuration files. If you don't configure a consistent `ipv6.addr-gen-mode` in these locations, IPv6 address mismatches can occur between CSR resources and `BareMetalHost` resources in the cluster. 
+
+.Prerequisites 
+
+* Install the NMState CLI (`nmstate`).
+
+.Procedure
+
+. Optional: Consider testing the NMState YAML syntax with the `nmstatectl gc` command before including it in the `install-config.yaml` file because the installation program will not check the NMState YAML syntax.
+
+.. Create an NMState YAML file:
++
+[source,yaml]
+----
+interfaces:
+- name: eth0 
+  ipv6:
+    addr-gen-mode: <address_mode> <1>
+----
+<1> Replace `<address_mode>` with the type of address generation mode required for IPv6 addresses in the cluster. Valid values are `eui64`, `stable-privacy`, or `random`.
+
+.. Test the configuration file by running the following command:
++
+[source,terminal]
+----
+$ nmstatectl gc <nmstate_yaml_file> <1>
+----
+<1> Replace `<nmstate_yaml_file>` with the name of the test configuration file.
+
+. Add the NMState configuration to the `hosts.networkConfig` section within the install-config.yaml file:
++
+[source,yaml]
+----
+    hosts:
+      - name: openshift-master-0
+        role: master
+        bmc:
+          address: redfish+http://<out_of_band_ip>/redfish/v1/Systems/
+          username: <user>
+          password: <password>
+          disableCertificateVerification: null
+        bootMACAddress: <NIC1_mac_address>
+        bootMode: UEFI
+        rootDeviceHints:
+          deviceName: "/dev/sda"
+        networkConfig: 
+          interfaces:
+          - name: eth0
+            ipv6:
+              addr-gen-mode: <address_mode> <1>
+...
+
+----
+<1> Replace `<address_mode>` with the type of address generation mode required for IPv6 addresses in the cluster. Valid values are `eui64`, `stable-privacy`, or `random`.


### PR DESCRIPTION
OCPBUGS-9194: CP of #60903 to 4.11

Version(s):
4.11

Issue:
https://issues.redhat.com/browse/OCPBUGS-9194

Link to docs preview:
https://65016--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow#ipi-install-modifying-install-config-for-slaac-dual-stack-network_ipi-install-installation-workflow

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
