### PR TITLE
OCPBUGS-18522: removes ovn-kubernetes-master from 4.13

### DIFF
--- a/modules/nw-ovn-kubernetes-list-resources.adoc
+++ b/modules/nw-ovn-kubernetes-list-resources.adoc
@@ -54,16 +54,13 @@ configmap/control-plane-status       1      55m
 configmap/kube-root-ca.crt           1      57m
 configmap/openshift-service-ca.crt   1      57m
 configmap/ovn-ca                     1      57m
-configmap/ovn-kubernetes-master      0      55m
 configmap/ovnkube-config             1      57m
 configmap/signer-ca                  1      57m
 ----
 +
 There are three `ovnkube-masters` that run on the control plane nodes, and two daemon sets used to deploy the `ovnkube-master` and `ovnkube-node` pods.
 There is one `ovnkube-node` pod for each node in the cluster.
-In this example, there are 5, and since there is one `ovnkube-node` per node in the cluster, there are five nodes in the cluster.
 The `ovnkube-config` `ConfigMap` has the {product-title} OVN-Kubernetes configurations started by online-master and `ovnkube-node`.
-The `ovn-kubernetes-master` `ConfigMap` has the information of the current online master leader.
 
 . List all the containers in the `ovnkube-master` pods by running the following command:
 +
@@ -97,3 +94,17 @@ ovn-controller ovn-acl-logging kube-rbac-proxy kube-rbac-proxy-ovn-metrics ovnku
 ----
 +
 The `ovnkube-node` pod has a container (`ovn-controller`) that resides on each {product-title} node. Each node’s `ovn-controller` connects the OVN northbound to the OVN southbound database to learn about the OVN configuration. The `ovn-controller` connects southbound to `ovs-vswitchd` as an OpenFlow controller, for control over network traffic, and to the local `ovsdb-server` to allow it to monitor and control Open vSwitch configuration.
+
+. List the currently elected OVN-Kubernetes master leader by running the following command:
++
+[source,terminal]
+----
+$ oc get lease -n openshift-ovn-kubernetes
+----
+.Expected output
++
+[source,terminal]
+----
+NAME                    HOLDER                               AGE
+ovn-kubernetes-master   ci-ln-gz990pb-72292-rthz2-master-2   50m
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-18522
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
Preview [link](https://65373--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-architecture-assembly#:~:text=3%20more...%20%20%2019m-,NAME,-DATA%20%20%20AGE%0Aconfigmap)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
