### PR TITLE
Update azure and aws config parameters for installation

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -25,13 +25,11 @@
 ifeval::["{context}" == "installing-aws-customizations"]
 :aws:
 endif::[]
-//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC . This attribute excludes arm64 content from installing on gov regions. When government regions are supported on arm64, change `aws-govcloud` to `aws`.
 ifeval::["{context}" == "installing-aws-government-region"]
-:aws-govcloud:
+:aws:
 endif::[]
-//Starting in 4.10, aws on arm64 is only supported for installation on custom, network custom, private clusters and VPC. This attribute excludes arm64 content from installing on secret regions. When secret regions are supported on arm64, change `aws-secret` to `aws`.
 ifeval::["{context}" == "installing-aws-secret-region"]
-:aws-secret:
+:aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :aws:
@@ -462,11 +460,14 @@ ifndef::aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 |String
 endif::aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 
-ifdef::aws,bare,azure,gcp[]
+ifdef::aws,azure,gcp,bare[]
 |`compute.architecture`
-|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. 
+ifdef::aws,azure[]
+ Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
+endif::aws,azure[]
 |String
-endif::aws,bare,azure,gcp[]
+endif::aws,azure,gcp,bare[]
 
 ifdef::ibm-z[]
 |`compute.architecture`
@@ -529,11 +530,14 @@ ifndef::aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 |String
 endif::aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 
-ifdef::aws,bare,azure,gcp[]
+ifdef::aws,azure,gcp,bare[]
 |`controlPlane.architecture`
-|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. 
+ifdef::aws,azure[]
+ Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
+endif::aws,azure[]
 |String
-endif::aws,bare,azure,gcp[]
+endif::aws,azure,gcp,bare[]
 
 ifdef::ibm-z[]
 |`controlPlane.architecture`
@@ -629,10 +633,10 @@ endif::openshift-origin[]
 |`publish`
 |How to publish or expose the user-facing endpoints of your cluster, such as the Kubernetes API, OpenShift routes.
 |
-ifdef::aws,aws-govcloud,aws-secret,azure,gcp,ibm-cloud[]
+ifdef::aws,azure,gcp,ibm-cloud[]
 `Internal` or `External`. To deploy a private cluster, which cannot be accessed from the internet, set `publish` to `Internal`. The default value is `External`.
 endif::[]
-ifndef::aws,aws-govcloud,aws-secret,azure,gcp,ibm-cloud[]
+ifndef::aws,azure,gcp,ibm-cloud[]
 `Internal` or `External`. The default value is `External`.
 
 Setting this field to `Internal` is not supported on non-cloud platforms.
@@ -656,7 +660,7 @@ a|For example, `sshKey: ssh-ed25519 AAAA..`.
 
 |====
 
-ifdef::aws,aws-govcloud,aws-secret[]
+ifdef::aws[]
 [id="installation-configuration-parameters-optional-aws_{context}"]
 == Optional AWS configuration parameters
 
@@ -793,7 +797,7 @@ For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to th
 |`true` or `false`. The default value is `false`, which results in the S3 bucket being deleted.
 
 |====
-endif::aws,aws-govcloud,aws-secret[]
+endif::aws[]
 
 ifdef::osp[]
 [id="installation-configuration-parameters-additional-osp_{context}"]
@@ -2027,10 +2031,10 @@ ifeval::["{context}" == "installing-aws-customizations"]
 :!aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-government-region"]
-:!aws-govcloud:
+:!aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-secret-region"]
-:!aws-secret:
+:!aws:
 endif::[]
 ifeval::["{context}" == "installing-aws-network-customizations"]
 :!aws:


### PR DESCRIPTION
**Version(s):** 4.11+ 

**Link to docs preview:**

Updates under:
 `compute.architecture`
 `controlPlane.architecture`

- [Installing on AWS -> Installing a cluster on AWS with customizations](https://65097--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#installation-configuration-parameters_installing-aws-customizations) 
- [Installing on Azure -> Installation configuration parameters for Azure](https://65097--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure#installation-configuration-parameters-optional_installation-config-parameters-azure)
- [Installing on GCP -> Installation configuration parameters for GCP ](https://65097--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-optional_installation-config-parameters-gcp)
- [Installing on bare metal -> Installation configuration parameters for bare metal](https://65097--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installation-config-parameters-bare-metal#installation-configuration-parameters-optional_installation-config-parameters-bare-metal)


**QE review:**
- Format change, No QE required
