### PR TITLE
OSDOCS#7809: Changed compliance reference to mode

### DIFF
--- a/modules/security-hosts-vms-openshift.adoc
+++ b/modules/security-hosts-vms-openshift.adoc
@@ -9,11 +9,11 @@ installer-provisioned infrastructure (there are several available platforms)
 or your own user-provisioned infrastructure.
 ifndef::openshift-origin[]
 Some low-level security-related configuration, such as enabling FIPS
-compliance or adding kernel modules required at first boot, might 
+mode or adding kernel modules required at first boot, might 
 benefit from a user-provisioned infrastructure.
 endif::[]
 ifdef::openshift-origin[]
-Some low-level security-related configuration, such as adding kernel modules required at first boot, might 
+Some low-level security-related configuration, such as adding kernel modules required at first boot, might
 benefit from a user-provisioned infrastructure.
 endif::[]
 Likewise, user-provisioned infrastructure is appropriate for disconnected {product-title} deployments.

--- a/security/container_security/security-hosts-vms.adoc
+++ b/security/container_security/security-hosts-vms.adoc
@@ -38,3 +38,9 @@ include::modules/security-hosts-vms-vs-containers.adoc[leveloffset=+1]
 
 // Securing OpenShift
 include::modules/security-hosts-vms-openshift.adoc[leveloffset=+1]
+
+ifndef::openshift-origin[]
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing-fips.adoc#installing-fips[FIPS cryptography]
+endif::[]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
This issue addresses [osdocs-7809](https://issues.redhat.com/browse/OSDOCS-7809).

Link to docs preview:

[Understanding host and VM security](https://65526--docspreview.netlify.app/openshift-enterprise/latest/security/container_security/security-hosts-vms)

QE review:
- [N/A] QE has approved this change.
Changed a single word at the request of @knewcomerRH.

Additional information:
While this change applies to all supported versions of the docs, the 4.13 doc set currently does not include Support for FIPS cryptography. This is by design and is the result of FIPS related content being removed by https://github.com/openshift/openshift-docs/pull/60873. After the effort to update the 4.14 docs with the new FIPS language is complete, a separate effort will be undertaken to update the 4.13 doc set, at which point these changes will also be merged into 4.13. Until then, this content will only be merged into main, 4.11, 4.12, and 4.14.
