### PR TITLE
OSDOCS 7180- Allow Ingress to Modify the HAProxy Log Length when using a Sidecar

### DIFF
--- a/modules/nw-configure-ingress-access-logging.adoc
+++ b/modules/nw-configure-ingress-access-logging.adoc
@@ -116,3 +116,47 @@ spec:
   logging:
     access: null
 ----
+
+Allow the Ingress Controller to modify the HAProxy log length when using a sidecar.
+
+* Use `spec.logging.access.destination.syslog.maxLength` if you are using `spec.logging.access.destination.type: Syslog`.
+
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 2
+  logging:
+    access:
+      destination:
+        type: Syslog
+        syslog:
+          address: 1.2.3.4
+          maxLength: 4096
+          port: 10514
+----
+* Use `spec.logging.access.destination.container.maxLength` if you are using `spec.logging.access.destination.type: Container`.
+
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1
+kind: IngressController
+metadata:
+  name: default
+  namespace: openshift-ingress-operator
+spec:
+  replicas: 2
+  logging:
+    access:
+      destination:
+        type: Container
+        container:
+          maxLength: 8192
+----
+


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: (https://issues.redhat.com/browse/OSDOCS-7180)

Link to docs preview: https://65658--docspreview.netlify.app/openshift-enterprise/latest/networking/ingress-operator#nw-configure-ingress-access-logging_configuring-ingress 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
