### PR TITLE
TRACING-3552: Add documentation for Kafka receiver and exporter in OTEL

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -116,10 +116,10 @@ endif::[]
 //distributed tracing
 :DTProductName: Red Hat OpenShift distributed tracing platform
 :DTShortName: distributed tracing platform
-:DTProductVersion: 2.9
+:DTProductVersion: 3.0
 :JaegerName: Red Hat OpenShift distributed tracing platform (Jaeger)
 :JaegerShortName: distributed tracing platform (Jaeger)
-:JaegerVersion: 1.47.0
+:JaegerVersion: ?.??.?
 :OTELName: Red Hat OpenShift distributed tracing data collection
 :OTELShortName: distributed tracing data collection
 :OTELOperator: Red Hat OpenShift distributed tracing data collection Operator
@@ -127,7 +127,7 @@ endif::[]
 :TempoName: Red Hat OpenShift distributed tracing platform (Tempo)
 :TempoShortName: distributed tracing platform (Tempo)
 :TempoOperator: Tempo Operator
-:TempoVersion: 2.1.1
+:TempoVersion: ?.?.?
 //logging
 :logging-title: logging subsystem for Red Hat OpenShift
 :logging-title-uc: Logging subsystem for Red Hat OpenShift

--- a/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
+++ b/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
@@ -21,6 +21,8 @@ include::modules/distr-tracing-tempo-config-storage.adoc[leveloffset=+2]
 
 include::modules/distr-tracing-tempo-config-query-frontend.adoc[leveloffset=+2]
 
+include::modules/distr-tracing-tempo-config-spanmetrics.adoc[leveloffset=+2]
+
 [id="setting-up-monitoring-for-tempo"]
 == Setting up monitoring for the {TempoShortName}
 

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -373,7 +373,7 @@ The Logging exporter prints data to the standard output.
 ==== BASICAUTH extension
 
 The BasicAuth extension can be used as an authenticator on receivers and exporters.
-The configuration must specify only one instance of the BasicAuth extension: for client authentication or server authentication.
+Client authentication and server authentication for the BasicAuth extension are configured in separate sections in the OpenTelemetry Collector custom resource.
 
 * Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
 * Supported signals: traces, metrics, logs

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -417,4 +417,4 @@ service:
 <3> The username configuration of basicauth extension getting configured as a client authenticator.
 <4> The password configuration of basicauth extension getting configured as a client authenticator.
 <5> The authenticator configuration getting assigned to an otlp receiver.
-<6> The authenticator configuration getting assigned to an otlp exporter.
+<6> Here the authenticator configuration is assigned to an OTLP exporter.

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -38,8 +38,8 @@ spec:
           http:
     processors:
     exporters:
-      jaeger:
-        endpoint: jaeger-production-collector-headless.tracing-system.svc:14250
+      otlp:
+        endpoint: jaeger-production-collector-headless.tracing-system.svc:4317
         tls:
           ca_file: "/var/run/secrets/kubernetes.io/serviceaccount/service-ca.crt"
       prometheus:
@@ -76,7 +76,7 @@ spec:
 
 |exporters:
 |An exporter sends data to one or more back ends or destinations. By default, no exporters are configured. There must be at least one enabled exporter for a configuration to be considered valid. Exporters are enabled by being added to a pipeline. Exporters might be used with their default settings, but many require configuration to specify at least the destination and security settings.
-|`otlp`, `otlphttp`, `jaeger`, `logging`, `prometheus`
+|`otlp`, `otlphttp`, `logging`, `prometheus`
 |None
 
 |service:
@@ -342,33 +342,6 @@ The OTLP HTTP exporter exports data using the OpenTelemetry protocol (OTLP).
 <1> The OTLP HTTP endpoint. If the `+https://+` scheme is used, then client transport security is enabled and overrides the `insecure` setting in the `tls`.
 <2> The client side TLS configuration. Defines paths to TLS certificates.
 <3> Headers are sent in every HTTP request.
-
-[id="jaeger-exporter_{context}"]
-==== Jaeger exporter
-
-The Jaeger exporter exports data using the Jaeger proto format through gRPC.
-
-* Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
-* Supported signals: traces
-
-.OpenTelemetry Collector custom resource with enabled Jaeger exporter
-[source,yaml]
-----
-  config: |
-    exporters:
-      jaeger:
-        endpoint: jaeger-all-in-one:14250 <1>
-        tls: <2>
-          ca_file: ca.pem
-          cert_file: cert.pem
-          key_file: key.pem
-    service:
-      pipelines:
-        traces:
-          exporters: [jaeger]
-----
-<1> The Jaeger gRPC endpoint.
-<2> The client side TLS configuration. Defines paths to TLS certificates.
 
 [id="logging-exporter_{context}"]
 ==== Logging exporter

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -412,7 +412,7 @@ service:
       receivers: [otlp]
       exporters: [otlp]
 ----
