### PR TITLE
[OSDOCS-8095] Fixes IBM CCM support status in `main`

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -10,9 +10,9 @@
 
 [NOTE]
 ====
-The status of this Operator is General Availability for Amazon Web Services (AWS), global Microsoft Azure, Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and VMware vSphere.
+The status of this Operator is General Availability for Amazon Web Services (AWS), IBM Cloud, global Microsoft Azure, Microsoft Azure Stack Hub, Nutanix, {rh-openstack-first}, and VMware vSphere.
 
-The Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Google Cloud Platform (GCP), IBM Cloud, and IBM Cloud Power VS.
+The Operator is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Google Cloud Platform (GCP), and IBM Cloud Power VS.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-8095](https://issues.redhat.com//browse/OSDOCS-8095)

Link to docs preview:
[Cluster Cloud Controller Manager Operator](https://65942--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
- [x] QE has approved this change.

Additional information:
Change is already in 4.14 in #65941, but must be in `main` as well