### PR TITLE
OSDOCS-7623: Added notice of future deprecation for OpenShift SDN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -883,6 +883,14 @@ Kubernetes 1.27 removed the following deprecated API, so you must migrate manife
 
 {product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups.
 
+[id="ocp-4-14-future-deprecation"]
+=== Notice of future deprecation
+
+[id="ocp-4-14-future-deprecation-sdn"]
+==== Future deprecation of the OpenShift SDN network plugin
+
+Targeting {product-title} 4.15, the OpenShift SDN CNI network plugin will not be an option for new installations, but will continue to be supported in clusters upgrading to 4.15 and 4.16 from clusters previously installed with the OpenShift SDN network plugin. In a future release, targeting no earlier than 4.17, the OpenShift SDN network plugin will be removed and and will no longer be supported.
+
 [id="ocp-4-14-bug-fixes"]
 == Bug fixes
 


### PR DESCRIPTION
Version(s):
4.14 only (release note)

Issue:
https://issues.redhat.com/browse/OSDOCS-7623

Link to docs preview:
https://65601--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-future-deprecation-sdn