-<1> The basicauth extension getting configured as a server authenticator reading credentials from a `.htpasswd` file.
+<1> Here the BasicAuth extension is configured as a server authenticator that reads credentials from an `.htpasswd` file.
 <2> The basicauth extension getting configured as a server authenticator reading the credentials from an inline string. This string consists of the read-in environment variables `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`.
 <3> The username configuration of basicauth extension getting configured as a client authenticator.
 <4> The password configuration of basicauth extension getting configured as a client authenticator.

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -413,7 +413,7 @@ service:
       exporters: [otlp]
 ----
 <1> Here the BasicAuth extension is configured as a server authenticator that reads credentials from an `.htpasswd` file.
-<2> The basicauth extension getting configured as a server authenticator reading the credentials from an inline string. This string consists of the read-in environment variables `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`.
+<2> Here the BasicAuth extension is configured as a server authenticator to read the credentials from an inline string that consists of environment variables.
 <3> The client username is configured as a client authenticator for the BasicAuth extension.
 <4> The client password is configured as a client authenticator for the BasicAuth extension.
 <5> Here the authenticator configuration is assigned to an OTLP receiver.

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -378,7 +378,7 @@ The configuration must specify only one instance of the BasicAuth extension: for
 * Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
 * Supported signals: traces, metrics, logs
 
-.OpenTelemetry Collector custom resource with a client and server basicauth extension
+.OpenTelemetry Collector custom resource with client and server authentication configured for the BasicAuth extension
 [source,yaml]
 ----
   config: |

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -372,7 +372,7 @@ The Logging exporter prints data to the standard output.
 [id="basicauth-extension_{context}"]
 ==== BASICAUTH extension
 
-The BasicAuth extension can be used as an Authenticator on receivers and exporters.
+The BasicAuth extension can be used as an authenticator on receivers and exporters.
 The configuration should specify only one instance of basicauth extension for either client or server authentication.
 
 * Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -373,7 +373,7 @@ The Logging exporter prints data to the standard output.
 ==== BASICAUTH extension
 
 The BasicAuth extension can be used as an authenticator on receivers and exporters.
-The configuration should specify only one instance of basicauth extension for either client or server authentication.
+The configuration must specify only one instance of the BasicAuth extension: for client authentication or server authentication.
 
 * Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
 * Supported signals: traces, metrics, logs

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -237,6 +237,46 @@ The Zipkin receiver ingests data in the Zipkin v1 and v2 formats.
 <1> The Zipkin HTTP endpoint. If omitted, the default `+0.0.0.0:9411+` is used.
 <2> The TLS server side configuration. See the OTLP receiver configuration section for more details.
 
+[id="kafka-receiver_{context}"]
+==== Kafka Receiver
+
+The Kafka receiver receives traces, metrics, and logs from Kafka in OTLP format.
+
+* Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
+* Supported signals: metrics, logs, traces
+
+.OpenTelemetry Collector custom resource with enabled Kafka receiver
+[source,yaml]
+----
+  config: |
+    receivers:
+      kafka:
+        brokers: ["localhost:9092"] <1>
+        protocol_version: 2.0.0 <2>
+        topic: otlp_spans <3>
+        auth:
+          plain_text: <4>
+            username: example
+            password: example
+          tls: <5>
+            ca_file: ca.pem
+            cert_file: cert.pem
+            key_file: key.pem
+            insecure: false <6>
+            server_name_override: kafka.example.corp <7>
+    service:
+      pipelines:
+        traces:
+          receivers: [kafka]
+----
+<1> The list of Kafka brokers. Default: `+localhost:9092+`
+<2> Kafka protocol version, for example `+2.0.0+`. This is a required field.
+<3> The name of the Kafka topic to read from. Default: `+otlp_spans+`
+<4> The plaintext authentication configuration. If omitted, plaintext authentication is disabled.
+<5> The client side TLS configuration. Defines paths to TLS certificates. If omitted, TLS authentication is disabled.
+<6> Disable verifying the server's certificate chain and host name. Default: `+false+`.
+<7> ServerName indicates the name of the server requested by the client, in order to support virtual hosting.
+
 [id="processors_{context}"]
 === Processors
 
@@ -367,6 +407,46 @@ The Logging exporter prints data to the standard output.
           exporters: [logging]
 ----
 <1> Verbosity of the logging export: `detailed` or `normal` or `basic`. When set to `detailed`, pipeline data is verbosely logged. Defaults to `normal`.
