### PR TITLE
[WIP] [DO NOT MERGE] [RHDEVDOCS-5452] Bump versions to 1.12

### DIFF
--- a/modules/op-creating-a-github-application-in-administrator-perspective.adoc
+++ b/modules/op-creating-a-github-application-in-administrator-perspective.adoc
@@ -10,7 +10,7 @@
 As a cluster administrator, you can configure your GitHub App with the {product-title} cluster to use {pac}. This configuration allows you to execute a set of tasks required for build deployment.
 
 .Prerequisites
-You have installed the {pipelines-title} `{pipelines-ver}` operator from the Operator Hub.
+You have installed the {pipelines-title} operator from the Operator Hub.
 
 .Procedure
 . In the administrator perspective, navigate to *Pipelines* using the navigation pane.

--- a/modules/op-installing-pipelines-as-code-cli.adoc
+++ b/modules/op-installing-pipelines-as-code-cli.adoc
@@ -9,13 +9,13 @@
 [role="_abstract"]
 Cluster administrators can use the `tkn pac` and `opc` CLI tools on local machines or as containers for testing. The `tkn pac` and `opc` CLI tools are installed automatically when you install the `tkn` CLI for {pipelines-title}.
 
-You can install the `tkn pac` and `opc` version `1.11.0` binaries for the supported platforms:
+You can install the `tkn pac` and `opc` version `1.12.0` binaries for the supported platforms:
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-macos-amd64.tar.gz[macOS]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-windows-amd64.zip[Windows]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-macos-amd64.tar.gz[macOS]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-windows-amd64.zip[Windows]
 
 // In addition, you can install `tkn pac` using the following methods:
 

--- a/modules/op-installing-tkn-on-linux-using-rpm.adoc
+++ b/modules/op-installing-tkn-on-linux-using-rpm.adoc
@@ -51,21 +51,21 @@ For {op-system-base-full} version 8, you can install the {pipelines-title} CLI a
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="pipelines-1.11-for-rhel-8-x86_64-rpms"
+# subscription-manager repos --enable="pipelines-1.12-for-rhel-8-x86_64-rpms"
 ----
 +
 * Linux on {ibmzProductName} and {linuxoneProductName} (s390x)
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="pipelines-1.11-for-rhel-8-s390x-rpms"
+# subscription-manager repos --enable="pipelines-1.12-for-rhel-8-s390x-rpms"
 ----
 +
 * Linux on {ibmpowerProductName} (ppc64le)
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="pipelines-1.11-for-rhel-8-ppc64le-rpms"
+# subscription-manager repos --enable="pipelines-1.12-for-rhel-8-ppc64le-rpms"
 ----
 ifndef::openshift-rosa,openshift-dedicated[]
 +
@@ -73,7 +73,7 @@ ifndef::openshift-rosa,openshift-dedicated[]
 +
 [source,terminal]
 ----
-# subscription-manager repos --enable="pipelines-1.11-for-rhel-8-arm64-rpms"
+# subscription-manager repos --enable="pipelines-1.12-for-rhel-8-arm64-rpms"
 ----
 endif::openshift-rosa,openshift-dedicated[]
 . Install the `openshift-pipelines-client` package:

--- a/modules/op-installing-tkn-on-linux.adoc
+++ b/modules/op-installing-tkn-on-linux.adoc
@@ -14,14 +14,14 @@ For Linux distributions, you can download the CLI as a `tar.gz` archive.
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
 
 ifndef::openshift-rosa,openshift-dedicated[]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
 endif::openshift-rosa,openshift-dedicated[]
 
 // Binaries also need to be updated in the following modules:

--- a/modules/op-installing-tkn-on-macos.adoc
+++ b/modules/op-installing-tkn-on-macos.adoc
@@ -14,10 +14,10 @@ For macOS, you can download the CLI as a `tar.gz` archive.
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-macos-amd64.tar.gz[macOS]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-macos-amd64.tar.gz[macOS]
 
 ifndef::openshift-rosa,openshift-dedicated[]
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-macos-arm64.tar.gz[macOS on ARM]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-macos-arm64.tar.gz[macOS on ARM]
 endif::openshift-rosa,openshift-dedicated[]
 
 . Unpack and extract the archive.

--- a/modules/op-installing-tkn-on-windows.adoc
+++ b/modules/op-installing-tkn-on-windows.adoc
@@ -12,7 +12,7 @@ For Windows, you can download the CLI as a `zip` archive.
 
 .Procedure
 
-.  Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-windows-amd64.zip[CLI tool].
+.  Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.12.0/tkn-windows-amd64.zip[CLI tool].
 
 . Extract the archive with a ZIP program.
 ifndef::openshift-rosa,openshift-dedicated[]


### PR DESCRIPTION
Do not merge before the Pipelines 1.12 GA

Version(s):
4.12+

Issue: https://issues.redhat.com/browse/RHDEVDOCS-5452

Links to doc preview: 

https://65179--docspreview.netlify.app/openshift-enterprise/latest/cicd/pipelines/using-pipelines-as-code.html#installing-pipelines-as-code-cli_using-pipelines-as-code

https://65179--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/tkn_cli/installing-tkn.html

Download links don't work yet. They need to be checked shortly before merging.

QE review: @ppitonak , @rupalibehera 

 QE has approved this change.