### PR TITLE
[enterprise-4.12] [WIP] [DOCS] OBSDOCS-544 & 545 - Logging 5.6.12 & 5.5.17 Release Notes

### DIFF
--- a/logging/v5_5/logging-5-5-release-notes.adoc
+++ b/logging/v5_5/logging-5-5-release-notes.adoc
@@ -7,6 +7,8 @@ toc::[]
 
 include::snippets/logging-compatibility-snip.adoc[]
 
+include::modules/logging-rn-5.5.17.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.5.16.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.5.14.adoc[leveloffset=+1]

--- a/logging/v5_6/logging-5-6-release-notes.adoc
+++ b/logging/v5_6/logging-5-6-release-notes.adoc
@@ -9,6 +9,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-rn-5.6.12.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.6.11.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.9.adoc[leveloffset=+1]

--- a/modules/logging-rn-5.5.17.adoc
+++ b/modules/logging-rn-5.5.17.adoc
@@ -1,0 +1,25 @@
+// Module included in the following assemblies:
+// logging-5-5-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-5-17_{context}"]
+= Logging 5.5.17
+This release includes link:https://access.redhat.com/errata/RHSA-2023:5542[OpenShift Logging Bug Fix Release 5.5.17].
+
+[id="openshift-logging-5-5-17-bug-fixes_{context}"]
+== Bug fixes
+None.
+
+[id="openshift-logging-5-5-17-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-2002[CVE-2023-2002]
+* link:https://access.redhat.com/security/cve/CVE-2023-3090[CVE-2023-3090]
+* link:https://access.redhat.com/security/cve/CVE-2023-3390[CVE-2023-3390]
+* link:https://access.redhat.com/security/cve/CVE-2023-3776[CVE-2023-3776]
+* link:https://access.redhat.com/security/cve/CVE-2023-4004[CVE-2023-4004]
+* link:https://access.redhat.com/security/cve/CVE-2023-4863[CVE-2023-4863]
+* link:https://access.redhat.com/security/cve/CVE-2023-5129[CVE-2023-5129]
+* link:https://access.redhat.com/security/cve/CVE-2023-20593[CVE-2023-20593]
+* link:https://access.redhat.com/security/cve/CVE-2023-29491[CVE-2023-29491]
+* link:https://access.redhat.com/security/cve/CVE-2023-30630[CVE-2023-30630]
+* link:https://access.redhat.com/security/cve/CVE-2023-35001[CVE-2023-35001]
+* link:https://access.redhat.com/security/cve/CVE-2023-35788[CVE-2023-35788]

--- a/modules/logging-rn-5.6.12.adoc
+++ b/modules/logging-rn-5.6.12.adoc
@@ -1,0 +1,26 @@
+// Module included in the following assemblies:
+// logging-5-6-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-6-12_{context}"]
+= Logging 5.6.12
+This release includes link:https://access.redhat.com/errata/RHSA-2023:5541[OpenShift Logging Bug Fix Release 5.6.12].
+
+[id="openshift-logging-5-6-12-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, deploying LokiStack on IPv6-only or dual-stack OCP clusters caused the LokiStack memberlist registration to fail. As a result, the distributor pods went into a crash loop. With this update, the administrator can enable IPv6 using `lokistack.spec.hashRing.memberlist.enableIPv6: true` which resolves the issue. (link:https://issues.redhat.com/browse/LOG-4570[LOG-4570])
+
+
+[id="openshift-logging-5-6-12-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-2002[CVE-2023-2002]
+* link:https://access.redhat.com/security/cve/CVE-2023-3090[CVE-2023-3090]
+* link:https://access.redhat.com/security/cve/CVE-2023-3390[CVE-2023-3390]
+* link:https://access.redhat.com/security/cve/CVE-2023-3776[CVE-2023-3776]
+* link:https://access.redhat.com/security/cve/CVE-2023-4004[CVE-2023-4004]
+* link:https://access.redhat.com/security/cve/CVE-2023-4863[CVE-2023-4863]
+* link:https://access.redhat.com/security/cve/CVE-2023-5129[CVE-2023-5129]
+* link:https://access.redhat.com/security/cve/CVE-2023-20593[CVE-2023-20593]
+* link:https://access.redhat.com/security/cve/CVE-2023-29491[CVE-2023-29491]
+* link:https://access.redhat.com/security/cve/CVE-2023-30630[CVE-2023-30630]
+* link:https://access.redhat.com/security/cve/CVE-2023-35001[CVE-2023-35001]
+* link:https://access.redhat.com/security/cve/CVE-2023-35788[CVE-2023-35788]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.6.12 & 5.5.17
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-545 & https://issues.redhat.com/browse/OBSDOCS-544 

Fix Version: 4.11 & 4.12

Doc Previews:
For 5.6.11: https://65923--docspreview.netlify.app/openshift-enterprise/latest/logging/v5_6/logging-5-6-release-notes 
For 5.5.16: https://65923--docspreview.netlify.app/openshift-enterprise/latest/logging/v5_5/logging-5-5-release-notes

SME Review: 
QE Review: 
Peer Review: