### PR TITLE
OBSDOCS-540: "FluentD Buffer Availability" chart description is incorrect

### DIFF
--- a/modules/cluster-logging-dashboards-logging.adoc
+++ b/modules/cluster-logging-dashboards-logging.adoc
@@ -64,8 +64,8 @@ Fetch latency typically takes less time than query latency. If fetch latency is 
 |FluentD emit count
 |The total number of Fluentd messages per second for the Fluentd default output, and the retry count for the default output.
 
-|FluentD Buffer Availability
-|The percent of the Fluentd buffer that is available for chunks. A full buffer might indicate that Fluentd is not able to process the number of logs received.
+|FluentD Buffer Usage
+|The percent of the Fluentd buffer that is being used for chunks. A full buffer might indicate that Fluentd is not able to process the number of logs received.
 
 |Elastic rx bytes
 |The total number of bytes that Elasticsearch has received from FluentD, the Elasticsearch nodes, and other sources.


### PR DESCRIPTION
FluentD Buffer Availability chart shows us the usage of the buffer, not availability. We change the description and chart title according to the buffer usage chart.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

OpenShift Logging 5.7+
OpenShift 4.x

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

The chart name and description are not matched with current buffer usage chart.

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
N/A

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

This changes should be applied after merging this PR, https://github.com/openshift/cluster-logging-operator/pull/2172