### PR TITLE
Adjust git clone for depth=10 to allow git diff to pick up multi-commit changes in scripts/get-updated-distros.sh

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,12 +6,11 @@ cache:
 # env:
 #   - PR_AUTHOR=${TRAVIS_PULL_REQUEST_SLUG::-15}
 git:
-  depth: 2
+  depth: 10
 jobs:
   allow_failures:
     env:
       - CAN_FAIL=true
-
   include:
     - stage: validate-and-build
       name: "Validate and build"

--- a/scripts/get-updated-distros.sh
+++ b/scripts/get-updated-distros.sh
@@ -3,14 +3,8 @@
 # Returns a list of updated _topic_map.yml files.
 # The list includes any topic maps that are themselves modified, and indirectly modifed topic maps where incldued AsciiDoc files have been updated.
 
-# Handle the git diff differently for Travis and local
 # Get the *.adoc and distro maps files in the pull request
-if [ "$TRAVIS" = true ] ; then
-    FILES=$(git diff --name-only HEAD $TRAVIS_BRANCH --diff-filter=d "*.yml" "*.adoc" ':(exclude)_unused_topics/*')
-
-else
-    FILES=$(git diff --name-only HEAD@{1} --diff-filter=d "*.yml" "*.adoc" ':(exclude)_unused_topics/*')
-fi
+FILES=$(git diff --name-only HEAD@{1} --diff-filter=d "*.yml" "*.adoc" ':(exclude)_unused_topics/*')
 
 REPO_PATH=$(git rev-parse --show-toplevel)
 


### PR DESCRIPTION
Adjust git clone for depth=10 to allow git diff to pick up multi-commit changes in scripts/get-updated-distros.sh

This allows the following to succeed without error in Travis: 

```
FILES=$(git diff --name-only HEAD@{1} --diff-filter=d "*.yml" "*.adoc" ':(exclude)_unused_topics/*')
```

