### PR TITLE
[enterprise-4.12] OCPBUGS-11899-RE: Updated Creating the K8S manifest and Ignition conf…

### DIFF
--- a/installing/installing_aws/installing-restricted-networks-aws.adoc
+++ b/installing/installing_aws/installing-restricted-networks-aws.adoc
@@ -98,7 +98,12 @@ include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 
 //include::modules/installation-three-node-cluster.adoc[leveloffset=+2]
 
+// Creating the Kubernetes manifest and Ignition config files
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_aws/manually-creating-iam.adoc#manually-create-iam_manually-creating-iam-aws[Manually creating IAM]
 
 include::modules/installation-extracting-infraid.adoc[leveloffset=+1]
 

--- a/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
+++ b/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc
@@ -72,7 +72,14 @@ include::modules/installation-azure-stack-hub-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 include::modules/installation-user-infra-exporting-common-variables-arm-templates.adoc[leveloffset=+2]
+
+// Creating the Kubernetes manifest and Ignition config files
 include::modules/installation-user-infra-generate-k8s-manifest-ignition.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../installing/installing_azure/manually-creating-iam-azure.adoc#manually-create-iam_manually-creating-iam-azure[Manually creating IAM]
+
 include::modules/installation-disk-partitioning-upi-templates.adoc[leveloffset=+2]
 
 include::modules/installation-azure-create-resource-group-and-identity.adoc[leveloffset=+1]

--- a/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
+++ b/modules/installation-user-infra-generate-k8s-manifest-ignition.adoc
@@ -184,9 +184,9 @@ ifndef::user-infra-vpc[]
 the Kubernetes manifest files that define the worker machines:
 endif::user-infra-vpc[]
 endif::gcp[]
-ifdef::aws,azure,ash,user-infra-vpc[]
+ifdef::azure,ash,user-infra-vpc[]
 . Remove the Kubernetes manifest files that define the worker machines:
-endif::aws,azure,ash,user-infra-vpc[]
+endif::azure,ash,user-infra-vpc[]
 ifdef::aws,azure,ash,gcp[]
 +
 [source,terminal]
@@ -315,7 +315,6 @@ status:
   domain: ''
   selector: ''
 ----
-
 endif::user-infra-vpc[]
 
 ifdef::ash[]
@@ -419,7 +418,22 @@ stringData:
   azure_resourcegroup: ${resource_group}
   azure_region: ${azure_region}
 ----
+endif::ash[]
 
+ifdef::aws,ash[]
+. Optional: If you manually created a cloud identity and access management (IAM) role, locate any `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation in the release image by running the following command: 
++
+[source,terminal]
+----
+$ oc adm release extract quay.io/openshift-release-dev/ocp-release:4.y.z-x86_64 --credentials-requests --cloud=<platform_name>
+----
++
+.Example output
+[source,terminal]
+----
+0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-set: TechPreviewNoUpgrade
+----
++
 [IMPORTANT]
 ====
 The release image includes `CredentialsRequest` objects for Technology Preview features that are enabled by the `TechPreviewNoUpgrade` feature set. You can identify these objects by their use of the `release.openshift.io/feature-set: TechPreviewNoUpgrade` annotation.
@@ -428,22 +442,13 @@ The release image includes `CredentialsRequest` objects for Technology Preview f
 
 * If you are using any of these features, you must create secrets for the corresponding objects.
 ====
-
-*** To find `CredentialsRequest` objects with the `TechPreviewNoUpgrade` annotation, run the following command:
-+
-[source,terminal]
-----
-$ grep "release.openshift.io/feature-set" *
-----
-+
-.Example output
-[source,terminal]
-----
-0000_30_capi-operator_00_credentials-request.yaml:  release.openshift.io/feature-set: TechPreviewNoUpgrade
-----
 // Right now, only the CAPI Operator is an issue, but it might make sense to update `0000_30_capi-operator_00_credentials-request.yaml` to `<tech_preview_credentials_request>.yaml` for the future.
++
+.. Delete all `CredentialsRequest` objects that have the `TechPreviewNoUpgrade` annotation.
+endif::aws,ash[]
 
-.. Create a `cco-configmap.yaml` file in the manifests directory with the Cloud Credential Operator (CCO) disabled:
+ifdef::ash[]
+. Create a `cco-configmap.yaml` file in the manifests directory with the Cloud Credential Operator (CCO) disabled:
 +
 .Sample `ConfigMap` object
 [source,yaml]


### PR DESCRIPTION
Cherry-picked from #64288, commit 2db15f5f6a7cb957be85d510ca3773766e58ebe5

[OCPBUGS-11899](https://issues.redhat.com/browse/OCPBUGS-11899)

Version(s):
4.13

Link to docs preview:
* [Creating the Kubernetes manifest and Ignition config files (AWS)](https://66073--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-restricted-networks-aws#installation-user-infra-generate-k8s-manifest-ignition_installing-restricted-networks-aws)
* [Creating the Kubernetes manifest and Ignition config files (Azure)](https://66073--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-user-infra#installation-user-infra-generate-k8s-manifest-ignition_installing-azure-user-infra)
* [Creating the Kubernetes manifest and Ignition config files (Azure Stack Hub)](https://66073--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra#installation-user-infra-generate-k8s-manifest-ignition_installing-azure-stack-hub-user-infra)

QE review:
- [x] QE approval on the JIRA

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
