### PR TITLE
Unhiding Registry book from Customer Portal

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -101,7 +101,7 @@ Topics:
 - Name: Configuring Microsoft Entra ID (formerly Azure Active Directory) as an identity provider
   File: cloud-experts-entra-id-idp
 - Name: Using AWS Secrets Manager CSI on ROSA with STS
-  File: cloud-experts-aws-secret-manager  
+  File: cloud-experts-aws-secret-manager
 ---
 Name: Getting started
 Dir: rosa_getting_started
@@ -422,7 +422,7 @@ Topics:
 ---
 Name: Registry
 Dir: registry
-Distros: openshift-rosa,openshift-rosa-portal
+Distros: openshift-rosa
 Topics:
 - Name: Registry overview
   File: index


### PR DESCRIPTION
[OSDOCS-4908:](https://issues.redhat.com/browse/OSDOCS-4908) Deprecation of ROSA docs from docs.openshift.com
Aligned team: Service Delivery
OCP version for cherry-picking: enterprise-4.13+
JIRA issues: [OSDOCS-4908](https://issues.redhat.com/browse/OSDOCS-4908)
Preview pages:
Peer review requested: @kalexand-rh 
Making the Registry book visible on Customer Poprtal