### PR TITLE
WIP- OADP 2399 - ResticRepository CR is renamed as BackupRepository CR

### DIFF
--- a/modules/oadp-backing-up-applications-restic.adoc
+++ b/modules/oadp-backing-up-applications-restic.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="oadp-backing-up-applications-restic_{context}"]
-= Backing up applications with Restic
+= Backing up applications
 
-You back up Kubernetes resources, internal images, and persistent volumes with Restic by editing the `Backup` custom resource (CR).
+You back up Kubernetes resources, internal images, and persistent volumes with Kopia, Restic or _____ by editing the `Backup` custom resource (CR).
 
 You do not need to specify a snapshot location in the `DataProtectionApplication` CR.
 
@@ -18,7 +18,7 @@ Restic does not support backing up `hostPath` volumes. For more information, see
 .Prerequisites
 
 * You must install the OpenShift API for Data Protection (OADP) Operator.
-* You must not disable the default Restic installation by setting `spec.configuration.restic.enable` to `false` in the `DataProtectionApplication` CR.
+* If you are using Restic, You must not disable the default Restic installation by setting `spec.configuration.restic.enable` to `false` in the `DataProtectionApplication` CR.
 * The `DataProtectionApplication` CR must be in a `Ready` state.
 
 .Procedure

--- a/modules/oadp-backing-up-applications-restic.adoc
+++ b/modules/oadp-backing-up-applications-restic.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="oadp-backing-up-applications-restic_{context}"]
-= Backing up applications
+= Backing up applications with external providers
 
 You back up Kubernetes resources, internal images, and persistent volumes with Kopia, Restic or _____ by editing the `Backup` custom resource (CR).
 
@@ -18,7 +18,7 @@ Restic does not support backing up `hostPath` volumes. For more information, see
 .Prerequisites
 
 * You must install the OpenShift API for Data Protection (OADP) Operator.
-* If you are using Restic, You must not disable the default Restic installation by setting `spec.configuration.restic.enable` to `false` in the `DataProtectionApplication` CR.
+* If you are using Restic, you must not disable the default Restic installation by setting `spec.configuration.restic.enable` to `false` in the `DataProtectionApplication` CR.
 * The `DataProtectionApplication` CR must be in a `Ready` state.
 
 .Procedure

--- a/modules/oadp-using-data-mover-for-csi-snapshots.adoc
+++ b/modules/oadp-using-data-mover-for-csi-snapshots.adoc
@@ -186,7 +186,7 @@ spec:
     sourcePVCData:
       name: <source_pvc_name>
       size: <source_pvc_size>
-    resticrepository: <your_restic_repo>
+    backuprepository: <your_backup_repo>
     volumeSnapshotClassName: <vsclass_name>
 ----
 <1> Specify the namespace where the volume snapshot exists.


### PR DESCRIPTION
OADP 1.3.0

OCP 4.11+

Resolves - https://issues.redhat.com/browse/OADP-2399

Deploy preview - https://65565--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc

https://docs.openshift.com/container-platform/4.13/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html#oadp-using-data-mover-for-csi-snapshots_backing-up-applications
