### PR TITLE
[OSDOCS-7407]:CSI drivers NOT installed by default

### DIFF
--- a/modules/persistent-storage-csi-drivers-supported.adoc
+++ b/modules/persistent-storage-csi-drivers-supported.adoc
@@ -9,12 +9,25 @@
 
 To create CSI-provisioned persistent volumes that mount to these supported storage assets, {product-title} installs the necessary CSI driver Operator, the CSI driver, and the required storage class by default. For more details about the default namespace of the Operator and driver, see the documentation for the specific CSI Driver Operator.
 
-The following table describes the CSI drivers that are installed with {product-title} and which CSI features they support, such as volume snapshots, cloning, and resize.
+ifndef::openshift-rosa[]
+[IMPORTANT]
+====
+The AWS EFS and GCP Filestore CSI drivers are not installed by default, and must be installed manually. For instructions on installing the AWS EFS CSI driver, see link:https://access.redhat.com/documentation/en-us/openshift_dedicated/4/html/storage/using-container-storage-interface-csi#osd-persistent-storage-aws-efs-csi[Setting up AWS Elastic File Service CSI Driver Operator]. For instructions on installing the GCP Filestore CSI driver, see link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html/storage/using-container-storage-interface-csi#persistent-storage-csi-google-cloud-file-overview[Google Compute Platform Filestore CSI Driver Operator].
+====
+endif::openshift-rosa[]
+The following table describes the CSI drivers that are
+ifndef::openshift-dedicated[]
+installed with {product-title}
+endif::openshift-dedicated[]
+ifndef::openshift-rosa[]
+supported by {product-title}
+endif::openshift-rosa[]
+and which CSI features they support, such as volume snapshots and resize.
 
 .Supported CSI drivers and features in {product-title}
 [cols=",^v,^v,^v,^v,^v width="100%",options="header"]
 |===
-|CSI driver |CSI volume snapshots  |CSI cloning  |CSI resize |  inline ephemeral volumes
+|CSI driver |CSI volume snapshots  |CSI cloning  |CSI resize |Inline ephemeral volumes
 ifndef::openshift-dedicated,openshift-rosa[]
 |AliCloud Disk | ✅ | - | ✅ | -
 endif::openshift-dedicated,openshift-rosa[]
@@ -25,7 +38,7 @@ ifndef::openshift-rosa[]
 |GCP Filestore | ✅ | - | ✅| -
 endif::openshift-rosa[]
 ifndef::openshift-dedicated,openshift-rosa[]
-|{ibmpowerProductName} Virtual Server Block | - | - | ✅ | - 
+|{ibmpowerProductName} Virtual Server Block | - | - | ✅ | -
 |IBM VPC Block | ✅^[3]^ | - | ✅^[3]^| -
 |Microsoft Azure Disk | ✅ | ✅ | ✅| -
 |Microsoft Azure Stack Hub | ✅ | ✅ | ✅| -


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-7407
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://65796--docspreview.netlify.app/openshift-dedicated/latest/storage/container_storage_interface/persistent-storage-csi#csi-drivers-supported_persistent-storage-csi
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
