### PR TITLE
[enterprise-4.14] HCCDOC-1415 Insights Operator RN tech preview features

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -347,6 +347,17 @@ With this update, you can add the `nodeLabels` field in the `SiteConfig` CR to c
 [id="ocp-4-14-hcp"]
 === Hosted control planes (Technology Preview)
 
+[id="ocp-4-14-insights-operator"]
+=== Insights Operator
+
+[id="ocp-4-14-insights-operator-on-demand-data-gathering"]
+==== On demand data gathering (Technology Preview)
+In {product-title} 4.14, Insights Operator can now run gather operations on demand. For more information about running gather operations on demand, see xref:../support/remote_health_monitoring/using-insights-operator.adoc#running-insights-operator-gather_using-insights-operator[Running an Insights Operator gather operation].
+
+[id="ocp-4-14-insights-operator-individual-pods"]
+==== Running gather operations as individual pods (Technology Preview)
+In {product-title} 4.14 Technology Preview clusters, Insights Operator runs gather operations in individual pods. This supports the new on demand data gathering feature.
+
 [id="install-sno-requirements-for-installing-on-a-single-node"]
 === Requirements for installing {product-title} on a single node
 


### PR DESCRIPTION
Insights Operator RN -> Technology Preview Features 

Version(s):
4.14

Issue:
[HCCDOC-1415](https://issues.redhat.com//browse/HCCDOC-1415)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://65067--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-insights-operator
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
