### PR TITLE
OCPBUGS-18998

### DIFF
--- a/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
+++ b/modules/nvidia-gpu-aws-adding-a-gpu-node.adoc
@@ -8,22 +8,11 @@
 
 You can copy and modify a default compute machine set configuration to create a GPU-enabled machine set and machines for the AWS EC2 cloud provider.
 
-The following table lists the validated instance types:
+For more information about the supported instance types, see the following NVIDIA documentation:
 
-[cols="1,1,1,1"]
-|===
-|Instance type |NVIDIA GPU accelerator |Maximum number of GPUs |Architecture
+* link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html[NVIDIA GPU Operator Community support matrix]
 
-|`p4d.24xlarge`
-|A100
-|8
-|x86
-
-|`g4dn.xlarge`
-|T4
-|1
-|x86
-|===
+* link:https://docs.nvidia.com/ai-enterprise/latest/product-support-matrix/index.html[NVIDIA AI Enterprise support matrix]
 
 .Procedure
 


### PR DESCRIPTION
OCPBUGS-18998: Unclear if only validated GPU is only supported one

Jira: https://issues.redhat.com/browse/OCPBUGS-18998?src=confmacro

Version(s): 4.12.z+

Link to docs preview: https://66092--docspreview.netlify.app/openshift-enterprise/latest/machine_management/creating_machinesets/creating-machineset-aws#nvidia-gpu-aws-adding-a-gpu-node_creating-machineset-aws

SME review: @egallen
QE review: @cdvultur

Additional information:
Remove the specific list of supported instances in the Red Hat documentation to keep one source of truth in the [nvidia.com](http://nvidia.com/) web site