### PR TITLE
[OSDOCS-8075] OCP content port to ROSA and OSD: Machine Management

### DIFF
--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -634,6 +634,117 @@ Topics:
 - Name: Config map reference for the Cluster Monitoring Operator
   File: config-map-reference-for-the-cluster-monitoring-operator
 ---
+Name: Machine management
+Dir: machine_management
+Distros: openshift-dedicated
+Topics:
+# No links work for hidden assemblies
+#- Name: Overview of machine management
+#  File: index
+#- Name: Managing compute machines with the Machine API
+#  Dir: creating_machinesets
+#  Distros: openshift-dedicated
+#  Topics:
+# Not supported
+#  - Name: Creating a compute machine set on Alibaba Cloud
+#    File: creating-machineset-alibaba
+# cannot create resource "machinesets"
+#  - Name: Creating a compute machine set on AWS
+#    File: creating-machineset-aws
+# Not supported
+#  - Name: Creating a compute machine set on Azure
+#    File: creating-machineset-azure
+#  - Name: Creating a compute machine set on Azure Stack Hub
+#    File: creating-machineset-azure-stack-hub
+# cannot create resource "machinesets"
+#  - Name: Creating a compute machine set on GCP
+#    File: creating-machineset-gcp
+# Not supported
+#  - Name: Creating a compute machine set on IBM Cloud
+#    File: creating-machineset-ibm-cloud
+#  - Name: Creating a compute machine set on IBM Power Virtual Server
+#    File: creating-machineset-ibm-power-vs
+#  - Name: Creating a compute machine set on Nutanix
+#    File: creating-machineset-nutanix
+#  - Name: Creating a compute machine set on OpenStack
+#    File: creating-machineset-osp
+#  - Name: Creating a compute machine set on RHV
+#    File: creating-machineset-rhv
+#    Distros: openshift-enterprise
+#  - Name: Creating a compute machine set on oVirt
+#    File: creating-machineset-rhv
+#    Distros: openshift-origin
+#  - Name: Creating a compute machine set on vSphere
+#    File: creating-machineset-vsphere
+#  - Name: Creating a compute machine set on bare metal
+#    File: creating-machineset-bare-metal
+# cannot patch resource "machines", cannot patch resource "machinesets/scale"
+# - Name: Manually scaling a compute machine set
+#   File: manually-scaling-machineset
+# cannot patch resource "machines", cannot patch resource "machinesets/scale"
+# - Name: Manually scaling a compute machine set
+#   File: manually-scaling-machineset
+# - Name: Modifying a compute machine set
+#  File: modifying-machineset
+# cannot delete resource "machines"
+#- Name: Deleting a machine
+#  File: deleting-machine
+# cannot create resource "clusterautoscalers"
+#- Name: Applying autoscaling to a cluster
+#  File: applying-autoscaling
+# cannot create resource "machinesets"
+# - Name: Creating infrastructure machine sets
+#  File: creating-infrastructure-machinesets
+# - Name: Adding a RHEL compute machine
+#  File: adding-rhel-compute
+#  Distros: openshift-enterprise
+#- Name: Adding more RHEL compute machines
+#  File: more-rhel-compute
+#  Distros: openshift-enterprise
+# - Name: Managing user-provisioned infrastructure manually
+#  Dir: user_infra
+#  Topics:
+#  - Name: Adding compute machines to clusters with user-provisioned infrastructure manually
+#    File: adding-compute-user-infra-general
+#  - Name: Adding compute machines to AWS using CloudFormation templates
+#    File: adding-aws-compute-user-infra
+# Not supported
+#  - Name: Adding compute machines to vSphere manually
+#    File: adding-vsphere-compute-user-infra
+#  - Name: Adding compute machines to a cluster on RHV
+#    File: adding-rhv-compute-user-infra
+#  - Name: Adding compute machines to bare metal
+#    File: adding-bare-metal-compute-user-infra
+# Tech preview, not supported
+#- Name: Managing machines with the Cluster API
+#  File: capi-machine-management
+- Name: Managing control plane machines
+  Dir: control_plane_machine_management
+  Topics:
+# Only descriptive info
+  - Name: About control plane machine sets
+    File: cpmso-about
+# cannot create/list/get resource "controlplanemachinesets" 
+#  - Name: Getting started with control plane machine sets
+#    File: cpmso-getting-started
+# Only descriptive info, cannot create/list/get resource "controlplanemachinesets"
+  - Name: Control plane machine set configuration
+    File: cpmso-configuration
+# cannot create/list/get resource "controlplanemachinesets" 
+#  - Name: Using control plane machine sets
+#    File: cpmso-using
+  - Name: Control plane resiliency and recovery
+    File: cpmso-resiliency
+#  cannot patch resource "machines", cannot get resource "controlplanemachinesets"
+#  - Name: Troubleshooting the control plane machine set
+#    File: cpmso-troubleshooting
+# cannot delete/get resource "controlplanemachinesets"
+#  - Name: Disabling the control plane machine set
+#    File: cpmso-disabling
+# cannot create resource "machinehealthchecks", baremetal not supported
+#- Name: Deploying machine health checks
+#  File: deploying-machine-health-checks
+---
 Name: Serverless
 Dir: serverless
 Distros: openshift-dedicated

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -875,6 +875,116 @@ Topics:
   - Name: Removing Service Mesh
     File: removing-ossm
 ---
