### PR TITLE
OSDOCS#6417: Adding RN for custom RHCOS image for Azure cluster

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -141,6 +141,27 @@ Before you set a path value for the `template` parameter, ensure that the defaul
 
 {product-title} {product-version} is now supported on 64-bit ARM architecture-based Google Cloud Platform installer-provisioned and user-provisioned infrastructures. You can also now use the `oc mirror` CLI plug-in disconnected environments on 64-bit ARM clusters. For more information about instance availability and installation documentation, see xref:../installing/installing-preparing.adoc#supported-installation-methods-for-different-platforms[Supported installation methods for different platforms].
 
+[id="ocp-4-14-azure-custom-rhcos"]
+==== Using a custom {op-system} image for a Microsoft Azure cluster
+
+By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane and compute machines. With this enhancement, you can now override the default behavior by modifying the installation configuration file (`install-config.yaml`) to specify a custom {op-system} image. Before you deploy the cluster, you can modify the following installation parameters:
+
+* `compute.platorm.azure.osImage.publisher`
+* `compute.platorm.azure.osImage.offer`
+* `compute.platorm.azure.osImage.sku`
+* `compute.platorm.azure.osImage.version`
+* `controlPlane.platorm.azure.osImage.publisher`
+* `controlPlane.platorm.azure.osImage.offer`
+* `controlPlane.platorm.azure.osImage.sku`
+* `controlPlane.platorm.azure.osImage.version`
+* `platform.azure.defaultMachinePlatform.osImage.publisher`
+* `platform.azure.defaultMachinePlatform.osImage.offer`
+* `platform.azure.defaultMachinePlatform.osImage.sku`
+* `platform.azure.defaultMachinePlatform.osImage.version`
+
+For more information about these parameters, see xref:../installing/installing_azure/installation-config-parameters-azure.adoc#installation-configuration-parameters-additional-azure_installation-config-parameters-azure[Additional Azure configuration parameters].
+
+
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
This PR addresses the release note for [osdocs-6417](https://issues.redhat.com/browse/OSDOCS-6417).

Link to docs preview:

[Using a custom RHCOS image for a Microsoft Azure cluster](https://66006--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-azure-custom-rhcos)

QE review:
- [x] QE has approved this change.
