### PR TITLE
OSDOCS-7858: Add FedRAMP firewall prerequisites for ROSA

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -1,7 +1,16 @@
 // Module included in the following assemblies:
 //
+// * osd_planning/aws-ccs.adoc
 // * rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
 // * rosa_planning/rosa-sts-aws-prereqs.adoc
+// * rosa_planning/rosa-hcp-prereqs.adoc
+
+ifeval::["{context}" == "rosa-sts-aws-prereqs"]
+:fedramp:
+endif::[]
+ifeval::["{context}" == "rosa-hcp-aws-prereqs"]
+:fedramp:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="osd-aws-privatelink-firewall-prerequisites_{context}"]
@@ -98,11 +107,26 @@ This section provides the necessary details that enable you to control egress tr
 |`catalog.redhat.com`
 |443
 |The `registry.access.redhat.com` and `https://registry.redhat.io` sites redirect through `catalog.redhat.com`.
+
+ifdef::fedramp[]
+|`time-a-g.nist.gov`
+|123 ^[2]^
+|Allows NTP traffic for FedRAMP.
+
+|`time-a-wwv.nist.gov`
+|123 ^[2]^
+|Allows NTP traffic for FedRAMP.
+
+|`time-a-b.nist.gov`
+|123 ^[2]^
+|Allows NTP traffic for FedRAMP.
+endif::fedramp[]
 |===
 +
 [.small]
 --
 1. In a firewall environment, ensure that the `access.redhat.com` resource is on the allowlist. This resource hosts a signature store that a container client requires for verifying images when pulling them from `registry.access.redhat.com`.
+2. Both TCP and UDP ports.
 --
 +
 When you add a site such as `quay.io` to your allowlist, do not add a wildcard entry such as `*.quay.io` to your denylist. In most cases, image registries use a content delivery network (CDN) to serve images. If a firewall blocks access, then image downloads are denied when the initial download request is redirected to a host name such as `cdn01.quay.io`.
@@ -293,3 +317,10 @@ The S3 endpoint should be in the following format:
 
 . Allowlist any site that provides resources for a language or framework that your builds require.
 . Allowlist any outbound URLs that depend on the languages and frameworks used in OpenShift. See link:https://access.redhat.com/solutions/2998411[OpenShift Outbound URLs to Allow] for a list of recommended URLs to be allowed on the firewall or proxy.
+
+ifeval::["{context}" == "rosa-sts-aws-prereqs"]
+:!fedramp:
+endif::[]
+ifeval::["{context}" == "rosa-hcp-aws-prereqs"]
+:!fedramp:
+endif::[]

--- a/rosa_planning/rosa-hcp-prereqs.adoc
+++ b/rosa_planning/rosa-hcp-prereqs.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 include::_attributes/attributes-openshift-dedicated.adoc[]
-:context: rosa-sts-aws-prereqs
+:context: rosa-hcp-aws-prereqs
 [id="rosa-hcp-prereqs"]
 = AWS prerequisites for {hcp-title}
 


### PR DESCRIPTION
[OSDOCS-7858](https://issues.redhat.com//browse/OSDOCS-7858): Add FedRAMP firewall prerequisites for ROSA

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7858

Link to docs preview:
ROSA Classic: https://65772--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
