### PR TITLE
OSSM-4853 OSSMC Documentation GA (2.5 Release)

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -3833,6 +3833,8 @@ Topics:
     File: ossm-federation
   - Name: Extensions
     File: ossm-extensions
+  - Name: OpenShift Service Mesh Console plugin
+    File: ossm-kiali-ossmc-plugin
   - Name: 3scale WebAssembly for 2.1
     File: ossm-threescale-webassembly-module
   - Name: 3scale Istio adapter for 2.0

--- a/modules/ossm-kiali-ossmc-plugin-install-cli.adoc
+++ b/modules/ossm-kiali-ossmc-plugin-install-cli.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-kiali-ossmc-plugin.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-kiali-ossmc-plugin-install-cli_{context}"]
+= Installing OpenShift Service Mesh Console plugin using the CLI
+
+You can install the {SMProductName} (OSSMC) plugin using the CLI, instead of the {product-title} web console.
+
+.Prerequisites
+
+* OpenShift 4.12+ is installed.
+* Kiali Operator provided by Red Hat 1.73 is installed.
+* {SMProductName} (OSSMC) is installed.
+* Kiali Server is installed.
+
+.Procedure
+
+. Create a small `OSSMConsole` custom resource (CR) to instruct the operator to install the plugin:
++
+[source, yaml]
+----
+cat <<EOM | oc apply -f -
+apiVersion: kiali.io/v1alpha1
+kind: OSSMConsole
+metadata:
+  namespace: openshift-operators
+  name: ossmconsole
+EOM
+----
++
+[NOTE]
+====
+The plugin resources are deployed in the same namespace where the `OSSMConsole` CR is created.
+====
++
+. Go to the {product-title} web console.
+. Refresh the browser window to see the new OSSMC plugin menu options.

--- a/modules/ossm-kiali-ossmc-plugin-install-web-console.adoc
+++ b/modules/ossm-kiali-ossmc-plugin-install-web-console.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-kiali-ossmc-plugin.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-kiali-ossmc-plugin-install-web-console_{context}"]
+= Installing OpenShift Service Mesh Console plugin using the {product-title} web console
+
+You can install the OpenShift Service Mesh Console (OSSMC) plugin using the {product-title} web console.
+
+.Prerequisites
+
+* OpenShift 4.12+ is installed.
+* Kiali Operator provided by Red Hat 1.73 is installed.
+* {SMProductName} (OSSM) is installed.
+* Kiali Server is installed.
+
+.Procedure
+
+. Navigate to *Installed Operators* -> *Operator details*.
+. Use the *Create OSSMConsole* form to create an instance of the `OSSMConsole` custom resource (CR).
+* *Name* and *Version* are required fields.*Name* and *Version* are required fields.
++
+[NOTE]
+====
+The *Version* field must match the `spec.version` field in your Kiali CR.
+====
+. Click *Create*.
+. Navigate back to the {product-title} web console and use the new menu options for visibility into your Service Mesh.

--- a/modules/ossm-kiali-ossmc-plugin-uninstall-cli.adoc
+++ b/modules/ossm-kiali-ossmc-plugin-uninstall-cli.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-kiali-ossmc-plugin.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-kiali-ossmc-plugin-uninstall-cli_{context}"]
+= Uninstalling OpenShift Service Mesh Console plugin using the CLI
+
+You can uninstall the {SMProductName} (OSSMC) plugin by using the {oc-first}.
+
+.Procedure
+
+. Remove the `OSSMC` custom resource (CR) by running the following command:
++
+[source,terminal]
+----
+ oc delete ossmconsoles <custom_resource_name> -n <custom_resource_namespace>
+----
++
+. Verify all CRs are deleted from all namespaces by running the following command:
++
+[source,terminal]
+----
+for r in $(oc get ossmconsoles --ignore-not-found=true --all-namespaces -o custom-columns=NS:.metadata.namespace,N:.metadata.name --no-headers | sed 's/  */:/g'); do oc delete ossmconsoles -n $(echo $r|cut -d: -f1) $(echo $r|cut -d: -f2); done
+----

