### PR TITLE
[enterprise-4.14] CNV#15738: RN - Update the documentation with supported upgrade paths

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -95,6 +95,9 @@ The SVVP Certification applies to:
 ** `KubevirtHyperconvergedClusterOperatorUSModification` has been renamed xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbook-UnsupportedHCOModification[`UnsupportedHCOModification`].
 ** `SSPOperatorDown` has been renamed xref:../../virt/monitoring/virt-runbooks.adoc#virt-runbook-SSPDown[`SSPDown`].
 
+// CNV-15738: Update the documentation with supported upgrade paths
+* Retrospective upgrades between previously released z-streams are now supported.
+
 [id="virt-4-14-quick-starts"]
 === Quick starts
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/CNV-15738

Link to docs preview:
https://66048--docspreview.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes#virt-4-14-new

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
