### PR TITLE
OADP and FIPS

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-features-plugins.adoc
@@ -26,4 +26,6 @@ OADP 1.1.0 was tested successfully against {product-title} 4.11 for both {ibm-po
 include::modules/oadp-ibm-power-test-support.adoc[leveloffset=+2]
 include::modules/oadp-ibm-z-test-support.adoc[leveloffset=+2]
 
+include::modules/oadp-fips.adoc[leveloffset=+1]
+
 :!oadp-features-plugins:

--- a/modules/oadp-fips.adoc
+++ b/modules/oadp-fips.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.adoc
+
+
+:_content-type: CONCEPT
+[id="oadp-fips_{context}"]
+= OADP and FIPS
+
+Federal Information Processing Standards (FIPS) are a set of computer security standards developed by the United States federal government in line with the Federal Information Security Management Act (FISMA).
+
+{oadp-first} has been tested and works on FIPS-enabled {product-title} clusters.


### PR DESCRIPTION
OADP 1.3; OCP 4.11+

Resolves: https://issues.redhat.com/browse/OADP-2692 by adding a short note describe OADP compliance with FIPS.

Preview: https://65310--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/oadp-features-plugins#oadp-fips_oadp-features-plugins

OADP QE approved this PR. 