### PR TITLE
[OSDOCS-7881]: Unify `ccoctl` install step order across providers

### DIFF
--- a/installing/installing_aws/installing-aws-china.adoc
+++ b/installing/installing_aws/installing-aws-china.adoc
@@ -40,39 +40,6 @@ include::modules/installation-aws-upload-custom-rhcos-ami.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-== Optional: Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
-
-[NOTE]
-====
-To use the AWS STS, you must configure the Cloud Credential Operator (CCO) to run in manual mode. As part of the installation process, you set `credentialsMode` parameter to `Manual` after creating the `install-config.yaml` installation configuration file.
-====
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-=== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-china.adoc#cco-ccoctl-creating-at-once_installing-aws-china-region[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-china.adoc#cco-ccoctl-creating-individually_installing-aws-china-region[Creating AWS resources individually].
-
-//Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
-
-//Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
-
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -94,20 +61,48 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_aws/installing-aws-china.adoc#cco-ccoctl-install-creating-manifests_installing-aws-china-region[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-china.adoc#manually-create-iam_installing-aws-china-region[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-china.adoc#manually-create-iam_installing-aws-china-region[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_aws/installing-aws-china.adoc#installing-aws-with-short-term-creds_installing-aws-china-region[Configuring an AWS cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-china.adoc#cco-ccoctl-creating-at-once_installing-aws-china-region[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-china.adoc#cco-ccoctl-creating-individually_installing-aws-china-region[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-customizations.adoc
+++ b/installing/installing_aws/installing-aws-customizations.adoc
@@ -37,39 +37,6 @@ include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-== Optional: Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
-
-[NOTE]
-====
-To use the AWS STS, you must configure the Cloud Credential Operator (CCO) to run in manual mode. As part of the installation process, you set `credentialsMode` parameter to `Manual` after creating the `install-config.yaml` installation configuration file.
-====
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-=== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-customizations.adoc#cco-ccoctl-creating-at-once_installing-aws-customizations[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-customizations.adoc#cco-ccoctl-creating-individually_installing-aws-customizations[Creating AWS resources individually].
-
-//Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
-
-//Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -91,20 +58,48 @@ include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_aws/installing-aws-customizations.adoc#cco-ccoctl-install-creating-manifests_installing-aws-customizations[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-customizations.adoc#manually-create-iam_installing-aws-customizations[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-customizations[Configuring an AWS cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-customizations.adoc#cco-ccoctl-creating-at-once_installing-aws-customizations[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-customizations.adoc#cco-ccoctl-creating-individually_installing-aws-customizations[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-government-region.adoc
+++ b/installing/installing_aws/installing-aws-government-region.adoc
@@ -41,39 +41,6 @@ include::modules/installation-aws-marketplace-subscribe.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-== Optional: Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
-
-[NOTE]
-====
-To use the AWS STS, you must configure the Cloud Credential Operator (CCO) to run in manual mode. As part of the installation process, you set `credentialsMode` parameter to `Manual` after creating the `install-config.yaml` installation configuration file.
-====
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-=== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-government-region.adoc#cco-ccoctl-creating-at-once_installing-aws-government-region[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-government-region.adoc#cco-ccoctl-creating-individually_installing-aws-government-region[Creating AWS resources individually].
-
-//Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
-
-//Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
-
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -95,20 +62,48 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_aws/installing-aws-government-region.adoc#cco-ccoctl-install-creating-manifests_installing-aws-government-region[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-government-region.adoc#manually-create-iam_installing-aws-government-region[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-government-region.adoc#manually-create-iam_installing-aws-government-region[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_aws/installing-aws-government-region.adoc#installing-aws-with-short-term-creds_installing-aws-government-region[Incorporating the Cloud Credential Operator utility manifests].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-government-region.adoc#cco-ccoctl-creating-at-once_installing-aws-government-region[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-government-region.adoc#cco-ccoctl-creating-individually_installing-aws-government-region[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-network-customizations.adoc
+++ b/installing/installing_aws/installing-aws-network-customizations.adoc
@@ -36,39 +36,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-== Optional: Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
-
-[NOTE]
-====
-To use the AWS STS, you must configure the Cloud Credential Operator (CCO) to run in manual mode. As part of the installation process, you set `credentialsMode` parameter to `Manual` after creating the `install-config.yaml` installation configuration file.
-====
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-=== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#cco-ccoctl-creating-at-once_installing-aws-network-customizations[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#cco-ccoctl-creating-individually_installing-aws-network-customizations[Creating AWS resources individually].
-
-//Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
-
-//Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
-
 include::modules/nw-network-config.adoc[leveloffset=+1]
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
@@ -91,20 +58,48 @@ include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#cco-ccoctl-install-creating-manifests_installing-aws-network-customizations[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#manually-create-iam_installing-aws-network-customizations[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#manually-create-iam_installing-aws-network-customizations[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#installing-aws-with-short-term-creds_installing-aws-network-customizations[Configuring an AWS cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#cco-ccoctl-creating-at-once_installing-aws-network-customizations[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-network-customizations.adoc#cco-ccoctl-creating-individually_installing-aws-network-customizations[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 // Network Operator specific configuration
 include::modules/nw-operator-cr.adoc[leveloffset=+1]

