### PR TITLE
OCPBUGS-19822 Additional Network and MetalLB cannot use same network

### DIFF
--- a/modules/nw-metallb-bgp-limitations.adoc
+++ b/modules/nw-metallb-bgp-limitations.adoc
@@ -18,13 +18,6 @@ However, you can anticipate that a change in the number of `speaker` pods affect
 To avoid or reduce the likelihood of a service interruption, you can specify a node selector when you add a BGP peer.
 By limiting the number of nodes that start BGP sessions, a fault on a node that does not have a BGP session has no affect on connections to the service.
 
-[id="additional_network_and_metallb_limitation_{context}"]
-== Additional Network and MetalLB cannot use same network
-
-There is a limitation when using the same VLAN for both MetalLB and an additional network interface on a source pod. In such cases, a connection failure occurs, when the MetalLB IP and the source pod share the same node.
-
-You can address this by ensuring the MetalLB IP is in another subnet so the traffic coming from a pod would take the default gateway, which is OVN-K and reach the destination via the OVN overlay. Alternatively use a MACVLAN interface instead of a VLAN interface.
-
 [id="nw-metallb-bgp-limitations-single-asn_{context}"]
 == Support for a single ASN and a single router ID only
 

--- a/modules/nw-metallb-bgp-limitations.adoc
+++ b/modules/nw-metallb-bgp-limitations.adoc
@@ -18,6 +18,13 @@ However, you can anticipate that a change in the number of `speaker` pods affect
 To avoid or reduce the likelihood of a service interruption, you can specify a node selector when you add a BGP peer.
 By limiting the number of nodes that start BGP sessions, a fault on a node that does not have a BGP session has no affect on connections to the service.
 
+[id="additional_network_and_metallb_limitation_{context}"]
+== Additional Network and MetalLB cannot use same network
+
+There is a limitation when using the same VLAN for both MetalLB and an additional network interface on a source pod. In such cases, a connection failure occurs, when the MetalLB IP and the source pod share the same node.
+
+You can address this by ensuring the MetalLB IP is in another subnet so the traffic coming from a pod would take the default gateway, which is OVN-K and reach the destination via the OVN overlay. Alternatively use a MACVLAN interface instead of a VLAN interface.
+
 [id="nw-metallb-bgp-limitations-single-asn_{context}"]
 == Support for a single ASN and a single router ID only
 

--- a/modules/nw-metallb-infra-considerations.adoc
+++ b/modules/nw-metallb-infra-considerations.adoc
@@ -24,12 +24,6 @@ MetalLB Operator and MetalLB are supported with the OpenShift SDN and OVN-Kubern
 [id="additional_network_and_metallb_limitation_{context}"]
 == Additional Network and MetalLB cannot use same network
 
-If you use the same VLAN for both MetalLB and an additional network interface configured on a source pod, it can lead to a connection failure. A connection failure happens when both the MetalLB IP and the source pod are on the same node.
+Using the same VLAN for both MetalLB and an additional network interface set up on a source pod may result in a connection failure. This occurs when both the MetalLB IP and the source pod reside on the same node.
 
-To resolve this issue, you have a couple of options:
-
-* **Use Different Subnets**: To avoid connection failures, consider placing the MetalLB IP in a different subnet from the one where the source pod resides. By doing this, traffic from the source pod will take the default gateway, which is typically OVN-K. This way, the traffic can reach its destination by using the OVN overlay network, and the connection should work as expected.
-
-* **Switch to MACVLAN Interface**: Alternatively, you can opt to use a MACVLAN interface instead of a VLAN interface for your additional network configuration. MACVLAN interfaces provide a more isolated network environment and can help prevent conflicts with MetalLB configurations. This change in interface type can help you avoid the connection issues that might arise when using the same VLAN for MetalLB and an additional network interface on the source pod.
-
-You can address this by ensuring the MetalLB IP is in another subnet so the traffic coming from a pod would take the default gateway, which is OVN-K and reach the destination via the OVN overlay. Alternatively use a MACVLAN interface instead of a VLAN interface.
+To avoid connection failures, place the MetalLB IP in a different subnet from the one where the source pod resides. This configuration ensures that traffic from the source pod will take the default gateway, which is typically OVN-Kubernetes. Consequently, the traffic can effectively reach its destination by using the OVN overlay network, ensuring that the connection functions as intended.

--- a/modules/nw-metallb-infra-considerations.adoc
+++ b/modules/nw-metallb-infra-considerations.adoc
@@ -20,10 +20,3 @@ For example, the following infrastructures can benefit from adding the MetalLB O
 * {ibmpowerProductName}
 
 MetalLB Operator and MetalLB are supported with the OpenShift SDN and OVN-Kubernetes network providers.
