### PR TITLE
OSDOCS-7659: update backup and restore

### DIFF
--- a/microshift_backup_and_restore/microshift-backup-and-restore.adoc
+++ b/microshift_backup_and_restore/microshift-backup-and-restore.adoc
@@ -1,20 +1,21 @@
 :_content-type: ASSEMBLY
 [id="microshift-backup-and-restore"]
-= Backing up and restoring {product-title} data
+= Backing up and restoring {microshift-short} data
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-backup-and-restore
 
 toc::[]
 
-You can manually back up and restore the {product-title} database on all supported systems. The {product-title} service must be stopped and Greenboot health checks must be completed prior to any backups.
+You can manually back up and restore the {microshift-short} database on all supported systems. Greenboot health checks must be completed and you must stop the {microshift-short} service prior to any backups.
 
 [NOTE]
 ====
-Only {product-title} data is backed up with the following procedures. Application data is not included.
+Only {microshift-short} data is backed up with the following procedures. Application data is not included.
 ====
 
-* On `rpm-ostree` systems, {product-title} automatically creates a backup on every start. These automatic backups are deleted and replaced with the latest backup each time the system restarts.
-* If you are using an `rpm-ostree` system, restoring data is also automated. Otherwise, you must back up and restore data manually.
+* On `rpm-ostree` systems, {microshift-short} automatically creates a backup on every start. These automatic backups are deleted and replaced with the latest backup each time the system restarts.
+* If you are using an `rpm-ostree` system, the data is automatically restored after Greenboot rolls the system back. This data restoration ensures that the database matches the software running on the host after the rollback is completed.
+* On other system types, you must back up and restore data manually.
 
 include::modules/microshift-service-stopping.adoc[leveloffset=+1]
 

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -1,12 +1,12 @@
 :_content-type: ASSEMBLY
 [id="microshift-install-rpm"]
-= Installing {product-title} from an RPM package
+= Installing {microshift-short} from an RPM package
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-install-rpm
 
 toc::[]
 
-You can install {product-title} from an RPM package on a machine with {op-system-base-full} {op-system-version}.
+You can install {microshift-short} from an RPM package on a machine with {op-system-base-full} {op-system-version}.
 
 //include::snippets/microshift-tech-preview-snip.adoc[leveloffset=+1]
 

--- a/modules/microshift-backing-up-manually.adoc
+++ b/modules/microshift-backing-up-manually.adoc
@@ -4,60 +4,42 @@
 
 :_content-type: PROCEDURE
 [id="microshift-backing-up-manually_{context}"]
-= Backing up {product-title} data manually
+= Backing up {microshift-short} data manually
 
-You can back up {product-title} data manually at any time. Data backups are advised before any system updates. Backups are created in the `/var/lib/microshift-backups` directory by default. You can also specify a directory by adding custom parameters to the required backup command.
-
-[NOTE]
-====
-On `rpm-ostree` systems, {product-title} creates an automatic backup on every start and restores data automatically.
-====
+You can back up {microshift-short} data manually at any time. Back up your data before system updates to preserve it for use if an update fails or for other system trouble. Automated backups are created in the `/var/lib/microshift-backups` directory. You can use this directory for manually backing up and restoring data by specifying it in each command. When you create a backup, you must use the entire file path for the output file.
 
 .Prerequisites
+
 * You have root access to the host.
-* {product-title} is stopped.
+* {microshift-short} is stopped.
 
 .Procedure
-. Manually create a backup by using the default name and parent directory, `/var/lib/microshift-backups/<default-backup-name>`, by running the following command:
+
+. Manually create a backup by using the parent directory and specifying a name, such as `/var/lib/microshift-backups/<my_manual_backup>`, by running the following command:
 +
 [source,terminal]
 ----
-$ sudo microshift backup
+$ sudo microshift backup /var/lib/microshift-backups/<my_manual_backup>
 ----
+Replace `<my_manual_backup>` with the backup name that you want to use.
++
 .Example output
 +
 [source,terminal]
 ----
