### PR TITLE
[enterprise-4.13] TELCODOCS-1340-413 documenting ptp must-gather

### DIFF
--- a/modules/cnf-about-collecting-ptp-data.adoc
+++ b/modules/cnf-about-collecting-ptp-data.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+//
+// * networking/using-ptp.adoc
+
+:_content-type: PROCEDURE
+[id="cnf-about-collecting-nro-data_{context}"]
+= Collecting Precision Time Protocol (PTP) Operator data
+
+You can use the `oc adm must-gather` CLI command to collect information about your cluster, including features and objects associated with Precision Time Protocol (PTP) Operator.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+* You have installed the {oc-first}.
+
+* You have installed the PTP Operator.
+
+.Procedure
+
+* To collect PTP Operator data with `must-gather`, you must specify the PTP Operator `must-gather` image.
++
+[source,terminal,subs="attributes+"]
+----
+$ oc adm must-gather --image=registry.redhat.io/openshift4/ptp-must-gather-rhel8:v{product-version}
+----

--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -63,6 +63,9 @@ endif::openshift-dedicated[]
 |`registry.redhat.io/workload-availability/self-node-remediation-must-gather-rhel8:v<installed-version-SNR>`
 |Data collection for the Self Node Remediation (SNR) Operator and the Node Health Check (NHC) Operator.
 
+|`registry.redhat.io/openshift4/ptp-must-gather-rhel8:v<installed-version-ptp>`
+|Data collection for the PTP Operator.
+
 |`registry.redhat.io/workload-availability/node-maintenance-must-gather-rhel8:v<installed-version-NMO>`
 |Data collection for the Node Maintenance Operator (NMO).
 

--- a/networking/using-ptp.adoc
+++ b/networking/using-ptp.adoc
@@ -89,6 +89,8 @@ include::modules/cnf-configuring-log-filtering-for-linuxptp.adoc[leveloffset=+2]
 
 include::modules/cnf-troubleshooting-common-ptp-operator-issues.adoc[leveloffset=+1]
 
+include::modules/cnf-about-collecting-ptp-data.adoc[leveloffset=+2]
+
 == PTP hardware fast event notifications framework
 
 Cloud native applications such as virtual RAN (vRAN) require access to notifications about hardware timing events that are critical to the functioning of the overall network.


### PR DESCRIPTION
[TELCODOCS-1340]: Documenting PTP must-gather

Cherry Picked from https://github.com/openshift/openshift-docs/pull/64731/commits/d7812d94a97935e2958b128b92079a5779972109 xref: https://github.com/openshift/openshift-docs/pull/64731

Version(s):  4.13

Issue: https://issues.redhat.com/browse/TELCODOCS-1340

Link to docs preview:

https://65309--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data.html#gathering-data-specific-features_gathering-cluster-data
https://65309--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp#cnf-about-collecting-nro-data_using-ptp
QE review:

 QE has approved this change.
Additional information:
