### PR TITLE
OSDOCS-7633: add storage migrator release note

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -84,10 +84,11 @@ With this release, updates for both minor releases and patch releases are suppor
 
 [id="microshift-4-14-storage"]
 === Storage
+With this release, the Migrator Controller embedded in {product-title} is used to update stored data to the latest storage version. You can update data without having to recreate custom resources (CRs). See xref:../microshift_storage/microshift-storage-migration.adoc#microshift-storage-migration[Storage migration using the Kube Storage Version Migrator] for details.
 
 [id="microshift-backup-and-restore"]
 === Backup and restore
-The capability to back up and restore the {product-title} database is now available. You can manually back up and restore data on all supported systems at any time. See the xref:../microshift_backup_and_restore/microshift-backup-and-restore.adoc#microshift-backup-and-restore[Backing up and restoring {product-title} data] documentation for more information.
+The capability to back up and restore the {product-title} database is now available. You can manually back up and restore data on all supported systems at any time. See xref:../microshift_backup_and_restore/microshift-backup-and-restore.adoc#microshift-backup-and-restore[Backing up and restoring {product-title} data] for more information.
 
 //[id="microshift-4-14-running-apps"]
 //=== Running Applications
@@ -118,7 +119,7 @@ In the following tables, features are marked with the following statuses:
 
 |Network configuration flags
 |-
-|Depricated
+|Deprecated
 |Removed
 
 |CIDR notation


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7633

Link to docs preview:
https://65750--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-storage

QE review:
- QE approved doc content [here](https://github.com/openshift/openshift-docs/pull/64470).

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
