### PR TITLE
TELCODOCS-1302 RAN 414 known issues

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2670,6 +2670,41 @@ To avoid this issue, you can enable confidential VMs on an existing cluster by u
 
 * Installation fails when installing {product-title} with the `bootMode` set to `UEFISecureBoot` on a node where Secure Boot is disabled. Subsequent attempts to install {product-title} with Secure Boot enabled will proceed normally. (link:https://issues.redhat.com/browse/OCPBUGS-19884)[*OCPBUGS-19884*])
 
+[id="ocp-telco-ran-4-14-known-issues"]
+* When you run CNF latency tests on an {product-title} cluster, the `oslat` test can sometimes return results greater than 20 microseconds. This results in an `oslat` test failure.
+(link:https://issues.redhat.com/browse/RHEL-9279[*RHEL-9279*])
+
+* When you use `preempt-rt` patches with the realtime kernel and you update the SMP affinity of a network interrupt, the corresponding IRQ thread does not immediately receive the update.
+Instead, the update takes effect when the next interrupt is received, and the thread is subsequently migrated to the correct core.
+(link:https://issues.redhat.com/browse/RHEL-9148[*RHEL-9148*])
+
+* Low-latency applications that rely on high-resolution timers to wake up their threads might experience higher wake up latencies than expected. Although the expected wake up latency is under 20μs, latencies exceeding this can occasionally be seen when running the `cyclictest` tool for long durations (24 hours or more). Testing has shown that wake up latencies are under 20μs for over 99.999999% of the samples.
+(link:https://issues.redhat.com/browse/RHELPLAN-138733[*RHELPLAN-138733*])
+
+* The global navigation satellite system (GNSS) module in an Intel Westport Channel e810 NIC that is configured as a grandmaster clock (T-GM) can report the GPS `FIX` state and the GNSS offset between the GNSS module and the GNSS constellation satellites.
++
+The current T-GM implementation does not use the `ubxtool` CLI to probe the `ublox` module for reading the GNSS offset and GPS `FIX` values.
+Instead, it uses the `gpsd` service to read the GPS `FIX` information.
+This is because the current implementation of the `ubxtool` CLI takes 2 seconds to receive a response, and with every call, it increases CPU usage threefold.
+(link:https://issues.redhat.com/browse/OCPBUGS-17422[*OCPBUGS-17422*])
+
+* In a PTP grandmaster clock clocked sourced from GNSS, when the GNSS signal is lost, the Digital Phase Locked Loop (DPLL) clock state can change in 2 ways: it can transition to unlocked, or it can enter a holdover state. Currently, the driver transitions the DPLL state to unlocked by default.
+An upstream change is currently being developed to handle the holdover state functionality and to configure which state machine handling is used.
+(link:https://issues.redhat.com/browse/RHELPLAN-164754[*RHELPLAN-164754*])
+
+* The DPLL subsystem and DPLL support is not currently enabled in the Intel Westport Channel e810 NIC ice driver.
+(link:https://issues.redhat.com/browse/RHELPLAN-165955[*RHELPLAN-165955*])
+
+* The current grandmaster clock (T-GM) implementation has a single NMEA sentence generator sourced from the GNSS without a backup NMEA sentence generator.
+If NMEA sentences are lost on their way to the e810 NIC, the T-GM cannot synchronize the devices in the network synchronization chain and the PTP Operator reports an error.
+A proposed fix is to report a `FREERUN` event when the NMEA string is lost.
+(link:https://issues.redhat.com/browse/OCPBUGS-19838[*OCPBUGS-19838*])
+
+* Currently, due to differences in setting up a container's cgroup hierarchy, containers that use the `crun` OCI runtime along with a `PerformaceProfile` configuration encounter performance degradation.
+As a workaround, use the `runc` OCI container runtime.
+Although the `runc` container runtime has lower performance during container startup, shutdown operations, and `exec` probes, the `crun` and `runc` container runtimes are functionally identical.
+It is anticipated that an upcoming z-stream release will include a fix for this issue.
+(link:https://issues.redhat.com/browse/OCPBUGS-20492[*OCPBUGS-20492*])
 
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Known issues for telco RAN 4.14.

Version(s):
enterprise-4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-1302

Link to docs preview:
https://65662--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-telco-ran-4-14-known-issues

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
