### PR TITLE
[enterprise-4.12] OCPBUGS-18108-412 updating http://registry.access.redhat.com/rhel:latest

### DIFF
--- a/modules/cnf-scheduling-numa-aware-workloads.adoc
+++ b/modules/cnf-scheduling-numa-aware-workloads.adoc
@@ -67,7 +67,7 @@ spec:
             memory: "100Mi"
             cpu: "10"
       - name: ctnr2
-        image: gcr.io/google_containers/pause-amd64:3.0
+        image: registry.access.redhat.com/rhel:latest
         imagePullPolicy: IfNotPresent
         command: ["/bin/sh", "-c"]
         args: [ "while true; do sleep 1h; done;" ]


### PR DESCRIPTION
[OCPBUGS-18108]: Replace image: gcr.io/google_containers/pause-amd64:3.0 with registry.access.redhat.com/rhel:latest in file scalability_and_performance/cnf-numa-aware-scheduling.adoc

Cherry Picked from c6a3cbb73f7f491df76262ec9b9d1c2610452757 xref: https://github.com/openshift/openshift-docs/pull/64168

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12 
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-18108
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://65029--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-scheduling-numa-aware-workloads_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This is a CP from https://github.com/openshift/openshift-docs/pull/64168 all approvals tracked there.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

