### PR TITLE
OCPBUGS-14687

### DIFF
--- a/modules/cluster-wide-proxy-preqs.adoc
+++ b/modules/cluster-wide-proxy-preqs.adoc
@@ -22,7 +22,17 @@ ifdef::openshift-dedicated[]
 * You are using the Customer Cloud Subscription (CCS) model for your cluster.
 endif::openshift-dedicated[]
 * The proxy can access the VPC for the cluster and the private subnets of the VPC. The proxy is also accessible from the VPC for the cluster and from the private subnets of the VPC.
-* You have added the `ec2.<aws_region>.amazonaws.com`, `elasticloadbalancing.<aws_region>.amazonaws.com`, and `s3.<aws_region>.amazonaws.com` endpoints to your VPC endpoint. These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works at the container level and not at the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not enough.
+* You have added the following endpoints to your VPC endpoint:
+** `ec2.<aws_region>.amazonaws.com`
+** `elasticloadbalancing.<aws_region>.amazonaws.com`
+** `s3.<aws_region>.amazonaws.com`
++
+These endpoints are required to complete requests from the nodes to the AWS EC2 API. Because the proxy works at the container level and not at the node level, you must route these requests to the AWS EC2 API through the AWS private network. Adding the public IP address of the EC2 API to your allowlist in your proxy server is not enough.
++
+[NOTE]
+====
+When using a cluster-wide proxy, you must configure the `s3.<aws_region>.amazonaws.com` endpoint as type `Gateway`. Also, you can configure the `ec2.<aws_region>.amazonaws.com` and `elasticloadbalancing.<aws_region>.amazonaws.com` endpoints only as type `Interface`.
+====
 
 [discrete]
 [id="cluster-wide-proxy-network-prereqs_{context}"]


### PR DESCRIPTION
[OCPBUGS-14687](https://issues.redhat.com/browse/OCPBUGS-14687): [DOCS] Missing information in cluster-wide proxy configuration in ROSA
Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OCPBUGS-14687](https://issues.redhat.com/browse/OCPBUGS-14687)
Preview pages: [Click to see the build preview in your browser](https://65285--docspreview.netlify.app/openshift-rosa/latest/networking/configuring-cluster-wide-proxy#cluster-wide-proxy-prereqs_configuring-a-cluster-wide-proxy)
SME review **completed**: @halfsquatch
QE review **completed**:  @yingzhanredhat
Peer review **completed**: @GroceryBoyJr

Note: We have QE approval in [Jira comment](https://issues.redhat.com/browse/OCPBUGS-14687?focusedId=23231329&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23231329).
