### PR TITLE
OSDOCS#7979: Adds 4.13.14 release to MS RNs

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -273,3 +273,12 @@ Issued: 2023-09-19
 {product-title} release 4.13.13 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5157[RHBA-2023:5157] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5155[RHSA-2023:5155] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-14-dp"]
+=== RHBA-2023:5386 - {product-title} 4.13.14 bug fix update
+
+Issued: 2023-10-05
+
+{product-title} release 4.13.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5386[RHBA-2023:5386] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5382[RHBA-2023:5382] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
OSDOCS#7979: Adds 4.13.14 release to MS RNs

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-7979

Link to docs preview:
https://65739--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-14-dp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