-
-[id="additional_network_and_metallb_limitation_{context}"]
-== Additional Network and MetalLB cannot use same network
-
-Using the same VLAN for both MetalLB and an additional network interface set up on a source pod may result in a connection failure. This occurs when both the MetalLB IP and the source pod reside on the same node.
-
-To avoid connection failures, place the MetalLB IP in a different subnet from the one where the source pod resides. This configuration ensures that traffic from the source pod will take the default gateway, which is typically OVN-Kubernetes. Consequently, the traffic can effectively reach its destination by using the OVN overlay network, ensuring that the connection functions as intended.

--- a/modules/nw-metallb-infra-considerations.adoc
+++ b/modules/nw-metallb-infra-considerations.adoc
@@ -21,3 +21,15 @@ For example, the following infrastructures can benefit from adding the MetalLB O
 
 MetalLB Operator and MetalLB are supported with the OpenShift SDN and OVN-Kubernetes network providers.
 
+[id="additional_network_and_metallb_limitation_{context}"]
+== Additional Network and MetalLB cannot use same network
+
+If you use the same VLAN for both MetalLB and an additional network interface configured on a source pod, it can lead to a connection failure. A connection failure happens when both the MetalLB IP and the source pod are on the same node.
+
+To resolve this issue, you have a couple of options:
+
+* **Use Different Subnets**: To avoid connection failures, consider placing the MetalLB IP in a different subnet from the one where the source pod resides. By doing this, traffic from the source pod will take the default gateway, which is typically OVN-K. This way, the traffic can reach its destination by using the OVN overlay network, and the connection should work as expected.
+
+* **Switch to MACVLAN Interface**: Alternatively, you can opt to use a MACVLAN interface instead of a VLAN interface for your additional network configuration. MACVLAN interfaces provide a more isolated network environment and can help prevent conflicts with MetalLB configurations. This change in interface type can help you avoid the connection issues that might arise when using the same VLAN for MetalLB and an additional network interface on the source pod.
+
+You can address this by ensuring the MetalLB IP is in another subnet so the traffic coming from a pod would take the default gateway, which is OVN-K and reach the destination via the OVN overlay. Alternatively use a MACVLAN interface instead of a VLAN interface.

--- a/modules/nw-metallb-layer2-limitations.adoc
+++ b/modules/nw-metallb-layer2-limitations.adoc
@@ -37,7 +37,6 @@ During an unplanned failover, the service IPs are unreachable until the outdated
 [id="additional_network_and_metallb_limitation_{context}"]
 == Additional Network and MetalLB cannot use same network
 
-Using the same VLAN for both MetalLB and an additional network interface set up on a source pod may result in a connection failure. This occurs when both the MetalLB IP and the source pod reside on the same node.
+Using the same VLAN for both MetalLB and an additional network interface set up on a source pod might result in a connection failure. This occurs when both the MetalLB IP and the source pod reside on the same node.
 
-To avoid connection failures, place the MetalLB IP in a different subnet from the one where the source pod resides. This configuration ensures that traffic from the source pod will take the default gateway, which is typically OVN-Kubernetes. Consequently, the traffic can effectively reach its destination by using the OVN overlay network, ensuring that the connection functions as intended.
-
+To avoid connection failures, place the MetalLB IP in a different subnet from the one where the source pod resides. This configuration ensures that traffic from the source pod will take the default gateway. Consequently, the traffic can effectively reach its destination by using the OVN overlay network, ensuring that the connection functions as intended.

--- a/modules/nw-metallb-layer2-limitations.adoc
+++ b/modules/nw-metallb-layer2-limitations.adoc
@@ -34,3 +34,10 @@ The old node can continue to forward traffic for outdated clients until their ca
 
 During an unplanned failover, the service IPs are unreachable until the outdated clients refresh their cache entries.
 
+[id="additional_network_and_metallb_limitation_{context}"]
+== Additional Network and MetalLB cannot use same network
+
+Using the same VLAN for both MetalLB and an additional network interface set up on a source pod may result in a connection failure. This occurs when both the MetalLB IP and the source pod reside on the same node.
+
+To avoid connection failures, place the MetalLB IP in a different subnet from the one where the source pod resides. This configuration ensures that traffic from the source pod will take the default gateway, which is typically OVN-Kubernetes. Consequently, the traffic can effectively reach its destination by using the OVN overlay network, ensuring that the connection functions as intended.
+


### PR DESCRIPTION
[OCPBUGS-19822]: Additional Network and MetalLB cannot use same network

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11, 4.12, 4.13, 4.14, 4.15 main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-19822
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://66003--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/about-metallb#additional_network_and_metallb_limitation_about-metallb-and-metallb-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