+
+[id="kafka-exporter_{context}"]
+==== Kafka exporter
+
+The Kafka exporter exports logs, metrics, and traces to Kafka. This exporter uses a synchronous producer that blocks and does not batch messages, therefore it should be used with batch and queued retry processors for higher throughput and resiliency.
+
+* Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
+* Supported signals: metrics, logs, traces
+
+.OpenTelemetry Collector custom resource with enabled Kafka exporter
+[source,yaml]
+----
+  config: |
+    exporters:
+      kafka:
+        brokers: ["localhost:9092"] <1>
+        protocol_version: 2.0.0 <2>
+        topic: otlp_spans <3>
+        auth:
+          plain_text: <4>
+            username: example
+            password: example
+          tls: <5>
+            ca_file: ca.pem
+            cert_file: cert.pem
+            key_file: key.pem
+            insecure: false <6>
+            server_name_override: kafka.example.corp <7>
+    service:
+      pipelines:
+        traces:
+          exporters: [kafka]
+----
+<1> The list of Kafka brokers. Default: `+localhost:9092+`
+<2> Kafka protocol version, for example `+2.0.0+`. This is a required field.
+<3> The name of the Kafka topic to read from. Default: `+otlp_spans+` for traces, `+otlp_metrics+` for metrics, `+otlp_logs+` for logs.
+<4> The plaintext authentication configuration. If omitted, plaintext authentication is disabled.
+<5> The client side TLS configuration. Defines paths to TLS certificates. If omitted, TLS authentication is disabled.
+<6> Disable verifying the server's certificate chain and host name. Default: `+false+`.
+<7> ServerName indicates the name of the server requested by the client, in order to support virtual hosting.
 
 [id="extensions_{context}"]
 === Extensions

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -365,3 +365,56 @@ The Logging exporter prints data to the standard output.
           exporters: [logging]
 ----
 <1> Verbosity of the logging export: `detailed` or `normal` or `basic`. When set to `detailed`, pipeline data is verbosely logged. Defaults to `normal`.
+
+[id="extensions_{context}"]
+=== Extensions
+
+[id="basicauth-extension_{context}"]
+==== BASICAUTH extension
+
+The BasicAuth extension can be used as an Authenticator on receivers and exporters.
+The configuration should specify only one instance of basicauth extension for either client or server authentication.
+
+* Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
+* Supported signals: traces, metrics, logs
+
+.OpenTelemetry Collector custom resource with a client and server basicauth extension
+[source,yaml]
+----
+  config: |
+    extensions:
+      basicauth/server:
+        htpasswd:
+          file: .htpasswd <1>
+        inline: |
+          ${env:BASIC_AUTH_USERNAME}:${env:BASIC_AUTH_PASSWORD} <2>
+
+      basicauth/client:
+        client_auth:
+          username: username <3>
+          password: password <4>
+
+    receivers:
+      otlp:
+        protocols:
+          http:
+            auth:
+              authenticator: basicauth/server <5>
+    exporters:
+      otlp:
+        auth:
+          authenticator: basicauth/client <6>
+
+service:
+  extensions: [basicauth/server, basicauth/client]
+  pipelines:
+    traces:
+      receivers: [otlp]
+      exporters: [otlp]
+----
+<1> The basicauth extension getting configured as a server authenticator reading credentials from a `.htpasswd` file.
+<2> The basicauth extension getting configured as a server authenticator reading the credentials from an inline string. This string consists of the read-in environment variables `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`.
+<3> The username configuration of basicauth extension getting configured as a client authenticator.
+<4> The password configuration of basicauth extension getting configured as a client authenticator.
+<5> The authenticator configuration getting assigned to an otlp receiver.
+<6> The authenticator configuration getting assigned to an otlp exporter.

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -26,10 +26,9 @@ metadata:
   namespace: tracing-system
 spec:
   mode: deployment
-  ports:
-  - name: promexporter
-    port: 8889
-    protocol: TCP
+  observability:
+    metrics:
+      enableMetrics: true
   config: |
     receivers:
       otlp:

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -416,5 +416,5 @@ service:
 <2> The basicauth extension getting configured as a server authenticator reading the credentials from an inline string. This string consists of the read-in environment variables `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`.
 <3> The username configuration of basicauth extension getting configured as a client authenticator.
 <4> The password configuration of basicauth extension getting configured as a client authenticator.
-<5> The authenticator configuration getting assigned to an otlp receiver.
+<5> Here the authenticator configuration is assigned to an OTLP receiver.
 <6> Here the authenticator configuration is assigned to an OTLP exporter.

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -372,7 +372,7 @@ The Logging exporter prints data to the standard output.
 [id="basicauth-extension_{context}"]
 ==== BasicAuth extension
 
