### PR TITLE
[No issue] Clarifies procedure guidance and fixes a link

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -367,12 +367,12 @@ For more information about creating concept modules, see the
 link:https://redhat-documentation.github.io/modular-docs/#creating-concept-modules[_Red Hat modular docs reference guide_] and the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_CONCEPT_concept-explanation.adoc[concept template].
 
 == Writing procedures
-A _procedure_ contains the steps that users follow to complete a process or task. Procedures contain ordered steps and explicit commands. In most cases, create your procedures as individual modules and include them in appropriate assemblies.
+A _procedure_ contains the steps that users follow to complete a single process or task. Procedures contain ordered steps and explicit commands. In most cases, create your procedures as individual modules and include them in appropriate assemblies.
 
 Use a gerund in the procedure title, such as "Creating".
 
 For more information about writing procedures, see the
-link:https://redhat-documentation.github.io/modular-docs/#creating-procedure-modules[_Red Hat modular docs reference guide_] and the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc[procedure template].
+link:https://redhat-documentation.github.io/modular-docs/#con-creating-procedure-modules_writing-mod-docs[_Red Hat modular docs reference guide_] and the link:https://raw.githubusercontent.com/redhat-documentation/modular-docs/master/modular-docs-manual/files/TEMPLATE_PROCEDURE_doing-one-procedure.adoc[procedure template].
 
 [NOTE]
 ====


### PR DESCRIPTION
Version(s):
`main`

Issue:
N/A

Link to docs preview:
[Writing procedures](https://github.com/openshift/openshift-docs/blob/60b833cf5c932aa3361dcff31d6ac210a0f63eae/contributing_to_docs/doc_guidelines.adoc#writing-procedures)

QE review:
N/A

Additional information:
Requires DPM ack