### PR TITLE
OSDOCS-7871: add greenboot status check

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -124,6 +124,8 @@ Topics:
   File: microshift-using-config-tools
 - Name: Cluster access with kubeconfig
   File: microshift-cluster-access-kubeconfig
+- Name: Checking the status of Greenboot health checks
+  File: microshift-greenboot-checking-status
 ---
 Name: Networking
 Dir: microshift_networking
@@ -189,7 +191,7 @@ Topics:
   File: microshift-troubleshoot-cluster
 - Name: Troubleshoot updates
   File: microshift-troubleshoot-updates
-- Name: Checking audit logs 
+- Name: Checking audit logs
   File: microshift-audit-logs
 - Name: Additional information
   File: microshift-things-to-know

--- a/microshift_configuring/microshift-greenboot-checking-status.adoc
+++ b/microshift_configuring/microshift-greenboot-checking-status.adoc
@@ -1,0 +1,13 @@
+:_content-type: ASSEMBLY
+[id="microshift-greenboot-checking-status"]
+= Checking Greenboot scripts status
+include::_attributes/attributes-microshift.adoc[]
+:context: microshift-greenboot-script-status
+
+toc::[]
+
+To deploy applications or make other changes through the {product-title} API with tools other than `kustomize` manifests, you must wait until the Greenboot health checks have finished. This ensures that your changes are not lost if Greenboot rolls your `rpm-ostree` system back to an earlier state.
+
+The `greenboot-healthcheck` service runs one time and then exits. After Greenboot has exited and the system is in a healthy state, you can proceed with configuration changes and deployments.
+
+include::modules/microshift-greenboot-check-status.adoc[leveloffset=+1]

--- a/microshift_configuring/microshift-using-config-tools.adoc
+++ b/microshift_configuring/microshift-using-config-tools.adoc
@@ -8,6 +8,14 @@ toc::[]
 
 A YAML file customizes {product-title} instances with your preferences, settings, and parameters.
 
+include::snippets/microshift-greenboot-status-snip.adoc[leveloffset=+2]
+
 include::modules/microshift-config-yaml.adoc[leveloffset=+1]
 
 include::modules/microshift-config-nodeport-limits.adoc[leveloffset=+1]
+
+//[id="additional-resources_microshift-using-config-tools_{context}"]
+//[role="_additional-resources"]
+//== Additional resources
+
+//TODO:add xref to check greenboot status module after merge

--- a/microshift_troubleshooting/microshift-troubleshoot-updates.adoc
+++ b/microshift_troubleshooting/microshift-troubleshoot-updates.adoc
@@ -26,3 +26,5 @@ include::modules/microshift-updates-troubleshooting.adoc[leveloffset=+1]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html-single/composing_installing_and_managing_rhel_for_edge_images/index#rolling_back_rhel_for_edge_images[Rolling back RHEL for Edge images]
 
 include::modules/microshift-check-journal-logs-updates.adoc[leveloffset=+1]
+
+include::modules/microshift-greenboot-check-status.adoc[leveloffset=+1]

--- a/modules/microshift-greenboot-check-status.adoc
+++ b/modules/microshift-greenboot-check-status.adoc
@@ -1,0 +1,36 @@
+// Module included in the following assemblies:
+//
+// * microshift_running applications/checking-greenboot-scripts-status.adoc
+
+:_content-type: PROCEDURE
+[id="microshift-greenboot-check-status_{context}"]
+= Checking the status of Greenboot health checks
+
+Check the status of Greenboot health checks before making changes to the system or during troubleshooting. You can use any of the following commands to help you ensure that Greenboot scripts have finished running.
+
+.Procedure
+
+* To see a report of health check status, use the following command:
++
+[source,terminal]
+----
+$ systemctl show --property=SubState --value greenboot-healthcheck.service
+----
++
+** An output of `start` means that Greenboot checks are still running.
+** An output of `exited` means that checks have passed and Greenboot has exited. Greenboot runs the scripts in the `green.d` directory when the system is a healthy state.
+** An output of `failed` means that checks have not passed. Greenboot runs the scripts in `red.d` directory when the system is in this state and might restart the system.
+
+* To see a report showing the numerical exit code of the service where `0` means success and non-zero values mean a failure occurred, use the following command:
++
+[source,terminal]
+----
+$ systemctl show --property=ExecMainStatus --value greenboot-healthcheck.service
+----
+
+* To see a report showing a message about boot status, such as `Boot Status is GREEN - Health Check SUCCESS`, use the following command:
++
+[source,terminal]
+----
+$ cat /run/motd.d/boot-status
+----

--- a/snippets/microshift-greenboot-status-snip.adoc
+++ b/snippets/microshift-greenboot-status-snip.adoc
@@ -1,0 +1,14 @@
+// Text snippet included in the following assemblies:
+//
+// * microshift_configuring/microshift-using-config-tools.adoc
+//
+// Text snippet included in the following modules:
+//
+// *
+
+:_content-type: SNIPPET
+
+[NOTE]
+====
+If you want to make configuration changes or deploy applications through the {product-title} API with tools other than `kustomize` manifests, you must wait until the Greenboot health checks have finished. This ensures that your changes are not lost if Greenboot rolls your `rpm-ostree` system back to an earlier state.
+====


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-7871

Link to docs preview:
https://65191--docspreview.netlify.app/microshift/latest/microshift_configuring/microshift-greenboot-checking-status

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
