### PR TITLE
[OCPBUGS-18984]: Release note for changes to etcd backup trigger

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -572,6 +572,14 @@ If you are receiving pod security violations, see the following resources:
 
 The {cert-manager-operator} 1.11 is now generally available in {product-title} 4.14 as well as {product-title} 4.13 and {product-title} 4.12.
 
+[discrete]
+[id="ocp-4-14-triggered-updates-for-etcd-backups"]
+=== Updates to z releases no longer require an etcd backup
+
+An earlier link:https://github.com/openshift/cluster-etcd-operator/pull/835[bug fix] introduced a backup trigger on every z release. However, the Cluster Version Operator (CVO) logic was not updated along with that bug fix, and as a result, the update process did not stop until an etcd snapshot was taken. This behavior affected versions 4.10 and later.
+
+//lahinson - oct. 2023 - when I have more information about automated backups, mention that functionality here.
+
 [id="ocp-4-14-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-18984
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://65835--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-notable-technical-changes (scroll to the "Updates to z releases no longer require an etcd backup" section)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
