### PR TITLE
OCP 4.14 RN's: Update known issues

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1694,6 +1694,10 @@ ERROR failed to fetch Master Machines: failed to load asset "Install Config": fa
 +
 As a workaround, if you have an installation configuration file, update it with a specific project id to use (`platform.gcp.projectID`). Otherwise, manually create an installation configuration file, and enter a specific project id. Run the installation program again, specifying the file. (link:https://issues.redhat.com/browse/OCPBUGS-15238[*OCPBUGS-15238*])
 
+* Booting fails in a large compute node. (link:https://issues.redhat.com/browse/OCPBUGS-20075[*OCPBUGS-20075*])
+
+* When you deploy a cluster with a Network Type of `OVNKubernetes` on {ibmpowerProductName}, compute nodes may reboot because of a kernel stack overflow. As a workaround, you can deploy the cluster with a Network Type of `OpenShiftSDN`. (link:https://issues.redhat.com/browse/RHEL-3901[*RHEL-3901*])
+
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Version(s): 4.14

## **Known Issue 1:**  **Booting fails in a large compute node**
- Issue: https://issues.redhat.com/browse/OCPBUGS-20075
- Link to docs preview: https://65853--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-known-issues

QE review: by @mkumatag 
- [x] QE has approved this change.

## **Known Issue 2: kernel crash** 
- Link to docs preview: https://65853--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-known-issues

QE review: by @manojnkumar 
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
