### PR TITLE
OSDOCS-5851-Newer: Document post-install AWS LZ work

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -585,6 +585,9 @@ Topics:
 - Name: Fedora CoreOS (FCOS) image layering
   File: coreos-layering
   Distros: openshift-origin
+- Name: AWS Local Zone tasks
+  File: aws-compute-edge-tasks
+  Distros: openshift-enterprise
 ---
 Name: Updating clusters
 Dir: updating

--- a/modules/edge-machine-pools-aws-local-zones.adoc
+++ b/modules/edge-machine-pools-aws-local-zones.adoc
@@ -1,5 +1,10 @@
 // Module included in the following assemblies:
 // * installing/installing_aws/installing-aws-localzone.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
+
+ifeval::["{context}" == "aws-compute-edge-tasks"]
+:edge:
+endif::[]
 
 :_content-type: CONCEPT
 [id="edge-machine-pools-aws-local-zones_{context}"]
@@ -14,7 +19,7 @@ When deploying a cluster that uses Local Zones, consider the following points:
 
 [IMPORTANT]
 ====
-Generally, the Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. For more information, see link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation. 
+Generally, the maximum transmission unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. For more information, see link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation.
 The cluster network MTU must be always less than the EC2 MTU to account for the overhead. The specific overhead is determined by the network plugin, for example:
 
 - OVN-Kubernetes: `100 bytes`
@@ -39,6 +44,7 @@ By default, the system creates the edge compute pool manifests only if users add
 
 By default, the machine sets for the edge compute pool defines the taint of `NoSchedule` to prevent regular workloads from spreading on Local Zone instances. Users can only run user workloads if they define tolerations in the pod specification.
 
+ifndef::edge[]
 The following examples show `install-config.yaml` files that use the edge machine pool.
 
 .Configuration that uses an edge pool with a custom instance type
@@ -106,3 +112,8 @@ pullSecret: '{"auths": ...}'
 sshKey: ssh-ed25519 AAAA...
 ----
 <1> Specify the name of the security group as it appears in the Amazon EC2 console, including the `sg` prefix.
+endif::edge[]
+
+ifeval::["{context}" == "aws-compute-edge-tasks"]
+:!edge:
+endif::[]

--- a/modules/installation-aws-add-local-zone-locations.adoc
+++ b/modules/installation-aws-add-local-zone-locations.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/installing-aws-localzone.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
 
 :_content-type: PROCEDURE
 [id="installation-aws-add-local-zone-locations_{context}"]
@@ -12,6 +13,23 @@ If you plan to create the subnets in AWS Local Zones, you must opt in to each zo
 
 * You have installed the AWS CLI.
 * You have determined an AWS Region for where you want to deploy your {product-title} cluster.
+* You have attached a permissive IAM policy to a user or role account that opts in to the zone group. Consider the following configuration as an example IAM policy:
++
+[source,yaml]
+----
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Action": [
+        "ec2:ModifyAvailabilityZoneGroup"
+      ],
+      "Effect": "Allow",
+      "Resource": "*"
+    }
+  ]
+}
+----
 
 .Procedure
 
@@ -36,6 +54,7 @@ Depending on the AWS Region, the list of available zones can be long. The comman
 [source,terminal]
 ----
 $ aws ec2 modify-availability-zone-group \
-    --group-name "<value_of_GroupName>" \
+    --group-name "<value_of_GroupName>" \// <1>
     --opt-in-status opted-in
 ----
+<1> For `<value_of_GroupName>`, specify the name of the group of the Local Zone where you want to create subnets. For example, specify `us-east-1-nyc-1` to use the zone `us-east-1-nyc-1a` (US East New York).

--- a/modules/installation-cloudformation-subnet-localzone.adoc
+++ b/modules/installation-cloudformation-subnet-localzone.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/installing-aws-localzone.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
 
 :_content-type: REFERENCE
 [id="installation-cloudformation-subnet-localzone_{context}"]

