### PR TITLE
MIG-1449: Release notes catch-up for 4.11

### DIFF
--- a/migration_toolkit_for_containers/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/mtc-release-notes.adoc
@@ -17,6 +17,18 @@ You can migrate from xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
 include::modules/migration-mtc-release-notes-1-8.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-12.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-11.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-10.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-09.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-08.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-07.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-06.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-05.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-04.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-03.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-02.adoc[leveloffset=+1]
+include::modules/migration-mtc-release-notes-1-7-01.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-6.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-5.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-7-01.adoc
+++ b/modules/migration-mtc-release-notes-1-7-01.adoc
@@ -1,0 +1,35 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-01_{context}"]
+= {mtc-full} 1.7.1 release notes
+
+[id="resolved-issues-1-7-01_{context}"]
+== Resolved issues
+
+There are no major resolved issues in this release.
+
+[id="known-issues-1-7-01_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+.Incorrect DNS validation for destination namespace
+MigPlan cannot be validated because the destination namespace starts with a non-alphabetic character. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102231[*BZ#2102231*])
+
+.Cloud propagation phase in migration controller is not functioning due to missing labels on Velero pods
+The Cloud propagation phase in the migration controller is not functioning due to missing labels on Velero pods. The `EnsureCloudSecretPropagated` phase in the migration controller waits until replication repository secrets are propagated on both sides. As this label is missing on Velero pods, the phase is not functioning as expected. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2088026[*BZ#2088026*])
+
+.Default CPU requests on Velero/Restic are too demanding when making scheduling fail in certain environments
+Default CPU requests on Velero/Restic are too demanding when making scheduling fail in certain environments. Default CPU requests for Velero and Restic Pods are set to 500m. These values are high. The resources can be configured in DPA using the `podConfig` field for Velero and Restic. Migration operator should set CPU requests to a lower value, such as 100m, so that Velero and Restic pods can be scheduled in resource constrained environments MTC often operates in. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2088022[*BZ#2088022*])
+
+.Warning is displayed on persistentVolumes page after editing storage class conversion plan
+A warning is displayed on the *persistentVolumes* page after editing the storage class conversion plan. When editing the existing migration plan, a warning is displayed on the UI `At least one PVC must be selected for Storage Class Conversion`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2079549[*BZ#2079549*])
+
+.Velero pod log missing from downloaded logs
+When downloading a compressed (.zip) folder for all logs, the velero pod is missing. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076599[*BZ#2076599*])
+
+.Velero pod log missing from UI drop down
+After a migration is performed, the velero pod log is not included in the logs provided in the dropdown list. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076593[*BZ#2076593*])

--- a/modules/migration-mtc-release-notes-1-7-02.adoc
+++ b/modules/migration-mtc-release-notes-1-7-02.adoc
@@ -1,0 +1,62 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-02_{context}"]
+= {mtc-full} 1.7.2 release notes
+
+[id="resolved-issues-1-7-02_{context}"]
+== Resolved issues
+
+This release has the following major resolved issues:
+
+.MTC UI does not display logs correctly
+In previous releases, the MTC UI did not display logs correctly. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2062266[*BZ#2062266*])
+
+.StorageClass conversion plan adding migstorage reference in migplan
+In previous releases, StorageClass conversion plans had a `migstorage` reference even though it was not being used. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2078459[*BZ#2078459*])
+
+.Velero pod log missing from downloaded logs
+In previous releases, when downloading a compressed (.zip) folder for all logs, the velero pod was missing. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076599[*BZ#2076599*])
+
+.Velero pod log missing from UI drop down
+In previous releases, after a migration was performed, the velero pod log was not included in the logs provided in the dropdown list. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2076593[*BZ#2076593*])
+
+.Rsync options logs not visible in log-reader pod
+In previous releases, when trying to set any valid or invalid rsync options in the `migrationcontroller`, the log-reader was not showing any logs regarding the invalid options or about the rsync command being used. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2079252[*BZ#2079252*])
+
+.Default CPU requests on Velero/Restic are too demanding and fail in certain environments
+In previous releases, the default CPU requests on Velero/Restic were too demanding and fail in certain environments. Default CPU requests for Velero and Restic Pods are set to 500m. These values were high. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2088022[*BZ#2088022*])
+
+
+
+
+[id="known-issues-1-7-02_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+.Updating the replication repository to a different storage provider type is not respected by the UI
+After updating the replication repository to a different type and clicking *Update Repository*, it shows connection successful, but the UI is not updated with the correct details. When clicking on the *Edit* button again, it still shows the old replication repository information.
+
+Furthermore, when trying to update the replication repository again, it still shows the old replication details. When selecting the new repository, it also shows all the information you entered previously and the *Update repository* is not enabled, as if there are no changes to be submitted. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102020[*BZ#2102020*])
+
+.Migrations fails because the backup is not found
+Migration fails at the restore stage because of initial backup has not been found. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2104874[*BZ#2104874*])
+
+.Update Cluster button is not enabled when updating Azure resource group
+When updating the remote cluster, selecting the *Azure resource group* checkbox, and adding a resource group does not enable the *Update cluster* option. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2098594[*BZ#2098594*])
+
+.Error pop-up in UI on deleting migstorage resource
+When creating a `backupStorage` credential secret in {OCP}, if the `migstorage` is removed from the UI, a 404 error is returned and the underlying secret is not removed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2100828[*BZ#2100828*])
+
+.Miganalytic resource displaying resource count as 0 in UI
+After creating a migplan from backend, the Miganalytic resource displays the resource count as `0` in UI. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102139[*BZ#2102139*])
+
+.Registry validation fails when two trailing slashes are added to the Exposed route host to image registry
+After adding two trailing slashes, meaning `//`, to the exposed registry route, the MigCluster resource is showing the status as `connected`. When creating a migplan from backend with DIM, the plans move to the `unready` status. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2104864[*BZ#2104864*])
+
+.Service Account Token not visible while editing source cluster
+When editing the source cluster that has been added and is in *Connected* state, in the UI, the service account token is not visible in the field. To save the wizard, you have to fetch the token again and provide details inside the field. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2097668[*BZ#2097668*])
+

--- a/modules/migration-mtc-release-notes-1-7-03.adoc
+++ b/modules/migration-mtc-release-notes-1-7-03.adoc
@@ -1,0 +1,26 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-03_{context}"]
+= {mtc-full} 1.7.3 release notes
+
+[id="resolved-issues-1-7-03_{context}"]
+== Resolved issues
+
+This release has the following major resolved issues:
+
+.Correct DNS validation for destination namespace
+In previous releases, the MigPlan could not  be validated if the destination namespace started with a non-alphabetic character. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102231[*BZ#2102231*])
+
+.Deselecting all PVCs from UI still results in an attempted PVC transfer
+In previous releases, while doing a full migration, unselecting the persistent volume claims (PVCs) would not skip selecting the PVCs and still try to migrate them. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2106073[*BZ#2106073*])
+
+.Incorrect DNS validation for destination namespace
+In previous releases, MigPlan could not be validated because the destination namespace started with a non-alphabetic character. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2102231[*BZ#2102231*])
+
+[id="known-issues-1-7-03_{context}"]
+== Known issues
+
+There are no known issues in this release.

--- a/modules/migration-mtc-release-notes-1-7-04.adoc
+++ b/modules/migration-mtc-release-notes-1-7-04.adoc
@@ -1,0 +1,20 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-04_{context}"]
+= {mtc-full} 1.7.4 release notes
+
+[id="resolved-issues-1-7-04_{context}"]
+== Resolved issues
+
+There are no major resolved issues in this release.
+
+
+[id="known-issues-1-7-04_{context}"]
+== Known issues
+
+.Rollback missing out deletion of some resources from the target cluster
+On performing the roll back of an application from the MTC UI, some resources are not being deleted from the target cluster and the roll back is showing a status as successfully completed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2126880[*BZ#2126880*])
+

--- a/modules/migration-mtc-release-notes-1-7-05.adoc
+++ b/modules/migration-mtc-release-notes-1-7-05.adoc
@@ -1,0 +1,27 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-05_{context}"]
+= {mtc-full} 1.7.5 release notes
+
+[id="resolved-issues-1-7-05_{context}"]
+== Resolved issues
+
+This release has the following major resolved issue:
+
+.Direct Volume Migration is failing as rsync pod on source cluster move into Error state
+In previous release, migration succeeded with warnings but Direct Volume Migration failed with rsync pod on source namespace going into error state. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2132978[**BZ#2132978*])
+
+
+[id="known-issues-1-7-05_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+.Velero image cannot be overridden in the MTC operator
+In previous releases, it was not possible to override the velero image using the `velero_image_fqin` parameter in the `MigrationController` Custom Resource (CR). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2143389[*BZ#2143389*])
+
+.When editing a MigHook in the UI, the page might fail to reload
+The UI might fail to reload when editing a hook if there is a network connection issue. After the network connection is restored, the page will fail to reload until the cache is cleared. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2140208[*BZ#2140208*])

--- a/modules/migration-mtc-release-notes-1-7-06.adoc
+++ b/modules/migration-mtc-release-notes-1-7-06.adoc
@@ -1,0 +1,30 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-06_{context}"]
+= {mtc-full} 1.7.6 release notes
+
+[id="new-features-1-7-6_{context}"]
+== New features
+
+.Implement proposed changes for DVM support with PSA in Red Hat OpenShift Container Platform 4.12
+With the incoming enforcement of Pod Security Admission (PSA) in {OCP} 4.12 the default pod would run with a `restricted` profile. This `restricted` profile would mean workloads to migrate would be in violation of this policy and no longer work as of now. The following enhancement outlines the changes that will be required to remain compatible with OCP 4.12. (link:https://issues.redhat.com/browse/MIG-1240[*MIG-1240*])
+
+[id="resolved-issues-1-7-06_{context}"]
+== Resolved issues
+
+This release has the following major resolved issue:
+
+.Unable to create Storage Class Conversion plan due to missing cronjob error in Red Hat OpenShift Platform 4.12
+In previous releases, on the persistent volumes page, an error is thrown that a CronJob is not available in version `batch/v1beta1`, and when clicking on cancel, the migplan is created with status `Not ready`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2143628[*BZ#2143628*])
+
+
+[id="known-issues-1-7-06_{context}"]
+== Known issues
+
+This release has the following known issue:
+
+.Conflict conditions are cleared briefly after they are created
+When creating a new state migration plan that will result in a conflict error, that error is cleared shorty after it is displayed. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2144299[*BZ#2144299*])

--- a/modules/migration-mtc-release-notes-1-7-07.adoc
+++ b/modules/migration-mtc-release-notes-1-7-07.adoc
@@ -1,0 +1,18 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-07_{context}"]
+= {mtc-full} 1.7.7 release notes
+
+[id="resolved-issues-1-7-07_{context}"]
+== Resolved issues
+
+There are no major resolved issues in this release.
+
+[id="known-issues-1-7-07_{context}"]
+== Known issues
+
+There are no known issues in this release.
+

--- a/modules/migration-mtc-release-notes-1-7-08.adoc
+++ b/modules/migration-mtc-release-notes-1-7-08.adoc
@@ -1,0 +1,30 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-08_{context}"]
+= {mtc-full} 1.7.8 release notes
+
+[id="resolved-issues-1-7-08_{context}"]
+== Resolved issues
+
+This release has the following major resolved issues:
+
+.Velero image cannot be overridden in the MTC operator
+In previous releases, it was not possible to override the velero image using the `velero_image_fqin` parameter in the `MigrationController` Custom Resource (CR). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2143389[*BZ#2143389*])
+
+.Adding a MigCluster from the UI fails when the domain name has more than six characters
+In previous releases, adding a MigCluster from the UI failed when the domain name had more than six characters. The UI code expected a domain name of between two and six characters. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2152149[*BZ#2152149*])
+
+.UI fails to render the Migrations' page: Cannot read properties of undefined (reading 'name')
+In previous releases, the UI failed to render the Migrations' page, returning `Cannot read properties of undefined (reading 'name')`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2163485[*BZ#2163485*])
+
+.Creating DPA resource fails on Red Hat OpenShift Container Platform 4.6 clusters
+In previous releases, when deploying MTC on an {OCP} 4.6 cluster, the DPA failed to be created according to the logs, which resulted in some pods missing. From the logs in the migration-controller in the OCP 4.6 cluster, it indicated that an unexpected `null` value was passed, which caused the error. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2173742[*BZ#2173742*])
+
+[id="known-issues-1-7-08_{context}"]
+== Known issues
+
+There are no known issues in this release.
+

--- a/modules/migration-mtc-release-notes-1-7-09.adoc
+++ b/modules/migration-mtc-release-notes-1-7-09.adoc
@@ -1,0 +1,22 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-09_{context}"]
+= {mtc-full} 1.7.9 release notes
+
+[id="resolved-issues-1-7-09_{context}"]
+== Resolved issues
+
+There are no major resolved issues in this release.
+
+
+[id="known-issues-1-7-09_{context}"]
+== Known issues
+
+This release has the following known issue:
+
+.Adjust rsync options in DVM
+
+In this release, users are unable to prevent absolute symlinks from being manipulated by rsync during direct volume migration (DVM). (link:https://bugzilla.redhat.com/show_bug.cgi?id=2204461[*BZ#2204461*])

--- a/modules/migration-mtc-release-notes-1-7-10.adoc
+++ b/modules/migration-mtc-release-notes-1-7-10.adoc
@@ -1,0 +1,23 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-10_{context}"]
+= {mtc-full} 1.7.10 release notes
+
+[id="resolved-issues-1-7-10_{context}"]
+== Resolved issues
+
+This release has the following major resolved issue:
+
+.Adjust rsync options in DVM
+
+In this release, you can prevent absolute symlinks from being manipulated by Rsync in the course of direct volume migration (DVM). Running DVM in privileged mode preserves absolute symlinks inside the persistent volume claims (PVCs). To switch to privileged mode, in the `MigrationController` CR, set the `migration_rsync_privileged` spec to `true`. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2204461[*BZ#2204461*])
+
+[id="known-issues-1-7-10_{context}"]
+== Known issues
+
+There are no known issues in this release.
+
+

--- a/modules/migration-mtc-release-notes-1-7-11.adoc
+++ b/modules/migration-mtc-release-notes-1-7-11.adoc
@@ -1,0 +1,19 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-11_{context}"]
+= {mtc-full} 1.7.11 release notes
+
+[id="resolved-issues-1-7-11_{context}"]
+== Resolved issues
+
+There are no major resolved issues in this release.
+
+[id="known-issues-1-7-11_{context}"]
+== Known issues
+
+There are no known issues in this release.
+
+

--- a/modules/migration-mtc-release-notes-1-7-12.adoc
+++ b/modules/migration-mtc-release-notes-1-7-12.adoc
@@ -1,0 +1,26 @@
+
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_content-type: REFERENCE
+[id="migration-mtc-release-notes-1-7-12_{context}"]
+= {mtc-full} 1.7.12 release notes
+
+[id="resolved-issues-1-7-12_{context}"]
+== Resolved issues
+
+There are no major resolved issues in this release.
+
+
+[id="known-issues-1-7-12_{context}"]
+== Known issues
+
+This release has the following known issues:
+
+.Error code 504 is displayed on the Migration details page
+
+On the *Migration details* page, at first, the `migration details` are displayed without any issues. However, after sometime, the details disappear, and a `504` error is returned. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2231106[*BZ#2231106*])
+
+.Old restic pods are not removed when upgrading MTC 1.7.x to MTC 1.8
+
+On upgrading the MTC operator from 1.7.x to 1.8.x, the old restic pods are not removed. After the upgrade, both restic and node-agent pods are visible in the namespace. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2236829[*BZ#2236829*])


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
[MIG-1449](https://issues.redhat.com/browse/MIG-1449)
<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

 branch/enterprise-4.11
 
 MTC 1.7.0.1 to MTC 1.7.12 release notes

[Approval](https://github.com/openshift/openshift-docs/pull/64356)

[Merge fail - cherry pick](https://github.com/openshift/openshift-docs/pull/64356#issuecomment-1712189174) 

### Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Merge failed to Enterprise 4.11 → branch/enterprise-4.11


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
[MTC release notes](https://64356--docspreview.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-release-notes)

QE review:
- [ X] QE has approved this change. - Reviewed by Rayford Johnson
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.---