### PR TITLE
[OSDOCS-8025]: Azure confidential computing via MAPI

### DIFF
--- a/machine_management/control_plane_machine_management/cpmso-using.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-using.adoc
@@ -83,6 +83,12 @@ include::modules/machineset-troubleshooting-azure-ultra-disk.adoc[leveloffset=+3
 //Enabling customer-managed encryption keys for a machine set
 include::modules/machineset-customer-managed-encryption-azure.adoc[leveloffset=+2]
 
+//Configuring trusted launch for Azure virtual machines by using machine sets
+include::modules/machineset-azure-trusted-launch.adoc[leveloffset=+2]
+
+//Configuring Azure confidential virtual machines by using machine sets
+include::modules/machineset-azure-confidential-vms.adoc[leveloffset=+2]
+
 // Accelerated Networking for Microsoft Azure VMs
 include::modules/machineset-azure-accelerated-networking.adoc[leveloffset=+2]
 

--- a/machine_management/creating_machinesets/creating-machineset-azure.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-azure.adoc
@@ -53,6 +53,12 @@ include::modules/machineset-troubleshooting-azure-ultra-disk.adoc[leveloffset=+2
 //Enabling customer-managed encryption keys for a machine set
 include::modules/machineset-customer-managed-encryption-azure.adoc[leveloffset=+1]
 
+//Configuring trusted launch for Azure virtual machines by using machine sets
+include::modules/machineset-azure-trusted-launch.adoc[leveloffset=+1]
+
+//Configuring Azure confidential virtual machines by using machine sets
+include::modules/machineset-azure-confidential-vms.adoc[leveloffset=+1]
+
 // Accelerated Networking for Microsoft Azure VMs
 include::modules/machineset-azure-accelerated-networking.adoc[leveloffset=+1]
 

--- a/modules/machineset-azure-confidential-vms.adoc
+++ b/modules/machineset-azure-confidential-vms.adoc
@@ -1,0 +1,91 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-azure.adoc
+// * machine_management/control_plane_machine_management/cpmso-using.adoc
+
+ifeval::["{context}" == "cpmso-using"]
+:cpmso:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="machineset-azure-confidential-vms_{context}"]
+= Configuring Azure confidential virtual machines by using machine sets
+
+:FeatureName: Using Azure confidential virtual machines
+include::snippets/technology-preview.adoc[]
+
+{product-title} {product-version} supports Azure confidential virtual machines (VMs).
+
+[NOTE]
+====
+Confidential VMs are currently not supported on 64-bit ARM architectures.
+====
+
+By editing the machine set YAML file, you can configure the confidential VM options that a machine set uses for machines that it deploys. For example, you can configure these machines to use UEFI security features such as Secure Boot or a dedicated virtual Trusted Platform Module (vTPM) instance.
+
+ifdef::cpmso[]
+[WARNING]
+====
+Not all instance types support confidential VMs. Do not change the instance type for a control plane machine set that is configured to use confidential VMs to a type that is incompatible. Using an incompatible instance type can cause your cluster to become unstable.
+====
+endif::cpmso[]
+
+For more information about related features and functionality, see the Microsoft Azure documentation about link:https://learn.microsoft.com/en-us/azure/confidential-computing/confidential-vm-overview[Confidential virtual machines].
+
+.Procedure
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Edit the following section under the `providerSpec` field:
++
+--
+.Sample configuration
+[source,yaml]
+----
+ifndef::cpmso[]
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+endif::cpmso[]
+ifdef::cpmso[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+endif::cpmso[]
+# ...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          osDisk:
+            # ...
+            managedDisk:
+              securityProfile: # <1>
+                securityEncryptionType: VMGuestStateOnly # <2>
+            # ...
+          securityProfile: # <3>
+            settings:
+                securityType: ConfidentialVM # <4>
+                confidentialVM:
+                  uefiSettings: # <5>
+                    secureBoot: Disabled # <6>
+                    virtualizedTrustedPlatformModule: Enabled # <7>
+          vmSize: Standard_DC16ads_v5 # <8>
+# ...
+----
+<1> Specifies security profile settings for the managed disk when using a confidential VM.
+<2> Enables encryption of the Azure VM Guest State (VMGS) blob. This setting requires the use of vTPM.
+<3> Specifies security profile settings for the confidential VM.
+<4> Enables the use of confidential VMs. This value is required for all valid configurations.
+<5> Specifies which UEFI security features to use. This section is required for all valid configurations.
+<6> Disables UEFI Secure Boot.
+<7> Enables the use of a vTPM.
+<8> Specifies an instance type that supports confidential VMs.
+--
+
+.Verification
+
+* On the Azure portal, review the details for a machine deployed by the machine set and verify that the confidential VM options match the values that you configured.
+
+ifeval::["{context}" == "cpmso-using"]
+:!cpmso:
+endif::[]

--- a/modules/machineset-azure-trusted-launch.adoc
+++ b/modules/machineset-azure-trusted-launch.adoc
@@ -1,0 +1,111 @@
+// Module included in the following assemblies:
+//
+// * machine_management/creating_machinesets/creating-machineset-azure.adoc
+// * machine_management/control_plane_machine_management/cpmso-using.adoc
+
+ifeval::["{context}" == "cpmso-using"]
+:cpmso:
+endif::[]
+
+:_content-type: PROCEDURE
+[id="machineset-azure-trusted-launch_{context}"]
+= Configuring trusted launch for Azure virtual machines by using machine sets
+
+:FeatureName: Using trusted launch for Azure virtual machines
+include::snippets/technology-preview.adoc[]
+
+{product-title} {product-version} supports trusted launch for Azure virtual machines (VMs). By editing the machine set YAML file, you can configure the trusted launch options that a machine set uses for machines that it deploys. For example, you can configure these machines to use UEFI security features such as Secure Boot or a dedicated virtual Trusted Platform Module (vTPM) instance.
+
+[NOTE]
+====
+Some feature combinations result in an invalid configuration.
+====
+
+.UEFI feature combination compatibility
+|====
+|Secure Boot^[1]^ |vTPM^[2]^ |Valid configuration
+
+|Enabled
+|Enabled
+|Yes
+
+|Enabled
+|Disabled
+|Yes
+
+|Enabled
+|Omitted
+|Yes
+
+|Disabled
+|Enabled
+|Yes
+
+|Omitted
+|Enabled
+|Yes
+
+|Disabled
+|Disabled
+|No
+
+|Omitted
+|Disabled
+|No
+
+|Omitted
+|Omitted
+|No
+|====
+[.small]
+--
+1. Using the `secureBoot` field.
+2. Using the `virtualizedTrustedPlatformModule` field.
+--
+
+For more information about related features and functionality, see the Microsoft Azure documentation about link:https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch[Trusted launch for Azure virtual machines].
+
+.Procedure
+
+. In a text editor, open the YAML file for an existing machine set or create a new one.
+
+. Edit the following section under the `providerSpec` field to provide a valid configuration:
++
+.Sample valid configuration with UEFI Secure Boot and vTPM enabled
+[source,yaml]
+----
+ifndef::cpmso[]
+apiVersion: machine.openshift.io/v1beta1
+kind: MachineSet
+endif::cpmso[]
+ifdef::cpmso[]
+apiVersion: machine.openshift.io/v1
+kind: ControlPlaneMachineSet
+endif::cpmso[]
+# ...
+spec:
+  template:
+    spec:
+      providerSpec:
+        value:
+          securityProfile:
+            settings:
+              securityType: TrustedLaunch # <1>
+              trustedLaunch:
+                uefiSettings: # <2>
+                  secureBoot: Enabled # <3>
+                  virtualizedTrustedPlatformModule: Enabled # <4>
+# ...
+----
+<1> Enables the use of trusted launch for Azure virtual machines. This value is required for all valid configurations.
+<2> Specifies which UEFI security features to use. This section is required for all valid configurations.
+<3> Enables UEFI Secure Boot.
+<4> Enables the use of a vTPM.
+
+.Verification
+
+* On the Azure portal, review the details for a machine deployed by the machine set and verify that the trusted launch options match the values that you configured.
+
+ifeval::["{context}" == "cpmso-using"]
+:!cpmso:
+endif::[]

--- a/modules/machineset-gcp-shielded-vms.adoc
+++ b/modules/machineset-gcp-shielded-vms.adoc
@@ -30,7 +30,7 @@ ifdef::cpmso[]
 apiVersion: machine.openshift.io/v1
 kind: ControlPlaneMachineSet
 endif::cpmso[]
-...
+# ...
 spec:
   template:
     spec:
@@ -40,19 +40,19 @@ spec:
             integrityMonitoring: Enabled <2>
             secureBoot: Disabled <3>
             virtualizedTrustedPlatformModule: Enabled <4>
-...
+# ...
 ----
 +
 --
 <1> In this section, specify any Shielded VM options that you want.
-<2> Specify whether UEFI Secure Boot is enabled. Valid values are `Disabled` or `Enabled`.
-<3> Specify whether integrity monitoring is enabled. Valid values are `Disabled` or `Enabled`.
+<2> Specify whether integrity monitoring is enabled. Valid values are `Disabled` or `Enabled`.
 +
 [NOTE]
 ====
 When integrity monitoring is enabled, you must not disable virtual trusted platform module (vTPM).
 ====
 
+<3> Specify whether UEFI Secure Boot is enabled. Valid values are `Disabled` or `Enabled`.
 <4> Specify whether vTPM is enabled. Valid values are `Disabled` or `Enabled`.
 --
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-8025](https://issues.redhat.com//browse/OSDOCS-8025)

Link to docs preview:
* Configuring trusted launch for Azure virtual machines by using machine sets
  * [For compute machines](https://65764--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-azure-trusted-launch_creating-machineset-azure)
  * [For control plane machines](https://65764--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-using#machineset-azure-trusted-launch_cpmso-using)
* Configuring Azure confidential virtual machines by using machine sets
  * [For compute machines](https://65764--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-azure.html#machineset-azure-confidential-vms_creating-machineset-azure)
  * [For control plane machines](https://65764--docspreview.netlify.app/openshift-enterprise/latest/machine_management/control_plane_machine_management/cpmso-using#machineset-azure-confidential-vms_cpmso-using)

QE review:
- [x] QE has approved this change.

Additional information:
[needs TP status](https://issues.redhat.com/browse/OCPSTRAT-366?focusedId=23272210&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23272210) for one or both