### PR TITLE
fixing typos nw-networkpolicy-deny-all-allowed.adoc

### DIFF
--- a/modules/nw-networkpolicy-deny-all-allowed.adoc
+++ b/modules/nw-networkpolicy-deny-all-allowed.adoc
@@ -68,8 +68,8 @@ endif::multi[]
 ----
 ifdef::multi[]
 <1> `namespace: default` deploys this policy to the `default` namespace.
-<2> `podSelector:` is empty, this means it matches all the pods. Therefore, the policy applies to all pods in the default namespace.
-<3> `network_name`: specifies the name of a network attachment definition.
+<2> `network_name`: specifies the name of a network attachment definition.
+<3> `podSelector:` is empty, this means it matches all the pods. Therefore, the policy applies to all pods in the default namespace.
 <4> There are no `ingress` rules specified. This causes incoming traffic to be dropped to all pods.
 endif::multi[]
 ifndef::multi[]


### PR DESCRIPTION
Fixing typos in help description 

Version(s): 4.12+

Issue: Fixing typo errors in help description of `Creating a default deny all multi-network policy`
Link to docs preview: https://docs.openshift.com/container-platform/4.13/networking/multiple_networks/configuring-multi-network-policy.html#nw-networkpolicy-deny-all-multi-network-policy_configuring-multi-network-policy

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
