### PR TITLE
[OSDOCS-8095] Fixes IBM CCM support status in 4.14 docs

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-The status of this Operator is General Availability for Amazon Web Services (AWS), global Microsoft Azure, Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and VMware vSphere.
+The status of this Operator is General Availability for Amazon Web Services (AWS), IBM Cloud, global Microsoft Azure, Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and VMware vSphere.
 
-The Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Google Cloud Platform (GCP), IBM Cloud, and IBM Cloud Power VS.
+The Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Google Cloud Platform (GCP), and IBM Cloud Power VS.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -145,7 +145,7 @@ Before you set a path value for the `template` parameter, ensure that the defaul
 === Post-installation configuration
 
 [id="ocp-4-14-OCP-on-multi-arch-clusters"]
-==== {product-title} cluster with multi-architecture compute machines 
+==== {product-title} cluster with multi-architecture compute machines
 {product-title} {product-version} clusters with multi-architecture compute machines are now supported on Google Cloud Platform (GCP) as a Day 2 operation. {product-title} clusters with multi-architecture compute machines on bare metal installations are now generally available. For more information on clusters with multi-architecture compute machines and supported platforms, see xref:../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc#multi-architecture-configuration[About clusters with multi-architecture compute machines].
 
 [id="ocp-4-14-web-console"]
@@ -1571,6 +1571,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 
 |Cloud controller manager for Google Cloud Platform
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Cloud controller manager for IBM Cloud Power VS
 |Technology Preview
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-8095](https://issues.redhat.com//browse/OSDOCS-8095)

Link to docs preview:
[Machine management Technology Preview features](https://65941--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#machine-management-technology-preview-features)
[Cluster Cloud Controller Manager Operator](https://65941--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information:
Will update the Operator note in `main` as well (#65942)