### PR TITLE
RHDEVDOCS-5358 set up direct link and latest redirects for GitOps

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -238,7 +238,33 @@ AddType text/vtt                            vtt
     # redirect top-level without filespec to the about file
     RewriteRule ^gitops/(1\.8|1\.9)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
+    # GitOps landing page
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html[L,R=302]
 
+    # redirect any links to existing OCP embedded content to standalone equivalent for each assembly
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes.html  [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/understanding-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/installing-openshift-gitops.html /gitops/latest/installing_gitops/installing-openshift-gitops.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/uninstalling-openshift-gitops.html /gitops/latest/removing_gitops/uninstalling-openshift-gitops.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/setting-up-argocd-instance.html /gitops/latest/argocd_instance/setting-up-argocd-instance.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/monitoring-argo-cd-instances.html /gitops/latest/observability/monitoring/monitoring-argo-cd-instances.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/using-argo-rollouts-for-progressive-deployment-delivery.html /gitops/latest/argo_rollouts/using-argo-rollouts-for-progressive-deployment-delivery.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html /gitops/latest/declarative_clusterconfig/configuring-an-openshift-cluster-by-deploying-an-application-with-cluster-configurations.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/deploying-a-spring-boot-application-with-argo-cd.html /gitops/latest/argocd_applications/deploying-a-spring-boot-application-with-argo-cd.html [L,R=302] 
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/argo-cd-custom-resource-properties.html /gitops/latest/argocd_instance/argo-cd-cr-component-properties.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/configuring-secure-communication-with-redis.html /gitops/latest/securing_openshift_gitops/configuring-secure-communication-with-redis.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/health-information-for-resources-deployment.html /gitops/latest/observability/monitoring/health-information-for-resources-deployment.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/configuring-sso-on-argo-cd-using-dex.html /gitops/latest/accesscontrol_usermanagement/configuring-sso-on-argo-cd-using-dex.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/configuring-sso-for-argo-cd-using-keycloak.html /gitops/latest/accesscontrol_usermanagement/configuring-sso-for-argo-cd-using-keycloak.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/configuring-argo-cd-rbac.html /gitops/latest/accesscontrol_usermanagement/configuring-argo-cd-rbac.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/configuring-resource-quota.html /gitops/latest/managing_resource/configuring-resource-quota.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/monitoring-argo-cd-custom-resource-workloads.html /gitops/latest/observability/monitoring/monitoring-argo-cd-custom-resource-workloads.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/viewing-argo-cd-logs.html /gitops/latest/observability/logging/viewing-argo-cd-logs.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/run-gitops-control-plane-workload-on-infra-nodes.html /gitops/latest/gitops_workloads_infranodes/run-gitops-control-plane-workload-on-infra-nodes.html [L,R=302] 
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/about-sizing-requirements-gitops.html /gitops/latest/installing_gitops/preparing-gitops-install.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/collecting-debugging-data-for-support.html /gitops/latest/understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support.html [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/troubleshooting-issues-in-GitOps.html /gitops/latest/troubleshooting_gitops_issues/auto-reboot-during-argo-cd-sync-with-machine-configurations.html [L,R=302]
+ 
     # Pipelines handling unversioned and latest links
     RewriteRule ^pipelines/?$ /pipelines/latest [R=302]
     RewriteRule ^pipelines/latest/?(.*)$ /pipelines/1\.11/$1 [NE,R=302]


### PR DESCRIPTION
**Version(s):** main only

**Issue:**

- [RHDEVDOCS 5358](https://issues.redhat.com/browse/RHDEVDOCS-5358) 
- [RHDEVDOCS 5172](https://issues.redhat.com/browse/RHDEVDOCS-5172)

**Additional information:** This PR creates a redirect that should send the user to the GitOps standalone doc when the "About OpenShift GitOps " link is clicked in the navigation tree. It does not alter documentation content.