### PR TITLE
OSDOCS#3994: ROSA - port 'Scalability and performance' content from OCP

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1338,7 +1338,7 @@ Topics:
       File: optimizing-cpu-usage
 #- Name: Managing bare metal hosts
 #  File: managing-bare-metal-hosts
-  Distros: openshift-rosa,openshift-dedicated
+#  Distros: openshift-rosa,openshift-dedicated
 - Name: What huge pages do and how they are consumed by apps
   File: what-huge-pages-do-and-how-they-are-consumed-by-apps
   Distros: openshift-rosa,openshift-dedicated

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1131,27 +1131,27 @@ Topics:
     File: adding-rhv-compute-user-infra
   - Name: Adding compute machines to bare metal
     File: adding-bare-metal-compute-user-infra
-- Name: Managing machines with the Cluster API
-  File: capi-machine-management
-- Name: Managing control plane machines
-  Dir: control_plane_machine_management
-  Topics:
-  - Name: About control plane machine sets
-    File: cpmso-about
-  - Name: Getting started with control plane machine sets
-    File: cpmso-getting-started
-  - Name: Control plane machine set configuration
-    File: cpmso-configuration
-  - Name: Using control plane machine sets
-    File: cpmso-using
-  - Name: Control plane resiliency and recovery
-    File: cpmso-resiliency
-  - Name: Troubleshooting the control plane machine set
-    File: cpmso-troubleshooting
-  - Name: Disabling the control plane machine set
-    File: cpmso-disabling
-- Name: Deploying machine health checks
-  File: deploying-machine-health-checks
+#- Name: Managing machines with the Cluster API
+#  File: capi-machine-management
+#- Name: Managing control plane machines
+#  Dir: control_plane_machine_management
+#  Topics:
+#  - Name: About control plane machine sets
+#    File: cpmso-about
+#  - Name: Getting started with control plane machine sets
+#    File: cpmso-getting-started
+#  - Name: Control plane machine set configuration
+#    File: cpmso-configuration
+#  - Name: Using control plane machine sets
+#    File: cpmso-using
+#  - Name: Control plane resiliency and recovery
+#    File: cpmso-resiliency
+#  - Name: Troubleshooting the control plane machine set
+#    File: cpmso-troubleshooting
+#  - Name: Disabling the control plane machine set
+#    File: cpmso-disabling
+#- Name: Deploying machine health checks
+#  File: deploying-machine-health-checks
 ---
 Name: Logging
 Dir: logging

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1064,73 +1064,73 @@ Topics:
 #  Topics:
 #  - Name: Adding worker nodes to single-node OpenShift clusters
 #    File: nodes-sno-worker-nodes
