### PR TITLE
[WIP]RHDEVDOCS-5358 add 1.10 to version dropdown for gitops

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -218,6 +218,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.10">1.10</option>
               <option value="1.9">1.9</option>
               <option value="1.8">1.8</option>
             </select>


### PR DESCRIPTION

Version(s):
main only

Issue:
[RHDEVDOCS-5358](https://issues.redhat.com//browse/RHDEVDOCS-5358)

Additional information:
Adds 1.10 to the version dropdown on gitops

