### PR TITLE
OSDOCS#8139: Adding warning about default namespaces

### DIFF
--- a/applications/projects/working-with-projects.adoc
+++ b/applications/projects/working-with-projects.adoc
@@ -14,10 +14,7 @@ isolation from other communities.
 Projects starting with `openshift-` and `kube-` are  xref:../../authentication/using-rbac.adoc#rbac-default-projects_using-rbac[default projects]. These projects host cluster components that run as pods and other infrastructure components. As such, {product-title} does not allow you to create projects starting with `openshift-` or `kube-` using the `oc new-project` command. Cluster administrators can create these projects using the `oc adm new-project` command.
 ====
 
-[NOTE]
-====
-You cannot assign an SCC to pods created in one of the default namespaces: `default`, `kube-system`, `kube-public`, `openshift-node`, `openshift-infra`, and `openshift`. You cannot use these namespaces for running pods or services.
-====
+include::snippets/default-projects.adoc[]
 
 include::modules/creating-a-project-using-the-web-console.adoc[leveloffset=+1]
 

--- a/applications/quotas/quotas-setting-across-multiple-projects.adoc
+++ b/applications/quotas/quotas-setting-across-multiple-projects.adoc
@@ -10,6 +10,8 @@ A multi-project quota, defined by a `ClusterResourceQuota` object, allows quotas
 
 This guide describes how cluster administrators can set and manage resource quotas across multiple projects.
 
+include::snippets/default-projects.adoc[]
+
 include::modules/quotas-selecting-projects.adoc[leveloffset=+1]
 include::modules/quotas-viewing-clusterresourcequotas.adoc[leveloffset=+1]
 include::modules/quotas-selection-granularity.adoc[leveloffset=+1]

--- a/modules/admission-plug-ins-default.adoc
+++ b/modules/admission-plug-ins-default.adoc
@@ -6,7 +6,11 @@
 = Default admission plugins
 
 //Future xref - A set of default admission plugins is enabled in {product-title} {product-version}. These default plugins contribute to fundamental control plane functionality, such as ingress policy, xref:../nodes/clusters/nodes-cluster-overcommit.adoc#nodes-cluster-resource-override_nodes-cluster-overcommit[cluster resource limit override] and quota policy.
-Default validating and admission plugins are enabled in {product-title} {product-version}. These default plugins contribute to fundamental control plane functionality, such as ingress policy, cluster resource limit override and quota policy. The following lists contain the default admission plugins:
+Default validating and admission plugins are enabled in {product-title} {product-version}. These default plugins contribute to fundamental control plane functionality, such as ingress policy, cluster resource limit override and quota policy. 
+
+include::snippets/default-projects.adoc[]
+
+The following lists contain the default admission plugins:
 
 .Validating admission plugins
 [%collapsible]

--- a/modules/creating-a-project-using-the-CLI.adoc
+++ b/modules/creating-a-project-using-the-CLI.adoc
@@ -13,11 +13,6 @@ If allowed by your cluster administrator, you can create a new project.
 Projects starting with `openshift-` and `kube-` are considered critical by {product-title}. As such, {product-title} does not allow you to create Projects starting with `openshift-` or `kube-` using the `oc new-project` command. Cluster administrators can create these Projects using the `oc adm new-project` command.
 ====
 
-[NOTE]
-====
-You cannot assign an SCC to pods created in one of the default namespaces: `default`, `kube-system`, `kube-public`, `openshift-node`, `openshift-infra`, and `openshift`. You cannot use these namespaces for running pods or services.
-====
-
 .Procedure
 
 * Run:

--- a/modules/creating-a-project-using-the-web-console.adoc
+++ b/modules/creating-a-project-using-the-web-console.adoc
@@ -13,11 +13,6 @@ If allowed by your cluster administrator, you can create a new project.
 Projects starting with `openshift-` and `kube-` are considered critical by {product-title}. As such, {product-title} does not allow you to create Projects starting with `openshift-` using the web console.
 ====
 
-[NOTE]
-====
-You cannot assign an SCC to pods created in one of the default namespaces: `default`, `kube-system`, `kube-public`, `openshift-node`, `openshift-infra`, and `openshift`. You cannot use these namespaces for running pods or services.
-====
-
 .Procedure
 
 . Navigate to *Home* -> *Projects*.

--- a/modules/images-managing-images-enabling-imagestreams-kube.adoc
+++ b/modules/images-managing-images-enabling-imagestreams-kube.adoc
@@ -9,10 +9,7 @@
 
 When using image streams with Kubernetes resources, you can only reference image streams that reside in the same project as the resource. The image stream reference must consist of a single segment value, for example `ruby:2.5`, where `ruby` is the name of an image stream that has a tag named `2.5` and resides in the same project as the resource making the reference.
 
-[NOTE]
-====
-This feature can not be used in the `default` namespace, nor in any `openshift-` or `kube-` namespace.
-====
+include::snippets/default-projects.adoc[]
 
 There are two ways to enable image streams with Kubernetes resources:
 

--- a/modules/odc-creating-projects-using-developer-perspective.adoc
+++ b/modules/odc-creating-projects-using-developer-perspective.adoc
@@ -13,11 +13,6 @@ You can use the *Developer* perspective in the {product-title} web console to cr
 Projects starting with `openshift-` and `kube-` are considered critical by {product-title}. As such, {product-title} does not allow you to create projects starting with `openshift-` or `kube-` using the *Developer* perspective. Cluster administrators can create these projects using the `oc adm new-project` command.
 ====
 
