### PR TITLE
OSDOCS-5979: Fix Broken Link to download the ROSA CLI

### DIFF
--- a/modules/rosa-sts-setting-up-environment.adoc
+++ b/modules/rosa-sts-setting-up-environment.adoc
@@ -54,7 +54,7 @@ $ aws sts get-caller-identity
 ----
 +
 . Install the latest version of the ROSA CLI (`rosa`).
-.. Download the link:https://access.redhat.com/products/red-hat-openshift-service-aws/[latest release] of the ROSA CLI for your operating system.
+.. Download the latest release of the link:https://console.redhat.com/openshift/downloads[ROSA CLI] for your operating system.
 .. Optional: Rename the file you downloaded to `rosa` and make the file executable. This documentation uses `rosa` to refer to the executable file.
 +
 [source,terminal]


### PR DESCRIPTION
[OSDOCS-5979](https://issues.redhat.com//browse/OSDOCS-5979): Fix the broken link to download the ROSA CLI

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-5979

Link to docs preview:
ROSA:https://65623--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-setting-up-environment

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
