### PR TITLE
OBSDOCS-539: Put 5.8 logging docs live

### DIFF
--- a/logging/cluster-logging-loki.adoc
+++ b/logging/cluster-logging-loki.adoc
@@ -20,7 +20,6 @@ include::modules/logging-loki-gui-install.adoc[leveloffset=+1]
 
 include::modules/logging-loki-cli-install.adoc[leveloffset=+1]
 
-////
 include::modules/logging-loki-restart-hardening.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -37,7 +36,6 @@ include::modules/logging-loki-reliability-hardening.adoc[leveloffset=+1]
 ifdef::openshift-enterprise[]
 * xref:../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
 endif::[]
-////
 
 include::modules/logging-loki-retention.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.12+ (5.8 release, Nov 2nd 2023)

Issue:
https://issues.redhat.com/browse/OBSDOCS-539

Link to docs preview:
- Loki restart hardening: https://65038--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki#logging-loki-restart-hardening_cluster-logging-loki
- Loki reliability hardening: https://65038--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki#logging-loki-reliability-hardening_cluster-logging-loki
- Multi CLF: https://65038--docspreview.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/log-forwarding

QE review:
All doc changes were previously approved by QE before merging, this PR just uncomments the changes.