-The BasicAuth extension can be used as an authenticator on receivers and exporters.
+You can use the BasicAuth extension as an authenticator on receivers and exporters.
 Client authentication and server authentication for the BasicAuth extension are configured in separate sections in the OpenTelemetry Collector custom resource.
 
 * Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -412,9 +412,9 @@ service:
       receivers: [otlp]
       exporters: [otlp]
 ----
-<1> Here the BasicAuth extension is configured as a server authenticator that reads credentials from an `.htpasswd` file.
-<2> Here the BasicAuth extension is configured as a server authenticator to read the credentials from an inline string that consists of environment variables.
+<1> The BasicAuth extension can be configured as a server authenticator that reads credentials from a `.htpasswd` file.
+<2> The BasicAuth extension can be configured as a client authenticator to read the credentials from an inline string that consists of environment variables.
 <3> The client username is configured as a client authenticator for the BasicAuth extension.
 <4> The client password is configured as a client authenticator for the BasicAuth extension.
-<5> Here the authenticator configuration is assigned to an OTLP receiver.
-<6> Here the authenticator configuration is assigned to an OTLP exporter.
+<5> The authenticator configuration can be assigned to an OTLP receiver.
+<6> The authenticator configuration can be assigned to an OTLP exporter.

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -370,7 +370,7 @@ The Logging exporter prints data to the standard output.
 === Extensions
 
 [id="basicauth-extension_{context}"]
-==== BASICAUTH extension
+==== BasicAuth extension
 
 The BasicAuth extension can be used as an authenticator on receivers and exporters.
 Client authentication and server authentication for the BasicAuth extension are configured in separate sections in the OpenTelemetry Collector custom resource.

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -415,6 +415,6 @@ service:
 <1> Here the BasicAuth extension is configured as a server authenticator that reads credentials from an `.htpasswd` file.
 <2> The basicauth extension getting configured as a server authenticator reading the credentials from an inline string. This string consists of the read-in environment variables `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`.
 <3> The client username is configured as a client authenticator for the BasicAuth extension.
-<4> The password configuration of basicauth extension getting configured as a client authenticator.
+<4> The client password is configured as a client authenticator for the BasicAuth extension.
 <5> Here the authenticator configuration is assigned to an OTLP receiver.
 <6> Here the authenticator configuration is assigned to an OTLP exporter.

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -414,7 +414,7 @@ service:
 ----
 <1> Here the BasicAuth extension is configured as a server authenticator that reads credentials from an `.htpasswd` file.
 <2> The basicauth extension getting configured as a server authenticator reading the credentials from an inline string. This string consists of the read-in environment variables `BASIC_AUTH_USERNAME` and `BASIC_AUTH_PASSWORD`.
-<3> The username configuration of basicauth extension getting configured as a client authenticator.
+<3> The client username is configured as a client authenticator for the BasicAuth extension.
 <4> The password configuration of basicauth extension getting configured as a client authenticator.
 <5> Here the authenticator configuration is assigned to an OTLP receiver.
 <6> Here the authenticator configuration is assigned to an OTLP exporter.

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -14,7 +14,7 @@ Processors:: Optional. Processors run through the data between it is received an
 
 Exporters:: An exporter, which can be push or pull based, is how you send data to one or more back ends or destinations. By default, no exporters are configured. One or more exporters must be configured. Exporters can support one or more data sources. Exporters might be used with their default settings, but many exporters require configuration to specify at least the destination and security settings.
 
-Connectors:: A connector is both an exporter and receiver. As the name suggests a Connector connects two pipelines: It consumes data as an exporter at the end of one pipeline and emits data as a receiver at the start of another pipeline. It may consume and emit data of the same data type, or of different data types. A connector may generate and emit data to summarize the consumed data, or it may simply replicate or route data.
+Connectors:: A connector connects two pipelines: It consumes data as an exporter at the end of one pipeline and emits data as a receiver at the start of another pipeline. It can consume and emit data of the same or different data type. It can generate and emit data to summarize the consumed data, or it can merely replicate or route data.
 
 You can define multiple instances of components in a custom resource YAML file. When configured, these components must be enabled through pipelines defined in the `spec.config.service` section of the YAML file. As a best practice, only enable the components that you need.
 
@@ -427,7 +427,7 @@ service:
 [id="spanmetrics-connector_{context}"]
 ==== Spanmetrics connector
 
-Aggregates Request, Error and Duration (R.E.D) OpenTelemetry metrics from span data.
+Aggregates Request, Error, and Duration (R.E.D) OpenTelemetry metrics from span data.
 
 * Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
 * Supported signals: traces

--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -14,6 +14,8 @@ Processors:: Optional. Processors run through the data between it is received an
 
 Exporters:: An exporter, which can be push or pull based, is how you send data to one or more back ends or destinations. By default, no exporters are configured. One or more exporters must be configured. Exporters can support one or more data sources. Exporters might be used with their default settings, but many exporters require configuration to specify at least the destination and security settings.
 
