### PR TITLE
OCPBUGS#19857: Revert CNV Gathering data about specifics section

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -25,7 +25,7 @@ ifndef::openshift-origin[]
 |===
 |Image |Purpose
 
-|`registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v<installed_version_virt>`
+|`registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel8:v{HCOVersion}`
 |Data collection for {VirtProductName}.
 
 |`registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8`


### PR DESCRIPTION
[OCPBUGS-19857](https://issues.redhat.com/browse/OCPBUGS-19857)

Version(s):
4.12 and 4.11

**Note:** {HCOVersion} renders to `4.12.6` for 4.12 and `4.11.6` for 4.11

Issue:
[Gathering data about specific features](https://65357--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data#gathering-data-specific-features_gathering-cluster-data)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Original update was made through https://issues.redhat.com/browse/OCPBUGS-15273
