### PR TITLE
Set up redirect to 1.10 for GitOps

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -231,12 +231,12 @@ AddType text/vtt                            vtt
     RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
 
 
-    # redirect gitops latest to 1.9
+    # redirect gitops latest to 1.10
     RewriteRule ^gitops/?$ /gitops/latest [R=302]
-    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.9/$1 [NE,R=302]
+    RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.10/$1 [NE,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^gitops/(1\.8|1\.9)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
+    RewriteRule ^gitops/(1\.8|1\.9|1\.10)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # GitOps landing page
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]


### PR DESCRIPTION
**Version(s):** main only

**Issue:**
-  [RHDEVDOCS 5358](https://issues.redhat.com/browse/RHDEVDOCS-5358)
-  [RHDEVDOCS 5172](https://issues.redhat.com/browse/RHDEVDOCS-5172)

**Additional information:** This PR creates a redirect that should send the user to the 1.10 GitOps standalone doc when the "About OpenShift GitOps " link is clicked in the navigation tree. It does not alter documentation content.