### PR TITLE
[virt] DPDK cluster config: Update Perf Profile

### DIFF
--- a/modules/virt-configuring-cluster-dpdk.adoc
+++ b/modules/virt-configuring-cluster-dpdk.adoc
@@ -60,6 +60,7 @@ spec:
   cpu:
     isolated: 4-39,44-79
     reserved: 0-3,40-43
+  globallyDisableIrqLoadBalancing: true
   hugepages:
     defaultHugepagesSize: 1G
     pages:


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
Update the PerformanceProfile required when using
DPDK VMs to have `globallyDisableIrqLoadBalancing` enabled. When this setting is enabled, the packet losses decreases.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.


* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://66011--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-using-dpdk-with-sriov#virt-configuring-cluster-dpdk_virt-using-dpdk-with-sriov

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
