### PR TITLE
[enterprise-4.13] OSDOCS-7854: Remove registry config for OSD/ROSA

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -424,7 +424,7 @@ Topics:
 ---
 Name: Registry
 Dir: registry
-Distros: openshift-rosa
+Distros: openshift-rosa,openshift-rosa-portal
 Topics:
 - Name: Registry overview
   File: index


### PR DESCRIPTION
Cherry Picked from 60988e8cac67b40b160afc52c1fc2787a36ab5fc xref: https://github.com/openshift/openshift-docs/pull/65135