### PR TITLE
OCPBUGS#11410: Add required Azure AD permission

### DIFF
--- a/modules/installation-azure-permissions.adoc
+++ b/modules/installation-azure-permissions.adoc
@@ -7,9 +7,15 @@
 [id="installation-azure-permissions_{context}"]
 = Required Azure roles
 
-{product-title} needs a service principal so it can manage Microsoft Azure resources. Before you can create a service principal, your Azure account subscription must have the following roles:
+{product-title} needs a service principal so it can manage Microsoft Azure resources. Before you can create a service principal, review the following information:
+
+Your Azure account subscription must have the following roles:
 
 * `User Access Administrator`
 * `Contributor`
+
+Your Azure Active Directory (AD) must have the following permission:
+
+* `"microsoft.directory/servicePrincipals/createAsOwner"`
 
 To set roles on the Azure portal, see the link:https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal[Manage access to Azure resources using RBAC and the Azure portal] in the Azure documentation.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.10+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-11410
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://65911--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account#installation-azure-permissions_installing-azure-account
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The "Required Azure roles" section or `modules/installation-azure-permissions.adoc` file will not be available in the preview. The file is currently not present in 4.14 and main. But it is being used from 4.10 - 4.13. Once this PR is merged, I will create a manual cherry-pick for 4.14. 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
