### PR TITLE
[OSDOCS-8095] Fixes IBM CCM support status in 4.12 docs

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-This Operator is only fully supported for Microsoft Azure Stack Hub.
+This Operator is fully supported for Microsoft Azure Stack Hub and IBM Cloud.
 
-It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud, IBM Cloud Power VS, Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
+It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud Power VS, Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -2911,6 +2911,16 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
+|Cloud controller manager for IBM Cloud
+|Technology Preview
+|Technology Preview
+|General Availability
+
+|Cloud controller manager for IBM Cloud Power VS
+|Not Available
+|Not Available
+|Technology Preview
+
 |Cloud controller manager for Microsoft Azure
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-8095](https://issues.redhat.com//browse/OSDOCS-8095)

Link to docs preview:
[Machine management Technology Preview features](https://65939--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#machine-management-technology-preview-features)
[Cluster Cloud Controller Manager Operator](https://65939--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information:
