### PR TITLE
Adds an IMPORTANT admonition to limitations of egress firewall

### DIFF
--- a/modules/nw-egressnetworkpolicy-about.adoc
+++ b/modules/nw-egressnetworkpolicy-about.adoc
@@ -96,6 +96,13 @@ Egress firewall rules do not apply to traffic that goes through routers. Any use
 An egress firewall has the following limitations:
 
 * No project can have more than one {kind} object.
+ifdef::openshift-sdn[]
++
+[IMPORTANT]
+====
+The creation of more than one {kind} object is allowed, however it should not be done. When you create more than one {kind} object, the following message is returned: `dropping all rules`. In actuality, all external traffic is dropped, which can cause security risks for your organization.
+====
+endif::openshift-sdn[]
 
 ifdef::ovn[]
 * A maximum of one {kind} object with a maximum of 8,000 rules can be defined per project.
@@ -114,7 +121,7 @@ ifdef::openshift-sdn[]
   - Projects merged by using the `oc adm pod-network join-projects` command cannot use an egress firewall in any of the joined projects.
 endif::openshift-sdn[]
 
-Violating any of these restrictions results in a broken egress firewall for the project, and might cause all external network traffic to be dropped.
+Violating any of these restrictions results in a broken egress firewall for the project. Consequently, all external network traffic is dropped, which can cause security risks for your organization.
 
 An Egress Firewall resource can be created in the `kube-node-lease`, `kube-public`, `kube-system`, `openshift` and `openshift-` projects.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-19477

Link to docs preview:
https://65075--docspreview.netlify.app/openshift-enterprise/latest/networking/openshift_sdn/configuring-egress-firewall#limitations-of-an-egress-firewall_openshift-sdn-egress-firewall

OVN K (to show that IMPORTANT admonition does not appear): https://65075--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-firewall-ovn#limitations-of-an-egress-firewall_configuring-egress-firewall-ovn

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
