### PR TITLE
[enterprise-4.12] OSDOCS#7761: Release notes for the cert-manager Operator 1.12.0

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,6 +12,26 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1.12.0"]
+== Release notes for {cert-manager-operator} 1.12.0
+
+Issued: 2023-10-02
+
+The following advisory is available for the {cert-manager-operator} 1.12.0:
+
+* link:https://access.redhat.com/errata/RHEA-2023:5339[RHEA-2023:5339]
+
+Version `1.12.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.12.4`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.12/#v1124[cert-manager project release notes for v1.12.4].
+
+[id="cert-manager-operator-1.12.0-bug-fixes"]
+=== Bug fixes
+
+* Previously, you could not configure the CPU and memory requests and limits for the cert-manager components such as cert-manager controller, CA injector, and Webhook. Now, you can configure the CPU and memory requests and limits for the cert-manager components by using the command-line interface (CLI). For more information, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-configure-cpu-memory_cert-manager-customizing-api-fields[Overriding CPU and memory limits for the cert-manager components]. (link:https://issues.redhat.com/browse/OCPBUGS-13830[*OCPBUGS-13830*])
+
+* Previously, if you updated the `ClusterIssuer` object, the {cert-manager-operator} could not verify and update the change in the cluster issuer. Now, if you modify the `ClusterIssuer` object, the {cert-manager-operator} verifies the ACME account registration and updates the change. (link:https://issues.redhat.com/browse/OCPBUGS-8210[*OCPBUGS-8210*])
+
+* Previously, the {cert-manager-operator} did not support enabling the  `--enable-certificate-owner-ref` flag. Now, the {cert-manager-operator} supports enabling the `--enable-certificate-owner-ref` flag by adding the `spec.controllerConfig.overrideArgs` field in the `cluster` object. After enabling the `--enable-certificate-owner-ref` flag, cert-manager can automatically delete the secret when the `Certificate` resource is removed from the cluster. For more information on enabling the `--enable-certificate-owner-ref` flag and deleting the TLS secret automatically, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-override-flag-controller_cert-manager-customizing-api-fields[Deleting a TLS secret automatically upon Certificate removal] (link:https://issues.redhat.com/browse/CM-98[*CM-98*])
+
 [id="cert-manager-operator-release-notes-1.11.4"]
 == Release notes for {cert-manager-operator} 1.11.4
 


### PR DESCRIPTION
Cherry-picked from the comit: 1fbf836dc2d9775920f610f0b15d80c46a4e8c76

main PR https://github.com/openshift/openshift-docs/pull/64825