### PR TITLE
[enterpirse-4.12] OCPBUGS#18561-12: Added prere to vSphere docs for reachable vCenter

### DIFF
--- a/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+++ b/installing/installing_vsphere/installing-vsphere-network-customizations.adoc
@@ -12,11 +12,11 @@ configuration options. By customizing your network configuration, your cluster
 can coexist with existing IP address allocations in your environment and
 integrate with existing MTU and VXLAN configurations.
 
+include::snippets/vcenter-support.adoc[]
+
 You must set most of the network configuration parameters during installation,
 and you can modify only `kubeProxy` configuration parameters in a running
 cluster.
-
-include::snippets/vcenter-support.adoc[]
 
 [IMPORTANT]
 ====

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1680,68 +1680,86 @@ ifdef::vsphere,vmc[]
 Additional VMware vSphere configuration parameters are described in the following table:
 
 .Additional VMware vSphere cluster parameters
-[cols=".^2,.^3a,.^3a",options="header"]
+[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-|`platform.vsphere.vCenter`
+l|platform
+     vsphere
+       vCenter
 |The fully-qualified hostname or IP address of the vCenter server.
 |String
 
-|`platform.vsphere.username`
+l|platform
+     vsphere
+       username
 |The user name to use to connect to the vCenter instance with. This user must have at least
 the roles and privileges that are required for
 link:https://github.com/vmware-archive/vsphere-storage-for-kubernetes/blob/master/documentation/vcp-roles.md[static or dynamic persistent volume provisioning]
 in vSphere.
 |String
 
-|`platform.vsphere.password`
+l|platform
+     vsphere
+       password
 |The password for the vCenter user name.
 |String
 
-|`platform.vsphere.datacenter`
+l|platform
+     vsphere
+       datacenter
 |The name of the data center to use in the vCenter instance.
 |String
 
-|`platform.vsphere.defaultDatastore`
+l|platform
+    vsphere
+      defaultDatastore
 |The name of the default datastore to use for provisioning volumes.
 |String
 
-|`platform.vsphere.folder`
+l|platform
+    vsphere
+      folder
 |Optional. The absolute path of an existing folder where the installation program creates the virtual machines. If you do not provide this value, the installation program creates a folder that is named with the infrastructure ID in the data center virtual machine folder.
 |String, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`.
 
-|`platform.vsphere.resourcePool`
+l|platform
+    vsphere
+      resourcePool
 |Optional. The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not specify a value, the installation program installs the resources in the root of the cluster under `/<datacenter_name>/host/<cluster_name>/Resources`.
 |String, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`.
 
-|`platform.vsphere.network`
+l|platform
+    vsphere
+      network
 |The network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured.
 |String
 
-|`platform.vsphere.cluster`
+l|platform
+    vsphere
+      cluster
 |The vCenter cluster to install the {product-title} cluster in.
 |String
 
-|`platform.vsphere.apiVIPs`
+l|platform
+    vsphere
+      apiVIPs
 |The virtual IP (VIP) address that you configured for control plane API access.
+
+*Note:* In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `apiVIPs` configuration setting.
 |An IP address, for example `128.0.0.1`.
 
-[NOTE]
-====
-In {product-title} 4.12 and later, the `apiVIP` configuration setting is deprecated. Instead, use a list format to enter a value in the `apiVIPs` configuration setting.
-====
-
-|`platform.vsphere.ingressVIPs`
+l|platform
+    vsphere
+      ingressVIPs
 |The virtual IP (VIP) address that you configured for cluster ingress.
-|An IP address, for example `128.0.0.1`.
 
-[NOTE]
-====
-In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a list format to enter a value in the `ingressVIPs` configuration setting.
-====
+*Note:* In {product-title} 4.12 and later, the `ingressVIP` configuration setting is deprecated. Instead, use a `List` format to enter a value in the `ingressVIPs` configuration setting.
+a|An IP address, for example `128.0.0.1`.
 
-|`platform.vsphere.diskType`
+l|platform
+    vsphere
+      diskType
 |Optional. The disk provisioning method. This value defaults to the vSphere default storage policy if not set.
 |Valid values are `thin`, `thick`, or `eagerZeroedThick`.
 |====
@@ -1752,27 +1770,38 @@ In {product-title} 4.12 and later, the `ingressVIP` configuration setting is dep
 Optional VMware vSphere machine pool configuration parameters are described in the following table:
 
 .Optional VMware vSphere machine pool parameters
-[cols=".^2,.^3a,.^3a",options="header"]
+[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-|`platform.vsphere.clusterOSImage`
+l|platform
+    vsphere
+      clusterOSImage
 |The location from which the installation program downloads the {op-system} image. You must set this parameter to perform an installation in a restricted network.
 |An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
 
-|`platform.vsphere.osDisk.diskSizeGB`
+l|platform
+    vsphere
+      osDisk
+        diskSizeGB
 |The size of the disk in gigabytes.
 |Integer
 
-|`platform.vsphere.cpus`
+l|platform
+    vsphere
+      cpus
 |The total number of virtual processor cores to assign a virtual machine. The value of `platform.vsphere.cpus` must be a multiple of `platform.vsphere.coresPerSocket` value.
 |Integer
 
-|`platform.vsphere.coresPerSocket`
+l|platform
+    vsphere
+      coresPerSocket
 |The number of cores per socket in a virtual machine. The number of virtual sockets on the virtual machine is `platform.vsphere.cpus`/`platform.vsphere.coresPerSocket`. The default value for control plane nodes and worker nodes is `4` and `2`, respectively.
 |Integer
 
-|`platform.vsphere.memoryMB`
+l|platform
+    vsphere
+      memoryMB
 |The size of a virtual machine's memory in megabytes.
 |Integer
 |====
@@ -1788,47 +1817,82 @@ Before you modify the `install-config.yaml` file to configure a region and zone 
 ====
 
 .Region and zone enablement parameters
-[cols=".^2,.^3a,.^3a",options="header"]
+[cols=".^2,.^4,.^2",options="header,word-wrap",subs="+quotes,+attributes"]
 |====
 |Parameter|Description|Values
 
-|`platform.vsphere.failureDomains`
+l|platform
+    vsphere
+      failureDomains
 |Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
 |String
 
-|`platform.vsphere.failureDomains.name`
+l|platform
+    vsphere
+      failureDomains
+        name
 |The name of the failure domain. The machine pools use this name to reference the failure domain.
 |String
 
-|`platform.vsphere.failureDomains.region`
+l|platform
+    vsphere
+      failureDomains
+        region
 |You define a region by using a tag from the `openshift-region` tag category. The tag must be attached to the vCenter datacenter.
 |String
 
-|`platform.vsphere.failureDomains.zone`
+l|platform
+    vsphere
+      failureDomains
+        zone   
 |You define a zone by using a tag from the `openshift-zone` tag category. The tag must be attached to the vCenter datacenter.
 |String
 
-|`platform.vsphere.failureDomains.topology.computeCluster`
+l|platform
+    vsphere
+      failureDomains
+        topology
+          computeCluster
 |This parameter defines the compute cluster associated with the failure domain. If you do not define this parameter in your configuration, the compute cluster takes the value of `platform.vsphere.cluster` and `platform.vsphere.datacenter`.
 |String
 
-|`platform.vsphere.failureDomains.topology.folder`
+l|platform
+    vsphere
+      failureDomains
+        topology
+          folder
 |The absolute path of an existing folder where the installation program creates the virtual machines. If you do not define this parameter in your configuration, the folder takes the value of `platform.vsphere.folder`.
 |String
 
-|`platform.vsphere.failureDomains.topology.datacenter`
+l|platform
+    vsphere
+      failureDomains
+        topology
+          datacenter
 |Defines the datacenter where {product-title} virtual machines (VMs) operate. If you do not define this parameter in your configuration, the datacenter defaults to `platform.vsphere.datacenter`.
 |String
 
-|`platform.vsphere.failureDomains.topology.datastore`
+l|platform
+    vsphere
+      failureDomains
+        topology
+          datastore
 | The name of the datastore to use for provisioning volumes. If you do not define this parameter in your configuration, the datastore takes the value of `platform.vsphere.defaultDatastore`.
 |String
 
-|`platform.vsphere.failureDomains.topology.networks`
+l|platform
+    vsphere
+      failureDomains
+        topology
+          networks
 | Lists any network in the vCenter instance that contains the virtual IP addresses and DNS records that you configured. If you do not define this parameter in your configuration, the network takes the value of `platform.vsphere.network`.
 |String
 
-|`platform.vsphere.failureDomains.topology.resourcePool`
+l|platform
+    vsphere
+      failureDomains
+        topology
+          resourcePool
 |The absolute path of an existing resource pool where the installation program creates the virtual machines. If you do not define this parameter in your configuration, the resource pool takes the value of `platform.vsphere.failureDomains.topology.computeCluster`.
 |====
 endif::vsphere,vmc[]

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -16,8 +16,8 @@
 // * installing/installing_vmc/installing-vmc-user-infra.adoc
 // * installing/installing_vmc/installing-vmc-network-customizations-user-infra.adoc
 // * installing/installing_vsphere/installing-restricted-networks-vsphere.adoc
-// * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_vsphere/installing-vsphere-network-customizations.adoc
+// * installing/installing_vsphere/installing-vsphere.adoc
 // * installing/installing_ibm_z/installing-ibm-z.adoc
 // * installing/installing_azure_stack_hub/installing-azure-stack-hub-network-customizations.adoc
 
@@ -27,14 +27,20 @@ endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :ash:
 endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:vsphere-upi-vsphere:
+endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:restricted:
+:restricted-upi:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
 :restricted:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :restricted:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:vsphere-upi:
 endif::[]
 ifeval::["{context}" == "installing-aws-china-region"]
 :aws-china:
@@ -71,9 +77,17 @@ endif::[]
 [id="installation-initializing-manual_{context}"]
 = Manually creating the installation configuration file
 
-ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,aws-private,azure-private,gcp-private,gcp-shared,ash-default,ash-network,ibm-cloud-private[]
+ifdef::restricted,vsphere-upi-vsphere[]
 For user-provisioned installations of {product-title}, you manually generate your installation configuration file.
-endif::aws-china,aws-gov,aws-secret,azure-gov,ash,aws-private,azure-private,gcp-private,gcp-shared,ash-default,ash-network,ibm-cloud-private[]
+endif::restricted,vsphere-upi-vsphere[]
+ifdef::vsphere-upi,restricted-upi[]
+For user-provisioned installations of {product-title}, you manually generate your installation configuration file.
+
+[IMPORTANT]
+====
+The Cluster Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
+====
+endif::vsphere-upi,restricted-upi[]
 ifdef::aws-china,aws-gov,aws-secret[]
 Installing the cluster requires that you manually generate the installation configuration file.
 //Made this update as part of feedback in PR3961. tl;dr Simply state you have to create the config file, instead of creating a number of conditions to explain why.
@@ -100,11 +114,11 @@ endif::aws-china,aws-secret[]
 * You have an SSH public key on your local machine to provide to the installation program. The key will be used for SSH authentication onto your cluster nodes for debugging and disaster recovery.
 * You have obtained the {product-title} installation program and the pull secret for your
 cluster.
-ifdef::restricted[]
+ifdef::restricted,restricted-upi[]
 * Obtain the `imageContentSources` section from the output of the command to
 mirror the repository.
 * Obtain the contents of the certificate for your mirror registry.
-endif::restricted[]
+endif::restricted,restricted-upi[]
 
 .Procedure
 
@@ -132,14 +146,14 @@ it in the `<installation_directory>`.
 ====
 You must name this configuration file `install-config.yaml`.
 ====
-ifdef::restricted[]
+ifdef::restricted,restricted-upi[]
 ** Unless you use a registry that {op-system} trusts by default, such as
 `docker.io`, you must provide the contents of the certificate for your mirror
 repository in the `additionalTrustBundle` section. In most cases, you must
 provide the certificate for your mirror.
 ** You must include the `imageContentSources` section from the output of the command to
 mirror the repository.
-endif::restricted[]
+endif::restricted,restricted-upi[]
 +
 
 ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,ash-default,ash-network,gcp-shared,ibm-cloud-private[]
@@ -211,14 +225,20 @@ endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :!ash:
 endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:!vsphere-upi-vsphere:
+endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:!restricted:
+:!restricted-upi:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
 :!restricted:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :!restricted:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!vsphere-upi:
 endif::[]
 ifeval::["{context}" == "installing-aws-china-region"]
 :!aws-china:

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -115,6 +115,11 @@ If you disable simultaneous multithreading, ensure that your capacity planning a
 <5> The number of control plane machines that you add to the cluster. Because the cluster uses this values as the number of etcd endpoints in the cluster, the value must match the number of control plane machines that you deploy.
 <6> The cluster name that you specified in your DNS records.
 <7> The fully-qualified hostname or IP address of the vCenter server.
++
+[IMPORTANT]
+====
+The Cluster Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
+====
 <8> The name of the user for accessing the server.
 <9> The password associated with the vSphere user.
 <10> The vSphere datacenter.


### PR DESCRIPTION
[OCPBUGS-18561](https://issues.redhat.com/browse/OCPBUGS-18561)

Commit cherry-picked from #64748 

Version(s):
4.12

Link to docs preview:
* [Installing a cluster on vSphere with network customizations](https://65098--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations#installation-initializing-manual_installing-vsphere-network-customizations)

* [Installing a cluster on vSphere with user-provisioned infrastructure](https://65098--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere#installation-initializing-manual_installing-vsphere)

* [Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure](https://65098--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere#installation-initializing-manual_installing-restricted-networks-vsphere)

* [Installation configuration parameters](https://65098--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere#installation-configuration-parameters_installing-restricted-networks-installer-provisioned-vsphere)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
