### PR TITLE
[enterprise-4.14] OCPBUGS-18561-dup-fix

### DIFF
--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -25,11 +25,17 @@ endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :ash:
 endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:vsphere-upi-vsphere:
+endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :restricted-upi:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :restricted:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:vsphere-upi:
 endif::[]
 ifeval::["{context}" == "installing-aws-china-region"]
 :aws-china:
@@ -64,20 +70,14 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-power-vs-private-cluster"]
 :ibm-power-vs-private:
 endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:vsphere-upi-vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:vsphere-upi:
-endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-initializing-manual_{context}"]
 = Manually creating the installation configuration file
 
-ifndef::aws-china,aws-gov,aws-secret,azure-gov,ash,aws-private,azure-private,gcp-private,gcp-shared,ash-default,ash-network,ibm-cloud-private,ibm-power-vs-private[]
+ifdef::restricted,vsphere-upi-vsphere[]
 For user-provisioned installations of {product-title}, you manually generate your installation configuration file.
-endif::aws-china,aws-gov,aws-secret,azure-gov,ash,aws-private,azure-private,gcp-private,gcp-shared,ash-default,ash-network,ibm-cloud-private,ibm-power-vs-private[]
+endif::restricted,vsphere-upi-vsphere[]
 ifdef::vsphere-upi,restricted-upi[]
 For user-provisioned installations of {product-title}, you manually generate your installation configuration file.
 
@@ -227,11 +227,17 @@ endif::[]
 ifeval::["{context}" == "installing-azure-stack-hub-user-infra"]
 :!ash:
 endif::[]
+ifeval::["{context}" == "installing-vsphere"]
+:!vsphere-upi-vsphere:
+endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
-:!restricted:
+:!restricted-upi:
 endif::[]
 ifeval::["{context}" == "installing-restricted-networks-bare-metal"]
 :!restricted:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!vsphere-upi:
 endif::[]
 ifeval::["{context}" == "installing-aws-china-region"]
 :!aws-china:
@@ -265,11 +271,5 @@ ifeval::["{context}" == "installing-ibm-cloud-private"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-power-vs-private-cluster"]
 :!ibm-power-vs-private:
-endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:vsphere-upi-vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:vsphere-upi:
 endif::[]
 :!platform:

--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -30,10 +30,6 @@
 // * installing/installing_openstack/installing-openstack-installer-kuryr.adoc
 // * installing/installing_openstack/installing-openstack-installer-restricted.adoc
 // * installing/installing_openstack/installing-openstack-installer.adoc
-// * installing/installing_vmc/installing-vmc.adoc
-// * installing/installing_vmc/installing-vmc-network-customizations.adoc
-// * installing/installing_vmc/installing-vmc-customizations.adoc
-// * installing/installing_vmc/installing-restricted-networks-vmc.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations.adoc
 // * installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations.adoc


### PR DESCRIPTION
Fix ifeval statements as duplicate line in UPI files:

![Screenshot from 2023-09-25 11-37-56](https://github.com/openshift/openshift-docs/assets/57954076/df67b556-f838-478f-9d59-e7d13e7df3af)

Also, removed some missed VMC references, as VMC doc set drops from 4.14. See https://github.com/openshift/openshift-docs/pull/60614

[OCPBUGS-18561](https://issues.redhat.com/browse/OCPBUGS-18561)

Version(s):
4.14

Link to docs preview:
* [Installing a cluster on vSphere with user-provisioned infrastructure](https://65159--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere#installation-initializing-manual_installing-vsphere)
* [Installing a cluster on vSphere with network customizations](https://65159--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations#installation-initializing-manual_installing-vsphere-network-customizations)
* [Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure](https://65159--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere#installation-initializing-manual_installing-restricted-networks-vsphere)
* [Installing a user-provisioned bare metal cluster on a restricted network](https://65159--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal#installation-initializing-manual_installing-restricted-networks-bare-metal)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
