### PR TITLE
OSDOCS-7812 added note about FIPS compliance to the CO docs

### DIFF
--- a/security/compliance_operator/co-scans/compliance-operator-remediation.adoc
+++ b/security/compliance_operator/co-scans/compliance-operator-remediation.adoc
@@ -8,6 +8,17 @@ toc::[]
 
 Each `ComplianceCheckResult` represents a result of one compliance rule check. If the rule can be remediated automatically, a `ComplianceRemediation` object with the same name, owned by the `ComplianceCheckResult` is created. Unless requested, the remediations are not applied automatically, which gives an {product-title} administrator the opportunity to review what the remediation does and only apply a remediation once it has been verified.
 
+[IMPORTANT]
+====
+Full remediation for Federal Information Processing Standards (FIPS) compliance requires enabling FIPS mode for the cluster. To enable FIPS mode, you must run the installation program from a {op-system-base-full} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
+
+FIPS mode is supported on the following architectures:
+
+* `x86_64`
+* `ppc64le`
+* `s390x`
+====
+
 include::modules/compliance-filtering-results.adoc[leveloffset=+1]
 
 include::modules/compliance-review.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7812

Link to docs preview:
[Compliance Operator remediation (Important note, top of the page)](https://file.rdu.redhat.com/antaylor/OSDOCS-7812/security/compliance_operator/co-scans/compliance-operator-remediation.html)

Additional information:
None