### PR TITLE
TELCODOCS-1526: Added a documentation bug fix section to complete change management.

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1882,6 +1882,12 @@ With this release, replacement control plane nodes are assigned to the correct i
 * Previously, the *Samples* page in the {product-title} did not allow distinguishing between the types of samples listed. With this fix, you can identify the sample from the badges displayed on the *Samples* page. (link:https://issues.redhat.com/browse/OCPBUGS-10679[*OCPBUGS-10679*])
 
 [discrete]
+[id="ocp-4-13-documentation-bug-fixes"]
+==== Documentation
+
+Previously, the {product-title} documentation included a sub-section titled "Expanding a cluster with on-premise bare metal nodes." However, this has been removed in order to maintain accurate, up to date documentation.
+
+[discrete]
 [id="ocp-4-13-cloud-etcd-operator-bug-fixes"]
 ==== etcd Cluster Operator
 


### PR DESCRIPTION
Final note related to https://github.com/openshift/openshift-docs/pull/64490 and https://github.com/openshift/openshift-docs/pull/65049
Version(s): 4.13

Issue: https://issues.redhat.com/browse/TELCODOCS-1526

Link to docs preview: http://184.23.213.161:8080/TELCODOCS-1526-4.13/release_notes/ocp-4-13-release-notes.html#ocp-4-13-documentation-bug-fixes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
