### PR TITLE
OPNET-363: Add support for vSphere dual-stack

### DIFF
--- a/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
+++ b/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.adoc
@@ -11,7 +11,7 @@ After converting to dual-stack, all newly created pods are dual-stack enabled.
 
 [NOTE]
 ====
-A dual-stack network is supported on clusters provisioned on bare metal, IBM Power, {ibmzProductName} infrastructure, and single node OpenShift clusters.
+A dual-stack network is supported on clusters provisioned on bare metal, VMware vSphere, IBM Power, {ibmzProductName} infrastructure, and single node OpenShift clusters.
 ====
 
 [NOTE]


### PR DESCRIPTION
Fixes: [OPNET-363](https://issues.redhat.com//browse/OPNET-363)

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

4.13

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

[OPNET-363](https://issues.redhat.com//browse/OPNET-363)

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

https://66074--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/converting-to-dual-stack.html

QE review:
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

There is already Prow CI testing 4.13 vSphere, thus additional test coverage not needed

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
