### PR TITLE
OSDOCS#6189: Updated AWS AMI image IDs

### DIFF
--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -23,91 +23,91 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-052b3e6b060b5595d`
+|`ami-01860370941726bdd`
 
 |`ap-east-1`
-|`ami-09c502968481ee218`
+|`ami-05bc702cdaf7e4251`
 
 |`ap-northeast-1`
-|`ami-06b1dbe049e3c1d23`
+|`ami-098932fd93c15690d`
 
 |`ap-northeast-2`
-|`ami-08add6eb5aa1c8639`
+|`ami-006f4e02d97910a36`
 
 |`ap-northeast-3`
-|`ami-0af4dfc64506fe20e`
+|`ami-0c4bd5b1724f82273`
 
 |`ap-south-1`
-|`ami-09b1532dd3d63fdc0`
+|`ami-0cbf22b638724853d`
 
 |`ap-south-2`
-|`ami-0a915cedf8558e600`
+|`ami-031f4d165f4b429c4`
 
 |`ap-southeast-1`
-|`ami-0c914fd7a50130c9e`
+|`ami-0dc3e381a731ab9fc`
 
 |`ap-southeast-2`
-|`ami-04b54199f4be0ec9d`
+|`ami-032ae8d0f287a66a6`
 
 |`ap-southeast-3`
-|`ami-0be3ee78b9a3fdf07`
+|`ami-0393130e034b86423`
 
 |`ap-southeast-4`
-|`ami-00a44d7d5054bb5f8`
+|`ami-0b38f776bded7d7d7`
 
 |`ca-central-1`
-|`ami-0bb1fd49820ea09ae`
+|`ami-058ea81b3a1d17edd`
 
 |`eu-central-1`
-|`ami-03d9cb166a11c9b8a`
+|`ami-011010debd974a250`
 
 |`eu-central-2`
-|`ami-089865c640f876630`
+|`ami-0623b105ae811a5e2`
 
 |`eu-north-1`
-|`ami-0e94d896e72eeae0d`
+|`ami-0c4bb9ce04f3526d4`
 
 |`eu-south-1`
-|`ami-04df4e2850dce0721`
+|`ami-06c29eccd3d74df52`
 
 |`eu-south-2`
-|`ami-0d80de3a5ba722545`
+|`ami-00e0b5f3181a3f98b`
 
 |`eu-west-1`
-|`ami-066f2d86026ef97a8`
+|`ami-087bfa513dc600676`
 
 |`eu-west-2`
-|`ami-0f1c0b26b1c99499d`
+|`ami-0ebad59c0e9554473`
 
 |`eu-west-3`
-|`ami-0f639505a9c74d9a2`
+|`ami-074e63b65eaf83f96`
 
 |`me-central-1`
-|`ami-0fbb2ece8478f1402`
+|`ami-0179d6ae1d908ace9`
 
 |`me-south-1`
-|`ami-01507551558853852`
+|`ami-0b60c75273d3efcd7`
 
 |`sa-east-1`
-|`ami-097132aa0da53c981`
+|`ami-0913cbfbfa9a7a53c`
 
 |`us-east-1`
-|`ami-0624891c612b5eaa0`
+|`ami-0f71dcd99e6a1cd53`
 
 |`us-east-2`
-|`ami-0dc6c4d1bd5161f13`
+|`ami-0545fae7edbbbf061`
 
 |`us-gov-east-1`
-|`ami-0bab20368b3b9b861`
+|`ami-081eabdc478e501e5`
 
 |`us-gov-west-1`
-|`ami-0fe8299f8e808e720`
+|`ami-076102c394767f319`
 
 |`us-west-1`
-|`ami-0c03b7e5954f10f9b`
+|`ami-0609e4436c4ae5eff`
 
 |`us-west-2`
-|`ami-0f4cdfd74e4a3fc29`
+|`ami-0c5d3e03c0ab9b19a`
 
 |===
 
@@ -120,91 +120,91 @@ ifndef::openshift-origin[]
 |AWS AMI
 
 |`af-south-1`
-|`ami-0d684ca7c09e6f5fc`
+|`ami-08dd66a61a2caa326`
 
 |`ap-east-1`
-|`ami-01b0e1c24d180fe5d`
+|`ami-0232cd715f8168c34`
 
 |`ap-northeast-1`
-|`ami-06439c626e2663888`
+|`ami-0bc0b17618da96700`
 
 |`ap-northeast-2`
-|`ami-0a19d3bed3a2854e3`
+|`ami-0ee505fb62eed2fd6`
 
 |`ap-northeast-3`
-|`ami-08b8fa76fd46b5c58`
+|`ami-0462cd2c3b7044c77`
 
 |`ap-south-1`
-|`ami-0ec6463b788929a6a`
+|`ami-0e0b4d951b43adc58`
 
 |`ap-south-2`
-|`ami-0f5077b6d7e1b10a5`
+|`ami-06d457b151cc0e407`
 
 |`ap-southeast-1`
-|`ami-081a6c6a24e2ee453`
+|`ami-0874e1640dfc15f17`
 
 |`ap-southeast-2`
-|`ami-0a70049ac02157a02`
+|`ami-05f215734ceb0f5ad`
 
 |`ap-southeast-3`
-|`ami-065fd6311a9d7e6a6`
+|`ami-073030df265c88b3f`
 
 |`ap-southeast-4`
-|`ami-0105993dc2508c4f4`
+|`ami-043f4c40a6fc3238a`
 
 |`ca-central-1`
-|`ami-04582d73d5aad9a85`
+|`ami-0840622f99a32f586`
 
 |`eu-central-1`
-|`ami-0f72c8b59213f628e`
+|`ami-09a5e6ebe667ae6b5`
 
 |`eu-central-2`
-|`ami-0647f43516c31119c`
+|`ami-0835cb1bf387e609a`
 
 |`eu-north-1`
-|`ami-0d155ca6a531f5f72`
+|`ami-069ddbda521a10a27`
 
 |`eu-south-1`
-|`ami-02f8d2794a663dbd0`
+|`ami-09c5cc21026032b4c`
 
 |`eu-south-2`
-|`ami-0427659985f520cae`
+|`ami-0c36ab2a8bbeed045`
 
 |`eu-west-1`
-|`ami-04e9944a8f9761c3e`
+|`ami-0d2723c8228cb2df3`
 
 |`eu-west-2`
-|`ami-09c701f11d9a7b167`
+|`ami-0abd66103d069f9a8`
 
 |`eu-west-3`
-|`ami-02cd8181243610e0d`
+|`ami-08c7249d59239fc5c`
 
 |`me-central-1`
-|`ami-03008d03f133e6ec0`
+|`ami-0685f33ebb18445a2`
 
 |`me-south-1`
-|`ami-096bc3b4ec0faad76`
+|`ami-0466941f4e5c56fe6`
 
 |`sa-east-1`
-|`ami-01f9b5a4f7b8c50a1`
+|`ami-08cdc0c8a972f4763`
 
 |`us-east-1`
-|`ami-09ea6f8f7845792e1`
+|`ami-0d461970173c4332d`
 
 |`us-east-2`
-|`ami-039cdb2bf3b5178da`
+|`ami-0e9cdc0e85e0a6aeb`
 
 |`us-gov-east-1`
-|`ami-0fed54a5ab75baed0`
+|`ami-0b896df727672ce09`
 
 |`us-gov-west-1`
-|`ami-0fc5be5af4bb1d79f`
+|`ami-0b896df727672ce09`
 
 |`us-west-1`
-|`ami-018e5407337da1062`
+|`ami-027b7cc5f4c74e6c1`
 
 |`us-west-2`
-|`ami-0c0c67ef81b80e8eb`
+|`ami-0b189d89b44bdfbf2`
 
 |===
 endif::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.14

Issue:
This PR addresses [osdocs-6189](https://issues.redhat.com/browse/OSDOCS-6189).

Link to docs preview:

[RHCOS AMIs for the AWS infrastructure](https://65975--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws.html#installation-aws-user-infra-rhcos-ami_installing-restricted-networks-aws)

QE review:
- [x] QE has approved this change.