--- a/modules/installation-creating-aws-subnet-localzone.adoc
+++ b/modules/installation-creating-aws-subnet-localzone.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * installing/installing_aws/installing-aws-localzone.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
 
 :_content-type: PROCEDURE
 [id="installation-creating-aws-subnet-localzone_{context}"]

--- a/modules/installation-extend-edge-nodes-aws-local-zones.adoc
+++ b/modules/installation-extend-edge-nodes-aws-local-zones.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * post_installation_configuration/cluster-tasks.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
 
 ifeval::["{context}" == "installing-aws-localzone"]
 :localzone:

--- a/modules/machine-edge-pool-review-nodes.adoc
+++ b/modules/machine-edge-pool-review-nodes.adoc
@@ -1,5 +1,6 @@
 // Module included in the following assemblies
 // * installing/installing_aws/installing-aws-localzone.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
 
 :_content-type: PROCEDURE
 [id="machine-edge-pool-review-nodes_{context}"]

--- a/modules/machineset-creating.adoc
+++ b/modules/machineset-creating.adoc
@@ -7,11 +7,13 @@
 // * machine_management/creating_machinesets/creating-machineset-gcp.adoc
 // * machine_management/creating_machinesets/creating-machineset-osp.adoc
 // * machine_management/creating_machinesets/creating-machineset-vsphere.adoc
-// * post_installation_configuration/cluster-tasks.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-aws.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-azure.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-vsphere.adoc
 // * windows_containers/creating_windows_machinesets/creating-windows-machineset-gcp.adoc
+// * post_installation_configuration/cluster-tasks.adoc
+// * post_installation_configuration/installation-creating-aws-subnet-localzone.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
 
 ifeval::["{context}" == "creating-windows-machineset-aws"]
 :win:
@@ -27,6 +29,9 @@ ifeval::["{context}" == "creating-windows-machineset-vsphere"]
 endif::[]
 ifeval::["{context}" == "creating-machineset-vsphere"]
 :vsphere:
+endif::[]
+ifeval::["{context}" == "aws-compute-edge-tasks"]
+:localzone:
 endif::[]
 
 :_content-type: PROCEDURE
@@ -198,17 +203,22 @@ $ oc get machineset -n openshift-machine-api
 .Example output
 [source,terminal]
 ----
+ifdef::win,localzone[]
+NAME                                       DESIRED   CURRENT   READY   AVAILABLE   AGE
 ifdef::win[]
-NAME                                      DESIRED   CURRENT   READY   AVAILABLE   AGE
-agl030519-vplxk-windows-worker-us-east-1a    1         1         1       1        11m
-agl030519-vplxk-worker-us-east-1a            1         1         1       1        55m
-agl030519-vplxk-worker-us-east-1b            1         1         1       1        55m
-agl030519-vplxk-worker-us-east-1c            1         1         1       1        55m
-agl030519-vplxk-worker-us-east-1d            0         0                          55m
-agl030519-vplxk-worker-us-east-1e            0         0                          55m
-agl030519-vplxk-worker-us-east-1f            0         0                          55m
+agl030519-vplxk-windows-worker-us-east-1a  1         1         1       1           11m
 endif::win[]
-ifndef::win[]
+ifdef::localzone[]
+agl030519-vplxk-edge-us-east-1-nyc-1a      1         1         1       1           11m
+endif::localzone[]
+agl030519-vplxk-worker-us-east-1a          1         1         1       1           55m
+agl030519-vplxk-worker-us-east-1b          1         1         1       1           55m
+agl030519-vplxk-worker-us-east-1c          1         1         1       1           55m
+agl030519-vplxk-worker-us-east-1d          0         0                             55m
+agl030519-vplxk-worker-us-east-1e          0         0                             55m
+agl030519-vplxk-worker-us-east-1f          0         0                             55m
+endif::win,localzone[]
+ifndef::win,localzone[]
 NAME                                DESIRED   CURRENT   READY   AVAILABLE   AGE
 agl030519-vplxk-infra-us-east-1a    1         1         1       1           11m
 agl030519-vplxk-worker-us-east-1a   1         1         1       1           55m
