### PR TITLE
Replacing "defaultVolumesToRestic" with "defaultVolumesToFsBackup"

### DIFF
--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc.adoc
@@ -45,7 +45,7 @@ metadata:
     velero.io/storage-location: default
   namespace: openshift-adp
 spec:
-  defaultVolumesToRestic: true <1>
+  defaultVolumesToFsBackup: true <1>
 ...
 ----
-<1> Add `defaultVolumesToRestic: true` to the `spec` block.
+<1> In OADP version 1.2 and later, add the `defaultVolumesToFsBackup: true` setting within the `spec` block. In OADP  version 1.1, add `defaultVolumesToRestic: true`.

--- a/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc
+++ b/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc.adoc
@@ -57,14 +57,14 @@ spec:
     includedNamespaces:
     - <namespace> <2>
     storageLocation: <velero-sample-1> <3>
-    defaultVolumesToRestic: true <4>
+    defaultVolumesToFsBackup: true <4>
     ttl: 720h0m0s
 EOF
 ----
 <1> `cron` expression to schedule the backup, for example, `0 7 * * *` to perform a backup every day at 7:00.
 <2> Array of namespaces to back up.
 <3> Name of the `backupStorageLocations` CR.
-<4> Optional: Add the `defaultVolumesToRestic: true` key-value pair if you are backing up volumes with Restic.
+<4> Optional: In OADP version 1.2 and later, add the `defaultVolumesToFsBackup: true` key-value pair to your configuration when performing backups of volumes with Restic. In OADP 1.1, add the `defaultVolumesToRestic: true` key-value pair when you back up volumes with Restic.
 
 . Verify that the status of the `Schedule` CR is `Completed` after the scheduled backup runs:
 +

--- a/modules/oadp-backing-up-applications-restic.adoc
+++ b/modules/oadp-backing-up-applications-restic.adoc
@@ -35,9 +35,7 @@ metadata:
     velero.io/storage-location: default
   namespace: openshift-adp
 spec:
-  defaultVolumesToRestic: true <1>
+  defaultVolumesToFsBackup: true <1>
 ...
 ----
-<1> Add `defaultVolumesToRestic: true` to the `spec` block.
-
-
+<1> In OADP version 1.2 and later, add the `defaultVolumesToFsBackup: true` setting within the `spec` block. In OADP  version 1.1, add `defaultVolumesToRestic: true`.

--- a/modules/oadp-installing-dpa.adoc
+++ b/modules/oadp-installing-dpa.adoc
@@ -83,7 +83,7 @@ spec:
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
-<3> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<3> Set this value to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that Restic pods run on each working node. In OADP version 1.2 and later, you can configure Restic for backups by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR. In OADP version 1.1, add `spec.defaultVolumesToRestic: true` to the `Backup` CR.
 <4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
 <5> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
 <6> Specify a prefix for Velero backups, for example, `velero`, if the bucket is used for multiple purposes.
@@ -137,7 +137,7 @@ spec:
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
-<3> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<3> Set this value to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that Restic pods run on each working node. In OADP version 1.2 and later, you can configure Restic for backups by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR. In OADP version 1.1, add `spec.defaultVolumesToRestic: true` to the `Backup` CR.
 <4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
 <5> Specify the Azure resource group.
 <6> Specify the Azure storage account ID.
@@ -187,7 +187,7 @@ spec:
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
-<3> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<3> Set this value to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that Restic pods run on each working node. In OADP version 1.2 and later, you can configure Restic for backups by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR. In OADP version 1.1, add `spec.defaultVolumesToRestic: true` to the `Backup` CR.
 <4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
 <5> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
 <6> Specify a bucket as the backup storage location. If the bucket is not a dedicated bucket for Velero backups, you must specify a prefix.
@@ -234,7 +234,7 @@ spec:
 ----
 <1> The `openshift` plugin is mandatory.
 <2> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
-<3> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<3> Set this value to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that Restic pods run on each working node. In OADP version 1.2 and later, you can configure Restic for backups by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR. In OADP version 1.1, add `spec.defaultVolumesToRestic: true` to the `Backup` CR.
 <4> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
 <5> Specify the URL of the S3 endpoint.
 <6> If you do not specify this value, the default name, `{credentials}`, is used. If you specify a custom name, the custom name is used for the backup location.
