### PR TITLE
builds-version-selector: add version selector for Builds

### DIFF
--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -52,6 +52,8 @@
 
     unsupported_versions_gitops = [];
 
+    unsupported_versions_builds = [];
+
     unsupported_versions_origin = ["3.0", "3.1", "3.2", "3.3", "3.4", "3.5", "3.6", "3.7", "3.9", "3.10", "3.11", "4.1", "4.2", "4.3", "4.4", "4.5", "4.6", "4.7", "4.8", "4.9", "4.10", "4.11", "4.12"];
 
   %>
@@ -110,6 +112,16 @@
         <span>
           <div class="alert alert-danger" role="alert" id="support-alert">
             <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/pipelines/latest/about/understanding-openshift-pipelines.html" style="color: #545454 !important" class="link-primary">latest Pipelines docs</a>.
+          </div>
+        </span>
+
+      <% end %>
+
+      <% if ((unsupported_versions_builds.include? version) && (distro_key == "openshift-builds")) %>
+
+        <span>
+          <div class="alert alert-danger" role="alert" id="support-alert">
+            <strong>You are viewing documentation for a release that is no longer maintained.</strong> To view the documentation for the most recent version, see the <a href="https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html" style="color: #545454 !important" class="link-primary">latest Builds docs</a>.
           </div>
         </span>
 
@@ -214,6 +226,13 @@
               <option value="1.11">1.11</option>
               <option value="1.10">1.10</option>
             </select>
+         <% elsif (distro_key == "openshift-builds") %>
+            <a href="https://docs.openshift.com/builds/<%= version %>/about/overview-openshift-builds.html">
+              <%= distro %>
+            </a>
+            <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.0">1.0</option>
+            </select>   
         <% elsif (distro_key == "openshift-gitops") %>
             <a href="https://docs.openshift.com/gitops/<%= version %>/release_notes/gitops-release-notes.html">
               <%= distro %>
@@ -262,7 +281,7 @@
       <li class="hidden-xs active">
         <%= breadcrumb_topic %>
       </li>
-      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs"  && distro_key != "openshift-serverless"  && distro_key != "openshift-gitops" && distro_key != "openshift-pipelines") %>
+      <% if (distro_key != "openshift-origin" && distro_key != "openshift-aro" && distro_key != "openshift-acs"  && distro_key != "openshift-serverless"  && distro_key != "openshift-gitops" && distro_key != "openshift-pipelines" && distro_key != "openshift-builds") %>
       <span text-align="right" style="float: right !important">
         <a href="https://github.com/openshift/openshift-docs/commits/<%=
         ((distro_key == "openshift-enterprise") ? "enterprise-#{version}"
@@ -343,6 +362,22 @@
             </a>
           <% end %>
         </span>
+      <% elsif (distro_key == "openshift-builds") %>
+        <span text-align="right" style="float: right !important">
+          <a href="https://github.com/openshift/build-docs/commits/<%= (distro_key == "openshift-builds") ? "build-docs-#{version}" : "build-docs" %>/<%= repo_path %>">
+            <span class="material-icons-outlined" title="Page history">history
+            </span>
+          </a>
+          <% unless (unsupported_versions_builds.include? version) %>
+            <a href="https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12317820&issuetype=1&components=12332358&priority=4&summary=<%= "[build-docs-#{version}]+Issue+in+file+#{repo_path}"%>">
+              <span class="material-icons-outlined" title="Open an issue">bug_report
+              </span>
+            </a>
+            <a href="javascript: void(0);" onclick="window.print()">
+              <span class="material-icons-outlined" title="Print page (Save as PDF)">picture_as_pdf</span>
+            </a>
+          <% end %>
+        </span>  
       <% elsif (distro_key == "openshift-gitops") %>
         <span text-align="right" style="float: right !important">
           <a href="https://github.com/openshift/openshift-docs/commits/<%= (distro_key == "openshift-gitops") ? "gitops-docs-#{version}" : "gitops-docs" %>/<%= repo_path %>">
@@ -442,6 +477,7 @@
     'openshift-acs' : ['docs_acs', version],
     'openshift-serverless' : ['docs_serverless', version],
     'openshift-pipelines' : ['docs_pipelines', version],
+    'openshift-builds' : ['docs_builds', version],
     'openshift-gitops' : ['docs_gitops', version]
   };
 


### PR DESCRIPTION
Purpose: To add version dropdown for the Builds documentation (https://issues.redhat.com/browse/RHDEVDOCS-5484)

versions(s): main only