+Name: Machine management
+Dir: machine_management
+Distros: openshift-rosa
+Topics:
+# No links work for hidden assemblies
+#- Name: Overview of machine management
+#  File: index
+#- Name: Managing compute machines with the Machine API
+#  Dir: creating_machinesets
+#  Distros: openshift-rosa
+#  Topics:
+# Not supported
+#  - Name: Creating a compute machine set on Alibaba Cloud
+#    File: creating-machineset-alibaba
+# cannot create resource "machinesets"
+#  - Name: Creating a compute machine set on AWS
+#   File: creating-machineset-aws
+# Not supported
+#  - Name: Creating a compute machine set on Azure
+#    File: creating-machineset-azure
+#  - Name: Creating a compute machine set on Azure Stack Hub
+#    File: creating-machineset-azure-stack-hub
+# - Name: Creating a compute machine set on GCP
+#   File: creating-machineset-gcp
+# Not supported
+#  - Name: Creating a compute machine set on IBM Cloud
+#    File: creating-machineset-ibm-cloud
+#  - Name: Creating a compute machine set on IBM Power Virtual Server
+#    File: creating-machineset-ibm-power-vs
+#  - Name: Creating a compute machine set on Nutanix
+#    File: creating-machineset-nutanix
+#  - Name: Creating a compute machine set on OpenStack
+#    File: creating-machineset-osp
+#  - Name: Creating a compute machine set on RHV
+#    File: creating-machineset-rhv
+#    Distros: openshift-enterprise
+#  - Name: Creating a compute machine set on oVirt
+#    File: creating-machineset-rhv
+#    Distros: openshift-origin
+#  - Name: Creating a compute machine set on vSphere
+#    File: creating-machineset-vsphere
+#  - Name: Creating a compute machine set on bare metal
+#    File: creating-machineset-bare-metal
+# cannot patch resource "machines", cannot patch resource "machinesets/scale"
+# - Name: Manually scaling a compute machine set
+#   File: manually-scaling-machineset
+# cannot patch resource "machines", cannot patch resource "machinesets/scale"
+# - Name: Manually scaling a compute machine set
+#   File: manually-scaling-machineset
+# - Name: Modifying a compute machine set
+#  File: modifying-machineset
+# cannot delete resource "machines"
+#- Name: Deleting a machine
+#  File: deleting-machine
+# cannot create resource "clusterautoscalers"
+#- Name: Applying autoscaling to a cluster
+#  File: applying-autoscaling
+# cannot create resource "machinesets"
+# cannot create resource "machinesets"
+# - Name: Creating infrastructure machine sets
+#  File: creating-infrastructure-machinesets
+# - Name: Adding a RHEL compute machine
+#  File: adding-rhel-compute
+#  Distros: openshift-enterprise
+#- Name: Adding more RHEL compute machines
+#  File: more-rhel-compute
+#  Distros: openshift-enterprise
+# - Name: Managing user-provisioned infrastructure manually
+#  Dir: user_infra
+#  Topics:
+#  - Name: Adding compute machines to clusters with user-provisioned infrastructure manually
+#    File: adding-compute-user-infra-general
+# Only for clusters installed by using the provided AWS CloudFormation templates.
+#  - Name: Adding compute machines to AWS using CloudFormation templates
+#    File: adding-aws-compute-user-infra
+# Not supported
+#  - Name: Adding compute machines to vSphere manually
+#    File: adding-vsphere-compute-user-infra
+#  - Name: Adding compute machines to a cluster on RHV
+#    File: adding-rhv-compute-user-infra
+#  - Name: Adding compute machines to bare metal
+#    File: adding-bare-metal-compute-user-infra
+# Tech preview, not supported
+#- Name: Managing machines with the Cluster API
+#  File: capi-machine-management
+- Name: Managing control plane machines
+  Dir: control_plane_machine_management
+  Topics:
+  - Name: About control plane machine sets
+    File: cpmso-about
+# cannot create/list/get resource "controlplanemachinesets", 
+#  - Name: Getting started with control plane machine sets
+#    File: cpmso-getting-started
+  - Name: Control plane machine set configuration
+    File: cpmso-configuration
+# cannot create/list/get resource "controlplanemachinesets" 
+#  - Name: Using control plane machine sets
+#    File: cpmso-using
+  - Name: Control plane resiliency and recovery
+    File: cpmso-resiliency
+#  cannot patch resource "machines", cannot get resource "controlplanemachinesets"
+#  - Name: Troubleshooting the control plane machine set
+#    File: cpmso-troubleshooting
+# cannot delete/get resource "controlplanemachinesets"
+#  - Name: Disabling the control plane machine set
+#    File: cpmso-disabling
+# cannot create resource "machinehealthchecks", baremetal not supported
+#- Name: Deploying machine health checks
+#  File: deploying-machine-health-checks
+---
 Name: Serverless
 Dir: serverless
 Distros: openshift-rosa

--- a/machine_management/control_plane_machine_management/cpmso-about.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-about.adoc
@@ -42,9 +42,11 @@ Attempting to deploy control plane machines as AWS Spot Instances, GCP preemptib
 
 * Making changes to the control plane machine set during or prior to installation is not supported. You must make any changes to the control plane machine set only after installation.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 [id="additional-resources_cpmso-about"]
 == Additional resources
 
 * xref:../../operators/operator-reference.adoc#control-plane-machine-set-operator_cluster-operators-ref[Control Plane Machine Set Operator reference]
 * xref:../../rest_api/machine_apis/controlplanemachineset-machine-openshift-io-v1.adoc#controlplanemachineset-machine-openshift-io-v1[`ControlPlaneMachineSet` custom resource]
+endif::openshift-rosa,openshift-dedicated[]

--- a/machine_management/control_plane_machine_management/cpmso-configuration.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-configuration.adoc
@@ -11,12 +11,15 @@ These example YAML file and snippets demonstrate the base structure for a contro
 //Sample YAML for a control plane machine set custom resource
 include::modules/cpmso-yaml-sample-cr.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with control plane machine sets]
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-feat-config-update_cpmso-using[Updating the control plane configuration]
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [discrete]
 [id="cpmso-sample-yaml-provider-specific_{context}"]
 === Provider-specific configuration
@@ -30,7 +33,9 @@ The `<platform_provider_spec>` and `<platform_failure_domains>` sections of the 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Sample YAML snippets for configuring Microsoft Azure clusters]
 
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[Sample YAML snippets for configuring VMware vSphere clusters]
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-dedicated[]
 [id="cpmso-sample-yaml-aws_{context}"]
 == Sample YAML for configuring Amazon Web Services clusters
 
@@ -42,10 +47,14 @@ include::modules/cpmso-yaml-provider-spec-aws.adoc[leveloffset=+2]
 //Sample AWS failure domain configuration
 include::modules/cpmso-yaml-failure-domain-aws.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-supported-features-aws_cpmso-using[Enabling Amazon Web Services features for control plane machines]
+endif::openshift-rosa,openshift-dedicated[]
+endif::openshift-dedicated[]
 
+ifndef::openshift-rosa[]
 [id="cpmso-sample-yaml-gcp_{context}"]
 == Sample YAML for configuring Google Cloud Platform clusters
 
@@ -62,6 +71,9 @@ include::modules/cpmso-yaml-failure-domain-gcp.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-supported-features-gcp_cpmso-using[Enabling Google Cloud Platform features for control plane machines]
 ////
+endif::openshift-rosa[]
+
+ifndef::openshift-rosa,openshift-dedicated[]
 [id="cpmso-sample-yaml-azure_{context}"]
 == Sample YAML for configuring Microsoft Azure clusters
 