--- a/installing/installing_aws/installing-aws-outposts-remote-workers.adoc
+++ b/installing/installing_aws/installing-aws-outposts-remote-workers.adoc
@@ -41,39 +41,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-== Optional: Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
-
-[NOTE]
-====
-To use the AWS STS, you must configure the Cloud Credential Operator (CCO) to run in manual mode. As part of the installation process, you set `credentialsMode` parameter to `Manual` after creating the `install-config.yaml` installation configuration file.
-====
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-=== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-outposts-remote-workers.adoc#cco-ccoctl-creating-at-once_installing-aws-outposts-remote-workers[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-outposts-remote-workers.adoc#cco-ccoctl-creating-individually_installing-aws-outposts-remote-workers[Creating AWS resources individually].
-
-//Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
-
-//Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
-
 include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -94,20 +61,48 @@ include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
 
 include::modules/installation-aws-editing-manifests.adoc[leveloffset=+1]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_aws/installing-aws-outposts-remote-workers.adoc#cco-ccoctl-install-creating-manifests_installing-aws-outposts-remote-workers[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-outposts-remote-workers.adoc#manually-create-iam_installing-aws-outposts-remote-workers[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-outposts-remote-workers.adoc#manually-create-iam_installing-aws-outposts-remote-workers[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_aws/installing-aws-outposts-remote-workers.adoc#installing-aws-with-short-term-creds_installing-aws-outposts-remote-workers[Configuring an AWS cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-outposts-remote-workers.adoc#cco-ccoctl-creating-at-once_installing-aws-outposts-remote-workers[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-outposts-remote-workers.adoc#cco-ccoctl-creating-individually_installing-aws-outposts-remote-workers[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-private.adoc
