### PR TITLE
OSDOCS-7854: Remove registry config for OSD/ROSA

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -301,8 +301,8 @@ Topics:
   File: configuring-registry-operator
 - Name: Accessing the registry
   File: accessing-the-registry
-- Name: Exposing the registry
-  File: securing-exposing-registry
+# - Name: Exposing the registry
+#   File: securing-exposing-registry
 ---
 Name: Networking
 Dir: networking

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -404,7 +404,7 @@ Topics:
 ---
 Name: Registry
 Dir: registry
-Distros: openshift-rosa-portal
+Distros: openshift-rosa,openshift-rosa-portal
 Topics:
 - Name: Registry overview
   File: index
@@ -412,8 +412,8 @@ Topics:
   File: configuring-registry-operator
 - Name: Accessing the registry
   File: accessing-the-registry
-- Name: Exposing the registry
-  File: securing-exposing-registry
+# - Name: Exposing the registry
+#   File: securing-exposing-registry
 ---
 Name: Networking
 Dir: networking

--- a/modules/registry-checking-the-status-of-registry-pods.adoc
+++ b/modules/registry-checking-the-status-of-registry-pods.adoc
@@ -6,15 +6,26 @@
 [id="checking-the-status-of-registry-pods_{context}"]
 = Checking the status of the registry pods
 
-As a cluster administrator, you can list the image registry pods running in the `openshift-image-registry` project and check their status.
+ifndef::openshift-dedicated,openshift-rosa[]
+As a cluster administrator,
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+As an administrator with the `dedicated-admin` role,
+endif::openshift-dedicated,openshift-rosa[]
+you can list the image registry pods running in the `openshift-image-registry` project and check their status.
 
 .Prerequisites
 
+ifndef::openshift-dedicated,openshift-rosa[]
 * You have access to the cluster as a user with the `cluster-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
+ifdef::openshift-dedicated,openshift-rosa[]
+* You have access to the cluster as a user with the `dedicated-admin` role.
+endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 
-. List the pods in the `openshift-image-registry` project and view their status:
+* List the pods in the `openshift-image-registry` project and view their status:
 +
 [source,terminal]
 ----

--- a/modules/registry-viewing-logs.adoc
+++ b/modules/registry-viewing-logs.adoc
@@ -10,7 +10,7 @@ You can view the logs for the registry by using the `oc logs` command.
 
 .Procedure
 
-. Use the `oc logs` command with deployments to view the logs for the container
+* Use the `oc logs` command with deployments to view the logs for the container
 image registry:
 +
 [source,terminal]

--- a/registry/accessing-the-registry.adoc
+++ b/registry/accessing-the-registry.adoc
@@ -6,6 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 Use the following sections for instructions on accessing the registry, including
 viewing logs and metrics, as well as securing and exposing the registry.
 
@@ -14,10 +15,16 @@ you to push images to or pull them from the integrated registry directly using
 operations like `podman push` or `podman pull`. To do so, you must be logged in
 to the registry using the `podman login` command. The operations you can perform
 depend on your user permissions, as described in the following sections.
+endif::openshift-dedicated,openshift-rosa[]
 
+ifdef::openshift-dedicated,openshift-rosa[]
+In {product-title}, Red Hat Site Reliability Engineering (SRE) manages the registry for you. However, you can check the status of the registry pods and view the registry logs.
+endif::openshift-dedicated,openshift-rosa[]
+
+ifndef::openshift-dedicated,openshift-rosa[]
 == Prerequisites
 
-* You have access to the cluster as a user with the cluster-admin role.
+* You have access to the cluster as a user with the `cluster-admin` role.
 * You must have configured an identity provider (IDP).
 * For pulling images, for example when using the `podman pull` command,
 the user must have the `registry-viewer` role. To add this role, run the following command:
@@ -36,17 +43,19 @@ $ oc policy add-role-to-user registry-editor <user_name>
 ----
 +
 ** Your cluster must have an existing project where the images can be pushed to.
+endif::openshift-dedicated,openshift-rosa[]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/registry-accessing-directly.adoc[leveloffset=+1]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/registry-checking-the-status-of-registry-pods.adoc[leveloffset=+1]
 
 include::modules/registry-viewing-logs.adoc[leveloffset=+1]
 
+ifndef::openshift-dedicated,openshift-rosa[]
 include::modules/registry-accessing-metrics.adoc[leveloffset=+1]
 
-// These additional resources may be relevant to OSD/ROSA, but they xref topics that don't currently exist in the OSD/ROSA distros.
-ifndef::openshift-dedicated,openshift-rosa[]
 [id="accessing-the-registry-additional-resources"]
 [role="_additional-resources"]
 == Additional resources

--- a/registry/configuring-registry-operator.adoc
+++ b/registry/configuring-registry-operator.adoc
@@ -31,6 +31,7 @@ If insufficient information is available to define a complete `configs.imageregi
 
 The Image Registry Operator runs in the `openshift-image-registry` namespace, and manages the registry instance in that location as well. All configuration and workload resources for the registry reside in that namespace.
 
+ifndef::openshift-dedicated,openshift-rosa[]
 [IMPORTANT]
 ====
 The Image Registry Operator's behavior for managing the pruner is orthogonal to the `managementState` specified on the `ClusterOperator` object for the Image Registry Operator. If the Image Registry Operator is not in the `Managed` state, the image pruner can still be configured and managed by the `Pruning` custom resource.
@@ -40,22 +41,22 @@ However, the `managementState` of the Image Registry Operator alters the behavio
 * `Managed`: the `--prune-registry` flag for the image pruner is set to `true`.
 * `Removed`: the `--prune-registry` flag for the image pruner is set to `false`, meaning it only prunes image metatdata in etcd.
 ====
+endif::openshift-dedicated,openshift-rosa[]
 
 ifndef::openshift-dedicated,openshift-rosa[]
 [id="image-registry-on-bare-metal-vsphere"]
 == Image Registry on bare metal, Nutanix, and vSphere
 
 include::modules/registry-removed.adoc[leveloffset=+2]
-endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/registry-operator-distribution-across-availability-zones.adoc[leveloffset=+1]
 
-ifndef::openshift-dedicated,openshift-rosa,openshift-rosa-portal[]
+ifndef::openshift-rosa-portal[]
 [role="_additional-resources"]
 == Additional resources
 
 * xref:../nodes/scheduling/nodes-scheduler-pod-topology-spread-constraints.adoc#nodes-scheduler-pod-topology-spread-constraints[Configuring pod topology spread constraints]
-endif::openshift-dedicated,openshift-rosa,openshift-rosa-portal[]
+endif::openshift-rosa-portal[]
 
 include::modules/registry-operator-configuration-resource-overview.adoc[leveloffset=+1]
 
@@ -65,7 +66,6 @@ include::modules/images-configuration-cas.adoc[leveloffset=+1]
 
 include::modules/registry-operator-config-resources-storage-credentials.adoc[leveloffset=+1]
 
-ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 == Additional resources
 


### PR DESCRIPTION
Update the Registry book to condition-out the registry configuration content from OSD and ROSA. The content is unchanged for OCP.

Version(s):
* `enterprise-4.12`
* `enterprise-4.13`
* `main`

Issue:
[OSDOCS-7854](https://issues.redhat.com/browse/OSDOCS-7854)

Link to docs preview:
* OCP: https://65135--docspreview.netlify.app/openshift-enterprise/latest/registry/
* OSD: https://65135--docspreview.netlify.app/openshift-dedicated/latest/registry/
* ROSA: https://65135--docspreview.netlify.app/openshift-rosa/latest/registry/

QE review:
- [ ] QE has approved this change.
