### PR TITLE
Start the preview stage before others

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,8 +78,8 @@ jobs:
         - ./autopreview.sh
 
 stages:
+  - netlify
   - cache-and-validate
   - build
-  - netlify
   #- check-with-vale
   #- automerge


### PR DESCRIPTION
Moved `Netlify` stage to the top, to run it before other stages.
- This means that Travis CI build will progress simultaneously with the preview build.