+++ b/installing/installing_aws/installing-aws-private.adoc
@@ -34,39 +34,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-== Optional: Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
-
-[NOTE]
-====
-To use the AWS STS, you must configure the Cloud Credential Operator (CCO) to run in manual mode. As part of the installation process, you set `credentialsMode` parameter to `Manual` after creating the `install-config.yaml` installation configuration file.
-====
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-=== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-private.adoc#cco-ccoctl-creating-at-once_installing-aws-private[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-private.adoc#cco-ccoctl-creating-individually_installing-aws-private[Creating AWS resources individually].
-
-//Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
-
-//Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
-
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -89,20 +56,48 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_aws/installing-aws-private.adoc#cco-ccoctl-install-creating-manifests_installing-aws-private[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-private.adoc#manually-create-iam_installing-aws-private[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-private.adoc#manually-create-iam_installing-aws-private[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_aws/installing-aws-private.adoc#installing-aws-with-short-term-creds_installing-aws-private[Configuring an AWS cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-private.adoc#cco-ccoctl-creating-at-once_installing-aws-private[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-private.adoc#cco-ccoctl-creating-individually_installing-aws-private[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-secret-region.adoc
+++ b/installing/installing_aws/installing-aws-secret-region.adoc
@@ -44,39 +44,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-== Optional: Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
-
-[NOTE]
-====
-To use the AWS STS, you must configure the Cloud Credential Operator (CCO) to run in manual mode. As part of the installation process, you set `credentialsMode` parameter to `Manual` after creating the `install-config.yaml` installation configuration file.
-====
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-=== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-secret-region.adoc#cco-ccoctl-creating-at-once_installing-aws-secret-region[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-secret-region.adoc#cco-ccoctl-creating-individually_installing-aws-secret-region[Creating AWS resources individually].
-
-//Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
-
-//Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
-
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -88,20 +55,48 @@ include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_aws/installing-aws-secret-region.adoc#cco-ccoctl-install-creating-manifests_installing-aws-secret-region[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-secret-region.adoc#manually-create-iam_installing-aws-secret-region[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-secret-region.adoc#manually-create-iam_installing-aws-secret-region[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_aws/installing-aws-secret-region.adoc#installing-aws-with-short-term-creds_installing-aws-secret-region[Configuring an AWS cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-secret-region.adoc#cco-ccoctl-creating-at-once_installing-aws-secret-region[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-secret-region.adoc#cco-ccoctl-creating-individually_installing-aws-secret-region[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-aws-vpc.adoc
+++ b/installing/installing_aws/installing-aws-vpc.adoc
@@ -32,39 +32,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-== Optional: Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
-
-[NOTE]
-====
-To use the AWS STS, you must configure the Cloud Credential Operator (CCO) to run in manual mode. As part of the installation process, you set `credentialsMode` parameter to `Manual` after creating the `install-config.yaml` installation configuration file.
-====
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-=== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-vpc.adoc#cco-ccoctl-creating-at-once_installing-aws-vpc[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-vpc.adoc#cco-ccoctl-creating-individually_installing-aws-vpc[Creating AWS resources individually].
-
-//Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
-
-//Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -87,20 +54,48 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 include::modules/installation-applying-aws-security-groups.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_aws/installing-aws-vpc.adoc#cco-ccoctl-install-creating-manifests_installing-aws-vpc[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-vpc.adoc#manually-create-iam_installing-aws-vpc[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-aws-vpc.adoc#manually-create-iam_installing-aws-vpc[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_aws/installing-aws-vpc.adoc#installing-aws-with-short-term-creds_installing-aws-vpc[Configuring an AWS cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-aws-vpc.adoc#cco-ccoctl-creating-at-once_installing-aws-vpc[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-aws-vpc.adoc#cco-ccoctl-creating-individually_installing-aws-vpc[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc
@@ -44,39 +44,6 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring an AWS cluster to use short-term credentials
-[id="installing-aws-with-short-term-creds_{context}"]
-== Optional: Configuring an AWS cluster to use short-term credentials
-
-To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
-
-[NOTE]
-====
-To use the AWS STS, you must configure the Cloud Credential Operator (CCO) to run in manual mode. As part of the installation process, you set `credentialsMode` parameter to `Manual` after creating the `install-config.yaml` installation configuration file.
-====
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required AWS resources
-[id="sts-mode-create-aws-resources-ccoctl_{context}"]
-=== Creating AWS resources with the Cloud Credential Operator utility
-
-You have the following options when creating AWS resources:
-
-* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#cco-ccoctl-creating-at-once_installing-restricted-networks-aws-installer-provisioned[Creating AWS resources with a single command].
-
-* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#cco-ccoctl-creating-individually_installing-restricted-networks-aws-installer-provisioned[Creating AWS resources individually].
-
-//Task part 2a: Creating the required AWS resources all at once
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
-
-//Task part 2b: Creating the required AWS resources individually
-include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+3]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -94,20 +61,48 @@ include::modules/installation-aws-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-aws-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in See xref:../../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#cco-ccoctl-install-creating-manifests_installing-restricted-networks-aws-installer-provisioned[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#manually-create-iam_installing-restricted-networks-aws-installer-provisioned[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in See xref:../../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#manually-create-iam_installing-restricted-networks-aws-installer-provisioned[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-aws-with-short-term-creds_installing-restricted-networks-aws-installer-provisioned[Configuring an AWS cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring an AWS cluster to use short-term credentials
+[id="installing-aws-with-short-term-creds_{context}"]
+=== Configuring an AWS cluster to use short-term credentials
+
+To install a cluster that is configured to use the AWS Security Token Service (STS), you must configure the CCO utility and create the required AWS resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required AWS resources
+[id="sts-mode-create-aws-resources-ccoctl_{context}"]
+==== Creating AWS resources with the Cloud Credential Operator utility
+
+You have the following options when creating AWS resources:
+
+* You can use the `ccoctl aws create-all` command to create the AWS resources automatically. This is the quickest way to create the resources. See xref:../../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#cco-ccoctl-creating-at-once_installing-restricted-networks-aws-installer-provisioned[Creating AWS resources with a single command].
+
+* If you need to review the JSON files that the `ccoctl` tool creates before modifying AWS resources, or if the process the `ccoctl` tool uses to create AWS resources automatically does not meet the requirements of your organization, you can create the AWS resources individually. See xref:../../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#cco-ccoctl-creating-individually_installing-restricted-networks-aws-installer-provisioned[Creating AWS resources individually].
+
+//Task part 2a: Creating the required AWS resources all at once
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+4]
+
+//Task part 2b: Creating the required AWS resources individually
+include::modules/cco-ccoctl-creating-individually.adoc[leveloffset=+4]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-customizations.adoc
@@ -25,21 +25,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-== Optional: Configuring a GCP cluster to use short-term credentials
-
-To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required GCP resources
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
-
 include::modules/installing-gcp-user-defined-labels-and-tags.adoc[leveloffset=+1]
 
 //Configuring user-defined labels and tags for GCP
