### PR TITLE
OSDOCS-7961 Z-stream RNs for 4.12.36

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4113,3 +4113,22 @@ $ oc adm release info 4.12.35 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-36"]
+=== RHSA-2023:5390 - {product-title} 4.12.36 bug fix and security update
+
+Issued: 2023-10-04
+
+{product-title} release 4.12.36, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5390[RHSA-2023:5390] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5392[RHBA-2023:5392] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.36 --pullspecs
+----
+
+[id="ocp-4-12-36-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-7961](https://issues.redhat.com/browse/OSDOCS-7961)

Link to docs preview:
[Preview](https://65539--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-36)

QE review:
- [ ] QE has approved this change.
Not needed

Additional information:
Expected merge date is October 4, 2023.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
