### PR TITLE
OCPBUGS-19661 Updating image to registry.access.redhat.com/rhel:latest

### DIFF
--- a/modules/cnf-scheduling-numa-aware-workloads-with-manual-performance-setttings.adoc
+++ b/modules/cnf-scheduling-numa-aware-workloads-with-manual-performance-setttings.adoc
@@ -43,7 +43,7 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: numa-deployment-1
-  namespace: <namespace> <1>
+  namespace: openshift-numaresources
 spec:
   replicas: 1
   selector:
@@ -54,7 +54,7 @@ spec:
       labels:
         app: test
     spec:
-      schedulerName: topo-aware-scheduler <2>
+      schedulerName: topo-aware-scheduler <1>
       containers:
       - name: ctnr
         image: quay.io/openshifttest/hello-openshift:openshift
@@ -67,8 +67,10 @@ spec:
             memory: "100Mi"
             cpu: "10"
       - name: ctnr2
-        image: gcr.io/google_containers/pause-amd64:3.0
+        image: registry.access.redhat.com/rhel:latest
         imagePullPolicy: IfNotPresent
+        command: ["/bin/sh", "-c"]
+        args: [ "while true; do sleep 1h; done;" ]
         resources:
           limits:
             memory: "100Mi"
@@ -77,8 +79,7 @@ spec:
             memory: "100Mi"
             cpu: "8"
 ----
-<1> Replace with the namespace for your deployment.
-<2> `schedulerName` must match the name of the NUMA-aware scheduler that is deployed in your cluster, for example `topo-aware-scheduler`.
+<1> `schedulerName` must match the name of the NUMA-aware scheduler that is deployed in your cluster, for example `topo-aware-scheduler`.
 
 .. Create the `Deployment` CR by running the following command:
 +
@@ -128,7 +129,7 @@ Events:
 Deployments that request more resources than is available for scheduling will fail with a `MinimumReplicasUnavailable` error. The deployment succeeds when the required resources become available. Pods remain in the `Pending` state until the required resources are available.
 ====
 
-. Verify that the expected allocated resources are listed for the node. 
+. Verify that the expected allocated resources are listed for the node.
 
 .. Identify the node that is running the deployment pod by running the following command, replacing <namespace> with the namespace you specified in the `Deployment` CR:
 +

--- a/modules/cnf-scheduling-numa-aware-workloads.adoc
+++ b/modules/cnf-scheduling-numa-aware-workloads.adoc
@@ -149,7 +149,7 @@ numa-deployment-1-65684f8fcc-bw4bw   0/2     Running   0          82m   10.128.2
 +
 [source,terminal]
 ----
-$ oc describe noderesourcetopologies.topology.node.k8s.io
+$ oc describe noderesourcetopologies.topology.node.k8s.io <node_name>
 ----
 +
 .Example output


### PR DESCRIPTION
[OCPBUGS-19661]: Replace image: gcr.io/google_containers/pause-amd64:3.0 with registry.access.redhat.com/rhel:latest in file scalability_and_performance/cnf-numa-aware-scheduling.adoc

Version(s): 4.13, 4.14, main

Issue:https://issues.redhat.com/browse/OCPBUGS-19661

Link to docs preview: https://65507--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-scheduling-numa-aware-workloads_numa-aware

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

 QE has approved this change.
Additional information: This is a not exactly a CP but change was made in  https://github.com/openshift/openshift-docs/pull/64168. I should have added for additional file the references the same image. All approvals tracked there. Alongside this PR https://github.com/openshift/openshift-docs/pull/65083 for 4.12 content in this section with both PRs is now in sync across these releases. 