### PR TITLE
Fixing version upgrade for mustgather in v1.10 GitOps doc

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -9,6 +9,7 @@
 :toc-title:
 :imagesdir: images
 :prewrap!:
+:HCOVersion: 4.13.0
 
 //gitops
 :gitops-title: Red Hat OpenShift GitOps

--- a/modules/collecting-gitops-debugging-data.adoc
+++ b/modules/collecting-gitops-debugging-data.adoc
@@ -27,7 +27,14 @@ Use the `oc adm must-gather` CLI command to collect the following details about 
 +
 [source,terminal]
 ----
-$ oc adm must-gather --image=registry.redhat.io/openshift-gitops-1/gitops-must-gather-rhel8:v1.9.0
+$ oc adm must-gather --image=registry.redhat.io/openshift-gitops-1/must-gather-rhel8:<image_version_tag> <1>
+----
+<1> The must-gather image for {gitops-shortname}.
++
+.Example command
+[source,terminal]
+----
+$ oc adm must-gather --image=registry.redhat.io/openshift-gitops-1/must-gather-rhel8:v1.10.0
 ----
 +
 The `must-gather` tool creates a new directory that starts with `./must-gather.local` in the current directory. For example, `./must-gather.local.4157245944708210399`.
@@ -36,7 +43,8 @@ The `must-gather` tool creates a new directory that starts with `./must-gather.l
 +
 [source,terminal]
 ----
-$ tar -cvaf must-gather.tar.gz must-gather.local.4157245944708210399
+$ tar -cvaf must-gather.tar.gz must-gather.local.4157245944708210399 <1>
 ----
+<1> Replace `must-gather-local.4157245944708210399` with the actual directory name.
 
 . Attach the compressed file to your support case on the link:https://access.redhat.com/[Red Hat Customer Portal].


### PR DESCRIPTION
**Version(s):** CP to `gitops-docs` and `gitops-docs-1.10`

**Issue:**
-  [RHDEVDOCS 5642](https://issues.redhat.com/browse/RHDEVDOCS-5642)
-  [RHDEVDOCS 5643](https://issues.redhat.com/browse/RHDEVDOCS-5643)

**Preview link:**
- [About the must-gather tool](https://65742--docspreview.netlify.app/openshift-gitops/latest/understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support#about-must-gather_gathering-gitops-diagnostic-information-for-support)
- [Collecting debugging data for Red Hat OpenShift GitOps](https://65742--docspreview.netlify.app/openshift-gitops/latest/understanding_openshift_gitops/gathering-gitops-diagnostic-information-for-support#collecting-debugging-data-for-gitops_gathering-gitops-diagnostic-information-for-support)

**SME review:** Completed by @reginapizza 

**QE review:** Completed by @varshab1210 

**Peer review:** Completed by @lahinson 

**Additional information:** This PR fixes the version upgrade and the attribute in the must-gather command for v1.10 GitOps docs.

- Link to an equivalent PR on a different branch #65744