### PR TITLE
Nodes hiding Graceful Node Shutdown release note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1155,6 +1155,9 @@ Enabling the `TechPreviewNoUpgrade` feature set on your cluster cannot be undone
 
 For more information, see xref:../nodes/pods/nodes-pods-configuring.adoc#pod-disruption-eviction-policy_nodes-pods-configuring[Specifying the eviction policy for unhealthy pods].
 
+////
+Hiding this release note per @rphillips: "We are trying to enable the feature, but there are cases we are running into where networking does not get enabled at boot."
+
 [id="ocp-4-13-graceful-node-shutdown"]
 ==== Support for graceful node shutdown
 
@@ -1163,6 +1166,7 @@ A graceful node shutdown delays the eviction of pods during a node shutdown. In 
 To configure graceful node shutdowns, you can specify a termination grace period for regular and critical pods in the `KubeletConfig` custom resource. A termination grace period defines a time period for the pod to complete any ongoing tasks before terminating. You can also add priority classes to pods to specify the order of termination.
 
 For further information see xref:../nodes/nodes/nodes-nodes-graceful-shutdown.adoc#nodes-nodes-graceful-shutdown[Managing graceful node shutdown].
+////
 
 [id="ocp-4-13-metal3-remediation-support"]
 ==== Metal3 remediation support


### PR DESCRIPTION
Removing the Graceful node shutdown feature from Release Notes, as not supported.

https://issues.redhat.com/browse/OCPBUGS-17478

[Current docs](https://docs.openshift.com/container-platform/4.13/release_notes/ocp-4-13-release-notes.html#ocp-4-13-pdb-eviction-policy) -- Graceful shutdown release note, right after Pod Disruption Budget release note.
[Preview](https://65843--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-pdb-eviction-policy) Release note after PDB removed.

QE review: No QE review needed

[PR to remove graceful node shutdown from docs](https://github.com/openshift/openshift-docs/pull/65842).