### PR TITLE
[OCPBUGS#9167]: Updated oc adm upgrade output to reflect 4.14 oc client 

### DIFF
--- a/modules/update-upgrading-cli.adoc
+++ b/modules/update-upgrading-cli.adoc
@@ -34,23 +34,19 @@ $ oc adm upgrade
 .Example output
 [source,terminal]
 ----
-Cluster version is 4.9.23
+$ oc adm upgrade
+Cluster version is 4.13.10
 
 Upstream is unset, so the cluster will use an appropriate default.
-Channel: stable-4.9 (available channels: candidate-4.10, candidate-4.9, fast-4.10, fast-4.9, stable-4.10, stable-4.9, eus-4.10)
+Channel: stable-4.13 (available channels: candidate-4.13, candidate-4.14, fast-4.13, stable-4.13)
 
 Recommended updates:
 
-VERSION IMAGE
-4.9.24  quay.io/openshift-release-dev/ocp-release@sha256:6a899c54dda6b844bb12a247e324a0f6cde367e880b73ba110c056df6d018032
-4.9.25  quay.io/openshift-release-dev/ocp-release@sha256:2eafde815e543b92f70839972f585cc52aa7c37aa72d5f3c8bc886b0fd45707a
-4.9.26  quay.io/openshift-release-dev/ocp-release@sha256:3ccd09dd08c303f27a543351f787d09b83979cd31cf0b4c6ff56cd68814ef6c8
-4.9.27  quay.io/openshift-release-dev/ocp-release@sha256:1c7db78eec0cf05df2cead44f69c0e4b2c3234d5635c88a41e1b922c3bedae16
-4.9.28  quay.io/openshift-release-dev/ocp-release@sha256:4084d94969b186e20189649b5affba7da59f7d1943e4e5bc7ef78b981eafb7a8
-4.9.29  quay.io/openshift-release-dev/ocp-release@sha256:b04ca01d116f0134a102a57f86c67e5b1a3b5da1c4a580af91d521b8fa0aa6ec
-4.9.31  quay.io/openshift-release-dev/ocp-release@sha256:2a28b8ebb53d67dd80594421c39e36d9896b1e65cb54af81fbb86ea9ac3bf2d7
-4.9.32  quay.io/openshift-release-dev/ocp-release@sha256:ecdb6d0df547b857eaf0edb5574ddd64ca6d9aff1fa61fd1ac6fb641203bedfa
-
+  VERSION     IMAGE
+  4.13.14     quay.io/openshift-release-dev/ocp-release@sha256:406fcc160c097f61080412afcfa7fd65284ac8741ac7ad5b480e304aba73674b
+  4.13.13     quay.io/openshift-release-dev/ocp-release@sha256:d62495768e335c79a215ba56771ff5ae97e3cbb2bf49ed8fb3f6cefabcdc0f17
+  4.13.12     quay.io/openshift-release-dev/ocp-release@sha256:73946971c03b43a0dc6f7b0946b26a177c2f3c9d37105441315b4e3359373a55
+  4.13.11     quay.io/openshift-release-dev/ocp-release@sha256:e1c2377fdae1d063aaddc753b99acf25972b6997ab9a0b7e80cfef627b9ef3dd
 ----
 +
 [NOTE]
@@ -59,7 +55,9 @@ For details and information on how to perform an `EUS-to-EUS` channel update, pl
 _Preparing to perform an EUS-to-EUS upgrade_ page, listed in the Additional resources section.
 ====
 
-. Based on your organization requirements, set the appropriate update channel. For example, you can set your channel to `stable-4.12`, `fast-4.12`, or `eus-4.12`. For more information about channels, refer to _Understanding update channels and releases_ listed in the Additional resources section.
+. Based on your organization requirements, set the appropriate update channel. For example, you can set your channel to `stable-4.13` or `fast-4.13`. For more information about channels, refer to _Understanding update channels and releases_ listed in the Additional resources section.
+//this example will need to be updated per eus release to reflect options available
+
 +
 [source,terminal]
 ----
@@ -117,17 +115,16 @@ updated to the new version:
 +
 [source,terminal]
 ----
-$ oc get clusterversion
+$ oc adm upgrade
 ----
 +
 .Example output
 [source,terminal]
 ----
-
 Cluster version is <version>
 
 Upstream is unset, so the cluster will use an appropriate default.
-Channel: stable-4.10 (available channels: candidate-4.10, candidate-4.11, eus-4.10, fast-4.10, fast-4.11, stable-4.10)
+Channel: stable-<version> (available channels: candidate-<version>, eus-<version>, fast-<version>, stable-<version>)
 
 No updates available. You may force an update to a specific release image, but doing so might not be supported and might result in downtime or data loss.
 ----
@@ -138,7 +135,7 @@ If the `oc get clusterversion` command displays the following error while the `P
 [source,terminal]
 ----
 NAME    VERSION AVAILABLE PROGRESSING SINCE STATUS
-version 4.10.26 True      True        24m   Unable to apply 4.11.0-rc.7: an unknown error has occurred: MultipleErrors
+version <version> True      True        24m   Unable to apply <version>: an unknown error has occurred: MultipleErrors
 ----
 ====
 . If you are updating your cluster to the next minor version, such as version X.y to X.(y+1), it is recommended to confirm that your nodes are updated before deploying workloads that rely on a new feature:


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-9167

Link to docs preview:
https://65618--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating-cluster-cli#update-upgrading-cli_updating-cluster-cli

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
