### PR TITLE
OSDOCS-8088: Edit domain name in step 3.2 of ROSA Shared VPC docs

### DIFF
--- a/modules/rosa-sharing-vpc-hosted-zones.adoc
+++ b/modules/rosa-sharing-vpc-hosted-zones.adoc
@@ -37,7 +37,7 @@ image::372_OpenShift_on_AWS_persona_worflows_0923_3.png[]
   ]
 }
 ----
-. Create a private hosted zone in the link:https://us-east-1.console.aws.amazon.com/route53/v2/[Route 53 section of the AWS console]. In the hosted zone configuration, the domain name is `<cluster-name>.openshiftapps.com`. The private hosted zone must be associated with the created VPC.
+. Create a private hosted zone in the link:https://us-east-1.console.aws.amazon.com/route53/v2/[Route 53 section of the AWS console]. In the hosted zone configuration, the domain name is `<cluster_name>.<reserved_dns_domain>`. The private hosted zone must be associated with the created VPC.
 . After the hosted zone is created and associated with the VPC, provide the following to the *Cluster Creator* to continue configuration:
 * Hosted zone ID
 * AWS region


### PR DESCRIPTION
[OSDOCS-8088](https://issues.redhat.com//browse/OSDOCS-8088): Edit the domain name in step 3.2 of the ROSA Shared VPC docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-8088

Link to docs preview:
https://65909--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config#rosa-sharing-vpc-hosted-zones_rosa-shared-vpc-config

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
