### PR TITLE
Removing old pidslimit and logSizeMax parameter from Crtcfg

### DIFF
--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -116,7 +116,7 @@ spec:
  containerRuntimeConfig: <2>
    logLevel: debug
    overlaySize: 8G
-   ----
+----
 <1> Specify a label for the machine config pool that you want you want to modify.
 <2> Set the parameters as needed.
 

--- a/modules/create-a-containerruntimeconfig-crd.adoc
+++ b/modules/create-a-containerruntimeconfig-crd.adoc
@@ -50,7 +50,6 @@ $ oc get ctrcfg
 [source,terminal]
 ----
 NAME         AGE
-ctr-pid      24m
 ctr-overlay  15m
 ctr-level    5m45s
 ----
@@ -75,7 +74,7 @@ $ oc get mc | grep container
 ...
 ----
 
-The following example raises the `pids_limit` to 2048, sets the `log_level` to `debug`, sets the overlay size to 8 GB, and sets the `log_size_max` to unlimited:
+The following example sets the `log_level` to `debug` and sets the overlay size to 8 GB:
 
 .Example `ContainerRuntimeConfig` CR
 [source,yaml]
@@ -89,19 +88,14 @@ spec:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: '' <1>
  containerRuntimeConfig:
-   pidsLimit: 2048 <2>
-   logLevel: debug <3>
-   overlaySize: 8G <4>
-   logSizeMax: "-1" <5>
-   defaultRuntime: "crun" <6>
+   logLevel: debug <2>
+   overlaySize: 8G <3>
+   defaultRuntime: "crun" <4>
 ----
 <1> Specifies the machine config pool label.
-<2> Optional: Specifies the maximum number of processes allowed in a container.
-<3> Optional: Specifies the level of verbosity for log messages.
-<4> Optional: Specifies the maximum size of a container image.
-<5> Optional: Specifies the maximum size allowed for the container log file. If
-	set to a positive number, it must be at least 8192.
-<6> Optional: Specifies the container runtime to deploy to new containers. The default is `runc`.
+<2> Optional: Specifies the level of verbosity for log messages.
+<3> Optional: Specifies the maximum size of a container image.
+<4> Optional: Specifies the container runtime to deploy to new containers. The default is `runc`.
 
 .Procedure
 
@@ -120,11 +114,9 @@ spec:
    matchLabels:
      pools.operator.machineconfiguration.openshift.io/worker: '' <1>
  containerRuntimeConfig: <2>
-   pidsLimit: 2048
    logLevel: debug
    overlaySize: 8G
-   logSizeMax: "-1"
-----
+   ----
 <1> Specify a label for the machine config pool that you want you want to modify.
 <2> Set the parameters as needed.
 
@@ -195,15 +187,13 @@ sh-4.4# chroot /host
 +
 [source,terminal]
 ----
-sh-4.4# crio config | egrep 'log_level|pids_limit|log_size_max'
+sh-4.4# crio config | egrep 'log_level'
 ----
 +
 .Example output
 +
 [source,terminal]
 ----
-pids_limit = 2048
-log_size_max = -1
 log_level = "debug"
 ----
 


### PR DESCRIPTION
Removing the old pidslimit and logSizeMax parameter  from Crtcfg CR as those are deprecated

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. --> OCP version 4.12 and above

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-20172

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://docs.openshift.com/container-platform/4.12/post_installation_configuration/machine-configuration-tasks.html#create-a-kubeletconfig-crd-to-edit-kubelet-parameters_post-install-machine-configuration-tasks
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
