### PR TITLE
OSDOCS#6401: Multi-arch compute machines 4.14 release note

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -140,6 +140,10 @@ Before you set a path value for the `template` parameter, ensure that the defaul
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration
 
+[id="ocp-4-14-OCP-on-multi-arch-clusters"]
+==== {product-title} cluster with multi-architecture compute machines 
+{product-title} {product-version} clusters with multi-architecture compute machines are now supported on Google Cloud Platform (GCP) as a Day 2 operation. {product-title} clusters with multi-architecture compute machines on bare metal installations are now generally available. For more information on clusters with multi-architecture compute machines and supported platforms, see xref:../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc#multi-architecture-configuration[About clusters with multi-architecture compute machines].
+
 [id="ocp-4-14-web-console"]
 === Web console
 


### PR DESCRIPTION
**Version:** 4.14
**Issue:** [OSDOCS-6401](https://issues.redhat.com//browse/OSDOCS-6401) 

**Link to docs preview:**

- [Post installation configuration -> OpenShift container platform clusters with multi-architecture compute machines](https://65825--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-post-installation)

**QE review:**
- [x] QE approval

