### PR TITLE
[OSDOCS-7872] updated OSD and ROSA descriptions to remove ROSA from OSD docs

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -7,10 +7,12 @@
 [id="osd-aws-privatelink-firewall-prerequisites_{context}"]
 = AWS firewall prerequisites
 
+ifdef::openshift-rosa[]
 [IMPORTANT]
 ====
 Only ROSA clusters deployed with PrivateLink can use a firewall to control egress traffic.
 ====
+endif::[]
 
 This section provides the necessary details that enable you to control egress traffic from your {product-title} cluster. If you are using a firewall to control egress traffic, you must configure your firewall to grant access to the domain and port combinations below. {product-title} requires this access to provide a fully managed OpenShift service.
 

--- a/modules/sd-planning-cluster-maximums.adoc
+++ b/modules/sd-planning-cluster-maximums.adoc
@@ -4,18 +4,18 @@
 // * rosa_planning/rosa-limits-scalability.adoc
 
 [id="tested-cluster-maximums-sd_{context}"]
-= ROSA tested cluster maximums
+= Cluster maximums
 
 Consider the following tested object maximums when you plan a {product-title}
 ifdef::openshift-rosa[]
-(ROSA) 
+(ROSA)
 endif::[]
-cluster installation. The table specifies the maximum limits for each tested type in a 
+cluster installation. The table specifies the maximum limits for each tested type in a
 ifdef::openshift-rosa[]
-(ROSA) 
+(ROSA)
 endif::[]
 ifdef::openshift-dedicated[]
-{product-title}  
+{product-title}
 endif::[]
 cluster.
 

--- a/networking/cidr-range-definitions.adoc
+++ b/networking/cidr-range-definitions.adoc
@@ -26,10 +26,12 @@ OVN-Kubernetes, the default network provider in {product-title} 4.11 and later, 
 == Machine CIDR
 In the Machine CIDR field, you must specify the IP address range for machines or cluster nodes. This range must encompass all CIDR address ranges for your virtual private cloud (VPC) subnets. Subnets must be contiguous. A minimum IP address range of 128 addresses, using the subnet prefix `/25`, is supported for single availability zone deployments. A minimum address range of 256 addresses, using the subnet prefix `/24`, is supported for deployments that use multiple availability zones. The default is `10.0.0.0/16`. This range must not conflict with any connected networks.
 
+ifdef::openshift-rosa[]
 [NOTE]
 ====
 When using {hcp-title}, the static IP address `172.20.0.1` is reserved for the internal Kubernetes API address. The machine, pod, and service CIDRs ranges must not conflict with this IP address.
 ====
+endif::[]
 
 [id="service-cidr-description"]
 == Service CIDR


### PR DESCRIPTION
[OSDOCS-7872] updated OSD and ROSA descriptions to remove ROSA from OSD docs

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7872

Link to docs preview:
https://65989--docspreview.netlify.app/openshift-dedicated/latest/osd_planning/osd-limits-scalability#tested-cluster-maximums-sd_osd-limits-scalability
https://65989--docspreview.netlify.app/openshift-dedicated/latest/networking/cidr-range-definitions#machine-cidr-description
https://65989--docspreview.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs#osd-aws-privatelink-firewall-prerequisites_aws-ccs


QE review:
- [ ] No QE needed.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
