### PR TITLE
Adds release note for SRIOV Broadcom support

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -106,7 +106,7 @@ You can provision bootstrap, control plane, and compute nodes with static IP add
 :FeatureName: Static IP addresses for vSphere nodes
 include::snippets/technology-preview.adoc[]
 
-After you deployed your cluster to run nodes with static IP addresses, you can scale a machine to use one of these static IP addresses. Additionally, you can use a machine set to configure a machine to use one of the configured static IP addresses.
+After you have deployed your cluster to run nodes with static IP addresses, you can scale a machine to use one of these static IP addresses. Additionally, you can use a machine set to configure a machine to use one of the configured static IP addresses.
 
 For more information, see the "Static IP addresses for vSphere nodes" section in the xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc[Installing a cluster on vSphere] document.
 
@@ -264,6 +264,13 @@ For more information, see xref:../networking/metallb/metallb-configure-bgp-peers
 With this update, you can assoicate a Virtual Routing and Forwarding (VRF) instance with a network interface by using a `NodeNetworkConfigurationPolicy` custom resource. By associating a VRF instance with a network interface, you can support traffic isolation, independent routing decisions, and the logical separation of network resources. This is available as a Technology Preview feature.
 
 For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-host-vrf_k8s_nmstate-updating-node-network-config[Example: Network interface with a VRF instance node network configuration policy].
+
+[id="ocp-414-broadcom-bcm57504-support"]
+==== Support for Broadcom BCM57504 is now GA
+
+Support for the Broadcom BCM57504 network interface controller is now available for the SR-IOV Network Operator. 
+
+For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
 
 [id="ocp-4-14-storage"]
 === Storage


### PR DESCRIPTION
Adding a release note for SRIOV Broadcom support; also fixing a small nit for a sentence that should grammatically be in the past participle form. It was not enough to hold up a merge review, so I'm fixing it here.  

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7870

Link to docs preview:
https://65069--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-414-broadcom-bcm57504-support

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
