### PR TITLE
TELCODOCS-1456: Docs and RN: OCPVE-385 Implement OR logic for deviceSelector to support multi-node clusters

### DIFF
--- a/modules/lvms-creating-logical-volume-manager-cluster.adoc
+++ b/modules/lvms-creating-logical-volume-manager-cluster.adoc
@@ -50,15 +50,18 @@ spec:
       - name: vg1
         fstype: ext4 <2>
         default: true <3>
-        deviceSelector:
+        deviceSelector: <4>
           paths:
           - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
           - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
+          optionalPaths:
+          - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
+          - /dev/disk/by-path/pci-0000:90:00.0-nvme-1
         thinPoolConfig:
           name: thin-pool-1
           sizePercent: 90
           overprovisionRatio: 10
-        nodeSelector: <4>
+        nodeSelector: <5>
           nodeSelectorTerms:
             - matchExpressions:
               - key: app
@@ -72,7 +75,8 @@ When configuring multiple device classes, you must specify the device path for e
 <2> Set `fstype` to `ext4` or `xfs`. By default, it is set to `xfs` if the setting is not specified.
 <3> Mandatory: The `LVMCluster` resource must contain a single default storage class. Set `default: false` for secondary device storage classes.
 If you are upgrading the `LVMCluster` resource from a previous version, you must specify a single default device class.
-<4> Optional: To control what worker nodes the `LVMCluster` CR is applied to, specify a set of node selector labels.
+<4> Optional. To control or restrict the volume group to your preferred devices, you can manually specify the local paths of the devices in the `deviceSelector` section of the `LVMCluster` YAML. The `paths` section refers to devices the `LVMCluster` adds, which means those paths must exist. The `optionalPaths` section refers to devices the `LVMCluster` might add. You must specify at least one of `paths` or `optionalPaths` when specifying the `deviceSelector` section. If you specify `paths`, you do not have to specify `optionalPaths`. If you specify `optionalPaths`, you do not have to specify `paths` but at least one optional path must be present on the node. If you do not specify any paths, it will add all unused devices on the node.
+<5> Optional: To control what worker nodes the `LVMCluster` CR is applied to, specify a set of node selector labels.
 The specified labels must be present on the node in order for the `LVMCluster` to be scheduled on that node.
 
 .. Create the `LVMCluster` CR:

--- a/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-cli.adoc
@@ -107,6 +107,9 @@ spec:
        paths:
        - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
        - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
+       optionalPaths:
+       - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
+       - /dev/disk/by-path/pci-0000:90:00.0-nvme-1
      thinPoolConfig:
        name: thin-pool-1
        sizePercent: 90

--- a/modules/lvms-installing-logical-volume-manager-operator-using-rhacm.adoc
+++ b/modules/lvms-installing-logical-volume-manager-operator-using-rhacm.adoc
@@ -135,6 +135,9 @@ spec:
                        paths:
                        - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
                        - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
+                       optionalPaths:
+                       - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
+                       - /dev/disk/by-path/pci-0000:90:00.0-nvme-1
                      thinPoolConfig:
                        name: thin-pool-1
                        sizePercent: 90
@@ -150,7 +153,7 @@ spec:
         severity: low
 ----
 <1> Replace the key and value in `PlacementRule.spec.clusterSelector` to match the labels set on the {sno} clusters on which you want to install {lvms}.
-<2> To control or restrict the volume group to your preferred disks, you can manually specify the local paths of the disks in the `deviceSelector` section of the `LVMCluster` YAML.
+<2> Optional. To control or restrict the volume group to your preferred devices, you can manually specify the local paths of the devices in the `deviceSelector` section of the `LVMCluster` YAML. The `paths` section refers to devices the `LVMCluster` adds, which means those paths must exist. The `optionalPaths` section refers to devices the `LVMCluster` might add. You must specify at least one of `paths` or `optionalPaths` when specifying the `deviceSelector` section. If you specify `paths`, you do not have to specify `optionalPaths`. If you specify `optionalPaths`, you do not have to specify `paths` but at least one optional path must be present on the node. If you do not specify any paths, it will add all unused devices on the node. 
 <3> To add a node filter, which is a subset of the additional worker nodes, specify the required filter in the `nodeSelector` section. {lvms} detects and uses the additional worker nodes when the new nodes show up.
 +
 --

--- a/modules/lvms-reference-file.adoc
+++ b/modules/lvms-reference-file.adoc
@@ -36,7 +36,9 @@ spec:
         paths:
         - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
         - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
+        optionalPaths:
         - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
+        - /dev/disk/by-path/pci-0000:90:00.0-nvme-1
       thinPoolConfig: <6>
         name: thin-pool-1 <7>
         sizePercent: 90 <8>

