### PR TITLE
OSDOCS_8148: Support CMA on OSD/ROSA

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -607,6 +607,37 @@ Topics:
     - Name: Custom domains for applications
       File: osd-config-custom-domains-applications
 ---
+Name: Nodes
+Dir: nodes
+Distros: openshift-dedicated
+Topics:
+- Name: Automatically scaling pods with the Custom Metrics Autoscaler Operator
+  Dir: cma
+  Distros: openshift-dedicated
+  Topics:
+  - Name: Custom Metrics Autoscaler Operator overview
+    File: nodes-cma-autoscaling-custom
+  - Name: Custom Metrics Autoscaler Operator release notes
+    File: nodes-cma-autoscaling-custom-rn
+  - Name: Installing the custom metrics autoscaler
+    File: nodes-cma-autoscaling-custom-install
+  - Name: Understanding the custom metrics autoscaler triggers
+    File: nodes-cma-autoscaling-custom-trigger
+  - Name: Understanding the custom metrics autoscaler trigger authentications
+    File: nodes-cma-autoscaling-custom-trigger-auth
+  - Name: Pausing the custom metrics autoscaler
+    File: nodes-cma-autoscaling-custom-pausing
+  - Name: Gathering audit logs
+    File: nodes-cma-autoscaling-custom-audit-log
+  - Name: Gathering debugging data
+    File: nodes-cma-autoscaling-custom-debugging
+  - Name: Viewing Operator metrics
+    File: nodes-cma-autoscaling-custom-metrics
+  - Name: Understanding how to add custom metrics autoscalers
+    File: nodes-cma-autoscaling-custom-adding
+  - Name: Removing the Custom Metrics Autoscaler Operator
+    File: nodes-cma-autoscaling-custom-removing
+---
 Name: Logging
 Dir: logging
 Distros: openshift-dedicated

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -775,6 +775,37 @@ Topics:
 - Name: Installing OADP on ROSA with STS
   File: backing-up-applications
 ---
+Name: Nodes
+Dir: nodes
+Distros: openshift-rosa
+Topics:
+- Name: Automatically scaling pods with the Custom Metrics Autoscaler Operator
+  Dir: cma
+  Distros: openshift-rosa
+  Topics:
+  - Name: Custom Metrics Autoscaler Operator overview
+    File: nodes-cma-autoscaling-custom
+  - Name: Custom Metrics Autoscaler Operator release notes
+    File: nodes-cma-autoscaling-custom-rn
+  - Name: Installing the custom metrics autoscaler
+    File: nodes-cma-autoscaling-custom-install
+  - Name: Understanding the custom metrics autoscaler triggers
+    File: nodes-cma-autoscaling-custom-trigger
+  - Name: Understanding the custom metrics autoscaler trigger authentications
+    File: nodes-cma-autoscaling-custom-trigger-auth
+  - Name: Pausing the custom metrics autoscaler
+    File: nodes-cma-autoscaling-custom-pausing
+  - Name: Gathering audit logs
+    File: nodes-cma-autoscaling-custom-audit-log
+  - Name: Gathering debugging data
+    File: nodes-cma-autoscaling-custom-debugging
+  - Name: Viewing Operator metrics
+    File: nodes-cma-autoscaling-custom-metrics
+  - Name: Understanding how to add custom metrics autoscalers
+    File: nodes-cma-autoscaling-custom-adding
+  - Name: Removing the Custom Metrics Autoscaler Operator
+    File: nodes-cma-autoscaling-custom-removing
+---
 Name: Logging
 Dir: logging
 Distros: openshift-rosa

--- a/modules/nodes-cma-autoscaling-custom-audit.adoc
+++ b/modules/nodes-cma-autoscaling-custom-audit.adoc
@@ -18,6 +18,7 @@ You can configure auditing for the Custom Metrics Autoscaler Operator by editing
 
 . Edit the `KedaController` custom resource to add the `auditConfig` stanza:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,yaml]
 ----
 kind: KedaController
