### PR TITLE
OCPBUGS-19881: adds prerequisites for RHEL 8 ovnkube-trace tool

### DIFF
--- a/modules/nw-ovn-kubernetes-install-ovnkube-trace-local.adoc
+++ b/modules/nw-ovn-kubernetes-install-ovnkube-trace-local.adoc
@@ -14,7 +14,6 @@ The `ovnkube-trace` tool traces packet simulations for arbitrary UDP or TCP traf
 * You are logged in to the cluster with a user with `cluster-admin` privileges.
 
 .Procedure
-
 . Create a pod variable by using the following command:
 +
 [source,terminal]
@@ -28,6 +27,11 @@ $  POD=$(oc get pods -n openshift-ovn-kubernetes -l app=ovnkube-control-plane -o
 ----
 $  oc cp -n openshift-ovn-kubernetes $POD:/usr/bin/ovnkube-trace -c ovnkube-cluster-manager ovnkube-trace
 ----
++
+[NOTE]
+====
+If you are using {op-system-base-full} 8 to run the `ovnkube-trace` tool, you must copy the file `/usr/lib/rhel8/ovnkube-trace` to your local host.
+====
 
 . Make `ovnkube-trace` executable by running the following command:
 +


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OCPBUGS-19881
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://66120--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/ovn-kubernetes-tracing-using-ovntrace
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