@@ -217,11 +227,30 @@ agl030519-vplxk-worker-us-east-1c   1         1         1       1           55m
 agl030519-vplxk-worker-us-east-1d   0         0                             55m
 agl030519-vplxk-worker-us-east-1e   0         0                             55m
 agl030519-vplxk-worker-us-east-1f   0         0                             55m
-endif::win[]
+endif::win,localzone[]
 ----
 +
 When the new compute machine set is available, the `DESIRED` and `CURRENT` values match. If the compute machine set is not available, wait a few minutes and run the command again.
 
+ifdef::localzone[]
+* Optional: To check nodes that were created by the edge machine, run the following command:
++
+[source,terminal]
+----
+$ oc get nodes -l node-role.kubernetes.io/edge
+----
++
+.Example output
+[source,terminal]
+----
+NAME                           STATUS   ROLES         AGE    VERSION
+ip-10-0-207-188.ec2.internal   Ready    edge,worker   172m   v1.25.2+d2e245f
+----
+endif::localzone[]
+
+ifeval::["{context}" == "aws-compute-edge-tasks"]
+:!localzone:
+endif::[]
 ifeval::["{context}" == "creating-machineset-vsphere"]
 :!vsphere:
 endif::[]

--- a/modules/machineset-yaml-aws.adoc
+++ b/modules/machineset-yaml-aws.adoc
@@ -2,22 +2,32 @@
 //
 // * machine_management/creating-infrastructure-machinesets.adoc
 // * machine_management/creating_machinesets/creating-machineset-aws.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :infra:
+endif::[]
+ifeval::["{context}" == "aws-compute-edge-tasks"]
+:edge:
 endif::[]
 
 :_content-type: REFERENCE
 [id="machineset-yaml-aws_{context}"]
 =  Sample YAML for a compute machine set custom resource on AWS
 
+ifndef::edge[]
 This sample YAML defines a compute machine set that runs in the `us-east-1a` Amazon Web Services (AWS) zone and creates nodes that are labeled with
-ifndef::infra[`node-role.kubernetes.io/<role>: ""`.]
+endif::edge[]
+ifndef::infra,edge[`node-role.kubernetes.io/<role>: ""`.]
 ifdef::infra[`node-role.kubernetes.io/infra: ""`.]
+ifdef::edge[]
+This sample YAML defines a compute machine set that runs in the `us-east-1-nyc-1a` Amazon Web Services (AWS) zone and creates nodes that are labeled with `node-role.kubernetes.io/edge: ""`.
+endif::[]
 
 In this sample, `<infrastructure_id>` is the infrastructure ID label that is based on the cluster ID that you set when you provisioned the cluster, and
-ifndef::infra[`<role>`]
+ifndef::infra,edge[`<role>`]
 ifdef::infra[`<infra>`]
+ifdef::edge[`<edge>`]
 is the node label to add.
 
 [source,yaml]
@@ -27,21 +37,25 @@ kind: MachineSet
 metadata:
   labels:
     machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-ifndef::infra[]
+ifndef::infra,edge[]
   name: <infrastructure_id>-<role>-<zone> <2>
-endif::infra[]
+endif::infra,edge[]
 ifdef::infra[]
   name: <infrastructure_id>-infra-<zone> <2>
 endif::infra[]
+ifdef::edge[]
+  name: <infrastructure_id>-edge-<zone> <2>
+endif::edge[]
   namespace: openshift-machine-api
 spec:
   replicas: 1
   selector:
     matchLabels:
       machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-ifndef::infra[]
