### PR TITLE
TRACING-3280: Add documentation for the Memory Limiter processor in OTEL

### DIFF
--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -296,6 +296,60 @@ The batch processor batches the data to reduce the number of outgoing connection
 | 1000
 |===
 
+[id="memorylimiter-processor_{context}"]
+==== Memory Limiter processor
+
+The Memory Limiter processor periodically checks the Collector's memory usage and pauses data processing when the soft memory limit is reached.
+The preceding component, which is typically a receiver, is expected to retry sending the same data and may apply a backpressure to the incoming data.
+When memory usage exceeds the hard limit, the Memory Limiter processor forces garbage collection to run.
+
+* Support level: General Availability
+* Supported signals: traces, metrics, logs
+
+.Example of the OpenTelemetry Collector custom resource when using the Memory Limiter processor
+[source,yaml]
+----
+  config: |
+    processor:
+      memory_limiter:
+        check_interval: 1s
+        limit_mib: 4000
+        spike_limit_mib: 800
+    service:
+      pipelines:
+        traces:
+          processors: [batch]
+        metrics:
+          processors: [batch]
+----
+
+.Parameters used by the Memory Limiter processor
+[cols="3",options="header"]
+|===
+| Parameter | Description | Default
+
+| `check_interval`
+| Time between memory usage measurements. The optimal value is 1s. For spiky traffic patterns, you can decrease the `check_interval` or increase the `spike_limit_mib`.
+| `0s`
+
+| `limit_mib`
+| The hard limit, which is the maximum amount of memory in MiB allocated on the heap. Typically, the total memory usage of the OpenTelemetry Collector is about 50 MiB greater than this value.
+| `0`
+
+| `spike_limit_mib`
+| Spike limit, which is the maximum expected spike of memory usage in MiB. The optimal value is approximately 20% of `limit_mib`. To calculate the soft limit, subtract the `spike_limit_mib` from the `limit_mib`.
+| 20% of `limit_mib`
+
+| `limit_percentage`
+| Same as the `limit_mib` but expressed as a percentage of the total available memory. The `limit_mib` setting takes precedence over this setting.
+| `0`
+
+| `spike_limit_percentage`
+| Same as the `spike_limit_mib` but expressed as a percentage of the total available memory. Intended to be used with the `limit_percentage` setting.
+| `0`
+
+|===
+
 [id="resource-detection-processor_{context}"]
 ==== Resource Detection processor
 


### PR DESCRIPTION
Version(s):
4.11, 4.12, 4.13

Issue:
https://issues.redhat.com/browse/TRACING-3280

Link to docs preview: https://65036--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_otel/distr-tracing-otel-configuring#memorylimiter-processor_distr-tracing-otel-configuring

QE review:
- [x] QE has approved this change.

Additional information:
@IshwarKanse
@max-cx
