### PR TITLE
OSSM-4874 [DOC] 2.4.4 Release Notes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -145,7 +145,7 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.4.3
+:SMProductVersion: 2.4.4
 :MaistraVersion: 2.4
 //Service Mesh v1
 :SMProductVersion1x: 1.1.18.2

--- a/modules/ossm-rn-fixed-issues.adoc
+++ b/modules/ossm-rn-fixed-issues.adoc
@@ -14,6 +14,12 @@ Provide the following info for each issue if possible:
 *Result* - How has the behavior changed as a result? Try to avoid “It is fixed” or “The issue is resolved” or “The error no longer presents”.
 ////
 
+The following issues have been resolved in the current release:
+
+* https://issues.redhat.com/browse/OSSM-4851[OSSM-4851] Previously, an error occurred in the operator deploying new pods in a namespace scoped inside the mesh when `runAsGroup`, `runAsUser`, or `fsGroup` parameters were `nil`. Now, a yaml validation has been added to avoid the `nil` value.
+
+* https://issues.redhat.com/browse/OSSM-3771[OSSM-3771] Previously, OpenShift routes could not be disabled for additional ingress gateways defined in a Service Mesh Control Plane (SMCP). Now, a `routeConfig` block can be added to each `additionalIngress` gateway so the creation of OpenShift routes can be enabled or disabled for each gateway.
+
 The following issues have been resolved in previous releases: 
 
 [id="ossm-rn-fixed-issues-ossm_{context}"]

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -15,6 +15,32 @@ Module included in the following assemblies:
 
 This release adds improvements related to the following components and concepts.
 
+== New features {SMProductName} version 2.4.4
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.11 and later versions.
+
+=== Component versions included in {SMProductName} version 2.4.4
+//Istio stays the same
+//Envoy updated to 1.24.12
+//According to distributed tracing release 2.9, the latest at time of OSSM 2.4.4, Jaeger has been updated to 1.47.0
+//Kiali updated to 1.65.9
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.12
+
+|Jaeger
+|1.47.0
+
+|Kiali
+|1.65.9
+|===
+//Components updated for 2.4.4
+
 == New features {SMProductName} version 2.4.3
 
 * The {SMProductName} Operator is now available on ARM-based clusters as a Technology Preview feature.
@@ -227,6 +253,33 @@ spec:
 * HBONE protocol for sidecars is an experimental feature that is not supported.
 * {SMProductShortName} on ARM64 architecture is not supported.
 * OpenTelemetry API remains a Technology Preview feature.
+
+== New features {SMProductName} version 2.3.8
+//Update with 2.4.4
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.11 and later versions.
+
+=== Component versions included in {SMProductName} version 2.3.8
+//Istio for 2.3.8 is now 1.14.5
+//Kiali is 1.57.13
+//Jaeger is 1.47.0
+//Envoy stays the same
+|===
+|Component |Version
+
+|Istio
+|1.14.5
+
+|Envoy Proxy
+|1.22.11
+
+|Jaeger
+|1.47.0
+
+|Kiali
+|1.57.13
+|===
+//Components updated for 2.3.8 as part of 2.4.4 update
 
 == New features {SMProductName} version 2.3.7
 
@@ -479,6 +532,32 @@ Additionally, the SMMR must also be configured for cluster-wide deployment. This
     - '*' <1>
 ----
 <1> Adds all namespaces to the mesh, including any namespaces you subsequently create. The following namespaces are not part of the mesh: kube, openshift, kube-* and openshift-*.
+
+== New features {SMProductName} version 2.2.11
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.11 and later versions.
+
+=== Component versions included in {SMProductName} version 2.2.11
+//Istio remains the same
+//Kiali updated to 1.48.10
+//Jaeger updated to 1.47.0
+//Envoy remains the same
+|===
+|Component |Version
+
+|Istio
+|1.12.9
+
+|Envoy Proxy
+|1.20.8
+
+|Jaeger
+|1.47.0
+
+|Kiali
+|1.48.10
+|===
+//Components updated for 2.2.11 with 2.4.4 release
 
 == New features {SMProductName} version 2.2.10
 


### PR DESCRIPTION
[OSSM-4874](https://issues.redhat.com//browse/OSSM-4874) [DOC] 2.4.4 Release Notes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSSM-4874

Link to docs preview:

2.4.4 release component table: https://65346--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-4-4

2.3.8 component table: https://65346--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-3-8

2.2.11 component table: https://65346--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-2-11

Fixed Issues: https://65346--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#ossm-rn-fixed-issues_ossm-release-notes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Only 2 issues under "Fixed issues" need to be reviewed:

[OSSM-4851](https://issues.redhat.com/browse/OSSM-4851) Previously, an error occurred in the operator deploying new pods in a namespace scoped inside the mesh when runAsGroup, runAsUser, or fsGroup were nil. Now, a yaml validation has been added to avoid the nil value.

[OSSM-3771](https://issues.redhat.com/browse/OSSM-3771) Previously, OpenShift routes could not be disabled for additional ingress gateways defined in a Service Mesh Control Plane (SMCP). Now, a routeConfig block can be added to each additionalIngress gateway so the creation of OpenShift routes can be enabled or disabled for each gateway.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
