### PR TITLE
OSDOCS-7875-main: Documented the RN for vSphere templates parameter

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1745,7 +1745,7 @@ Optional VMware vSphere machine pool configuration parameters are described in t
 l|platform
     vsphere
       clusterOSImage
-|The location from which the installation program downloads the {op-system-first} image. Before setting a path value for this parameter, ensure that the {op-system} image's version matches the version of {op-system} that you installed on your {product-title} cluster.
+|The location from which the installation program downloads the {op-system-first} image. Before setting a path value for this parameter, ensure that the default {op-system} boot image in the {product-title} release matches the {op-system} image template or virtual machine version; otherwise, cluster installation might fail.
 |An HTTP or HTTPS URL, optionally with a SHA-256 checksum. For example, `\https://mirror.openshift.com/images/rhcos-<version>-vmware.<architecture>.ova`.
 
 l|platform


### PR DESCRIPTION
[OSDOCS-7875](https://issues.redhat.com/browse/OSDOCS-7875)

Version(s):
4.14

Link to docs preview:
* [Optional VMware vSphere machine pool configuration parameters](https://65091--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-optional-vsphere_installation-config-parameters-vsphere)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
