### PR TITLE
Add 4.14 relnotes for token auth via CCO / AWS STS

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -145,7 +145,7 @@ Before you set a path value for the `template` parameter, ensure that the defaul
 === Post-installation configuration
 
 [id="ocp-4-14-OCP-on-multi-arch-clusters"]
-==== {product-title} cluster with multi-architecture compute machines 
+==== {product-title} cluster with multi-architecture compute machines
 {product-title} {product-version} clusters with multi-architecture compute machines are now supported on Google Cloud Platform (GCP) as a Day 2 operation. {product-title} clusters with multi-architecture compute machines on bare metal installations are now generally available. For more information on clusters with multi-architecture compute machines and supported platforms, see xref:../post_installation_configuration/configuring-multi-arch-compute-machines/multi-architecture-configuration.adoc#multi-architecture-configuration[About clusters with multi-architecture compute machines].
 
 [id="ocp-4-14-web-console"]
@@ -156,14 +156,14 @@ Before you set a path value for the `template` parameter, ensure that the defaul
 
 With this release, there are several updates to the *Administrator* perspective of the web console. You can now perform the following actions:
 
-* Narrow down the list of resources in a list view or search page with exact search capabilities. This will help when you have similarly named resources and fuzzy search doesn't narrow down your search.
+* Narrow down the list of resources in a list view or search page with exact search capabilities. This will help when you have similarly named resources and fuzzy search does not narrow down your search.
 * Provide direct feedback about features and report a bug by clicking the *Help* button on the toolbar and clicking *Share Feedback* from the drop-down list.
 * Display and hide tooltips in the YAML editor. The tooltips will persist so you don't have to change it every time you navigate to the page.
 
 [id="supported-os-types-cluster"]
-===== Operating system based filtering in Operator Hub
+===== Operating system based filtering in OperatorHub
 
-With this update, Operators in the Operator Hub are now filtered based on the nodes operating system since cluster can contain heterogenous nodes.
+With this update, Operators in OperatorHub are now filtered based on the nodes operating system because clusters can contain heterogenous nodes.
 
 [id="console-supports-installing-specific-operator-versions"]
 ===== Support for installing specific Operator versions in the web console
@@ -171,6 +171,14 @@ With this update, Operators in the Operator Hub are now filtered based on the no
 With this update, you can now choose from a list of available versions for an Operator based on the selected channel on the *OperatorHub* page in the console. Additionally, you can view the metadata for that channel and version when available. When selecting an older version, a manual approval update strategy is required, otherwise the Operator will immediately update back to the latest version on the channel.
 
 //link to content in Operator book TBD
+
+[id="console-supports-aws-sts-detection"]
+===== OperatorHub support for AWS STS
+
+With this release, OperatorHub detects when an Amazon Web Services (AWS) cluster is using the Security Token Service (STS). When detected, a "Cluster in STS Mode" notification displays with additional instructions before installing an Operator to ensure it runs correctly. The *Operator Installation* page is also modified to add the required *role ARN* field.
+
+For more information, see _Token authentication for Operators on cloud providers_.
+//xref:../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
 
 [id="ocp-4-14-developer-perspective"]
 ==== Developer Perspective
@@ -241,6 +249,14 @@ For more information, see xref:../authentication/understanding-and-managing-pod-
 With this release, if a user manually modifies a pod security admission label from the automatically labeled value on a label-synchronized namespace, synchronization is disabled for that label. Users can enable synchronization again, if necessary.
 
 For more information, see xref:../authentication/understanding-and-managing-pod-security-admission.adoc#security-context-constraints-psa-sync-exclusions_understanding-and-managing-pod-security-admission[Pod security admission synchronization namespace exclusions].
+
+[id="ocp-4-14-auth-cco-sts"]
+==== OLM-based Operator support for AWS STS
+
+With this release, some Operators managed by Operator Lifecycle Manager (OLM) on Amazon Web Services (AWS) clusters can use the Cloud Credential Operator (CCO) in manual mode with the Security Token Service (STS). These Operators authenticate with limited-privilege, short-term credentials that are managed outside the cluster.
+
+For more information, see _Token authentication for Operators on cloud providers_.
+//xref:../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
 
 [id="ocp-4-14-networking"]
 === Networking
@@ -373,6 +389,14 @@ For more information about disabling the Image Registry Operator, see xref:../in
 
 [id="ocp-4-14-osdk"]
 === Operator development
+
+[id="ocp-4-14-osdk-cco-sts"]
+==== Token authentication for Operators on cloud providers: AWS STS
+
+With this release, Operators managed by Operator Lifecycle Manager (OLM) can support token authentication when running on Amazon Web Services (AWS) clusters that use the Security Token Service (STS). The Cloud Credential Operator (CCO) is updated to semi-automate provisioning certain limited-privilege, short-term credentials, provided that the Operator author has enabled their Operator to support AWS STS.
+
+For more information about enabling OLM-based Operators to support CCO-based workflows with AWS STS, see _Token authentication for Operators on cloud providers_.
+//xref:../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
 
 [id="ocp-4-14-machine-config-operator"]
 === Machine Config Operator


### PR DESCRIPTION
Release notes for https://github.com/openshift/openshift-docs/pull/64808

OCP 4.14

* Operator development: [Token authentication for Operators on cloud providers: AWS STS](https://66133--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-osdk-cco-sts)
* Authentication and authorization: [OLM-based Operator support for AWS STS](https://66133--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-auth-cco-sts)
* Web console: [OperatorHub support for AWS STS mode](https://66133--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#console-supports-aws-sts-detection)