### PR TITLE
CNV-20458: RN Hot plugging VM seconday network interface

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -64,8 +64,6 @@ The SVVP Certification applies to:
 
 //CNV-20240 Release notes: CHANGE
 
-//CNV-20458 Release notes: NEW
-
 //CNV-25428 Release note: NEW
 
 //CNV-26316 Release notes: CHANGE
@@ -192,7 +190,8 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //CNV-28944 Release note: Preview Cluster level eviction strategy change
 
 //CNV-29940 Release note: Preview UI Bridged network interface hot-plug for VMs
-* You can hot plug a bridge network interface and then restart or live migrate the virtual machine (VM) to apply the change. Hot unplugging is supported only for VMs created with {VirtProductName} 4.13 or later.
+//CNV-20458 Release notes: PREVIEW
+* You can xref:../../virt/vm_networking/virt-hot-plugging-network-interfaces.adoc#virt-hot-plugging-network-interfaces[hot plug a bridge network interface] to a running virtual machine (VM). Hot plugging and hot unplugging is supported only for VMs created with {VirtProductName} 4.14 or later.
 
 [id="virt-4-14-bug-fix"]
 == Bug fix


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-20458](https://issues.redhat.com//browse/CNV-20458)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://66051--docspreview.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes#virt-4-14-technology-preview
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: A release note covering this feature was added in https://github.com/openshift/openshift-docs/pull/63953. I edited the text and added a link to the associated documentation.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
