### PR TITLE
TELCODOCS-1528

### DIFF
--- a/modules/kmm-customizing-upgrades-for-kernel-modules.adoc
+++ b/modules/kmm-customizing-upgrades-for-kernel-modules.adoc
@@ -13,9 +13,10 @@ Use this procedure to upgrade the kernel module while running maintenance operat
 This procedure requires knowledge of the workload utilizing the kernel module and must be managed by the cluster administrator.
 ====
 
+
 .Prerequisites
 
-* Before upgrading, set the `kmm.node.kubernetes.io/version-module.<module-namespace>.<module-name>=$moduleVersion` label on all the nodes that will be used by the kernel module.
+* Before upgrading, set the `kmm.node.kubernetes.io/version-module.<module_namespace>.<module_name>=$moduleVersion` label on all the nodes that are used by the kernel module.
 
 * Terminate all user application workloads on the node or move them to another node.
 
@@ -23,13 +24,11 @@ This procedure requires knowledge of the workload utilizing the kernel module an
 
 * Ensure that the user workload (the application running in the cluster that is accessing kernel module) is not running on the node prior to kernel module unloading and that the workload is back running on the node after the new kernel module version has been loaded.
 
-* Ensure that the device plugin managed by KMM on the node is unloaded before the upgrade process and reloaded following the upgrade process.
-
-* Due to Kubernetes limitations in label names, the combined length of `Module` name and namespace must not exceed 39 characters.
-
 .Procedure
 
-. Update the following fields in the `Module` CR:
+. Ensure that the device plugin managed by KMM on the node is unloaded.
+
+. Update the following fields in the `Module` custom resource (CR):
 - `containerImage` (to the appropriate kernel version)
 - `version`
 +
@@ -37,15 +36,30 @@ The update should be atomic; that is, both the `containerImage` and `version` fi
 
 . Terminate any workload using the kernel module on the node being upgraded.
 
-. Remove the `kmm.node.kubernetes.io/version-module.<module-namespace>.<module-name>` label on the node. This unloads the kernel module from the node.
+. Remove the `kmm.node.kubernetes.io/version-module.<module_namespace>.<module_name>` label on the node.
+Run the following command to unload the kernel module from the node:
++
+[source,terminal]
+----
+$ oc label node/<node_name> kmm.node.kubernetes.io/version-module.<module_namespace>.<module_name>-
+----
 
-. If required, perform any additional maintenance required on the node for the kernel module upgrade.
+. If required, as the cluster administrator, perform any additional maintenance required on the node for the kernel module upgrade.
++
+If no additional upgrading is needed, you can skip Steps 3 through 6 by updating the `kmm.node.kubernetes.io/version-module.<module-namespace>.<module-name>` label value to the new `$moduleVersion` as set in the `Module`.
 
-. Add the `kmm.node.kubernetes.io/version-module.<module-namespace>.<module-name>=$moduleVersion` label to the node. `$moduleVersion` should be equal to the new value of the `version` field in the `Module` CR.
+. Run the following command to add the `kmm.node.kubernetes.io/version-module.<module_namespace>.<module_name>=$moduleVersion` label to the node. The `$moduleVersion` must be equal to the new value of the `version` field in the `Module` CR.
++
+[source,terminal]
+----
+$ oc label node/<node_name> kmm.node.kubernetes.io/version-module.<module_namespace>.<module_name>=<desired_version>
+----
++
+[NOTE]
+====
+Because of Kubernetes limitations in label names, the combined length of `Module` name and namespace must not exceed 39 characters.
+====
 
 . Restore any workload that leverages the kernel module on the node.
 
-[NOTE]
-====
-If no additional upgrading is needed, you can skip Steps 3 through 6 by updating the `kmm.node.kubernetes.io/version-module.<module-namespace>.<module-name>` label value to the new `$moduleVersion` as set in the `Module`.
-====
+. Reload the device plugin managed by KMM on the node.


### PR DESCRIPTION
Enhancement: Add "how to" details to the Customizing upgrades for kernel modules procedure

Worksheet: https://docs.google.com/document/d/1WDCTwplZpFDPCF3TFkmiAY8UvwmLuJlFRtsB6aFJ42M/edit

Jira: https://issues.redhat.com/browse/TELCODOCS-1528

Version(s): KMMO 1.1

This enhancement request ticket covers updates identified in PR, which includes adding oc commands for some steps and other clarifications provided in the original PR:  https://github.com/openshift/openshift-docs/pull/63309. Note that these are minor enhancements made to the original Jira: [TELCODOCS-1277](https://issues.redhat.com/browse/TELCODOCS-1277).

Link to docs preview: https://65893--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management#kmm-customizing-upgrades-for-kernel-modules_kernel-module-management-operator

SME review: @qbarrand
QE review: @cdvultur
Contributor: @aireilly 

Dev and QE review complete.