### PR TITLE
OSDOCS#7888: Document support for the enable-certificate-owner-ref flag

### DIFF
--- a/modules/cert-manager-override-flag-controller.adoc
+++ b/modules/cert-manager-override-flag-controller.adoc
@@ -1,0 +1,84 @@
+// Module included in the following assemblies:
+//
+// * security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
+
+:_content-type: PROCEDURE
+[id="cert-manager-override-flag-controller_{context}"]
+= Deleting a TLS secret automatically upon Certificate removal
+
+You can enable the `--enable-certificate-owner-ref` flag for the {cert-manager-operator} by adding a `spec.controllerConfig` section in the `CertManager` resource. The `--enable-certificate-owner-ref` flag sets the certificate resource as an owner of the secret where the TLS certificate is stored.
++
+[WARNING]
+====
+If you uninstall the {cert-manager-operator} or delete certificate resources from the cluster, the secret is deleted automatically. This might cause network connectivity issues depending upon where the certificate TLS secret is being used.
+====
+
+.Prerequisites
+
+* You have access to the {product-title} cluster as a user with the `cluster-admin` role.
+* You have installed the {cert-manager-operator} 1.12.0 or later.
+
+
+.Procedure
+
+. Check that the `Certificate` object and its secret are available by running the following command:
++
+[source,terminal]
+----
+$ oc get certificate
+----
++
+.Example output
+[source,terminal]
+----
+NAME                                             READY   SECRET                                           AGE
+certificate-from-clusterissuer-route53-ambient   True    certificate-from-clusterissuer-route53-ambient   8h
+----
+
+. Edit the `CertManager` resource by running the following command:
++
+[source,terminal]
+----
+$ oc edit certmanager cluster
+----
+
+. Add a `spec.controllerConfig` section with the following override arguments:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: CertManager
+metadata:
+  name: cluster
+# ...
+spec:
+# ...
+  controllerConfig:
+    overrideArgs:
+      - '--enable-certificate-owner-ref'
+----
+
+. Save your changes and quit the text editor to apply your changes.
+
+.Verification
+
+* Verify that the `--enable-certificate-owner-ref` flag is updated for cert-manager controller pod by running the following command:
++
+[source,terminal]
+----
+$ oc get pods -l app.kubernetes.io/name=cert-manager -n cert-manager -o yaml
+----
++
+.Example output
+[source,yaml]
+----
+# ...
+  metadata:
+    name: cert-manager-6e4b4d7d97-zmdnb
+    namespace: cert-manager
+# ...
+  spec:
+    containers:
+    - args:
+      - --enable-certificate-owner-ref
+----

--- a/security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
+++ b/security/cert_manager_operator/cert-manager-customizing-api-fields.adoc
@@ -16,3 +16,5 @@ To override unsupported arguments, you can add `spec.unsupportedConfigOverrides`
 include::modules/cert-manager-override-environment-variables.adoc[leveloffset=+1]
 
 include::modules/cert-manager-override-arguments.adoc[leveloffset=+1]
+
+include::modules/cert-manager-override-flag-controller.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-7888
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://65158--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-customizing-api-fields#cert-manager-override-flag-controller_cert-manager-customizing-api-fields
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

SME review:
- [x] SME has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
