### PR TITLE
adding new get-updated-distros.sh script and updated Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,39 +13,32 @@ jobs:
       - CAN_FAIL=true
 
   include:
-    - stage: cache-and-validate
-      name: "Create install cache and validate updated assemblies"
+    - stage: validate-and-build
+      name: "Validate and build"
       install:
         - gem install asciidoctor asciidoctor-diagram rouge
         - pip3 install pyyaml aura.tar.gz
       script:
-        # Fail if Asciidoctor encounters errors. Pass otherwise.
+        # Fail if Asciidoctor encounters errors. Pass otherwise. Then, build updated distros
         - chmod +x ./scripts/check-asciidoctor-build.sh
+        - chmod +x ./scripts/get-updated-distros.sh
         - ./scripts/check-asciidoctor-build.sh || travis_terminate 1
+        - |
+          ./scripts/get-updated-distros.sh |
+            while read -r filename; do
+              if [ "$filename" == "_topic_maps/_topic_map.yml" ]; then python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.14 --no-upstream-fetch
 
-    - stage: build
-      if: branch IN (main, enterprise-4.13, enterprise-4.14)
-      name: "Build openshift-enterprise distro"
-      script:
-        - python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.14 --no-upstream-fetch && python3 makeBuild.py
+              elif [ "$filename" == "_topic_maps/_topic_map_osd.yml" ]; then python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch
 
-    - # stage name not required, will continue to use `build`
-      if: branch IN (main, enterprise-4.13, enterprise-4.14)
-      name: "Build openshift-dedicated distro"
-      script:
-        - python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch && python3 makeBuild.py
+              elif [ "$filename" == "_topic_maps/_topic_map_ms.yml" ]; then python3 build.py --distro microshift --product "Microshift" --version 4 --no-upstream-fetch
 
-    - # stage name not required, will continue to use `build`
-      if: branch IN (main, enterprise-4.13, enterprise-4.14)
-      name: "Build openshift-rosa distro"
-      script:
-        - python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch && python3 makeBuild.py
+              elif [ "$filename" == "_topic_maps/_topic_map_rosa.yml" ]; then python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch
 
-    - # stage name not required, will continue to use `build`
-      if: branch IN (main, enterprise-4.13, enterprise-4.14)
-      name: "Build microshift distro"
-      script:
-        - python3 build.py --distro microshift --product "Microshift" --version 4 --no-upstream-fetch && python3 makeBuild.py
+              elif [ "$filename" == "_distro_map.yml" ]; then python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.14 --no-upstream-fetch
+              fi
+            done
+
+          if [ -d "drupal-build" ]; then python3 makeBuild.py; fi
 
     # Remove Vale stage until PR commenting feature is ready
     # - stage: check-with-vale
@@ -78,8 +71,7 @@ jobs:
         - ./autopreview.sh
 
 stages:
-  - cache-and-validate
-  - build
   - netlify
+  - validate-and-build
   #- check-with-vale
   #- automerge

--- a/scripts/get-updated-distros.sh
+++ b/scripts/get-updated-distros.sh
@@ -1,0 +1,47 @@
+#!/bin/bash
+
+# Returns a list of updated _topic_map.yml files.
+# The list includes any topic maps that are themselves modified, and indirectly modifed topic maps where incldued AsciiDoc files have been updated.
+
+# Get the *.adoc and distro maps files in the pull request
+FILES=$(git diff --name-only HEAD HEAD~$(git rev-list --count --no-merges origin/main..) --diff-filter=d "*.yml" "*.adoc" ':(exclude)_unused_topics/*')
+REPO_PATH=$(git rev-parse --show-toplevel)
+# Init an empty array
+DISTROS=()
+
+# Get the modules in the PR, search for assemblies that include them, and concat with any updated assemblies files
+
+MODULES=$(echo "$FILES" | awk '/modules\/(.*)\.adoc/')
+if [ "${MODULES}" ]
+then
+    # $UPDATED_ASSEMBLIES is the list of assemblies that contains changed modules
+    UPDATED_ASSEMBLIES=$(grep -rnwl "$REPO_PATH" --include=\*.adoc --exclude-dir={snippets,modules} -e "$MODULES")
+    # Exit 0 if there are no modified assemblies
+    if [[ -z "${UPDATED_ASSEMBLIES}" ]]
+    then
+        exit 0
+    fi
+    # Subtract $REPO_PATH from path with bash substring replacement
+    UPDATED_ASSEMBLIES=${UPDATED_ASSEMBLIES//"$REPO_PATH/"/}
+fi
+# ASSEMBLIES is the list of modifed assemblies
+ASSEMBLIES=$(echo "$FILES" | awk '!/modules\/(.*)\.adoc/')
+# Concatenate both lists and remove dupe entries
+ALL_ASSEMBLIES=$(echo "$UPDATED_ASSEMBLIES $ASSEMBLIES" | tr ' ' '\n' | sort -u)
+# Check that assemblies are in a topic_map
+for ASSEMBLY in $ALL_ASSEMBLIES; do
+    # Get the page name to search the topic_map
+    # Search for files only, not folders
+    PAGE="File: $(basename "$ASSEMBLY" .adoc)"
+    # Don't include the assembly if it is not in a topic map
+    if grep -rq "$PAGE" --include "*.yml" _topic_maps ; then
+        DISTROS+=("$(grep -rl "$PAGE" --include "*.yml" _topic_maps)")
+    fi
+done
+
+# Handle modified topic maps  
+UPDATED_DISTROS=$(echo "$FILES" | awk '/_topic_maps\/(.*)\.yml/')
+# Concat all the updated topic maps
+DISTROS+=("${UPDATED_DISTROS}")
+# Clean up and remove duplicates
+echo "${DISTROS[@]}" | tr ' ' '\n' | sort | uniq


### PR DESCRIPTION
Updates Travs to run against modified distro maps only.

Merge to main, CP 4.10+

Build when no adoc or yml is modified (portal build is skipped entirely):
https://app.travis-ci.com/github/openshift/openshift-docs/jobs/611142849

Build when ROSA yml is modified (ROSA portal build only):
https://app.travis-ci.com/github/openshift/openshift-docs/jobs/611143430

Build when ROSA adoc is modified (ROSA portal build only):
https://app.travis-ci.com/github/openshift/openshift-docs/jobs/611143730

Build when adoc included in multiple distros is modified (multiple distros built):
https://app.travis-ci.com/github/openshift/openshift-docs/jobs/611149763

Updated to handle multiple commits:
https://app.travis-ci.com/github/openshift/openshift-docs/jobs/611302682



