### PR TITLE
Exclude new Vale rule for module TOC from assemblies

### DIFF
--- a/.vale.ini
+++ b/.vale.ini
@@ -26,3 +26,4 @@ OpenShiftAsciiDoc.ModuleContainsParentAssemblyComment = NO
 OpenShiftAsciiDoc.NoNestingInModules = NO
 OpenShiftAsciiDoc.NoXrefInModules = NO
 OpenShiftAsciiDoc.IdHasContextVariable = NO
+OpenShiftAsciiDoc.NoTocInModules = NO


### PR DESCRIPTION
A new Vale rule checks to ensure you don't put a `toc::[]` in a module: https://github.com/redhat-documentation/vale-at-red-hat/pull/661

This commit excludes this rule from assemblies by editing the top-level Vale config file that is used by assemblies.

Version(s):
main