+Connectors:: A connector is both an exporter and receiver. As the name suggests a Connector connects two pipelines: It consumes data as an exporter at the end of one pipeline and emits data as a receiver at the start of another pipeline. It may consume and emit data of the same data type, or of different data types. A connector may generate and emit data to summarize the consumed data, or it may simply replicate or route data.
+
 You can define multiple instances of components in a custom resource YAML file. When configured, these components must be enabled through pipelines defined in the `spec.config.service` section of the YAML file. As a best practice, only enable the components that you need.
 
 .Example of the OpenTelemetry Collector custom resource file
@@ -418,3 +420,30 @@ service:
 <4> The client password is configured as a client authenticator for the BasicAuth extension.
 <5> The authenticator configuration can be assigned to an OTLP receiver.
 <6> The authenticator configuration can be assigned to an OTLP exporter.
+
+[id="connectors_{context}"]
+=== Connectors
+
+[id="spanmetrics-connector_{context}"]
+==== Spanmetrics connector
+
+Aggregates Request, Error and Duration (R.E.D) OpenTelemetry metrics from span data.
+
+* Support level: link:https://access.redhat.com/support/offerings/techpreview[Technology Preview]
+* Supported signals: traces
+
+.OpenTelemetry Collector custom resource with an enabled spanmetrics connector
+[source,yaml]
+----
+  config: |
+    connectors:
+      spanmetrics:
+        metrics_flush_interval: 15s <1>
+    service:
+      pipelines:
+        traces:
+          exporters: [spanmetrics]
+        metrics:
+          receivers: [spanmetrics]
+----
+<1>: Defines the flush interval of the generated metrics. Defaults to `15s`.

--- a/modules/distr-tracing-otel-config-send-metrics-monitoring-stack.adoc
+++ b/modules/distr-tracing-otel-config-send-metrics-monitoring-stack.adoc
@@ -6,9 +6,9 @@ This module is included in the following assemblies:
 [id="distr-tracing-send-metrics-monitoring-stack_{context}"]
 = Sending metrics to the monitoring stack
 
-You can configure the OpenTelemetry Collector custom resource to create a Prometheus `ServiceMonitor` to scrape the collector's pipeline metrics and the enabled Prometheus exporters.
+You can configure the OpenTelemetry Collector custom resource (CR) to create a Prometheus `ServiceMonitor` CR to scrape the collector's pipeline metrics and the enabled Prometheus exporters.
 
-.Example of the OpenTelemetry Collector custom resource with Prometheus exporter
+.Example of the OpenTelemetry Collector custom resource with the Prometheus exporter
 [source,yaml]
 ----
 spec:
@@ -31,7 +31,7 @@ spec:
           receivers: [otlp]
           exporters: [prometheus]
 ----
-<1> Configures the operator to create Prometheus `ServiceMonitor` to scrape collector's internal and Prometheus exporter metric endpoints. The metrics will be stored in the OpenShift monitoring stack.
+<1> Configures the operator to create the Prometheus `ServiceMonitor` CR to scrape the collector's internal metrics endpoint and Prometheus exporter metric endpoints. The metrics will be stored in the OpenShift monitoring stack.
 
 
 Alternatively, the Prometheus `PodMonitor` can be created manually, which offers more fine-grained control, for instance remove duplicated labels added during Prometheus scraping.

--- a/modules/distr-tracing-otel-config-send-metrics-monitoring-stack.adoc
+++ b/modules/distr-tracing-otel-config-send-metrics-monitoring-stack.adoc
@@ -6,7 +6,35 @@ This module is included in the following assemblies:
 [id="distr-tracing-send-metrics-monitoring-stack_{context}"]
 = Sending metrics to the monitoring stack
 
-You can configure the monitoring stack to scrape OpenTelemetry Collector metrics endpoints and to remove duplicated labels that the monitoring stack has added during scraping.
+The OpenTelemetry Collector custom resource can be configured to create Prometheus `ServiceMonitor` to scrape collector's pipeline metrics and enabled Prometheus exporters.
+
+.Example of the OpenTelemetry Collector custom resource with Prometheus exporter
+[source,yaml]
+----
+spec:
+  mode: deployment
+  observability:
+    metrics:
+      enableMetrics: true <1>
+  config: |
+    exporters:
+      prometheus:
+        endpoint: 0.0.0.0:8889
+        resource_to_telemetry_conversion:
+          enabled: true # by default resource attributes are dropped
+    service:
+      telemetry:
+        metrics:
+          address: ":8888"
+      pipelines:
+        metrics:
+          receivers: [otlp]
+          exporters: [prometheus]
+----
+<1> Configures the operator to create Prometheus `ServiceMonitor` to scrape collector's internal and Prometheus exporter metric endpoints. The metrics will be stored in the OpenShift monitoring stack.
+
+
+Alternatively, the Prometheus `PodMonitor` can be created manually, which offers more fine-grained control, for instance remove duplicated labels added during Prometheus scraping.
 
 .Sample `PodMonitor` custom resource (CR) that configures the monitoring stack to scrape Collector metrics
 [source,yaml]
