### PR TITLE
OSDOCS-7875: Documented the RN for vSphere templates parameter

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -121,6 +121,17 @@ For {product-title} {product-version}, you can quickly install a cluster on Amaz
 For more information, see xref:../installing/installing_aws/installing-aws-localzone.adoc#installation-cluster-quickly-extend-workers_installing-aws-localzone[Intall a cluster quickly in AWS Local Zones].
 
 
+[id="ocp-4-14-vsphere-pre-existing-template"]
+==== Quickly install {op-system} on vSphere hosts by using a pre-existing {op-system} image template
+{product-title} {product-version} includes a new VMware vSphere configuration parameter for use on installer-provisioned infrastructure: `template`. By using this parameter, you can now specify the absolute path to a pre-existing {op-system-first} image template or virtual machine in the installation configuration file. The installation program can then use the image template or virtual machine to quickly install {op-system} on vSphere hosts.
+
+This installation method is an alternative to uploading an {op-system} image on vSphere hosts.
+
+[IMPORTANT]
+====
+Before you set a path value for the `template` parameter, ensure that the default {op-system} boot image in the {product-title} release matches the {op-system} image template or virtual machine version; otherwise, cluster installation might fail.
+====
+
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
[OSDOCS-7875](https://issues.redhat.com/browse/OSDOCS-7875)

Version(s):
4.14

Link to docs preview:
* [Quickly install RHCOS on vSphere hosts by using a pre-existing Red Hat Enterprise Linux CoreOS (RHCOS) image template](https://65091--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-vsphere-pre-existing-template)
* [Optional VMware vSphere machine pool configuration parameters](https://65091--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-optional-vsphere_installation-config-parameters-vsphere)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
