### PR TITLE
Remove dulplicated TOC

### DIFF
--- a/modules/rosa-attaching-the-policy.adoc
+++ b/modules/rosa-attaching-the-policy.adoc
@@ -8,8 +8,6 @@
 
 :context: rosa-attaching-the-policy
 
-toc::[]
-
 Once you have created an identity-based IAM policy, attach it to the relevant IAM users, groups, or roles in your AWS account to prevent IP-based role assumption for those entities.
 
 .Procedure

--- a/modules/rosa-create-an-identity-based-policy.adoc
+++ b/modules/rosa-create-an-identity-based-policy.adoc
@@ -8,8 +8,6 @@
 
 :context: rosa-create-an-identity-based-policy
 
-toc::[]
-
 You can create an identity-based Identity and Access Management (IAM) policy that denies access to all AWS actions when the request originates from an IP address other than Red Hat provided IPs.
 
 .Prerequisites


### PR DESCRIPTION
We need to remove duplicated TOC which is displayed on the right side of the page.

Link: https://docs.openshift.com/rosa/security/rosa-adding-additional-constraints-for-ip-based-aws-role-assumption.html

Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
Preview pages: [Click to see the build preview in your browser](https://65705--docspreview.netlify.app/openshift-rosa/latest/security/rosa-adding-additional-constraints-for-ip-based-aws-role-assumption)
