### PR TITLE
OCPBUGS#17717:IBM BM removed IPV4 note

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -156,11 +156,11 @@ You can customize your installation configuration based on the requirements of y
 // https://bugzilla.redhat.com/show_bug.cgi?id=2020416
 // Once BM UPI supports dual-stack, uncomment all the following conditionals and blocks
 
-ifndef::bare,vsphere[]
+ifndef::bare,ibm-power,ibm-z,vsphere[]
 Only IPv4 addresses are supported.
-endif::[]
+endif::bare,ibm-power,ibm-z,vsphere[]
 
-ifdef::bare,vsphere[]
+ifdef::bare,ibm-power,ibm-z,vsphere[]
 * If you use the {openshift-networking} OVN-Kubernetes network plugin, both IPv4 and IPv6 address families are supported.
 
 * If you use the {openshift-networking} OpenShift SDN network plugin, only the IPv4 address family is supported.
@@ -199,7 +199,7 @@ networking:
   - 172.30.0.0/16
   - fd00:172:16::/112
 ----
-endif::[]
+endif::bare,ibm-power,ibm-z,vsphere[]
 
 [NOTE]
 ====


### PR DESCRIPTION
[OCPBUGS-17717](https://issues.redhat.com/browse/OCPBUGS-17717)

Version(s):
4.14 through to 4.11

Link to docs preview:
* [Network configuration parameters - IBM Z and IBM LinuxONE](https://65085--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installation-config-parameters-ibm-z#installation-configuration-parameters-network_installation-config-parameters-ibm-z)
* [Network configuration parameters - bare metal](https://65085--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installation-config-parameters-bare-metal#installation-configuration-parameters-network_installation-config-parameters-bare-metal)
* [Network configuration parameters - vSphere](https://65085--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-network_installation-config-parameters-vsphere)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
