### PR TITLE
RHDEVDOCS-5369-cp: Pipelines as Code, Logging Configuration

### DIFF
--- a/modules/op-configuring-pipelines-as-code-logging.adoc
+++ b/modules/op-configuring-pipelines-as-code-logging.adoc
@@ -1,0 +1,151 @@
+// This module is included in the following assembly:
+//
+// * pac/pac-command-reference.adoc
+
+:_content-type: PROCEDURE
+[id="configuring-pipelines-as-code-logging_{context}"]
+= Configuring {pac} logging 
+
+You can configure {pac} logging by editing the `pac-config-logging` config map in the `TektonConfig` custom resource (CR).
+
+.Prerequisites
+
+* You have {pac} installed on your cluster.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, go to *Administration* → *CustomResourceDefinitions*.
+
+. Use the *Search by name* field to search for the `tektonconfigs.operator.tekton.dev` custom resource definition (CRD) and click *TektonConfig* to view the CRD *Details* page.
+
+. Click the *Instances* tab.
+
+. Click the *config* instance to view the `TektonConfig` CR details.
+
+. Click the *YAML* tab.
+
+. Edit the `loglevel.` fields under the `.options.configMaps.pac-config-logging.data` parameter based on your requirements.
++
+.Example `TektonConfig` CR with the {pac} log level fields set to `warn`
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  platforms:
+    openshift:
+      pipelinesAsCode:
+        options:
+          configMaps:
+            pac-config-logging:
+              data:
+                loglevel.pac-watcher: warn <1>
+                loglevel.pipelines-as-code-webhook: warn <2>
+                loglevel.pipelinesascode: warn <3>
+                zap-logger-config: |
+                  {
+                    "level": "info",
+                    "development": false,
+                    "sampling": {
+                      "initial": 100,
+                      "thereafter": 100
+                    },
+                    "outputPaths": ["stdout"],
+                    "errorOutputPaths": ["stderr"],
+                    "encoding": "json",
+                    "encoderConfig": {
+                      "timeKey": "ts",
+                      "levelKey": "level",
+                      "nameKey": "logger",
+                      "callerKey": "caller",
+                      "messageKey": "msg",
+                      "stacktraceKey": "stacktrace",
+                      "lineEnding": "",
+                      "levelEncoder": "",
+                      "timeEncoder": "iso8601",
+                      "durationEncoder": "",
+                      "callerEncoder": ""
+                    }
+                  }
+----
+<1> The log level for the `pipelines-as-code-watcher` component.
+<2> The log level for the `pipelines-as-code-webhook` component.
+<3> The log level for the `pipelines-as-code-controller` component.
+
+. Optional: Create a custom logging config map for the {pac} components by changing the `.env.value` for each component under the `.options.deployments` field. The example below shows the configuration with the custom config map called `custom-pac-config-logging`.
++
+.Example `TektonConfig` CR with the {pac} custom logging config map
+[source,yaml]
+----
+apiVersion: operator.tekton.dev/v1alpha1
+kind: TektonConfig
+metadata:
+  name: config
+spec:
+  platforms:
+    openshift:
+      pipelinesAsCode:
+        enable: true
+        options:
+          configMaps:
+            custom-pac-config-logging:
+              data:
+                loglevel.pac-watcher: warn
+                loglevel.pipelines-as-code-webhook: warn
+                loglevel.pipelinesascode: warn
+                zap-logger-config: |
+                  {
+                    "level": "info",
+                    "development": false,
+                    "sampling": {
+                      "initial": 100,
+                      "thereafter": 100
+                    },
+                    "outputPaths": ["stdout"],
+                    "errorOutputPaths": ["stderr"],
+                    "encoding": "json",
+                    "encoderConfig": {
+                      "timeKey": "ts",
+                      "levelKey": "level",
+                      "nameKey": "logger",
+                      "callerKey": "caller",
+                      "messageKey": "msg",
+                      "stacktraceKey": "stacktrace",
+                      "lineEnding": "",
+                      "levelEncoder": "",
+                      "timeEncoder": "iso8601",
+                      "durationEncoder": "",
+                      "callerEncoder": ""
+                    }
+                  }
+          deployments:
+            pipelines-as-code-controller:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - name: pac-controller
+                      env:
+                      - name: CONFIG_LOGGING_NAME
+                        value: custom-pac-config-logging
+            pipelines-as-code-watcher:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - name: pac-watcher
+                      env:
+                      - name: CONFIG_LOGGING_NAME
+                        value: custom-pac-config-logging
+            pipelines-as-code-webhook:
+              spec:
+                template:
+                  spec:
+                    containers:
+                    - name: pac-webhook
+                      env:
+                      - name: CONFIG_LOGGING_NAME
+                        value: custom-pac-config-logging
+----

--- a/pac/pac-command-reference.adoc
+++ b/pac/pac-command-reference.adoc
@@ -7,9 +7,11 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 [role="_abstract"]
-You can use the `tkn pac` CLI tool to control {pac}. You can also use the `oc` command to view {pac} logs.
+You can use the `tkn pac` CLI tool to control {pac}. You can also configure {pac} logging with the `TektonConfig` custom resource and use the `oc` command to view {pac} logs.
 
 include::modules/op-pipelines-as-code-command-reference.adoc[leveloffset=+1]
+
+include::modules/op-configuring-pipelines-as-code-logging.adoc[leveloffset=+1]
 
 include::modules/op-splitting-pipelines-as-code-logs-by-namespace.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This is a manual cherry-pick of #63525 into the standalone.
• **Pipeline version for cherry-picking**: pipelines-docs-1.12
Preview: https://65303--docspreview.netlify.app/openshift-pipelines/latest/pac/pac-command-reference#configuring-pipelines-as-code-logging_pac-command-reference
