### PR TITLE
OSSM-4877 [DOC] Release Notes Update 2.3.7 and 2.2.10

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -228,6 +228,28 @@ spec:
 * {SMProductShortName} on ARM64 architecture is not supported.
 * OpenTelemetry API remains a Technology Preview feature.
 
+== New features {SMProductName} version 2.3.7
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.10 and later versions.
+
+=== Component versions included in {SMProductName} version 2.3.7
+
+|===
+|Component |Version
+
+|Istio
+|1.14.6
+
+|Envoy Proxy
+|1.22.11
+
+|Jaeger
+|1.42.0
+
+|Kiali
+|1.57.11
+|===
+
 == New features {SMProductName} version 2.3.6
 
 This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.10 and later versions.
@@ -457,6 +479,28 @@ Additionally, the SMMR must also be configured for cluster-wide deployment. This
     - '*' <1>
 ----
 <1> Adds all namespaces to the mesh, including any namespaces you subsequently create. The following namespaces are not part of the mesh: kube, openshift, kube-* and openshift-*.
+
+== New features {SMProductName} version 2.2.10
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.10 and later versions.
+
+=== Component versions included in {SMProductName} version 2.2.10
+
+|===
+|Component |Version
+
+|Istio
+|1.12.9
+
+|Envoy Proxy
+|1.20.8
+
+|Jaeger
+|1.42.0
+
+|Kiali
+|1.48.8
+|===
 
 == New features {SMProductName} version 2.2.9
 


### PR DESCRIPTION
OSSM [DOC] Release Notes Update 2.3.7 and 2.2.10

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSSM-4877

Link to docs preview:

2.3.7: https://65391--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-3-7

2.2.10: https://65391--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-2-10

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Adds updated component information for 2.3.7 and 2.2.10.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