@@ -42,6 +43,33 @@ spec:
         maxBackup: "1"
         maxSize: "50"
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,yaml]
+----
+kind: KedaController
+apiVersion: keda.sh/v1alpha1
+metadata:
+  name: keda
+  namespace: keda
+spec:
+# ...
+  metricsServer:
+# ...
+    auditConfig:
+      logFormat: "json" <1>
+      logOutputVolumeClaim: "pvc-audit-log" <2>
+      policy:
+        rules: <3>
+        - level: Metadata
+        omitStages: "RequestReceived" <4>
+        omitManagedFields: false <5>
+      lifetime: <6>
+        maxAge: "2"
+        maxBackup: "1"
+        maxSize: "50"
+----
+endif::openshift-rosa,openshift-dedicated[]
 <1> Specifies the output format of the audit log, either `legacy` or `json`.
 <2> Specifies an existing persistent volume claim for storing the log data. All requests coming to the API server are logged to this persistent volume claim. If you leave this field empty, the log data is sent to stdout.
 <3> Specifies which events should be recorded and what data they should include:
@@ -74,10 +102,18 @@ oc adm must-gather -- /usr/bin/gather_audit_logs
 
 .. Obtain the name of the `keda-metrics-apiserver-*` pod:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 oc get pod -n openshift-keda
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+oc get pod -n keda
+----
+endif::openshift-rosa,openshift-dedicated[]
 +
 .Example output
 +
@@ -117,6 +153,7 @@ $ oc logs keda-metrics-apiserver-65c7cc44fd-rrl4r|grep -i metadata
 +
 .. Use a command similar to the following to log into the `keda-metrics-apiserver-*` pod:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc rsh pod/keda-metrics-apiserver-<hash> -n openshift-keda
@@ -128,6 +165,20 @@ For example:
 ----
 $ oc rsh pod/keda-metrics-apiserver-65c7cc44fd-rrl4r -n openshift-keda
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc rsh pod/keda-metrics-apiserver-<hash> -n keda
+----
++
+For example:
++
+[source,terminal]
+----
+$ oc rsh pod/keda-metrics-apiserver-65c7cc44fd-rrl4r -n keda
+----
+endif::openshift-rosa,openshift-dedicated[]
 
 .. Change to the `/var/audit-policy/` directory:
 +

--- a/modules/nodes-cma-autoscaling-custom-gather.adoc
+++ b/modules/nodes-cma-autoscaling-custom-gather.adoc
@@ -28,7 +28,9 @@ The standard {product-title} `must-gather` command, `oc adm must-gather`, does n
 
 .Procedure
 
+// Hide note from ROSA/OSD, as restricted is not supported.
 . Navigate to the directory where you want to store the `must-gather` data.
+ifndef::openshift-rosa,openshift-dedicated[]
 +
 [NOTE]
 ====
@@ -39,6 +41,7 @@ If your cluster is using a restricted network, you must take additional steps. I
 $ oc import-image is/must-gather -n openshift
 ----
 ====
+endif::openshift-rosa,openshift-dedicated[]
 
 . Perform one of the following:
 +
@@ -74,6 +77,7 @@ $ oc adm must-gather --image-stream=openshift/must-gather --image=${IMAGE}
 --
 +
 .Example must-gather output for the Custom Metric Autoscaler:
+ifndef::openshift-rosa,openshift-dedicated[]
 [%collapsible]
 ====
 [source,terminal]