-Name: Machine management
-Dir: machine_management
-Distros: openshift-origin,openshift-enterprise
-Topics:
-- Name: Overview of machine management
-  File: index
-- Name: Managing compute machines with the Machine API
-  Dir: creating_machinesets
-  Distros: openshift-origin,openshift-enterprise
-  Topics:
-  - Name: Creating a compute machine set on Alibaba Cloud
-    File: creating-machineset-alibaba
-  - Name: Creating a compute machine set on AWS
-    File: creating-machineset-aws
-  - Name: Creating a compute machine set on Azure
-    File: creating-machineset-azure
-  - Name: Creating a compute machine set on Azure Stack Hub
-    File: creating-machineset-azure-stack-hub
-  - Name: Creating a compute machine set on GCP
-    File: creating-machineset-gcp
-  - Name: Creating a compute machine set on IBM Cloud
-    File: creating-machineset-ibm-cloud
-  - Name: Creating a compute machine set on IBM Power Virtual Server
-    File: creating-machineset-ibm-power-vs
-  - Name: Creating a compute machine set on Nutanix
-    File: creating-machineset-nutanix
-  - Name: Creating a compute machine set on OpenStack
-    File: creating-machineset-osp
-  - Name: Creating a compute machine set on RHV
-    File: creating-machineset-rhv
-    Distros: openshift-enterprise
-  - Name: Creating a compute machine set on oVirt
-    File: creating-machineset-rhv
-    Distros: openshift-origin
-  - Name: Creating a compute machine set on vSphere
-    File: creating-machineset-vsphere
-  - Name: Creating a compute machine set on bare metal
-    File: creating-machineset-bare-metal
-- Name: Manually scaling a compute machine set
-  File: manually-scaling-machineset
-- Name: Modifying a compute machine set
-  File: modifying-machineset
-- Name: Deleting a machine
-  File: deleting-machine
-- Name: Applying autoscaling to a cluster
-  File: applying-autoscaling
-- Name: Creating infrastructure machine sets
-  File: creating-infrastructure-machinesets
-- Name: Adding a RHEL compute machine
-  File: adding-rhel-compute
-  Distros: openshift-enterprise
-- Name: Adding more RHEL compute machines
-  File: more-rhel-compute
-  Distros: openshift-enterprise
-- Name: Managing user-provisioned infrastructure manually
-  Dir: user_infra
-  Topics:
-  - Name: Adding compute machines to clusters with user-provisioned infrastructure manually
-    File: adding-compute-user-infra-general
-  - Name: Adding compute machines to AWS using CloudFormation templates
-    File: adding-aws-compute-user-infra
-  - Name: Adding compute machines to vSphere manually
-    File: adding-vsphere-compute-user-infra
-  - Name: Adding compute machines to a cluster on RHV
-    File: adding-rhv-compute-user-infra
-  - Name: Adding compute machines to bare metal
-    File: adding-bare-metal-compute-user-infra
+# Name: Machine management
+# Dir: machine_management
+# Distros: openshift-origin,openshift-enterprise
+# Topics:
+# - Name: Overview of machine management
+#   File: index
+# - Name: Managing compute machines with the Machine API
+#  Dir: creating_machinesets
+#  Distros: openshift-origin,openshift-enterprise
+#  Topics:
+#  - Name: Creating a compute machine set on Alibaba Cloud
+#    File: creating-machineset-alibaba
+#  - Name: Creating a compute machine set on AWS
+#    File: creating-machineset-aws
+#  - Name: Creating a compute machine set on Azure
+#    File: creating-machineset-azure
+#  - Name: Creating a compute machine set on Azure Stack Hub
+#    File: creating-machineset-azure-stack-hub
+#  - Name: Creating a compute machine set on GCP
+#    File: creating-machineset-gcp
+#  - Name: Creating a compute machine set on IBM Cloud
+#    File: creating-machineset-ibm-cloud
+#  - Name: Creating a compute machine set on IBM Power Virtual Server
+#    File: creating-machineset-ibm-power-vs
+#  - Name: Creating a compute machine set on Nutanix
+#    File: creating-machineset-nutanix
+#  - Name: Creating a compute machine set on OpenStack
+#    File: creating-machineset-osp
+#  - Name: Creating a compute machine set on RHV
+#    File: creating-machineset-rhv
+#    Distros: openshift-enterprise
+#  - Name: Creating a compute machine set on oVirt
+#    File: creating-machineset-rhv
+#    Distros: openshift-origin
+#  - Name: Creating a compute machine set on vSphere
+#    File: creating-machineset-vsphere
+#  - Name: Creating a compute machine set on bare metal
+#    File: creating-machineset-bare-metal
+#- Name: Manually scaling a compute machine set
+#  File: manually-scaling-machineset
+#- Name: Modifying a compute machine set
+#  File: modifying-machineset
+#- Name: Deleting a machine
+#  File: deleting-machine
+#- Name: Applying autoscaling to a cluster
+#  File: applying-autoscaling
+#- Name: Creating infrastructure machine sets
+#  File: creating-infrastructure-machinesets
+#- Name: Adding a RHEL compute machine
+#  File: adding-rhel-compute
+#  Distros: openshift-enterprise
+#- Name: Adding more RHEL compute machines
+#  File: more-rhel-compute
+#  Distros: openshift-enterprise
+#- Name: Managing user-provisioned infrastructure manually
+#  Dir: user_infra
+#  Topics:
+#  - Name: Adding compute machines to clusters with user-provisioned infrastructure manually
+#    File: adding-compute-user-infra-general
+#  - Name: Adding compute machines to AWS using CloudFormation templates
+#    File: adding-aws-compute-user-infra
+#  - Name: Adding compute machines to vSphere manually
+#    File: adding-vsphere-compute-user-infra
+#  - Name: Adding compute machines to a cluster on RHV
+#    File: adding-rhv-compute-user-infra
+#  - Name: Adding compute machines to bare metal
+#    File: adding-bare-metal-compute-user-infra
 #- Name: Managing machines with the Cluster API
 #  File: capi-machine-management
 #- Name: Managing control plane machines

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1312,11 +1312,9 @@ Topics:
 - Name: Planning your environment according to object maximums
   File: planning-your-environment-according-to-object-maximums
   Distros: openshift-rosa,openshift-dedicated
-  ifndef::openshift-dedicated,openshift-rosa[]
-- Name: Recommended host practices for IBM Z & IBM LinuxONE environments
-  File: ibm-z-recommended-host-practices
-  Distros: openshift-rosa,openshift-dedicated
-  endif::[]
+#- Name: Recommended host practices for IBM Z & IBM LinuxONE environments
+#  File: ibm-z-recommended-host-practices
+#  Distros: openshift-rosa,openshift-dedicated
 - Name: Using the Node Tuning Operator
   File: using-node-tuning-operator
   Distros: openshift-rosa,openshift-dedicated

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1064,6 +1064,94 @@ Topics:
 #  Topics:
 #  - Name: Adding worker nodes to single-node OpenShift clusters
 #    File: nodes-sno-worker-nodes
