### PR TITLE
OSDOCS-7879 4.12.35 Z-stream release notes

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4094,3 +4094,22 @@ $ oc adm release info 4.12.34 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-35"]
+=== RHBA-2023:5321 - {product-title} 4.12.35 bug fix update
+
+Issued: 2023-09-27
+
+{product-title} release 4.12.35 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5321[RHBA-2023:5321] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5323[RHBA-2023:5323] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.35 --pullspecs
+----
+
+[id="ocp-4-12-35-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-7879](https://issues.redhat.com/browse/OSDOCS-7879)

Link to docs preview:
[Preview](https://65105--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-35)

QE review:
- [ ] QE has approved this change.
Not needed

Additional information:
Links will not work until Sept. 27th.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
