### PR TITLE
RHDEVDOCS 5172 Adding sections from main to GitOps-docs 1.10 branch

### DIFF
--- a/accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.adoc
+++ b/accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.adoc
@@ -8,9 +8,9 @@ toc::[]
 
 After the {gitops-title} Operator is installed, Argo CD automatically creates a user with `admin` permissions. To manage multiple users, cluster administrators can use Argo CD to configure Single Sign-On (SSO).
 
-[IMPORTANT]
+[NOTE]
 ====
-The `spec.dex` parameter in the ArgoCD CR is deprecated. In a future release of {gitops-title} v1.10.0, configuring Dex using the `spec.dex` parameter in the ArgoCD CR is planned to be removed. Consider using the `.spec.sso` parameter instead.
+The `spec.dex` parameter in the ArgoCD CR is no longer supported from {gitops-title} v1.10.0 onwards. Consider using the `.spec.sso` parameter instead.
 ====
 
 include::modules/gitops-creating-a-new-client-in-dex.adoc[leveloffset=+1]
@@ -19,7 +19,7 @@ include::modules/gitops-dex-role-mappings.adoc[leveloffset=+2]
 
 //include::modules/gitops-configuring-argo-cd-using-dex-github-conector.adoc[leveloffset=+1]
 
-include::modules/gitops-disable-dex.adoc[leveloffset=+1]
+//include::modules/gitops-disable-dex.adoc[leveloffset=+1]
 
 include::modules/gitops-disable-dex-using-spec-sso.adoc[leveloffset=+1]
 

--- a/modules/gitops-about-argo-rollout-manager-custom-resources-and-spec.adoc
+++ b/modules/gitops-about-argo-rollout-manager-custom-resources-and-spec.adoc
@@ -20,7 +20,7 @@ You can specify the command arguments, environment variables, a custom image nam
 .Example: `RolloutManager` CR
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: RolloutManager
 metadata:
   name: argo-rollout

--- a/modules/gitops-argo-cd-notification.adoc
+++ b/modules/gitops-argo-cd-notification.adoc
@@ -14,7 +14,7 @@ To enable or disable the link:https://argo-cd.readthedocs.io/en/stable/operator-
 
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/modules/gitops-argo-cd-properties.adoc
+++ b/modules/gitops-argo-cd-properties.adoc
@@ -69,7 +69,9 @@ a|* _<AutoTLS>_ - Use the provider to create the Redis server's TLS certificate 
   * _<Image>_ - The container image for Redis. This overrides the `ARGOCD_REDIS_IMAGE` environment variable.
   * _<Resources>_ - The container compute resources.
   * _<Version>_ - The tag to use with the Redis container image.
-|`ResourceCustomizations` |Customize resource behavior.|`__<empty>__` |
+|`ResourceHealthChecks` |Customize resource health check behavior.|`__<empty>__` |
+|`ResourceIgnoreDifferences` |Customize resource ignore difference behavior.|`__<empty>__` |
+|`ResourceActions` |Customize resource action behavior.|`__<empty>__` |
 |`ResourceExclusions` |Completely ignore entire classes of resource group.|`__<empty>__` |
 |`ResourceInclusions` |The configuration to configure which resource group/kinds are applied.|`__<empty>__` |
 |`Server` |Argo CD Server configuration options.|`__<Object>__`
@@ -87,13 +89,9 @@ a|* _<Autoscale>_ - Server autoscale configuration options.
   * _<LogFormat>_ - The log format used by the Argo CD Application Controller component. Valid options are `text` or `json`.
   * _<Env>_ - Environment to set for the server workloads.
 |`SSO` |Single Sign-on options.|`__<Object>__`
-a|* _<Image>_ - The container image for Keycloak. This overrides the `ARGOCD_KEYCLOAK_IMAGE` environment variable.
-  * _<Keycloak>_ - Configuration options for Keycloak SSO provider.
+a|* _<Keycloak>_ - Configuration options for Keycloak SSO provider.
   * _<Dex>_ - Configuration options for Dex SSO provider.
   * _<Provider>_ - The name of the provider used to configure Single Sign-on. For now the supported options are Dex and Keycloak.
-  * _<Resources>_ - The container compute resources.
-  * _<VerifyTLS>_ - Whether to enforce strict TLS checking when communicating with Keycloak service.
-  * _<Version>_ - The tag to use with the Keycloak container image.
 |`StatusBadgeEnabled` |Enable application status badge.|`true` |
 |`TLS` |TLS configuration options.|`__<Object>__`
 a|* _<CA.ConfigMapName>_ - The name of the `ConfigMap` which contains the CA certificate.

