### PR TITLE
Simplify CLI instructions for Compliance Operator

### DIFF
--- a/modules/compliance-operator-cli-uninstall.adoc
+++ b/modules/compliance-operator-cli-uninstall.adoc
@@ -21,71 +21,49 @@ To remove the Compliance Operator, you must first delete the objects in the name
 +
 [source,terminal]
 ----
-$ oc delete ssb <ScanSettingBinding-name> -n openshift-compliance
+$ oc delete ssb --all -n openshift-compliance
 ----
 
 .. Delete the `ScanSetting` objects:
 +
 [source,terminal]
 ----
-$ oc delete ss <ScanSetting-name> -n openshift-compliance
+$ oc delete ss --all -n openshift-compliance
 ----
 
 .. Delete the `ComplianceSuite` objects:
 +
 [source,terminal]
 ----
-$ oc delete suite <compliancesuite-name> -n openshift-compliance
+$ oc delete suite --all -n openshift-compliance
 ----
 
 .. Delete the `ComplianceScan` objects:
 +
 [source,terminal]
 ----
-$ oc delete scan <compliancescan-name> -n openshift-compliance
-----
-
-.. Obtain the `ProfileBundle` objects:
-+
-[source,terminal]
-----
-$ oc get profilebundle.compliance -n openshift-compliance
-----
-+
-.Example output
-[source,terminal]
-----
-NAME     CONTENTIMAGE                                                                     CONTENTFILE         STATUS
-ocp4     registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:<hash>   ssg-ocp4-ds.xml     VALID
-rhcos4   registry.redhat.io/compliance/openshift-compliance-content-rhel8@sha256:<hash>   ssg-rhcos4-ds.xml   VALID
+$ oc delete scan --all -n openshift-compliance
 ----
 
 .. Delete the `ProfileBundle` objects:
 +
 [source,terminal]
 ----
-$ oc delete profilebundle.compliance ocp4 rhcos4 -n openshift-compliance
-----
-+
-.Example output
-[source,terminal]
-----
-profilebundle.compliance.openshift.io "ocp4" deleted
-profilebundle.compliance.openshift.io "rhcos4" deleted
+$ oc delete profilebundle.compliance --all -n openshift-compliance
 ----
 
 . Delete the Subscription object:
 +
 [source,terminal]
 ----
-$ oc delete sub <Subscription-Name> -n openshift-compliance
+$ oc delete sub --all -n openshift-compliance
 ----
 
 . Delete the CSV object:
 +
 [source,terminal]
 ----
-$ oc delete csv <ComplianceCSV-Name> -n openshift-compliance
+$ oc delete csv --all -n openshift-compliance
 ----
 
 . Delete the project:


### PR DESCRIPTION
The uninstall instructions used variables that users need to interpret to run commands in their own environments. This commit uses the `--all` argument to delete all instances of a particular resource, removing the need for users to query each resource and delete them individually.

This makes the commands easier to copy/paste.

Version(s):

This change is applicable to all supported versions of OpenShift.

Link to docs preview:
[Uninstalling the OpenShift Compliance Operator from OpenShift Container Platform using the CLI](https://65096--docspreview.netlify.app/openshift-enterprise/latest/security/compliance_operator/compliance-operator-uninstallation#compliance-operator-uninstall-cli_compliance-operator-uninstallation)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
