### PR TITLE
OSDOCS#7808: Updating statement of FIPS support

### DIFF
--- a/installing/installing-fips.adoc
+++ b/installing/installing-fips.adoc
@@ -6,14 +6,18 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can install an {product-title} cluster that uses FIPS validated or Modules In Process cryptographic libraries on the `x86_64`, `ppc64le`, and `s390x` architectures.
+You can install an {product-title} cluster in FIPS mode.
+
+{product-title} is designed for FIPS. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the x86_64, ppc64le, and s390x architectures.
+
+For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status for the individual versions of {op-system-base} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/2918071#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
 
 [IMPORTANT]
 ====
-To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
 ====
 
-For the {op-system-first} machines in your cluster, this change is applied when the machines are deployed based on the status of an option in the `install-config.yaml` file, which governs the cluster options that a user can change during cluster deployment. With {op-system-base-full} machines, you must enable FIPS mode when you install the operating system on the machines that you plan to use as worker machines. These configuration methods ensure that your cluster meets the requirements of a FIPS compliance audit: only FIPS validated or Modules In Process cryptography packages are enabled before the initial system boot.
+For the {op-system-first} machines in your cluster, this change is applied when the machines are deployed based on the status of an option in the `install-config.yaml` file, which governs the cluster options that a user can change during cluster deployment. With {op-system-base-full} machines, you must enable FIPS mode when you install the operating system on the machines that you plan to use as worker machines.
 
 Because FIPS must be enabled before the operating system that your cluster uses boots for the first time, you cannot enable FIPS after you deploy a cluster.
 
@@ -74,6 +78,11 @@ To ensure that containers know that they are running on a host that is using FIP
 ==  Installing a cluster in FIPS mode
 
 To install a cluster in FIPS mode, follow the instructions to install a customized cluster on your preferred infrastructure. Ensure that you set `fips: true` in the `install-config.yaml` file before you deploy your cluster.
+
+[IMPORTANT]
+====
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
+====
 
 * xref:../installing/installing_aws/installing-aws-customizations.adoc#installing-aws-customizations[Amazon Web Services]
 * xref:../installing/installing_alibaba/installing-alibaba-customizations.adoc#installing-alibaba-customizations[Alibaba Cloud]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
This PR addresses [osdocs-7808](https://issues.redhat.com/browse/OSDOCS-7808).

Link to docs preview:

[Support for FIPS cryptography](https://65392--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-fips)

QE review:
- [N/A] QE has approved this change.
Similar to the updates made in https://github.com/openshift/openshift-docs/pull/65055, the wording came directly from engineering and Kirsten Newcomer, whom have both approved this PR, as it is more of a support/legal change than a technical one.

Additional information:
References to FIPS were largely removed in 4.13 by https://github.com/openshift/openshift-docs/pull/60873. With the effort now underway to update the `4.14` docs with new FIPS language, `4.14` docs are being updated first. After the `4.14` effort is complete, the content in this PR will also be merged into `4.13` as part of a separate effort. 