### PR TITLE
RHDEVDOCS-5358 add gitops 1.10 to build

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -322,6 +322,9 @@ openshift-gitops:
     gitops-docs-1.9:
       name: '1.9'
       dir: gitops/1.9
+    gitops-docs-1.10:
+      name: '1.10'
+      dir: gitops/1.10
 openshift-pipelines:
   name: Red Hat OpenShift Pipelines
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
Version(s):
main only

Issue:
[RHDEVDOCS-5358](https://issues.redhat.com//browse/RHDEVDOCS-5358)

Add GitOps 1.10 to d.o.c build
