### PR TITLE
OSDOCS-6844:  Installing a user-provisioned bare metal cluster on a restricted network - PXE Customize

### DIFF
--- a/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
@@ -8,6 +8,11 @@
 = Modifying a live install {boot-media} with customized network settings
 You can embed a NetworkManager keyfile into the live {boot-media} and pass it through to the installed system with the `--network-keyfile` flag of the `customize` subcommand.
 
+[WARNING]
+====
+When creating a connection profile, you must use a `.nmconnection` filename extension in the filename of the connection profile. If you do not use a `.nmconnection` filename extension, the cluster will apply the connection profile to the live environment, but it will not apply the configuration when the cluster first boots up the nodes, resulting in a setup that does not work.
+====
+
 .Procedure
 
 . Download the `coreos-installer` binary from the link:https://mirror.openshift.com/pub/openshift-v4/clients/coreos-installer/latest/[`coreos-installer` image mirror] page.
@@ -38,7 +43,7 @@ method=auto
 
 [proxy]
 ----
-+
+
 . Create a connection profile for a secondary interface to add to the bond. For example, create the `bond0-proxy-em1.nmconnection` file in your local directory with the following content:
 +
 [source,ini]
@@ -55,7 +60,7 @@ slave-type=bond
 [ethernet]
 mac-address-blacklist=
 ----
-+
+
 . Create a connection profile for a secondary interface to add to the bond. For example, create the `bond0-proxy-em2.nmconnection` file in your local directory with the following content:
 +
 [source,ini]
@@ -72,7 +77,7 @@ slave-type=bond
 [ethernet]
 mac-address-blacklist=
 ----
-+
+
 ifeval::["{boot-media}" == "ISO image"]
 . Retrieve the {op-system} ISO image from the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/[{op-system} image mirror] page and run the following command to customize the ISO image with your configured networking:
 +


### PR DESCRIPTION
Added a warning about using a .nmconnection file name extension to a network manager connection profile.

Fixes: [OSDOCS-6844](https://issues.redhat.com//browse/OSDOCS-6844)

See https://issues.redhat.com/browse/OSDOCS-6844 for additional details.

Preview URL: http://184.23.213.161:8080/OSDOCS-6844/installing/installing_bare_metal/installing-restricted-networks-bare-metal.html#installation-user-infra-machines-advanced-customizing-live-iso-serial-console_installing-restricted-networks-bare-metal

For release(s): 4.15, 4.14, 4.13, 4.12, 4.11, 4.10
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
