### PR TITLE
[RHACS] Fixed title out of sequence warning

### DIFF
--- a/cli/installing-the-roxctl-cli.adoc
+++ b/cli/installing-the-roxctl-cli.adoc
@@ -17,11 +17,11 @@ You can install the `roxctl` CLI by downloading the binary or you can run the `r
 You can install the `roxctl` CLI to interact with {product-title-short} from a command-line interface. You can install `roxctl` on Linux, Windows, or macOS.
 
 // Installing the CLI by downloading the binary
-include::modules/install-roxctl-cli-linux.adoc[leveloffset=+3]
+include::modules/install-roxctl-cli-linux.adoc[leveloffset=+2]
 
-include::modules/install-roxctl-cli-macos.adoc[leveloffset=+3]
+include::modules/install-roxctl-cli-macos.adoc[leveloffset=+2]
 
-include::modules/install-roxctl-cli-windows.adoc[leveloffset=+3]
+include::modules/install-roxctl-cli-windows.adoc[leveloffset=+2]
 
 // Running the CLI by using a container image
 include::modules/run-roxctl-from-container.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixeses the following three warning in the build:
```
asciidoctor: WARNING: modules/install-roxctl-cli-linux.adoc: line 6: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: modules/install-roxctl-cli-macos.adoc: line 6: section title out of sequence: expected level 2, got level 3
asciidoctor: WARNING: modules/install-roxctl-cli-windows.adoc: line 6: section title out of sequence: expected level 2, got level 3
```

Cherry-pick into 
- `rhacs-docs-4.2`
- `rhacs-docs-4.1`