### PR TITLE
TELCODOCS-277: Added ValidatingWebhooks release note for the BMH CR.

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -110,6 +110,10 @@ After you have deployed your cluster to run nodes with static IP addresses, you 
 
 For more information, see the "Static IP addresses for vSphere nodes" section in the xref:../installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc[Installing a cluster on vSphere] document.
 
+[id="ocp-4-14-bmo-validations"]
+==== Additional validation for the Bare Metal Host CR
+
+The Bare Metal Host Custom Resource (CR) now contains the `ValidatingWebhooks` parameter. With this parameter, the Bare Metal Operator now catches any configuration errors before accepting the CR, and returns a message with the configuration errors to the user.
 
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration


### PR DESCRIPTION
Adds a release note about the addition of the `ValidatingWebhooks` parameter to the Bare Metal Host CR. There is no additional documentation required, so no link to any additional content.

Version(s): 4.14

Issue: https://issues.redhat.com/browse/TELCODOCS-277

Link to docs preview: http://184.23.213.161:8080/TELCODOCS-277-4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-bmo-validations

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
