### PR TITLE
TELCODOCS-898: BM IPI customer feedback regarding NTP sync and L2 connectivity

### DIFF
--- a/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
+++ b/installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc
@@ -10,6 +10,15 @@ include::modules/ipi-install-installing-rhel-on-the-provisioner-node.adoc[levelo
 
 include::modules/ipi-install-preparing-the-provisioner-node-for-openshift-install.adoc[leveloffset=+1]
 
+include::modules/ipi-install-checking-ntp-sync.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-ntp-for-disconnected-clusters_ipi-install-installation-workflow[Optional: Configuring NTP for disconnected clusters]
+
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc#network-requirements-ntp_ipi-install-prerequisites[Network Time Protocol (NTP)]
+
 include::modules/ipi-install-configuring-networking.adoc[leveloffset=+1]
 
 include::modules/ipi-install-establishing-communication-between-subnets.adoc[leveloffset=+1]

--- a/modules/ipi-install-checking-ntp-sync.adoc
+++ b/modules/ipi-install-checking-ntp-sync.adoc
@@ -1,0 +1,55 @@
+// Module included in the following assemblies:
+//
+// * list of assemblies where this module is included
+// ipi-install-installation-workflow.adoc
+
+:_content-type: PROCEDURE
+[id="checking-ntp-sync_{context}"]
+= Checking NTP server synchronization
+
+The {product-title} installation program installs the `chrony` Network Time Protocol (NTP) service on the cluster nodes. To complete installation, each node must have access to an NTP time server. You can verify NTP server synchronization by using the `chrony` service.
+
+For disconnected clusters, you must configure the NTP servers on the control plane nodes. For more information see the _Additional resources_ section.
+
+.Prerequisites
+
+* You installed the `chrony` package on the target node.
+
+.Procedure
+
+. Log in to the node by using the `ssh` command.
+
+. View the NTP servers available to the node by running the following command:
++
+[source,terminal]
+----
+$ chronyc sources
+----
++
+.Example output
+[source,terminal]
+----
+MS Name/IP address         Stratum Poll Reach LastRx Last sample
+===============================================================================
+^+ time.cloudflare.com           3  10   377   187   -209us[ -209us] +/-   32ms
+^+ t1.time.ir2.yahoo.com         2  10   377   185  -4382us[-4382us] +/-   23ms
+^+ time.cloudflare.com           3  10   377   198   -996us[-1220us] +/-   33ms
+^* brenbox.westnet.ie            1  10   377   193  -9538us[-9761us] +/-   24ms
+----
+
+. Use the `ping` command to ensure that the node can access an NTP server, for example:
++
+[source,terminal]
+----
+$ ping time.cloudflare.com
+----
++
+.Example output
+[source,terminal]
+----
+PING time.cloudflare.com (162.159.200.123) 56(84) bytes of data.
+64 bytes from time.cloudflare.com (162.159.200.123): icmp_seq=1 ttl=54 time=32.3 ms
+64 bytes from time.cloudflare.com (162.159.200.123): icmp_seq=2 ttl=54 time=30.9 ms
+64 bytes from time.cloudflare.com (162.159.200.123): icmp_seq=3 ttl=54 time=36.7 ms
+...
+----

--- a/modules/ipi-install-network-requirements.adoc
+++ b/modules/ipi-install-network-requirements.adoc
@@ -3,7 +3,7 @@
 // * installing/installing_bare_metal_ipi/ipi-install-prerequisites.adoc
 
 :_content-type: CONCEPT
-[id='network-requirements_{context}']
+[id="network-requirements_{context}"]
 = Network requirements
 
 Installer-provisioned installation of {product-title} involves several network requirements. First, installer-provisioned installation involves an optional non-routable `provisioning` network for provisioning the operating system on each bare metal node. Second, installer-provisioned installation involves a routable `baremetal` network.
@@ -49,7 +49,7 @@ Certain ports must be open between cluster nodes for installer-provisioned insta
 
 Before deploying {product-title}, increase the network maximum transmission unit (MTU) to 1500 or more. If the MTU is lower than 1500, the Ironic image that is used to boot the node might fail to communicate with the Ironic inspector pod, and inspection will fail. If this occurs, installation stops because the nodes are not available for installation.
 
-[id='network-requirements-config-nics_{context}']
+[id="network-requirements-config-nics_{context}"]
 == Configuring NICs
 
 {product-title} deploys with two networks:
@@ -67,7 +67,7 @@ The `provisioning` network is optional, but it is required for PXE booting. If y
 When using a VLAN, each NIC must be on a separate VLAN corresponding to the appropriate network.
 ====
 
-[id='network-requirements-dns_{context}']
+[id="network-requirements-dns_{context}"]
 == DNS requirements
 
 Clients access the {product-title} cluster nodes over the `baremetal` network. A network administrator must configure a subdomain or subzone where the canonical name extension is the cluster name.
@@ -120,14 +120,14 @@ For example, `console-openshift-console.apps.<cluster_name>.<base_domain>` is us
 You can use the `dig` command to verify DNS resolution.
 ====
 
-[id='network-requirements-dhcp-reqs_{context}']
+[id="network-requirements-dhcp-reqs_{context}"]
 == Dynamic Host Configuration Protocol (DHCP) requirements
 
 By default, installer-provisioned installation deploys `ironic-dnsmasq` with DHCP enabled for the `provisioning` network. No other DHCP servers should be running on the `provisioning` network when the `provisioningNetwork` configuration setting is set to `managed`, which is the default value. If you have a DHCP server running on the `provisioning` network, you must set the `provisioningNetwork` configuration setting to `unmanaged` in the `install-config.yaml` file.
 
 Network administrators must reserve IP addresses for each node in the {product-title} cluster for the `baremetal` network on an external DHCP server.
 
-[id='network-requirements-reserving-ip-addresses_{context}']
+[id="network-requirements-reserving-ip-addresses_{context}"]
 == Reserving IP addresses for nodes with the DHCP server
 
 For the `baremetal` network, a network administrator must reserve a number of IP addresses, including:
@@ -179,7 +179,14 @@ The following table provides an exemplary embodiment of fully qualified domain n
 If you do not create DHCP reservations, the installer requires reverse DNS resolution to set the hostnames for the Kubernetes API node, the provisioner node, the control plane nodes, and the worker nodes.
 ====
 
-[id='network-requirements-ntp_{context}']
+[id="network-requirements-provisioner_{context}"]
+== Provisioner node requirements
+
+You must specify the MAC address for the provisioner node in your installation configuration. The `bootMacAddress` specification is typically associated with PXE network booting. However, the Ironic provisioning service also requires the `bootMacAddress` specification to identify nodes during the inspection of the cluster, or during node redeployment in the cluster. 
+
+The provisioner node requires layer 2 connectivity for network booting, DHCP and DNS resolution, and local network communication. The provisioner node requires layer 3 connectivity for virtual media booting. 
+
+[id="network-requirements-ntp_{context}"]
 == Network Time Protocol (NTP)
 
 Each {product-title} node in the cluster must have access to an NTP server. {product-title} nodes use NTP to synchronize their clocks. For example, cluster nodes use SSL certificates that require validation, which might fail if the date and time between the nodes are not in sync.
@@ -191,7 +198,7 @@ Define a consistent clock date and time format in each cluster node's BIOS setti
 
 You can reconfigure the control plane nodes to act as NTP servers on disconnected clusters, and reconfigure worker nodes to retrieve time from the control plane nodes.
 
-[id='network-requirements-out-of-band_{context}']
+[id="network-requirements-out-of-band_{context}"]
 == Port access for the out-of-band management IP address
 
 The out-of-band management IP address is on a separate network from the node. To ensure that the out-of-band management can communicate with the provisioner node during installation, the out-of-band management IP address must be granted access to port `6180` on the provisioner node and on the {product-title} control plane nodes. TLS port `6183` is required for virtual media installation, for example, by using Redfish.


### PR DESCRIPTION
[TELCODOCS-898](https://issues.redhat.com//browse/TELCODOCS-898): Customer feedback regarding IPI workflow. Customer wants to understand why the Bootstrap VM needs to have L2 connectivity, or to understand what boot processes are taking place. And wants early checking for NTP sync, which they didn't have caused problems with their installation.

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/TELCODOCS-898

Link to docs preview:
NTP:
https://65174--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-installation-workflow#checking-ntp-sync_ipi-install-installation-workflow
Provisioner node:
https://65174--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal_ipi/ipi-install-prerequisites#network-requirements-provisioner_ipi-install-prerequisites

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