@@ -18,7 +46,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: otel-collector
+      app.kubernetes.io/name: otel-collector <1>
   podMetricsEndpoints:
   - port: metrics <1>
   - port: promexporter <2>
@@ -35,5 +63,6 @@ spec:
     - action: labeldrop
       regex: job
 ----
-<1> The name of the internal metrics port for the OpenTelemetry Collector. This port name is always `metrics`.
-<2> The name of the Prometheus exporter port for the OpenTelemetry Collector. This port name is defined in the `.spec.ports` section of the `OpenTelemetryCollector` CR.
+<1> The name of the OpenTelemetry customer resource e.g. `<cr-name>-collector`.
+<2> The name of the internal metrics port for the OpenTelemetry Collector. This port name is always `metrics`.
+<3> The name of the Prometheus exporter port for the OpenTelemetry Collector.

--- a/modules/distr-tracing-otel-config-send-metrics-monitoring-stack.adoc
+++ b/modules/distr-tracing-otel-config-send-metrics-monitoring-stack.adoc
@@ -6,7 +6,7 @@ This module is included in the following assemblies:
 [id="distr-tracing-send-metrics-monitoring-stack_{context}"]
 = Sending metrics to the monitoring stack
 
-The OpenTelemetry Collector custom resource can be configured to create Prometheus `ServiceMonitor` to scrape collector's pipeline metrics and enabled Prometheus exporters.
+You can configure the OpenTelemetry Collector custom resource to create a Prometheus `ServiceMonitor` to scrape the collector's pipeline metrics and the enabled Prometheus exporters.
 
 .Example of the OpenTelemetry Collector custom resource with Prometheus exporter
 [source,yaml]
@@ -46,7 +46,7 @@ metadata:
 spec:
   selector:
     matchLabels:
-      app.kubernetes.io/name: otel-collector <1>
+      app.kubernetes.io/name: `<cr-name>-collector` <1>
   podMetricsEndpoints:
   - port: metrics <1>
   - port: promexporter <2>
@@ -63,6 +63,6 @@ spec:
     - action: labeldrop
       regex: job
 ----
-<1> The name of the OpenTelemetry customer resource e.g. `<cr-name>-collector`.
+<1> The name of the OpenTelemetry custom resource.
 <2> The name of the internal metrics port for the OpenTelemetry Collector. This port name is always `metrics`.
 <3> The name of the Prometheus exporter port for the OpenTelemetry Collector.

--- a/modules/distr-tracing-tempo-config-spanmetrics.adoc
+++ b/modules/distr-tracing-tempo-config-spanmetrics.adoc
@@ -1,0 +1,93 @@
+////
+This module included in the following assemblies:
+// * distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
+////
+:_content-type: REFERENCE
+[id="distr-tracing-tempo-config-spanmetrics_{context}"]
+= Configure monitor tab in Jaeger UI
+
+Trace data contains rich information and most importantly the data is normalized across instrumented languages and frameworks.
+Therefore, additional metrics can be extracted from traces. These metrics are request count, duration and error count (RED).
+The metrics can be visualized in Jaeger console in the Monitor tab.
+
+The metrics are derived from spans in the OpenTelemetry collector, then scraped from the collector by the Prometheus deployed in the user-workload monitoring stack.
+Jaeger UI queries these metrics from the Prometheus endpoint and visualizes.
+
+== OpenTelemetry collector configuration
+
+The OpenTelemetry collector needs to configure `spanmetrics` connector which derives metrics from traces and exports the metrics in the Prometheus format.
+
+.OpenTelemetry collector CR for span RED
+[source,yaml]
+----
+kind: OpenTelemetryCollector
+apiVersion: opentelemetry.io/v1alpha1
+metadata:
+  name: otel
+spec:
+  mode: deployment
+  observability:
+    metrics:
+      enableMetrics: true
+  config: |
+    connectors:
+      spanmetrics: <1>
+        metrics_flush_interval: 15s
+
+    receivers:
+      otlp: <2>
+        protocols:
+          grpc:
+          http:
+
+    exporters:
+      prometheus: <3>
+        endpoint: 0.0.0.0:8889
+        resource_to_telemetry_conversion:
+          enabled: true # by default resource attributes are dropped
+
+    service:
+      pipelines:
+        traces:
+          receivers: [otlp]
+          exporters: [otlp, spanmetrics] <4>
+        metrics:
+          receivers: [spanmetrics] <5>
+          exporters: [prometheus]
+----
+<1> Spanmetrics connector receives traces and exports metrics.
+<2> OTLP receiver to receive spans in the OpenTelemetry protocol.
+<3> Prometheus exporter is used to export metrics in the Prometheus format.
+<4> Spanmetrics connector is configured as exporter in traces pipeline.
+<5> Spanmetrics connector is configured as receiver in metrics pipeline.
+
+// TODO Max please fix this appropriately
+The setup as well requires to configure the user-workload monitoring stack to scrape the Prometheus endpoint of the collector - https://github.com/openshift/openshift-docs/pull/60953/files#diff-bd0dc510dd646c60e63a7daf0b9d22eb7525adc8467753a6bdb37948345992ddR7
+
+== Tempo configuration
+
+The `TempoStack` CR needs to enable the monitor tab and set the Prometheus endpoint to Thanos querier service to query the data from the user-defined monitoring stack.
+
+.TempoStack CR with enabled monitor tab
+[source,yaml]
+----
+kind:  TempoStack
+apiVersion: tempo.grafana.com/v1alpha1
+metadata:
+  name: simplest
+spec:
+  template:
+    gateway:
+      enabled: false <1>
+    queryFrontend:
+      jaegerQuery:
+        enabled: true
+        monitorTab:
+          enabled: true <2>
+          prometheusEndpoint: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091 <3>
+        ingress:
+          type: route
+----
+<1> Gateway is enabled because the monitor tab is not supported thorough the gateway deployment.
+<2> Enables monitoring tab in Jaeger console.
+<3> The Thanos querier service name from user-workload monitoring.

