### PR TITLE
Fixing breadcrumb links for the GitOps and Pipelines standalone docs

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -120,7 +120,7 @@
 
         <span>
           <div class="alert alert-danger" role="alert" id="support-alert">
-            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/gitops/latest/gitops-release-notes.html" style="color: #545454 !important" class="link-primary">latest GitOps docs</a>.
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/gitops/latest/release_notes/gitops-release-notes.html" style="color: #545454 !important" class="link-primary">latest GitOps docs</a>.
           </div>
         </span>
 
@@ -206,7 +206,7 @@
               <option value="1.28">1.28</option>
             </select>
         <% elsif (distro_key == "openshift-pipelines") %>
-            <a href="https://docs.openshift.com/pipelines/<%= version %>/about/understanding-openshift-pipelines.html">
+            <a href="https://docs.openshift.com/pipelines/<%= version %>/about/op-release-notes.html">
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
@@ -215,7 +215,7 @@
               <option value="1.10">1.10</option>
             </select>
         <% elsif (distro_key == "openshift-gitops") %>
-            <a href="https://docs.openshift.com/gitops/<%= version %>/gitops-release-notes.html">
+            <a href="https://docs.openshift.com/gitops/<%= version %>/release_notes/gitops-release-notes.html">
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">


### PR DESCRIPTION
**Version(s):** main only

**Issue:**
-  [RHDEVDOCS 5172](https://issues.redhat.com/browse/RHDEVDOCS-5172)
-  [RHDEVDOCS 5440](https://issues.redhat.com/browse/RHDEVDOCS-5440)

**Additional information:** This PR fixed breadcrumb links for the GitOps and Pipelines standalone docs. It does not alter documentation content.