--- a/modules/lvms-scaling-storage-of-single-node-openshift-cluster-using-rhacm.adoc
+++ b/modules/lvms-scaling-storage-of-single-node-openshift-cluster-using-rhacm.adoc
@@ -10,20 +10,19 @@ You can scale the storage capacity of your configured worker nodes on a {sno} cl
 
 .Prerequisites
 
-* You have access to the {rh-rhacm} cluster using an account with `cluster-admin` privilages.
-* You have additional unused disks on each {sno} cluster to be used by {lvms}.
+* You have access to the {rh-rhacm} cluster using an account with `cluster-admin` privileges.
+* You have additional unused devices on each {sno} cluster that {lvms} can use.
 
 .Procedure
 
 . Log in to the {rh-rhacm} CLI using your {product-title} credentials.
-. Find the disk that you want to add. The disk to be added needs to match with the device name and path of the existing disks.
+. Find the device that you want to add. The device to be added needs to match with the device name and path of the existing devices.
 . To add capacity to the {sno} cluster, edit the `deviceSelector` section of the existing policy YAML, for example, `policy-lvms-operator.yaml`.
 
 +
 [NOTE]
 ====
-In case the `deviceSelector` field is not included during the `LVMCluster` creation, it is not possible to add the `deviceSelector` section to the CR.
-You need to remove the `LVMCluster` and then recreate from the new CR.
+In case the `deviceSelector` field is not included during the `LVMCluster` creation, it is not possible to add the `deviceSelector` section to the CR. You need to remove the `LVMCluster` and then recreate it from the new CR.
 ====
 
 +
@@ -130,11 +129,13 @@ spec:
                    deviceClasses:
                    - name: vg1
                      default: true
-                     deviceSelector:
+                     deviceSelector: <1>
                        paths:
                        - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
                        - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
-                       - /dev/disk/by-path/pci-0000:89:00.0-nvme-1 # new disk is added
+                       optionalPaths:
+                       - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
+                       - /dev/disk/by-path/pci-0000:90:00.0-nvme-1
                      thinPoolConfig:
                        name: thin-pool-1
                        sizePercent: 90
@@ -149,6 +150,7 @@ spec:
         remediationAction: enforce
         severity: low
 ----
+<1> Optional. To control or restrict the volume group to your preferred devices, you can manually specify the local paths of the devices in the `deviceSelector` section of the `LVMCluster` YAML. The `paths` section refers to devices the `LVMCluster` adds, which means those paths must exist. The `optionalPaths` section refers to devices the `LVMCluster` might add. You must specify at least one of `paths` or `optionalPaths` when specifying the `deviceSelector` section. If you specify `paths`, you do not have to specify `optionalPaths`. If you specify `optionalPaths`, you do not have to specify `paths` but at least one optional path must be present on the node. If you do not specify any paths, it will add all unused devices on the node.
 
 . Edit the policy by running the following command:
 +

--- a/modules/lvms-scaling-storage-of-single-node-openshift-cluster.adoc
+++ b/modules/lvms-scaling-storage-of-single-node-openshift-cluster.adoc
@@ -40,15 +40,16 @@ spec:
     deviceClasses:
     - name: vg1
       default: true
-      deviceSelector:
+      deviceSelector: <1>
         paths:
-        - /dev/disk/by-path/pci-0000:87:00.0-nvme-1 <1>
+        - /dev/disk/by-path/pci-0000:87:00.0-nvme-1
         - /dev/disk/by-path/pci-0000:88:00.0-nvme-1
-        - /dev/disk/by-path/pci-0000:89:00.0-nvme-1 <2>
+        optionalPaths:
+        - /dev/disk/by-path/pci-0000:89:00.0-nvme-1
+        - /dev/disk/by-path/pci-0000:90:00.0-nvme-1
       thinPoolConfig:
         name: thin-pool-1
         sizePercent: 90
         overprovisionRatio: 10
 ----
-<1> The path can be added by name (`/dev/sdb`) or by path.
-<2> A new disk is added.
+<1> Optional. To control or restrict the volume group to your preferred devices, you can manually specify the local paths of the devices in the `deviceSelector` section of the `LVMCluster` YAML. The `paths` section refers to devices the `LVMCluster` adds, which means those paths must exist. The `optionalPaths` section refers to devices the `LVMCluster` might add. You must specify at least one of `paths` or `optionalPaths` when specifying the `deviceSelector` section. If you specify `paths`, you do not have to specify `optionalPaths`. If you specify `optionalPaths`, you do not have to specify `paths` but at least one optional path must be present on the node. If you do not specify any paths, it will add all unused devices on the node.


### PR DESCRIPTION
Added optionalPaths to deviceSelector setting.

Fixes: [TELCODOCS-1456](https://issues.redhat.com//browse/TELCODOCS-1456)

See https://issues.redhat.com/browse/TELCODOCS-1456 for additional details.

Preview URL: http://184.23.213.161:8080/TELCODOCS-1456/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html

For release(s): 4.15, 4.14
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