@@ -47,7 +32,6 @@ include::modules/installing-gcp-cluster-creation.adoc[leveloffset=+2]
 
 //Querying user-defined labels and tags for GCP
 include::modules/installing-gcp-querying-labels-tags-gcp.adoc[leveloffset=+2]
-
 
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
@@ -81,20 +65,35 @@ include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-gcp-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#cco-ccoctl-install-creating-manifests_installing-gcp-customizations[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#manually-create-iam_installing-gcp-customizations[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-customizations[Configuring a GCP cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring a GCP cluster to use short-term credentials
+[id="installing-gcp-with-short-term-creds_{context}"]
+=== Configuring a GCP cluster to use short-term credentials
+
+To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required GCP resources
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-gcp-marketplace.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-network-customizations.adoc
+++ b/installing/installing_gcp/installing-gcp-network-customizations.adoc
@@ -31,21 +31,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-== Optional: Configuring a GCP cluster to use short-term credentials
-
-To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required GCP resources
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -78,20 +63,35 @@ include::modules/installation-gcp-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-gcp-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-network-customizations.adoc#cco-ccoctl-install-creating-manifests_installing-gcp-network-customizations[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-network-customizations.adoc#manually-create-iam_installing-gcp-network-customizations[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-network-customizations.adoc#manually-create-iam_installing-gcp-network-customizations[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-network-customizations.adoc#installing-gcp-with-short-term-creds_installing-gcp-network-customizations[Configuring a GCP cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring a GCP cluster to use short-term credentials
+[id="installing-gcp-with-short-term-creds_{context}"]
+=== Configuring a GCP cluster to use short-term credentials
+
+To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required GCP resources
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 // Network Operator specific configuration
 include::modules/nw-network-config.adoc[leveloffset=+1]

--- a/installing/installing_gcp/installing-gcp-private.adoc
+++ b/installing/installing_gcp/installing-gcp-private.adoc
@@ -28,21 +28,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-== Optional: Configuring a GCP cluster to use short-term credentials
-
-To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required GCP resources
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
-
 include::modules/installation-initializing-manual.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -78,20 +63,35 @@ include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-gcp-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-private.adoc#cco-ccoctl-install-creating-manifests_installing-gcp-private[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-private.adoc#manually-create-iam_installing-gcp-private[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-private.adoc#manually-create-iam_installing-gcp-private[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-private.adoc#installing-gcp-with-short-term-creds_installing-gcp-private[Configuring a GCP cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring a GCP cluster to use short-term credentials
+[id="installing-gcp-with-short-term-creds_{context}"]
+=== Configuring a GCP cluster to use short-term credentials
+
+To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required GCP resources
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-shared-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-shared-vpc.adoc
@@ -27,21 +27,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-== Optional: Configuring a GCP cluster to use short-term credentials
-
-To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required GCP resources
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
-
 include::modules/installation-user-infra-generate.adoc[leveloffset=+1]
 
 include::modules/installation-initializing-manual.adoc[leveloffset=+2]
