### PR TITLE
Admission controller docs fixes during ROSA review

### DIFF
--- a/architecture/admission-plug-ins.adoc
+++ b/architecture/admission-plug-ins.adoc
@@ -6,6 +6,9 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+// Sentence taken from Architecture -> Index.
+Admission plugins are used to help regulate how {product-title} functions.
+
 // Concept modules
 include::modules/admission-plug-ins-about.adoc[leveloffset=+1]
 

--- a/modules/admission-plug-ins-about.adoc
+++ b/modules/admission-plug-ins-about.adoc
@@ -6,7 +6,7 @@
 [id="admission-plug-ins-about_{context}"]
 = About admission plugins
 
-Admission plugins are used to help regulate how {product-title} {product-version} functions. Admission plugins intercept requests to the master API to validate resource requests and ensure policies are adhered to, after the request is authenticated and authorized. For example, they are commonly used to enforce security policy, resource limitations or configuration requirements.
+Admission plugins intercept requests to the master API to validate resource requests. After a request is authenticated and authorized, the admission plugins ensure that any associated policies are followed. For example, they are commonly used to enforce security policy, resource limitations or configuration requirements.
 
 Admission plugins run in sequence as an admission chain. If any admission plugin in the sequence rejects a request, the whole chain is aborted and an error is returned.
 

--- a/rosa_architecture/rosa-admission-plug-ins.adoc
+++ b/rosa_architecture/rosa-admission-plug-ins.adoc
@@ -1,0 +1,38 @@
+:_content-type: ASSEMBLY
+[id="rosa-admission-plug-ins"]
+= Admission plugins
+include::_attributes/common-attributes.adoc[]
+:context: admission-plug-ins
+
+toc::[]
+
+
+Admission plugins are used to help regulate how {product-title} functions. 
+
+// Concept modules
+include::modules/admission-plug-ins-about.adoc[leveloffset=+1]
+
+include::modules/admission-plug-ins-default.adoc[leveloffset=+1]
+
+include::modules/admission-webhooks-about.adoc[leveloffset=+1]
+
+include::modules/admission-webhook-types.adoc[leveloffset=+1]
+
+// user (groups=["dedicated-admins" "system:authenticated:oauth" "system:authenticated"]) is attempting to grant RBAC permissions not currently held, clusterroles.rbac.authorization.k8s.io "system:openshift:online:my-webhook-server" not found, cannot get resource "rolebindings", cannot create resource "apiservices", cannot create resource "validatingwebhookconfigurations" 
+ifndef::openshift-rosa,openshift-dedicated[]
+// Procedure module
+include::modules/configuring-dynamic-admission.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
+
+[role="_additional-resources"]
+[id="admission-plug-ins-additional-resources"]
+== Additional resources
+
+ifndef::openshift-rosa,openshift-dedicated[]
+* xref: /networking/hardware_networks/configuring-sriov-operator.adoc#configuring-sriov-operator[Configuring the SR-IOV Network Operator]
+endif::openshift-rosa,openshift-dedicated[]
+
+* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations_dedicating_nodes-scheduler-taints-tolerations[Controlling pod placement using node taints]
+
+* xref:../nodes/pods/nodes-pods-priority.adoc#admin-guide-priority-preemption-names_nodes-pods-priority[Pod priority names]
+


### PR DESCRIPTION
Fixing various errors in the Admission Controller docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

Previews: 
[Admission plugins](https://65099--docspreview.netlify.app/openshift-enterprise/latest/architecture/admission-plug-ins)
[About admission plugins](https://65099--docspreview.netlify.app/openshift-enterprise/latest/architecture/admission-plug-ins#admission-plug-ins-about_admission-plug-ins)