### PR TITLE
[enterprise-4.11] OCPBUGS#18560: Added important vSphere note about AD username integra…

### DIFF
--- a/modules/installation-launching-installer.adoc
+++ b/modules/installation-launching-installer.adoc
@@ -366,6 +366,15 @@ ifdef::vsphere,vmc[]
 .. Specify the user name and password for the vCenter account that has the required permissions to create the cluster.
 +
 The installation program connects to your vCenter instance.
++
+[IMPORTANT]
+====
+Some VMware vCenter Single Sign-On (SSO) environments with Active Directory (AD) integration might primarily require you to use the traditional login method, which requires the `<domain>\` construct.
+
+To ensure that vCenter account permission checks complete properly, consider using the User Principal Name (UPN) login method, such as `<username>@<fully_qualified_domainname>`.
+====
++
+.. Select the data center in your vCenter instance to connect to.
 .. Select the datacenter in your vCenter instance to connect to.
 .. Select the default vCenter datastore to use.
 +


### PR DESCRIPTION
Cherry-picked from #64480 commit f61807b1a5eefdd841989615e6a7608408c16638

[OCPBUGS-18560](https://issues.redhat.com/browse/OCPBUGS-18560)

Version(s):
4.11

Link to docs preview:
[Deploying the cluster: step 2d](https://65160--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned#installation-launching-installer_installing-vsphere-installer-provisioned)