### PR TITLE
[OCPBUGS-19981]:Amended xref in Creating a HCP cluster subsection

### DIFF
--- a/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
@@ -38,7 +38,7 @@ To successfully install ROSA clusters, use the latest version of the ROSA CLI (`
 +
 [NOTE]
 ====
-When creating a {hcp-title} cluster, the default machine Classless Inter-Domain Routing (CIDR) is `10.0.0.0/16`. If this does not correspond to the CIDR range for your VPC subnets, add `--machine-cidr <address_block>` to the following commands. To learn more about the default CIDR ranges for {product-title}, see xref:../networking/cidr-range-definitions.adoc[CIDR range definitions].
+When creating a {hcp-title} cluster, the default machine Classless Inter-Domain Routing (CIDR) is `10.0.0.0/16`. If this does not correspond to the CIDR range for your VPC subnets, add `--machine-cidr <address_block>` to the following commands. To learn more about the default CIDR ranges for {product-title}, see xref:../networking/cidr-range-definitions.adoc#cidr-range-definitions[CIDR range definitions].
 ====
 +
 ** Create a cluster with a single, initial machine pool, publicly available API, and publicly available Ingress by running the following command:


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-19981

Link to docs preview:
https://65576--docspreview.netlify.app/openshift-rosa/latest/rosa_hcp/rosa-hcp-sts-creating-a-cluster-quickly

This PR is a follow-up to https://github.com/openshift/openshift-docs/pull/64882. When changes went live on the portal, I noticed the link in [1.4. Creating a ROSA with HCP cluster using the CLI](https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/install_rosa_with_hcp_clusters/rosa-hcp-sts-creating-a-cluster-quickly#rosa-hcp-sts-creating-a-cluster-cli_rosa-hcp-sts-creating-a-cluster-quickly) is incorrectly bringing users to the [Networking](https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/networking/index#doc-wrapper) section, instead of the [CIDR ranges](https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html-single/networking/index#cidr-range-definitions) subsection. 

As this is just a link update, this PR only requires a peer review. SME and QE approval was received in #64882. 

SME review:
- [x] SME has approved this change.

QE review:
- [x] QE has approved this change. 

Peer review:
- [x] Peer reviewer has approved this change. 



