### PR TITLE
Replace AWS image used to create Windows Machines in AWS

### DIFF
--- a/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
+++ b/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
@@ -14,12 +14,27 @@ You can create a Windows `MachineSet` object to serve a specific purpose in your
 * You installed the Windows Machine Config Operator (WMCO) using Operator Lifecycle Manager (OLM).
 * You are using a supported Windows Server as the operating system image.
 +
-Use the following `aws` command to query valid AMI images:
+Use one of the the following `aws` commands, as appropriate for your Windows Server release, to query valid AMI images:
++
+.Example Windows Server 2022 command
 +
 [source,terminal]
 ----
-$ aws ec2 describe-images --region <aws region name> --filters "Name=name,Values=Windows_Server-2019*English*Full*Containers*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output table
+$ aws ec2 describe-images --region <aws_region_name> --filters "Name=name,Values=Windows_Server-2022*English*Core*Base*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output table
 ----
++
+.Example Windows Server 2019 command
++
+[source,terminal]
+----
+$ aws ec2 describe-images --region <aws_region_name> --filters "Name=name,Values=Windows_Server-2019*English*Core*Base*" "Name=is-public,Values=true" --query "reverse(sort_by(Images, &CreationDate))[*].{name: Name, id: ImageId}" --output table
+----
++
+--
+where:
+
+<aws_region_name>:: Specifies the name of your AWS region.
+--
 
 include::modules/machine-api-overview.adoc[leveloffset=+1]
 include::modules/windows-machineset-aws.adoc[leveloffset=+1]


### PR DESCRIPTION
The Windows Server image `Windows_Server-2019*English*Full*Containers*`, shown in an example command`,  isn't available anymore in EC2. For that reason, it needs to be replaced by the Core image.

Issue:
https://issues.redhat.com/browse/OCPBUGS-17638
https://github.com/openshift/openshift-docs/issues/65324

Link to docs preview:
 Creating a Windows machine set on AWS -> [Prerequisites](https://65600--docspreview.netlify.app/openshift-enterprise/latest/windows_containers/creating_windows_machinesets/creating-windows-machineset-aws): Updated example command for Windows Server 2019 and added new command for Windows Server 2022.

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

@DCChadwick FYI