### PR TITLE
Changes to GitOps 1.10 Release Note

### DIFF
--- a/modules/gitops-release-notes-1-10-0.adoc
+++ b/modules/gitops-release-notes-1-10-0.adoc
@@ -12,14 +12,14 @@
 == Errata updates
 
 [id="gitops-1-10-0-security-update-advisory_{context}"]
-=== RHSA-2023:XXXX and RHEA-2023:YYYY - {gitops-title} 1.10.0 security update advisory
+=== RHSA-2023:5407 and RHEA-2023:5408 - {gitops-title} 1.10.0 security update advisory
 
-Issued: 2023-09-27
+Issued: 2023-09-29
 
 The list of security fixes and enhancements that are included in this release is documented in the following advisories:
 
-* link:https://errata.devel.redhat.com/advisory/120274[RHSA-2023:XXXX]
-* link:https://errata.engineering.redhat.com/advisory/120119[RHEA-2023:YYYY]
+* link:https://access.redhat.com/errata/RHSA-2023:5407[RHSA-2023:5407]
+* link:https://access.redhat.com/errata/RHEA-2023:5408[RHEA-2023:5408]
 
 If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
 
@@ -49,7 +49,7 @@ Disabling or changing the content of the dashboards is not supported.
 
 * Previously, timestamps were presented in a Unix epoch format. With this update, the timestamps are changed to RFC3339 format, for example: 2023-06-27T07:12:48-04:00, to improve overall readability. link:https://issues.redhat.com/browse/GITOPS-2898[GITOPS-2898]
 
-* With this update, the default Argo CD instance in the `openshift-gitops` namespace has restricted permissions for non-admin users by default. This improves security because non-admin users no longer have access to sensitive information. However, as an administrator, you can set permissions and grant non-admin users access to the resources managed by the default `openshift-gitops` Argo CD instance by configuring your Argo CD RBAC. This change only applies to the default {gitops-title} instance. link:https://issues.redhat.com/browse/GITOPS-3032[GITOPS-3032]
+* With this update, the default Argo CD instance in the `openshift-gitops` namespace has restricted permissions for non-admin users by default. This improves security because non-admin users no longer have access to sensitive information. However, as an administrator, you can set permissions and grant non-admin users access to the resources managed by the default `openshift-gitops` Argo CD instance by configuring your Argo CD RBAC. This change only applies to the default `openshift-gitops` Argo CD instance. link:https://issues.redhat.com/browse/GITOPS-3032[GITOPS-3032]
 
 * With this update, the default installation namespace for {gitops-title} Operator is changed to its own namespace called `openshift-gitops-operator`. You can still choose the old default installation namespace, `openshift-operators`, through a drop-down menu available in the OperatorHub UI at installation time. You can also enable cluster monitoring on the new namespace by selecting the check box, which makes the Operator's performance metrics accessible within the {OCP} web console. link:https://issues.redhat.com/browse/GITOPS-3073[GITOPS-3073]
 +

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -20,13 +20,12 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 ====
 
 |===
-|*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
+|*OpenShift GitOps* 8+|*Component Versions*|*OpenShift Versions*
 
-|*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |
-|1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |NA |2.35.1 GA |7.5.1 GA |4.12-4.13
-|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
-|1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
-|1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
+|*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*Argo Rollouts*|*ApplicationSet* |*Dex*     |*RH SSO* |
+|1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |1.5.0 |NA |2.35.1 GA |7.5.1 GA |4.12-4.13
+|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
+|1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
 |===
 
 * `kam` is the {gitops-title} Application Manager command-line interface (CLI).


### PR DESCRIPTION
Version(s): gitops-docs, gitops-docs-1.10.

Issue:
[RHDEVDOCS-5172](https://issues.redhat.com//browse/RHDEVDOCS-5172)
[RHDEVDOCS-5550](https://issues.redhat.com/browse/RHDEVDOCS-5550)

Link to docs preview: https://65359--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes.html

Peer review and Merge review: @gabriel-rh