### PR TITLE
ALBO: remove unused ingressClass from controller CR

### DIFF
--- a/modules/creating-instance-aws-load-balancer-controller.adoc
+++ b/modules/creating-instance-aws-load-balancer-controller.adoc
@@ -28,7 +28,7 @@ spec:
   additionalResourceTags: <4>
   - key: example.org/security-scope
     value: staging
-  ingressClass: cloud <5>
+  ingressClass: alb <5>
   config:
     replicas: 2 <6>
   enabledAddons: <7>


### PR DESCRIPTION
Change the ingress class to `alb` as it's used later on the same page.