### PR TITLE
OCPBUGS-11520: Remove Grafana from reference config

### DIFF
--- a/modules/ztp-sno-du-reducing-resource-usage-with-cluster-monitoring.adoc
+++ b/modules/ztp-sno-du-reducing-resource-usage-with-cluster-monitoring.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: CONCEPT
 [id="ztp-sno-du-reducing-resource-usage-with-cluster-monitoring_{context}"]
-= Grafana and Alertmanager
+= Alertmanager
 
-{sno-caps} clusters that run DU workloads require reduced CPU resources consumed by the {product-title} monitoring components. The following `ConfigMap` custom resource (CR) disables Grafana and Alertmanager.
+{sno-caps} clusters that run DU workloads require reduced CPU resources consumed by the {product-title} monitoring components. The following `ConfigMap` custom resource (CR) disables Alertmanager.
 
 .Recommended cluster monitoring configuration (ReduceMonitoringFootprint.yaml)
 [source,yaml]

--- a/snippets/ztp_ReduceMonitoringFootprint.yaml
+++ b/snippets/ztp_ReduceMonitoringFootprint.yaml
@@ -7,8 +7,6 @@ metadata:
     ran.openshift.io/ztp-deploy-wave: "1"
 data:
   config.yaml: |
-    grafana:
-      enabled: false
     alertmanagerMain:
       enabled: false
     prometheusK8s:


### PR DESCRIPTION
OCPBUGS-11520: Grafana no longer part of OCP monitoring stack

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-11520

Link to docs preview:
https://65788--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-reference-cluster-configuration-for-vdu#ztp-sno-du-reducing-resource-usage-with-cluster-monitoring_sno-configure-for-vdu

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
