### PR TITLE
OSDOCS:8142: Removed platform.gcp.licenses parameter

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -467,7 +467,7 @@ endif::aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 
 ifdef::aws,azure,gcp,bare[]
 |`compute.architecture`
-|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. 
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
 ifdef::aws,azure[]
  Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
 endif::aws,azure[]
@@ -537,7 +537,7 @@ endif::aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 
 ifdef::aws,azure,gcp,bare[]
 |`controlPlane.architecture`
-|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. 
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
 ifdef::aws,azure[]
  Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
 endif::aws,azure[]
@@ -850,7 +850,7 @@ Additional {rh-openstack} configuration parameters are described in the followin
 |`platform.openstack.cloud`
 |The name of the {rh-openstack} cloud to use from the list of clouds in the `clouds.yaml` file.
 
-In the cloud configuration in the `clouds.yaml` file, if possible, use application credentials rather than a user name and password combination. Using application credentials avoids disruptions from secret propogation that follow user name and password rotation. 
+In the cloud configuration in the `clouds.yaml` file, if possible, use application credentials rather than a user name and password combination. Using application credentials avoids disruptions from secret propogation that follow user name and password rotation.
 
 |String, for example `MyCloud`.
 
@@ -1229,14 +1229,6 @@ Additional GCP configuration parameters are described in the following table:
 |`platform.gcp.computeSubnet`
 |The name of the existing subnet where you want to deploy your compute machines.
 |The subnet name.
-
-|`platform.gcp.licenses`
-|A list of license URLs that must be applied to the compute images.
-[IMPORTANT]
-====
-The `licenses` parameter is a deprecated field and nested virtualization is enabled by default. It is not recommended to use this field.
-====
-|Any license available with the link:https://cloud.google.com/compute/docs/reference/rest/v1/licenses/list[license API], such as the license to enable link:https://cloud.google.com/compute/docs/instances/nested-virtualization/overview[nested virtualization]. You cannot use this parameter with a mechanism that generates pre-built images. Using a license URL forces the installation program to copy the source image before use.
 
 |`platform.gcp.defaultMachinePlatform.zones`
 |The availability zones where the installation program creates machines.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
This issue addresses [osdocs-8142](https://issues.redhat.com/browse/OSDOCS-8142).

Link to docs preview:

[Additional Google Cloud Platform (GCP) configuration parameters](https://66113--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp) (note the absence of `platform.gcp.licenses` from the table.)

QE review:
- [x] QE has approved this change.

Additional information:
This GCP parameter was deprecated in 4.10. Docs stated deprecation in https://github.com/openshift/openshift-docs/pull/37422. Engineering has removed this parameter in 4.14.

The corresponding release note PR that indicates that the parameter is removed is https://github.com/openshift/openshift-docs/pull/66116