+Name: Machine management
+Dir: machine_management
+Distros: openshift-origin,openshift-enterprise
+Topics:
+- Name: Overview of machine management
+  File: index
+- Name: Managing compute machines with the Machine API
+  Dir: creating_machinesets
+  Distros: openshift-origin,openshift-enterprise
+  Topics:
+  - Name: Creating a compute machine set on Alibaba Cloud
+    File: creating-machineset-alibaba
+  - Name: Creating a compute machine set on AWS
+    File: creating-machineset-aws
+  - Name: Creating a compute machine set on Azure
+    File: creating-machineset-azure
+  - Name: Creating a compute machine set on Azure Stack Hub
+    File: creating-machineset-azure-stack-hub
+  - Name: Creating a compute machine set on GCP
+    File: creating-machineset-gcp
+  - Name: Creating a compute machine set on IBM Cloud
+    File: creating-machineset-ibm-cloud
+  - Name: Creating a compute machine set on IBM Power Virtual Server
+    File: creating-machineset-ibm-power-vs
+  - Name: Creating a compute machine set on Nutanix
+    File: creating-machineset-nutanix
+  - Name: Creating a compute machine set on OpenStack
+    File: creating-machineset-osp
+  - Name: Creating a compute machine set on RHV
+    File: creating-machineset-rhv
+    Distros: openshift-enterprise
+  - Name: Creating a compute machine set on oVirt
+    File: creating-machineset-rhv
+    Distros: openshift-origin
+  - Name: Creating a compute machine set on vSphere
+    File: creating-machineset-vsphere
+  - Name: Creating a compute machine set on bare metal
+    File: creating-machineset-bare-metal
+- Name: Manually scaling a compute machine set
+  File: manually-scaling-machineset
+- Name: Modifying a compute machine set
+  File: modifying-machineset
+- Name: Deleting a machine
+  File: deleting-machine
+- Name: Applying autoscaling to a cluster
+  File: applying-autoscaling
+- Name: Creating infrastructure machine sets
+  File: creating-infrastructure-machinesets
+- Name: Adding a RHEL compute machine
+  File: adding-rhel-compute
+  Distros: openshift-enterprise
+- Name: Adding more RHEL compute machines
+  File: more-rhel-compute
+  Distros: openshift-enterprise
+- Name: Managing user-provisioned infrastructure manually
+  Dir: user_infra
+  Topics:
+  - Name: Adding compute machines to clusters with user-provisioned infrastructure manually
+    File: adding-compute-user-infra-general
+  - Name: Adding compute machines to AWS using CloudFormation templates
+    File: adding-aws-compute-user-infra
+  - Name: Adding compute machines to vSphere manually
+    File: adding-vsphere-compute-user-infra
+  - Name: Adding compute machines to a cluster on RHV
+    File: adding-rhv-compute-user-infra
+  - Name: Adding compute machines to bare metal
+    File: adding-bare-metal-compute-user-infra
+- Name: Managing machines with the Cluster API
+  File: capi-machine-management
+- Name: Managing control plane machines
+  Dir: control_plane_machine_management
+  Topics:
+  - Name: About control plane machine sets
+    File: cpmso-about
+  - Name: Getting started with control plane machine sets
+    File: cpmso-getting-started
+  - Name: Control plane machine set configuration
+    File: cpmso-configuration
+  - Name: Using control plane machine sets
+    File: cpmso-using
+  - Name: Control plane resiliency and recovery
+    File: cpmso-resiliency
+  - Name: Troubleshooting the control plane machine set
+    File: cpmso-troubleshooting
+  - Name: Disabling the control plane machine set
+    File: cpmso-disabling
+- Name: Deploying machine health checks
+  File: deploying-machine-health-checks
 ---
 Name: Logging
 Dir: logging
@@ -1206,6 +1294,105 @@ Topics:
   File: troubleshooting-monitoring-issues
 - Name: Config map reference for the Cluster Monitoring Operator
   File: config-map-reference-for-the-cluster-monitoring-operator
