### PR TITLE
OSDOCS-8042: iptables deprecation

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -586,6 +586,15 @@ If you are receiving pod security violations, see the following resources:
 
 The {cert-manager-operator} 1.11 is now generally available in {product-title} 4.14 as well as {product-title} 4.13 and {product-title} 4.12.
 
+[discrete]
+[id="ocp-4-14-iptables-deprecation"]
+=== Impact of iptables deprecation
+
+With the link:https://access.redhat.com/solutions/6739041[deprecation of iptables], there are some consequences if you do not migrate all use of iptables to the newer nftables.
+
+* In {op-system-base-full} 9.x, a single log message generates during node startup on every {product-title} node.  Insights rules will trigger on all {product-title} nodes.
+* In {op-system-base} 10, iptables will no longer work. Neither the command-line tools nor the kernel modules will be present.
+
 [id="ocp-4-14-deprecated-removed-features"]
 == Deprecated and removed features
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8042

Link to docs preview:
https://65905--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-iptables-deprecation

QE review:
- [ ] QE has approved this change.