### PR TITLE
OSDOCS#7823: Added FIPS support statement to About this release

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -35,6 +35,10 @@ Starting with {product-title} 4.14, Extended Update Support (EUS) is extended to
 //TODO: The line below should be used when it is next appropriate. Revisit in August 2023 timeframe.
 Maintenance support ends for version 4.12 on 25 January 2025 and goes to extended life phase. For more information, see the link:https://access.redhat.com/support/policy/updates/openshift[Red Hat {product-title} Life Cycle Policy].
 
+// Added in 4.14. Language came directly from Kirsten Newcomer.
+{product-title} is designed for FIPS. When running {op-system-base-full} or {op-system-first} booted in FIPS mode, {product-title} core components use the {op-system-base} cryptographic libraries that have been submitted to NIST for FIPS 140-2/140-3 Validation on only the `x86_64`, `ppc64le`, and `s390x` architectures.
+
+For more information about the NIST validation program, see link:https://csrc.nist.gov/Projects/cryptographic-module-validation-program/validated-modules[Cryptographic Module Validation Program]. For the latest NIST status for the individual versions of {op-system-base} cryptographic libraries that have been submitted for validation, see link:https://access.redhat.com/articles/2918071#fips-140-2-and-fips-140-3-2[Compliance Activities and Government Standards].
 
 [id="ocp-4-14-add-on-support-status"]
 == {product-title} layered and dependent component support and compatibility


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->
Version(s):
4.14

Issue:
This PR addresses [osdocs-7823](https://issues.redhat.com/browse/OSDOCS-7823).

Link to docs preview:

[About this release](https://65887--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-about-this-release)

QE review:
- [N/A] QE has approved this change.
Similar to the updates made in https://github.com/openshift/openshift-docs/pull/65392, the wording came directly from engineering and Kirsten Newcomer, whom have both approved this PR, as it is more of a support/legal change than a technical one.