@@ -279,7 +279,7 @@ spec:
 <3> Specify the `csi` default plugin if you use CSI snapshots to back up PVs. The `csi` plugin uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
 <4> The `openshift` plugin is mandatory.
 <5> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
-<6> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<6> Set this value to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that Restic pods run on each working node. In OADP version 1.2 and later, you can configure Restic for backups by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR. In OADP version 1.1, add `spec.defaultVolumesToRestic: true` to the `Backup` CR.
 <7> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
 <8> Specify the backup provider.
 <9> Specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`, if you use a default plugin for the backup provider. If specifying a custom name, then the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.
@@ -324,7 +324,7 @@ spec:
 <3> The `csi` plugin is mandatory for backing up PVs with CSI snapshots. The `csi` plugin uses the link:https://{velero-domain}/docs/main/csi/[Velero CSI beta snapshot APIs]. You do not need to configure a snapshot location.
 <4> The `openshift` plugin is mandatory.
 <5> Specify how many minutes to wait for several Velero resources before timeout occurs, such as Velero CRD availability, volumeSnapshot deletion, and backup repository availability. The default is 10m.
-<6> Set to `false`, if you want to disable the Restic installation. Restic deploys a daemon set, which means that each worker node has `Restic` pods running. You can configure Restic for backups by adding `spec.defaultVolumesToRestic: true` to the `Backup` CR.
+<6> Set this value to `false` if you want to disable the Restic installation. Restic deploys a daemon set, which means that Restic pods run on each working node. In OADP version 1.2 and later, you can configure Restic for backups by adding `spec.defaultVolumesToFsBackup: true` to the `Backup` CR. In OADP version 1.1, add `spec.defaultVolumesToRestic: true` to the `Backup` CR.
 <7> Specify on which nodes Restic is available. By default, Restic runs on all nodes.
 <8> Specify the backup provider.
 <9> Specify the correct default name for the `Secret`, for example, `cloud-credentials-gcp`, if you use a default plugin for the backup provider. If specifying a custom name, then the custom name is used for the backup location. If you do not specify a `Secret` name, the default name is used.

--- a/modules/oadp-scheduling-backups.adoc
+++ b/modules/oadp-scheduling-backups.adoc
@@ -54,14 +54,14 @@ spec:
     includedNamespaces:
     - <namespace> <2>
     storageLocation: <velero-sample-1> <3>
-    defaultVolumesToRestic: true <4>
+    defaultVolumesToFsBackup: true <4>
     ttl: 720h0m0s
 EOF
 ----
 <1> `cron` expression to schedule the backup, for example, `0 7 * * *` to perform a backup every day at 7:00.
 <2> Array of namespaces to back up.
 <3> Name of the `backupStorageLocations` CR.
-<4> Optional: Add the `defaultVolumesToRestic: true` key-value pair if you are backing up volumes with Restic.
+<4> Optional: In OADP version 1.2 and later, add the `defaultVolumesToFsBackup: true` key-value pair to your configuration when performing backups of volumes with Restic. In OADP version 1.1, add the `defaultVolumesToRestic: true` key-value pair when you back up volumes with Restic.
 
 . Verify that the status of the `Schedule` CR is `Completed` after the scheduled backup runs:
 +


### PR DESCRIPTION
OADP 1.2, OCP 4.11+

This PR has passed OADP QA. 

Resolves https://issues.redhat.com/browse/OADP-2853 by Replacing `defaultVolumesToRestic` with `defaultVolumesToFsBackup` throughout the _Backup and restore_ user guide. 

Previews:
1. https://66083--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-backing-up-applications-restic-doc [Change to the `Backup` CR]
2. https://66083--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/oadp-scheduling-backups-doc [Change to the `Schedule` CR]
3. https://66083--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg#oadp-installing-dpa_installing-oadp-mcg [text of callout 3 in the documentation of YAML view for all platforms except ODF]