### PR TITLE
OSDOCS-8014: Admin Network Policy as Tech Preview release note

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -304,9 +304,16 @@ For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-no
 [id="ocp-414-broadcom-bcm57504-support"]
 ==== Support for Broadcom BCM57504 is now GA
 
-Support for the Broadcom BCM57504 network interface controller is now available for the SR-IOV Network Operator. 
+Support for the Broadcom BCM57504 network interface controller is now available for the SR-IOV Network Operator.
 
 For more information, see xref:../networking/hardware_networks/about-sriov.adoc#supported-devices_about-sriov[Supported devices].
+
+[id="ocp-4-14-admin-network-policy"]
+==== Admin Network Policy (Technology Preview)
+
+Admin Network Policy is available as a Technology Preview feature.
+
+You can enable `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` resources, which are part of the Network Policy V2 API, in clusters running the OVN-Kubernetes CNI plugin. Cluster administrators can apply cluster-scoped policies and safeguards for an entire cluster before namespaces are created. Network administrators can secure clusters by enforcing network traffic controls that cannot be overridden by users. Network administrators can enforce optional baseline network traffic controls that can be overridden by users in the cluster, if necessary. Currently, these APIs support only expressing policies for intra-cluster traffic.
 
 [id="ocp-4-14-storage"]
 === Storage
@@ -325,7 +332,7 @@ With this release, the logical volume manager (LVM) cluster custom resource (CR)
 === Registry
 
 [id="ocp-4-14-optional-image-registry-operator"]
-==== Optional Image Registry Operator 
+==== Optional Image Registry Operator
 
 With this release, the Image Registry Operator is now an optional component. This feature helps reduce the overall resources footprint of {product-title} in Telco environments when the Image Registry Operator is not needed.
 
@@ -1126,6 +1133,11 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |VRF specification in `NodeNetworkConfigurationPolicy` custom resource
+|Not Available
+|Not Available
+|Technology Preview
+
+|Admin Network Policy (`AdminNetworkPolicy`)
 |Not Available
 |Not Available
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8014

Links to docs previews:

Feature description - https://65846--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-admin-network-policy

Tech Preview table update - https://65846--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-technology-preview

QE already approved this language in the sister PR https://github.com/openshift/openshift-docs/pull/65682
