### PR TITLE
OSDOCS-6321: SR-IOV: Document VF usage on management port

### DIFF
--- a/modules/nw-sriov-hwol-improving-network-traffic-performance.adoc
+++ b/modules/nw-sriov-hwol-improving-network-traffic-performance.adoc
@@ -1,0 +1,122 @@
+// Module included in the following assemblies:
+//
+// * networking/hardware_networks/configuring-hardware-offloading.adoc
+
+:_content-type: PROCEDURE
+[id="improving-network-traffic-performance-using-vf_{context}"]
+= Improving network traffic performance using a virtual function
+
+Follow this procedure to assign a virtual function to the OVN-Kubernetes management port and increase its network traffic performance.
+
+This procedure results in the creation of two pools: the first has a virtual function used by OVN-Kubernetes, and the second comprises the remaining virtual functions.
+
+.Prerequisites
+
+* You installed the OpenShift CLI (`oc`).
+* You have access to the cluster as a user with the `cluster-admin` role.
+
+.Procedure
+
+. Add the `network.operator.openshift.io/smart-nic` label to each worker node with a SmartNIC present by running the following command:
++
+[source,terminal]
+----
+$ oc label node <node-name> network.operator.openshift.io/smart-nic=
+----
++
+Use the `oc get nodes` command to get a list of the available nodes.
+
+. Create a policy named `sriov-node-mgmt-vf-policy.yaml` for the management port with content such as the following example:
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: sriov-node-mgmt-vf-policy
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: netdevice
+  eSwitchMode: "switchdev"
+  nicSelector:
+    deviceID: "1019"
+    rootDevices:
+    - 0000:d8:00.0
+    vendor: "15b3"
+    pfNames:
+    - ens8f0#0-0 <.>
+  nodeSelector:
+    network.operator.openshift.io/smart-nic: ""
+  numVfs: 6 <.>
+  priority: 5
+  resourceName: mgmtvf
+----
+<.> Replace this device with the appropriate network device for your use case. The `#0-0` part of the `pfNames` value reserves a single virtual function used by OVN-Kubernetes.
+<.> The value provided here is an example. Replace this value with one that meets your requirements. For more information, see _SR-IOV network node configuration object_ in the _Additional resources_ section.
+
+. Create a policy named `sriov-node-policy.yaml` with content such as the following example:
++
+[source,yaml]
+----
+apiVersion: sriovnetwork.openshift.io/v1
+kind: SriovNetworkNodePolicy
+metadata:
+  name: sriov-node-policy
+  namespace: openshift-sriov-network-operator
+spec:
+  deviceType: netdevice
+  eSwitchMode: "switchdev"
+  nicSelector:
+    deviceID: "1019"
+    rootDevices:
+    - 0000:d8:00.0
+    vendor: "15b3"
+    pfNames:
+    - ens8f0#1-5 <.>
+  nodeSelector:
+    network.operator.openshift.io/smart-nic: ""
+  numVfs: 6 <.>
+  priority: 5
+  resourceName: mlxnics
+----
+<.> Replace this device with the appropriate network device for your use case.
+<.> The value provided here is an example. Replace this value with the value specified in the `sriov-node-mgmt-vf-policy.yaml` file. For more information, see _SR-IOV network node configuration object_ in the _Additional resources_ section.
++
+[NOTE]
+====
+The `sriov-node-mgmt-vf-policy.yaml` file has different values for the `pfNames` and `resourceName` keys than the `sriov-node-policy.yaml` file.
+====
+
+. Apply the configuration for both policies:
++
+[source,terminal]
+----
+$ oc create -f sriov-node-policy.yaml
+----
++
+[source,terminal]
+----
+$ oc create -f sriov-node-mgmt-vf-policy.yaml
+----
+
+. Create a Cluster Network Operator (CNO) ConfigMap in the cluster for the management configuration:
+
+.. Create a ConfigMap named `hardware-offload-config.yaml` with the following contents:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: ConfigMap
+metadata:
+    name: hardware-offload-config
+    namespace: openshift-network-operator
+data:
+    mgmt-port-resource-name: openshift.io/mgmtvf
+----
+
+.. Apply the configuration for the ConfigMap:
++
+[source,terminal]
+----
+$ oc create -f hardware-offload-config.yaml
+----

--- a/networking/hardware_networks/configuring-hardware-offloading.adoc
+++ b/networking/hardware_networks/configuring-hardware-offloading.adoc
@@ -32,6 +32,14 @@ include::modules/nw-sriov-hwol-creating-sriov-policy.adoc[leveloffset=+1]
 
 include::modules/nw-sriov-hwol-ref-openstack-sriov-policy.adoc[leveloffset=+2]
 
+// Improving network traffic performance using a virtual function
+include::modules/nw-sriov-hwol-improving-network-traffic-performance.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_using-vf-improve-network-traffic-performance"]
+.Additional resources
+* xref:../../networking/hardware_networks/configuring-sriov-device.adoc#nw-sriov-networknodepolicy-object_configuring-sriov-device[SR-IOV network node configuration object]
+
 //Creating a Network Attachment Definition
 include::modules/nw-sriov-hwol-creating-network-attachment-definition.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-6321](https://issues.redhat.com/browse/OSDOCS-6321)

Link to docs preview:
[Using a virtual function to improve network traffic performance](https://65518--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-hardware-offloading#using-vf-improve-network-traffic-performance_configuring-hardware-offloading)

QE review:
- [x] QE has approved this change.

Additional information:
N/A