### PR TITLE
OSDOCS#4639: PXE booting support for Agent

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -343,6 +343,8 @@ Topics:
     File: understanding-disconnected-installation-mirroring
   - Name: Installing a cluster with Agent-based Installer
     File: installing-with-agent-based-installer
+  - Name: Preparing PXE assets for OCP
+    File: prepare-pxe-assets-agent
   - Name: Preparing an Agent-based installed cluster for the multicluster engine for Kubernetes
     File: preparing-an-agent-based-installed-cluster-for-mce
 - Name: Installing on a single node

--- a/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
+++ b/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent.adoc
@@ -1,0 +1,38 @@
+:_content-type: ASSEMBLY
+[id="prepare-pxe-assets-agent"]
+= Preparing PXE assets for {product-title}
+include::_attributes/common-attributes.adoc[]
+:context: prepare-pxe-assets-agent
+
+toc::[]
+
+Use the following procedures to create the assets needed to PXE boot an {product-title} cluster using the Agent-based Installer.
+
+The assets you create in these procedures will deploy a single-node {product-title} installation. You can use these procedures as a basis and modify configurations according to your requirements.
+
+[id="prerequisites_prepare-pxe-assets-agent"]
+== Prerequisites
+
+* You reviewed details about the xref:../../architecture/architecture-installation.adoc#architecture-installation[{product-title} installation and update] processes.
+
+// Downloading the Agent-based Installer
+include::modules/installing-ocp-agent-download.adoc[leveloffset=+1]
+
+// Creating the preferred configuration inputs
+include::modules/installing-ocp-agent-inputs.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#modifying-install-config-for-dual-stack-network_ipi-install-installation-workflow[Deploying with dual-stack networking].
+* xref:../../installing/installing_bare_metal_ipi/ipi-install-installation-workflow.adoc#configuring-the-install-config-file_ipi-install-installation-workflow[Configuring the install-config yaml file].
+* See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-three-node-cluster_installing-restricted-networks-bare-metal[Configuring a three-node cluster] to deploy three-node clusters in bare metal environments.
+* xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints].
+* link:https://nmstate.io/examples.html[NMState state examples].
+
+// Creating the PXE assets
+include::modules/pxe-assets-ocp-agent.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_prepare-pxe-assets-agent"]
+== Additional resources
+* See xref:../../installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc#installing-with-agent-based-installer[Installing an {product-title} cluster with the Agent-based Installer] to learn about more configurations available with the Agent-based Installer.

--- a/modules/installing-ocp-agent-boot.adoc
+++ b/modules/installing-ocp-agent-boot.adoc
@@ -11,7 +11,6 @@ Use this procedure to boot the agent image on your machines.
 .Procedure
 
 . Create the agent image by running the following command:
-
 +
 [source,terminal]
 ----

--- a/modules/installing-ocp-agent-download.adoc
+++ b/modules/installing-ocp-agent-download.adoc
@@ -1,14 +1,15 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
+// * installing/installing_with_agent_based_installer/prepare-pxe-infra-agent.adoc
 
 :_content-type: PROCEDURE
 [id="installing-ocp-agent-retrieve_{context}"]
 = Downloading the Agent-based Installer
 
-.Procedure
-
 Use this procedure to download the Agent-based Installer and the CLI needed for your installation.
+
+.Procedure
 
 . Log in to the {product-title} web console using your login credentials.
 

--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -1,12 +1,22 @@
 // Module included in the following assemblies:
 //
 // * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
+// *installing/installing_with_agent_based_installer/prepare-pxe-infra-agent.adoc
+
+ifeval::["{context}" == "prepare-pxe-assets-agent"]
+:pxe-boot:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installing-ocp-agent-inputs_{context}"]
 = Creating the preferred configuration inputs
 
+ifndef::pxe-boot[]
 Use this procedure to create the preferred configuration inputs used to create the agent image.
+endif::pxe-boot[]
+ifdef::pxe-boot[]
+Use this procedure to create the preferred configuration inputs used to create the PXE files.
+endif::pxe-boot[]
 
 .Procedure
 
@@ -117,7 +127,7 @@ platform:
 [source,terminal]
 ----
 $ cat > agent-config.yaml << EOF
-apiVersion: v1alpha1
+apiVersion: v1beta1
 kind: AgentConfig
 metadata:
   name: sno-cluster
@@ -160,3 +170,24 @@ You must provide the rendezvous IP address when you do not specify at least one 
 <3> Optional: Overrides the hostname obtained from either the Dynamic Host Configuration Protocol (DHCP) or a reverse DNS lookup. Each host must have a unique hostname supplied by one of these methods.
 <4> Enables provisioning of the Red Hat Enterprise Linux CoreOS (RHCOS) image to a particular device. It examines the devices in the order it discovers them, and compares the discovered values with the hint values. It uses the first discovered device that matches the hint value.
 <5> Optional: Configures the network interface of a host in NMState format.
+
+ifdef::pxe-boot[]
+
+. Optional: To create an iPXE script, add the `bootArtifactsBaseURL` to the `agent-config.yaml` file:
++
+[source,yaml]
+----
+apiVersion: v1beta1
+kind: AgentConfig
+metadata:
+  name: sno-cluster
+rendezvousIP: 192.168.111.80
+bootArtifactsBaseURL: <asset_server_URL>
+----
++
+Where `<asset_server_URL>` is the URL of the server you will upload the PXE assets to.
+endif::pxe-boot[]
+
+ifeval::["{context}" == "prepare-pxe-assets-agent"]
+:!pxe-boot:
+endif::[]

--- a/modules/pxe-assets-ocp-agent.adoc
+++ b/modules/pxe-assets-ocp-agent.adoc
@@ -1,0 +1,42 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_with_agent_based_installer/prepare-pxe-infra-agent.adoc
+
+:_content-type: PROCEDURE
+[id="pxe-assets-ocp-agent_{context}"]
+= Creating the PXE assets
+
+Use the following procedure to create the assets and optional script to implement in your PXE infrastructure.
+
+.Procedure
+
+. Create the PXE assets by running the following command:
++
+[source,terminal]
+----
+$ openshift-install agent create pxe-files
+----
++
+The generated PXE assets and optional iPXE script can be found in the `boot-artifacts` directory.
++
+.Example filesystem with PXE assets and optional iPXE script
+[source,terminal]
+----
+boot-artifacts
+    ├─ agent.x86_64-initrd.img
+    ├─ agent.x86_64.ipxe
+    ├─ agent.x86_64-rootfs.img
+    └─ agent.x86_64-vmlinuz
+----
++
+[NOTE]
+====
+Red Hat Enterprise Linux CoreOS (RHCOS) supports multipathing on the primary disk, allowing stronger resilience to hardware failure to achieve higher host availability. Multipathing is enabled by default in the agent ISO image, with a default `/etc/multipath.conf` configuration.
+====
+
+. Upload the PXE assets and optional script to your infrastructure where they will be accessible during the boot process.
++
+[NOTE]
+====
+If you generated an iPXE script, the location of the assets must match the `bootArtifactsBaseURL` you added to the `agent-config.yaml` file.
+====


### PR DESCRIPTION
[OSDOCS-4639](https://issues.redhat.com/browse/OSDOCS-4639)

Versions: 4.14+

Preview: [Preparing PXE assets for OCP](https://65762--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/prepare-pxe-assets-agent)

This PR documents how to create assets needed to PXE boot a cluster using the Agent-based Installer

QE review:
- [ ] QE has approved this change.

