### PR TITLE
TELCODOCS-1525 bringing 412 guidance inline with 413

### DIFF
--- a/modules/cnf-configuring-node-groups-for-the-numaresourcesoperator.adoc
+++ b/modules/cnf-configuring-node-groups-for-the-numaresourcesoperator.adoc
@@ -1,0 +1,73 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_content-type: PROCEDURE
+
+[id="cnf-configuring-node-groups-for-the-numaresourcesoperator_{context}"]
+= Optional: Configuring polling operations for NUMA resources updates
+
+The daemons controlled by the NUMA Resources Operator in their `nodeGroup` poll resources to retrieve updates about available NUMA resources. You can fine-tune polling operations for these daemons by configuring the `spec.nodeGroups` specification in the `NUMAResourcesOperator` custom resource (CR). This provides advanced control of polling operations. Configure these specifications to improve scheduling behaviour and troubleshoot suboptimal scheduling decisions.
+
+The configuration options are the following:
+
+* `infoRefreshMode`: Determines the trigger condition for polling the kubelet. The NUMA Resources Operator reports the resulting information to the API server.
+* `infoRefreshPeriod`: Determines the duration between polling updates.
+* `podsFingerprinting`: Determines if point-in-time information for the current set of pods running on a node is exposed in polling updates.
++
+[NOTE]
+====
+`podsFingerprinting` is enabled by default. `podsFingerprinting` is a requirement for the `cacheResyncPeriod` specification in the `NUMAResourcesScheduler` CR. The `cacheResyncPeriod` specification helps to report more exact resource availability by monitoring pending resources on nodes.
+====
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Install the NUMA Resources Operator.
+
+.Procedure
+
+* Configure the `spec.nodeGroups` specification in your `NUMAResourcesOperator` CR:
++
+[source,yaml]
+----
+apiVersion: nodetopology.openshift.io/v1
+kind: NUMAResourcesOperator
+metadata:
+  name: numaresourcesoperator
+spec:
+  nodeGroups:
+  - config:
+      infoRefreshMode: Periodic <1>
+      infoRefreshPeriod: 10s <2>
+      podsFingerprinting: Enabled <3>
+    name: worker
+----
+<1> Valid values are `Periodic`, `Events`, `PeriodicAndEvents`. Use `Periodic` to poll the kubelet at intervals that you define in `infoRefreshPeriod`. Use `Events` to poll the kubelet at every pod lifecycle event. Use `PeriodicAndEvents` to enable both methods.
+<2> Define the polling interval for `Periodic` or `PeriodicAndEvents` refresh modes. The field is ignored if the refresh mode is `Events`.
+<3> Valid values are `Enabled` or `Disabled`. Setting to `Enabled` is a requirement for the `cacheResyncPeriod` specification in the `NUMAResourcesScheduler`.
+
+.Verification
+
+. After you deploy the NUMA Resources Operator, verify that the node group configurations were applied by running the following command:
++
+[source,terminal]
+----
+$ oc get numaresop numaresourcesoperator -o json | jq '.status'
+----
++
+.Example output
+[source,terminal]
+----
+      ...
+
+        "config": {
+        "infoRefreshMode": "Periodic",
+        "infoRefreshPeriod": "10s",
+        "podsFingerprinting": "Enabled"
+      },
+      "name": "worker"
+
+      ...
+----

