### PR TITLE
OSDOCS#4549: Adding docs for exposing services on firewalls

### DIFF
--- a/microshift_networking/microshift-firewall.adoc
+++ b/microshift_networking/microshift-firewall.adoc
@@ -29,6 +29,8 @@ include::modules/microshift-firewall-apply-settings.adoc[leveloffset=+1]
 
 include::modules/microshift-firewall-verify-settings.adoc[leveloffset=+1]
 
+include::modules/microshift-firewall-update-for-service.adoc[leveloffset=+1]
+
 [id="additional-resources_microshift-using-a-firewall_{context}"]
 [role="_additional-resources"]
 == Additional resources

--- a/modules/microshift-firewall-update-for-service.adoc
+++ b/modules/microshift-firewall-update-for-service.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * microshift_networking/microshift-firewall.adoc
+
+:_content-type: CONCEPT
+[id="microshift-firewall-update-for-service_{context}"]
+= Overview of firewall ports when a service is exposed
+
+Firewalld is often active when you run services on {microshift-short}. This can disrupt certain services on {microshift-short} because traffic to the ports might be blocked by the firewall. You must ensure that the necessary firewall ports are open if you want certain services to be accessible from outside the host. There are several options for opening your ports:
+
+* Services of the `NodePort` and `LoadBalancer` type are automatically available with OVN-Kubernetes.
++
+In these cases, OVN-Kubernetes adds iptables rules so the traffic to the node IP address is delivered to the relevant ports. This is done using the PREROUTING rule chain and is then forwarded to the OVN-K to bypass the firewalld rules for local host ports and services. Iptables and firewalld are backed by nftables in {rhel-major}. The nftables rules, which the iptables generates, always has priority over the rules that the firewalld generates.
+
+* Pods with the `HostPort` parameter settings are automatically available. This also includes the `router-default` pod, which uses ports 80 and 443.
++
+For `HostPort` pods, the CRI-O config sets up iptables DNAT (Destination Network Address Translation) to the pod's IP address and port.
+
+These methods function for clients whether they are on the same host or on a remote host. The iptables rules, which are added by OVN-Kubernetes and CRI-O, attach to the PREROUTING and OUTPUT chains. The local traffic goes through the OUTPUT chain with the interface set to the `lo` type. The DNAT runs before it hits filler rules in the INPUT chain.
+
+Because the {microshift-short} API server does not run in CRI-O, it is subject to the firewall configurations. You can open port 6443 in the firewall to access the API server in your {microshift-short} cluster. 


### PR DESCRIPTION
**Version(s):** 4.14+
**Issue:** [OSDOCS-4549](https://issues.redhat.com//browse/OSDOCS-4549)

**Link to docs preview:**

[Firewall configuration -> Updating firewall ports when a service is exposed](https://65738--docspreview.netlify.app/microshift/latest/microshift_networking/microshift-firewall#microshift-firewall-update-for-service_microshift-firewall)

**QE review:**
- [x] QE has approved this change.