### PR TITLE
RHDEVDOCS-5358 set up direct link  redirect for GitOps

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -239,7 +239,7 @@ AddType text/vtt                            vtt
     RewriteRule ^gitops/(1\.8|1\.9)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # GitOps landing page
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html[L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent for each assembly
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes.html  [L,R=302]


### PR DESCRIPTION
**Version(s):** main only

**Issue:**

- [RHDEVDOCS 5358](https://issues.redhat.com/browse/RHDEVDOCS-5358) 
- [RHDEVDOCS 5172](https://issues.redhat.com/browse/RHDEVDOCS-5172)

**Additional information:** This PR creates a redirect that should send the user to the GitOps standalone doc when the "About OpenShift GitOps " link is clicked in the navigation tree. It does not alter documentation content.