--- a/modules/gitops-configuring-argo-cd-oidc.adoc
+++ b/modules/gitops-configuring-argo-cd-oidc.adoc
@@ -50,7 +50,7 @@ $ oc edit argocd -n <your_namespace>
 .Example of `argocd` custom resource
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   creationTimestamp: null

--- a/modules/gitops-configuring-argo-cd-using-dex-github-conector.adoc
+++ b/modules/gitops-configuring-argo-cd-using-dex-github-conector.adoc
@@ -11,7 +11,7 @@
 +
 [source,yaml]
 ----
-  apiVersion: argoproj.io/v1alpha1
+  apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-disabled.adoc
@@ -25,7 +25,7 @@ You can manually configure TLS encryption for Redis by creating the `argocd-oper
 .Example ArgoCD CR with autotls disabled
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: argocd <1>

--- a/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
+++ b/modules/gitops-configuring-tls-for-redis-with-autotls-enabled.adoc
@@ -30,7 +30,7 @@ By default, the `autotls` setting is disabled.
 .Example Argo CD CR with autotls enabled
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: argocd <1>

--- a/modules/gitops-configuring-workloads.adoc
+++ b/modules/gitops-configuring-workloads.adoc
@@ -12,7 +12,7 @@ The following Argo CD instance deploys the Argo CD workloads such as `Applicatio
 
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example

--- a/modules/gitops-creating-a-new-client-in-dex.adoc
+++ b/modules/gitops-creating-a-new-client-in-dex.adoc
@@ -6,27 +6,22 @@
 [id="gitops-creating-a-new-client-in-dex_{context}"]
 = Configuration to enable the Dex OpenShift OAuth Connector
 
-Dex is installed by default for all the Argo CD instances created by the Operator. Dex uses the users and groups defined within OpenShift by checking the `OAuth` server provided by the platform. You can configure the options for the Dex SSO provider. The following example shows the properties of Dex along with example configurations:
+Dex is installed by default for all the Argo CD instances created by the Operator. You can configure {gitops-title} to use Dex as the SSO authentication provider by setting the `.spec.sso` parameter. 
 
+Dex uses the users and groups defined within {OCP} by checking the `OAuth` server provided by the platform.
+
+.Procedure
+
+* To enable Dex, set the `.spec.sso.provider` parameter to `dex` in the YAML resource of the Operator:
++
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
-kind: ArgoCD
-metadata:
-  name: example-argocd
-  labels:
-    example: openshift-oauth
+# ...
 spec:
-  dex:
-    openShiftOAuth: true <1>
-    groups:<2>
-     - default
-  rbac:<3>
-    defaultPolicy: 'role:readonly'
-    policy: |
-      g, cluster-admins, role:admin
-    scopes: '[groups]'
+  sso:
+    provider: dex
+    dex:
+      openShiftOAuth: true <1>
+# ...
 ----
-<1> The `openShiftOAuth` property triggers the Operator to automatically configure the built-in OpenShift `OAuth` server when the value is set to `true`.
-<2> The `groups` property allows users of the specified group(s) to log in.
-<3> The RBAC policy property assigns the admin role in the Argo CD cluster to users in the OpenShift `cluster-admins` group.
+<1> The `openShiftOAuth` property triggers the Operator to automatically configure the built-in {OCP} `OAuth` server when the value is set to `true`.

--- a/modules/gitops-creating-a-new-client-using-keycloak.adoc
+++ b/modules/gitops-creating-a-new-client-using-keycloak.adoc
@@ -35,7 +35,7 @@ dex:
 +
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd
@@ -52,13 +52,13 @@ spec:
 ----
 <1> A custom certificate used to verify the Keycloak's TLS certificate.
 + 
