### PR TITLE
[OSDOCS-7934]: ROSA documentation is missing any reference for creating machine pool for specific AZ on a multi AZ cluster

### DIFF
--- a/modules/creating-a-machine-pool-cli.adoc
+++ b/modules/creating-a-machine-pool-cli.adoc
@@ -30,6 +30,8 @@ $ rosa create machinepool --cluster=<cluster-name> \
                           --spot-max-price=0.5 \ <7>
 ifdef::openshift-rosa[]
                           --disk-size=<disk_size> <8>
+                          --availability-zone=<az> <9>
+
 endif::openshift-rosa[]
 ----
 <1> Specifies the name of the machine pool. Replace `<machine_pool_id>` with the name of your machine pool.
@@ -40,7 +42,8 @@ endif::openshift-rosa[]
 <6> Optional: Configures your machine pool to deploy machines as non-guaranteed AWS Spot Instances. For information, see link:https://aws.amazon.com/ec2/spot/[Amazon EC2 Spot Instances] in the AWS documentation. If you select *Use Amazon EC2 Spot Instances* for a machine pool, you cannot disable the option after the machine pool is created.
 <7> Optional: If you have opted to use Spot Instances, you can specify this argument to define a maximum hourly price for a Spot Instance. If this argument is not specified, the on-demand price is used.
 ifdef::openshift-rosa[]
-<8> Optional: Specifies the worker node disk size. The value can be in GB, GiB, TB, or TiB. Replace '<disk_size>' with a numeric value and unit, for example '--disk-size=200GiB'.
+<8> Optional: Specifies the worker node disk size. The value can be in GB, GiB, TB, or TiB. Replace `<disk_size>` with a numeric value and unit, for example `--disk-size=200GiB`.
+<9> Optional: For Multi-AZ clusters, you can create a machine pool in a Single-AZ of your choice. Replace `<az>` with a Single-AZ.
 endif::openshift-rosa[]
 +
 [IMPORTANT]
@@ -76,6 +79,7 @@ $ rosa create machinepool --cluster=<cluster-name> \
                           --taints=<key>=<value>:<effect>,<key>=<value>:<effect> \ <6>
                           --use-spot-instances \ <7>
                           --spot-max-price=0.5 <8>
+                          --availability-zone=<az> <9>
 ----
 <1> Specifies the name of the machine pool. Replace `<machine_pool_id>` with the name of your machine pool.
 <2> Enables autoscaling in the machine pool to meet the deployment needs.
@@ -85,6 +89,7 @@ $ rosa create machinepool --cluster=<cluster-name> \
 <6> Optional: Defines the taints for the machine pool. Replace `<key>=<value>:<effect>,<key>=<value>:<effect>` with a key, value, and effect for each taint, for example `--taints=key1=value1:NoSchedule,key2=value2:NoExecute`. Available effects include `NoSchedule`, `PreferNoSchedule`, and `NoExecute`.
 <7> Optional: Configures your machine pool to deploy machines as non-guaranteed AWS Spot Instances. For information, see link:https://aws.amazon.com/ec2/spot/[Amazon EC2 Spot Instances] in the AWS documentation. If you select *Use Amazon EC2 Spot Instances* for a machine pool, you cannot disable the option after the machine pool is created.
 <8> Optional: If you have opted to use Spot Instances, you can specify this argument to define a maximum hourly price for a Spot Instance. If this argument is not specified, the on-demand price is used.
+<9> Optional: For Multi-AZ clusters, you can create a machine pool in a Single-AZ of your choice. Replace `<az>` with a Single-AZ.
 +
 [IMPORTANT]
 ====

--- a/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.adoc
@@ -48,7 +48,14 @@ Multiple machine pools can exist on a single cluster, and each machine pool can 
 In a cluster created across multiple Availability Zones (AZ), the machine pools can be created across either all of the three AZs or any single AZ of your choice. The machine pool created by default at the time of cluster creation will be created with machines in all three AZs and scale in multiples of three.
 
 
-If you create a new Multi-AZ cluster, the machine pools are replicated to those zones automatically. If you add a machine pool to an existing Multi-AZ, the new pool is automatically created in those zones. Similarly, deleting a machine pool will delete it from all zones.
+If you create a new Multi-AZ cluster, the machine pools are replicated to those zones automatically. By default, if you add a machine pool to an existing Multi-AZ cluster, the new machine pool is automatically created in all of the zones.
+
+[NOTE]
+====
+You can override this default setting and create a machine pool in a Single-AZ of your choice.
+====
+
+Similarly, deleting a machine pool will delete it from all zones.
 Due to this multiplicative effect, using machine pools in Multi-AZ cluster can consume more of your project's quota for a specific region when creating machine pools.
 
 == Additional resources


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-7934
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://65624--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes#creating_machine_pools_cli_rosa-managing-worker-nodes

https://65624--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about#machine-pools

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/946cebd8-4310-4747-bb78-56972d1d5f2a)
![image](https://github.com/openshift/openshift-docs/assets/122639474/7dda0322-6daf-41ac-b5c3-118db07cfa78)
