### PR TITLE
[MULTIARCH-3485] Single Node Cluster Support (SNO) for P

### DIFF
--- a/installing/installing_sno/install-sno-installing-sno.adoc
+++ b/installing/installing_sno/install-sno-installing-sno.adoc
@@ -10,6 +10,7 @@ You can install {sno} using the web-based Assisted Installer and a discovery ISO
 
 ifndef::openshift-origin[]
 
+[id="installing-sno-assisted-installer"]
 == Installing {sno} using the Assisted Installer
 
 To install {product-title} on a single node, use the web-based Assisted Installer wizard to guide you through the process and manage the installation.
@@ -78,7 +79,7 @@ include::modules/creating-custom-live-rhcos-iso.adoc[leveloffset=+1]
 
 == Installing {sno} with {ibmzProductName} and {linuxoneProductName}
 
-Installing a single node cluster on {ibmzProductName} and {linuxoneProductName} requires user-provisioned installation using either the "Installing a cluster with {op-system-base} KVM on {ibmzProductName} and {linuxoneProductName}" or the "Installing a cluster with z/VM on {ibmzProductName} and {linuxoneProductName}" procedure.
+Installing a single-node cluster on {ibmzProductName} and {linuxoneProductName} requires user-provisioned installation using either the "Installing a cluster with {op-system-base} KVM on {ibmzProductName} and {linuxoneProductName}" or the "Installing a cluster with z/VM on {ibmzProductName} and {linuxoneProductName}" procedure.
 
 [NOTE]
 ====
@@ -106,3 +107,33 @@ You can use dedicated or shared IFLs to assign sufficient compute resources. Res
 include::modules/install-sno-ibm-z.adoc[leveloffset=+2]
 
 include::modules/install-sno-ibm-z-kvm.adoc[leveloffset=+2]
+
+[id="installing-sno-with-ibmpower"]
+== Installing {sno} with {ibmpowerProductName}
+
+Installing a single-node cluster on {ibmpowerProductName} requires user-provisioned installation using the "Installing a cluster with {ibmpowerProductName}" procedure.
+
+[NOTE]
+====
+Installing a single-node cluster on {ibmpowerProductName} simplifies installation for development and test environments and requires less resource requirements at entry level.
+====
+
+[discrete]
+=== Hardware requirements
+
+* The equivalent of two Integrated Facilities for Linux (IFL), which are SMT2 enabled, for each cluster.
+* At least one network connection to connect to the `LoadBalancer` service and to serve data for traffic outside of the cluster.
+
+[NOTE]
+====
+You can use dedicated or shared IFLs to assign sufficient compute resources. Resource sharing is one of the key strengths of {ibmpowerProductName}. However, you must adjust capacity correctly on each hypervisor layer and ensure sufficient resources for every {product-title} cluster.
+====
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_ibm_power/installing-ibm-power.adoc#installing-ibm-power[Installing a cluster on {ibmpowerProductName}]
+
+include::modules/setting-up-bastion-for-sno.adoc[leveloffset=+2]
+
+include::modules/install-sno-ibm-power.adoc[leveloffset=+2]

--- a/modules/install-sno-ibm-power.adoc
+++ b/modules/install-sno-ibm-power.adoc
@@ -1,0 +1,49 @@
+// This is included in the following assemblies:
+//
+// installing_sno/install-sno-installing-sno.adoc
+
+:_content-type: PROCEDURE
+[id="installing-sno-on-ibm-power_{context}"]
+= Installing {sno} with {ibmpowerProductName}
+
+.Prerequisites
+
+* You have set up bastion.
+
+.Procedure
+
+There are two steps for the {sno} cluster installation. First the {sno} logical partition (LPAR) needs to boot up with PXE, then you need to monitor the installation progress.
+
+. Use the following command to boot powerVM with netboot:
++
+[source,terminal]
+----
+$ lpar_netboot -i -D -f -t ent -m <sno_mac> -s auto -d auto -S <server_ip> -C <sno_ip> -G <gateway> <lpar_name> default_profile <cec_name>
+----
++
+where:
++
+--
+sno_mac:: Specifies the MAC address of the {sno} cluster.
+sno_ip:: Specifies the IP address of the {sno} cluster.
+server_ip:: Specifies the IP address of bastion (PXE server).
+gateway:: Specifies the Network's gateway IP.
+lpar_name:: Specifies the {sno} lpar name in HMC.
+cec_name:: Specifies the System name where the sno_lpar resides
+--
+
+. After the {sno} LPAR boots up with PXE, use the `openshift-install` command to monitor the progress of installation:
+
+.. Run the following command after the bootstrap is complete:
++
+[source,terminal]
+---- 
+./openshift-install wait-for bootstrap-complete
+----
+
+.. Run the following command after it returns successfully:
++
+[source,terminal]
+----
+./openshift-install wait-for install-complete
+----

