### PR TITLE
ML-RHDEVDOCS-4233| Documented guidance on authentication strategies for pipel…

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -106,6 +106,8 @@ Topics:
   File: securing-webhooks-with-event-listeners
 - Name: Authenticating pipelines using git secret
   File: authenticating-pipelines-using-git-secret
+- Name: Authenticating pipelines and tasks using secrets
+  File: authenticating-pipelines-and-tasks-using-secrets
 - Name: Unprivileged building of container images using Buildah
   File: unprivileged-building-of-container-images-using-buildah
 ---

--- a/modules/op-using-secrets-and-workspaces.adoc
+++ b/modules/op-using-secrets-and-workspaces.adoc
@@ -1,0 +1,168 @@
+// This module is included in the following assemblies:
+// * secure/authenticating-pipelines-and-tasks-using-secrets.adoc
+
+[id="op-using-secrets-and-workspaces_{context}"]
+= Using secrets and workspaces
+
+Using Secrets and Workspaces in the Tekton Pipeline provides a flexible approach to managing credentials in Tekton Pipelines. You can bind a Secret to a Workspace, and then use that Secret content in your Task. 
+
+The following examples illustrate how to use Secrets and Workspaces.
+
+== git-clone Task
+
+This approach involves creating a task called `git-clone`, which clones a git repository using SSH authentication. The following are the steps to use Secrets and Workspace in Tekton Pipelines:
+
+. Create a Task called `git-clone` that clones a git repository using SSH authentication. 
+
+. Define workspace, add the description for creating a secret, and bind it to the workspace.
++
+.Example
++
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: Secret
+metadata:
+  name: my-github-ssh-credentials
+type: Opaque
+data:
+  id_ed25519: # […]
+  known_hosts: # […]
+  # config: # […] # optional
+----
+
+. Create the secret by running the following command:
++
+[source, terminal]
+----
+$ oc create secret generic my-github-ssh-credentials\
+  --from-file=id_ed25519=/path/to/.ssh/id_ed25519 \
+  --from-file=known_hosts=/path/to/.ssh/known_hosts
+----
+
+. Define task parameters for the repository URL, revision, and the git-init image that the Task uses.
+
+. Define results that the Task produces, for example, the commit SHA and the repository URL. 
+
+. Define the steps that the Task executes, for example, copying the content of the ssh secret to the user’s home directory and running the git-init binary to clone the repository. 
+
+. Start the Task with the required parameters and workspace bindings by running the following command:
++
+[source, terminal]
+----
+$ tkn task start git-clone 
+      --param url=git@github.com:<username>/buildkit-tekton 
+      --workspace name=output,emptyDir="" 
+      --workspace name=ssh-directory,secret=my-github-ssh-credentials 
+      --use-param-defaults --showlog
+----
+
+.Example: Tekton Task for cloning a Git repository using an SSH key for authentication
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone
+spec:
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this Workspace.
+    - name: ssh-directory <1>
+      description: | <2>
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types
+  params:
+    - name: url
+      description: Repository URL to clone from.
+      type: string
+    - name: revision
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      type: string
+      default: ""
+    - name: gitInitImage
+      description: The image providing the git-init binary that this Task runs.
+      type: string
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.37.0"
+  results:
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task.
+    - name: url
+      description: The precise URL that was fetched by this Task.
+  steps:
+    - name: clone
+      image: "$(params.gitInitImage)"
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        # This is necessary for recent version of git
+        git config --global --add safe.directory '*' <3>
+        cp -R "$(workspaces.ssh-directory.path)" "${HOME}"/.ssh
+        chmod 700 "${HOME}"/.ssh
+        chmod -R 400 "${HOME}"/.ssh/*
+        CHECKOUT_DIR="$(workspaces.output.path)/"
+        /ko-app/git-init \
+          -url="$(params.url)" \
+          -revision="$(params.revision)" \
+          -path="${CHECKOUT_DIR}"
+        cd "${CHECKOUT_DIR}"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        EXIT_CODE="$?"
+        if [ "${EXIT_CODE}" != 0 ] ; then
+          exit "${EXIT_CODE}"
+        fi
+        printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+        printf "%s" "$(params.url)" > "$(results.url.path)"
+----
+<1> The workspaces that the Task needs to run, for example, ssh-directory.
+<2> The description that outlines the process for creating the secret. 
+<3> The script copies the content of the secret (in the form of a folder) to ${HOME}/.ssh, which is the standard folder where `ssh` searches for credentials.
++
+[NOTE]
+====
+For flexibility, the `git clone` task can be adapted to include optional workspaces by setting the `spec.workspaces.optional` parameter to  `true`.
+====
+
+== Using an existing docker configuration file
+
+This approach uses an existing docker configuration file inside a Task. The Task definition is the same as that of “A git-clone task” approach, but Skopeo is used to replicate an image to a personal repository. This approach can be adapted to other tools such as Podman, or Buildah, as long as they can interprete a docker client configuration file.
+
+Following are the steps for using an existing Docker configuration file inside a Tekton Pipeline task:
+
+. Define a Tekton Task in your {product-title} cluster with a reference to Skopeo image that copies a docker image to a specified repository.
+
+. In the Task definition, create a workspace called `dockerconfig` that holds a `config.json` file.
+
+. Define a secret in {product-title} containing the `config.json` file, which contains the Docker authentication information.
+
+. Create the secret by using the `oc create secret`, specifying the path to the `config.json` file on your local machine.
+
+. Start the TeKton Task by running the `tkn task start` command, specifying the name of the Task, the workspace name (`dockerconfig`),  and the secret name (`regcred`).
+
+.Example: Using an existing docker configuration file inside a Task
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: skopeo-copy
+spec:
+  workspaces:
+    - name: dockerconfig <1>
+      description: Includes a docker `config.json`
+  steps:
+    - name: clone
+      image: quay.io/skopeo/stable:v1.8.0
+      env:
+      - name: DOCKER_CONFIG
+        value: $(workspaces.dockerconfig.path) <2>
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        skopeo copy docker://docker.io/library/ubuntu:latest docker://docker.io/vdemeester/ubuntu-copy:latest
+----
+<1>  The name of the workspace that contains the config.json file. For a secret, this represents a key named config.json.
+<2> The DOCKER_CONFIG environment variable points to the `dockerconfig` workspace path `skopeo` to get the authentication information.
+

--- a/modules/op-using-serviceaccounts.adoc
+++ b/modules/op-using-serviceaccounts.adoc
@@ -1,0 +1,84 @@
+// This module is included in the following assembly:
+// * secure/authenticating-pipelines-and-tasks-using-secrets.adoc
+
+[id="op-using-serviceaccounts_{context}"]
+= Using ServiceAccounts
+
+This approach involves the following steps:
+
+. Annotating specific secrets using either the Git or Docker annotation
+
+. Linking the annotated `Secrets` to `ServiceAccounts`
+
+. Specifying the `ServiceAccounts` on PipelineRun or TaskRuns
+
+== Annotations
+
+Tekton offers two types of authentication for secrets: 
+
+* `tekton.dev/git-{}` - Used to mark the annotated secret as a kid secret. 
+
+* `tekton.dev/docker-{}` - Used to mark the annotated secret as a docker secret.
+
+Additionally, Tekton supports different types of secrets for each authentication type. 
+
+For `git` it supports the following types of secrets:
+
+* kubernetes.io/basic-auth : basic authentication 
+
+* kubernetes.io/ssh-auth : ssh based authentication (keys, …)
+
+For `docker` it supports the following types of secrets:
+
+* kubernetes.io/basic-auth : basic authentications 
+
+* kubernetes.io/dockercfg : serialized ~/.dockercfg file 
+
+* kubernetes.io/dockerconfigjson : serialized ~/.docker/config.json file
+
+== Linking the annotated secrets to  ServiceAccounts
+
+To link a secret to a _ServiceAccount_, you can reference the Secret by the name in the *secrets* field of the _ServiceAccount_.
+
+.Example
+[source,yaml,subs="attributes+"]
+----
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: build-bot
+secrets:
+  - name: regcred
+  - name: a-git-auth-secret
+----
+
+== Specifying the ServiceAccounts on PipelineRun or TaskRuns
+
+To specify a _ServiceAccount_ for a _PipelineRun_ or a _TaskRun_, use the `serviceAccountName` field.
+
+.Example
+
+[source,yaml,subs="attributes+"]
+----
+apiVersion: tekton.dev/v1
+kind: PipelineRun
+metadata:
+  name: demo-pipeline
+  namespace: default
+spec:
+  pipelineRef:
+    name: demo-pipeline
+  taskRunTemplate:
+    serviceAccountName: build-bot
+    # [...]
+----
+
+Alternatively, you can also use the `tkn` command to specify a _ServiceAccount_ for a _PipelineRun_ or a _TaskRun_. 
+
+.Example
+
+[source,terminal,subs="attributes+"]
+----
+$ tkn pipeline start demo-pipeline --serviceaccount build-bot --param # […].
+----
+

--- a/secure/authenticating-pipelines-and-tasks-using-secrets.adoc
+++ b/secure/authenticating-pipelines-and-tasks-using-secrets.adoc
@@ -1,0 +1,17 @@
+:_content-type: ASSEMBLY
+[id="authenticating-pipelines-and-tasks-using-secrets"]
+= Authenticating pipelines and tasks using secrets
+include::_attributes/common-attributes.adoc[]
+:context: authenticating-pipelines-and-tasks-using-secrets
+
+toc::[]
+
+For authenticating to GitHub, GitLab, or Container Image Registry in your Pipeline and Task, you can use secrets. Secrets are sensitive pieces of data that you can securely store in your project and access when needed. To use secrets for authentication, use the following recommended approaches:
+
+* Using secrets and workspaces
+
+* Using ServiceAccount 
+
+include::modules/op-using-secrets-and-workspaces.adoc[leveloffset=+1]
+
+include::modules/op-using-serviceaccounts.adoc[leveloffset=+1]


### PR DESCRIPTION
**This  PR is the continuation of  [PR-57140](https://github.com/openshift/openshift-docs/pull/57140), addapted for pipeline standalone**

- Aligned team: DevTools
- OCP version for cherry-picking: enterprise-4.10, enterprise-4.11, enterprise-4.12, and enterprise-4.13
- JIRA issue: [RHDEVDOCS-4233](https://issues.redhat.com/browse/RHDEVDOCS-4233)
- Preview pages: [docs-preview](https://66069--docspreview.netlify.app/openshift-pipelines/latest/secure/authenticating-pipelines-and-tasks-using-secrets)
- SME review: @vdemeester
- QE review: @ppitonak 
- Peer review: