### PR TITLE
OCPBUGS-19644 Adding per-pod-power-management to output of help

### DIFF
--- a/modules/cnf-performance-profile-creator-arguments.adoc
+++ b/modules/cnf-performance-profile-creator-arguments.adoc
@@ -75,7 +75,7 @@ Possible values:
 Default: `default`.
 
 | `per-pod-power-management`
-a|Enable per-pod power management. You cannot use this argument if you configured `ultra-low-latency` as the power consumption mode.
+a|Enable per pod power management. You cannot use this argument if you configured `ultra-low-latency` as the power consumption mode.
 
 Possible values: `true` or `false`.
 

--- a/modules/cnf-running-the-performance-creator-profile-offline.adoc
+++ b/modules/cnf-running-the-performance-creator-profile-offline.adoc
@@ -146,6 +146,7 @@ Flags:
       --mcp-name string                   MCP name corresponding to the target machines (required)
       --must-gather-dir-path string       Must gather directory path (default "must-gather")
       --offlined-cpu-count int            Number of offlined CPUs
+      --per-pod-power-management          Enable Per Pod Power Management
       --power-consumption-mode string     The power consumption mode.  [Valid values: default, low-latency, ultra-low-latency] (default "default")
       --profile-name string               Name of the performance profile to be created (default "performance")
       --reserved-cpu-count int            Number of reserved CPUs (required)

--- a/modules/cnf-running-the-performance-creator-profile.adoc
+++ b/modules/cnf-running-the-performance-creator-profile.adoc
@@ -68,6 +68,7 @@ Flags:
       --mcp-name string                   MCP name corresponding to the target machines (required)
       --must-gather-dir-path string       Must gather directory path (default "must-gather")
       --offlined-cpu-count int            Number of offlined CPUs
+      --per-pod-power-management          Enable Per Pod Power Management
       --power-consumption-mode string     The power consumption mode.  [Valid values: default, low-latency, ultra-low-latency] (default "default")
       --profile-name string               Name of the performance profile to be created (default "performance")
       --reserved-cpu-count int            Number of reserved CPUs (required)


### PR DESCRIPTION
[OCPBUGS-19644]: per-pod-power-management missing from output of podman run

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12, 4.13, 4.14, main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-19644
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://65512--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-create-performance-profiles.html#running-the-performance-profile-profile-cluster-using-podman_cnf-create-performance-profiles
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Simple update to the output of a command which did not reflect the addition of a new option. I checked myself and QE verified that help was updated. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