@@ -157,6 +161,92 @@ $ oc adm must-gather --image-stream=openshift/must-gather --image=${IMAGE}
         └── routes.yaml
 ----
 ====
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[%collapsible]
+====
+[source,terminal]
+----
+└── keda
+    ├── apps
+    │   ├── daemonsets.yaml
+    │   ├── deployments.yaml
+    │   ├── replicasets.yaml
+    │   └── statefulsets.yaml
+    ├── apps.openshift.io
+    │   └── deploymentconfigs.yaml
+    ├── autoscaling
+    │   └── horizontalpodautoscalers.yaml
+    ├── batch
+    │   ├── cronjobs.yaml
+    │   └── jobs.yaml
+    ├── build.openshift.io
+    │   ├── buildconfigs.yaml
+    │   └── builds.yaml
+    ├── core
+    │   ├── configmaps.yaml
+    │   ├── endpoints.yaml
+    │   ├── events.yaml
+    │   ├── persistentvolumeclaims.yaml
+    │   ├── pods.yaml
+    │   ├── replicationcontrollers.yaml
+    │   ├── secrets.yaml
+    │   └── services.yaml
+    ├── discovery.k8s.io
+    │   └── endpointslices.yaml
+    ├── image.openshift.io
+    │   └── imagestreams.yaml
+    ├── k8s.ovn.org
+    │   ├── egressfirewalls.yaml
+    │   └── egressqoses.yaml
+    ├── keda.sh
+    │   ├── kedacontrollers
+    │   │   └── keda.yaml
+    │   ├── scaledobjects
+    │   │   └── example-scaledobject.yaml
+    │   └── triggerauthentications
+    │       └── example-triggerauthentication.yaml
+    ├── monitoring.coreos.com
+    │   └── servicemonitors.yaml
+    ├── networking.k8s.io
+    │   └── networkpolicies.yaml
+    ├── keda.yaml
+    ├── pods
+    │   ├── custom-metrics-autoscaler-operator-58bd9f458-ptgwx
+    │   │   ├── custom-metrics-autoscaler-operator
+    │   │   │   └── custom-metrics-autoscaler-operator
+    │   │   │       └── logs
+    │   │   │           ├── current.log
+    │   │   │           ├── previous.insecure.log
+    │   │   │           └── previous.log
+    │   │   └── custom-metrics-autoscaler-operator-58bd9f458-ptgwx.yaml
+    │   ├── custom-metrics-autoscaler-operator-58bd9f458-thbsh
+    │   │   └── custom-metrics-autoscaler-operator
+    │   │       └── custom-metrics-autoscaler-operator
+    │   │           └── logs
+    │   ├── keda-metrics-apiserver-65c7cc44fd-6wq4g
+    │   │   ├── keda-metrics-apiserver
+    │   │   │   └── keda-metrics-apiserver
+    │   │   │       └── logs
+    │   │   │           ├── current.log
+    │   │   │           ├── previous.insecure.log
+    │   │   │           └── previous.log
+    │   │   └── keda-metrics-apiserver-65c7cc44fd-6wq4g.yaml
+    │   └── keda-operator-776cbb6768-fb6m5
+    │       ├── keda-operator
+    │       │   └── keda-operator
+    │       │       └── logs
+    │       │           ├── current.log
+    │       │           ├── previous.insecure.log
+    │       │           └── previous.log
+    │       └── keda-operator-776cbb6768-fb6m5.yaml
+    ├── policy
+    │   └── poddisruptionbudgets.yaml
+    └── route.openshift.io
+        └── routes.yaml
+----
+====
+endif::openshift-rosa,openshift-dedicated[]
 
 ifndef::openshift-origin[]
 . Create a compressed file from the `must-gather` directory that was created in your working directory. For example, on a computer that uses a Linux

