### PR TITLE
OSDOCS-7900: Documented the 4.11.50 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3730,7 +3730,7 @@ $ oc adm release info 4.11.48 --pullspecs
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
 
 [id="ocp-4-11-49"]
-=== RHSA-2023:5001 {product-title} 4.11.49 bug fix update
+=== RHSA-2023:5001 {product-title} 4.11.49 bug fix update and security update
 
 Issued: 2023-09-13
 
@@ -3744,6 +3744,46 @@ $ oc adm release info 4.11.49 --pullspecs
 ----
 
 [id="ocp-4-11-49-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-11-50"]
+=== RHBA-2023:5350 {product-title} 4.11.50 bug fix update
+
+Issued: 2023-10-04
+
+{product-title} release 4.11.50 is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHBA-2023:5350[RHBA-2023:5350] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5352[RHBA-2023:5352] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.50 --pullspecs
+----
+
+[id="ocp-4-11-50-features"]
+==== Features
+
+[id="ocp-4-11-50-custom-rhcos-image-for-gcp"]
+===== Using a custom {op-system-first} image for a Google Cloud Provider cluster
+
+By default, the installation program downloads and installs the {op-system-first} image that is used to start control plane and compute machines. With this enhancement, you can now override the default behavior by modifying the installation configuration file (install-config.yaml) to specify a custom {op-system} image. Before you deploy the cluster, you can modify the following installation parameters:
+
+* `controlPlane.platform.gcp.osImage.project`
+* `controlPlane.platform.gcp.osImage.name`
+* `compute.platform.gcp.osImage.project`
+* `compute.platform.gcp.osImage.name`
+* `platform.gcp.defaultMachinePlatform.osImage.project`
+* `platform.gcp.defaultMachinePlatform.osImage.name`
+
+For more information about these parameters, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-configuration-parameters-additional-gcp_installing-gcp-customizations[Additional Google Cloud Platform configuration parameters].
+
+[id="ocp-4-11-50-bug-fixes"]
+==== Bug fixes
+* Previously, the cloud credentials used in the Manila CSI Driver Operator were cached, resulting in authentication issues if these credentials were rotated. With this update, this issue is resolved. (link:https://issues.redhat.com/browse/OCPBUGS-18782[*OCPBUGS-18782*])
+
+[id="ocp-4-11-50-upgrading"]
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
[OSDOCS-7900](https://issues.redhat.com/browse/OSDOCS-7900)

Version(s):
4.11

Link to docs preview:
[4.11.50](https://65225--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-50)

QE review:
- [X] QE not required

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
