### PR TITLE
OCPBUGS-19984 - typo fixes in ZTP docs

### DIFF
--- a/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
+++ b/modules/ztp-preparing-the-hub-cluster-for-ztp.adoc
@@ -50,7 +50,8 @@ $ oc patch argocd openshift-gitops \
 
 . In {rh-rhacm} 2.7 and later, the multicluster engine enables the `cluster-proxy-addon` feature by default.
 To disable this feature, apply the following patch to disable and remove the relevant hub cluster and managed cluster pods that are responsible for this add-on.
-
+Run the following command:
++
 [source,terminal]
 ----
 $ oc patch multiclusterengines.multicluster.openshift.io multiclusterengine --type=merge --patch-file out/argocd/deployment/disable-cluster-proxy-addon.json

--- a/modules/ztp-preparing-the-ztp-git-repository.adoc
+++ b/modules/ztp-preparing-the-ztp-git-repository.adoc
@@ -20,7 +20,7 @@ Before you can use the {ztp-first} pipeline, you need to prepare the Git reposit
 +
 [NOTE]
 ====
-Keep `SiteConfig` and `PolicyGenTemplate` CRs in separate directories. 
+Keep `SiteConfig` and `PolicyGenTemplate` CRs in separate directories.
 Both the `SiteConfig` and `PolicyGenTemplate` directories must contain a `kustomization.yaml` file that explicitly includes the files in that directory.
 ====
 
@@ -54,24 +54,21 @@ $ podman run --log-driver=none --rm registry.redhat.io/openshift4/ztp-site-gener
 
 . The out/extra-manifests directory contains the reference manifests for a RAN DU cluster. 
 Copy the `out/extra-manifests` directory into the `SiteConfig` folder.
-This directory should contain CRs from the `ztp-site-generate` container only. 
+This directory should contain CRs from the `ztp-site-generate` container only.
 Do not add custom CRs here.  
-If you want to work with custom CRs you must create another directory for that content. 
+If you want to work with custom CRs you must create another directory for that content.
+For example:
 +
-[NOTE]
-====
-Here is an example of the directory structure: 
-source,text]
+[source,text]
 ----
-example
-├── policygentemplates
-│   ├── kustomization.yaml
-│   └── source-crs/
-└── siteconfig
-    ├── extra-manifests
-    └── kustomization.yaml
+example/
+  ├── policygentemplates
+  │   ├── kustomization.yaml
+  │   └── source-crs/
+  └── siteconfig
+        ├── extra-manifests
+        └── kustomization.yaml
 ----
-====
 
 . Commit the directory structure and the `kustomization.yaml` files and push to your Git repository. 
 The initial push to Git should include the `kustomization.yaml` files.
@@ -89,21 +86,21 @@ The following example describes a set of CRs for a network of single-node cluste
 
 [source,text]
 ----
-example
-├── policygentemplates
-│   ├── common-ranGen.yaml
-│   ├── example-sno-site.yaml
-│   ├── group-du-sno-ranGen.yaml
-│   ├── group-du-sno-validator-ranGen.yaml
-│   ├── kustomization.yaml
-│   ├── source-crs/
-│   └── ns.yaml
-└── siteconfig
-    ├── example-sno.yaml
-    ├── extra-manifests/ <1> 
-    ├── custom-manifests/ <2>
-    ├── KlusterletAddonConfigOverride.yaml
-    └── kustomization.yaml
+example/
+  ├── policygentemplates
+  │   ├── common-ranGen.yaml
+  │   ├── example-sno-site.yaml
+  │   ├── group-du-sno-ranGen.yaml
+  │   ├── group-du-sno-validator-ranGen.yaml
+  │   ├── kustomization.yaml
+  │   ├── source-crs/
+  │   └── ns.yaml
+  └── siteconfig
+        ├── example-sno.yaml
+        ├── extra-manifests/ <1>
+        ├── custom-manifests/ <2>
+        ├── KlusterletAddonConfigOverride.yaml
+        └── kustomization.yaml
 ----
 <1> Contains reference manifests from the `ztp-container`.
 <2> Contains custom manifests.


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-19984 Typo fixes in ZTP docs

Fixes these issues: 
![image](https://github.com/openshift/openshift-docs/assets/74046732/85de73a1-345e-4d5a-be1e-0cc007d6be4b)
![image](https://github.com/openshift/openshift-docs/assets/74046732/ca5ace28-cd4c-4349-8dc4-4c54dbb83106)

Version(s):
openshift-4.14

Issue:
N/A

Link to docs preview:
https://65586--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#ztp-preparing-the-ztp-git-repository_ztp-preparing-the-hub-cluster

QE review:
- [N/A] QE has approved this change.