--- a/modules/cnf-creating-nrop-cr-with-manual-performance-settings.adoc
+++ b/modules/cnf-creating-nrop-cr-with-manual-performance-settings.adoc
@@ -1,0 +1,93 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_module-type: PROCEDURE
+[id="cnf-creating-nrop-cr-with-manual-performance-settings_{context}"]
+= Creating the NUMAResourcesOperator custom resource with manual performance settings
+
+When you have installed the NUMA Resources Operator, then create the `NUMAResourcesOperator` custom resource (CR) that instructs the NUMA Resources Operator to install all the cluster infrastructure needed to support the NUMA-aware scheduler, including daemon sets and APIs.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+* Log in as a user with `cluster-admin` privileges.
+* Install the NUMA Resources Operator.
+
+.Procedure
+
+. Optional: Create the `MachineConfigPool` custom resource that enables custom kubelet configurations for worker nodes:
++
+[NOTE]
+====
+By default, {product-title} creates a `MachineConfigPool` resource for worker nodes in the cluster. You can create a custom `MachineConfigPool` resource if required.
+====
+
+.. Save the following YAML in the `nro-machineconfig.yaml` file:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: MachineConfigPool
+metadata:
+  labels:
+    cnf-worker-tuning: enabled
+    machineconfiguration.openshift.io/mco-built-in: ""
+    pools.operator.machineconfiguration.openshift.io/worker: ""
+  name: worker
+spec:
+  machineConfigSelector:
+    matchLabels:
+      machineconfiguration.openshift.io/role: worker
+  nodeSelector:
+    matchLabels:
+      node-role.kubernetes.io/worker: ""
+----
+
+.. Create the `MachineConfigPool` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f nro-machineconfig.yaml
+----
+
+. Create the `NUMAResourcesOperator` custom resource:
+
+.. Save the following YAML in the `nrop.yaml` file:
++
+[source,yaml]
+----
+apiVersion: nodetopology.openshift.io/v1
+kind: NUMAResourcesOperator
+metadata:
+  name: numaresourcesoperator
+spec:
+  nodeGroups:
+  - machineConfigPoolSelector:
+      matchLabels:
+        pools.operator.machineconfiguration.openshift.io/worker: "" <1>
+----
+<1> Should match the label applied to worker nodes in the related `MachineConfigPool` CR.
+
+.. Create the `NUMAResourcesOperator` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f nrop.yaml
+----
+
+.Verification
+
+* Verify that the NUMA Resources Operator deployed successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get numaresourcesoperators.nodetopology.openshift.io
+----
++
+.Example output
+[source,terminal]
+----
+NAME                    AGE
+numaresourcesoperator   10m
+----

--- a/modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc
+++ b/modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc
@@ -1,0 +1,124 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+:_module-type: PROCEDURE
+[id="cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings_{context}"]
+= Deploying the NUMA-aware secondary pod scheduler with manual performance settings
+
+After you install the NUMA Resources Operator, do the following to deploy the NUMA-aware secondary pod scheduler:
+
+* Configure the pod admittance policy for the required machine profile.
+
+* Create the required machine config pool.
+
+* Deploy the NUMA-aware secondary scheduler.
+
+.Prerequisites
+
+* Install the OpenShift CLI (`oc`).
+
+* Log in as a user with `cluster-admin` privileges.
+
+* Install the NUMA Resources Operator.
+
+.Procedure
+. Create the `KubeletConfig` custom resource that configures the pod admittance policy for the machine profile:
+
+.. Save the following YAML in the `nro-kubeletconfig.yaml` file:
++
+[source,yaml]
+----
+apiVersion: machineconfiguration.openshift.io/v1
+kind: KubeletConfig
+metadata:
+  name: cnf-worker-tuning
+spec:
+  machineConfigPoolSelector:
+    matchLabels:
+      cnf-worker-tuning: enabled
+  kubeletConfig:
+    cpuManagerPolicy: "static" <1>
+    cpuManagerReconcilePeriod: "5s"
+    reservedSystemCPUs: "0,1"
+    memoryManagerPolicy: "Static" <2>
+    evictionHard:
+      memory.available: "100Mi"
+    kubeReserved:
+      memory: "512Mi"
+    reservedMemory:
+      - numaNode: 0
+        limits:
+          memory: "1124Mi"
+    systemReserved:
+      memory: "512Mi"
+    topologyManagerPolicy: "single-numa-node" <3>
+    topologyManagerScope: "pod"
+----
+<1> For `cpuManagerPolicy`, `static` must use a lowercase `s`.
+<2> For `memoryManagerPolicy`, `Static` must use an uppercase `S`.
+<3> `topologyManagerPolicy` must be set to `single-numa-node`.
+
+.. Create the `KubeletConfig` custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+$ oc create -f nro-kubeletconfig.yaml
+----
+
+. Create the `NUMAResourcesScheduler` custom resource that deploys the NUMA-aware custom pod scheduler:
+
+.. Save the following YAML in the `nro-scheduler.yaml` file:
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: nodetopology.openshift.io/v1
+kind: NUMAResourcesScheduler
+metadata:
+  name: numaresourcesscheduler
+spec:
+  imageSpec: "registry.redhat.io/openshift4/noderesourcetopology-scheduler-container-rhel8:v{product-version}"
+  cacheResyncPeriod: "5s" <1>
+----
+<1> Enter an interval value in seconds for synchronization of the scheduler cache. A value of `5s` is typical for most implementations.
++
+[NOTE]
+====
+* Enable the `cacheResyncPeriod` specification to help the NUMA Resource Operator report more exact resource availability by monitoring pending resources on nodes and synchronizing this information in the scheduler cache at a defined interval. This also helps to minimize `Topology Affinity Error` errors because of sub-optimal scheduling decisions. The lower the interval the greater the network load. The `cacheResyncPeriod` specification is disabled by default.
+
+* Setting a value of `Enabled` for the `podsFingerprinting` specification in the `NUMAResourcesOperator` CR is a requirement for the implementation of the `cacheResyncPeriod` specification.
+====
+
+.. Create the `NUMAResourcesScheduler` CR by running the following command:
++
+[source,terminal]
+----
+$ oc create -f nro-scheduler.yaml
+----
+
+.Verification
+
+* Verify that the required resources deployed successfully by running the following command:
++
+[source,terminal]
+----
+$ oc get all -n openshift-numaresources
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                                    READY   STATUS    RESTARTS   AGE
+pod/numaresources-controller-manager-7575848485-bns4s   1/1     Running   0          13m
+pod/numaresourcesoperator-worker-dvj4n                  2/2     Running   0          16m
+pod/numaresourcesoperator-worker-lcg4t                  2/2     Running   0          16m
+pod/secondary-scheduler-56994cf6cf-7qf4q                1/1     Running   0          16m
+NAME                                          DESIRED   CURRENT   READY   UP-TO-DATE   AVAILABLE   NODE SELECTOR                     AGE
+daemonset.apps/numaresourcesoperator-worker   2         2         2       2            2           node-role.kubernetes.io/worker=   16m
+NAME                                               READY   UP-TO-DATE   AVAILABLE   AGE
+deployment.apps/numaresources-controller-manager   1/1     1            1           13m
+deployment.apps/secondary-scheduler                1/1     1            1           16m
+NAME                                                          DESIRED   CURRENT   READY   AGE
+replicaset.apps/numaresources-controller-manager-7575848485   1         1         1       13m
+replicaset.apps/secondary-scheduler-56994cf6cf                1         1         1       16m
+----

