### PR TITLE
OCP 4.14: IBM PowerVS IPI updates for PER enablement

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -657,6 +657,13 @@ ifdef::ibm-power-vs[]
 endif::ibm-power-vs[]
 |====
 
+ifdef::ibm-power-vs[]
+[NOTE]
+====
+Cloud connections are no longer supported in the `install-config.yaml` while deploying in the `dal10` region, as they have been replaced by the Power Edge Router (PER).
+====
+endif::ibm-power-vs[]
+
 ifdef::aws[]
 [id="installation-configuration-parameters-optional-aws_{context}"]
 == Optional AWS configuration parameters

--- a/modules/installation-ibm-cloud-regions.adoc
+++ b/modules/installation-ibm-cloud-regions.adoc
@@ -38,6 +38,7 @@ endif::ibm-vpc[]
 ifdef::ibm-power-vs[]
 
 * `dal` (Dallas, USA)
+** `dal10`
 ** `dal12`
 * `us-east` (Washington DC, USA)
 ** `us-east`

--- a/modules/quotas-and-limits-ibm-power-vs.adoc
+++ b/modules/quotas-and-limits-ibm-power-vs.adoc
@@ -32,6 +32,11 @@ VPC ALBs are supported. Classic ALBs are not supported for {ibmpowerProductName}
 
 There is a limit of two cloud connections per {ibmpowerProductName} Virtual Server instance. It is recommended that you have only one cloud connection in your {ibmpowerProductName} Virtual Server instance to serve your cluster.
 
+[NOTE]
+====
+Cloud Connections are no longer supported in `dal10`. A transit gateway is used instead.
+====
+
 [discrete]
 == Dynamic Host Configuration Protocol Service
 


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OCPBUGS-20182


Link to docs preview:
https://65856--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs#quotas-and-limits-ibm-power-vs_installing-ibm-cloud-account-power-vs
https://65856--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installing-ibm-cloud-account-power-vs#installation-ibm-power-vs-regions_installing-ibm-cloud-account-power-vs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
