### PR TITLE
OCPBUGS-17478: removed graceful node shutdown support from topic map

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2330,8 +2330,8 @@ Topics:
     File: nodes-nodes-working
   - Name: Managing nodes
     File: nodes-nodes-managing
-  - Name: Managing graceful node shutdown
-    File: nodes-nodes-graceful-shutdown
+//  - Name: Managing graceful node shutdown
+//    File: nodes-nodes-graceful-shutdown
   - Name: Managing the maximum number of pods per node
     File: nodes-nodes-managing-max-pods
   - Name: Using the Node Tuning Operator


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: OCPBUGS-17478
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: will add when generated
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: release notes will also be updated (will post link to PR when available)
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
