### PR TITLE
OSDOCS-7954: fix changed attribute in relnotes

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -13,7 +13,7 @@ toc::[]
 [id="microshift-4-13-about-this-release"]
 == About this release
 
-The Red Hat build of {product-title} is Technology Preview only. Features and known issues that pertain to {product-title} {ocp-version} are included in this topic. This Technology Preview software is not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using {product-title} in production. Technology Preview provides early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+The {product-title} is Technology Preview only. Features and known issues that pertain to {product-title} {ocp-version} are included in this topic. This Technology Preview software is not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using {product-title} in production. Technology Preview provides early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
 
 For more information about the support scope of Red Hat Technology Preview features, read link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
 


### PR DESCRIPTION
Version(s):
4.13 only

Issue:
https://issues.redhat.com/browse/OCPBUGS-19913

Link to docs preview:
https://65538--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes

QE review:
- N/A

Additional resources:
DPM is aware that the preview attribute is not resolving properly. On the Customer Portal, the {product-title} attribute resolves as Red Hat Build of MicroShift. In this preview it is resolving only as MicroShift.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
