### PR TITLE
OSDOCS-7183: updates 4.14 docs that are impacted by OVN-K i/c archite…

### DIFF
--- a/modules/cnf-du-management-pods.adoc
+++ b/modules/cnf-du-management-pods.adoc
@@ -252,7 +252,7 @@ The following tables identify the namespaces and pods that can be restricted to 
 | packageserver
 
 | openshift-ovn-kubernetes
-| ovnkube-master
+| ovnkube-control-plane
 
 | openshift-ovn-kubernetes
 | ovnkube-node

--- a/modules/nw-ovn-ipsec-verification.adoc
+++ b/modules/nw-ovn-ipsec-verification.adoc
@@ -10,30 +10,29 @@ As a cluster administrator, you can verify that IPsec is enabled.
 
 .Verification
 
-. To find the names of the OVN-Kubernetes control plane pods, enter the following command:
+. To find the names of the OVN-Kubernetes data plane pods, enter the following command:
 +
 [source,terminal]
 ----
-$ oc get pods -n openshift-ovn-kubernetes | grep ovnkube-master
+$ oc get pods -n openshift-ovn-kubernetes -l=app=ovnkube-node
 ----
 +
 .Example output
 [source,terminal]
 ----
-ovnkube-master-4496s        1/1     Running   0          6h39m
-ovnkube-master-d6cht        1/1     Running   0          6h42m
-ovnkube-master-skblc        1/1     Running   0          6h51m
-ovnkube-master-vf8rf        1/1     Running   0          6h51m
-ovnkube-master-w7hjr        1/1     Running   0          6h51m
-ovnkube-master-zsk7x        1/1     Running   0          6h42m
+ovnkube-node-5xqbf                       8/8     Running   0              28m
+ovnkube-node-6mwcx                       8/8     Running   0              29m
+ovnkube-node-ck5fr                       8/8     Running   0              31m
+ovnkube-node-fr4ld                       8/8     Running   0              26m
+ovnkube-node-wgs4l                       8/8     Running   0              33m
+ovnkube-node-zfvcl                       8/8     Running   0              34m
 ----
 
 . Verify that IPsec is enabled on your cluster:
 +
 [source,terminal]
 ----
-$ oc -n openshift-ovn-kubernetes -c nbdb rsh ovnkube-master-<XXXXX> \
-  ovn-nbctl --no-leader-only get nb_global . ipsec
+$ oc -n openshift-ovn-kubernetes -c nbdb rsh ovnkube-node-<XXXXX> ovn-nbctl --no-leader-only get nb_global . ipsec
 ----
 +
 --


### PR DESCRIPTION
Updates 4.14 docs that are impacted by OVN-K i/c architecture change

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-7183
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[IPsec](https://65876--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-ipsec-ovn#nw-ovn-ipsec-verification_configuring-ipsec-ovn)

<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
