### PR TITLE
Fixes assembly reference in OMR docs

### DIFF
--- a/modules/mirror-registry-localhost-update.adoc
+++ b/modules/mirror-registry-localhost-update.adoc
@@ -1,6 +1,6 @@
 // module included in the following assembly:
 //
-// * /home/stevsmit/pp/openshift-docs/installing/disconnected_install/installing-mirroring-creating-registry.adoc
+// * installing/disconnected_install/installing-mirroring-creating-registry.adoc
 
 :_content-type: PROCEDURE
 [id="mirror-registry-localhost-update_{context}"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
Follow up to https://github.com/openshift/openshift-docs/pull/65486

Link to docs preview:

No impact on preview 

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
