### PR TITLE
Fixing asciidoctor build errors

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-intro.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-intro.adoc
@@ -14,9 +14,9 @@ However, OADP does not serve as a disaster recovery solution for xref:../../back
 
 
 [id="oadp-apis_{context}"]
-= {oadp-full} APIs
+== {oadp-full} APIs
 
-{oadp-first} provides APIs that enable multiple approaches to customizing backups and preventing the inclusion of unnecessary or inappropriate resources. 
+{oadp-first} provides APIs that enable multiple approaches to customizing backups and preventing the inclusion of unnecessary or inappropriate resources.
 
 OADP provides the following APIs:
 

--- a/modules/oadp-backing-up-pvs-csi.adoc
+++ b/modules/oadp-backing-up-pvs-csi.adoc
@@ -5,8 +5,6 @@
 :_content-type: PROCEDURE
 [id="oadp-backing-up-pvs-csi_{context}"]
 = Backing up persistent volumes with CSI snapshots
-include::_attributes/common-attributes.adoc[]
-include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: backing-up-applications
 
 toc::[]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
None

Link to docs preview (VPN required):
[OpenShift API for Data Protection APIs](https://file.rdu.redhat.com/antaylor/asciidoctor-build-errors/backup_and_restore/application_backup_and_restore/oadp-intro.html#oadp-apis_oadp-api)

Additional information:
Fixes build issues introduced in #64198 and #64811

```
asciidoctor: ERROR: oadp-intro.adoc: line 17: level 0 sections can only be used when doctype is book
asciidoctor: ERROR: modules/oadp-backing-up-pvs-csi.adoc: line 8: include file not found: /home/antaylor/openshift-docs/modules/_attributes/common-attributes.adoc
asciidoctor: ERROR: modules/oadp-backing-up-pvs-csi.adoc: line 9: include file not found: /home/antaylor/openshift-docs/modules/_attributes/attributes-openshift-dedicated.adoc
```
