### PR TITLE
[OSDOCS-8095] Fixes IBM CCM support status in 4.11 docs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2184,8 +2184,8 @@ In the table below, features are marked with the following statuses:
 
 |Cloud controller manager for IBM Cloud
 |-
-|GA
-|GA
+|TP
+|TP
 
 |Cloud controller manager for Microsoft Azure
 |TP


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-8095](https://issues.redhat.com//browse/OSDOCS-8095)

Link to docs preview:
[Technology Preview features](https://65937--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-technology-preview)

QE review:
- [x] QE has approved this change.

Additional information:
