### PR TITLE
Remove extra space before "EOF" in Update installing-ocp-agent-inputs.adoc

### DIFF
--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -65,7 +65,7 @@ platform:
 pullSecret: '<pull_secret>' <4>
 sshKey: |
   '<ssh_pub_key>' <5>
-  EOF
+EOF
 ----
 +
 <1> Specify the system architecture, valid values are `amd64` and `arm64`.


### PR DESCRIPTION
Removed the additional spaces before "EOF" which prevents execution of file on terminal.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): All

Issue: The extra space in before the "EOF" in install-config.yaml prevents the execution on terminal.

Link to docs preview:
https://docs.openshift.com/container-platform/4.12/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.html

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
