### PR TITLE
OSDOCS-6607: Adding HIPAA Compliance to OSD docs

### DIFF
--- a/modules/policy-security-regulation-compliance.adoc
+++ b/modules/policy-security-regulation-compliance.adoc
@@ -56,7 +56,9 @@ Any issues that are discovered are prioritized based on severity. Any issues fou
 .Security and control certifications for {product-title}
 [cols= "3,3,3",options="header"]
 |===
-| Certification | {product-title} on AWS | {product-title} on GCP
+| Compliance | {product-title} on AWS | {product-title} on GCP
+
+| HIPAA Qualified | Yes (Only Customer Cloud Subscriptions) | Yes (Only Customer Cloud Subscriptions)
 
 | ISO 27001 | Yes | Yes
 

--- a/modules/sdpolicy-security.adoc
+++ b/modules/sdpolicy-security.adoc
@@ -59,7 +59,9 @@ $ oc adm policy add-cluster-role-to-group self-provisioner system:authenticated:
 .Security and control certifications for {product-title}
 [cols= "3,3,3",options="header"]
 |===
-| Certification | {product-title} on AWS | {product-title} on GCP
+| Compliance | {product-title} on AWS | {product-title} on GCP
+
+| HIPAA Qualified | Yes (Only Customer Cloud Subscriptions) | Yes (Only Customer Cloud Subscriptions)
 
 | ISO 27001 | Yes | Yes
 


### PR DESCRIPTION
[OSDOCS-6607](https://issues.redhat.com//browse/OSDOCS-6607): Add HIPAA compliance to OSD docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-6607

Link to docs preview:
OSD: https://65625--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/policy-process-security

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
HIPAA qualification info: https://source.redhat.com/departments/products_and_global_engineering/product_security/pscr/ps_compliance/hipaa

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
