### PR TITLE
installer-ibm-name-fixed

### DIFF
--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -13,7 +13,7 @@ In {product-title} {product-version}, you can install a cluster that uses instal
 * Amazon Web Services (AWS)
 * Bare metal
 * Google Cloud Platform (GCP)
-* IBM Cloud&#174 VPC
+* IBM Cloud&#174; VPC
 * Microsoft Azure
 * Microsoft Azure Stack Hub
 * Nutanix


### PR DESCRIPTION
[INTERNAL FIX]

Follow up from https://github.com/openshift/openshift-docs/pull/65304 . Tiny fix for main and 4.14.

Link to docs preview:
[Supported platforms for OpenShift Container Platform clusters](https://65782--docspreview.netlify.app/openshift-enterprise/latest/installing/#supported-platforms-for-openshift-clusters_ocp-installation-overview)