--- a/modules/nodes-cma-autoscaling-custom-uninstalling.adoc
+++ b/modules/nodes-cma-autoscaling-custom-uninstalling.adoc
@@ -16,7 +16,12 @@ Use the following procedure to remove the custom metrics autoscaler from your {p
 
 . In the {product-title} web console, click *Operators* -> *Installed Operators*.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 . Switch to the *openshift-keda* project.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+. Switch to the *keda* project.
+endif::openshift-rosa,openshift-dedicated[]
 
 . Remove the `KedaController` custom resource.
 
@@ -83,14 +88,30 @@ $ oc delete clusterrolebinding.keda.sh-v1alpha1-admin
 
 . Delete the custom metrics autoscaler project:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc delete project openshift-keda
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc delete project keda
+----
+endif::openshift-rosa,openshift-dedicated[]
 
 . Delete the Cluster Metric Autoscaler Operator:
 +
+ifndef::openshift-rosa,openshift-dedicated[]
 [source,terminal]
 ----
 $ oc delete operator/openshift-custom-metrics-autoscaler-operator.openshift-keda 
 ----
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[source,terminal]
+----
+$ oc delete operator/openshift-custom-metrics-autoscaler-operator.keda 
+----
+endif::openshift-rosa,openshift-dedicated[]

--- a/modules/sd-nodes-cma-autoscaling-custom-install.adoc
+++ b/modules/sd-nodes-cma-autoscaling-custom-install.adoc
@@ -3,17 +3,18 @@
 // * nodes/cma/nodes-cma-autoscaling-custom-install.adoc
 
 :_content-type: PROCEDURE
-[id="nodes-cma-autoscaling-custom-install_{context}"]
+[id="sd-nodes-cma-autoscaling-custom-install_{context}"]
 = Installing the custom metrics autoscaler
 
 You can use the following procedure to install the Custom Metrics Autoscaler Operator.
 
 .Prerequisites
-ifdef::openshift-origin[]
-* Ensure that you have downloaded the {cluster-manager-url-pull} as shown in _Obtaining the installation program_ in the installation documentation for your platform.
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+ifdef::openshift-dedicated[]
 +
-If you have the pull secret, add the `redhat-operators` catalog to the OperatorHub custom resource (CR) as shown in _Configuring {product-title} to use Red Hat Operators_.
-endif::openshift-origin[]
+If your {product-title} cluster is in a cloud account that is owned by Red Hat (non-CCS), you must request `cluster-admin` privileges.
+endif::openshift-dedicated[]
 
 * Remove any previously-installed Technology Preview versions of the Cluster Metrics Autoscaler Operator.
 
@@ -31,16 +32,29 @@ $ oc delete crd scaledobjects.keda.k8s.io
 $ oc delete crd triggerauthentications.keda.k8s.io
 ----
 
+* Ensure that the `keda` namespace exists. If not, you must manaully create the `keda` namespace.
+
 .Procedure
 
 . In the {product-title} web console, click *Operators* -> *OperatorHub*.
 
 . Choose *Custom Metrics Autoscaler* from the list of available Operators, and click *Install*.
 
-. On the *Install Operator* page, ensure that the *All namespaces on the cluster (default)* option
-is selected for *Installation Mode*. This installs the Operator in all namespaces.
+. On the *Install Operator* page, ensure that the *A specific namespace on the cluster* option
+is selected for *Installation Mode*.
 
-. Ensure that the *openshift-keda* namespace is selected for *Installed Namespace*. {product-title} creates the namespace, if not present in your cluster.  
+. For *Installed Namespace*, click *Select a namespace*.
+
+. Click *Select Project*: 
++
+* If the `keda` namespace exists, select *keda* from the list.
+* If the `keda` namespace does not exist: 
++
+.. Select *Create Project* to open the *Create Project* window. 
+.. In the *Name* field, enter `keda`. 
+.. In the *Display Name* field, enter a descriptive name, such as `keda`.  
+.. Optional: In the *Display Name* field, add a description for the namespace.
+.. Click *Create*.    
 
 . Click *Install*.
 
@@ -48,21 +62,21 @@ is selected for *Installation Mode*. This installs the Operator in all namespace
 
 .. Navigate to *Workloads* -> *Pods*.
 
-.. Select the `openshift-keda` project from the drop-down menu and verify that the `custom-metrics-autoscaler-operator-*` pod is running.
+.. Select the `keda` project from the drop-down menu and verify that the `custom-metrics-autoscaler-operator-*` pod is running.
 
 .. Navigate to *Workloads* -> *Deployments* to verify that the `custom-metrics-autoscaler-operator` deployment is running.
 
-. Optional: Verify the installation in the OpenShift CLI using the following commands:
+. Optional: Verify the installation in the OpenShift CLI using the following command:
 +
 [source,terminal]
 ----
-$ oc get all -n openshift-keda
+$ oc get all -n keda
 ----
 +
 The output appears similar to the following:
 +
 .Example output
-[source,terminal]
+[source,text]
 ----
 NAME                                                      READY   STATUS    RESTARTS   AGE
 pod/custom-metrics-autoscaler-operator-5fd8d9ffd8-xt4xp   1/1     Running   0          18m
@@ -90,7 +104,7 @@ kind: KedaController
 apiVersion: keda.sh/v1alpha1
 metadata:
   name: keda
-  namespace: openshift-keda
+  namespace: keda
 spec:
   watchNamespace: '' <1>
   operator:
@@ -112,10 +126,10 @@ spec:
         maxSize: "50"
   serviceAccount: {}
 ----
-<1> Specifies the namespaces that the custom autoscaler should watch. Enter names in a comma-separated list. Omit or set empty to watch all namespaces. The default is empty.
+<1> Specifies a single namespace where the custom autoscaler is to scale applications. Omit or set empty to scale applications in all namespaces. The default is empty.
 <2> Specifies the level of verbosity for the Custom Metrics Autoscaler Operator log messages. The allowed values are `debug`, `info`, `error`. The default is `info`.
 <3> Specifies the logging format for the Custom Metrics Autoscaler Operator log messages. The allowed values are `console` or `json`. The default is `console`.
 <4> Specifies the logging level for the Custom Metrics Autoscaler Metrics Server. The allowed values are `0` for `info` and `4` or `debug`. The default is `0`.
-<5> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section. 
+<5> Activates audit logging for the Custom Metrics Autoscaler Operator and specifies the audit policy to use, as described in the "Configuring audit logging" section.
 
 .. Click *Create* to create the KEDA controller.

--- a/nodes/cma/nodes-cma-autoscaling-custom-adding.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-adding.adoc
@@ -14,4 +14,8 @@ You can create only one scaled object for each workload that you want to scale. 
 // If you want to scale based on a custom trigger and CPU/Memory, you can create multiple triggers in the scaled object or scaled job.
 
 include::modules/nodes-cma-autoscaling-custom-creating-workload.adoc[leveloffset=+1]
+
+//Scaling by using a scaled job is a Technology Preview feature. TP not supported in ROSA/OSD
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/nodes-cma-autoscaling-custom-creating-job.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]

