### PR TITLE
Adding TP status to Argo Rollouts in GitOps RN 1.10 compatibility matrix

### DIFF
--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -23,8 +23,8 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 |*OpenShift GitOps* 8+|*Component Versions*|*OpenShift Versions*
 
 |*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*Argo Rollouts*|*ApplicationSet* |*Dex*     |*RH SSO* |
-|1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |1.5.0 |NA |2.35.1 GA |7.5.1 GA |4.12-4.13
-|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
+|1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |1.5.0 TP |NA |2.35.1 GA |7.5.1 GA |4.12-4.13
+|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 TP |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
 |1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
 |===
 


### PR DESCRIPTION
Version(s): gitops-docs, gitops-docs-1.10.

Issue:
[RHDEVDOCS-5172](https://issues.redhat.com//browse/RHDEVDOCS-5172)
[RHDEVDOCS-5550](https://issues.redhat.com/browse/RHDEVDOCS-5550)

Link to docs preview: https://65527--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes.html

Peer review and Merge review: @gabriel-rh