### PR TITLE
OSDOCS-8104: Adding OVS drops type to Packet drops

### DIFF
--- a/modules/network-observability-packet-drops.adoc
+++ b/modules/network-observability-packet-drops.adoc
@@ -34,7 +34,7 @@ spec:
     ebpf:
       features:
        - PacketDrop            <1>                         
-      privileged: true       <2>
+      privileged: true         <2>
 ----
 <1> You can start reporting the packet drops of each network flow by listing the `PacketDrop` parameter in the `spec.agent.ebpf.features` specification list.   
 <2> The `spec.agent.ebpf.privileged` specification value must be `true` for packet drop tracking.
@@ -43,5 +43,5 @@ spec:
 * When you refresh the *Network Traffic* page, the *Overview*, *Traffic Flow*, and *Topology* views display new information about packet drops:
 .. Select new choices in *Manage panels* to choose which graphical visualizations of packet drops to display in the *Overview*.
 .. Select new choices in *Manage columns* to choose which packet drop information to display in the *Traffic flows* table.  
-... In the *Traffic Flows* view, you can also expand the side panel to view more information about packet drops. 
+... In the *Traffic Flows* view, you can also expand the side panel to view more information about packet drops. Host drops are prefixed with `SKB_DROP` and OVS drops are prefixed with `OVS_DROP`.
 .. In the *Topology* view, red lines are displayed where drops are present.

--- a/modules/network-observability-pktdrop-overview.adoc
+++ b/modules/network-observability-pktdrop-overview.adoc
@@ -21,5 +21,14 @@ When packet drop tracking is enabled, you can see the following metrics represen
 * Top X dropped cause
 * Top X flow dropped rates stacked with total
 
+Two kinds of packet drops are detected by Network Observability: host drops and OVS drops. Host drops are prefixed with `SKB_DROP` and OVS drops are prefixed with `OVS_DROP`. Dropped flows are shown in the side panel of the *Traffic flows* table along with a link to a description of each drop type. Examples of host drop reasons are as follows:
+
+* `SKB_DROP_REASON_NO_SOCKET`: the packet dropped due to a missing socket. 
+* `SKB_DROP_REASON_TCP_CSUM`: the packet dropped due to a TCP checksum error.
+
+Examples of OVS drops reasons are as follows:
+
+* `OVS_DROP_LAST_ACTION`: OVS packets dropped due to an implicit drop action, for example due to a configured network policy.
+* `OVS_DROP_IP_TTL`: OVS packets dropped due to an expired IP TTL.
 
 See the _Additional Resources_ of this section for more information about enabling and working with packet drop tracking.

--- a/network_observability/network-observability-operator-release-notes.adoc
+++ b/network_observability/network-observability-operator-release-notes.adoc
@@ -96,7 +96,7 @@ You can now export eBPF-enriched network flows to the IPFIX collector. For more 
 
 [id="network-observability-packet-drop-1.4"]
 ==== Packet drops
-In the 1.4 release of the Network Observability Operator, eBPF tracepoint hooks are used to enable packet drop tracking. You can now detect and analyze the cause for packet drops and make decisions to optimize network performance. This feature is only supported in {product-title} versions 4.13+. For more information, see xref:../network_observability/observing-network-traffic#network-observability-pktdrop-overview_nw-observe-network-traffic[Configuring packet drop tracking] and xref:../network_observability/observing-network-traffic#network-observability-packet-drops_nw-observe-network-traffic[Working with packet drops].
+In the 1.4 release of the Network Observability Operator, eBPF tracepoint hooks are used to enable packet drop tracking. You can now detect and analyze the cause for packet drops and make decisions to optimize network performance. In {product-title} 4.14 and later, both host drops and OVS drops are detected. In {product-title} 4.13, only host drops are detected. For more information, see xref:../network_observability/observing-network-traffic#network-observability-pktdrop-overview_nw-observe-network-traffic[Configuring packet drop tracking] and xref:../network_observability/observing-network-traffic#network-observability-packet-drops_nw-observe-network-traffic[Working with packet drops].
 
 ==== s390x architecture support
 Network Observability Operator can now run on `s390x` architecture. Previously it ran on `amd64`, `ppc64le`, or `arm64`.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8104
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Packet drop tracking overview: https://66047--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/observing-network-traffic#network-observability-pktdrop-overview_nw-observe-network-traffic

Working with packet drops: https://66047--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/observing-network-traffic#network-observability-packet-drops_nw-observe-network-traffic

Release note: https://66047--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/network-observability-operator-release-notes#network-observability-packet-drop-1.4
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
