### PR TITLE
OSDOCS-7975: Added third install route to Nutanix docs

### DIFF
--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -7,11 +7,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on your Nutanix instance with two methods:
+In {product-title} version {product-version}, you can choose one of the following options to install a cluster on your Nutanix instance:
 
-* Using the link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full}] hosted at link:http://console.redhat.com[console.redhat.com]. This method requires no setup for the installer, and is ideal for connected environments like Nutanix. Installing with the {ai-full} also provides integration with Nutanix, enabling autoscaling. See xref:../../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#installing-on-prem-assisted[Installing an on-premise cluster using the {ai-full}] for additional details.
+**Using installer-provisioned infrastructure**: Use the procedures in the following sections to use installer-provisioned infrastructure. Installer-provisioned infrastructure is ideal for installing in connected or disconnected network environments. The installer-provisioned infrastructure includes an installation program that provisions the underlying infrastructure for the cluster.
 
-* Using installer-provisioned infrastructure. Use the procedures in the following sections to use installer-provisioned infrastructure. Installer-provisioned infrastructure is ideal for installing in environments with air-gapped/restricted networks.
+**Using the Assisted Installer**: The link:https://access.redhat.com/documentation/en-us/assisted_installer_for_openshift_container_platform/2022/html-single/assisted_installer_for_openshift_container_platform/index[{ai-full}] hosted at link:http://console.redhat.com[console.redhat.com]. The {ai-full} cannot be used in disconnected environments. The {ai-full} does not provision the underlying infrastructure for the cluster, so you must provision the infrastructure before the running the {ai-full}. Installing with the {ai-full} also provides integration with Nutanix, enabling autoscaling. See xref:../../installing/installing_on_prem_assisted/installing-on-prem-assisted.adoc#installing-on-prem-assisted[Installing an on-premise cluster using the {ai-full}] for additional details.
+
+**Using user-provisioned infrastructure**: Complete the relevant steps outlined in the xref:../../installing/installing_platform_agnostic/installing-platform-agnostic.adoc#installing-platform-agnostic[Installing a cluster on any platform] documentation. 
 
 == Prerequisites
 


### PR DESCRIPTION
[OSDOCS-7975](https://issues.redhat.com/browse/OSDOCS-7975)

Version(s):
4.15 to 4.12

Link to docs preview:
[Installing a cluster on Nutanix](https://65599--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