@@ -58,20 +43,35 @@ include::modules/installation-gcp-shared-vpc-config.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-gcp-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-shared-vpc.adoc#cco-ccoctl-install-creating-manifests_installing-gcp-shared-vpc[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-shared-vpc.adoc#manually-create-iam_installing-gcp-shared-vpc[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-shared-vpc.adoc#manually-create-iam_installing-gcp-shared-vpc[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-shared-vpc.adoc#installing-gcp-with-short-term-creds_installing-gcp-shared-vpc[Configuring a GCP cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring a GCP cluster to use short-term credentials
+[id="installing-gcp-with-short-term-creds_{context}"]
+=== Configuring a GCP cluster to use short-term credentials
+
+To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required GCP resources
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-gcp-vpc.adoc
+++ b/installing/installing_gcp/installing-gcp-vpc.adoc
@@ -24,21 +24,6 @@ include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
 include::modules/installation-obtaining-installer.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-== Optional: Configuring a GCP cluster to use short-term credentials
-
-To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required GCP resources
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -74,20 +59,35 @@ include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-gcp-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#cco-ccoctl-install-creating-manifests_installing-gcp-vpc[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#manually-create-iam_installing-gcp-vpc[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#manually-create-iam_installing-gcp-vpc[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-gcp-vpc.adoc#installing-gcp-with-short-term-creds_installing-gcp-vpc[Configuring a GCP cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring a GCP cluster to use short-term credentials
+[id="installing-gcp-with-short-term-creds_{context}"]
+=== Configuring a GCP cluster to use short-term credentials
+
+To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required GCP resources
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
+++ b/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc
@@ -36,21 +36,6 @@ include::modules/cluster-entitlements.adoc[leveloffset=+1]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
-//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
-include::modules/cli-installing-cli.adoc[leveloffset=+1]
-
-//Supertask: Configuring a GCP cluster to use short-term credentials
-[id="installing-gcp-with-short-term-creds_{context}"]
-== Optional: Configuring a GCP cluster to use short-term credentials
-
-To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
-
-//Task part 1: Configuring the Cloud Credential Operator utility
-include::modules/cco-ccoctl-configuring.adoc[leveloffset=+2]
-
-//Task part 2: Creating the required GCP resources
-include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+2]
-
 include::modules/installation-initializing.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -80,20 +65,35 @@ include::modules/nw-gcp-installing-global-access-configuration.adoc[leveloffset=
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
+//Installing the OpenShift CLI by downloading the binary: Moved up to precede `ccoctl` steps, which require the use of `oc`
+include::modules/cli-installing-cli.adoc[leveloffset=+1]
+
 [id="installing-gcp-manual-modes_{context}"]
 == Alternatives to storing administrator-level secrets in the kube-system project
 
 By default, administrator secrets are stored in the `kube-system` project. If you configured the `credentialsMode` parameter in the `install-config.yaml` file to `Manual`, you must use one of the following alternatives:
 
-* If you configured the CCO utility (`ccoctl`) to implement short-term credentials for individual components, follow the procedure in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#cco-ccoctl-install-creating-manifests_installing-restricted-networks-gcp-installer-provisioned[Incorporating the Cloud Credential Operator utility manifests].
+* To manage long-term cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#manually-create-iam_installing-restricted-networks-gcp-installer-provisioned[Manually creating long-term credentials].
 
-* If you will manage cloud credentials manually, follow the procedure in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#manually-create-iam_installing-restricted-networks-gcp-installer-provisioned[Manually creating long-term credentials].
+* To implement short-term credentials that are managed outside the cluster for individual components, follow the procedures in xref:../../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-gcp-with-short-term-creds_installing-restricted-networks-gcp-installer-provisioned[Configuring a GCP cluster to use short-term credentials].
 
-// Additional steps for the Cloud Credential Operator utility (`ccoctl`)
-include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+2]
-
-//Manually creating IAM
+//Manually creating long-term credentials
 include::modules/manually-create-identity-access-management.adoc[leveloffset=+2]
+
+//Supertask: Configuring a GCP cluster to use short-term credentials
+[id="installing-gcp-with-short-term-creds_{context}"]
+=== Configuring a GCP cluster to use short-term credentials
+
+To install a cluster that is configured to use GCP Workload Identity, you must configure the CCO utility and create the required GCP resources for your cluster.
+
+//Task part 1: Configuring the Cloud Credential Operator utility
+include::modules/cco-ccoctl-configuring.adoc[leveloffset=+3]
+
+//Task part 2: Creating the required GCP resources
+include::modules/cco-ccoctl-creating-at-once.adoc[leveloffset=+3]
+
+//Task part 3: Incorporating the Cloud Credential Operator utility manifests
+include::modules/cco-ccoctl-install-creating-manifests.adoc[leveloffset=+3]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 

