### PR TITLE
ROX-14701: Document how to download roxctl for IBM P&Z

### DIFF
--- a/modules/install-roxctl-cli-linux.adoc
+++ b/modules/install-roxctl-cli-linux.adoc
@@ -9,12 +9,19 @@ You can install the `roxctl` CLI binary on Linux by using the following procedur
 
 .Procedure
 
-. Download the latest version of the `roxctl` CLI:
+. Download the `roxctl` CLI:
 +
 [source,terminal,subs=attributes+]
 ----
-$ curl -O https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Linux/roxctl
+$ arch="$(uname -m | sed "s/x86_64//")"; arch="${arch:+-$arch}"
 ----
++
+[source,terminal,subs=attributes+]
+----
+$ curl -f -o roxctl "https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Linux/roxctl${arch}"
+----
++
+NOTE: `roxctl` CLI for Linux is available for `amd64`, `ppcl64le`, and `s390x` architectures.
 . Make the `roxctl` binary executable:
 +
 [source,terminal]

--- a/modules/install-roxctl-cli-macos.adoc
+++ b/modules/install-roxctl-cli-macos.adoc
@@ -9,12 +9,14 @@ You can install the `roxctl` CLI binary on macOS by using the following procedur
 
 .Procedure
 
-. Download the latest version of the `roxctl` CLI:
+. Download the `roxctl` CLI:
 +
 [source,terminal,subs=attributes+]
 ----
-$ curl -O https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Darwin/roxctl
+$ curl -f -O https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Darwin/roxctl
 ----
++
+NOTE: `roxctl` CLI for macOS is available for the `amd64` architecture.
 . Remove all extended attributes from the binary:
 +
 [source,terminal]

--- a/modules/install-roxctl-cli-windows.adoc
+++ b/modules/install-roxctl-cli-windows.adoc
@@ -9,12 +9,14 @@ You can install the `roxctl` CLI binary on Windows by using the following proced
 
 .Procedure
 
-* Download the latest version of the `roxctl` CLI:
+* Download the `roxctl` CLI:
 +
 [source,terminal,subs=attributes+]
 ----
-$ curl -O https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Windows/roxctl.exe
+$ curl -f -O https://mirror.openshift.com/pub/rhacs/assets/{rhacs-version}/bin/Windows/roxctl.exe
 ----
++
+NOTE: `roxctl` CLI for Windows is available for the `amd64` architecture.
 
 .Verification
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
* Merge to `rhacs-docs`
* Cherry pick to `rhacs-docs-4.3`
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/ROX-14701
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://65916--docspreview.netlify.app/openshift-acs/latest/cli/installing-the-roxctl-cli
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I recommend reviewing this change per commit as I tried providing meaningful commit messages in each.
This complements https://github.com/stackrox/stackrox/pull/8011 by extending documentation.

Testing done:
I created a small script with the similar content and ran it against `zsh`, `bash` and `dash` to make sure commands are valid.

```bash
#!/usr/bin/env zsh

set -eux

arch="$(uname -m | sed "s/x86_64//")"; arch="${arch:+-$arch}"
#arch="$(echo "s390x" | sed "s/x86_64//")"; arch="${arch:+-$arch}"

curl -f -o roxctl "https://mirror.openshift.com/pub/rhacs/assets/4.2.0/bin/Linux/roxctl${arch}"
```

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