--- a/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
+++ b/modules/install-sno-requirements-for-installing-on-a-single-node.adoc
@@ -8,7 +8,11 @@
 
 Installing {product-title} on a single node alleviates some of the requirements for high availability and large scale clusters. However, you must address the following requirements:
 
-* *Administration host:* You must have a computer to prepare the ISO, to create the USB boot drive, and to monitor the installation.
+* *Administration host:* You must have a computer to prepare the ISO, to create the USB boot drive, and to monitor the installation. 
+[NOTE]
+====
+For the `ppc64le` platform, the host should prepare the ISO, but does not need to create the USB boot drive. The ISO can be mounted to PowerVM directly.
+====
 
 [NOTE]
 ====
@@ -41,7 +45,7 @@ The server must have a Baseboard Management Controller (BMC) when booting with v
 
 [NOTE]
 ====
-BMC is not supported on {ibmzProductName}.
+BMC is not supported on {ibmzProductName} and {ibmpowerProductName}.
 ====
 
 * *Networking:* The server must have access to the internet or access to a local registry if it is not connected to a routable network. The server must have a DHCP reservation or a static IP address for the Kubernetes API, ingress route, and cluster node domain names. You must configure the DNS to resolve the IP address to each of the following fully qualified domain names (FQDN):

--- a/modules/installation-aws_con_installing-sno-on-aws.adoc
+++ b/modules/installation-aws_con_installing-sno-on-aws.adoc
@@ -6,4 +6,4 @@
 [id="installing-sno-on-aws_{context}"]
 = Installing {sno} on AWS
 
-Installing a single node cluster on AWS requires installer-provisioned installation using the "Installing a cluster on AWS with customizations" procedure.
+Installing a single-node cluster on AWS requires installer-provisioned installation using the "Installing a cluster on AWS with customizations" procedure.