+      machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone>
+ifndef::infra,edge[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
-endif::infra[]
+endif::infra,edge[]
 ifdef::infra[]
       machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
 endif::infra[]
@@ -49,34 +63,41 @@ endif::infra[]
     metadata:
       labels:
         machine.openshift.io/cluster-api-cluster: <infrastructure_id> <1>
-ifndef::infra[]
+ifndef::infra,edge[]
         machine.openshift.io/cluster-api-machine-role: <role> <3>
         machine.openshift.io/cluster-api-machine-type: <role> <3>
-endif::infra[]
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
+endif::infra,edge[]
 ifdef::infra[]
         machine.openshift.io/cluster-api-machine-role: infra <3>
         machine.openshift.io/cluster-api-machine-type: infra <3>
-endif::infra[]
-ifndef::infra[]
-        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-<role>-<zone> <2>
-endif::infra[]
-ifdef::infra[]
         machine.openshift.io/cluster-api-machineset: <infrastructure_id>-infra-<zone> <2>
 endif::infra[]
+ifdef::edge[]
+        machine.openshift.io/cluster-api-machine-role: edge <3>
+        machine.openshift.io/cluster-api-machine-type: edge <3>
+        machine.openshift.io/cluster-api-machineset: <infrastructure_id>-edge-<zone> <2>
+endif::edge[]
     spec:
       metadata:
         labels:
-ifndef::infra[]
+ifndef::infra,edge[]
           node-role.kubernetes.io/<role>: "" <3>
-endif::infra[]
+endif::infra,edge[]
 ifdef::infra[]
           node-role.kubernetes.io/infra: "" <3>
 endif::infra[]
+ifdef::edge[]
+          machine.openshift.io/parent-zone-name: <value_of_ParentZoneName>
+          machine.openshift.io/zone-group: <value_of_GroupName>
+          machine.openshift.io/zone-type: <value_of_ZoneType>
+          node-role.kubernetes.io/edge: "" <3>
+endif::edge[]
       providerSpec:
         value:
           ami:
             id: ami-046fe691f52a953f9 <4>
-          apiVersion: awsproviderconfig.openshift.io/v1beta1
+          apiVersion: machine.openshift.io/v1beta1
           blockDevices:
             - ebs:
                 iops: 0
@@ -98,22 +119,33 @@ endif::infra[]
                   values:
                     - <infrastructure_id>-worker-sg <1>
           subnet:
+ifndef::edge[]
             filters:
               - name: tag:Name
                 values:
                   - <infrastructure_id>-private-<zone> <8>
+endif::edge[]
+ifdef::edge[]
+              id: <value_of_PublicSubnetIds> <8>
+          publicIp: true
           tags:
+endif::edge[]
             - name: kubernetes.io/cluster/<infrastructure_id> <1>
               value: owned
             - name: <custom_tag_name> <5>
               value: <custom_tag_value> <5>
           userDataSecret:
             name: worker-user-data
-ifdef::infra[]
+ifdef::infra,edge[]
       taints: <9>
+ifdef::infra[]
         - key: node-role.kubernetes.io/infra
-          effect: NoSchedule
 endif::infra[]
+ifdef::edge[]
+        - key: node-role.kubernetes.io/edge
+endif::edge[]
+          effect: NoSchedule
+endif::infra,edge[]
 ----
 <1> Specify the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 +
@@ -121,14 +153,18 @@ endif::infra[]
 ----
 $ oc get -o jsonpath='{.status.infrastructureName}{"\n"}' infrastructure cluster
 ----
-ifndef::infra[]
+ifndef::infra,edge[]
 <2> Specify the infrastructure ID, role node label, and zone.
 <3> Specify the role node label to add.
-endif::infra[]
+endif::infra,edge[]
 ifdef::infra[]
 <2> Specify the infrastructure ID, `infra` role node label, and zone.
 <3> Specify the `infra` role node label.
 endif::infra[]
+ifdef::edge[]
+<2> Specify the infrastructure ID, `edge` role node label, and zone name.
+<3> Specify the `edge` role node label.
+endif::edge[]
 <4> Specify a valid {op-system-first} Amazon
 Machine Image (AMI) for your AWS zone for your {product-title} nodes. If you want to use an AWS Marketplace image, you must complete the {product-title} subscription from the link:https://aws.amazon.com/marketplace/fulfillment?productId=59ead7de-2540-4653-a8b0-fa7926d5c845[AWS Marketplace] to obtain an AMI ID for your region.
 +
@@ -145,23 +181,38 @@ $ oc -n openshift-machine-api \
 Custom tags can also be specified during installation in the `install-config.yml` file. If the `install-config.yml` file and the machine set include a tag with the same `name` data, the value for the tag from the machine set takes priority over the value for the tag in the `install-config.yml` file.
 ====
 
+ifndef::edge[]
 <6> Specify the zone, for example, `us-east-1a`.
+endif::edge[]
+ifdef::edge[]
+<6> Specify the zone name, for example, `us-east-1-nyc-1a`.
+endif::edge[]
 <7> Specify the region, for example, `us-east-1`.
+ifndef::edge[]
 <8> Specify the infrastructure ID and zone.
-
-ifdef::infra[]
-<9> Specify a taint to prevent user workloads from being scheduled on infra nodes.
+endif::edge[]
+ifdef::edge[]
+<8> The ID of the public subnet that you created in AWS Local Zones. You created this public subnet ID on completing the procedure for "Creating a subnet in AWS Local Zones".
+endif::edge[]
+ifdef::infra,edge[]
+<9> Specify a taint to prevent user workloads from being scheduled on
+ifdef::infra[`infra`]
+ifdef::edge[`edge`]
+nodes.
 +
 [NOTE]
 ====
 After adding the `NoSchedule` taint on the infrastructure node, existing DNS pods running on that node are marked as `misscheduled`. You must either delete or link:https://access.redhat.com/solutions/6592171[add toleration on `misscheduled` DNS pods].
 ====
 
-endif::infra[]
+endif::infra,edge[]
 
 ifeval::["{context}" == "creating-infrastructure-machinesets"]
 :!infra:
 endif::[]
 ifeval::["{context}" == "cluster-tasks"]
 :!infra:
+endif::[]
+ifeval::["{context}" == "aws-compute-edge-tasks"]
+:!edge:
 endif::[]

--- a/modules/nw-cluster-mtu-change-about.adoc
+++ b/modules/nw-cluster-mtu-change-about.adoc
@@ -1,17 +1,18 @@
 // Module included in the following assemblies:
 //
 // * networking/changing-cluster-network-mtu.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
 
 :_content-type: CONCEPT
 [id="nw-cluster-mtu-change-about_{context}"]
 = About the cluster MTU
 
-During installation the maximum transmission unit (MTU) for the cluster network is detected automatically based on the MTU of the primary network interface of nodes in the cluster. You do not normally need to override the detected MTU.
+During installation the maximum transmission unit (MTU) for the cluster network is detected automatically based on the MTU of the primary network interface of nodes in the cluster. You do not usually need to override the detected MTU.
 
 You might want to change the MTU of the cluster network for several reasons:
 
-* The MTU detected during cluster installation is not correct for your infrastructure
-* Your cluster infrastructure now requires a different MTU, such as from the addition of nodes that need a different MTU for optimal performance
+* The MTU detected during cluster installation is not correct for your infrastructure.
+* Your cluster infrastructure now requires a different MTU, such as from the addition of nodes that need a different MTU for optimal performance.
 
 You can change the cluster MTU for only the OVN-Kubernetes and OpenShift SDN cluster network plugins.
 

--- a/modules/nw-cluster-mtu-change.adoc
+++ b/modules/nw-cluster-mtu-change.adoc
@@ -1,6 +1,11 @@
 // Module included in the following assemblies:
 //
 // * networking/changing-cluster-network-mtu.adoc
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
+
+ifeval::["{context}" == "aws-compute-edge-tasks"]
+:localzone:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="nw-cluster-mtu-change_{context}"]
@@ -8,7 +13,9 @@
 
 As a cluster administrator, you can change the maximum transmission unit (MTU) for your cluster. The migration is disruptive and nodes in your cluster might be temporarily unavailable as the MTU update rolls out.
 