-??? I0829 07:32:12.313961    6586 run_check.go:28] "Service state" service="microshift.service" state="inactive"
-??? I0829 07:32:12.318803    6586 run_check.go:28] "Service state" service="microshift-etcd.scope" state="inactive"
-??? I0829 07:32:12.318897    6586 version.go:227] "START reading version file"
-??? I0829 07:32:12.319122    6586 version.go:233] "END reading version file" contents={"version":"4.14.0","deployment_id":"rhel-35d7b5c80f0f1378d6846f6dc1304bbf1dcdc5847198fcd4e6099364eaf99048.0","boot_id":"80364fcf3df54284a6902687e2cdd4c2"}
-??? I0829 07:32:12.319256    6586 data_manager.go:82] "Copying data to backup directory" storage="/var/lib/microshift-backups" name="4.14.0__20230829_113212" data="/var/lib/microshift"
-??? I0829 07:32:12.319423    6586 data_manager.go:186] "Starting copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift /var/lib/microshift-backups/4.14.0__20230829_113212"
-??? I0829 07:32:12.324955    6586 data_manager.go:200] "Finished copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift /var/lib/microshift-backups/4.14.0__20230829_113212"
-??? I0829 07:32:12.325014    6586 data_manager.go:115] "Copied data to backup directory" backup="/var/lib/microshift-backups/4.14.0__20230829_113212" data="/var/lib/microshift"
-----
-
-. Optional: Manually create a backup with a specific name in the default directory by running the following command:
-+
-[source,terminal]
-----
-$ sudo microshift backup --name <my-custom-backup>
-----
-
-. Optional: Manually create a backup in a specific parent directory by running the following command:
-+
-[source,terminal]
-----
-$ sudo microshift backup --storage /var/lib/<custom-storage-location>
+??? I1017 07:38:16.770506    5900 data_manager.go:92] "Copying data to backup directory" storage="/var/lib/microshift-backups" name="test" data="/var/lib/microshift"
+??? I1017 07:38:16.770713    5900 data_manager.go:227] "Starting copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift /var/lib/microshift-backups/test"
+??? I1017 07:38:16.776162    5900 data_manager.go:241] "Finished copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift /var/lib/microshift-backups/test"
+??? I1017 07:38:16.776256    5900 data_manager.go:125] "Copied data to backup directory" backup="/var/lib/microshift-backups/test" data="/var/lib/microshift"
 ----
 
 . Optional: Manually create a backup in a specific parent directory with a custom name by running the following command:
 +
 [source,terminal]
 ----
-$ sudo microshift backup --storage /var/lib/<custom-storage-location>/ --name <my-custom-backup>
+$ sudo microshift backup /mnt/<other_backups_location>/<another_manual_backup>
 ----
+Replace `<other_backups_location>` with the directory you want to use and `<my_manual_backup>` with the backup name you want to use.
 
 .Verification
-* You can verify that the backup exists by viewing the data in the directory you chose. For example, `/var/lib/microshift-backups/<my-custom-backup>/` or `/var/lib/<custom-storage-location>/<my-custom-backup>/`.
+* You can verify that the backup exists by viewing the data in the directory you chose. For example, `/var/lib/microshift-backups/<my_manual_backup>/` or `/mnt/<other_backups_location>/<another_manual_backup>`.

--- a/modules/microshift-install-rpm-before.adoc
+++ b/modules/microshift-install-rpm-before.adoc
@@ -4,8 +4,8 @@
 
 :_content-type: CONCEPT
 [id="microshift-install-rpm-before_{context}"]
-= Before installing {product-title} from an RPM package
+= Before installing {microshift-short} from an RPM package
 
-{product-title} uses the logical volume manager storage (LVMS) Container Storage Interface (CSI) plugin for providing storage to persistent volumes (PVs). LVMS relies on the Linux logical volume manager (LVM) to dynamically manage the backing logical volumes (LVs) for PVs. For this reason, your machine must have an LVM volume group (VG) with unused space in which LVMS can create the LVs for your workload's PVs.
+{microshift-short} uses the logical volume manager storage (LVMS) Container Storage Interface (CSI) plugin for providing storage to persistent volumes (PVs). LVMS relies on the Linux logical volume manager (LVM) to dynamically manage the backing logical volumes (LVs) for PVs. For this reason, your machine must have an LVM volume group (VG) with unused space in which LVMS can create the LVs for your workload's PVs.
 
 To configure a volume group (VG) that allows LVMS to create the LVs for your workload's PVs, lower the *Desired Size* of your root volume during the installation of {op-system}. Lowering the size of your root volume allows unallocated space on the disk for additional LVs created by LVMS at runtime.

--- a/modules/microshift-install-rpm-preparing.adoc
+++ b/modules/microshift-install-rpm-preparing.adoc
@@ -4,13 +4,13 @@
 
 :_content-type: PROCEDURE
 [id="microshift-install-rpm-preparing_{context}"]
-= Preparing to install {product-title} from an RPM package
+= Preparing to install {microshift-short} from an RPM package
 
 Configure your {op-system} machine to have a logical volume manager (LVM) volume group (VG) with sufficient capacity for the persistent volumes (PVs) of your workload.
 
 .Prerequisites
 
