### PR TITLE
OSDOCS 8020 fix a link that used an autogenerated anchor

### DIFF
--- a/modules/persistent-storage-csi-migration-vsphere.adoc
+++ b/modules/persistent-storage-csi-migration-vsphere.adoc
@@ -9,6 +9,7 @@
 == New installations of {product-title}
 For new installations of {product-title} 4.13, or later, automatic migration is enabled by default.
 
+[id="upgrading-openshift_{context}"]
 == Upgrading {product-title}
 When upgrading from {product-title} 4.12, or earlier, to 4.13, automatic CSI migration for vSphere only occurs if you opt in.
 

--- a/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
+++ b/storage/container_storage_interface/persistent-storage-csi-vsphere.adoc
@@ -30,7 +30,7 @@ For vSphere:
 +
 CSI automatic migration should be seamless. Migration does not change how you use all existing API objects, such as persistent volumes, persistent volume claims, and storage classes. For more information about migration, see xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#persistent-storage-csi-migration[CSI automatic migration].
 
-* When upgrading from {product-title} 4.12, or earlier, to 4.13, automatic CSI migration for vSphere only occurs if you opt in. If you do not opt in, {product-title} defaults to using the in-tree (non-CSI) plugin to provision vSphere storage. xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#upgrading-openshift-container-platform[Carefully review the indicated consequences before opting in to migration].
+* When upgrading from {product-title} 4.12, or earlier, to 4.13, automatic CSI migration for vSphere only occurs if you opt in. If you do not opt in, {product-title} defaults to using the in-tree (non-CSI) plugin to provision vSphere storage. xref:../../storage/container_storage_interface/persistent-storage-csi-migration.adoc#upgrading-openshift_persistent-storage-csi-migration[Carefully review the indicated consequences before opting in to migration].
 
 After full migration, in-tree plugins will eventually be removed in future versions of {product-title}.
 ====
@@ -55,14 +55,14 @@ include::modules/persistent-storage-csi-vsphere-install-issues.adoc[leveloffset=
 [id="vsphere-pv-encryption"]
 == vSphere persistent disks encryption
 
-You can encrypt virtual machines (VMs) and dynamically provisioned persistent volumes (PVs) on {product-title} running on top of vSphere. 
+You can encrypt virtual machines (VMs) and dynamically provisioned persistent volumes (PVs) on {product-title} running on top of vSphere.
 
 [NOTE]
 ====
 {product-title} does not support RWX-encrypted PVs. You cannot request RWX PVs out of a storage class that uses an encrypted storage policy.
 ====
 
-You must encrypt VMs before you can encrypt PVs, which you can do during installation or post-installation. 
+You must encrypt VMs before you can encrypt PVs, which you can do during installation or post-installation.
 
 For information about encrypting VMs, see:
 
@@ -74,9 +74,9 @@ For information about encrypting VMs, see:
 
 After encrypting VMs, you can configure a storage class that supports dynamic encryption volume provisioning using the vSphere Container Storage Interface (CSI) driver. This can be accomplished in one of two ways using:
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-encryption-datastore-url_persistent-storage-csi-vsphere[Datastore URL]: This approach is not very flexible, and forces you to use a single datastore. It also does not support topology-aware provisioning. 
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-encryption-datastore-url_persistent-storage-csi-vsphere[Datastore URL]: This approach is not very flexible, and forces you to use a single datastore. It also does not support topology-aware provisioning.
 
-* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-encryption-tag-based_persistent-storage-csi-vsphere[Tag-based placement]: Encrypts the provisioned volumes and uses tag-based placement to target specific datastores. 
+* xref:../../storage/container_storage_interface/persistent-storage-csi-vsphere.adoc#persistent-storage-csi-vsphere-encryption-tag-based_persistent-storage-csi-vsphere[Tag-based placement]: Encrypts the provisioned volumes and uses tag-based placement to target specific datastores.
 
 include::modules/persistent-storage-csi-vsphere-encryption-datastore-url.adoc[leveloffset=+2]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cp to enterprise-4.13 and enterprise-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
OSDOCS 8020

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- No QE

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

A link was using autogenerated anchors; this nonstandard solution was causing a validation error in the updated Portal scripts. The link now uses a standard anchor. No change to documentation content.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
