### PR TITLE
OSDOCS-7970: QE and Style Revisions of MOBB Content for "Configuring the Cluster Log Forwarder for CloudWatch logs and STS"

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -86,8 +86,8 @@ Topics:
 #  File: rosa-mobb-prerequisites-tutorial
 - Name: Verifying Permissions for a ROSA STS Deployment
   File: rosa-mobb-verify-permissions-sts-deployment
-- Name: Configuring the Cluster Log Forwarder for Cloudwatch logs and STS
-  File: rosa-mobb-cloudwatch-sts
+- Name: Configuring the Cluster Log Forwarder for CloudWatch logs and STS
+  File: cloud-experts-rosa-cloudwatch-sts
 - Name: Using AWS WAF and Amazon CloudFront to protect ROSA workloads
   File: cloud-experts-using-cloudfront-and-waf
 - Name: Using AWS WAF and AWS ALBs to protect ROSA workloads

--- a/cloud_experts_tutorials/cloud-experts-rosa-cloudwatch-sts.adoc
+++ b/cloud_experts_tutorials/cloud-experts-rosa-cloudwatch-sts.adoc
@@ -1,8 +1,8 @@
 :_content-type: ASSEMBLY
-[id="rosa-mobb-cloudwatch-sts"]
-= Tutorial: Configuring the Cluster Log Forwarder for Cloudwatch logs and STS
+[id="cloud-experts-rosa-cloudwatch-sts"]
+= Tutorial: Configuring the Cluster Log Forwarder for CloudWatch logs and STS
 include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: rosa-mobb-cloudwatch-sts
+:context: cloud-experts-rosa-cloudwatch-sts
 
 toc::[]
 
@@ -18,23 +18,23 @@ toc::[]
 //   - Connor Wooley
 // ---
 
-This guide shows how to deploy the Cluster Log Forwarder Operator and configure it to use STS authentication to forward logs to CloudWatch.
+Use this tutorial to deploy the Cluster Log Forwarder Operator and configure it to use Security Token Services (STS) authentication to forward logs to CloudWatch.
 
-[id="rosa-mobb-cloudwatch-sts-prerequisites"]
-== Prerequisites
+[id="cloud-experts-rosa-cloudwatch-sts-prerequisites"]
+.Prerequisites
 
-* A ROSA cluster (configured with STS)
-* The `jq` cli command
-* The `aws` cli command
+* A {product-title} (ROSA) Classic cluster
+* The `jq` command-line interface (CLI)
+* The Amazon Web Services (AWS) CLI (`aws`)
 
-[id="rosa-mobb-cloudwatch-sts-environmental-setup"]
-== Environment Setup
+[id="cloud-experts-rosa-cloudwatch-sts-environment-setup"]
+== Setting up your environment
 
-* Configure the following environment variables:
+. Configure the following environment variables, changing the cluster name to suit your cluster:
 +
 [NOTE]
 ====
-Change the cluster name to match your ROSA cluster and ensure you are logged into the cluster as an Administrator. Ensure all fields are outputted correctly before moving on.
+You must be logged in as an administrator.
 ====
 +
 [source,terminal]
@@ -46,13 +46,19 @@ $ export AWS_ACCOUNT_ID=`aws sts get-caller-identity --query Account --output te
 $ export AWS_PAGER=""
 $ export SCRATCH="/tmp/${ROSA_CLUSTER_NAME}/clf-cloudwatch-sts"
 $ mkdir -p ${SCRATCH}
+----
+
+. Ensure all fields output correctly before moving to the next section:
++
+[source,terminal]
+----
 $ echo "Cluster: ${ROSA_CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
 ----
 
-[id="rosa-mobb-cloudwatch-sts-prep-aws"]
-== Prepare AWS Account
+[id="cloud-experts-rosa-cloudwatch-sts-prep-aws"]
+== Preparing your AWS account
 
-. Create an IAM policy for OpenShift Log Forwarding:
+. Create an Identity Access Management (IAM) policy for OpenShift Log Forwarding:
 +
 [source,terminal]
 ----
@@ -118,8 +124,8 @@ $ aws iam attach-role-policy --role-name "${ROSA_CLUSTER_NAME}-RosaCloudWatch" \
    --policy-arn ${POLICY_ARN}
 ----
 
-[id="rosa-mobb-cloudwatch-sts-deploy-Os"]
-== Deploy Operators
+[id="cloud-experts-rosa-cloudwatch-sts-deploy-Os"]
+== Deploying Operators
 
 . Deploy the Cluster Logging Operator:
 +
@@ -157,10 +163,10 @@ $  cat << EOF | oc apply -f -
 EOF
 ----
 
-[id="rosa-mobb-cloudwatch-sts-configure-cluster-logging"]
-== Configure cluster logging
+[id="cloud-experts-rosa-cloudwatch-sts-configure-cluster-logging"]
+== Configuring cluster logging
 
-. Create a cluster log forwarding resource:
+. Create a cluster-log forwarding resource:
 +
 [source,terminal]
 ----
@@ -209,15 +215,11 @@ $ cat << EOF | oc apply -f -
 EOF
 ----
 
-[id="rosa-mobb-cloudwatch-sts-check-aws"]
-== Check AWS CloudWatch for logs
+[id="cloud-experts-rosa-cloudwatch-sts-check-aws"]
+== Checking CloudWatch for logs
 
-* Use the AWS console or CLI to validate that there are log streams from the cluster:
-+
-[NOTE]
-====
-If this is a fresh cluster, you may not see a log group for `application` logs as there are no applications running yet.
-====
+* Use either the AWS console or the AWS CLI to validate that there are log streams from the cluster.
+** To validate the logs in the AWS CLI, run the following command:
 +
 [source,terminal]
 ----
@@ -247,11 +249,16 @@ $ aws logs describe-log-groups --log-group-name-prefix rosa-${ROSA_CLUSTER_NAME}
   ]
 }
 ----
++
+[NOTE]
+====
+If this is a new cluster, you might not see a log group for `application` logs as applications are not yet running.
+====
 
-[id="rosa-mobb-cloudwatch-sts-clean-up"]
-== Clean Up
+[id="cloud-experts-rosa-cloudwatch-sts-clean-up"]
+== Cleaning up your resources
 
-. Delete the cluster log forwarding resource:
+. Delete the cluster-log forwarding resource:
 +
 [source,terminal]
 ----
@@ -282,9 +289,9 @@ $ aws iam delete-role --role-name "${ROSA_CLUSTER_NAME}-RosaCloudWatch"
 
 . Delete the IAM policy:
 +
-[NOTE]
+[IMPORTANT]
 ====
-Only run this command if there are no other resources using the policy.
+Only delete the IAM policy if there are no other resources using the policy.
 ====
 +
 [source,terminal]
@@ -292,7 +299,7 @@ Only run this command if there are no other resources using the policy.
 $ aws iam delete-policy --policy-arn "${POLICY_ARN}"
 ----
 
-. Delete the CloudWatch Log Groups:
+. Delete the CloudWatch log groups:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
[OSDOCS-7970](https://issues.redhat.com//browse/OSDOCS-7970): Full QE review and style revisions of previously migrated MOBB content (" Configuring the Cluster Log Forwarder for CloudWatch logs and STS") in product docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7970

Link to docs preview:
https://65560--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-rosa-cloudwatch-sts

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
