### PR TITLE
OSDOCS#3462: Removed port 80 reference from Configuring your firewall…

### DIFF
--- a/modules/configuring-firewall.adoc
+++ b/modules/configuring-firewall.adoc
@@ -24,35 +24,35 @@ If your environment has a dedicated load balancer in front of your {product-titl
 |URL | Port | Function
 
 |`registry.redhat.io`
-|443, 80
+|443
 |Provides core container images
 
 |`access.redhat.com` ^[1]^
-|443, 80
+|443
 |Hosts all the container images that are stored on the Red Hat Ecosytem Catalog, including core container images.
 
 |`quay.io`
-|443, 80
+|443
 |Provides core container images
 
 |`cdn.quay.io`
-|443, 80
+|443
 |Provides core container images
 
 |`cdn01.quay.io`
-|443, 80
+|443
 |Provides core container images
 
 |`cdn02.quay.io`
-|443, 80
+|443
 |Provides core container images
 
 |`cdn03.quay.io`
-|443, 80
+|443
 |Provides core container images
 
 |`sso.redhat.com`
-|443, 80
+|443
 |The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
 [.small]
 |===
@@ -73,19 +73,19 @@ You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn
 |URL | Port | Function
 
 |`cert-api.access.redhat.com`
-|443, 80
+|443
 |Required for Telemetry
 
 |`api.access.redhat.com`
-|443, 80
+|443
 |Required for Telemetry
 
 |`infogw.api.openshift.com`
-|443, 80
+|443
 |Required for Telemetry
 
 |`console.redhat.com/api/ingress`
-|443, 80
+|443
 |Required for Telemetry and for `insights-operator`
 |===
 
@@ -97,14 +97,14 @@ You can use the wildcards `\*.quay.io` and `*.openshiftapps.com` instead of `cdn
 
 |Alibaba
 |`*.aliyuncs.com`
-|443, 80
+|443
 |Required to access Alibaba Cloud services and resources. Review the link:https://github.com/aliyun/alibaba-cloud-sdk-go/blob/master/sdk/endpoints/endpoints_config.go?spm=a2c4g.11186623.0.0.47875873ciGnC8&file=endpoints_config.go[Alibaba endpoints_config.go file] to determine the exact endpoints to allow for the regions that you use.
 
 .15+|AWS
 |`*.amazonaws.com`
 
 Alternatively, if you choose to not use a wildcard for AWS APIs, you must allowlist the following URLs:
-|443, 80
+|443
 |Required to access AWS services and resources. Review the link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS Service Endpoints] in the AWS documentation to determine the exact endpoints to allow for the regions that you use.
 
 |`ec2.amazonaws.com`
@@ -156,33 +156,33 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must allowl
 |Used to install and manage clusters in an AWS environment.
 
 |`servicequotas.<aws_region>.amazonaws.com`
-|443, 80
+|443
 |Required. Used to confirm quotas for deploying the service.
 
 |`tagging.<aws_region>.amazonaws.com`
-|443, 80
+|443
 |Allows the assignment of metadata about AWS resources in the form of tags.
 
 .2+|GCP
 |`*.googleapis.com`
-|443, 80
+|443
 |Required to access GCP services and resources. Review link:https://cloud.google.com/endpoints/[Cloud Endpoints] in the GCP documentation to determine the endpoints to allow for your APIs.
 
 |`accounts.google.com`
-|443, 80
+|443
 | Required to access your GCP account.
 
 .4+|Azure
 |`management.azure.com`
-|443, 80
+|443
 |Required to access Azure services and resources. Review the link:https://docs.microsoft.com/en-us/rest/api/azure/[Azure REST API reference] in the Azure documentation to determine the endpoints to allow for your APIs.
 
 |`*.blob.core.windows.net`
-|443, 80
+|443
 |Required to download Ignition files.
 
 |`login.microsoftonline.com`
-|443, 80
+|443
 |Required to access Azure services and resources. Review the link:https://docs.microsoft.com/en-us/rest/api/azure/[Azure REST API reference] in the Azure documentation to determine the endpoints to allow for your APIs.
 
 |===
@@ -194,39 +194,39 @@ Alternatively, if you choose to not use a wildcard for AWS APIs, you must allowl
 |URL | Port | Function
 
 |`mirror.openshift.com`
-|443, 80
+|443
 |Required to access mirrored installation content and images. This site is also a source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
 
 |`storage.googleapis.com/openshift-release`
-|443, 80
+|443
 |A source of release image signatures, although the Cluster Version Operator needs only a single functioning source.
 
 |`*.apps.<cluster_name>.<base_domain>`
-|443, 80
+|443
 |Required to access the default cluster routes unless you set an ingress wildcard during installation.
 
 |`quayio-production-s3.s3.amazonaws.com`
-|443, 80
+|443
 |Required to access Quay image content in AWS.
 
 |`api.openshift.com`
-|443, 80
+|443
 |Required both for your cluster token and to check if updates are available for the cluster.
 
 |`rhcos.mirror.openshift.com`
-|443, 80
+|443
 |Required to download {op-system-first} images.
 
 |`console.redhat.com/openshift`
-|443, 80
+|443
 |Required for your cluster token.
 
 // |`registry.access.redhat.com`
-// |443, 80
+// |443
 // |Required for `odo` CLI.
 
 |`sso.redhat.com`
-|443, 80
+|443
 |The `https://console.redhat.com/openshift` site uses authentication from `sso.redhat.com`
 
 |===
@@ -247,15 +247,15 @@ that is specified in the `spec.route.hostname` field of the
 |URL | Port | Function
 
 |`registry.connect.redhat.com`
-|443, 80
+|443
 |Required for all third-party images and certified operators.
 
 |`rhc4tp-prod-z8cxf-image-registry-us-east-1-evenkyleffocxqvofrk.s3.dualstack.us-east-1.amazonaws.com`
-|443, 80
+|443
 |Provides access to container images hosted on `registry.connect.redhat.com`
 
 |`oso-rhc4tp-docker-registry.s3-us-west-2.amazonaws.com`
-|443, 80
+|443
 |Required for Sonatype Nexus, F5 Big IP operators.
 |===
 +


### PR DESCRIPTION
[OSDOCS-3462](https://issues.redhat.com//browse/OSDOCS-3462)

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Link to docs preview:
[Configuring your firewall](https://65592--docspreview.netlify.app/openshift-enterprise/latest/installing/install_config/configuring-firewall)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