--- a/modules/cnf-scheduling-numa-aware-workloads-overview-with-manual-performance-settings.adoc
+++ b/modules/cnf-scheduling-numa-aware-workloads-overview-with-manual-performance-settings.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+:_content-type: CONCEPT
+[id="cnf-scheduling-numa-aware-workloads-with-manual-perofrmance-settings_{context}"]
+= Scheduling NUMA-aware workloads with manual performance settings
+
+Clusters running latency-sensitive workloads typically feature performance profiles that help to minimize workload latency and optimize performance. However, you can schedule NUMA-aware workloads in a pristine cluster that does not feature a performance profile. The following workflow features a pristine cluster that you can manually configure for performance by using the `KubeletConfig` resource. This is not the typical environment for scheduling NUMA-aware workloads.

--- a/modules/cnf-scheduling-numa-aware-workloads-overview.adoc
+++ b/modules/cnf-scheduling-numa-aware-workloads-overview.adoc
@@ -1,0 +1,8 @@
+// Module included in the following assemblies:
+//
+// *scalability_and_performance/cnf-numa-aware-scheduling.adoc
+:_content-type: CONCEPT
+[id="cnf-scheduling-numa-aware-workloads-overview_{context}"]
+= Scheduling NUMA-aware workloads
+
+Clusters running latency-sensitive workloads typically feature performance profiles that help to minimize workload latency and optimize performance. The NUMA-aware scheduler deploys workloads based on available node NUMA resources and with respect to any performance profile settings applied to the node. The combination of NUMA-aware deployments, and the performance profile of the workload, ensures that workloads are scheduled in a way that maximizes performance.

--- a/modules/cnf-scheduling-numa-aware-workloads-with-manual-performance-setttings.adoc
+++ b/modules/cnf-scheduling-numa-aware-workloads-with-manual-performance-setttings.adoc
@@ -3,8 +3,8 @@
 // *scalability_and_performance/cnf-numa-aware-scheduling.adoc
 
 :_content-type: PROCEDURE
-[id="cnf-scheduling-numa-aware-workloads_{context}"]
-= Scheduling workloads with the NUMA-aware scheduler
+[id="cnf-scheduling-numa-aware-workloads-with-manual-performance-setttings_{context}"]
+= Scheduling workloads with the NUMA-aware scheduler with manual performance settings
 
 You can schedule workloads with the NUMA-aware scheduler using `Deployment` CRs that specify the minimum required resources to process the workload.
 
@@ -126,14 +126,30 @@ Events:
 +
 [NOTE]
 ====
-Deployments that request more resources than is available for scheduling will fail with a `MinimumReplicasUnavailable` error. The deployment succeeds when the required resources become available. Pods remain in the `Pending` state until the required resources are available.
+Deployments that request more resources than are available for scheduling will fail with a `MinimumReplicasUnavailable` error. The deployment succeeds when the required resources become available. Pods remain in the `Pending` state until the required resources are available.
 ====
 
