### PR TITLE
TELCODOCS-1085 - cherrypick late review comments to enterprise-4.12

### DIFF
--- a/modules/ztp-adding-new-content-to-gitops-ztp.adoc
+++ b/modules/ztp-adding-new-content-to-gitops-ztp.adoc
@@ -11,7 +11,7 @@ Perform the following procedure to add new content to the ZTP pipeline.
 
 .Procedure
 
-. Create a subdirectory named `source-crs` in the directory containing the `kustomization.yaml` file for the `PolicyGenTemplate` custom resource (CR).
+. Create a subdirectory named `source-crs` in the directory that contains the `kustomization.yaml` file for the `PolicyGenTemplate` custom resource (CR).
 
 . Add your custom CRs to the `source-crs` subdirectory, as shown in the following example:
 +
@@ -35,13 +35,7 @@ example
 ----
 <1> The `source-crs` subdirectory must be in the same directory as the `kustomization.yaml` file.
 
-+
-[IMPORTANT]
-====
-To use your own resources, ensure that the custom CR names differ from the default source CRs provided in the ZTP container.
-====
-
-. Update the required `PolicyGenTemplate` CRs to include references to the content you added in the `source-crs/custom-crs` directory, as shown in the following example:
+. Update the required `PolicyGenTemplate` CRs to include references to the content you added in the `source-crs/custom-crs` and `source-crs/elasticsearch` directories. For example:
 +
 [source,yaml]
 ----
@@ -104,11 +98,11 @@ spec:
       remediationAction: inform
       policyName: "group-dev-disable-nic-lldp"
 ----
-<1> Set `fileName` to include the custom CR subdirectory from the `/source-crs` parent, such as `<subdirectory>/<filename>`.
+<1> Set the `fileName` field to include the relative path to the file from the `/source-crs` parent directory.
 
 . Commit the `PolicyGenTemplate` change in Git, and then push to the Git repository that is monitored by the GitOps ZTP Argo CD policies application.
 
-. Update the `ClusterGroupUpgrade` CR to include the changed `PolicyGenTemplate` and save it as `cgu-test.yaml`, as shown in the following example:
+. Update the `ClusterGroupUpgrade` CR to include the changed `PolicyGenTemplate` and save it as `cgu-test.yaml`. The following example shows a generated `cgu-test.yaml` file.
 +
 [source,yaml]
 ----


### PR DESCRIPTION
Cherrypicks review changes from https://github.com/openshift/openshift-docs/pull/64949 for [TELCODOCS-1085](https://issues.redhat.com//browse/TELCODOCS-1085) that were done in `main` after the [original PR](https://github.com/openshift/openshift-docs/pull/60970) was merged. 

Version(s):
enterprise-4.12

Issue:
https://issues.redhat.com/browse/TELCODOCS-1085

Link to docs preview: https://65995--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change in the original PR on main.