-* The system requirements for installing {product-title} have been met.
+* The system requirements for installing {microshift-short} have been met.
 * You have root user access to your machine.
 * You have configured your LVM VG with the capacity needed for the PVs of your workload.
 

--- a/modules/microshift-install-system-requirements.adoc
+++ b/modules/microshift-install-system-requirements.adoc
@@ -4,13 +4,13 @@
 
 :_content-type: REFERENCE
 [id="microshift-install-system-requirements_{context}"]
-= System requirements for installing {product-title}
+= System requirements for installing {microshift-short}
 
-The following conditions must be met prior to installing {product-title}:
+The following conditions must be met prior to installing {microshift-short}:
 
 * {op-system} {op-system-version}
 * 2 CPU cores
-* 2 GB RAM for {product-title} or 3 GB RAM, required by {op-system} for networked-based HTTPs or FTP installations
+* 2 GB RAM for {microshift-short} or 3 GB RAM, required by {op-system} for networked-based HTTPs or FTP installations
 * 10 GB of storage
-* You have an active {product-title} subscription on your Red Hat account. If you do not have a subscription, contact your sales representative for more information.
+* You have an active {microshift-short} subscription on your Red Hat account. If you do not have a subscription, contact your sales representative for more information.
 * You have a Logical Volume Manager (LVM) Volume Group (VG) with sufficient capacity for the Persistent Volumes (PVs) of your workload.

--- a/modules/microshift-restoring-data-backups.adoc
+++ b/modules/microshift-restoring-data-backups.adoc
@@ -4,42 +4,50 @@
 
 :_content-type: PROCEDURE
 [id="microshift-restoring-data-backups-manually_{context}"]
-= Restoring {product-title} data backups manually
+= Restoring {microshift-short} data backups manually
 
-You can restore {product-title} data from a backup manually. Backups can be restored after updates, or after other system events that remove or damage required data. Backups are in the `/var/lib/microshift-backups` directory by default. When you restore a backup, you must use the entire file path.
+You can restore {microshift-short} data from a backup manually. Backups can be restored after updates, or after other system events that remove or damage required data. Automated backups are in the `/var/lib/microshift-backups` directory by default. You can use this directory for manually backing up and restoring data by specifying it in each command. When you restore a backup, you must use the entire file path.
 
 [NOTE]
 ====
-On an `rpm-ostree` system, {product-title} backs up and restores data automatically.
+On an `rpm-ostree` system, {microshift-short} backs up and restores data automatically.
 ====
 
 .Prerequisites
+
 * Root access to the host.
 * Full path of the data backup file.
-* {product-title} is stopped.
+* {microshift-short} is stopped.
 
 .Procedure
 
-. Manually restore an application backup file by using the full file path of the backup you want to restore by running the following command:
+. Manually restore {microshift-short} data by using the full file path of the backup you want to restore by running the following command:
 +
 [source,terminal]
 ----
-$ sudo microshift restore /var/lib/<custom_backups>/<my_backup>
+$ sudo microshift restore /var/lib/microshift-backups/<my_manual_backup>
 ----
+Replace `<my_manual_backup>` with the backup name that you used. Optional: You can also restore automatic `ostree` backups using the full file path.
 +
 .Example output
 +
 [source,terminal]
 ----
-??? I0829 07:33:04.715104    6654 run_check.go:28] "Service state" service="microshift.service" state="inactive"
-??? I0829 07:33:04.719562    6654 run_check.go:28] "Service state" service="microshift-etcd.scope" state="inactive"
-??? I0829 07:33:04.719681    6654 data_manager.go:121] "Copying backup to data directory" storage="/var/lib/microshift-backups" name="4.14.0__20230829_113212" data="/var/lib/microshift"
-??? I0829 07:33:04.719802    6654 data_manager.go:138] "Renaming existing data dir" data="/var/lib/microshift" renamedTo="/var/lib/microshift.saved"
-??? I0829 07:33:04.719913    6654 data_manager.go:186] "Starting copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift-backups/4.14.0__20230829_113212 /var/lib/microshift"
-??? I0829 07:33:04.725032    6654 data_manager.go:200] "Finished copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift-backups/4.14.0__20230829_113212 /var/lib/microshift"
-??? I0829 07:33:04.725091    6654 data_manager.go:160] "Removing temporary data directory" path="/var/lib/microshift.saved"
-??? I0829 07:33:04.727461    6654 data_manager.go:165] "Copied backup to data directory" name="4.14.0__20230829_113212" data="/var/lib/microshift"
+??? I1017 07:39:52.055165    6007 data_manager.go:131] "Copying backup to data directory" storage="/var/lib/microshift-backups" name="test" data="/var/lib/microshift"
+??? I1017 07:39:52.055243    6007 data_manager.go:154] "Renaming existing data dir" data="/var/lib/microshift" renamedTo="/var/lib/microshift.saved"
+??? I1017 07:39:52.055326    6007 data_manager.go:227] "Starting copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift-backups/test /var/lib/microshift"
+??? I1017 07:39:52.061363    6007 data_manager.go:241] "Finished copy" cmd="/bin/cp --verbose --recursive --preserve --reflink=auto /var/lib/microshift-backups/test /var/lib/microshift"
+??? I1017 07:39:52.061404    6007 data_manager.go:175] "Removing temporary data directory" path="/var/lib/microshift.saved"
+??? I1017 07:39:52.063745    6007 data_manager.go:180] "Copied backup to data directory" name="test" data="/var/lib/microshift"
 ----
