### PR TITLE
OSDOCS-7827: Migrate Using ACK on ROSA from MOBB to ROSA

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -102,6 +102,8 @@ Topics:
   File: cloud-experts-entra-id-idp
 - Name: Using AWS Secrets Manager CSI on ROSA with STS
   File: cloud-experts-aws-secret-manager
+- Name: Using AWS Controllers for Kubernetes on ROSA
+  File: cloud-experts-using-aws-ack
 ---
 Name: Getting started
 Dir: rosa_getting_started

--- a/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
@@ -1,0 +1,242 @@
+:_content-type: ASSEMBLY
+[id=“cloud-experts-using-aws-ack]
+= Tutorial: Using AWS Controllers for Kubernetes on ROSA
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: cloud-experts-using-aws-ack
+
+toc::[]
+
+//Mobb content metadata
+//Brought into ROSA product docs 2023-09-21
+//---
+//date: '2022-06-02'
+//title: Using AWS Controllers for Kubernetes (ACK) on ROSA
+//weight: 1
+//tags: ["AWS", "ROSA"]
+//authors:
+//  - Paul Czarkowski
+//  - Connor Wooley
+//---
+
+link:https://aws-controllers-k8s.github.io/community/[AWS Controllers for Kubernetes] (ACK) lets you define and use AWS service resources directly from {product-title} (ROSA). With ACK, you can take advantage of AWS-managed services for your applications without needing to define resources outside of the cluster or run services that provide supporting capabilities like databases or message queues within the cluster.
+
+Users can install various ACK Operators directly from OperatorHub. This makes it relatively easy to get started and start using it with your applications. This controller is a component of the AWS Controller for Kubernetes project. This project is currently in developer preview.
+
+This tutorial shows you how to use the ACK S3 Operator as an example, but can be adapted for any other ACK Operator in the OperatorHub of your cluster.
+
+== Prerequisites
+
+* A ROSA cluster
+* A user account with `cluster-admin` privileges
+* You have access to the OpenShift CLI (`oc`)
+* You have access to the AWS CLI (`aws`)
+
+=== Environment Setup
+
+. Configure the following environment variables:
++
+[source,terminal]
+----
+$ export CLUSTER_NAME=$(oc get infrastructure cluster -o=jsonpath="{.status.infrastructureName}"  | sed 's/-[a-z0-9]\{5\}$//')
+$ export REGION=$(rosa describe cluster -c ${ROSA_CLUSTER_NAME} --output json | jq -r .region.id)
+$ export OIDC_ENDPOINT=$(oc get authentication.config.openshift.io cluster -o json | jq -r .spec.serviceAccountIssuer | sed  's|^https://||')
+$ export AWS_ACCOUNT_ID=`aws sts get-caller-identity --query Account --output text`
+$ export ACK_SERVICE=s3
+$ export ACK_SERVICE_ACCOUNT=ack-${ACK_SERVICE}-controller
+$ export POLICY_ARN=arn:aws:iam::aws:policy/AmazonS3FullAccess
+$ export AWS_PAGER=""
+$ export SCRATCH="/tmp/${ROSA_CLUSTER_NAME}/ack"
+$ mkdir -p ${SCRATCH}
+$ echo "Cluster: ${ROSA_CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
+----
+
+== Prepare AWS Account
+
+. Create an AWS IAM trust policy for the ACK Operator:
++
+[source,terminal]
+----
+$ cat <<EOF > "${SCRATCH}/trust-policy.json"
+{
+ "Version": "2012-10-17",
+ "Statement": [
+ {
+ "Effect": "Allow",
+ "Condition": {
+   "StringEquals" : {
+     "${OIDC_ENDPOINT}:sub": "system:serviceaccount:ack-system:${ACK_SERVICE_ACCOUNT}"
+   }
+ },
+ "Principal": {
+   "Federated": "arn:aws:iam::$AWS_ACCOUNT_ID:oidc-provider/${OIDC_ENDPOINT}"
+ },
+ "Action": "sts:AssumeRoleWithWebIdentity"
+ }
+ ]
+}
+EOF
+----
++
+. Create an AWS IAM role for the ACK Operator to assume with the `AmazonS3FullAccess` policy attached:
++
+[NOTE]
+====
+You can find the recommended policy in each project's GitHub repository, for example https://github.com/aws-controllers-k8s/s3-controller/blob/main/config/iam/recommended-policy-arn.
+====
++
+[source,terminal]
+----
+$ ROLE_ARN=$(aws iam create-role --role-name "ack-${ACK_SERVICE}-controller" \
+   --assume-role-policy-document "file://${SCRATCH}/trust-policy.json" \
+   --query Role.Arn --output text)
+$ echo $ROLE_ARN
+
+$ aws iam attach-role-policy --role-name "ack-${ACK_SERVICE}-controller" \
+     --policy-arn ${POLICY_ARN}
+----
+
+== Install the ACK S3 Controller
+
+. Create a project to install the ACK S3 Operator into:
++
+[source,terminal]
+----
+$ oc new-project ack-system
+----
++
+. Create a file with the ACK S3 Operator configuration:
++
+[NOTE]
+====
+`ACK_WATCH_NAMESPACE` is purposefully left blank so the controller can properly watch all namespaces in the cluster.
+====
++
+[source,terminal]
+----
+$ cat <<EOF > "${SCRATCH}/config.txt"
+ACK_ENABLE_DEVELOPMENT_LOGGING=true
+ACK_LOG_LEVEL=debug
+ACK_WATCH_NAMESPACE=
+AWS_REGION=${REGION}
+AWS_ENDPOINT_URL=
+ACK_RESOURCE_TAGS=${CLUSTER_NAME}
+ENABLE_LEADER_ELECTION=true
+LEADER_ELECTION_NAMESPACE=
+EOF
+----
++
+. Use the file from the previous step to create a ConfigMap:
++
+[source,terminal]
+----
+$ oc -n ack-system create configmap \
+  --from-env-file=${SCRATCH}/config.txt ack-${ACK_SERVICE}-user-config
+----
++
+. Install the ACK S3 Operator from OperatorHub:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: ack-${ACK_SERVICE}-controller
+  namespace: ack-system
+spec:
+  upgradeStrategy: Default
+---
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  name: ack-${ACK_SERVICE}-controller
+  namespace: ack-system
+spec:
+  channel: alpha
+  installPlanApproval: Automatic
+  name: ack-${ACK_SERVICE}-controller
+  source: community-operators
+  sourceNamespace: openshift-marketplace
+EOF
+----
++
+. Annotate the ACK S3 Operator service account with the AWS IAM role to assume and restart the deployment:
++
+[source,terminal]
+----
+$ oc -n ack-system annotate serviceaccount ${ACK_SERVICE_ACCOUNT} \
+  eks.amazonaws.com/role-arn=${ROLE_ARN} && \
+  oc -n ack-system rollout restart deployment ack-${ACK_SERVICE}-controller
+----
++
+. Verify that the ACK S3 Operator is running:
++
+[source,terminal]
+----
+$ oc -n ack-system get pods
+----
+.Example output
++
+[source,text]
+----
+NAME                                 READY   STATUS    RESTARTS   AGE
+ack-s3-controller-585f6775db-s4lfz   1/1     Running   0          51s
+----
+
+== Validating the deployment 
+
+. Deploy an S3 bucket resource:
++
+[source,terminal]
+----
+$ cat << EOF | oc apply -f -
+apiVersion: s3.services.k8s.aws/v1alpha1
+kind: Bucket
+metadata:
+   name: ${CLUSTER-NAME}-bucket
+   namespace: ack-system
+spec:
+   name: ${CLUSTER-NAME}-bucket
+EOF
+----
++
+. Verify the S3 bucket was created in AWS:
++
+[source,terminal]
+----
+$ aws s3 ls | grep ${CLUSTER_NAME}-bucket
+----
++
+.Example output
+[source,text]
+----
+2023-10-04 14:51:45 mrmc-test-maz-bucket
+----
+
+== Cleaning up
+
+. Delete the S3 bucket resource:
++
+[source,terminal]
+----
+$ oc -n ack-system delete bucket.s3.services.k8s.aws/${CLUSTER-NAME}-bucket
+----
++
+. Delete the ACK S3 Operator and the AWS IAM roles:
++
+[source,terminal]
+----
+$ oc -n ack-system delete subscription ack-${ACK_SERVICE}-controller
+$ aws iam detach-role-policy \
+  --role-name "ack-${ACK_SERVICE}-controller" \
+  --policy-arn ${POLICY_ARN}
+$ aws iam delete-role \
+  --role-name "ack-${ACK_SERVICE}-controller"
+----
++
+. Delete the `ack-system` project:
++
+[source,terminal]
+----
+$ oc delete project ack-system
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-7827
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://65756--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-using-aws-ack
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This supersedes #65028 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