+---
+Name: Scalability and performance
+Dir: scalability_and_performance
+Distros: openshift-rosa,openshift-dedicated
+Topics:
+- Name: Recommended performance and scalability practices
+  Dir: recommended-performance-scale-practices
+  Distros: openshift-rosa,openshift-dedicated
+  Topics:
+  - Name: Recommended control plane practices
+    File: recommended-control-plane-practices
+  - Name: Recommended infrastructure practices
+    File: recommended-infrastructure-practices
+  - Name: Recommended etcd practices
+    File: recommended-etcd-practices
+- Name: Planning your environment according to object maximums
+  File: planning-your-environment-according-to-object-maximums
+  Distros: openshift-rosa,openshift-dedicated
+  ifndef::openshift-dedicated,openshift-rosa[]
+- Name: Recommended host practices for IBM Z & IBM LinuxONE environments
+  File: ibm-z-recommended-host-practices
+  Distros: openshift-rosa,openshift-dedicated
+  endif::[]
+- Name: Using the Node Tuning Operator
+  File: using-node-tuning-operator
+  Distros: openshift-rosa,openshift-dedicated
+- Name: Using CPU Manager and Topology Manager
+  File: using-cpu-manager
+  Distros: openshift-rosa,openshift-dedicated
+- Name: Scheduling NUMA-aware workloads
+  File: cnf-numa-aware-scheduling
+  Distros: openshift-rosa,openshift-dedicated
+- Name: Scalability and performance optimization
+  Dir: optimization
+  Distros: openshift-rosa,openshift-dedicated
+  Topics:
+    - Name: Optimizing storage
+      File: optimizing-storage
+    - Name: Optimizing routing
+      File: routing-optimization
+    - Name: Optimizing networking
+      File: optimizing-networking
+    - Name: Optimizing CPU usage
+      File: optimizing-cpu-usage
+#- Name: Managing bare metal hosts
+#  File: managing-bare-metal-hosts
+  Distros: openshift-rosa,openshift-dedicated
+- Name: What huge pages do and how they are consumed by apps
+  File: what-huge-pages-do-and-how-they-are-consumed-by-apps
+  Distros: openshift-rosa,openshift-dedicated
+- Name: Low latency tuning
+  File: cnf-low-latency-tuning
+  Distros: openshift-rosa,openshift-dedicated
+- Name: Performing latency tests for platform verification
+  File: cnf-performing-platform-verification-latency-tests
+- Name: Improving cluster stability in high latency environments using worker latency profiles
+  File: scaling-worker-latency-profiles
+- Name: Creating a performance profile
+  File: cnf-create-performance-profiles
+  Distros: openshift-rosa,openshift-dedicated
+- Name: Workload partitioning
+  File: enabling-workload-partitioning
+  Distros: openshift-rosa,openshift-dedicated
+- Name: Requesting CRI-O and Kubelet profiling data by using the Node Observability Operator
+  File: node-observability-operator
+  Distros: openshift-rosa,openshift-dedicated
+- Name: Clusters at the network far edge
+  Dir: ztp_far_edge
+  Distros: openshift-rosa,openshift-dedicated
+  Topics:
+    - Name: Challenges of the network far edge
+      File: ztp-deploying-far-edge-clusters-at-scale
+    - Name: Preparing the hub cluster for ZTP
+      File: ztp-preparing-the-hub-cluster
+    - Name: Installing managed clusters with RHACM and SiteConfig resources
+      File: ztp-deploying-far-edge-sites
+    - Name: Configuring managed clusters with policies and PolicyGenTemplate resources
+      File: ztp-configuring-managed-clusters-policies
+    - Name: Manually installing a single-node OpenShift cluster with ZTP
+      File: ztp-manual-install
+    - Name: Recommended single-node OpenShift cluster configuration for vDU application workloads
+      File: ztp-reference-cluster-configuration-for-vdu
+    - Name: Validating cluster tuning for vDU application workloads
+      File: ztp-vdu-validating-cluster-tuning
+    - Name: Advanced managed cluster configuration with SiteConfig resources
+      File: ztp-advanced-install-ztp
+    - Name: Advanced managed cluster configuration with PolicyGenTemplate resources
+      File: ztp-advanced-policy-config
+    - Name: Updating managed clusters with the Topology Aware Lifecycle Manager
+      File: cnf-talm-for-cluster-upgrades
+      Distros: openshift-rosa,openshift-dedicated
+    - Name: Updating managed clusters in a disconnected environment with the Topology Aware Lifecycle Manager
+      File: ztp-talm-updating-managed-policies
+    - Name: Updating GitOps ZTP
+      File: ztp-updating-gitops
+    - Name: Expanding single-node OpenShift clusters with GitOps ZTP
+      File: ztp-sno-additional-worker-node
+    - Name: Pre-caching images for single-node OpenShift deployments
+      File: ztp-precaching-tool
 ---
 Name: Service Mesh
 Dir: service_mesh

--- a/logging/log_storage/cluster-logging-loki.adoc
+++ b/logging/log_storage/cluster-logging-loki.adoc
@@ -24,7 +24,7 @@ include::modules/logging-loki-pod-placement.adoc[leveloffset=+1]
 .Additional resources
 * link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podantiaffinity-v1-core[`PodAntiAffinity` v1 core Kubernetes documentation]
 * link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity[Assigning Pods to Nodes Kubernetes documentation]
-* xref:../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
+* xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
 
 include::modules/logging-loki-zone-aware-rep.adoc[leveloffset=+1]
 

