### PR TITLE
OSDOCS-8080 Zstream RNs for 4.12.37

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4132,3 +4132,22 @@ $ oc adm release info 4.12.36 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-37"]
+=== RHBA-2023:5450 - {product-title} 4.12.37 bug fix update
+
+Issued: 2023-10-11
+
+{product-title} release 4.12.37 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5450[RHBA-2023:5450] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5452[RHBA-2023:5452] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.37 --pullspecs
+----
+
+[id="ocp-4-12-37-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-8080](https://issues.redhat.com/browse/OSDOCS-8080)

Link to docs preview:
[Preview](https://65884--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-37)

QE review:
- [ ] QE has approved this change.
Not needed

Additional information:
Expected merge date October 11, 2023. Links will not work until then. 