### PR TITLE
[OSDOCS-7935]: Rel notes for CCO-related command updates

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -139,6 +139,24 @@ For {product-title} {product-version}, you can quickly install a cluster on Amaz
 
 For more information, see xref:../installing/installing_aws/installing-aws-localzone.adoc#installation-cluster-quickly-extend-workers_installing-aws-localzone[Intall a cluster quickly in AWS Local Zones].
 
+[id="ocp-4-14-install-update-cco-manual-enhancements"]
+==== Simplified installation and update experience for clusters with manually maintained cloud credentials
+
+This release includes changes that improve the experience of installing and updating clusters that use the Cloud Credential Operator (CCO) in manual mode for cloud provider authentication. The following parameters for the `oc adm release extract` command simplify the manual configuration of cloud credentials:
+
+`--included`:: Use this parameter to extract only the manifests that your specific cluster configuration needs.
++
+If you use cluster capabilities to disable one or more optional components, you are no longer required to delete the `CredentialsRequest` CRs for any disabled components before installing or updating a cluster.
++
+In a future release, this parameter might make the CCO utility (`ccoctl`) `--enable-tech-preview` parameter unnecessary.
+
+`--install-config`:: Use this parameter to specify the location of the `install-config.yaml` file when installing a cluster.
++
+By referencing the `install-config.yaml` file, the extract command can determine aspects of the cluster configuration for the cluster that you are about to create. This parameter is not needed during a cluster update because `oc` can connect to the cluster to determine its configuration.
++
+With this change, you are no longer required to specify the cloud platform you are installing on with the `--cloud` parameter. As a result, the `--cloud` parameter is deprecated starting in {product-title} 4.14.
+
+To understand how to use these parameters, see the installation procedure for your configuration and the procedures in xref:../updating/preparing_for_updates/preparing-manual-creds-update.adoc#preparing-manual-creds-update[Preparing to update a cluster with manually maintained credentials].
 
 [id="ocp-4-14-vsphere-pre-existing-template"]
 ==== Quickly install {op-system} on vSphere hosts by using a pre-existing {op-system} image template
@@ -771,6 +789,11 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 |Removed
+
+|`--cloud` parameter for `oc adm release extract`
+|General Availability
+|General Availability
+|Deprecated
 |====
 [.small]
 --
@@ -938,16 +961,23 @@ In the following tables, features are marked with the following statuses:
 === Deprecated features
 
 [id="ocp-4-14-deployment-config-deprecated"]
-=== DeploymentConfig resources are now deprecated
+==== DeploymentConfig resources are now deprecated
 
 As of {product-title} 4.14, `DeploymentConfig` objects are deprecated. `DeploymentConfig` objects are still supported, but are not recommended for new installations. Only security-related and critical issues will be fixed.
 
 Instead, use `Deployment` objects or another alternative to provide declarative updates for pods.
 
 [id="ocp-4-14-ztp-talm-defaultcatsrc-update"]
-=== Operator-specific CatalogSource CRs used in {gitops-shortname} ZTP are deprecated
+==== Operator-specific CatalogSource CRs used in {gitops-shortname} ZTP are deprecated
 
 From {product-title} {product-version}, you must only use the `DefaultCatSrc.yaml` `CatalogSource` CR when updating Operators with {cgu-operator-first}. All other `CatalogSource` CRs are deprecated and are planned to be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. For more information about `DefaultCatSrc` CR, see xref:../scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc#talo-operator-update_ztp-talm[Performing an Operator update].
+
+[id="ocp-4-14-dep-cloud-release-extract-param"]
+==== The `--cloud` parameter for the `oc adm release extract` command
+
+As of {product-title} 4.14, the `--cloud` parameter for the `oc adm release extract` command is deprecated. The introduction of the `--included` and `--install-config` parameters make the `--cloud` parameter unnecessary.
+
+For more information, see xref:../release_notes/ocp-4-14-release-notes.adoc#ocp-4-14-install-update-cco-manual-enhancements[Simplified installation and update experience for clusters with manually maintained cloud credentials].
 
 [id="ocp-4-14-removed-features"]
 === Removed features


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-7935](https://issues.redhat.com//browse/OSDOCS-7935)

Link to docs preview:
- **Installation and update** new features/enhancements: [Simplified installation and update experience for clusters with manually maintained cloud credentials](https://65421--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-install-update-cco-manual-enhancements)
- [Installation deprecated and removed features](https://65421--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#installation-deprecated-and-removed-features)
- Deprecation: [The `--cloud` parameter for the `oc adm release extract` command](https://65421--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-dep-cloud-release-extract-param)

QE review:
- [ ] QE has approved this change.

Additional information:
RN for changes in #62148