--- a/nodes/cma/nodes-cma-autoscaling-custom-debugging.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-debugging.adoc
@@ -17,7 +17,12 @@ endif::openshift-origin[]
 
 You can use the `must-gather` tool to collect data about the Custom Metrics Autoscaler Operator and its components, including the following items:
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * The `openshift-keda` namespace and its child objects.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+* The `keda` namespace and its child objects.
+endif::openshift-rosa,openshift-dedicated[]
 * The Custom Metric Autoscaler Operator installation objects.
 * The Custom Metric Autoscaler Operator CRD objects.
 

--- a/nodes/cma/nodes-cma-autoscaling-custom-install.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-install.adoc
@@ -17,4 +17,10 @@ The installation creates the following five CRDs:
 * `ScaledObject`
 * `TriggerAuthentication`
 
+ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/nodes-cma-autoscaling-custom-install.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
+
+ifdef::openshift-rosa,openshift-dedicated[]
+include::modules/sd-nodes-cma-autoscaling-custom-install.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]

--- a/nodes/cma/nodes-cma-autoscaling-custom-removing.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-removing.adoc
@@ -8,9 +8,17 @@ toc::[]
 
 You can remove the custom metrics autoscaler from your {product-title} cluster. After removing the Custom Metrics Autoscaler Operator, remove other components associated with the Operator to avoid potential issues. 
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [NOTE]
 ====
 Delete the `KedaController` custom resource (CR) first. If you do not delete the `KedaController` CR, {product-title} can hang when you delete the `openshift-keda` project. If you delete the Custom Metrics Autoscaler Operator before deleting the CR, you are not able to delete the CR.
 ====
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+[NOTE]
+====
+Delete the `KedaController` custom resource (CR) first. If you do not delete the `KedaController` CR, {product-title} can hang when you delete the `keda` project. If you delete the Custom Metrics Autoscaler Operator before deleting the CR, you are not able to delete the CR.
+====
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/nodes-cma-autoscaling-custom-uninstalling.adoc[leveloffset=+1]


### PR DESCRIPTION
I went through all the upstream changes, and I don't see anything that I think we need to call out. So the only things we might want to document are installation procedures for ROSA. We recommend installing in "single namespace" mode and selecting keda on ROSA (and similar cluster types) and openshift-keda namespace on traditional clusters. Another option is installing in "all namespaces" mode and installing to openshift-operators namespace. There is no difference in functionality when installing using "single namespace" mode and "all namespaces" mode. The latter is enabled on CMA only to provide the ability to install CMA in the openshift-operators namespace (which is required there). – [Joel Smith in Slack](https://redhat-internal.slack.com/archives/C02F1J9UJJD/p1696995769844949?thread_ts=1696597770.203589&cid=C02F1J9UJJD).

https://issues.redhat.com/browse/OSDOCS-8148

support/gathering-cluster-data.adoc -- remove ifndef::openshift-rosa,openshift-dedicated[] after CMA 2.11.2 released (10/23).

