### PR TITLE
Nodes hiding Graceful Node Shutdown docs

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2330,8 +2330,9 @@ Topics:
     File: nodes-nodes-working
   - Name: Managing nodes
     File: nodes-nodes-managing
-  - Name: Managing graceful node shutdown
-    File: nodes-nodes-graceful-shutdown
+# Hiding this assembly per @rphillips: "We are trying to enable the feature, but there are cases we are running into where networking does not get enabled at boot."
+#  - Name: Managing graceful node shutdown
+#    File: nodes-nodes-graceful-shutdown
   - Name: Managing the maximum number of pods per node
     File: nodes-nodes-managing-max-pods
   - Name: Using the Node Tuning Operator


### PR DESCRIPTION
Removing the _Graceful node shutdown_ feature, as not supported. 

https://issues.redhat.com/browse/OCPBUGS-17478

[Current docs](https://docs.openshift.com/container-platform/4.13/nodes/nodes/nodes-nodes-graceful-shutdown.html) -- _Managing graceful node shutdown_ assembly, after _Managing nodes_.
[Preview](https://65842--docspreview.netlify.app/openshift-enterprise/latest/nodes/nodes/nodes-nodes-managing) -- _Managing graceful node shutdown_ assembly after _Managing nodes_ removed.

QE review: No QE review needed

Docs not [used in console](https://github.com/openshift/console/blob/master/frontend/public/components/utils/documentation.tsx#L27-L87).