### PR TITLE
[OSDOCS-8010] Fix typo in "Creating a machine pool using the ROSA CLI" docs

### DIFF
--- a/modules/creating-a-machine-pool-cli.adoc
+++ b/modules/creating-a-machine-pool-cli.adoc
@@ -27,9 +27,9 @@ $ rosa create machinepool --cluster=<cluster-name> \
                           --labels=<key>=<value>,<key>=<value> \ <4>
                           --taints=<key>=<value>:<effect>,<key>=<value>:<effect> \ <5>
                           --use-spot-instances \ <6>
-                          --spot-max-price=0.5 <7>
+                          --spot-max-price=0.5 \ <7>
 ifdef::openshift-rosa[]
-                          --disk-size=<disk_size> \ <8>
+                          --disk-size=<disk_size> <8>
 endif::openshift-rosa[]
 ----
 <1> Specifies the name of the machine pool. Replace `<machine_pool_id>` with the name of your machine pool.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8010
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://65664--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes#creating_machine_pools_cli_rosa-managing-worker-nodes
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Description from JIRA ticket: 
Typo discovered by engineer and reported to docs. Specifically:

"I do see a typo in the left image: on the line marked as "7", the line continuation operand () is missing, and on the line marked as "8", the line continuation operand should be omitted."



 