### PR TITLE
OSDOCS#8136: Adding decription about x86 support on conf vms

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -90,7 +90,7 @@ For more information, see xref:../installing/installing_nutanix/installing-nutan
 
 [id="ocp-4-14-installation-gcp-confidential-vms"]
 ==== Installing a cluster on GCP using Confidential VMs is generally available
-In {product-title} {product-version}, using Confidential VMs when installing your cluster is generally available. For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-enabling-confidential-vms_installing-gcp-customizations[Enabling Confidential VMs].
+In {product-title} {product-version}, using Confidential VMs when installing your cluster is generally available. Confidential VMs are currently not supported on 64-bit ARM architectures. For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installation-gcp-enabling-confidential-vms_installing-gcp-customizations[Enabling Confidential VMs].
 
 [id="ocp-4-14-dc-build-apis-disabled"]
 ==== DeploymentConfig and Build APIs can now be disabled


### PR DESCRIPTION
**Version:** 4.14
**Issue:** [OSDOCS-8136](https://issues.redhat.com//browse/OSDOCS-8136)

**Link to docs preview:**

[Release notes -> Installing a cluster on GCP using Confidential VMs is generally available ](https://65944--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-installation-and-update)

**QE review:**
- [x] QE has approved this change.