--- a/modules/distr-tracing-tempo-config-spanmetrics.adoc
+++ b/modules/distr-tracing-tempo-config-spanmetrics.adoc
@@ -1,23 +1,23 @@
-////
-This module included in the following assemblies:
+// Module included in the following assemblies:
+//
 // * distr_tracing_tempo/distr-tracing-tempo-configuring.adoc
-////
+
 :_content-type: REFERENCE
 [id="distr-tracing-tempo-config-spanmetrics_{context}"]
-= Configure monitor tab in Jaeger UI
+= Configuration of the monitor tab in Jaeger UI
 
-Trace data contains rich information and most importantly the data is normalized across instrumented languages and frameworks.
-Therefore, additional metrics can be extracted from traces. These metrics are request count, duration and error count (RED).
-The metrics can be visualized in Jaeger console in the Monitor tab.
+Trace data contains rich information, and the data is normalized across instrumented languages and frameworks.
+Therefore, additional metrics can be extracted from traces. These metrics are request count, duration, and error count (RED).
+The metrics can be visualized in Jaeger console in the *Monitor* tab.
 
-The metrics are derived from spans in the OpenTelemetry collector, then scraped from the collector by the Prometheus deployed in the user-workload monitoring stack.
-Jaeger UI queries these metrics from the Prometheus endpoint and visualizes.
+The metrics are derived from spans in the OpenTelemetry Collector that are scraped from the Collector by the Prometheus deployed in the user-workload monitoring stack.
+The Jaeger UI queries these metrics from the Prometheus endpoint and visualizes them.
 
-== OpenTelemetry collector configuration
+== OpenTelemetry Collector configuration
 
-The OpenTelemetry collector needs to configure `spanmetrics` connector which derives metrics from traces and exports the metrics in the Prometheus format.
+The OpenTelemetry Collector requires configuration of the `spanmetrics` connector that derives metrics from traces and exports the metrics in the Prometheus format.
 
-.OpenTelemetry collector CR for span RED
+.OpenTelemetry Collector custom resource for span RED
 [source,yaml]
 ----
 kind: OpenTelemetryCollector
@@ -55,12 +55,12 @@ spec:
           receivers: [spanmetrics] <6>
           exporters: [prometheus]
 ----
-<1> Creates `ServiceMonitor` custom resource to enable scraping of the Prometheus exporter.
-<2> Spanmetrics connector receives traces and exports metrics.
-<3> OTLP receiver to receive spans in the OpenTelemetry protocol.
-<4> Prometheus exporter is used to export metrics in the Prometheus format.
-<5> Spanmetrics connector is configured as exporter in traces pipeline.
-<6> Spanmetrics connector is configured as receiver in metrics pipeline.
+<1> Creates the `ServiceMonitor` custom resource to enable scraping of the Prometheus exporter.
+<2> The Spanmetrics connector receives traces and exports metrics.
+<3> The OTLP receiver to receive spans in the OpenTelemetry protocol.
+<4> The Prometheus exporter is used to export metrics in the Prometheus format.
+<5> The Spanmetrics connector is configured as exporter in traces pipeline.
+<6> The Spanmetrics connector is configured as receiver in metrics pipeline.
 
 == Tempo configuration
 

