### PR TITLE
Incorrect API version in buildconfig 

### DIFF
--- a/modules/builds-manually-add-source-clone-secrets.adoc
+++ b/modules/builds-manually-add-source-clone-secrets.adoc
@@ -10,7 +10,7 @@ Source clone secrets can be added manually to a build configuration by adding a 
 
 [source,yaml]
 ----
-apiVersion: "v1"
+apiVersion: "build.openshift.io/v1"
 kind: "BuildConfig"
 metadata:
   name: "sample-build"


### PR DESCRIPTION
Incorrect API version in buildconfig  changed .

Version:
4.11+

Issue:
[issue #64730](https://github.com/openshift/openshift-docs/issues/64730)

Link to docs preview:
[preview](https://github.com/BTSisLove/openshift-docs/blob/rand/modules/builds-adding-source-clone-secrets.adoc)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

