### PR TITLE
RHDEVDOCS-5484-builds-redirect: redirecting to the builds standalone …

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -230,7 +230,16 @@ AddType text/vtt                            vtt
     # redirect any links to existing ROSA/Dedicated embedded content to standalone equivalent
     RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
 
+    # redirect builds latest to 1.0
+    RewriteRule ^builds/?$ /builds/latest [R=302]
+    RewriteRule ^builds/latest/?(.*)$ /builds/1.0/$1 [NE,R=302]
 
+    # redirect top-level without filespec to the about file
+    RewriteRule ^builds/(1\.0)/?$ /builds/$1/about/overview-openshift-builds.html  [L,R=302]
+
+    # Builds using Shipwright landing page
+    RewriteRule ^container-platform/(4\.14)/cicd/builds_using_shipwright/overview-openshift-builds.html /builds/latest/about/overview-openshift-builds.html  [L,R=302]
+	
     # redirect gitops latest to 1.10
     RewriteRule ^gitops/?$ /gitops/latest [R=302]
     RewriteRule ^gitops/latest/?(.*)$ /gitops/1\.10/$1 [NE,R=302]

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -342,7 +342,7 @@ openshift-pipelines:
       name: '1.12'
       dir: pipelines/1.12
 openshift-builds:
-  name: Builds for Red Hat OpenShift
+  name: builds for Red Hat OpenShift
   author: OpenShift documentation team <openshift-docs@redhat.com>
   site: commercial
   site_name: Documentation


### PR DESCRIPTION
Purpose: To redirect users to the Builds standalone page

version(s): main only

Additional info: On the docs.openshift.com site, we would be having this kind of structure:
![image](https://github.com/openshift/openshift-docs/assets/94683525/b4ee1431-f8ae-4f8b-bb44-963d166be850)

The existing Builds content would still be there, so no redirects for the existing Builds content.  We only need to navigate users to the builds standalone page when they look out for the Builds using Shipwright documentation. To have this structure, i created this PR: https://github.com/openshift/openshift-docs/pull/65361 and this is the preview: https://65361--docspreview.netlify.app/openshift-enterprise/latest/cicd/. 

**Context**:
On the docs.openshift.com site, we would be having this kind of Builds content structure as we now have 2 flavors for Builds:
* One is Builds using Shipwright with all the new content created from scratch in a separate standalone repo build-docs. If you expand Builds using Shipwright, we just have one file Overview of Builds under it. This file would act as a redirect point (like what we did with pipelines and gitops). Clicking this file would redirect a user to the [standalone page](https://docs.openshift.com/builds/1.0/about/overview-openshift-builds.html).
* The other is Builds using BuildConfig with old content that is going to be maintained in the docs.openshift.com site till the release of OCP 4.15. With OCP 4.15, plans are to also move the old content to the standalone repo build-docs. But for the OCP 4.14 release, the content would still be there on the docs site as is.