### PR TITLE
OSDOCS#8135: Added notes for non support for confidental VMs on ARM

### DIFF
--- a/modules/installation-gcp-enabling-confidential-vms.adoc
+++ b/modules/installation-gcp-enabling-confidential-vms.adoc
@@ -15,6 +15,11 @@
 
 You can use Confidential VMs when installing your cluster. Confidential VMs encrypt data while it is being processed. For more information, see Google's documentation on link:https://cloud.google.com/confidential-computing[Confidential Computing]. You can enable Confidential VMs and Shielded VMs at the same time, although they are not dependent on each other.
 
+[NOTE]
+====
+Confidential VMs are currently not supported on 64-bit ARM architectures. 
+====
+
 .Prerequisites
 * You have created an `install-config.yaml` file.
 

--- a/modules/machineset-gcp-confidential-vm.adoc
+++ b/modules/machineset-gcp-confidential-vm.adoc
@@ -15,6 +15,10 @@ By editing the machine set YAML file, you can configure the Confidential VM opti
 
 For more information about Confidential VM features, functions, and compatibility, see the GCP Compute Engine documentation about link:https://cloud.google.com/confidential-computing/confidential-vm/docs/about-cvm#confidential-vm[Confidential VM].
 
+[NOTE]
+====
+Confidential VMs are currently not supported on 64-bit ARM architectures. 
+====
 [IMPORTANT]
 ====
 {product-title} {product-version} does not support some Confidential Compute features, such as Confidential VMs with AMD Secure Encrypted Virtualization Secure Nested Paging (SEV-SNP).


### PR DESCRIPTION
**Version(s):** 4.14
**Issue:** [OSDOCS-8135](https://issues.redhat.com//browse/OSDOCS-8135)

**Link to docs preview:**

- [Installing a cluster on GCP with customizations -> Enabling Confidential VMs](https://66012--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-customizations#installation-gcp-enabling-confidential-vms_installing-gcp-customizations)
- [Creating a compute machines set on GCP -> Configuring Confidential VMs by using machine sets ](https://66012--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-gcp#machineset-gcp-confidential-vm_creating-machineset-gcp)

**QE review:**
- [x] QE has approved this change.
