### PR TITLE
OSDOCS-7767: add doc for advertiseAddress flag

### DIFF
--- a/modules/microshift-config-yaml.adoc
+++ b/modules/microshift-config-yaml.adoc
@@ -8,11 +8,13 @@
 
 {product-title} searches for a configuration file in the user-specific directory, `~/.microshift/config.yaml`, then the system-wide `/etc/microshift/config.yaml` directory. You must create the configuration file and specify any settings that should override the defaults before starting {product-title}.
 
+//include admonition snippet about waiting for greenboot
+
 [id="microshift-yaml-default_{context}"]
 == Default settings
-If you do not create a `config.yaml` file, the default values are used. The following example configuration contains the default settings. You must change any settings that should override the defaults before starting {product-title}.
+If you do not create a `config.yaml` file, the default values are used. The following example configuration shows the default settings. You must create a custom `config.yaml` file and change any settings that should override the defaults before starting {product-title}.
 
-.Default YAML file example
+.Default YAML values example
 [source,yaml]
 ----
 dns:
@@ -27,9 +29,10 @@ node:
   hostnameOverride: "" <5>
   nodeIP: "" <6>
 apiServer:
-  subjectAltNames: [] <7>
+  advertiseAddress: 10.44.0.0 <7>
+  subjectAltNames: [] <8>
 debugging:
-  logLevel: "Normal" <8>
+  logLevel: "Normal" <9>
 ----
 <1> Base domain of the cluster. All managed DNS records will be subdomains of this base.
 <2> A block of IP addresses from which Pod IP addresses are allocated.
@@ -37,10 +40,25 @@ debugging:
 <4> The port range allowed for Kubernetes services of type NodePort.
 <5> The name of the node. The default value is the hostname.
 <6> The IP address of the node. The default value is the IP address of the default route.
-<7> Subject Alternative Names for API server certificates.
-<8> Log verbosity. Valid values for this field are `Normal`, `Debug`, `Trace`, or `TraceAll`.
+<7> A string that specifies the IP address from which the API server is advertised to members of the cluster. The default value is calculated based on the address of the service network.
+<8> Subject Alternative Names for API server certificates.
+<9> Log verbosity. Valid values for this field are `Normal`, `Debug`, `Trace`, or `TraceAll`.
 
 [IMPORTANT]
 ====
 Restart {product-title} after changing any configuration settings to have them take effect. {product-title} reads the configuration file only on start.
 ====
+
+[id="microshift-yaml-custom_{context}"]
+== Custom settings
+You must change any settings that should override the defaults before starting {product-title}.
+
+advertiseAddress::
+The `apiserver.advertiseAddress` flag specifies the IP address on which to advertise the API server to members of the cluster. This address must be reachable by the cluster. You can set a custom IP address here, but you must also add the IP address to a host interface. Customizing this parameter preempts {product-title} from adding a default IP address to the `br-ex` network interface.
++
+[IMPORTANT]
+====
+If you customize the `advertiseAddress` IP address, make sure it is reachable by the cluster when {product-title} starts by adding the IP address to a host interface.
+====
++
+If unset, the default value is `10.44.0.0/32`. It will be set to the next immediate subnet after the service network. For example, when the service network is `10.43.0.0/16`, the `advertiseAddress` is set to `10.44.0.0/32`.

--- a/modules/microshift-configuring-ovn.adoc
+++ b/modules/microshift-configuring-ovn.adoc
@@ -24,7 +24,7 @@ $ sudo cp /etc/microshift/ovn.yaml.default /etc/microshift/ovn.yaml
 $ cat /etc/microshift/ovn.yaml.default
 ----
 +
-.Example 'yaml' configuration file with default maximum transmission unit (MTU) value
+.Example YAML file with default maximum transmission unit (MTU) value
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-7767

Link to docs preview:
https://65057--docspreview.netlify.app/microshift/latest/microshift_configuring/microshift-using-config-tools#microshift-yaml-default_microshift-configuring

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
