### PR TITLE
RHDEVDOCS-5358 set up latest redirects for gitops

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -233,6 +233,15 @@ AddType text/vtt                            vtt
     # redirect any links to existing ROSA/Dedicated embedded content to standalone equivalent
     RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
 
+
+    # redirect gitops latest to 1.9
+    RewriteRule ^gitops/?$ /gitops/latest [R=302]
+    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.9/$1 [NE,R=302]
+
+    # redirect top-level without filespec to the about file
+    RewriteRule ^gitops/(1\.8|1\.9)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
+
+
     # Pipelines handling unversioned and latest links
     RewriteRule ^pipelines/?$ /pipelines/latest [R=302]
     RewriteRule ^pipelines/latest/?(.*)$ /pipelines/1\.11/$1 [NE,R=302]


### PR DESCRIPTION
Version(s):
main only

Issue:
[RHDEVDOCS-5358](https://issues.redhat.com//browse/RHDEVDOCS-5358)


Additional information:
Set up redirects for gitops/latest to 1.9 for now