+
+. Optional. Manually restore data from a customized directory by using the full file path of the backup. Run the following command:
++
+[source,terminal]
+----
+$ sudo microshift restore /<mnt>/<other_backups_location>/<another_manual_backup>
+----
+Replace `<other_backups_location>` with the directory you used and `<my_manual_backup>` with the backup name you used when creating the backup you are restoring.
 +
 .Verification
-* Verify that your backup is restored by restarting {product-title} and checking the data.
+* Verify that your backup is restored by restarting {microshift-short} and checking the data.

--- a/modules/microshift-service-starting.adoc
+++ b/modules/microshift-service-starting.adoc
@@ -4,31 +4,31 @@
 
 :_content-type: PROCEDURE
 [id="starting-microshift_service_{context}"]
-= Starting the {product-title} service
+= Starting the {microshift-short} service
 
-Use the following procedure to start the {product-title} service.
+Use the following procedure to start the {microshift-short} service.
 
 .Prerequisites
 
-* You have installed {product-title} from an RPM package.
+* You have installed {microshift-short} from an RPM package.
 
 .Procedure
 
-. As a root user, start the {product-title} service by entering the following command:
+. As a root user, start the {microshift-short} service by entering the following command:
 +
 [source,terminal]
 ----
 $ sudo systemctl start microshift
 ----
 
-. Optional: To configure your {op-system} machine to start {product-title} when your machine starts, enter the following command:
+. Optional: To configure your {op-system} machine to start {microshift-short} when your machine starts, enter the following command:
 +
 [source,terminal]
 ----
 $ sudo systemctl enable microshift
 ----
 
-. Optional: To disable {product-title} from automatically starting when your machine starts, enter the following command:
+. Optional: To disable {microshift-short} from automatically starting when your machine starts, enter the following command:
 +
 [source,terminal]
 ----
@@ -37,6 +37,5 @@ $ sudo systemctl disable microshift
 +
 [NOTE]
 ====
-The first time that the {product-title} service starts, it downloads and initializes {product-title}'s container images. As a result, it can take several minutes for {product-title} to start the first time that the service is deployed.
-Boot time is reduced for subsequent starts of the {product-title} service.
+The first time that the {microshift-short} service starts, it downloads and initializes the container images for {microshift-short}. As a result, it can take several minutes for {microshift-short} to start the first time that the service is deployed. Boot time is reduced for subsequent starts of the {microshift-short} service.
 ====

--- a/modules/microshift-service-stopping.adoc
+++ b/modules/microshift-service-stopping.adoc
@@ -5,24 +5,24 @@
 
 :_content-type: PROCEDURE
 [id="stopping-microshift-service_{context}"]
-= Stopping the {product-title} service
+= Stopping the {microshift-short} service
 
-Use the following procedure to stop the {product-title} service.
+Use the following procedure to stop the {microshift-short} service.
 
 .Prerequisites
 
-* The {product-title} service is running.
+* The {microshift-short} service is running.
 
 .Procedure
 
-. Enter the following command to stop the {product-title} service:
+. Enter the following command to stop the {microshift-short} service:
 +
 [source,terminal]
 ----
 $ sudo systemctl stop microshift
 ----
 
-. Workloads deployed on {product-title} will continue running even after the {product-title} service has been stopped. Enter the following command to display running workloads:
+. Workloads deployed on {microshift-short} might continue running even after the {microshift-short} service has been stopped. Enter the following command to display running workloads:
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-7659

Link to docs preview:
https://66091--docspreview.netlify.app/microshift/latest/microshift_backup_and_restore/microshift-backup-and-restore

Note: only the {microshift-short} attribute was updated in the Install guide
https://66091--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
