### PR TITLE
ROX#19795: Release notes for 3.74.6 patch

### DIFF
--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -18,6 +18,7 @@ toc::[]
 |`3.74.3` | 2 May 2023
 |`3.74.4` | 5 June 2023
 |`3.74.5` | 13 July 2023
+|`3.74.6` | 28 September 2023
 |====
 
 [id="about-this-release-374"]
@@ -401,6 +402,16 @@ Release date: 13 July 2023
 * Fixed an issue with upgrades failing because {product-title-short} applied PSPs, even when not enabled.
 
 * Provides a Python3 security update. (link:https://access.redhat.com/errata/RHSA-2023:3591[RHSA-2023:3591])
+
+[id="resolved-in-version-3746"]
+=== Resolved in version 3.74.6
+
+Release date: 28 September 2023
+
+This release of {product-title-short} fixes the following security vulnerabilities:
+
+* link:https://access.redhat.com/security/cve/CVE-2023-2828[CVE-2023-2828]: BIND vulnerability that allows the configured `max-cache-size` limit to be exceeded significantly
+* link:https://access.redhat.com/security/cve/CVE-2023-3899[CVE-2023-3899]: Vulnerability in subscription-manager that allows local privilege escalation due to inadequate authorization
 
 [id="known-issues-374"]
 === Known issues


### PR DESCRIPTION
Version(s):

`rhacs-docs-3.74`

[Issue
](https://issues.redhat.com/browse/ROX-19795)

[Link to docs preview
](https://65264--docspreview.netlify.app/openshift-acs/latest/release_notes/374-release-notes)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
