### PR TITLE
TELCODOCS-1280: First draft

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -17,6 +17,10 @@ include::modules/kmm-installing-using-cli.adoc[leveloffset=+2]
 include::modules/kmm-installing-older-versions.adoc[leveloffset=+2]
 include::modules/kmm-deploying-modules.adoc[leveloffset=+1]
 include::modules/kmm-creating-module-cr.adoc[leveloffset=+2]
+
+// Added for TELCODOCS-1280
+include::modules/kmm-setting-soft-dependencies-between-kernel-modules.adoc[leveloffset=+2]
+
 include::modules/kmm-security.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/kmm-setting-soft-dependencies-between-kernel-modules.adoc
+++ b/modules/kmm-setting-soft-dependencies-between-kernel-modules.adoc
@@ -1,0 +1,41 @@
+// Module included in the following assemblies:
+//
+// * hardware_enablement/kmm-kernel-module-management.adoc
+
+:_content-type: CONCEPT
+[id="kmm-setting-soft-dependencies-between-kernel-modules_{context}"]
+= Set soft dependencies between kernel modules
+
+Some configurations require that several kernel modules be loaded in a specific order to work properly, even though the modules do not directly depend on each other through symbols.
+These are called soft dependencies.
+`depmod` is usually not aware of these dependencies, and they do not appear in the files it produces.
+For example, if `mod_a` has a soft dependency on `mod_b`, `modprobe mod_a` will not load `mod_b`.
+
+You can resolve these situations by declaring soft dependencies in the Module Custom Resource Definition (CRD) using the `modulesLoadingOrder` field.
+
+[source,yaml]
+----
+# ...
+spec:
+  moduleLoader:
+    container:
+      modprobe:
+        moduleName: mod_a
+        dirName: /opt
+        firmwarePath: /firmware
+        parameters:
+          - param=1
+        modulesLoadingOrder:
+          - mod_a
+          - mod_b
+----
+
+In the configuration above:
+
+* The loading order is `mod_b`, then `mod_a`.
+* The unloading order is `mod_a`, then `mod_b`.
+
+[NOTE]
+====
+The first value in the list, to be loaded last, must be equivalent to the `moduleName`.
+====


### PR DESCRIPTION
D/S Docs: Document Multi independent kernel modules deployment via single KMM Module ([MGMT-13873](https://issues.redhat.com//browse/MGMT-13873))

Jira: https://issues.redhat.com/browse/TELCODOCS-1280

Version: 4.13+

Affects Version/s: KMMO 1.1

Link to docs preview: https://65103--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management#kmm-setting-soft-dependencies-between-kernel-modules_kernel-module-management-operator

SME review: @yevgeny-shnaidman, @qbarrand @bthurber
QE review: @cdvultur