--- a/logging/log_storage/cluster-logging-loki.adoc
+++ b/logging/log_storage/cluster-logging-loki.adoc
@@ -24,7 +24,10 @@ include::modules/logging-loki-pod-placement.adoc[leveloffset=+1]
 .Additional resources
 * link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podantiaffinity-v1-core[`PodAntiAffinity` v1 core Kubernetes documentation]
 * link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity[Assigning Pods to Nodes Kubernetes documentation]
-* xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
+
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
+endif::[]
 
 include::modules/logging-loki-zone-aware-rep.adoc[leveloffset=+1]
 

--- a/logging/log_storage/cluster-logging-loki.adoc
+++ b/logging/log_storage/cluster-logging-loki.adoc
@@ -24,10 +24,7 @@ include::modules/logging-loki-pod-placement.adoc[leveloffset=+1]
 .Additional resources
 * link:https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.24/#podantiaffinity-v1-core[`PodAntiAffinity` v1 core Kubernetes documentation]
 * link:https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#inter-pod-affinity-and-anti-affinity[Assigning Pods to Nodes Kubernetes documentation]
-
-ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
-endif::[]
 
 include::modules/logging-loki-zone-aware-rep.adoc[leveloffset=+1]
 

--- a/modules/openshift-cluster-maximums-environment.adoc
+++ b/modules/openshift-cluster-maximums-environment.adoc
@@ -57,6 +57,7 @@
 5. Cluster is scaled in iterations and performance and scalability tests are executed at the specified node counts.
 --
 
+ifndef::openshift-dedicated,openshift-rosa[]
 == IBM Power platform
 
 [options="header",cols="6*"]
@@ -130,3 +131,4 @@
 4. Physical number of processors used is six Integrated Facilities for Linux (IFLs).
 5. Total physical memory used is 512 GiB.
 --
+endif::[]

--- a/modules/recommended-configurable-storage-technology.adoc
+++ b/modules/recommended-configurable-storage-technology.adoc
@@ -100,7 +100,12 @@ In a scaled/HA {product-registry} cluster deployment:
 * The storage technology must support RWX access mode.
 * The storage technology must ensure read-after-write consistency.
 * The preferred storage technology is object storage.
+ifndef::openshift-dedicated,openshift-rosa[]
 * Red Hat OpenShift Data Foundation (ODF), Amazon Simple Storage Service (Amazon S3), Google Cloud Storage (GCS), Microsoft Azure Blob Storage, and OpenStack Swift are supported.
