### PR TITLE
Small agent platform support fix

### DIFF
--- a/modules/installation-bare-metal-agent-installer-config-yaml.adoc
+++ b/modules/installation-bare-metal-agent-installer-config-yaml.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 
-//* installing-with-agent/installing-with-agent.adoc
+// * installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc
 // Re-used content from Sample install-config.yaml file for bare metal without conditionals
 
 :_content-type: CONCEPT
@@ -56,7 +56,7 @@ Class E CIDR range is reserved for a future use. To use the Class E CIDR range, 
 <7> The subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23`, then each node is assigned a `/23` subnet out of the given `cidr`, which allows for 510 (2^(32 - 23) - 2) pod IP addresses. If you are required to provide access to nodes from an external network, configure load balancers and routers to manage the traffic.
 <8> The cluster network plugin to install. The supported values are `OVNKubernetes` (default value) and `OpenShiftSDN`.
 <9> The IP address pool to use for service IP addresses. You can enter only one IP address pool. This block must not overlap with existing physical networks. If you need to access the services from an external network, configure load balancers and routers to manage the traffic.
-<10> You must set the platform to `none` for a single-node cluster. You can set the platform to either `vsphere` or `baremetal` for multi-node clusters.
+<10> You must set the platform to `none` for a single-node cluster. You can set the platform to `vsphere`, `baremetal`, or `none` for multi-node clusters.
 +
 [NOTE]
 ====


### PR DESCRIPTION
Versions: 4.14+

This PR corrects a sample file to state that platform None is supported for multi-node clusters.

QE review:
- [x] QE has approved this change.

Preview:  [Sample install-config.yaml file for bare metal](https://66033--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer#installation-bare-metal-agent-installer-config-yaml_preparing-to-install-with-agent-based-installer)