### PR TITLE
OCPBUGS#18842: remove only from rollback admonition

### DIFF
--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -14,7 +14,7 @@ During the migration you must reboot every node in your cluster.
 ifeval::["{context}" == "rollback-to-openshift-sdn"]
 [IMPORTANT]
 ====
-Only rollback to OpenShift SDN if the migration to OVN-Kubernetes fails.
+Rollback to OpenShift SDN if the migration to OVN-Kubernetes fails.
 ====
 endif::[]
 
@@ -127,7 +127,7 @@ The MTU for the VXLAN overlay network. This value is normally configured automat
 The UDP port for the VXLAN overlay network. If a value is not specified, the default is `4789`. The port cannot be the same as the Geneve port that is used by OVN-Kubernetes. The default value for the Geneve port is `6081`.
 --
 +
-.Example patch command 
+.Example patch command
 [source,terminal]
 ----
 $ oc patch Network.operator.openshift.io cluster --type=merge \


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-18842

Link to docs preview:
https://65525--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/rollback-to-openshift-sdn

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional info:
https://github.com/openshift/openshift-docs/pull/65149 fixes the other half of this bug

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
