### PR TITLE
OSDOCS-7866: Deploying ROSA in STS mode tutorial.

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -159,6 +159,8 @@ Topics:
     File: cloud-experts-getting-started-deleting
   - Name: Obtaining support
     File: cloud-experts-getting-started-support
+  - Name: Deploying ROSA in STS mode
+    File: cloud-experts-deploying-rosa-sts-mode    
 - Name: Deploying an application
   Dir: cloud-experts-deploying-application
   Distros: openshift-rosa

--- a/cloud_experts_tutorials/cloud-experts-deploying-rosa-sts-mode.adoc
+++ b/cloud_experts_tutorials/cloud-experts-deploying-rosa-sts-mode.adoc
@@ -1,0 +1,92 @@
+:_content-type: ASSEMBLY
+[id="cloud-experts-deploying-rosa-sts-mode.adoc"]
+= Tutorial: Deploying ROSA in STS mode
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: cloud-experts-deploying-rosa-sts-mode.adoc
+
+toc::[]
+
+// Mobb content metadata
+// Brought into ROSA product docs 2023-09-21
+// ---
+// date: '2022-05-27'
+// title: Deploying ROSA in STS mode
+// tags: ["AWS", "ROSA", "STS"]
+// weight: 1
+// aliases: ["/docs/quickstart-rosa.md"]
+//authors:
+//  - Paul Czarkowski
+//  - Michael Ducy
+// ---
+
+
+* https://youtu.be/R1T0yk9l6Ys[Introduction by Ryan Niksch (AWS) and Shaozen Ding (Red Hat)].
+
+Secure Token Service allows you to deploy ROSA without needing a ROSA admin account. STS uses roles and policies with Amazon STS (secure token service) to gain access to the AWS resources needed to install and operate the cluster.
+
+== Deploying a ROSA cluster
+
+. Set environment variables.
++
+[source,terminal]
+----
+$ export ROSA_CLUSTER_NAME=mycluster
+--query Account --output text`
+$ export REGION=us-east-2
+----
+. Make sure your ROSA CLI version is correct (v1.2.25 or above).
++
+[source,terminal]
+----
+$ rosa version
+----
+. Run the ROSA CLI to create your cluster.
+
++
+[source,terminal]
+----
+$ rosa create cluster --sts --cluster-name ${ROSA_CLUSTER_NAME} \
+--region ${REGION} --mode auto --yes
+----
+
+. Watch the install logs.
++
+[source,terminal]
+----
+$ rosa logs install -c $ROSA_CLUSTER_NAME --watch --tail 10
+----
+
+== Validating the cluster
+
+Once the cluster has finished installing, validate that you can access it.
+
+. Create an Admin user.
++
+[source,terminal]
+----
+$ rosa create admin -c $ROSA_CLUSTER_NAME
+----
+
+. Wait a few moments and run the `oc login` command it provides. If it fails, or if you get a warning about TLS certificates, wait a few minutes and try again.
+
+. Run `oc whoami --show-console`, browse to the provided URL and log in using the credentials provided above.
+
+== Cleaning up
+
+. Delete the ROSA cluster.
++
+[source,terminal]
+----
+$ rosa delete cluster -c $ROSA_CLUSTER_NAME
+----
+. Clean up the STS roles.
++
+Once the cluster has been deleted, you can delete the STS roles. Replace <id> with the IDs from the output of the previous step.
++
+[source,terminal]
+----
+$ rosa delete operator-roles -c <id> --yes --mode auto
+$ rosa delete oidc-provider -c <id>  --yes --mode auto
+----
+
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
enterprise-4.13+

Issue:
[OSDOCS-7866](https://issues.redhat.com/browse/OSDOCS-7866)

Link to docs preview:
[Tutorial: Deploying ROSA in STS mode](https://65061--ocpdocs-pr.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-deploying-rosa-sts-mode)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
