### PR TITLE
Fixed command in osdk-golang-quickstart.adoc

### DIFF
--- a/modules/osdk-quickstart.adoc
+++ b/modules/osdk-quickstart.adoc
@@ -219,9 +219,9 @@ endif::[]
 +
 Delete a CR by running the following command:
 +
-[source,terminal]
+[source,terminal,subs="attributes+"]
 ----
-$ oc delete -f config/samples/demo_v1_nginx.yaml -n nginx-operator-system
+$ oc delete -f config/samples/{group}_v1_{app} -n {app}-operator-system
 ----
 
 . *Clean up.*


### PR DESCRIPTION
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://65561--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/golang/osdk-golang-quickstart.html
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
The command uses a file and a namespace that don't exist. Probably a copy/paste error.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
