### PR TITLE
OCPBUGS#20363: Fix namespace typo in olm-cs-podsched

### DIFF
--- a/modules/olm-priority-class-name.adoc
+++ b/modules/olm-priority-class-name.adoc
@@ -48,7 +48,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: CatalogSource
 metadata:
   name: example-catalog
-  namespace: namespace: {global_ns}
+  namespace: {global_ns}
   annotations:
     operatorframework.io/priorityclass: system-cluster-critical
 ----


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-20363

OCP 4.11+

Preview: https://66112--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-cs-podsched.html#olm-priority-class-name_olm-cs-podsched