### PR TITLE
IBM Power Installation doc: teaming is deprecated in RHEL 9

### DIFF
--- a/modules/installation-user-infra-machines-static-network.adoc
+++ b/modules/installation-user-infra-machines-static-network.adoc
@@ -314,6 +314,7 @@ ip=10.10.10.2::10.10.10.254:255.255.255.0:core0.example.com:bond0:none
 ----
 endif::ibm-z[]
 
+ifndef::ibm-power[]
 [discrete]
 === Using network teaming
 
@@ -335,6 +336,7 @@ Use the following example to configure a network team:
 team=team0:em1,em2
 ip=team0:dhcp
 ----
+endif::ibm-power[]
 endif::ibm-z-kvm[]
 
 ifndef::ibm-z,ibm-z-kvm,ibm-power[]


### PR DESCRIPTION
Version(s): 4.13+

Issue: https://issues.redhat.com/browse/MULTIARCH-3707

Draft: https://docs.google.com/document/d/11bqp8ogDLsCorOQnbLUopKdTmSuhkkbwMYhO1qRGOxs/edit

Link to docs preview:
- Doc (preview of this PR): https://65914--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-restricted-networks-ibm-power#installation-user-infra-machines-static-network_installing-restricted-networks-ibm-power
- Doc (original- with network teaming): https://docs.openshift.com/container-platform/4.13/installing/installing_ibm_power/installing-ibm-power.html#installation-user-infra-machines-static-network_installing-ibm-power

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
FYI: [Teaming is deprecated in RHEL 9](https://access.redhat.com/solutions/6509691)
