### PR TITLE
OSDOCS#7662: Control plane node resizing alert

### DIFF
--- a/modules/sd-planning-considerations.adoc
+++ b/modules/sd-planning-considerations.adoc
@@ -58,10 +58,9 @@ Post-installation scaling requirements for control plane and infrastructure node
 
 .Rules for control plane node resizing alerts
 
-Resizing alerts are triggered for the control plane nodes in a cluster when either of the following scenarios are true: 
+The resizing alert is triggered for the control plane nodes in a cluster when the following occurs:
 
-* Each control plane node has less than 16GiB RAM, and there are more than 25 and less than 101 compute nodes.
-* Each control plane node has less than 32GiB RAM, and there are more than 100 compute nodes.
+* Control plane nodes sustain over 66% utilization on average in a classic ROSA cluster.
 +
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
[OSDOCS-7662](https://issues.redhat.com/browse/OSDOCS-7662)

Link to docs preview:
[Rules for control plane node resizing alert](https://65353--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-limits-scalability#node-scaling-after-installation_rosa-limits-scalability)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
