### PR TITLE
OCPBUGS-19857-4-13-plus: Revert CNV Gathering data about specifics se…

### DIFF
--- a/modules/gathering-data-specific-features.adoc
+++ b/modules/gathering-data-specific-features.adoc
@@ -25,7 +25,7 @@ ifndef::openshift-origin[]
 |===
 |Image |Purpose
 
-|`registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v<installed_version_virt>`
+|`registry.redhat.io/container-native-virtualization/cnv-must-gather-rhel9:v{HCOVersion}`
 |Data collection for {VirtProductName}.
 
 |`registry.redhat.io/openshift-serverless-1/svls-must-gather-rhel8`


### PR DESCRIPTION
[OCPBUGS-19857](https://issues.redhat.com/browse/OCPBUGS-19857)

Version(s):
4.13 and 4.14

**Note:** {HCOVersion} renders to `4.13.4` for 4.13. I see that the main branch renders this value as `4.13.0`, which is possibly incorrect for 4.14.

Issue:
[Gathering data about specific features](https://65357--docspreview.netlify.app/openshift-enterprise/latest/support/gathering-cluster-data#gathering-data-specific-features_gathering-cluster-data)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Original update was made through https://issues.redhat.com/browse/OCPBUGS-15273
