### PR TITLE
OSDOCS-8142: Noted platform.gcp.licenses as a removed feature

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -145,7 +145,7 @@ Before you set a path value for the `template` parameter, ensure that the defaul
 === Post-installation configuration
 
 [id="ocp-4-14-OCP-on-multi-arch-clusters"]
-==== {product-title} cluster with multi-architecture compute machines 
+==== {product-title} cluster with multi-architecture compute machines
 {product-title} {product-version} clusters with multi-architecture compute machines are now supported on Google Cloud Platform (GCP) as a Day 2 operation. {product-title} clusters with multi-architecture compute machines on bare metal installations are now generally available. For more information on clusters with multi-architecture compute machines and supported platforms, see xref:../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc#multi-architecture-configuration[About clusters with multi-architecture compute machines].
 
 [id="ocp-4-14-web-console"]
@@ -730,6 +730,11 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |General Availability
 |Deprecated
+
+|`platform.gcp.licenses` for Google Cloud Provider
+|Deprecated
+|Deprecated
+|Removed
 |====
 [.small]
 --


### PR DESCRIPTION
Version(s):
4.14

Issue:
This PR addresses the release note for [osdocs-8142](https://issues.redhat.com/browse/OSDOCS-8142).

Link to docs preview:

[Deprecated and removed features](https://github.com/openshift/openshift-docs/pull/65911#issuecomment-1759660857) > Installation deprecated and removed features

QE review:
- [x] QE has approved this change.


Additional information:
The corresponding PR that removes the `platform.gcp.licenses` parameter from the doc is https://github.com/openshift/openshift-docs/pull/66113
