### PR TITLE
[enterprise-4.12] OCPBUGS#18842: remove only from rollback admonition

### DIFF
--- a/modules/nw-ovn-kubernetes-rollback.adoc
+++ b/modules/nw-ovn-kubernetes-rollback.adoc
@@ -11,7 +11,7 @@ During the rollback, you must reboot every node in your cluster.
 
 [IMPORTANT]
 ====
-Only rollback to OpenShift SDN if the migration to OVN-Kubernetes fails.
+Rollback to OpenShift SDN if the migration to OVN-Kubernetes fails.
 ====
 
 .Prerequisites
@@ -112,7 +112,7 @@ The MTU for the VXLAN overlay network. This value is normally configured automat
 The UDP port for the VXLAN overlay network. If a value is not specified, the default is `4789`. The port cannot be the same as the Geneve port that is used by OVN-Kubernetes. The default value for the Geneve port is `6081`.
 --
 +
-.Example patch command 
+.Example patch command
 [source,terminal]
 ----
 $ oc patch Network.operator.openshift.io cluster --type=merge \


### PR DESCRIPTION
Version(s):
4.12

Issue:
Manual cherry-pick of https://github.com/openshift/openshift-docs/pull/65525

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- N/A

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
