### PR TITLE
OCPBUGS17478: hide graceful node shutdown in 4.13

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2346,8 +2346,8 @@ Topics:
     File: nodes-nodes-working
   - Name: Managing nodes
     File: nodes-nodes-managing
-  - Name: Managing graceful node shutdown
-    File: nodes-nodes-graceful-shutdown
+//   - Name: Managing graceful node shutdown
+//     File: nodes-nodes-graceful-shutdown
   - Name: Managing the maximum number of pods per node
     File: nodes-nodes-managing-max-pods
   - Name: Using the Node Tuning Operator

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1155,14 +1155,14 @@ Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone
 
 For more information, see xref:../nodes/pods/nodes-pods-configuring.adoc#pod-disruption-eviction-policy_nodes-pods-configuring[Specifying the eviction policy for unhealthy pods].
 
-[id="ocp-4-13-graceful-node-shutdown"]
-==== Support for graceful node shutdown
-
-A graceful node shutdown delays the eviction of pods during a node shutdown. In {product-title} {product-version}, you can configure the kubelet to enable a graceful node shutdown so that pods running critical workloads are not interrupted.
-
-To configure graceful node shutdowns, you can specify a termination grace period for regular and critical pods in the `KubeletConfig` custom resource. A termination grace period defines a time period for the pod to complete any ongoing tasks before terminating. You can also add priority classes to pods to specify the order of termination.
-
-For further information see xref:../nodes/nodes/nodes-nodes-graceful-shutdown.adoc#nodes-nodes-graceful-shutdown[Managing graceful node shutdown].
+// [id="ocp-4-13-graceful-node-shutdown"]
+// ==== Support for graceful node shutdown
+// 
+// A graceful node shutdown delays the eviction of pods during a node shutdown. In {product-title} {product-version}, you can configure the kubelet to enable a graceful node shutdown so that pods running critical workloads are not interrupted.
+// 
+// To configure graceful node shutdowns, you can specify a termination grace period for regular and critical pods in the `KubeletConfig` custom resource. A termination grace period defines a time period for the pod to complete any ongoing tasks before terminating. You can also add priority classes to pods to specify the order of termination.
+// 
+// For further information see xref:../nodes/nodes/nodes-nodes-graceful-shutdown.adoc#nodes-nodes-graceful-shutdown[Managing graceful node shutdown].
 
 [id="ocp-4-13-metal3-remediation-support"]
 ==== Metal3 remediation support


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): Enterprise-4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: OCPBUGS-17478
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: will add once generated
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Related to PR #65740
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
