### PR TITLE
TELCODOCS-1489: Align GitOps Operator version

### DIFF
--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -24,7 +24,7 @@ The Red Hat Telco Radio Access Network (RAN) version {product-version} solution 
 |2.7
 
 |{gitops-title}
-|1.6
+|1.9
 
 |{cgu-operator-first}
 |4.11, 4.12, or 4.13


### PR DESCRIPTION
[TELCODOCS-1489](https://issues.redhat.com//browse/TELCODOCS-1489): Version of GitOps Operator validated in 4.12+ is 1.9, not 1.6. 

Correct versions already here in the docs:
[Gitops compatibility and support matrix 4.12](https://docs.openshift.com/container-platform/4.12/cicd/gitops/gitops-release-notes.html#GitOps-compatibility-support-matrix_gitops-release-notes)

[Gitops compatibility and support matrix 4.13](https://docs.openshift.com/container-platform/4.13/cicd/gitops/gitops-release-notes.html#GitOps-compatibility-support-matrix_gitops-release-notes)

...just missed the update in the update table in this PR.

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/TELCODOCS-1489

Link to docs preview:
https://65164--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.html#ztp-telco-ran-software-versions_ztp-preparing-the-hub-cluster

Typo QE not needed.