### PR TITLE
[virt] vm latency checkup: Label the CM and Job

### DIFF
--- a/modules/virt-measuring-latency-vm-secondary-network.adoc
+++ b/modules/virt-measuring-latency-vm-secondary-network.adoc
@@ -105,6 +105,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: kubevirt-vm-latency-checkup-config
+  labels:
+    kiagnose/checkup-type: kubevirt-vm-latency
 data:
   spec.timeout: 5m
   spec.param.networkAttachmentDefinitionNamespace: <target_namespace>
@@ -136,6 +138,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: kubevirt-vm-latency-checkup
+  labels:
+    kiagnose/checkup-type: kubevirt-vm-latency
 spec:
   backoffLimit: 0
   template:
@@ -192,6 +196,8 @@ kind: ConfigMap
 metadata:
   name: kubevirt-vm-latency-checkup-config
   namespace: <target_namespace>
+  labels:
+    kiagnose/checkup-type: kubevirt-vm-latency
 data:
   spec.timeout: 5m
   spec.param.networkAttachmentDefinitionNamespace: <target_namespace>


### PR DESCRIPTION
In order for the UI to be able to get ConfigMap and Job objects that were manually created by oc,
label them as belonging to the checkup.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://65282--docspreview.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups#virt-measuring-latency-vm-secondary-network_virt-running-cluster-checkups

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