@@ -84,3 +96,4 @@ Some sections of the control plane machine set CR are provider-specific. The exa
 
 //Sample VMware vSphere provider specification
 include::modules/cpmso-yaml-provider-spec-vsphere.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]

--- a/machine_management/control_plane_machine_management/cpmso-resiliency.adoc
+++ b/machine_management/control_plane_machine_management/cpmso-resiliency.adoc
@@ -17,23 +17,33 @@ When possible, the control plane machine set spreads the control plane machines 
 include::modules/cpmso-failure-domains-provider.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
+ifndef::openshift-dedicated[]
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-yaml-failure-domain-aws_cpmso-configuration[Sample Amazon Web Services failure domain configuration]
-
+endif::openshift-dedicated[]
+ifndef::openshift-rosa[]
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-yaml-failure-domain-gcp_cpmso-configuration[Sample Google Cloud Platform failure domain configuration]
-
+endif::openshift-rosa[]
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-yaml-failure-domain-azure_cpmso-configuration[Sample Microsoft Azure failure domain configuration]
+endif::openshift-rosa,openshift-dedicated[]
 
 //Balancing control plane machines
 include::modules/cpmso-failure-domains-balancing.adoc[leveloffset=+2]
 
 //Recovery of the failed control plane machines
 include::modules/cpmso-control-plane-recovery.adoc[leveloffset=+1]
+
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[Deploying machine health checks]
+endif::openshift-rosa,openshift-dedicated[]
 
 //Quorum protection with machine lifecycle hooks
 include::modules/machine-lifecycle-hook-deletion-etcd.adoc[leveloffset=+1]
+
+ifndef::openshift-rosa,openshift-dedicated[]
 [role="_additional-resources"]
 .Additional resources
 * xref:../../machine_management/deleting-machine.adoc#machine-lifecycle-hook-deletion_deleting-machine[Lifecycle hooks for the machine deletion phase]
+endif::openshift-rosa,openshift-dedicated[]

--- a/machine_management/creating_machinesets/creating-machineset-aws.adoc
+++ b/machine_management/creating_machinesets/creating-machineset-aws.adoc
@@ -1,22 +1,41 @@
 :_content-type: ASSEMBLY
 [id="creating-machineset-aws"]
+
+ifndef::openshift-rosa,openshift-dedicated[]
 = Creating a compute machine set on AWS
 include::_attributes/common-attributes.adoc[]
 :context: creating-machineset-aws
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+= About compute machine sets on AWS
+include::_attributes/common-attributes.adoc[]
+:context: creating-machineset-aws
+endif::openshift-rosa,openshift-dedicated[]
+
 
 toc::[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 You can create a different compute machine set to serve a specific purpose in your {product-title} cluster on Amazon Web Services (AWS). For example, you might create infrastructure machine sets and related machines so that you can move supporting workloads to the new machines.
 
 //[IMPORTANT] admonition for UPI
 include::modules/machine-user-provisioned-limitations.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+Different compute machine sets serve a specific purpose in your {product-title} cluster on Amazon Web Services (AWS).
+endif::openshift-rosa,openshift-dedicated[]
 
 //Sample YAML for a compute machine set custom resource on AWS
 include::modules/machineset-yaml-aws.adoc[leveloffset=+1]
 
+// cannot create resource "machinesets"
+ifndef::openshift-rosa,openshift-dedicated[]
 //Creating a compute machine set
 include::modules/machineset-creating.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
+//cannot patch resource "machinesets"
+ifndef::openshift-rosa,openshift-dedicated[]
 //Machine sets that enable the Amazon EC2 Instance Metadata Service
 include::modules/machineset-imds-options.adoc[leveloffset=+1]
 
@@ -34,9 +53,16 @@ include::modules/machineset-non-guaranteed-instance.adoc[leveloffset=+1]
 
 //Creating Spot Instances by using compute machine sets
 include::modules/machineset-creating-non-guaranteed-instances.adoc[leveloffset=+2]
+endif::openshift-rosa,openshift-dedicated[]
 
+// cannot get resource "machineconfigs"
+ifndef::openshift-rosa,openshift-dedicated[]
 //Adding a GPU node to a machine set (stesmith)
 include::modules/nvidia-gpu-aws-adding-a-gpu-node.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]
 
+//  cannot create the required openshift-nfd namespaces
+ifndef::openshift-rosa,openshift-dedicated[]
 //Deploying the Node Feature Discovery Operator (stesmith)
 include::modules/nvidia-gpu-aws-deploying-the-node-feature-discovery-operator.adoc[leveloffset=+1]