+ifndef::localzone[]
 The following procedure describes how to change the cluster MTU by using either machine configs, DHCP, or an ISO. If you use the DHCP or ISO approach, you must refer to configuration artifacts that you kept after installing your cluster to complete the procedure.
+endif::localzone[]
 
 .Prerequisites
 
@@ -44,6 +51,7 @@ Status:
 ...
 ----
 
+ifndef::localzone[]
 . Prepare your configuration for the hardware MTU:
 
 ** If your hardware MTU is specified with DHCP, update your DHCP configuration such as with the following dnsmasq configuration:
@@ -158,6 +166,7 @@ $ for manifest in control-plane-interface worker-interface; do
     butane --files-dir . $manifest.bu > $manifest.yaml
   done
 ----
+endif::localzone[]
 
 . To begin the MTU migration, specify the migration configuration by entering the following command. The Machine Config Operator performs a rolling reboot of the nodes in the cluster in preparation for the MTU change.
 +
@@ -238,6 +247,7 @@ The machine config must include the following update to the systemd configuratio
 ExecStart=/usr/local/bin/mtu-migration.sh
 ----
 
+ifndef::localzone[]
 . Update the underlying network interface MTU value:
 
 ** If you are specifying the new MTU with a NetworkManager connection configuration, enter the following command. The MachineConfig Operator automatically performs a rolling reboot of the nodes in your cluster.