--- a/modules/ossm-kiali-ossmc-plugin-uninstall-web-console.adoc
+++ b/modules/ossm-kiali-ossmc-plugin-uninstall-web-console.adoc
@@ -1,0 +1,20 @@
+// Module included in the following assemblies:
+//
+// * service_mesh/v2x/ossm-kiali-ossmc-plugin.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="ossm-kiali-ossmc-plugin-uninstall-web-console_{context}"]
+= Uninstalling OpenShift Service Mesh Console plugin using the {product-title} web console
+
+You can uninstall the {SMProductName} (OSSMC) plugin by using the {product-title} web console.
+
+.Procedure
+
+. Navigate to *Installed Operators* -> *Operator details*.
+. Select the *OpenShift Service Mesh Console* tab.
+. Click *Delete OSSMConsole* from the options menu.
+
+[NOTE]
+====
+If you intend to also uninstall the Kiali Operator provided by Red Hat, you must first uninstall the OSSMC plugin and then uninstall the Operator. If you uninstall the Operator before ensuring the `OSSMConsole` CR is deleted then you may have difficulty removing that CR and its namespace. If this occurs then you must manually remove the finalizer on the CR in order to delete it and its namespace. You can do this using: `$ oc patch ossmconsoles <CR name> -n <CR namespace> -p '{"metadata":{"finalizers": []}}' --type=merge`.
+====

--- a/modules/ossm-kiali-ossmc-plugin-user-guide.adoc
+++ b/modules/ossm-kiali-ossmc-plugin-user-guide.adoc
@@ -1,0 +1,53 @@
+// Module included in the following assemblies:
+//
+//* *service_mesh/v2x/ossm-kiali-ossmc-plugin.adoc
+
+
+:_mod-docs-content-type: CONCEPT
+[id="ossm-kiali-ossmc-plugin-user-guide_{context}"]
+= About the OpenShift Service Mesh Console plugin
+//In the title include nouns or noun phrases that are used in the body text.
+//Do not start the title of concept modules with a verb.
+
+The {SMProductName} Console (OSSMC) plugin is an extension to the {product-title} web console that provides visibility into your Service Mesh.
+
+[WARNING]
+====
+The {SMPRoductName} Console (OSSMC) plugin only supports a single Kiali instance. Whether that Kiali instance is configured to access only a subset of OpenShift projects or has access cluster-wide to all projects does not matter. However, only a single Kiali instance can be accessed.
+====
+
+You can install the OSSMC plugin in only one of two ways: using the {product-title} web console, or through the CLI.
+
+Installing the OSSMC plugin creates a new category, *Service Mesh*, in the main {product-title} web console navigation. Click *Service Mesh* to see:
+
+* *Overview* for a summary of your mesh displayed as cards that represent the namespaces in the mesh
+* *Graph* for a full topology view of your mesh represented by nodes and edges, each node representing a component of the mesh and each edge representing traffic flowing through the mesh between components
+* *Istio config* for a list of all Istio configuration files in your mesh with a column that provides a quick way to know if the configuration for each resource is valid
+
+Under *Workloads*, the OSSMC plugin adds a *Service Mesh* tab that contains the following subtabs:
+
+* *Overview* subtab provides a summary of the selected workload including a localized topology graph showing the workload with all inbound and outbound edges and nodes
+* *Traffic* subtab displays information about all inbound and outbound traffic to the workload.
+* *Logs* subtab shows the logs for the workload's containers
++
+--
+** You can view container logs individually or in a unified fashion, ordered by log time. This is especially helpful to see how the Envoy sidecar proxy logs relate to your workload's application logs.
+** You can enable the tracing span integration which then allows you to see which logs correspond to trace spans.
+--
++
+* *Metrics* subtab shows both inbound and outbound metric graphs in the corresponding subtabs. All the workload metrics can be displayed here, providing you with a detail view of the performance of your workload.
++
+--
+** You can enable the tracing span integration which allows you to see which spans occurred at the same time as the metrics. Click a span marker in the graph to view the specific spans associated with that timeframe.
+--
++
+* *Traces* provides a chart showing the trace spans collected over the given timeframe.
++
+--
+** Click a bubble to drill down into those trace spans; the trace spans can provide you the most low-level detail within your workload application, down to the individual request level. The trace details view gives further details, including heatmaps that provide you with a comparison of one span in relation to other requests and spans in the same timeframe.
+** If you hover over a cell in a heatmap, a tooltip gives some details on the cell data.
+--
++
+* *Envoy* subtab provides information about the Envoy sidecar configuration. This is useful when you need to dig down deep into the sidecar configuration when debugging things such as connectivity issues.
+
+Under *Networking*, the OSSMC plugin adds a *Service Mesh* tab to Services and contains the *Overview*, *Traffic*, *Inbound Metrics*, and *Traces* subtabs that are similar to the same subtabs found in *Workloads*.