-[NOTE]
-====
-You cannot assign an SCC to pods created in one of the default namespaces: `default`, `kube-system`, `kube-public`, `openshift-node`, `openshift-infra`, and `openshift`. You cannot use these namespaces for running pods or services.
-====
-
 .Prerequisites
 
 * Ensure that you have the appropriate roles and permissions to create projects, applications, and other workloads in {product-title}.

--- a/modules/rbac-default-projects.adoc
+++ b/modules/rbac-default-projects.adoc
@@ -15,7 +15,4 @@ are considered critical, and the have guaranteed admission by kubelet.
 Pods created for master components in these namespaces are already marked as
 critical.
 
-[NOTE]
-====
-You cannot assign an SCC to pods created in one of the default namespaces: `default`, `kube-system`, `kube-public`, `openshift-node`, `openshift-infra`, and `openshift`. You cannot use these namespaces for running pods or services.
-====
+include::snippets/default-projects.adoc[]

--- a/modules/security-context-constraints-psa-about.adoc
+++ b/modules/security-context-constraints-psa-about.adoc
@@ -13,6 +13,8 @@ Globally, the `privileged` profile is enforced, and the `restricted` profile is 
 
 You can also configure the pod security admission settings at the namespace level.
 
+include::snippets/default-projects.adoc[]
+
 [id="psa-modes_{context}"]
 == Pod security admission modes
 

--- a/modules/security-context-constraints-rbac.adoc
+++ b/modules/security-context-constraints-rbac.adoc
@@ -10,10 +10,7 @@ you to scope access to your SCCs to a certain project or to the entire
 cluster. Assigning users, groups, or service accounts directly to an
 SCC retains cluster-wide scope.
 
-[NOTE]
-====
-You cannot assign a SCC to pods created in one of the default namespaces: `default`, `kube-system`, `kube-public`, `openshift-node`, `openshift-infra`, `openshift`. These namespaces should not be used for running pods or services.
-====
+include::snippets/default-projects.adoc[]
 
 To include access to SCCs for your role, specify the `scc` resource
 when creating a role.

--- a/openshift_images/image-streams-manage.adoc
+++ b/openshift_images/image-streams-manage.adoc
@@ -19,6 +19,8 @@ include::modules/images-imagestream-mapping.adoc[leveloffset=+1]
 
 The following sections describe how to use image streams and image stream tags.
 
+include::snippets/default-projects.adoc[]
+
 include::modules/images-getting-info-about-imagestreams.adoc[leveloffset=+2]
 include::modules/images-imagestream-adding-tags.adoc[leveloffset=+2]
 include::modules/images-imagestream-external-image-tags.adoc[leveloffset=+2]

--- a/snippets/default-projects.adoc
+++ b/snippets/default-projects.adoc
@@ -1,0 +1,25 @@
+// Text snippet included in the following assemblies:
+//
+// * applications/projects/working-with-projects.adoc
+// * applications/quotas/quotas-setting-across-multiple-projects.adoc
+// * openshift_images/image-streams-manage.adoc
+//
+// Text snippet included in the following modules:
+//
+// * modules/admission-plug-ins-about.adoc
+// * modules/creating-a-project-using-the-CLI.adoc
+// * modules/creating-a-project-using-the-web-console.adoc
+// * modules/images-managing-images-enabling-imagestreams-kube.adoc
+// * modules/odc-creating-projects-using-developer-perspective.adoc
+// * modules/rbac-default-projects.adoc
+// * modules/security-context-constraints-psa-about.adoc
+// * modules/security-context-constraints-rbac.adoc
+
+:_content-type: SNIPPET
+
+[IMPORTANT]
+====
+Do not run workloads in or share access to default projects. Default projects are reserved for running core cluster components.
+
+The following default projects are considered highly privileged: `default`, `kube-public`, `kube-system`, `openshift`, `openshift-infra`, `openshift-node`, and other system-created projects that have the `openshift.io/run-level` label set to `0` or `1`. Functionality that relies on admission plugins, such as pod security admission, security context constraints, cluster resource quotas, and image reference resolution, does not work in highly privileged projects.
+====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8139

Link to docs preview:

* https://66132--docspreview.netlify.app/openshift-enterprise/latest/applications/projects/working-with-projects
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/applications/quotas/quotas-setting-across-multiple-projects
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/architecture/admission-plug-ins#admission-plug-ins-about_admission-plug-ins
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/applications/projects/working-with-projects#creating-a-project-using-the-CLI_projects
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/applications/projects/working-with-projects#creating-a-project-using-the-web-console_projects
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/applications/projects/working-with-projects#odc-creating-projects-using-developer-perspective_projects
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/authentication/using-rbac#rbac-default-projects_using-rbac
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/authentication/using-rbac#rbac-default-projects_using-rbac
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/authentication/understanding-and-managing-pod-security-admission#security-context-constraints-psa-about_understanding-and-managing-pod-security-admission
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/authentication/managing-security-context-constraints#role-based-access-to-ssc_configuring-internal-oauth
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/image-streams-manage#working-with-image-streams
* https://66132--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/using-imagestreams-with-kube-resources

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

**Waiting on confirmation from the auth team on the link in the PSA section**