-. Verify that the expected allocated resources are listed for the node. Run the following command:
+. Verify that the expected allocated resources are listed for the node.
+
+.. Identify the node that is running the deployment pod by running the following command, replacing <namespace> with the namespace you specified in the `Deployment` CR:
 +
 [source,terminal]
 ----
-$ oc describe noderesourcetopologies.topology.node.k8s.io
+$ oc get pods -n <namespace> -o wide
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                 READY   STATUS    RESTARTS   AGE   IP            NODE     NOMINATED NODE   READINESS GATES
+numa-deployment-1-65684f8fcc-bw4bw   0/2     Running   0          82m   10.128.2.50   worker-0   <none>  <none>
+----
++
+.. Run the following command, replacing <node_name> with the name of that node that is running the deployment pod:
++
+[source,terminal]
+----
+$ oc describe noderesourcetopologies.topology.node.k8s.io <node_name>
 ----
 +
 .Example output
@@ -171,7 +187,7 @@ Zones:
 +
 Resources consumed by guaranteed pods are subtracted from the available node resources listed under `noderesourcetopologies.topology.node.k8s.io`.
 
-. Resource allocations for pods with a `Best-effort` or `Burstable` quality of service (`qosClass`) are not reflected in the NUMA node resources under `noderesourcetopologies.topology.node.k8s.io`. If a pod's consumed resources are not reflected in the node resource calculation, verify that the pod has `qosClass` of `Guaranteed` by running the following command:
+. Resource allocations for pods with a `Best-effort` or `Burstable` quality of service (`qosClass`) are not reflected in the NUMA node resources under `noderesourcetopologies.topology.node.k8s.io`. If a pod's consumed resources are not reflected in the node resource calculation, verify that the pod has `qosClass` of `Guaranteed` and the CPU request is an integer value, not a decimal value. You can verify the that the pod has a  `qosClass` of `Guaranteed` by running the following command:
 +
 [source,terminal]
 ----

--- a/scalability_and_performance/cnf-numa-aware-scheduling.adoc
+++ b/scalability_and_performance/cnf-numa-aware-scheduling.adoc
@@ -28,11 +28,27 @@ include::modules/cnf-installing-numa-resources-operator-cli.adoc[leveloffset=+2]
 
 include::modules/cnf-installing-numa-resources-operator-console.adoc[leveloffset=+2]
 
-include::modules/cnf-creating-nrop-cr.adoc[leveloffset=+1]
+include::modules/cnf-scheduling-numa-aware-workloads-overview.adoc[leveloffset=+1]
 
-include::modules/cnf-deploying-the-numa-aware-scheduler.adoc[leveloffset=+1]
+include::modules/cnf-creating-nrop-cr.adoc[leveloffset=+2]
 
-include::modules/cnf-scheduling-numa-aware-workloads.adoc[leveloffset=+1]
+include::modules/cnf-deploying-the-numa-aware-scheduler.adoc[leveloffset=+2]
+
+.Additional resources
+
+* xref:../scalability_and_performance/cnf-create-performance-profiles.adoc#cnf-about-the-profile-creator-tool_cnf-create-performance-profiles[About the Performance Profile Creator].
+
+include::modules/cnf-scheduling-numa-aware-workloads.adoc[leveloffset=+2]
+
+include::modules/cnf-scheduling-numa-aware-workloads-overview-with-manual-performance-settings.adoc[leveloffset=+1]
+
+include::modules/cnf-creating-nrop-cr-with-manual-performance-settings.adoc[leveloffset=+2]
+
+include::modules/cnf-deploying-the-numa-aware-scheduler-with-manual-performance-settings.adoc[leveloffset=+2]
+
+include::modules/cnf-scheduling-numa-aware-workloads-with-manual-performance-setttings.adoc[leveloffset=+2]
+
+include::modules/cnf-configuring-node-groups-for-the-numaresourcesoperator.adoc[leveloffset=+1]
 
 include::modules/cnf-troubleshooting-numa-aware-workloads.adoc[leveloffset=+1]
 


### PR DESCRIPTION
[TELCODOCS-1525]: NUMA aware scheduling: fix 4.12 recommended installation steps

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/TELCODOCS-1525
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://65083--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-scheduling-numa-aware-workloads_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: This PR addresses bringing the already merged and published 4.13/4.14 content into 4.12 which must have been an oversight at the time. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
