### PR TITLE
OSDOCS#CP-1892 - Removed rosa/registry redirects to access.redhat.com

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -719,13 +719,6 @@ AddType text/vtt                            vtt
     # OCP 4.1 redirects
     RewriteRule ^container-platform/4\.1/installing/installing_aws_upi/installing-aws-upi\.html /container-platform/4\.1/installing/installing_aws/installing-aws-user-infra.html [NE,R=301]
 
-    # START OF - ROSA REDIRECTS TO ACCESS.REDHAT.COM DOCUMENTATION
-
-    # AT THE MOMENT THERE IS ONLY A RULE FOR REGISTRY BOOK BUT MORE WILL COME IN THE FUTURE
-    RewriteRule ^rosa/registry/([^\.]+)\.html https://access.redhat.com/documentation/en-us/red_hat_openshift_service_on_aws/4/html/registry/$1 [NE,L,R=301]
-
-    # END OF - ROSA REDIRECTS TO ACCESS.REDHAT.COM DOCUMENTATION
-
   </Directory>
 </IfModule>
 


### PR DESCRIPTION
As per request by @karanthshashank I'm removing rosa/registry redirect to access.redhat.com from Openshift docs rewrite rules.

Version(s):
DNA

Issue:
https://issues.redhat.com/browse/CP-1892

Link to docs preview:
Does not exist

QE review:
Not possible due to no testing environment