--- a/service_mesh/v2x/ossm-kiali-ossmc-plugin.adoc
+++ b/service_mesh/v2x/ossm-kiali-ossmc-plugin.adoc
@@ -1,0 +1,29 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="ossm-kiali-ossmc-plugin"]
+= OpenShift Service Mesh Console plugin
+include::_attributes/common-attributes.adoc[]
+:context: ossm-kiali-ossmc-plugin
+
+toc::[]
+
+The {SMProductName} (OSSMC) plugin is an extension to the {product-title} web console that provides visibility into your Service Mesh. With the OSSMC plugin installed, a new *Service Mesh* menu option is available in the navigation menu on the left side of the web console, as well as new *Service Mesh* tabs that enhance the existing *Workloads* and *Services* console pages.
+
+[IMPORTANT]
+====
+If you are using a certificate that your browser does not initially trust, you must tell your browser to trust the certificate first before you are able to access the OSSMC plugin. To do this, go to the Kiali standalone user interface (UI) and tell the browser to accept its certificate.
+====
+
+include::modules/ossm-kiali-ossmc-plugin-user-guide.adoc[leveloffset=+1]
+
+include::modules/ossm-kiali-ossmc-plugin-install-web-console.adoc[leveloffset=+1]
+
+include::modules/ossm-kiali-ossmc-plugin-install-cli.adoc[leveloffset=+1]
+
+include::modules/ossm-kiali-ossmc-plugin-uninstall-web-console.adoc[leveloffset=+1]
+
+include::modules/ossm-kiali-ossmc-plugin-uninstall-cli.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_ossm-kiali-ossmc-plugin"]
+== Additional resources
+* link:https://kiali.io/docs/configuration/ossmconsoles.kiali.io/#.spec.kiali.serviceNamespace[.spec.kiali.serviceNamespace]

--- a/service_mesh/v2x/ossm-observability.adoc
+++ b/service_mesh/v2x/ossm-observability.adoc
@@ -50,6 +50,6 @@ include::modules/ossm-integrating-with-user-workload-monitoring.adoc[leveloffset
 
 ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../monitoring/enabling-monitoring-for-user-defined-projects.adoc[Enabling monitoring for user-defined projects]
-* xref:../../distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.adoc[Installing the distributed tracing platform (Tempo)]
-* xref:../../otel/otel-installing.adoc[Installing the Red Hat build of OpenTelemetry]
+* xref:../../observability/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-installing.adoc[Installing the distributed tracing platform (Tempo)]
+* xref:../../observability/otel/otel-installing.adoc[Installing the Red Hat build of OpenTelemetry]
 endif::[]


### PR DESCRIPTION
[OSSM-4853](https://issues.redhat.com//browse/OSSM-4853) OSSMC Documentation GA

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSSM-4853

Link to docs preview:
https://65700--ocpdocs-pr.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-kiali-ossmc-plugin

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

To be released with OSSM 2.5.

End user documentation for the new operator OpenShift Service Mesh Console 
Will be from https://github.com/kiali/openshift-servicemesh-plugin/blob/main/docs/users-guide.md (now https://kiali.io/docs/ossmc/users-guide/) 
and https://github.com/kiali/openshift-servicemesh-plugin/blob/main/docs/install-guide.md 

Both will be .adoc files. 

Dev/QE review: Done.
Doc Peer Review: Done.
Merge Review:

---
After first Doc Peer Review, "Kiali tenant" was changed to "Kiali instance."

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