--- a/modules/cco-ccoctl-install-verifying.adoc
+++ b/modules/cco-ccoctl-install-verifying.adoc
@@ -10,7 +10,7 @@ You can verify that your cluster is using short-term security credentials for in
 
 .Prerequisites
 
-* You deployed an {product-title} cluster using the Cloud Credential Operator utility (`ccoctl`).
+* You deployed an {product-title} cluster using the Cloud Credential Operator utility (`ccoctl`) to implement short-term credentials.
 
 * You installed the {oc-first}.
 
@@ -26,9 +26,31 @@ You can verify that your cluster is using short-term security credentials for in
 $ oc get secrets -n kube-system <secret_name>
 ----
 +
-where `<secret_name>` is `aws-creds` for AWS or `gcp-credentials` for GCP.
+where `<secret_name>` is the name of the root secret for your cloud provider.
 +
-An error confirms that the root secret is not present on the cluster.
+[cols=2,options=header]
+|===
+|Platform
+|Secret name
+
+|AWS
+|`aws-creds`
+
+|Azure
+|`azure-credentials`
+
+|GCP
+|`gcp-credentials`
+
+|===
++
+An error confirms that the root secret is not present on the cluster. The following example shows the expected output from an AWS cluster:
++
+.Example output
+[source,text]
+----
+Error from server (NotFound): secrets "aws-creds" not found
+----
 
 . Verify that the components are using short-term security credentials for individual components by running the following command:
 +


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-7881](https://issues.redhat.com//browse/OSDOCS-7881)

Link to docs preview:
"Alternatives to storing administrator-level secrets in the kube-system project" in:
* [Installing a cluster on AWS with customizations](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-customizations#installing-aws-manual-modes_installing-aws-customizations)
* [Installing a cluster on AWS with network customizations](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-network-customizations#installing-aws-manual-modes_installing-aws-network-customizations)
* [Installing a cluster on AWS in a restricted network](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws-installer-provisioned#installing-aws-manual-modes_installing-restricted-networks-aws-installer-provisioned)
* [Installing a cluster on AWS into an existing VPC](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-vpc#installing-aws-manual-modes_installing-aws-vpc)
* [Installing a private cluster on AWS](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-private#installing-aws-manual-modes_installing-aws-private)
* [Installing a cluster on AWS into a government region](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-government-region#installing-aws-manual-modes_installing-aws-government-region)
* [Installing a cluster on AWS into a Secret or Top Secret Region](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-secret-region#installing-aws-manual-modes_installing-aws-secret-region)
* [Installing a cluster on AWS China](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-china#installing-aws-manual-modes_installing-aws-china-region)
* [Installing a cluster on AWS with remote workers on AWS Outposts](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-outposts-remote-workers#installing-aws-manual-modes_installing-aws-outposts-remote-workers)
* [Installing a cluster on GCP with customizations](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installing-gcp-manual-modes_installing-gcp-customizations)
* [Installing a cluster on GCP with network customizations](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-network-customizations#installing-gcp-manual-modes_installing-gcp-network-customizations)
* [Installing a cluster on GCP in a restricted network](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned#installing-gcp-manual-modes_installing-restricted-networks-gcp-installer-provisioned)
* [Installing a cluster on GCP into an existing VPC](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-vpc#installing-gcp-manual-modes_installing-gcp-vpc)
* [Installing a cluster on GCP into a shared VPC](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-shared-vpc#installing-gcp-manual-modes_installing-gcp-shared-vpc)
* [Installing a private cluster on GCP](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-private#installing-gcp-manual-modes_installing-gcp-private)

Added Azure root secret value to [Clusters that use short-term credentials: Verifying the credentials configuration](https://65120--docspreview.netlify.app/openshift-enterprise/latest/installing/validating-an-installation#cco-ccoctl-install-verifying_validating-an-installation), reformatted for additional context.

QE review:
- [x] QE has approved this change.

Additional information:
- Planned for 4.14.z, add 4.15 label post GA