**Previews:**
**_ROSA:_** 
[Gathering audit logs](https://65703--docspreview.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-audit-log) -- Changed `openshift-keda` to `namespace: keda`.
[Installing the custom metrics autoscaler](https://65703--docspreview.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-install#sd-nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install) -- New file copied from [existing module](https://docs.openshift.com/container-platform/4.13/nodes/cma/nodes-cma-autoscaling-custom-install.html#nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install). -- Modified Prereqs, Steps 1-6. Step 7+,  changed `openshift-keda` to `namespace: keda`in a couple of places, otherwise no changes.
[Understanding how to add custom metrics autoscalers](https://65703--docspreview.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-adding#nodes-cma-autoscaling-custom-creating-workload_nodes-cma-autoscaling-custom-adding) -- Hide _Adding a custom metrics autoscaler to a job_ as TP not supported in ROSA/OSD. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/cma/nodes-cma-autoscaling-custom-adding.html#nodes-cma-autoscaling-custom-creating-job_nodes-cma-autoscaling-custom-adding)
[Gathering debugging data](https://65703--docspreview.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-debugging) -- Changed `openshift-keda` to `namespace: keda`.
[Uninstalling the Custom Metrics Autoscaler Operator](https://65703--docspreview.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-removing#nodes-cma-autoscaling-custom-uninstalling_nodes-cma-autoscaling-custom-removing) -- Changed `openshift-keda` to `namespace: keda`.
 
**_OSD:_** 
[Gathering audit logs](https://65703--docspreview.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-audit-log) -- Changed `openshift-keda` to `namespace: keda`.
[Installing the custom metrics autoscaler](https://65703--docspreview.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-install#sd-nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install) -- New file copied from [existing module](https://docs.openshift.com/container-platform/4.13/nodes/cma/nodes-cma-autoscaling-custom-install.html#nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install). -- Modified Prereqs, Steps 1-6. Step 7+,  changed `openshift-keda` to `namespace: keda`in a couple of places, otherwise no changes.
[Understanding how to add custom metrics autoscalers](https://65703--docspreview.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-adding#nodes-cma-autoscaling-custom-creating-workload_nodes-cma-autoscaling-custom-adding) -- Hide _Adding a custom metrics autoscaler to a job_ as TP not supported in ROSA/OSD. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/cma/nodes-cma-autoscaling-custom-adding.html#nodes-cma-autoscaling-custom-creating-job_nodes-cma-autoscaling-custom-adding)
[Gathering debugging data](https://65703--docspreview.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-debugging) -- Changed `openshift-keda` to `namespace: keda`.
[Uninstalling the Custom Metrics Autoscaler Operator](https://65703--docspreview.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-removing#nodes-cma-autoscaling-custom-uninstalling_nodes-cma-autoscaling-custom-removing) -- Changed `openshift-keda` to `namespace: keda`.

**_OCP:_** (no changes, verify ifdefs didn't cause problems)
[Gathering audit logs](https://65703--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-audit-log) -- Changed `openshift-keda` to `namespace: keda`.
[Installing the custom metrics autoscaler](https://65703--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-install#sd-nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install) -- New file copied from [existing module](https://docs.openshift.com/container-platform/4.13/nodes/cma/nodes-cma-autoscaling-custom-install.html#nodes-cma-autoscaling-custom-install_nodes-cma-autoscaling-custom-install). -- Modified Prereqs, Steps 1-6. Step 7+,  changed `openshift-keda` to `namespace: keda`in a couple of places, otherwise no changes.
[Understanding how to add custom metrics autoscalers](https://65703--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-adding#nodes-cma-autoscaling-custom-creating-workload_nodes-cma-autoscaling-custom-adding) -- Hide _Adding a custom metrics autoscaler to a job_ as TP not supported in ROSA/OSD. [Current docs](https://docs.openshift.com/container-platform/4.13/nodes/cma/nodes-cma-autoscaling-custom-adding.html#nodes-cma-autoscaling-custom-creating-job_nodes-cma-autoscaling-custom-adding)
[Gathering debugging data](https://65703--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-debugging) -- Changed `openshift-keda` to `namespace: keda`.
[Uninstalling the Custom Metrics Autoscaler Operator](https://65703--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-removing#nodes-cma-autoscaling-custom-uninstalling_nodes-cma-autoscaling-custom-removing) -- Changed `openshift-keda` to `namespace: keda`.
