### PR TITLE
WIP OADP 2401 - Restic daemonset is renamed as node-agent

### DIFF
--- a/backup_and_restore/application_backup_and_restore/oadp-api.adoc
+++ b/backup_and_restore/application_backup_and_restore/oadp-api.adoc
@@ -204,7 +204,7 @@ link:https://pkg.go.dev/github.com/openshift/oadp-operator/api/v1alpha1#ResticCo
 
 |`tolerations`
 |[]link:https://pkg.go.dev/k8s.io/api/core/v1#Toleration[Toleration]
-|Defines the list of tolerations to be applied to a Velero deployment or a Restic `daemonset`.
+|Defines the list of tolerations to be applied to a Velero deployment or a node-agent.
 
 |`resourceAllocations`
 |link:https://pkg.go.dev/k8s.io/api/core/v1#ResourceRequirements[ResourceRequirements]


### PR DESCRIPTION
OADP 1.3.0

OCP 4.11 +

Resolves - https://issues.redhat.com/browse/OADP-2401

Deploy preview - https://docs.openshift.com/container-platform/4.13/backup_and_restore/application_backup_and_restore/oadp-api.html