--- a/modules/setting-up-bastion-for-sno.adoc
+++ b/modules/setting-up-bastion-for-sno.adoc
@@ -1,0 +1,183 @@
+// This module is included in the following assemblies:
+//
+// installing_sno/install-sno-installing-sno.adoc
+
+:_content-type: PROCEDURE
+[id="setting-up-bastion-for-sno_{context}"]
+= Setting up basion for {sno} with {ibmpowerProductName}
+
+Prior to installing {sno} on {ibmpowerProductName}, you must set up bastion. Setting up a bastion server for {sno} on {ibmpowerProductName} requires the configuration of the following services: 
+
+* PXE is used for the {sno} cluster installation. PXE requires the following services to be configured and run:
+** DNS to define api, api-int, and *.apps
+** DHCP service to enable PXE and assign an IP address to {sno} node
+** HTTP to provide ignition and {op-system} rootfs image
+** TFTP to enable PXE
+* You must install `dnsmasq` to support DNS, DHCP and PXE, httpd for HTTP.
+
+Use the following procedure to configure a bastion server that meets these requirements.
+
+.Procedure
+
+. Use the following command to install `grub2`, which is required to enable PXE for PowerVM:
++
+[source,terminal]
+----
+grub2-mknetdir --net-directory=/var/lib/tftpboot
+----
++
+.Example `/var/lib/tftpboot/boot/grub2/grub.cfg` file
+[source,terminal]
+----
+default=0
+fallback=1
+timeout=1
+if [ ${net_default_mac} == fa:b0:45:27:43:20 ]; then
+menuentry "CoreOS (BIOS)" {
+   echo "Loading kernel"
+   linux "/rhcos/kernel" ip=dhcp rd.neednet=1 ignition.platform.id=metal ignition.firstboot coreos.live.rootfs_url=http://192.168.10.5:8000/install/rootfs.img ignition.config.url=http://192.168.10.5:8000/ignition/sno.ign
+   echo "Loading initrd"
+   initrd  "/rhcos/initramfs.img"
+}
+fi
+----
+
+. Use the following commands to download {op-system} image files from the mirror repo for PXE.
+
+.. Enter the following command to assign the `RHCOS_URL` variable the follow 4.12 URL:
++
+[source,terminal]
+----
+$ export RHCOS_URL=https://mirror.openshift.com/pub/openshift-v4/ppc64le/dependencies/rhcos/4.12/latest/
+----
+
+.. Enter the following command to navigate to the `/var/lib/tftpboot/rhcos` directory:
++
+[source,terminal]
+----
+$ cd /var/lib/tftpboot/rhcos
+----
+
+.. Enter the following command to download the specified {op-system} kernel file from the URL stored in the `RHCOS_URL` variable:
++
+[source,terminal]
+----
+$ wget ${RHCOS_URL}/rhcos-live-kernel-ppc64le -o kernel
+----
+
+.. Enter the following command to download the {op-system} `initramfs` file from the URL stored in the `RHCOS_URL` variable:
++
+[source,terminal]
+----
+$ wget ${RHCOS_URL}/rhcos-live-initramfs.ppc64le.img -o initramfs.img
+----
+
+.. Enter the following command to navigate to the `/var//var/www/html/install/` directory:
++
+[source,terminal]
+----
+$ cd /var//var/www/html/install/
+----
+
+.. Enter the following command to download, and save, the {op-system} `root filesystem` image file from the URL stored in the `RHCOS_URL` variable:
++
+[source,terminal]
+----
+$ wget ${RHCOS_URL}/rhcos-live-rootfs.ppc64le.img -o rootfs.img
+----
+
+. To create the ignition file for a {sno} cluster, you must create the `install-config.yaml` file.
+
+.. Enter the following command to create the work directory that holds the file:
++
+[source,terminal]
+----
+$ mkdir -p ~/sno-work
+----
+
+.. Enter the following command to navigate to the `~/sno-work` directory:
++
+[source,terminal]
+----
+$ cd ~/sno-work
+----
+
+.. Use the following sample file can to create the required `install-config.yaml` in the `~/sno-work` directory:
++
+[source,yaml]
+----
+apiVersion: v1
+baseDomain: <domain> <1>
+compute:
+- name: worker
+  replicas: 0 <2>
+controlPlane:
+  name: master
+  replicas: 1 <3>
+metadata:
+  name: <name> <4>
+networking: <5>
+  clusterNetwork:
+  - cidr: 10.128.0.0/14
+    hostPrefix: 23
+  machineNetwork:
+  - cidr: 10.0.0.0/16 <6>
+  networkType: OVNKubernetes
+  serviceNetwork:
+  - 172.30.0.0/16
+platform:
+  none: {}
+bootstrapInPlace:
+  installationDisk: /dev/disk/by-id/<disk_id> <7>
+pullSecret: '<pull_secret>' <8>
+sshKey: |
+  <ssh_key> <9>
+----
+<1> Add the cluster domain name.
+<2> Set the `compute` replicas to `0`. This makes the control plane node schedulable.
+<3> Set the `controlPlane` replicas to `1`. In conjunction with the previous `compute` setting, this setting ensures that the cluster runs on a single node.
+<4> Set the `metadata` name to the cluster name.
+<5> Set the `networking` details. OVN-Kubernetes is the only allowed network plugin type for single-node clusters.
+<6> Set the `cidr` value to match the subnet of the {sno} cluster.
+<7> Set the path to the installation disk drive, for example, `/dev/disk/by-id/wwn-0x64cd98f04fde100024684cf3034da5c2`.
+<8> Copy the {cluster-manager-url-pull} and add the contents to this configuration setting.
+<9> Add the public SSH key from the administration host so that you can log in to the cluster after installation.
+
+. Download the `openshift-install` image to create the ignition file and copy it to the `http` directory.
+
+.. Enter the following command to download the `openshift-install-linux-4.12.0` .tar file:
++
+[source,terminal]
+----
+$ wget https://mirror.openshift.com/pub/openshift-v4/ppc64le/clients/ocp/4.12.0/openshift-install-linux-4.12.0.tar.gz
+----
+
+.. Enter the following command to unpack the `openshift-install-linux-4.12.0.tar.gz` archive:
++
+[source,terminal]
+----
+$ tar xzvf openshift-install-linux-4.12.0.tar.gz
+----
+
+.. Enter the following command to
++
+[source,terminal]
+----
+$ ./openshift-install --dir=~/sno-work create create single-node-ignition-config
+----
+
+.. Enter the following command to create the ignition file:
++
+[source,terminal]
+----
+$ cp ~/sno-work/single-node-ignition-config.ign /var/www/html/ignition/sno.ign
+----
+
+.. Enter the following command to restore SELinux file for the `/var/www/html` directory:
++
+[source,terminal]
+----
+$ restorecon -vR /var/www/html || true
+----
++
+Bastion now has all the required files and is properly configured in order to install {sno}.


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/MULTIARCH-3485

Draft: https://docs.google.com/document/d/1W2R7HjjlFE0LVrOEjnp2O-Bj4UmTySKEIi2SxNMNEtQ/edit

Link to docs preview: https://65166--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_sno/install-sno-installing-sno#installing-single-node-openshift-with-ibm-power

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Reference: 
- https://community.ibm.com/community/user/powerdeveloper/blogs/chongshi-zhang/2023/02/09/installing-sno-to-powervm?CommunityKey=daf9dca2-95e4-4b2c-8722-03cd2275ab63
- [MULTIARCH-3486] IBM Z add sno support [#63974](https://github.com/openshift/openshift-docs/pull/63974)