### PR TITLE
[enterprise-4.12][DOCS] OBSDOCS-545 - Logging 5.6.12 Release Notes

### DIFF
--- a/logging/logging_release_notes/logging-5-6-release-notes.adoc
+++ b/logging/logging_release_notes/logging-5-6-release-notes.adoc
@@ -10,6 +10,8 @@ include::snippets/logging-compatibility-snip.adoc[]
 
 include::snippets/logging-stable-updates-snip.adoc[]
 
+include::modules/logging-rn-5.6.12.adoc[leveloffset=+1]
+
 include::modules/logging-rn-5.6.11.adoc[leveloffset=+1]
 
 include::modules/logging-rn-5.6.9.adoc[leveloffset=+1]

--- a/modules/logging-rn-5.6.12.adoc
+++ b/modules/logging-rn-5.6.12.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+// logging-5-6-release-notes.adoc
+:_content-type: REFERENCE
+[id="cluster-logging-release-notes-5-6-12_{context}"]
+= Logging 5.6.12
+This release includes link:https://access.redhat.com/errata/RHSA-2023:5541[OpenShift Logging Bug Fix Release 5.6.12].
+
+[id="openshift-logging-5-6-12-bug-fixes_{context}"]
+== Bug fixes
+* Before this update, deploying a LokiStack on IPv6-only or dual-stack {product-title} clusters caused the LokiStack memberlist registration to fail. As a result, the distributor pods went into a crash loop. With this update, an administrator can enable IPv6 by setting the `lokistack.spec.hashRing.memberlist.enableIPv6:` value to `true`, which resolves the issue. (link:https://issues.redhat.com/browse/LOG-4570[LOG-4570])
+
+* Before this update, there was an error in the query used for the *FluentD Buffer Availability* graph in the metrics dashboard created by the Cluster Logging Operator as it showed the minimum buffer usage. With this update, the graph shows the maximum buffer usage and is now renamed to *FluentD Buffer Usage*. (link:https://issues.redhat.com/browse/LOG-4579[LOG-4579])
+
+* Before this update, the unused metrics in the Event Router caused the container to fail due to excessive memory usage. With this update, there is reduction in the memory usage of the Event Router by removing the unused metrics. (link:https://issues.redhat.com/browse/LOG-4687[LOG-4687])
+
+
+[id="openshift-logging-5-6-12-CVEs_{context}"]
+== CVEs
+* link:https://access.redhat.com/security/cve/CVE-2023-0800[CVE-2023-0800]
+* link:https://access.redhat.com/security/cve/CVE-2023-0801[CVE-2023-0801]
+* link:https://access.redhat.com/security/cve/CVE-2023-0802[CVE-2023-0802]
+* link:https://access.redhat.com/security/cve/CVE-2023-0803[CVE-2023-0803]
+* link:https://access.redhat.com/security/cve/CVE-2023-0804[CVE-2023-0804]
+* link:https://access.redhat.com/security/cve/CVE-2023-2002[CVE-2023-2002]
+* link:https://access.redhat.com/security/cve/CVE-2023-3090[CVE-2023-3090]
+* link:https://access.redhat.com/security/cve/CVE-2023-3390[CVE-2023-3390]
+* link:https://access.redhat.com/security/cve/CVE-2023-3776[CVE-2023-3776]
+* link:https://access.redhat.com/security/cve/CVE-2023-4004[CVE-2023-4004]
+* link:https://access.redhat.com/security/cve/CVE-2023-4527[CVE-2023-4527]
+* link:https://access.redhat.com/security/cve/CVE-2023-4806[CVE-2023-4806]
+* link:https://access.redhat.com/security/cve/CVE-2023-4813[CVE-2023-4813]
+* link:https://access.redhat.com/security/cve/CVE-2023-4863[CVE-2023-4863]
+* link:https://access.redhat.com/security/cve/CVE-2023-4911[CVE-2023-4911]
+* link:https://access.redhat.com/security/cve/CVE-2023-5129[CVE-2023-5129]
+* link:https://access.redhat.com/security/cve/CVE-2023-20593[CVE-2023-20593]
+* link:https://access.redhat.com/security/cve/CVE-2023-29491[CVE-2023-29491]
+* link:https://access.redhat.com/security/cve/CVE-2023-30630[CVE-2023-30630]
+* link:https://access.redhat.com/security/cve/CVE-2023-35001[CVE-2023-35001]
+* link:https://access.redhat.com/security/cve/CVE-2023-35788[CVE-2023-35788]


### PR DESCRIPTION
Change type: Doc update; Logging Z-Stream Release Notes - 5.6.12
Doc JIRA: https://issues.redhat.com/browse/OBSDOCS-545

Fix Version: 4.11, 4.12, 4.13

Doc Previews: https://65987--docspreview.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-6-release-notes 

SME Review: @periklis 
QE Review: @kabirbhartiRH 
Peer Review: @bburt-rh 