### PR TITLE
ROX#19823: Release notes for patch 4.2.1

### DIFF
--- a/release_notes/42-release-notes.adoc
+++ b/release_notes/42-release-notes.adoc
@@ -15,7 +15,8 @@ toc::[]
 
 |{product-title-short} version |Released on
 
-|`4.2.0` | 18 Sep 2023
+|`4.2.0` | 18 September 2023
+|`4.2.1` | 3 October 2023
 
 |====
 
@@ -392,8 +393,7 @@ Red Hat has removed the *Use Container IAM role* option from {product-title-mana
 ** NIST SP 800-53 Compliance
 ** NIST SP 800-190 Compliance
 ** HIPAA 164 Compliance
-** ocp4-cis Compliance
-** ocp4-cis-node Compliance
+//removed ocp4-cis and ocp4-cis-node per dcaspin because only applies to users of compliance operator
 
 [id="bug-fixes_{context}"]
 == Bug fixes
@@ -401,7 +401,7 @@ Red Hat has removed the *Use Container IAM role* option from {product-title-mana
 [id="resolved-in-version-420_{context}"]
 === Resolved in version 4.2.0
 
-*Release date*: 18 Sep 2023
+*Release date*: 18 September 2023
 
 * Previously, if a non-blocking socket failed to open a connection, Collector would still report that as a connection. This issue has been fixed. (ROX-17486)
 * In {product-title-short} 4.2, Collector correctly handles asynchronous connection establishment.(ROX-17486)
@@ -409,6 +409,14 @@ Red Hat has removed the *Use Container IAM role* option from {product-title-mana
 * Previously, when using eBPF on IBM Z, {product-title-short} reported incorrect process UNIX group IDs (GID). This issue is now fixed. (ROX-17459)
 * In previous {product-title-short} versions, there was a mismatch in the number of CVEs reported by JSON output and table output. This issue is now fixed. (ROX-15277)
 * Previously, integrating {product-title-short} with Jira failed when you used an OAuth token or JWT while configuring the integration. This issue is fixed. (ROX-17992)
+
+[id="resolved-in-version-4201_{context}"]
+=== Resolved in version 4.2.1
+
+*Release date*: 3 October 2023
+
+* A sensor panic could occur in version 4.2.0 if a cluster contained deployments with an invalid image reference, for example, `image: " "`, and delegated scanning was enabled for all registries. This issue has been fixed.
+* The minimum permissions required to display 6 of the sidebar links in the {product-title-short} web portal were too strict in the 4.2.0 release, and are reduced in this release.
 
 [id="image-versions_{context}"]
 == Image versions


### PR DESCRIPTION
Version(s):

- Merge to `rhacs-docs`
- Cherry pick to `rhacs-docs-4.2`

[Issue
](https://issues.redhat.com/browse/ROX-19823)

[Link to docs preview
](https://65236--docspreview.netlify.app/openshift-acs/latest/release_notes/42-release-notes#resolved-in-version-4201_release-notes-42)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Includes change requested by Doron per [feedback from field](https://chat.google.com/room/AAAA9gJI6o4/rw_rbTla_3Q) about upcoming deprecations for dashboard widgets. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