-The Operator reconciles changes in the `.spec.keycloak.rootCA` parameter and updates the `oidc.config` parameter with the PEM encoded root certificate in the `argocd-cm` configuration map.
+The Operator reconciles changes in the `.spec.sso.keycloak.rootCA` parameter and updates the `oidc.config` parameter with the PEM encoded root certificate in the `argocd-cm` configuration map.
 
 * For an insecure connection, leave the value of the `rootCA` parameter empty and use the `oidc.tls.insecure.skip.verify` parameter as shown below:
 +
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/modules/gitops-creating-rolloutmanager-custom-resource.adoc
+++ b/modules/gitops-creating-rolloutmanager-custom-resource.adoc
@@ -29,7 +29,7 @@ To manage progressive delivery of deployments by using Argo Rollouts in {gitops-
 .Example: `RolloutManager` CR
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: RolloutManager
 metadata:
   name: argo-rollout

--- a/modules/gitops-disable-dex-using-spec-sso.adoc
+++ b/modules/gitops-disable-dex-using-spec-sso.adoc
@@ -4,24 +4,6 @@
 
 :_content-type: PROCEDURE
 [id="gitops-disable-dex-using-spec-sso_{context}"]
-= Enabling or disabling Dex using .spec.sso
+= Disabling Dex by replacing .spec.sso
 
-You can configure {gitops-title} to use Dex as its SSO authentication provider by setting the `.spec.sso` parameter.
-
-.Procedure
-
-. To enable Dex, set the `.spec.sso.provider: dex` parameter in the YAML resource of the Operator:
-
-+
-[source,yaml]
-----
-...
-spec:
-  sso:
-    provider: dex
-    dex:
-      openShiftOAuth: true
-...
-----
-+
-. To disable dex, either remove the `spec.sso` element from the Argo CD custom resource, or specify a different SSO provider.
+* To disable dex, either remove the `spec.sso` element from the Argo CD custom resource or specify a different SSO provider.

--- a/modules/gitops-disable-dex.adoc
+++ b/modules/gitops-disable-dex.adoc
@@ -19,11 +19,11 @@ In {gitops-title} v1.6.0, `DISABLE_DEX` is deprecated and is planned to be remov
 +
 [source,yaml]
 ----
-...
+# ...
 spec:
   config:
     env:
     - name: DISABLE_DEX
       value: "true"
-...
+# ...
 ----

--- a/modules/gitops-disabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
+++ b/modules/gitops-disabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
@@ -16,15 +16,15 @@ You can disable workload monitoring for specific Argo CD instances. Disabling wo
 
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd
   labels:
     example: repo
 spec:
-  ...
+ # ...
   monitoring:
     enabled: false
-  ...
+ # ...
 ----

--- a/modules/gitops-enable-replicas-for-argo-cd-server.adoc
+++ b/modules/gitops-enable-replicas-for-argo-cd-server.adoc
@@ -16,7 +16,7 @@ Argo CD-server and Argo CD-repo-server workloads are stateless. To better distri
 
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd

--- a/modules/gitops-enabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
+++ b/modules/gitops-enabling-monitoring-for-argo-cd-custom-resource-workloads.adoc
@@ -18,17 +18,17 @@ With {gitops-title}, you can enable workload monitoring for specific Argo CD ins
 
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: ArgoCD
 metadata:
   name: example-argocd
   labels:
     example: repo
 spec:
-  ...
+ # ...
   monitoring:
     enabled: true
-  ...
+ # ...
 ----
 
 . Verify whether an alert rule is included in the PrometheusRule created by the Operator:
@@ -46,7 +46,7 @@ spec:
   groups:
     - name: ArgoCDComponentStatus
       rules:
-        ...
+       # ...
         - alert: ApplicationSetControllerNotReady <1>
           annotations:
             message: >-

--- a/modules/gitops-installing-olm-operators-using-gitops.adoc
+++ b/modules/gitops-installing-olm-operators-using-gitops.adoc
@@ -44,14 +44,14 @@ To install namespace-scoped Operators, create and place the `Subscription` and `
 
 [source,yaml]
 ----
-...
+# ...
 apiVersion: v1
 kind: Namespace
 metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
   name: ansible-automation-platform
-...
+# ...
 apiVersion: operators.coreos.com/v1
 kind: OperatorGroup
 metadata:
@@ -60,7 +60,7 @@ metadata:
 spec:
   targetNamespaces:
     - ansible-automation-platform
-...
+# ...
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
@@ -72,7 +72,7 @@ spec:
   name: ansible-automation-platform-operator
   source: redhat-operators
   sourceNamespace: openshift-marketplace
-...
+# ...
 ----
 
 [IMPORTANT]

--- a/modules/gitops-release-notes-1-10-0.adoc
+++ b/modules/gitops-release-notes-1-10-0.adoc
@@ -1,0 +1,114 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="gitops-release-notes-1-10-0_{context}"]
+= Release notes for {gitops-title} 1.10.0
+
+{gitops-title} 1.10.0 is now available on {OCP} 4.12 and 4.13.
+
+[id="errata-updates-1-10.0_{context}"]
+== Errata updates
+
+[id="gitops-1-10-0-security-update-advisory_{context}"]
+=== RHSA-2023:XXXX and RHEA-2023:YYYY - {gitops-title} 1.10.0 security update advisory
+
+Issued: 2023-09-27
+
+The list of security fixes and enhancements that are included in this release is documented in the following advisories:
+
+* link:https://errata.devel.redhat.com/advisory/120274[RHSA-2023:XXXX]
+* link:https://errata.engineering.redhat.com/advisory/120119[RHEA-2023:YYYY]
+
+If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----
+
+[id="new-features-1-10-0_{context}"]
+== New features
+
+The current release adds the following improvements:
+
+* With this update, the Argo CD CRD API version is upgraded from `v1alpha1` to `v1beta1` to accomodate the breaking changes resulting from the deprecation of `.spec.dex` and certain `.spec.sso` fields. To streamline the automatic migration of existing `v1alpha1` Argo CD CRs to `v1beta1`, conversion webhook support is implemented. link:https://issues.redhat.com/browse/GITOPS-3040[GITOPS-3040]
++
+[NOTE]
+====
+By default, the conversion webhook is enabled only for OLM-installed Operators. For non-OLM installations of the Operator, enabling the webhook is optional. However, without conversion webhook support, you have to manually migrate any existing Argo CD `v1alpha1` CRs to `v1beta1`.
+====
+
+* With this update, the {gitops-title} Operator deploys three monitoring dashboards in the Administrator perspective of the web console. The three dashboards are *GitOps Overview*, *GitOps Components*, and *GitOps gRPC*. To access these dashboards, go to *Observe* → *Monitoring*. link:https:https://issues.redhat.com/browse/GITOPS-1767[GITOPS-1767]
++
+[NOTE]
+====
+Disabling or changing the content of the dashboards is not supported.
+====
+
+* Previously, timestamps were presented in a Unix epoch format. With this update, the timestamps are changed to RFC3339 format, for example: 2023-06-27T07:12:48-04:00, to improve overall readability. link:https://issues.redhat.com/browse/GITOPS-2898[GITOPS-2898]
+
+* With this update, the default Argo CD instance in the `openshift-gitops` namespace has restricted permissions for non-admin users by default. This improves security because non-admin users no longer have access to sensitive information. However, as an administrator, you can set permissions and grant non-admin users access to the resources managed by the default `openshift-gitops` Argo CD instance by configuring your Argo CD RBAC. This change only applies to the default {gitops-title} instance. link:https://issues.redhat.com/browse/GITOPS-3032[GITOPS-3032]
+
+* With this update, the default installation namespace for {gitops-title} Operator is changed to its own namespace called `openshift-gitops-operator`. You can still choose the old default installation namespace, `openshift-operators`, through a drop-down menu available in the OperatorHub UI at installation time. You can also enable cluster monitoring on the new namespace by selecting the check box, which makes the Operator's performance metrics accessible within the {OCP} web console. link:https://issues.redhat.com/browse/GITOPS-3073[GITOPS-3073]
++
+[NOTE]
+====
+The {gitops-title} Operator's metrics are only available when the Operator is installed in the default namespace, `openshift-gitops-operator`.
+====
+
+* With this update, the {gitops-title} Operator exports custom metrics that allow you to track the performance of the Operator. The following are the exported metrics:
+** `active_argocd_instances_total`: This shows the number of Argo CD instances currently managed across the cluster.
+** `active_argocd_instances_by_phase{phase="<_PHASE>"}`: This shows the number of Argo CD instances in a given phase, such as pending, available, among others.
+** `active_argocd_instance_reconciliation_count{namespace="<_YOUR-DEFINED-NAMESPACE>"}`: This shows the number of times the instance in a given namespace is reconciled.
+** `controller_runtime_reconcile_time_seconds_per_instance{namespace="<_YOUR-DEFINED-NAMESPACE>"}`: This metric displays the distribution of reconciliation cycles by their duration for the instance in a given namespace.
++
+To access these metrics, go to the *Observe* tab on the web console, and run queries against the monitoring stack. link:https://issues.redhat.com/browse/GITOPS-2645[GITOPS-2645]
++
+[NOTE]
+====
+You need to install the {gitops-title} Operator in the default `openshift-gitops-operator` namespace with monitoring enabled to have these metrics automatically available.
+====
+
+* Before this update, there was no option for choosing an algorithm for distributing the destination clusters equally across the different application controller shards. Now, you can set the sharding algorithm to the `round-robin` parameter, which distributes clusters equally across the different application controller shards so that the synchronization load is spread equally among the shards. link:https://issues.redhat.com/browse/GITOPS-3288[GITOPS-3288]
+
+* Before this update, there was no option for scaling the application controller replicas dynamically. Now, you can dynamically scale the number of application controllers based on the number of clusters managed by each application controller. link:https://issues.redhat.com/browse/GITOPS-3287[GITOPS-3287]
+
+[role="_additional-resources"]
+.Additional resources
+* link:https://developers.redhat.com/articles/2023/09/26/dynamically-scale-argo-cd-application-controller-openshift-gitops-110[Dynamically scale the Argo CD application controller with {gitops-title} 1.10.0]
+
+
+[id="deprecated-features-1-10-0_{context}"]
+== Deprecated and removed features
+
+* With this release, the following deprecated `sso` and `dex` fields are removed from Argo CD CR:
+** The `.spec.sso.image`, `.spec.sso.version`, `.spec.sso.resources`, and `.spec.sso.verifyTLS` fields for keycloak SSO configurations
+** The `.spec.dex` fields, along with `DISABLE_DEX` environment variable
++
+Additionally, the `.status.dex` and `.status.ssoConfig` fields are also removed, and a new status field, `.status.sso`, is introduced. The new field reflects the workload status of the SSO provider (dex or keycloak) configured through the `.spec.sso.provider` field. link:https://issues.redhat.com/browse/GITOPS-2473[GITOPS-2473]
++
+[IMPORTANT]
+====
+To configure dex or keycloak SSO, use the equivalent fields under `.spec.sso`.
+==== 
+
+* With this update, the deprecated `.spec.resourceCustomizations` field is removed from Argo CD CR. Bug fixes and support are only provided through the end of the {gitops-title} v1.9 lifecycle.
+As an alternative to `.spec.resourceCustomizations`, you can use `.spec.resourceHealthChecks`, `.spec.resourceIgnoreDifferences`, and `.spec.resourceActions` fields instead. link:https://issues.redhat.com/browse/GITOPS-3041[GITOPS-3041]
++
+[IMPORTANT]
+====
+To prevent data loss during upgrade to {gitops-title} Operator v1.10.0, ensure that you backup `.spec.resourceCustomization` value if it is used in your Argo CD CRs.
+==== 
+
+
+[id="fixed-issues-1-10-0_{context}"]
+== Fixed issues
+
+The following issues have been resolved in the current release:
+
+* Before this update, there were vulnerabilities on Redis. This update fixes the issue by upgrading Redis to the latest version of `registry.redhat.io/rhel-8/redis-6`. link:https://issues.redhat.com/browse/GITOPS-3069[GITOPS-3069]
+
+* Before this update, users were facing an "x509: certificate signed by unknown authority" error when using scmProvider with GitLab. This update fixes the issue by adding support for the `Insecure` flag for scmProvider with GitLab, and an option for mounting TLS certificate on the applicationSet controller.
+This certificate can then be utilized for scmProvider interactions with GitLab. link:https://issues.redhat.com/browse/GITOPS-3107[GITOPS-3107]

--- a/modules/gitops-release-notes-1-9-0.adoc
+++ b/modules/gitops-release-notes-1-9-0.adoc
@@ -96,7 +96,7 @@ metadata:
   labels:
     example: repo
 spec:
-   ...
+  # ...
   repo:
     env:
       - name: SSL_CERT_DIR
@@ -108,7 +108,7 @@ spec:
       - name: ssl
         configMap:
           name: user-ca-bundle
-   ...
+  # ...
 ---- 
 
 . Create an empty config map in the namespace where the subscription for your Operator exists and include the following label:

--- a/modules/gitops-uninstall-keycloak.adoc
+++ b/modules/gitops-uninstall-keycloak.adoc
@@ -10,7 +10,7 @@ You can delete the Keycloak resources and their relevant configurations by remov
 
 [source,yaml]
 ----
-  apiVersion: argoproj.io/v1alpha1
+  apiVersion: argoproj.io/v1beta1
   kind: ArgoCD
   metadata:
     name: example-argocd

--- a/modules/gitops-using-argo-cd-instance-to-manage-cluster-scoped-resources.adoc
+++ b/modules/gitops-using-argo-cd-instance-to-manage-cluster-scoped-resources.adoc
@@ -21,13 +21,13 @@ kind: Subscription
 metadata:
   name: openshift-gitops-operator
   namespace: openshift-operators
-...
+# ...
 spec:
   config:
     env:
     - name: ARGOCD_CLUSTER_CONFIG_NAMESPACES
       value: openshift-gitops, <list of namespaces of cluster-scoped Argo CD instances>
-...
+# ...
 ----
 +
 . To verify that the Argo instance is configured with a cluster role to manage cluster-scoped resources, perform the following steps:

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -23,6 +23,7 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 |*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
 
 |*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |
+|1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |NA |2.35.1 GA |7.5.1 GA |4.12-4.13
 |1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
 |1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
 |1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12

--- a/modules/go-settings-for-environment-labels-and-annotations.adoc
+++ b/modules/go-settings-for-environment-labels-and-annotations.adoc
@@ -21,13 +21,13 @@ spec:
     openshift.gitops/environment: <environment_name>
   destination:
     namespace: <environment_name>
-...
+# ...
 ----  
 
 .Example of an environment application manifest
 [source,yaml]
 ----
-apiVersion: argoproj.io/v1alpha1
+apiVersion: argoproj.io/v1beta1
 kind: Application
 metadata:
   name: dev-env <1>
@@ -37,7 +37,7 @@ spec:
     openshift.gitops/environment: dev-env
   destination:
     namespace: dev-env
-...
+# ...
 ----
 <1> The name of the environment application manifest. The value set is the same as the value of the `<environment_name>` variable.
 
@@ -55,7 +55,7 @@ metadata:
     app.openshift.io/vcs-uri: <application_source_url>
     app.openshift.io/vcs-ref: <branch_reference>
   name: <environment_name> <1>
-...
+# ...
 ----
 <1> The name of the environment namespace manifest. The value set is the same as the value of the `<environment_name>` variable.
 
@@ -71,5 +71,5 @@ metadata:
   labels:
     argocd.argoproj.io/managed-by: openshift-gitops
   name: dev-env
-...
+# ...
 ----  

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -22,6 +22,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-10-0.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-9-2.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-9-1.adoc[leveloffset=+1]


### PR DESCRIPTION
**Version(s):** gitops-docs, gitops-docs-1.10.

**Issue:**
[RHDEVDOCS-5172](https://issues.redhat.com//browse/RHDEVDOCS-5172)

**Link to docs preview:** https://65259--docspreview.netlify.app/openshift-gitops/latest/understanding_openshift_gitops/what-is-gitops.html

**Peer review and Merge review:** @gabriel-rh 

**Additional Info:** While it is a size L there is no significant new content. These files are seen in the PR as new but the content is all from the pre-existing assemblies/modules. Only necessary edits were made to rectify the legacy content errors to keep them in line with the OCP docs, mod docs, and RH SSG guidelines. 

The necessary edits are part of enabling the standalone documentation set for OpenShift GitOps. It was approved by the PM and Content Strategist. It does not affect the main at all, only gitops-docs and gitops-docs-1.10. The PR does not change documentation content, except copying modules or assemblies from the main that were already reviewed for merging to the main.

**Reference - 1.10 PRs in main:**
- https://github.com/openshift/openshift-docs/pull/59959 - [RHDEVDOCS-5098](https://issues.redhat.com//browse/RHDEVDOCS-5098):Remove all instances of .spec.dex parameter
- https://github.com/openshift/openshift-docs/pull/63663 - [RHDEVDOCS-5553](https://issues.redhat.com//browse/RHDEVDOCS-5553): Document removal of deprecated .spec.resourceCustomizations
- https://github.com/openshift/openshift-docs/pull/63781 - [RHDEVDOCS-5552](https://issues.redhat.com//browse/RHDEVDOCS-5552): Document ArgoCD CRD upgrade from v1alpha1 to v1beta1
- https://github.com/openshift/openshift-docs/pull/65102 - [RHDEVDOCS-5550](https://issues.redhat.com//browse/RHDEVDOCS-5550): GitOps 1.10.0 release notes documentation