### PR TITLE
RHDEVDOCS 5444 enable Pipelines 1.12 in distro map

### DIFF
--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -338,6 +338,9 @@ openshift-pipelines:
     pipelines-docs-1.11:
       name: '1.11'
       dir: pipelines/1.11
+    pipelines-docs-1.12:
+      name: '1.12'
+      dir: pipelines/1.12
 openshift-builds:
   name: Red Hat OpenShift Builds
   author: OpenShift documentation team <openshift-docs@redhat.com>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
main only

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 5444

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
This PR adds Pipelines 1.12 to _distro_map.yml , hopefully enabling the building of this version on docs.openshift.com . It does not affect documentation content.