### PR TITLE
OSDOCS#8041: Release note for z-stream 4.13.15 on MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -282,3 +282,12 @@ Issued: 2023-10-05
 {product-title} release 4.13.14 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5386[RHBA-2023:5386] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5382[RHBA-2023:5382] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-15-dp"]
+=== RHBA-2023:5386 - {product-title} 4.13.15 bug fix update
+
+Issued: 2023-10-10
+
+{product-title} release 4.13.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5469[RHBA-2023:5469] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5467[RHBA-2023:5467] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
**Version:** 4.13
**Issue:** [OSDOCS-8041](https://issues.redhat.com//browse/OSDOCS-8041)

**Link to docs preview:**

[MicroShift 4.13 release notes -> RHBA-2023:5386 - Red Hat build of MicroShift 4.13.15 bug fix update](https://65897--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-15-dp)

**QE review:**
- No QE needed