--- a/modules/distr-tracing-tempo-config-spanmetrics.adoc
+++ b/modules/distr-tracing-tempo-config-spanmetrics.adoc
@@ -64,9 +64,9 @@ spec:
 
 == Tempo configuration
 
-The `TempoStack` CR needs to enable the monitor tab and set the Prometheus endpoint to Thanos querier service to query the data from the user-defined monitoring stack.
+The `TempoStack` custom resource must specify the following: the *Monitor* tab is enabled, and the Prometheus endpoint is set to the Thanos querier service to query the data from the user-defined monitoring stack.
 
-.TempoStack CR with enabled monitor tab
+.TempoStack custom resource with the enabled Monitor tab
 [source,yaml]
 ----
 kind:  TempoStack
@@ -86,6 +86,6 @@ spec:
         ingress:
           type: route
 ----
-<1> Gateway is enabled because the monitor tab is not supported thorough the gateway deployment.
-<2> Enables monitoring tab in Jaeger console.
-<3> The Thanos querier service name from user-workload monitoring.
+<1> Gateway must be enabled because the Monitor tab is not supported thorough the gateway deployment.
+<2> Enables the monitoring tab in the Jaeger console.
+<3> The service name for Thanos Querier from user-workload monitoring.

--- a/modules/distr-tracing-tempo-config-spanmetrics.adoc
+++ b/modules/distr-tracing-tempo-config-spanmetrics.adoc
@@ -28,20 +28,20 @@ spec:
   mode: deployment
   observability:
     metrics:
-      enableMetrics: true
+      enableMetrics: true <1>
   config: |
     connectors:
-      spanmetrics: <1>
+      spanmetrics: <2>
         metrics_flush_interval: 15s
 
     receivers:
-      otlp: <2>
+      otlp: <3>
         protocols:
           grpc:
           http:
 
     exporters:
-      prometheus: <3>
+      prometheus: <4>
         endpoint: 0.0.0.0:8889
         resource_to_telemetry_conversion:
           enabled: true # by default resource attributes are dropped
@@ -50,19 +50,17 @@ spec:
       pipelines:
         traces:
           receivers: [otlp]
-          exporters: [otlp, spanmetrics] <4>
+          exporters: [otlp, spanmetrics] <5>
         metrics:
-          receivers: [spanmetrics] <5>
+          receivers: [spanmetrics] <6>
           exporters: [prometheus]
 ----
-<1> Spanmetrics connector receives traces and exports metrics.
-<2> OTLP receiver to receive spans in the OpenTelemetry protocol.
-<3> Prometheus exporter is used to export metrics in the Prometheus format.
-<4> Spanmetrics connector is configured as exporter in traces pipeline.
-<5> Spanmetrics connector is configured as receiver in metrics pipeline.
-
-// TODO Max please fix this appropriately
-The setup as well requires to configure the user-workload monitoring stack to scrape the Prometheus endpoint of the collector - https://github.com/openshift/openshift-docs/pull/60953/files#diff-bd0dc510dd646c60e63a7daf0b9d22eb7525adc8467753a6bdb37948345992ddR7
+<1> Creates `ServiceMonitor` custom resource to enable scraping of the Prometheus exporter.
+<2> Spanmetrics connector receives traces and exports metrics.
+<3> OTLP receiver to receive spans in the OpenTelemetry protocol.
+<4> Prometheus exporter is used to export metrics in the Prometheus format.
+<5> Spanmetrics connector is configured as exporter in traces pipeline.
+<6> Spanmetrics connector is configured as receiver in metrics pipeline.
 
 == Tempo configuration
 


### PR DESCRIPTION
Version(s):
4.11, 4.12, 4.13

Issue:
https://issues.redhat.com/browse/TRACING-3552

Link to docs preview:
https://65577--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_otel/distr-tracing-otel-configuring#kafka-receiver_distr-tracing-otel-configuring
https://65577--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_otel/distr-tracing-otel-configuring#kafka-exporter_distr-tracing-otel-configuring

QE review:
- [ ] QE has approved this change.

Additional information:
The downstream docs are effectively a subset from the upstream docs (https://github.com/open-telemetry/opentelemetry-collector-contrib/blob/main/receiver/kafkareceiver and https://github.com/open-telemetry/opentelemetry-collector-contrib/tree/main/exporter/kafkaexporter), which are licensed under Apache-2.0.
We should add a license notice somewhere on this page.

@pavolloffay
@IshwarKanse
@max-cx