+endif::openshift-rosa,openshift-dedicated[]

--- a/machine_management/index.adoc
+++ b/machine_management/index.adoc
@@ -11,8 +11,14 @@ You can control the cluster and perform auto-scaling, such as scaling up and dow
 
 It is important to have a cluster that adapts to changing workloads. The {product-title} cluster can horizontally scale up and down when the load increases or decreases.
 
+ifndef::openshift-rosa,openshift-dedicated[]
 Machine management is implemented as a xref:../operators/understanding/crds/crd-extending-api-with-crds.adoc#crd-extending-api-with-crds[custom resource definition] (CRD).
 A CRD object defines a new unique object `Kind` in the cluster and enables the Kubernetes API server to handle the object's entire lifecycle.
+endif::openshift-rosa,openshift-dedicated[]
+ifdef::openshift-rosa,openshift-dedicated[]
+Machine management is implemented as a custom resource definition (CRD).
+A CRD object defines a new unique object `Kind` in the cluster and enables the Kubernetes API server to handle the object's entire lifecycle.
+endif::openshift-rosa,openshift-dedicated[]
 
 The Machine API Operator provisions the following resources:
 
@@ -33,17 +39,25 @@ As a cluster administrator, you can perform the following actions:
 
 ** xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#creating-machineset-aws[AWS]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 ** xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#creating-machineset-azure[Azure]
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-rosa[]
 ** xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#creating-machineset-gcp[GCP]
