### PR TITLE
OSDOCS-3159: Update dedicated-admin privs and add additional resources

### DIFF
--- a/modules/rosa-sdpolicy-security.adoc
+++ b/modules/rosa-sdpolicy-security.adoc
@@ -30,6 +30,7 @@ In addition to normal users, {product-title} provides access to an {product-titl
 - Can add and manage `NetworkPolicy` objects.
 - Are able to view information about specific nodes and PVs in the cluster, including scheduler information.
 - Can access the reserved `dedicated-admin` project on the cluster, which allows for the creation of service accounts with elevated privileges and also gives the ability to update default limits and quotas for projects on the cluster.
+- Can install Operators from OperatorHub and perform all verbs in all `*.operators.coreos.com` API groups.
 
 [id="rosa-sdpolicy-cluster-admin-role_{context}"]
 == Cluster administration role

--- a/modules/sdpolicy-security.adoc
+++ b/modules/sdpolicy-security.adoc
@@ -30,6 +30,7 @@ In addition to normal users, {product-title} provides access to an {product-titl
 * Can add and manage `NetworkPolicy` objects.
 * Are able to view information about specific nodes and PVs in the cluster, including scheduler information.
 * Can access the reserved `dedicated-admin` project on the cluster, which allows for the creation of service accounts with elevated privileges and also gives the ability to update default limits and quotas for projects on the cluster.
+* Can install Operators from OperatorHub (`\*` verbs in all `*.operators.coreos.com` API groups).
 
 [id="cluster-admin-role_{context}"]
 == Cluster administration role

--- a/osd_getting_started/osd-getting-started.adoc
+++ b/osd_getting_started/osd-getting-started.adoc
@@ -49,6 +49,12 @@ include::modules/config-idp.adoc[leveloffset=+1]
 * For detailed steps to configure each of the supported identity provider types, see xref:../osd_install_access_delete_cluster/config-identity-providers.adoc#config-identity-providers[Configuring identity providers].
 
 include::modules/osd-grant-admin-privileges.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../osd_architecture/osd_policy/osd-service-definition.html#cluster-admin-user_osd-service-definition[Cluster administrator user]
+
 include::modules/access-cluster.adoc[leveloffset=+1]
 include::modules/deploy-app.adoc[leveloffset=+1]
 include::modules/scaling-cluster.adoc[leveloffset=+1]

--- a/osd_install_access_delete_cluster/config-identity-providers.adoc
+++ b/osd_install_access_delete_cluster/config-identity-providers.adoc
@@ -15,4 +15,10 @@ include::modules/config-google-idp.adoc[leveloffset=+1]
 include::modules/config-ldap-idp.adoc[leveloffset=+1]
 include::modules/config-openid-idp.adoc[leveloffset=+1]
 include::modules/config-htpasswd-idp.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../osd_architecture/osd_policy/osd-service-definition.html#cluster-admin-user_osd-service-definition[Cluster administrator user]
+
 include::modules/access-cluster.adoc[leveloffset=+1]

--- a/rosa_getting_started/rosa-getting-started.adoc
+++ b/rosa_getting_started/rosa-getting-started.adoc
@@ -61,6 +61,13 @@ include::modules/rosa-getting-started-configure-an-idp.adoc[leveloffset=+2]
 
 include::modules/rosa-getting-started-grant-user-access.adoc[leveloffset=+2]
 include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-cluster-admin-role_rosa-service-definition[Cluster administration role]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Cluster administrator user]
+
 include::modules/rosa-getting-started-access-cluster-web-console.adoc[leveloffset=+1]
 include::modules/deploy-app.adoc[leveloffset=+1]
 include::modules/rosa-getting-started-revoking-admin-privileges-and-user-access.adoc[leveloffset=+1]

--- a/rosa_getting_started/rosa-quickstart-guide-ui.adoc
+++ b/rosa_getting_started/rosa-quickstart-guide-ui.adoc
@@ -118,6 +118,11 @@ include::modules/rosa-getting-started-grant-user-access.adoc[leveloffset=+2]
 [discrete]
 include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+2]
 
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-cluster-admin-role_rosa-service-definition[Cluster administration role]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Cluster administrator user]
 
 //This content is pulled from rosa-getting-started-access-cluster-web-console.adoc
 include::modules/rosa-getting-started-access-cluster-web-console.adoc[leveloffset=+1]

--- a/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc
@@ -13,7 +13,18 @@ This document describes how to access a cluster and set up an IDP using the ROSA
 include::modules/rosa-accessing-your-cluster-quick.adoc[leveloffset=+1]
 include::modules/rosa-accessing-your-cluster.adoc[leveloffset=+1]
 include::modules/rosa-create-cluster-admins.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-cluster-admin-role_rosa-service-definition[Cluster administration role]
+
 include::modules/rosa-create-dedicated-cluster-admins.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Cluster administrator user]
 
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
[OSDOCS-3159]: Update description of dedicated-admin privileges

Version(s):
`enterprise-4.13+`

Issue:
https://issues.redhat.com/browse/OSDOCS-3159

Link to docs preview:
* ROSA: https://65765--docspreview.netlify.app/openshift-rosa/latest/rosa_architecture/rosa_policy_service_definition/rosa-service-definition#rosa-sdpolicy-customer-admin-user_rosa-service-definition
* OSD: https://65765--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition#cluster-admin-user_osd-service-definition

QE review:
- [ ] QE has approved this change.