### PR TITLE
[OSDOCS-8095] Fixes IBM CCM support status in 4.13 docs

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-This Operator is General Availability for Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and VMware vSphere.
+This Operator is General Availability for Microsoft Azure Stack Hub, IBM Cloud, Nutanix, {rh-openstack-first}, and VMware vSphere.
 
-It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud, IBM Cloud Power VS, and Microsoft Azure.
+It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud Power VS, and Microsoft Azure.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).

--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2624,6 +2624,16 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
+|Cloud controller manager for IBM Cloud
+|Technology Preview
+|General Availability
+|General Availability
+
+|Cloud controller manager for IBM Cloud Power VS
+|Not Available
+|Technology Preview
+|Technology Preview
+
 |Cloud controller manager for Microsoft Azure
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.13

Issue:
[OSDOCS-8095](https://issues.redhat.com//browse/OSDOCS-8095)

Link to docs preview:
[Machine management Technology Preview features](https://65940--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#machine-management-technology-preview-features)
[Cluster Cloud Controller Manager Operator](https://65940--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information:
