### PR TITLE
OSDOCS-7985: Adding warning about scaling to 0

### DIFF
--- a/modules/dr-hosted-cluster-within-aws-region-delete.adoc
+++ b/modules/dr-hosted-cluster-within-aws-region-delete.adoc
@@ -21,6 +21,13 @@ Ensure that the `kubeconfig` file of the destination management cluster is place
 
 . Scale the `deployment` and `statefulset` objects by entering these commands:
 +
+[IMPORTANT]
+====
+Do not scale the stateful set if the value of its `spec.persistentVolumeClaimRetentionPolicy.whenScaled` field is set to `Delete`, because this could lead to a loss of data.
+
+As a workaround, update the value of the `spec.persistentVolumeClaimRetentionPolicy.whenScaled` field to `Retain`. Ensure that no controllers exist that reconcile the stateful set and would return the value back to `Delete`, which could lead to a loss of data.
+====
++
 [source,terminal]
 ----
 # Just in case


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7985

Link to docs preview:
https://66118--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-backup-restore-dr#dr-hosted-cluster-within-aws-region-delete_hcp-backup-restore-dr

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
