### PR TITLE
[OSDOCS-2944] Resolve conditionals bug in 4.13 install docs 

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -2572,6 +2572,15 @@ endif::[]
 ifeval::["{context}" == "installing-restricted-networks-vmc"]
 :!vmc:
 endif::[]
+ifeval::["{context}" == "installing-vmc-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations-user-infra"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vmc-user-infra"]
+:!vmc:
+endif::[]
 ifeval::["{context}" == "installing-openstack-installer-restricted"]
 :!osp:
 :!osp-custom:

--- a/modules/installation-initializing-manual.adoc
+++ b/modules/installation-initializing-manual.adoc
@@ -76,12 +76,6 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-power-vs-private-cluster"]
 :ibm-power-vs-private:
 endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:vsphere-upi-vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:vsphere-upi:
-endif::[]
 ifeval::["{context}" == "installing-vmc-user-infra"]
 :three-node-cluster:
 endif::[]
@@ -289,12 +283,6 @@ ifeval::["{context}" == "installing-ibm-cloud-private"]
 endif::[]
 ifeval::["{context}" == "installing-ibm-power-vs-private-cluster"]
 :!ibm-power-vs-private:
-endif::[]
-ifeval::["{context}" == "installing-vsphere"]
-:vsphere-upi-vsphere:
-endif::[]
-ifeval::["{context}" == "installing-vsphere-network-customizations"]
-:vsphere-upi:
 endif::[]
 ifeval::["{context}" == "installing-vmc-user-infra"]
 :!three-node-cluster:

--- a/modules/installation-load-balancing-user-infra.adoc
+++ b/modules/installation-load-balancing-user-infra.adoc
@@ -271,6 +271,15 @@ If you are deploying a three-node cluster with zero compute nodes, the Ingress C
 If you are using HAProxy as a load balancer, you can check that the `haproxy` process is listening on ports `6443`, `22623`, `443`, and `80` by running `netstat -nltupe` on the HAProxy node.
 ====
 
+ifeval::["{context}" == "installing-vsphere"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!vsphere:
+endif::[]
 ifeval::["{context}" == "installing-ibm-z"]
 :!ibm-z:
 endif::[]

--- a/modules/installation-network-user-infra.adoc
+++ b/modules/installation-network-user-infra.adoc
@@ -303,6 +303,15 @@ If a DHCP server provides NTP server information, the chrony time service on the
 endif::ibm-z,ibm-z-restricted[]
 endif::azure,gcp[]
 
+ifeval::["{context}" == "installing-vsphere"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!vsphere:
+endif::[]
 ifeval::["{context}" == "installing-vmc-user-infra"]
 :!vmc:
 endif::[]

--- a/modules/installation-obtaining-installer.adoc
+++ b/modules/installation-obtaining-installer.adoc
@@ -187,3 +187,21 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :!private:
 endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vmc"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-customizations"]
+:!vmc:
+endif::[]
+ifeval::["{context}" == "installing-vmc-network-customizations"]
+:!vmc:
+endif::[]

--- a/modules/installation-osp-downloading-modules.adoc
+++ b/modules/installation-osp-downloading-modules.adoc
@@ -20,6 +20,9 @@ endif::[]
 ifeval::["{context}" == "uninstalling-openstack-user"]
 :osp-user-uninstall:
 endif::[]
+ifeval::["{context}" == "uninstalling-cluster-openstack"]
+:osp-user-uninstall:
+endif::[]
 
 :_content-type: PROCEDURE
 [id="installation-osp-downloading-modules_{context}"]
@@ -118,5 +121,8 @@ ifeval::["{context}" == "installing-openstack-user-sr-iov-kuryr"]
 :!osp-user:
 endif::[]
 ifeval::["{context}" == "uninstalling-cluster-openstack"]
+:!osp-user-uninstall:
+endif::[]
+ifeval::["{context}" == "uninstalling-openstack-user"]
 :!osp-user-uninstall:
 endif::[]

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -65,6 +65,9 @@ ifeval::["{context}" == "installing-restricted-networks-gcp"]
 :gcp:
 :restricted:
 endif::[]
+ifeval::["{context}" == "installing-osp-user"]
+:osp:
+endif::[]
 ifeval::["{context}" == "installing-openstack-user"]
 :osp:
 endif::[]
@@ -535,6 +538,9 @@ ifeval::["{context}" == "installing-restricted-networks-gcp"]
 :!restricted:
 endif::[]
 ifeval::["{context}" == "installing-osp-user"]
+:!osp:
+endif::[]
+ifeval::["{context}" == "installing-openstack-user"]
 :!osp:
 endif::[]
 ifeval::["{context}" == "installing-openstack-user-kuryr"]

--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -453,7 +453,7 @@ ifeval::["{context}" == "cluster-network-operator"]
 :!operator:
 endif::[]
 
-ifdef::post-install-network-configuration[]
+ifeval::["{context}" == "post-install-network-configuration"]
 :!post-install-network-configuration:
 endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-network-customizations"]

--- a/modules/nw-osp-configuring-external-load-balancer.adoc
+++ b/modules/nw-osp-configuring-external-load-balancer.adoc
@@ -173,3 +173,16 @@ content-type: text/html; charset=utf-8
 set-cookie: 1e2670d92730b515ce3a1bb65da45062=9b714eb87e93cf34853e87a92d6894be; path=/; HttpOnly; Secure; SameSite=None
 cache-control: private
 ----
+
+ifeval::["{context}" == "installing-vsphere-installer-provisioned"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-vsphere-installer-provisioned-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == installing-restricted-networks-installer-provisioned-vsphere]
+:!vsphere:
+endif::[]


### PR DESCRIPTION
Manual CP due to failure of https://github.com/openshift/openshift-docs/pull/65870, which is a cherrypick of https://github.com/openshift/openshift-docs/pull/65587.

Version: 4.13.

[OSDOCS-2944](https://issues.redhat.com//browse/OSDOCS-2944) -> [OSDOCS-8086](https://issues.redhat.com//browse/OSDOCS-8086)

QE not relevant.

Additional information: This problem seems to be centered around vSphere conditionals, but that could be a red herring. :shrug: 

Builds fails with these unresolved references:
```
installation-configuration-parameters-additional-vsphere_installing-vsphere
installation-configuration-parameters-additional-vsphere_installing-vsphere-network-customizations
installation-configuration-parameters-additional-vsphere_installing-restricted-networks-vsphere
deprecated-parameters-vsphere_installing-vsphere
deprecated-parameters-vsphere_installing-vsphere-network-customizations
deprecated-parameters-vsphere_installing-restricted-networks-vsphere
```

In this PR, the vSphere add'l and deprecated parameters modules are missing in installing-vsphere, installing-vsphere-network-customizations, and installing-restricted-networks-vsphere.

Live, Azure-specific lines appear in installation docs for non-Azure platforms, which might mean an unclosed Azure statement somewhere. 