### PR TITLE
[RHACS] Matched service description with Architecture description.

### DIFF
--- a/modules/acscs-architecture-overview.adoc
+++ b/modules/acscs-architecture-overview.adoc
@@ -14,4 +14,10 @@ You can also integrate it with your existing DevOps tools and workflows to impro
 .{product-title-managed-short} architecture
 image::acscs-architecture.png[{product-title-managed-short}]
 
-{product-title-managed-short} consists of a control plane called Central, which Red Hat manages, and secured cluster services, which you install and manage on each cluster you want to protect.
+Central services include the user interface (UI), data storage, {product-title-short} application programming interface (API), and image scanning capabilities.
+You deploy your Central service through the link:https://console.redhat.com/[Red Hat Hybrid Cloud Console.] When you create a new ACS instance, Red Hat creates your individual control plane for {product-title-short}.
+
+{product-title-managed-short} allows you to secure self-managed clusters that communicate with a Central instance.
+The clusters you secure, called Secured Clusters, are managed by you, and not by Red Hat.
+Secured Cluster services include optional vulnerability scanning services, admission control services, and data collection services used for runtime monitoring and compliance.
+You install Secured Cluster services on any OpenShift or Kubernetes cluster you want to secure.


### PR DESCRIPTION
Updated the description to match the existing description at https://docs.openshift.com/acs/4.2/cloud_service/rhacs-cloud-service-service-description.html#introduction-to-rhacs_access-policy-service-description

Preview: https://65157--docspreview.netlify.app/openshift-acs/latest/architecture/acscs-architecture

- cherrypick in `rhacs-docs-4.2`