### PR TITLE
Adding TP status to Argo Rollouts in GitOps RN 1.9 compatibility matrix

### DIFF
--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -23,7 +23,7 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 |*OpenShift GitOps* 8+|*Component Versions*|*OpenShift Versions*
 
 |*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*Argo Rollouts*|*ApplicationSet* |*Dex*     |*RH SSO* |
-|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
+|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 TP |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
 |1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
 |1.7.0    |0.0.46 TP |3.10.0 GA|4.5.7 GA   |2.5.4 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.12
 |===


### PR DESCRIPTION
**Version(s):** To `gitops-docs-1.9` **Only**.

**Issue:**
- [RHDEVDOCS-5172](https://issues.redhat.com//browse/RHDEVDOCS-5172)

**Link to docs preview:** https://65528--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes.html

**Peer review and Merge review:** @gabriel-rh

**Additional information:** This PR adds TP status to Argo Rollouts component in GitOps 1.9 RN compatibility matrix. Very minor change. No other changes to the documentation content.