### PR TITLE
Applications fix errors 2

### DIFF
--- a/applications/application-health.adoc
+++ b/applications/application-health.adoc
@@ -21,7 +21,10 @@ include::modules/application-health-configuring.adoc[leveloffset=+1]
 
 include::modules/odc-monitoring-application-health-using-developer-perspective.adoc[leveloffset=+1]
 
+// cannot add health checks in web console
+ifdef::openshift-rosa,openshift-dedicated[]
 include::modules/odc-adding-health-checks.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/odc-editing-health-checks.adoc[leveloffset=+1]
 

--- a/applications/connecting_applications_to_services/binding-workloads-using-sbo.adoc
+++ b/applications/connecting_applications_to_services/binding-workloads-using-sbo.adoc
@@ -45,7 +45,6 @@ include::modules/sbo-unbinding-workloads-from-a-backing-service.adoc[leveloffset
 [id="additional-resources_binding-workloads-sbo"]
 == Additional resources
 * xref:../../applications/connecting_applications_to_services/understanding-service-binding-operator.adoc#binding-a-workload-together-with-a-backing-service_understanding-service-binding-operator[Binding a workload together with a backing service].
-* xref:../../applications/connecting_applications_to_services/getting-started-with-service-binding.adoc#connecting-the-spring-petclinic-sample-application-to-the-postgresql-database-service[Connecting the Spring PetClinic sample application to the PostgreSQL database service].
+* xref:../../applications/connecting_applications_to_services/getting-started-with-service-binding.adoc#sbo-connecting-spring-petclinic-sample-app-to-postgresql-database-service_getting-started-with-service-binding[Connecting the Spring PetClinic sample application to the PostgreSQL database service].
 * xref:../../operators/understanding/crds/crd-managing-resources-from-crds.adoc#crd-creating-custom-resources-from-file_crd-managing-resources-from-crds[Creating custom resources from a file]
 * link:https://redhat-developer.github.io/service-binding-operator/userguide/binding-workloads-using-sbo/custom-path-injection.html#_workload_resource_mapping[Example schema of the ClusterWorkloadResourceMapping resource].
-

--- a/modules/application-health-about.adoc
+++ b/modules/application-health-about.adoc
@@ -75,7 +75,7 @@ metadata:
   labels:
     test: health-check
   name: my-application
-...
+# ...
 spec:
   containers:
   - name: goproxy-app <1>
@@ -86,7 +86,7 @@ spec:
         command: <5>
         - cat
         - /tmp/healthy
-...
+# ...
 ----
 
 <1> The container name.
@@ -104,7 +104,7 @@ metadata:
   labels:
     test: health-check
   name: my-application
-...
+# ...
 spec:
   containers:
   - name: goproxy-app <1>
@@ -124,7 +124,7 @@ spec:
         port: 8080 <9>
       failureThreshold: 30 <10>
       periodSeconds: 10 <11>
-...
+# ...
 ----
 
 <1> The container name.
@@ -148,7 +148,7 @@ metadata:
   labels:
     test: health-check
   name: my-application
-...
+# ...
 spec:
   containers:
   - name: goproxy-app <1>
@@ -163,7 +163,7 @@ spec:
       periodSeconds: 10 <6>
       successThreshold: 1 <7>
       failureThreshold: 3 <8>
-...
+# ...
 ----
 
 <1> The container name.
@@ -180,9 +180,12 @@ spec:
 ----
 kind: Deployment
 apiVersion: apps/v1
-...
+metadata:
+  labels:
+    test: health-check
+  name: my-application
 spec:
-...
+# ...
   template:
     spec:
       containers:
@@ -204,7 +207,7 @@ spec:
             periodSeconds: 10
             successThreshold: 1
             failureThreshold: 3
-...
+# ...
 ----
 <1> The readiness probe.
 <2> The liveness probe.

--- a/modules/application-health-configuring.adoc
+++ b/modules/application-health-configuring.adoc
@@ -91,7 +91,7 @@ $ oc create -f <file-name>.yaml
 +
 [source,terminal]
 ----
-$ oc describe pod health-check
+$ oc describe pod my-application
 ----
 +
 .Example output

--- a/modules/deployments-ab-testing-lb.adoc
+++ b/modules/deployments-ab-testing-lb.adoc
@@ -76,11 +76,14 @@ $ oc edit route <route_name>
 .Example output
 [source,terminal]
 ----
-...
+apiVersion: route.openshift.io/v1
+kind: Route
+metadata:
 metadata:
   name: route-alternate-service
   annotations:
     haproxy.router.openshift.io/balance: roundrobin
+# ...
 spec:
   host: ab-example.my-project.my-domain
   to:
@@ -91,7 +94,7 @@ spec:
   - kind: Service
     name: ab-example-b
     weight: 15
-...
+# ...
 ----
 
 [id="deployments-ab-testing-lb-web_{context}"]
@@ -212,6 +215,10 @@ Not all routers may support multiple or weighted backends.
 [source,terminal]
 ----
 $ oc new-app openshift/deployment-example --name=ab-example-a --as-deployment-config=true --labels=ab-example=true --env=SUBTITLE\=shardA
+----
++
+[source,terminal]
+----
 $ oc delete svc/ab-example-a
 ----
 +
@@ -222,6 +229,10 @@ The application is deployed and a service is created. This is the first shard.
 [source,terminal]
 ----
 $ oc expose deployment ab-example-a --name=ab-example --selector=ab-example\=true
+----
++
+[source,terminal]
+----
 $ oc expose service ab-example
 ----
 
@@ -234,6 +245,10 @@ $ oc expose service ab-example
 $ oc new-app openshift/deployment-example:v2 \
     --name=ab-example-b --labels=ab-example=true \
     SUBTITLE="shard B" COLOR="red" --as-deployment-config=true
+----
++
+[source,terminal]
+----
 $ oc delete svc/ab-example-b
 ----
 

--- a/modules/deployments-accessing-private-repos.adoc
+++ b/modules/deployments-accessing-private-repos.adoc
@@ -12,7 +12,11 @@ You can add a secret to your `DeploymentConfig` object so that it can access ima
 
 . Create a new project.
 
-. From the *Workloads* page, create a secret that contains credentials for accessing a private image repository.
+. Navigate to *Workloads* -> *Secrets*. 
+
+. Create a secret that contains credentials for accessing a private image repository.
+
+. Navigate to *Workloads* -> *DeploymentConfigs*. 
 
 . Create a `DeploymentConfig` object.
 

--- a/modules/deployments-assigning-pods-to-nodes.adoc
+++ b/modules/deployments-assigning-pods-to-nodes.adoc
@@ -23,10 +23,13 @@ a `Pod` template:
 ----
 apiVersion: v1
 kind: Pod
+metadata:
+  name: my-pod
+# ...
 spec:
   nodeSelector:
     disktype: ssd
-...
+# ...
 ----
 +
 Pods created when the node selector is in place are assigned to nodes with the

--- a/modules/deployments-custom-strategy.adoc
+++ b/modules/deployments-custom-strategy.adoc
@@ -10,14 +10,22 @@ The custom strategy allows you to provide your own deployment behavior.
 .Example custom strategy definition
 [source,yaml]
 ----
-strategy:
-  type: Custom
-  customParams:
-    image: organization/strategy
-    command: [ "command", "arg1" ]
-    environment:
-      - name: ENV_1
-        value: VALUE_1
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: example-dc
+# ...
+spec:
+# ...
+  strategy:
+    type: Custom
+    customParams:
+      image: organization/strategy
+      command: [ "command", "arg1" ]
+      environment:
+        - name: ENV_1
+          value: VALUE_1
+
 ----
 
 In the above example, the `organization/strategy` container image provides the deployment behavior. The optional `command` array overrides any `CMD` directive specified in the image's `Dockerfile`. The optional environment variables provided are added to the execution environment of the strategy process.
@@ -42,18 +50,25 @@ Alternatively, use the `customParams` object to inject the custom deployment log
 
 [source,yaml]
 ----
-strategy:
-  type: Rolling
-  customParams:
-    command:
-    - /bin/sh
-    - -c
-    - |
-      set -e
-      openshift-deploy --until=50%
-      echo Halfway there
-      openshift-deploy
-      echo Complete
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: example-dc
+# ...
+spec:
+# ...
+  strategy:
+    type: Rolling
+    customParams:
+      command:
+      - /bin/sh
+      - -c
+      - |
+        set -e
+        openshift-deploy --until=50%
+        echo Halfway there
+        openshift-deploy
+        echo Complete
 ----
 
 This results in following deployment:

--- a/modules/deployments-exec-cmd-in-container.adoc
+++ b/modules/deployments-exec-cmd-in-container.adoc
@@ -14,29 +14,46 @@ You can add a command to a container, which modifies the container's startup beh
 +
 [source,yaml]
 ----
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: example-dc
+# ...
 spec:
-  containers:
-  - name: <container_name>
-    image: 'image'
-    command:
-      - '<command>'
-    args:
-      - '<argument_1>'
-      - '<argument_2>'
-      - '<argument_3>'
+  template:
+# ...
+    spec:
+     containers:
+     - name: <container_name>
+       image: 'image'
+       command:
+         - '<command>'
+       args:
+         - '<argument_1>'
+         - '<argument_2>'
+         - '<argument_3>'
 ----
 +
 For example, to execute the `java` command with the `-jar` and `/opt/app-root/springboots2idemo.jar` arguments:
 +
 [source,yaml]
 ----
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: example-dc
+# ...
 spec:
-  containers:
-  - name: example-spring-boot
-    image: 'image'
-    command:
-      - java
-    args:
-      - '-jar'
-      - /opt/app-root/springboots2idemo.jar
+  template:
+# ...
+    spec:
+      containers:
+        - name: example-spring-boot
+          image: 'image'
+          command:
+            - java
+          args:
+            - '-jar'
+            - /opt/app-root/springboots2idemo.jar
+# ...
 ----

--- a/modules/deployments-recreate-strategy.adoc
+++ b/modules/deployments-recreate-strategy.adoc
@@ -10,12 +10,19 @@ The recreate strategy has basic rollout behavior and supports lifecycle hooks fo
 .Example recreate strategy definition
 [source,yaml]
 ----
-strategy:
-  type: Recreate
-  recreateParams: <1>
-    pre: {} <2>
-    mid: {}
-    post: {}
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: hello-openshift
+# ...
+spec:
+# ...
+  strategy:
+    type: Recreate
+    recreateParams: <1>
+      pre: {} <2>
+      mid: {}
+      post: {}
 ----
 
 <1> `recreateParams` are optional.

--- a/modules/deployments-rolling-strategy.adoc
+++ b/modules/deployments-rolling-strategy.adoc
@@ -19,16 +19,23 @@ A rolling deployment means you have both old and new versions of your code runni
 .Example rolling strategy definition
 [source,yaml]
 ----
-strategy:
-  type: Rolling
-  rollingParams:
-    updatePeriodSeconds: 1 <1>
-    intervalSeconds: 1 <2>
-    timeoutSeconds: 120 <3>
-    maxSurge: "20%" <4>
-    maxUnavailable: "10%" <5>
-    pre: {} <6>
-    post: {}
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: example-dc
+# ...
+spec:
+# ...
+  strategy:
+    type: Rolling
+    rollingParams:
+      updatePeriodSeconds: 1 <1>
+      intervalSeconds: 1 <2>
+      timeoutSeconds: 120 <3>
+      maxSurge: "20%" <4>
+      maxUnavailable: "10%" <5>
+      pre: {} <6>
+     post: {}
 ----
 <1> The time to wait between individual pod updates. If unspecified, this value defaults to `1`.
 <2> The time to wait between polling the deployment status after update. If unspecified, this value defaults to `1`.

--- a/modules/deployments-running-pod-svc-acct.adoc
+++ b/modules/deployments-running-pod-svc-acct.adoc
@@ -21,7 +21,13 @@ $ oc edit dc/<deployment_config>
 +
 [source,yaml]
 ----
+apiVersion: apps.openshift.io/v1
+kind: DeploymentConfig
+metadata:
+  name: example-dc
+# ...
 spec:
+# ...
   securityContext: {}
   serviceAccount: <service_account>
   serviceAccountName: <service_account>

--- a/modules/deployments-setting-resources.adoc
+++ b/modules/deployments-setting-resources.adoc
@@ -21,12 +21,19 @@ You can also limit resource use by specifying resource limits as part of the dep
 +
 [source,yaml]
 ----
-type: "Recreate"
-resources:
-  limits:
-    cpu: "100m" <1>
-    memory: "256Mi" <2>
-    ephemeral-storage: "1Gi" <3>
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: hello-openshift
+# ...
+spec:
+# ...
+  type: "Recreate"
+  resources:
+    limits:
+      cpu: "100m" <1>
+      memory: "256Mi" <2>
+      ephemeral-storage: "1Gi" <3>
 ----
 <1> `cpu` is in CPU units: `100m` represents 0.1 CPU units (100 * 1e-3).
 <2> `memory` is in bytes: `256Mi` represents 268435456 bytes (256 * 2 ^ 20).
@@ -39,6 +46,13 @@ However, if a quota has been defined for your project, one of the following two 
 +
 [source,yaml]
 ----
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: hello-openshift
+# ...
+spec:
+# ...
   type: "Recreate"
   resources:
     requests: <1>

--- a/modules/deployments-triggers.adoc
+++ b/modules/deployments-triggers.adoc
@@ -26,8 +26,15 @@ If a config change trigger is defined on a `DeploymentConfig` object, the first 
 .Config change deployment trigger
 [source,yaml]
 ----
-triggers:
-  - type: "ConfigChange"
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: example-dc
+# ...
+spec:
+# ...
+  triggers:
+    - type: "ConfigChange"
 ----
 
 [discrete]
@@ -39,16 +46,23 @@ The image change trigger results in a new replication controller whenever the co
 .Image change deployment trigger
 [source,yaml]
 ----
-triggers:
-  - type: "ImageChange"
-    imageChangeParams:
-      automatic: true <1>
-      from:
-        kind: "ImageStreamTag"
-        name: "origin-ruby-sample:latest"
-        namespace: "myproject"
-      containerNames:
-        - "helloworld"
+kind: DeploymentConfig
+apiVersion: apps.openshift.io/v1
+metadata:
+  name: example-dc
+# ...
+spec:
+# ...
+  triggers:
+    - type: "ImageChange"
+      imageChangeParams:
+        automatic: true <1>
+        from:
+          kind: "ImageStreamTag"
+          name: "origin-ruby-sample:latest"
+          namespace: "myproject"
+        containerNames:
+          - "helloworld"
 ----
 <1> If the `imageChangeParams.automatic` field is set to `false`, the trigger is disabled.
 

--- a/modules/odc-adding-health-checks.adoc
+++ b/modules/odc-adding-health-checks.adoc
@@ -3,23 +3,23 @@
 // applications/application-health
 
 :_mod-docs-content-type: PROCEDURE
-[id="odc-adding-health-checks"]
+[id="odc-adding-health-checks_{context}"]
 = Adding health checks using the Developer perspective
 
-You can use the *Topology* view to add health checks to your deployed application.
+You can use the *Topology* view to add health checks to your deployed application. 
 
 .Prerequisites:
 * You have switched to the *Developer* perspective in the web console.
 * You have created and deployed an application on {product-title} using the *Developer* perspective.
 
 .Procedure
-. In the *Topology* view, click on the application node to see the side panel. If the container does not have health checks added to ensure the smooth running of your application, a *Health Checks* notification is displayed with a link to add health checks.
+. In the *Topology* view, click on the application node to see the side panel. If the container does not have health checks added, a *Health Checks* notification is displayed with a link to add health checks.
 . In the displayed notification, click the *Add Health Checks* link.
-. Alternatively, you can also click the *Actions* drop-down list and select *Add Health Checks*. Note that if the container already has health checks, you will see the *Edit Health Checks* option instead of the add option.
-. In the *Add Health Checks* form, if you have deployed multiple containers, use the *Container* drop-down list to ensure that the appropriate container is selected.
+. Alternatively, you can also click the *Actions* list and select *Add Health Checks*. Note that if the container already has health checks, you will see the *Edit Health Checks* option instead of the add option.
+. In the *Add Health Checks* form, if you have deployed multiple containers, use the *Container* list to ensure that the appropriate container is selected.
 . Click the required health probe links to add them to the container. Default data for the health checks is prepopulated. You can add the probes with the default data or further customize the values and then add them. For example, to add a Readiness probe that checks if your container is ready to handle requests:
 .. Click *Add Readiness Probe*, to see a form containing the parameters for the probe.
-.. Click the *Type* drop-down list to select the request type you want to add. For example, in this case, select *Container Command* to select the command that will be executed inside the container.
+.. Click the *Type* list to select the request type you want to add. For example, in this case, select *Container Command* to select the command that will be executed inside the container.
 .. In the *Command* field, add an argument `cat`, similarly, you can add multiple arguments for the check, for example, add another argument `/tmp/healthy`.
 .. Retain or modify the default values for the other parameters as required.
 +

--- a/modules/odc-editing-deployments.adoc
+++ b/modules/odc-editing-deployments.adoc
@@ -15,7 +15,8 @@ You can edit the deployment strategy, image settings, environment variables, and
 
 .Procedure
 
-. Navigate to the *Topology* view. Click on your application to see the *Details* panel.
+. Navigate to the *Topology* view. 
+. Click your application to see the *Details* panel.
 . In the *Actions* drop-down menu, select *Edit Deployment* to view the *Edit Deployment* page.
 . You can edit the following *Advanced options* for your deployment:
 .. Optional: You can pause rollouts by clicking *Pause rollouts*, and then selecting the *Pause rollouts for this deployment* checkbox.

--- a/modules/odc-image-vulnerabilities-breakdown.adoc
+++ b/modules/odc-image-vulnerabilities-breakdown.adoc
@@ -6,7 +6,7 @@
 [id="odc-image-vulnerabilities-breakdown_{context}"]
 = Image vulnerabilities breakdown
 
-In the developer perspective, the project dashboard shows the *Image Vulnerabilities* link in the *Status* section. Using this link, you can view the *Image Vulnerabilities breakdown* window, which includes details regarding vulnerable container images and fixable container images. The icon color indicates severity:
+In the *Developer* perspective, the project dashboard shows the *Image Vulnerabilities* link in the *Status* section. Using this link, you can view the *Image Vulnerabilities breakdown* window, which includes details regarding vulnerable container images and fixable container images. The icon color indicates severity:
 
 * Red: High priority. Fix immediately.
 * Orange: Medium priority. Can be fixed after high-priority vulnerabilities.

--- a/modules/odc-importing-codebase-from-git-to-create-application.adoc
+++ b/modules/odc-importing-codebase-from-git-to-create-application.adoc
@@ -81,7 +81,8 @@ The *Add pipeline* checkbox is checked and *Configure PAC* is selected by defaul
 If your application does not expose its data on the default public port, 80, clear the check box, and set the target port number you want to expose.
 
 . Optional: You can use the following advanced options to further customize your application:
-
++
+--
 include::snippets/routing-odc.adoc[]
 include::snippets/serverless-domain-mapping-odc.adoc[]
 
@@ -108,5 +109,6 @@ Click the *Resource Limit* link to set the amount of *CPU* and *Memory* resource
 
 Labels::
 Click the *Labels* link to add custom labels to your application.
+--
 
 . Click *Create* to create the application and a success notification is displayed. You can see the build status of the application in the *Topology* view.

--- a/modules/odc-monitoring-application-health-using-developer-perspective.adoc
+++ b/modules/odc-monitoring-application-health-using-developer-perspective.adoc
@@ -2,7 +2,7 @@
 //
 // applications/application-health
 
-[id="odc-monitoring-application-health-using-developer-perspective"]
+[id="odc-monitoring-application-health-using-developer-perspective_{context}"]
 = Monitoring application health using the Developer perspective
 
 You can use the *Developer* perspective to add three types of health probes to your container to ensure that your application is healthy:

--- a/modules/odc-monitoring-your-project-metrics.adoc
+++ b/modules/odc-monitoring-your-project-metrics.adoc
@@ -10,7 +10,7 @@ After you create applications in your project and deploy them, you can use the *
 
 .Procedure
 
-. On the left navigation panel of the *Developer* perspective, click *Observe* to see the *Dashboard*, *Metrics*, *Alerts*, and *Events* for your project.
+. Go to *Observe* to see the *Dashboard*, *Metrics*, *Alerts*, and *Events* for your project.
 +
 . Optional: Use the *Dashboard* tab to see graphs depicting the following application metrics:
 +

--- a/modules/odc-starting-recreate-deployment.adoc
+++ b/modules/odc-starting-recreate-deployment.adoc
@@ -16,6 +16,7 @@ You can switch the deployment strategy from the default rolling update to a recr
 
 To switch to a recreate update strategy and to upgrade an application:
 
+. Click your application to see the *Details* panel.
 . In the *Actions* drop-down menu, select *Edit Deployment Config* to see the deployment configuration details of the application.
 . In the YAML editor, change the `spec.strategy.type` to `Recreate` and click *Save*.
 . In the *Topology* view, select the node to see the *Overview* tab in the side panel. The *Update Strategy* is now set to *Recreate*.

--- a/modules/odc-starting-rolling-deployment.adoc
+++ b/modules/odc-starting-rolling-deployment.adoc
@@ -15,7 +15,7 @@ You can upgrade an application by starting a rolling deployment.
 
 .Procedure
 
-. In the *Topology* view of the *Developer* perspective, click on the application node to see the *Overview* tab in the side panel. Note that the *Update Strategy* is set to the default *Rolling* strategy.
+. In the *Topology* view, click the application node to see the *Overview* tab in the side panel. Note that the *Update Strategy* is set to the default *Rolling* strategy.
 . In the *Actions* drop-down menu, select *Start Rollout* to start a rolling update. The rolling deployment spins up the new version of the application and then terminates the old one.
 +
 .Rolling update

--- a/modules/quotas-requiring-explicit-quota.adoc
+++ b/modules/quotas-requiring-explicit-quota.adoc
@@ -115,7 +115,7 @@ $ oc edit project.config.openshift.io/cluster
 apiVersion: config.openshift.io/v1
 kind: Project
 metadata:
-  ...
+#  ...
 spec:
   projectRequestTemplate:
     name: project-request

--- a/modules/sbo-connecting-spring-petclinic-sample-app-to-postgresql-database-service.adoc
+++ b/modules/sbo-connecting-spring-petclinic-sample-app-to-postgresql-database-service.adoc
@@ -1,6 +1,10 @@
-= Connecting the Spring PetClinic sample application to the PostgreSQL database service
+// Module included in the following assemblies:
+//
+// * /applications/connecting_applications_to_services/getting-started-with-service-binding.adoc
+
 :_mod-docs-content-type: PROCEDURE
 [id="sbo-connecting-spring-petclinic-sample-app-to-postgresql-database-service_{context}"]
+= Connecting the Spring PetClinic sample application to the PostgreSQL database service
 
 To connect the sample application to the database service, you must create a `ServiceBinding` custom resource (CR) that triggers the {servicebinding-title} to project the binding data into the application.
 

--- a/modules/setting-resource-quota-for-extended-resources.adoc
+++ b/modules/setting-resource-quota-for-extended-resources.adoc
@@ -30,12 +30,7 @@ Allocatable:
 +
 In this example, 2 GPUs are available.
 
-. Set a quota in the namespace `nvidia`. In this example, the quota is `1`:
-+
-[source,terminal]
-----
-# cat gpu-quota.yaml
-----
+. Create a `ResourceQuota` object to set a quota in the namespace `nvidia`. In this example, the quota is `1`:
 +
 .Example output
 [source,terminal]


### PR DESCRIPTION
Fixing various errors in the Applications docs as I find them during the ROSA content port. Mostly formatting, wording, and such.

[Understanding health checks](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/application-health#application-health-about_application-health) -- Added `# ...` and metadata to Example Probes code blocks.
 [Configuring health checks using the CLI](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/application-health#application-health-configuring_application-health) -- Updated the command in Step 3 to match the name in the Step 1 pod spec.
[Load balancing for A/B testing](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/route-based-deployment-strategies.html#deployments-ab-testing-lb_route-based-deployment-strategies) -- Added metadata and `# ... ` to code blocks. Split code blocks with two commands (in One service, multiple Deployment objects). [Current docs](https://docs.openshift.com/rosa/applications/deployments/route-based-deployment-strategies.html#deployments-ab-one-service-multi-dc_route-based-deployment-strategies).
[Accessing private repositories from DeploymentConfig objects](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/managing-deployment-processes#deployments-accessing-private-repos_deployment-operations) -- Updated procedure to add better details of how to do each step. No QE. 
[Assigning pods to specific nodes](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/managing-deployment-processes#deployments-assigning-pods-to-nodes_deployment-operations) -- Added `# ...`to code block. 
[Using Deployment Strategies -> Custom strategy](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/deployment-strategies#deployments-custom-strategy_recreate-strategy) -- Added `# ...`and metadata to code blocks.
[Executing commands inside a container](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/managing-deployment-processes#deployments-exe-cmd-in-container_deployment-operations) -- Added `# ...`and metadata to code blocks.
[Using Deployment Strategies -> Recreate strategy](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/deployment-strategies#deployments-recreate-strategy_rolling-strategy) -- Added `# ...`and metadata to code blocks.
[Using Deployment Strategies -> Rolling strategy](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/deployment-strategies#deployments-rolling-strategy_deployment-strategies) -- Added `# ...`and metadata to code blocks.
[Running a pod with a different service account](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/managing-deployment-processes#deployments-running-pod-svc-acct_deployment-operations) -- Added `# ...`and metadata to code blocks.
[Setting deployment resources](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/managing-deployment-processes#deployments-setting-resources_deployment-operations) -- Added `# ...`and metadata to code blocks.
[Deployment triggers](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/managing-deployment-processes#deployments-triggers_deployment-operations) -- Added `# ...`and metadata to code blocks.
Adding health checks using the Developer perspective -- Various edits
[Editing a deployment by using the Developer perspective](Editing a deployment by using the Developer perspective) -- Split Step 1 into two steps.
[Image vulnerabilities breakdown](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective#odc-image-vulnerabilities-breakdown_monitoring-project-and-application-metrics-using-developer-perspective) -- Added markup for web console reference.
[Importing a codebase from Git to create an application](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/creating_applications/odc-creating-applications-using-developer-perspective) -- Fixed formatting in Step 11. [Current docs](https://docs.openshift.com/rosa/applications/creating_applications/odc-creating-applications-using-developer-perspective.html#odc-importing-codebase-from-git-to-create-application_odc-creating-applications-using-developer-perspective). 
Monitoring application health using the Developer perspective -- Added [`_context` to ID string](https://github.com/openshift/openshift-docs/pull/65125/files#diff-2d54ccd21bd1a51370c28e5fca6aafe0823cd6136378e7c1a17b2d724548cff1). No preview.
[Monitoring health check failures using the Developer perspective](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/application-health#odc-monitoring-health-checks) -- s/click on/click.
[Monitoring your project metrics](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/odc-monitoring-project-and-application-metrics-using-developer-perspective#odc-monitoring-your-project-metrics_monitoring-project-and-application-metrics-using-developer-perspective) -- Minimalism and consistency change to Step 1.
[Starting a recreate deployment using the Developer perspective](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/deployment-strategies#odc-starting-recreate-deployment_recreate-strategy) -- Added Step 1.
[Starting a rolling deployment using the Developer perspective](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/deployments/deployment-strategies#odc-starting-rolling-deployment_rolling-strategy) -- Removed _Developer perspective_ from Step 1, as being in the Developer perspective is a prereq.
[Configuring explicit resource quotas](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/quotas/quotas-setting-per-project#configuring-explicit-resource-quotas_quotas-setting-per-project) -- Added `# ...` to Step 2b code block.
[Connecting the Spring PetClinic sample application to the PostgreSQL database service](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/connecting_applications_to_services/getting-started-with-service-binding#connecting-the-spring-petclinic-sample-application-to-the-postgresql-database-service) -- 
[Setting resource quota for extended resources](https://65125--ocpdocs-pr.netlify.app/openshift-enterprise/latest/applications/quotas/quotas-setting-per-project#setting-resource-quota-for-extended-resources_quotas-setting-per-project) -- Rewrote Step 2. [Current docs](https://docs.openshift.com/rosa/applications/quotas/quotas-setting-per-project.html#setting-resource-quota-for-extended-resources_quotas-setting-per-project). 

See also [Application fixes part 1](https://github.com/openshift/openshift-docs/pull/64699)