### PR TITLE
Adding Argo Rollouts to GitOps 1.9 RN compatibility matrix

### DIFF
--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -20,12 +20,12 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 ====
 
 |===
-|*OpenShift GitOps* 7+|*Component Versions*|*OpenShift Versions*
+|*OpenShift GitOps* 8+|*Component Versions*|*OpenShift Versions*
 
-|*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*ApplicationSet* |*Dex*     |*RH SSO* |
-|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
-|1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
-|1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
+|*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*Argo Rollouts*|*ApplicationSet* |*Dex*     |*RH SSO* |
+|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
+|1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
+|1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
 |===
 
 * `kam` is the {gitops-title} Application Manager command-line interface (CLI).


### PR DESCRIPTION
**Version(s):** To `gitops-docs-1.9` **Only**.

**Issue:**
- [RHDEVDOCS-5172](https://issues.redhat.com//browse/RHDEVDOCS-5172)

**Link to docs preview:** https://65522--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes.html

**Peer review and Merge review:** @gabriel-rh

**Additional information:** This PR adds Argo Rollouts as a component to GitOps 1.9 RN compatibility matrix. Very minor change. No other changes to the documentation content.