### PR TITLE
[SRVOCF-559] Updates to 1.30 known issues, add 1.30.1 release notes

### DIFF
--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-30-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-30-0.adoc[leveloffset=+1]
 // 1.30.0 additional resources
 [role="_additional-resources"]

--- a/modules/serverless-rn-1-30-0.adoc
+++ b/modules/serverless-rn-1-30-0.adoc
@@ -92,6 +92,6 @@ The query now has the `net-kourier-controller.knative-serving-ingress.svc.<clust
 +
 To work around this issue, use Podman version 4.5.
 
-* Function deployment using Pipelines-as-code is not supported on {ibmzProductName} and {ibmpowerProductName}.
+* On-cluster function building, including using Pipelines-as-code, is not supported on {ibmzProductName} and {ibmpowerProductName}.
 
-* Packbuilder is not supported on {ibmzProductName} and {ibmpowerProductName}.
+* Buildpack builder is not supported on {ibmzProductName} and {ibmpowerProductName}.

--- a/modules/serverless-rn-1-30-1.adoc
+++ b/modules/serverless-rn-1-30-1.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-30-1_{context}"]
+= Release notes for Red Hat {ServerlessProductName} 1.30.1
+
+{ServerlessProductName} 1.30.1 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+
+This release of {ServerlessProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on OpenShift Container Platform 4.10 and later versions.


### PR DESCRIPTION
Version(s):
`serverless-docs-1.30`+

Issue:
* for updates to 1.30.0 known issues https://issues.redhat.com/browse/SRVOCF-559
* no issue for the addition of 1.30.1 release notes section

Link to docs preview:
* Known issues corrections in 1.30.0:
https://65495--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes#known-issues-1-30-0_serverless-release-notes
* Section for 1.30.1:
https://docs.openshift.com/serverless/1.30/about/serverless-release-notes.html#serverless-rn-1-30-1_serverless-release-notes

QE review:
- [X] QE has approved this change.