@@ -303,6 +313,7 @@ where `<config_name>` is the name of the machine config from the `machineconfigu
 If the machine config is successfully deployed, the previous output contains the `/etc/NetworkManager/system-connections/<connection_name>` file path.
 +
 The machine config must not contain the `ExecStart=/usr/local/bin/mtu-migration.sh` line.
+endif::localzone[]
 
 . To finalize the MTU migration, enter one of the following commands:
 ** If you are using the OVN-Kubernetes network plugin:
@@ -336,6 +347,16 @@ where:
 
 .Verification
 
+ifdef::localzone[]
+* Verify that the node in your cluster uses the MTU that you specified in the previous procedure by entering the following command:
++
+[source,terminal]
+----
+$ oc describe network.config cluster
+----
+endif::localzone[]
+
+ifndef::localzone[]
 You can verify that a node in your cluster uses an MTU that you specified in the previous procedure.
 
 . To get the current MTU for the cluster network, enter the following command:
@@ -373,3 +394,8 @@ where:
 ----
 ens3: <BROADCAST,MULTICAST,UP,LOWER_UP> mtu 8051
 ----
+endif::localzone[]
+
+ifeval::["{context}" == "aws-compute-edge-tasks"]
+:!localzone:
+endif::[]

--- a/modules/post-install-edge-aws-extend-cluster.adoc
+++ b/modules/post-install-edge-aws-extend-cluster.adoc
@@ -1,0 +1,21 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
+
+:_content-type: CONCEPT
+[id="post-install-edge-aws-extend-cluster_{context}"]
+= Extend existing clusters to use AWS Local Zones
+
+As a post-installation task, you can extend an existing {product-title} cluster on Amazon Web Services (AWS) to use AWS Local Zones.
+
+Extending nodes to Local Zone locations comprises the following steps:
+
+- Adjusting the cluster-network maximum transmission unit (MTU)
+- Opting in the Local Zone group to AWS Local Zones
+- Creating a subnet in the existing VPC for a Local Zone location
+- Creating the machine set manifest, and then creating a node in each Local Zone location
+
+[IMPORTANT]
+====
+Before you extend an existing {product-title} cluster on AWS to use Local Zones, check that the existing VPC contains available Classless Inter-Domain Routing (CIDR) blocks. These blocks are needed for creating the subnets.
+====

--- a/modules/post-install-edge-aws-extend-machineset.adoc
+++ b/modules/post-install-edge-aws-extend-machineset.adoc
@@ -1,0 +1,52 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
+
+:_content-type: PROCEDURE
+[id="post-install-edge-aws-extend-machineset"]
+= Creating a machine set manifest for an AWS Local Zones node
+
+After you create subnets in AWS Local Zones, you can create a machine set manifest.
+
+The installation program sets the following labels for the `edge` machine pools at cluster installation time:
+
+* `machine.openshift.io/parent-zone-name: <value_of_ParentZoneName>`
+* `machine.openshift.io/zone-group: <value_of_ZoneGroup>`
+* `machine.openshift.io/zone-type: <value_of_ZoneType>`
+
+The following procedure details how you can create a machine set configuraton that matches the `edge` compute pool configuration.
+
+.Prerequisites
+
+* You have created subnets in AWS Local Zones.
+
+.Procedure
+
+* Manually preserve `edge` machine pool labels when creating the machine set manifest by gathering the AWS API. To complete this action, enter the following command in your command-line interface (CLI):
++
+[source,terminal]
+----
+$ aws ec2 describe-availability-zones --region <value_of_Region> \// <1>
+    --query 'AvailabilityZones[].{
+	ZoneName: ZoneName,
+	ParentZoneName: ParentZoneName,
+	GroupName: GroupName,
+	ZoneType: ZoneType}' \
+    --filters Name=zone-name,Values=<value_of_ZoneName> \// <2>
+    --all-availability-zones
+----
+<1> For `<value_of_Region>`, specify the name of the region for the zone.
+<2> For `<value_of_ZoneName>`, specify the name of the Local Zone.
+
+.Example output for Local Zone `us-east-1-nyc-1a`
+[source,terminal]
+----
+[
+    {
+        "ZoneName": "us-east-1-nyc-1a",
+        "ParentZoneName": "us-east-1f",
+        "GroupName": "us-east-1-nyc-1",
+        "ZoneType": "local-zone"
+    }
+]
+----

--- a/modules/post-install-existing-local-zone-subnet.adoc
+++ b/modules/post-install-existing-local-zone-subnet.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies:
+//
+// * post_installation_configuration/aws-compute-edge-tasks.adoc
+
+:_content-type: CONCEPT
+[id="post-install-existing-local-zone-subnet_{context}"]
+= Extend existing clusters to use AWS Local Zones
+
+If you want a Machine API to create an Amazon EC2 instance in a remote zone location, you must create a subnet in a Local Zone location. You can use any provisioning tool, such as Ansible or Terraform, to create subnets in the existing Virtual Private Cloud (VPC). You can configure the CloudFormation template to meet your requirements. 
+
+The following subsections include steps that use CloudFormation templates. Considering the limitation of NAT Gateways in AWS Local Zones, CloudFormation templates support only public subnets. You can reuse the template to create public subnets for each edge location to where you need to extend your cluster.

--- a/post_installation_configuration/aws-compute-edge-tasks.adoc
+++ b/post_installation_configuration/aws-compute-edge-tasks.adoc
@@ -1,0 +1,74 @@
+:_content-type: ASSEMBLY
+[id="aws-compute-edge-tasks"]
+= AWS Local Zone tasks
+include::_attributes/common-attributes.adoc[]
+:context: aws-compute-edge-tasks
+
+toc::[]
+
+After installing {product-title} on Amazon Web Services (AWS), you can further configure AWS Local Zones and an edge compute pool, so that you can expand and customize your cluster to meet your needs.
+
+// Extend existing clusters to use AWS Local Zones
+include::modules/post-install-edge-aws-extend-cluster.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* For more information about AWS Local Zones, the supported instances types, and services, see link:https://aws.amazon.com/about-aws/global-infrastructure/localzones/features/[AWS Local Zones features] in the AWS documentation.
+
+
+// About the Edge Compute Pool
+include::modules/edge-machine-pools-aws-local-zones.adoc[leveloffset=+2]
+
+[id="post-install-extend-existing-to-local-zones-mtu"]
+=== Changing the Cluster Network MTU to support AWS Local Zones subnets
+
+You might need to change the maximum transmission unit (MTU) value for the cluster
+network so that your cluster infrastructure can support Local Zone subnets.
+
+// About the cluster MTU
+include::modules/nw-cluster-mtu-change-about.adoc[leveloffset=+3]
+
+// Changing the cluster MTU
+include::modules/nw-cluster-mtu-change.adoc[leveloffset=+3]
+
+// Opting in to AWS Local Zones
+include::modules/installation-aws-add-local-zone-locations.adoc[leveloffset=+2]
+
+// Extend existing clusters to use AWS Local Zones
+include::modules/post-install-existing-local-zone-subnet.adoc[leveloffset=+2]
+
+// Creating a subnet in AWS Local Zones
+include::modules/installation-creating-aws-subnet-localzone.adoc[leveloffset=+3]
+
+// CloudFormation template for the subnet that uses AWS Local Zones
+include::modules/installation-cloudformation-subnet-localzone.adoc[leveloffset=+3]
+
+// Creating a machine set manifest for AWS Local Zones node
+include::modules/post-install-edge-aws-extend-machineset.adoc[leveloffset=+2]
+
+// Sample YAML for a compute machine set custom resource on AWS
+include::modules/machineset-yaml-aws.adoc[leveloffset=+3]
+
+// Creating a compute machine set
+include::modules/machineset-creating.adoc[leveloffset=+3]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_aws/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster on AWS with worker nodes on AWS Local Zones]
+
+// Creating user workloads in AWS Local Zones
+include::modules/installation-extend-edge-nodes-aws-local-zones.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../installing/installing_aws/installing-aws-localzone.adoc#installing-aws-localzone[Installing a cluster on AWS with worker nodes on AWS Local Zones]
+
+* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
+
+.Next steps
+
+* Optional: Use the AWS Load Balancer (ALB) Operator to expose a pod from a targeted edge worker node to services that run inside of a Local Zone subnet from a public network.
+See xref:../networking/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc#nw-installing-aws-load-balancer-operator_aws-load-balancer-operator[Installing the AWS Load Balancer Operator].

--- a/post_installation_configuration/cluster-tasks.adoc
+++ b/post_installation_configuration/cluster-tasks.adoc
@@ -544,21 +544,6 @@ include::modules/machineset-delete-policy.adoc[leveloffset=+2]
 
 include::modules/nodes-scheduler-node-selectors-cluster.adoc[leveloffset=+2]
 
-include::modules/installation-extend-edge-nodes-aws-local-zones.adoc[leveloffset=+2]
-
-.Next steps
-
-* Optional: Use the AWS Load Balancer (ALB) Operator to expose a pod from a targeted edge worker node to services that run inside a Local Zone subnet from a public network. See xref:../networking/aws_load_balancer_operator/install-aws-load-balancer-operator.adoc#nw-installing-aws-load-balancer-operator_aws-load-balancer-operator[Installing the AWS Load Balancer Operator].
-
-[role="_additional-resources"]
-.Additional resources
-
-* xref:../installing/installing_aws/installing-aws-localzone.adoc[Installing a cluster on AWS with worker nodes on AWS Local Zones]
-
-* xref:../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc[Understanding taints and tolerations]
-
-* xref:../logging/config/cluster-logging-tolerations.adoc[Using tolerations to control OpenShift Logging pod placement]
-
 [id="post-worker-latency-profiles"]
 == Improving cluster stability in high latency environments using worker latency profiles
 


### PR DESCRIPTION
[OSDOCS-5851](https://issues.redhat.com/browse/OSDOCS-5851)

Version(s):
4.14

Link to docs preview:
* [AWS Local Zone tasks (post-install)](https://65877--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/aws-compute-edge-tasks)
* [Sample YAML for a compute machine set custom resource on AWS (Creating a compute machine set on AWS)](https://65877--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#machineset-yaml-aws_creating-machineset-aws)
* [Sample YAML for a compute machine set custom resource on AWS (Creating infrastructure machine sets)](https://65877--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating-infrastructure-machinesets#machineset-yaml-aws_creating-infrastructure-machinesets)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* PR continues work from https://github.com/openshift/openshift-docs/pull/63729/files