+endif::[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* Amazon Simple Storage Service (Amazon S3) is supported.
+endif::[]
 * Object storage should be S3 or Swift compliant.
 * For non-cloud platforms, such as vSphere and bare metal installations, the only configurable technology is file storage.
 * Block storage is not configurable.

--- a/rosa_architecture/rosa-admission-plug-ins.adoc
+++ b/rosa_architecture/rosa-admission-plug-ins.adoc
@@ -30,9 +30,9 @@ endif::openshift-rosa,openshift-dedicated[]
 
 ifndef::openshift-rosa,openshift-dedicated[]
 * xref: /networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[Configuring the SR-IOV Network Operator]
-endif::openshift-rosa,openshift-dedicated[]
 
 * xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations_dedicating_nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
 
 * xref:../nodes/pods/nodes-pods-priority.adoc#admin-guide-priority-preemption-names_nodes-pods-priority[Pod priority names]
+endif::openshift-rosa,openshift-dedicated[]
 

--- a/scalability_and_performance/cnf-create-performance-profiles.adoc
+++ b/scalability_and_performance/cnf-create-performance-profiles.adoc
@@ -30,8 +30,10 @@ include::modules/cnf-performance-profile-creator-arguments.adoc[leveloffset=+2]
 
 include::modules/installation-openstack-ovs-dpdk-performance-profile.adoc[leveloffset=+2]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [id="{context}-additional-resources"]
 [role="_additional-resources"]
 == Additional resources
 * For more information about the `must-gather` tool,
 see xref:../support/gathering-cluster-data.adoc#nodes-nodes-managing[Gathering data about your cluster].
+endif::[]

--- a/scalability_and_performance/cnf-low-latency-tuning.adoc
+++ b/scalability_and_performance/cnf-low-latency-tuning.adoc
@@ -86,8 +86,10 @@ include::modules/cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-su
 [role="_additional-resources"]
 .Additional resources
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * For more information about MachineConfig and KubeletConfig,
 see xref:../nodes/nodes/nodes-nodes-managing.adoc#nodes-nodes-managing[Managing nodes].
+endif::[]
 
 * For more information about the Node Tuning Operator,
 see xref:../scalability_and_performance/using-node-tuning-operator.adoc#using-node-tuning-operator[Using the Node Tuning Operator].

--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -14,9 +14,11 @@ The NUMA Resources Operator allows you to schedule high-performance workloads in
 
 include::modules/cnf-about-numa-aware-scheduling.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 .Additional resources
 
 * For more information about running secondary pod schedulers in your cluster and how to deploy pods with a secondary pod scheduler, see xref:../nodes/scheduling/secondary_scheduler/nodes-secondary-scheduler-configuring.adoc#secondary-scheduler-configuring[Scheduling pods using a secondary scheduler].
+endif::[]
 
 [id="installing-the-numa-resources-operator_{context}"]
 == Installing the NUMA Resources Operator

--- a/scalability_and_performance/ibm-z-recommended-host-practices.adoc
+++ b/scalability_and_performance/ibm-z-recommended-host-practices.adoc
@@ -52,7 +52,9 @@ include::modules/ibm-z-choose-networking-setup.adoc[leveloffset=+1]
 
 * link:https://www.ibm.com/docs/en/linux-on-systems?topic=openshift-performance#openshift_perf__ocp_net[{product-title} on IBM Z Networking Performance]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../nodes/scheduling/nodes-scheduler-node-affinity.adoc[Controlling pod placement on nodes using node affinity rules]
+endif::[]
 
 include::modules/ibm-z-ensure-high-disk-performance-hyperpav.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/optimization/optimizing-cpu-usage.adoc
+++ b/scalability_and_performance/optimization/optimizing-cpu-usage.adoc
@@ -27,4 +27,6 @@ include::modules/running-services-with-encapsulation.adoc[leveloffset=+1]
 
 * link:https://www.redhat.com/sysadmin/container-namespaces-nsenter[Manage containers in namespaces by using nsenter]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../rest_api/machine_apis/machineconfig-machineconfiguration-openshift-io-v1.adoc[MachineConfig]
+endif::[]

--- a/scalability_and_performance/optimization/optimizing-networking.adoc
+++ b/scalability_and_performance/optimization/optimizing-networking.adoc
@@ -6,9 +6,11 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 The xref:../../networking/openshift_sdn/about-openshift-sdn.adoc#about-openshift-sdn[OpenShift SDN] uses OpenvSwitch, virtual extensible LAN (VXLAN) tunnels, OpenFlow rules, and iptables. This network can be tuned by using jumbo frames, network interface controllers (NIC) offloads, multi-queue, and ethtool settings.
 
 xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes.adoc#about-ovn-kubernetes[OVN-Kubernetes] uses Geneve (Generic Network Virtualization Encapsulation) instead of VXLAN as the tunnel protocol.
+endif::[]
 
 VXLAN provides benefits over VLANs, such as an increase in networks from 4096 to over 16 million, and layer 2 connectivity across physical networks. This allows for all pods behind a service to communicate with each other, even if they are running on different systems.
 
@@ -35,7 +37,9 @@ include::modules/ipsec-impact-networking.adoc[leveloffset=+1]
 [id="optimizing-networking-additional-resources"]
 == Additional resources
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#modifying-nwoperator-config-startup_installing-aws-network-customizations[Modifying advanced network configuration parameters]
 * xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-ovn-sdn_cluster-network-operator[Configuration parameters for the OVN-Kubernetes network plugin]
 * xref:../../networking/cluster-network-operator.adoc#nw-operator-configuration-parameters-for-openshift-sdn_cluster-network-operator[Configuration parameters for the OpenShift SDN network plugin]
+endif::[]
 * xref:../../scalability_and_performance/scaling-worker-latency-profiles.adoc#scaling-worker-latency-profiles[Improving cluster stability in high latency environments using worker latency profiles]

--- a/scalability_and_performance/optimization/optimizing-storage.adoc
+++ b/scalability_and_performance/optimization/optimizing-storage.adoc
@@ -30,7 +30,9 @@ include::modules/recommended-configurable-storage-technology.adoc[leveloffset=+1
 
 include::modules/data-storage-management.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/optimizing-storage-azure.adoc[leveloffset=+1]
+endif::[]
 
 [role="_additional-resources"]
 [id="admission-plug-ins-additional-resources"]

--- a/scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.adoc
@@ -21,20 +21,26 @@ If the control plane machines in an Amazon Web Services (AWS) cluster require mo
 ====
 The procedure for clusters that use a control plane machine set is different from the procedure for clusters that do not use a control plane machine set.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 If you are uncertain about the state of the `ControlPlaneMachineSet` CR in your cluster, you can xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-checking-status_cpmso-getting-started[verify the CR status].
+endif::[]
 ====
 
 //Changing the Amazon Web Services instance type by using a control plane machine set
 include::modules/cpms-changing-aws-instance-type.adoc[leveloffset=+3]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-using[Managing control plane machines with control plane machine sets]
+endif::[]
 
 //Changing the Amazon Web Services instance type by using the AWS console
 include::modules/aws-console-changing-aws-instance-type.adoc[leveloffset=+3]
 
 [role="_additional-resources"]
 .Additional resources
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc#backing-up-etcd[Backing up etcd]
+endif::[]
 * link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-resize.html[AWS documentation about changing the instance type]

--- a/scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc
+++ b/scalability_and_performance/recommended-performance-scale-practices/recommended-infrastructure-practices.adoc
@@ -24,4 +24,6 @@ include::modules/configuring-cluster-monitoring.adoc[leveloffset=+1]
 
 * link:https://access.redhat.com/solutions/5034771[Infrastructure Nodes in OpenShift 4]
 * xref:../../scalability_and_performance/planning-your-environment-according-to-object-maximums.adoc#planning-your-environment-according-to-object-maximums[{product-title} cluster maximums]
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../machine_management/creating-infrastructure-machinesets.adoc#creating-infrastructure-machinesets[Creating infrastructure machine sets]
+endif::[]

--- a/scalability_and_performance/using-node-tuning-operator.adoc
+++ b/scalability_and_performance/using-node-tuning-operator.adoc
@@ -23,9 +23,11 @@ include::modules/custom-tuning-example.adoc[leveloffset=+1]
 
 include::modules/node-tuning-operator-supported-tuned-daemon-plug-ins.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/node-tuning-hosted-cluster.adoc[leveloffset=+1]
 
 include::modules/advanced-node-tuning-hosted-cluster.adoc[leveloffset=+1]
+endif::[]
 
 [role="_additional-resources"]
 .Additional resources

--- a/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc
+++ b/scalability_and_performance/what-huge-pages-do-and-how-they-are-consumed-by-apps.adoc
@@ -12,10 +12,12 @@ include::modules/how-huge-pages-are-consumed-by-apps.adoc[leveloffset=+1]
 
 include::modules/consuming-huge-pages-resource-using-the-downward-api.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../nodes/containers/nodes-containers-downward-api.adoc#nodes-containers-downward-api[Allowing containers to consume Downward API objects]
+endif::[]
 
 include::modules/configuring-huge-pages.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc
@@ -75,7 +75,9 @@ include::modules/ztp-configuring-ptp-fast-events-amqp.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../networking/using-ptp.adoc#cnf-installing-amq-interconnect-messaging-bus_using-ptp[Installing the AMQ messaging bus]
+endif::[]
 * For more information about container image registries, see xref:../../registry/index.adoc#registry-overview[{product-registry} overview].
 
 [id="ztp-advanced-policy-config-bare-metal_{context}"]
@@ -87,12 +89,13 @@ include::snippets/ptp-amq-interconnect-eol.adoc[]
 
 include::modules/ztp-configuring-hwevents-using-pgt.adoc[leveloffset=+2]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../scalability_and_performance/using-rfhe.adoc#nw-rfhe-installing-operator-cli_using-rfhe[Installing the {redfish-operator} using the CLI]
-
-* xref:../../scalability_and_performance/using-rfhe.adoc#nw-rfhe-creating-hardware-event_using-rfhe[Creating the bare-metal event and Secret CRs]
+* xref:../../monitoring/using-rfhe.adoc#nw-rfhe-installing-operator-cli_using-rfhe[Installing the {redfish-operator} using the CLI]
+* xref:../../monitoring/using-rfhe.adoc#nw-rfhe-creating-hardware-event_using-rfhe[Creating the bare-metal event and Secret CRs]
+endif::[]
 
 include::modules/ztp-creating-hwevents-amqp.adoc[leveloffset=+2]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc
@@ -43,9 +43,11 @@ include::modules/ztp-sno-siteconfig-config-reference.adoc[leveloffset=+2]
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc#ztp-creating-the-site-secrets_ztp-manual-install[Creating the managed bare-metal host secrets]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
 
 * xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints]
+endif::[]
 
 include::modules/ztp-monitoring-installation-progress.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc
@@ -25,9 +25,11 @@ include::modules/ztp-generating-install-and-config-crs-manually.adoc[leveloffset
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-sno-du-enabling-workload-partitioning_sno-configure-for-vdu[Workload partitioning]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#bmc-addressing_ipi-install-installation-workflow[BMC addressing]
 
 * xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints]
+endif::[]
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-sno-siteconfig-config-reference_ztp-deploying-far-edge-sites[{sno-caps} SiteConfig CR installation reference]
 
@@ -42,7 +44,9 @@ include::modules/ztp-manually-install-a-single-managed-cluster.adoc[leveloffset=
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#ztp-managed-cluster-network-prereqs_sno-configure-for-vdu[Connectivity prerequisites for managed cluster networks]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.adoc#lvms-preface-sno-ran_logical-volume-manager-storage[Deploying LVM Storage on single-node OpenShift clusters]
+endif::[]
 
 * xref:../../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-provisioning-lvm-storage_ztp-advanced-policy-config[Configuring LVM Storage using PolicyGenTemplate CRs]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-precaching-tool.adoc
@@ -30,11 +30,15 @@ include::modules/ztp-precaching-booting-from-live-os.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * For more information about the `butane` utility, see xref:../../installing/install_config/installing-customizing.adoc#installation-special-config-butane-about_installing-customizing[About Butane].
 * For more information about creating a custom live {op-system} ISO, see xref:../../installing/installing_sno/install-sno-installing-sno.adoc#create-custom-live-rhcos-iso_install-sno-installing-sno-with-the-assisted-installer[Creating a custom live {op-system} ISO for remote server access].
+endif::[]
 * For more information about using the Dell RACADM tool, see link:https://www.dell.com/support/manuals/en-ie/poweredge-r440/idrac9_6.xx_racadm_pub/supported-racadm-interfaces?guid=guid-a5747353-fc88-4438-b617-c50ca260448e&lang=en-us[Integrated Dell Remote Access Controller 9 RACADM CLI Guide].
 * For more information about using the HP HPONCFG tool, see link:https://support.hpe.com/hpesc/public/docDisplay?docId=emr_na-a00007610en_us[Using HPONCFG].
+ifndef::openshift-dedicated,openshift-rosa[]
 * For more information about using the Redfish BMC API, see xref:../../installing/installing_sno/install-sno-installing-sno.adoc#install-booting-from-an-iso-over-http-redfish_install-sno-installing-sno-with-the-assisted-installer[Booting from an HTTP-hosted ISO image using the Redfish API].
+endif::[]
 
 include::modules/ztp-precaching-partitioning.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
@@ -26,10 +26,13 @@ include::modules/ztp-acm-installing-disconnected-rhacm.adoc[leveloffset=+1]
 
 * xref:../../scalability_and_performance/ztp_far_edge/cnf-talm-for-cluster-upgrades.adoc#installing-topology-aware-lifecycle-manager-using-cli_cnf-topology-aware-lifecycle-manager[Installing {cgu-operator}]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../operators/admin/olm-restricted-networks.adoc#olm-mirror-catalog_olm-restricted-networks[Mirroring an Operator catalog]
+endif::[]
 
 include::modules/ztp-acm-adding-images-to-mirror-registry.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
@@ -45,6 +48,7 @@ include::modules/ztp-configuring-the-cluster-for-a-disconnected-environment.adoc
 .Additional resources
 
 * xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the OpenShift Container Platform image repository]
+endif::[]
 
 include::modules/ztp-configuring-the-hub-cluster-to-use-unauthenticated-registries.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-sno-additional-worker-node.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-sno-additional-worker-node.adoc
@@ -26,7 +26,9 @@ include::snippets/technology-preview.adoc[]
 
 * For more information about {sno} clusters tuned for vDU application deployments, see xref:../../scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu.adoc#sno-configure-for-vdu[Reference configuration for deploying vDUs on {sno}].
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * For more information about worker nodes, see xref:../../nodes/nodes/nodes-sno-worker-nodes.adoc[Adding worker nodes to single-node OpenShift clusters].
+endif::[]
 
 include::modules/ztp-worker-node-applying-du-profile.adoc[leveloffset=+1]
 

--- a/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
+++ b/scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc
@@ -22,13 +22,17 @@ include::modules/cnf-topology-aware-lifecycle-manager-preparing-for-updates.adoc
 
 * For more information about how to update {ztp-first}, see xref:../../scalability_and_performance/ztp_far_edge/ztp-updating-gitops.adoc#ztp-updating-gitops[Upgrading {ztp}].
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * For more information about how to mirror an {product-title} image repository, see xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#installation-mirror-repository_installing-mirroring-installation-images[Mirroring the {product-title} image repository].
 
 * For more information about how to mirror Operator catalogs for disconnected clusters, see xref:../../installing/disconnected_install/installing-mirroring-installation-images.adoc#olm-mirror-catalog_installing-mirroring-installation-images[Mirroring Operator catalogs for use with disconnected clusters].
+endif::[]
 
 * For more information about how to prepare the disconnected environment and mirroring the desired image repository, see xref:../../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-hub-cluster[Preparing the disconnected environment].
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * For more information about update channels and releases, see xref:../../updating/understanding-upgrade-channels-release.adoc#understanding-upgrade-channels-releases[Understanding update channels and releases].
+endif::[]
 
 include::modules/cnf-topology-aware-lifecycle-manager-platform-update.adoc[leveloffset=+2]
 


### PR DESCRIPTION
This PR is to port the "Scalability and performance" OCP content to ROSA. Reference that section only for comments, reviews, etc.
[OSDOCS-3994](https://issues.redhat.com/browse/OSDOCS-3994)

Version(s):

Link to docs preview: https://file.rdu.redhat.com/tlove/sd-port-scale-tlove-main-branch/scalability_and_performance/recommended-performance-scale-practices/recommended-control-plane-practices.html#recommended-scale-practices_recommended-control-plane-practices  (Updated 03/21)

QE review: 

- [ ] QE has approved this change.