+endifndef::openshift-rosa[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 ** xref:../machine_management/creating_machinesets/creating-machineset-osp.adoc#creating-machineset-osp[{rh-openstack}]
 
 ** xref:../machine_management/creating_machinesets/creating-machineset-rhv.adoc#creating-machineset-rhv[{rh-virtualization}]
 
 ** xref:../machine_management/creating_machinesets/creating-machineset-vsphere.adoc#creating-machineset-vsphere[vSphere]
+endif::openshift-rosa,openshift-dedicated[]
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * Create a machine set for a bare metal deployment: xref:../machine_management/creating_machinesets/creating-machineset-bare-metal.adoc#creating-machineset-bare-metal[Creating a compute machine set on bare metal]
+endif::openshift-rosa,openshift-dedicated[]
 
 * xref:../machine_management/manually-scaling-machineset.adoc#manually-scaling-machineset[Manually scale a compute machine set] by adding or removing a machine from the compute machine set.
 
@@ -60,6 +74,7 @@ As a cluster administrator, you can perform the following actions:
 
 As a cluster administrator, you can perform the following actions:
 
+ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-feat-config-update_cpmso-using[Update your control plane configuration] with a control plane machine set for the following cloud providers:
 
 ** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-aws_cpmso-configuration[AWS]
@@ -67,6 +82,9 @@ As a cluster administrator, you can perform the following actions:
 ** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-azure_cpmso-configuration[Azure]
 
 ** xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-vsphere_cpmso-configuration[vSphere]
+endif::openshift-rosa,openshift-dedicated[]
+
+* xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-feat-config-update_cpmso-using[Update your control plane configuration] with a control plane machine set for your xref:../machine_management/control_plane_machine_management/cpmso-configuration.adoc#cpmso-sample-yaml-aws_cpmso-configuration[AWS cluster].
 
 * Configure and deploy a xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[machine health check] to automatically recover unhealthy control plane machines.
 

--- a/machine_management/user_infra/adding-compute-user-infra-general.adoc
+++ b/machine_management/user_infra/adding-compute-user-infra-general.adoc
@@ -13,6 +13,7 @@ You can add compute machines to a cluster on user-provisioned infrastructure eit
 
 To add more compute machines to your {product-title} cluster on Amazon Web Services (AWS), see xref:../../machine_management/user_infra/adding-aws-compute-user-infra.adoc#adding-aws-compute-user-infra[Adding compute machines to AWS by using CloudFormation templates].
 
+ifndef::openshift-dedicated[]
 [id="upi-adding-compute-azure"]
 == Adding compute machines to Microsoft Azure
 
@@ -22,12 +23,14 @@ To add more compute machines to your {product-title} cluster on Microsoft Azure,
 == Adding compute machines to Azure Stack Hub
 
 To add more compute machines to your {product-title} cluster on Azure Stack Hub, see xref:../../installing/installing_azure_stack_hub/installing-azure-stack-hub-user-infra.adoc#installation-creating-azure-worker_installing-azure-stack-hub-user-infra[Creating additional worker machines in Azure Stack Hub].
+endif::openshift-dedicated[]
 
 [id="upi-adding-compute-gcp"]
 == Adding compute machines to Google Cloud Platform
 
 To add more compute machines to your {product-title} cluster on Google Cloud Platform (GCP), see xref:../../installing/installing_gcp/installing-restricted-networks-gcp.adoc#installation-creating-gcp-worker_installing-restricted-networks-gcp[Creating additional worker machines in GCP].
 
+ifndef::openshift-dedicated[]
 [id="upi-adding-compute-vsphere"]
 == Adding compute machines to vSphere
 
@@ -44,3 +47,4 @@ To add more compute machines to your {product-title} cluster on {rh-virtualizati
 == Adding compute machines to bare metal
 
 To add more compute machines to your {product-title} cluster on bare metal, see xref:../../machine_management/user_infra/adding-bare-metal-compute-user-infra.adoc#adding-bare-metal-compute-user-infra[Adding compute machines to bare metal].
+endif::openshift-dedicated[]

--- a/modules/cpmso-failure-domains-provider.adoc
+++ b/modules/cpmso-failure-domains-provider.adoc
@@ -12,15 +12,17 @@ The control plane machine set concept of a failure domain is analogous to existi
 [cols="<.^,^.^,^.^"]
 |====
 |Cloud provider |Support for failure domains |Provider nomenclature
-
+ifndef::openshift-dedicated[]
 |Amazon Web Services (AWS)
 |X
 |link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-regions-availability-zones.html#concepts-availability-zones[Availability Zone (AZ)]
-
+endif::openshift-dedicated[]
+ifndef::openshift-rosa[]
 |Google Cloud Platform (GCP)
 |X
 |link:https://cloud.google.com/compute/docs/regions-zones[zone]
-
+endif::openshift-rosa[]
+ifndef::openshift-rosa,openshift-dedicated[]
 |Microsoft Azure
 |X
 |link:https://learn.microsoft.com/en-us/azure/azure-web-pubsub/concept-availability-zones[Azure availability zone]
@@ -28,6 +30,7 @@ The control plane machine set concept of a failure domain is analogous to existi
 |VMware vSphere
 |
 |Not applicable
+endif::openshift-rosa,openshift-dedicated[]
 |====
 
 The failure domain configuration in the control plane machine set custom resource (CR) is platform-specific. For more information about failure domain parameters in the CR, see the sample failure domain configuration for your provider.

--- a/modules/cpmso-yaml-provider-spec-aws.adoc
+++ b/modules/cpmso-yaml-provider-spec-aws.adoc
@@ -6,7 +6,9 @@
 [id="cpmso-yaml-provider-spec-aws_{context}"]
 = Sample AWS provider specification
 
+ifndef::openshift-rosa[]
 When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane `machine` CR that is created by the installation program. You can omit any field that is set in the failure domain section of the CR.
+endif::openshift-rosa[]
 
 In the following example, `<cluster_id>` is the infrastructure ID that is based on the cluster ID that you set when you provisioned the cluster. If you have the OpenShift CLI installed, you can obtain the infrastructure ID by running the following command:
 

--- a/modules/cpmso-yaml-provider-spec-gcp.adoc
+++ b/modules/cpmso-yaml-provider-spec-gcp.adoc
@@ -6,7 +6,9 @@
 [id="cpmso-yaml-provider-spec-gcp_{context}"]
 = Sample GCP provider specification
 
+ifndef::openshift-dedicated[]
 When you create a control plane machine set for an existing cluster, the provider specification must match the `providerSpec` configuration in the control plane machine custom resource (CR) that is created by the installation program. You can omit any field that is set in the failure domain section of the CR.
+endif::openshift-dedicated[]
 
 [discrete]
 [id="cpmso-yaml-provider-spec-gcp-oc_{context}"]


### PR DESCRIPTION
In my first pass through the Machine Management docs, there is little content that can be ported to ROSA/OSD because of the restrictions on working with machine, machineset, clustermachineset, etc. Per @AndrewJones-RH  [it is not worth adding](https://redhat-internal.slack.com/archives/C0605BL983H/p1696981959168099) this small amount of mostly or entirely descriptive info that the user cannot really apply.

https://issues.redhat.com/browse/OSDOCS-8075