### PR TITLE
[enterprise-4.13] OCPBUGS#18836: Add SCC flag and PSA references to OSDK CLI ref

### DIFF
--- a/modules/osdk-cli-ref-run-bundle-upgrade.adoc
+++ b/modules/osdk-cli-ref-run-bundle-upgrade.adoc
@@ -23,7 +23,14 @@ The `run bundle-upgrade` subcommand upgrades an Operator that was previously ins
 |`-n`, `--namespace` (string)
 |If present, namespace in which to run the CLI request.
 
+|`--security-context-config <security_context>`
+|Specifies the security context to use for the catalog pod. Allowed values include `restricted` and `legacy`. The default value is `legacy`. ^[1]^
+
 |`-h`, `--help`
 |Help output for the `run bundle` subcommand.
 
 |===
+[.small]
+--
+1. The `restricted` security context is not compatible with the `default` namespace. To configure your Operator's pod security admission in your production environment, see "Complying with pod security admission". For more information about pod security admission, see "Understanding and managing pod security admission".
+--

--- a/modules/osdk-cli-ref-run-bundle.adoc
+++ b/modules/osdk-cli-ref-run-bundle.adoc
@@ -29,7 +29,14 @@ The `run bundle` subcommand deploys an Operator in the bundle format with Operat
 |`-n`, `--namespace` (string)
 |If present, namespace in which to run the CLI request.
 
+|`--security-context-config <security_context>`
+|Specifies the security context to use for the catalog pod. Allowed values include `restricted` and `legacy`. The default value is `legacy`. ^[1]^
+
 |`-h`, `--help`
 |Help output for the `run bundle` subcommand.
 
 |===
+[.small]
+--
+1. The `restricted` security context is not compatible with the `default` namespace. To configure your Operator's pod security admission in your production environment, see "Complying with pod security admission". For more information about pod security admission, see "Understanding and managing pod security admission".
+--

--- a/modules/osdk-cli-ref-scorecard.adoc
+++ b/modules/osdk-cli-ref-scorecard.adoc
@@ -31,6 +31,9 @@ The `operator-sdk scorecard` command runs the scorecard tool to validate an Oper
 |`-o`, `--output` (string)
 |Output format for results. Available values are `text`, which is the default, and `json`.
 
+|`--pod-security <security_context>`
+|Option to run scorecard with the specified security context. Allowed values include `restricted` and `legacy`. The default value is `legacy`. ^[1]^
+
 |`-l`, `--selector` (string)
 |Label selector to determine which tests are run.
 
@@ -44,3 +47,7 @@ The `operator-sdk scorecard` command runs the scorecard tool to validate an Oper
 |Seconds to wait for tests to complete, for example `35s`. The default value is `30s`.
 
 |===
+[.small]
+--
+1. The `restricted` security context is not compatible with the `default` namespace. To configure your Operator's pod security admission in your production environment, see "Complying with pod security admission". For more information about pod security admission, see "Understanding and managing pod security admission".
+--

--- a/operators/operator_sdk/osdk-cli-ref.adoc
+++ b/operators/operator_sdk/osdk-cli-ref.adoc
@@ -38,11 +38,31 @@ include::modules/osdk-cli-ref-run-bundle.adoc[leveloffset=+2]
 .Additional resources
 
 * See xref:../../operators/understanding/olm/olm-understanding-operatorgroups.adoc#olm-operatorgroups-membership_olm-understanding-operatorgroups[Operator group membership] for details on possible install modes.
+* xref:../../operators/operator_sdk/osdk-complying-with-psa.adoc#osdk-complying-with-psa[Complying with pod security admission]
+// This xref points to a topic that is not currently included in the OSD/ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
+endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/osdk-cli-ref-run-bundle-upgrade.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../../operators/operator_sdk/osdk-complying-with-psa.adoc#osdk-complying-with-psa[Complying with pod security admission]
+// This xref points to a topic that is not currently included in the OSD and ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
+endif::openshift-dedicated,openshift-rosa[]
+
 include::modules/osdk-cli-ref-scorecard.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
 * See xref:../../operators/operator_sdk/osdk-scorecard.adoc#osdk-scorecard[Validating Operators using the scorecard tool] for details about running the scorecard tool.
+* xref:../../operators/operator_sdk/osdk-complying-with-psa.adoc#osdk-complying-with-psa[Complying with pod security admission]
+// This xref points to a topic that is not currently included in the OSD and ROSA docs.
+ifndef::openshift-dedicated,openshift-rosa[]
+* xref:../../authentication/understanding-and-managing-pod-security-admission.adoc#understanding-and-managing-pod-security-admission[Understanding and managing pod security admission]
+endif::openshift-dedicated,openshift-rosa[]


### PR DESCRIPTION
Cherry Picked from ee3e663e4d141e39599f50acbef35385a56cc195 xref: #64630 

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: OCPBUGS-18836
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
* Enterprise (has links to "Understanding pod security admission": 
  * run bundle: https://66098--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-cli-ref#osdk-cli-ref-run-bundle_osdk-cli-ref
  * run bundle upgrade: https://66098--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-cli-ref#osdk-cli-ref-run-bundle-upgrade_osdk-cli-ref
  * scorecard: https://66098--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-cli-ref#osdk-cli-ref-scorecard_osdk-cli-ref
* SD and ROSA (do not link to "understanding pod security admission ):
  * SD
    * run bundle: https://66098--docspreview.netlify.app/openshift-dedicated/latest/operators/operator_sdk/osdk-cli-ref#osdk-cli-ref-run-bundle_osdk-cli-ref
    * run bundle upgrade: https://66098--docspreview.netlify.app/openshift-dedicated/latest/operators/operator_sdk/osdk-cli-ref#osdk-cli-ref-run-bundle-upgrade_osdk-cli-ref
    * scorecard: https://66098--docspreview.netlify.app/openshift-dedicated/latest/operators/operator_sdk/osdk-cli-ref#osdk-cli-ref-scorecard_osdk-cli-ref
  * ROSA
    * run bundle: https://66098--docspreview.netlify.app/openshift-rosa/latest/operators/operator_sdk/osdk-cli-ref#osdk-cli-ref-run-bundle_osdk-cli-ref
    * run bundle upgrade: https://66098--docspreview.netlify.app/openshift-rosa/latest/operators/operator_sdk/osdk-cli-ref#osdk-cli-ref-run-bundle-upgrade_osdk-cli-ref
    * scorecard: https://66098--docspreview.netlify.app/openshift-rosa/latest/operators/operator_sdk/osdk-cli-ref#osdk-cli-ref-scorecard_osdk-cli-ref
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
