### PR TITLE
Compliance Operator 1.3.1 release notes

### DIFF
--- a/security/compliance_operator/co-management/compliance-operator-updating.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-updating.adoc
@@ -7,6 +7,13 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 As a cluster administrator, you can update the Compliance Operator on your {product-title} cluster.
+//
+// This will be un-commented for OCP 4.11-4.14 releases. Commented out in the main branch.
+//
+// [IMPORTANT]
+// ====
+// It is recommended to update the Compliance Operator to version 1.3.1 or later before updating your {product-title} cluster to version 4.14 or later.
+// ====
 
 include::modules/olm-preparing-upgrade.adoc[leveloffset=+1]
 include::modules/olm-changing-update-channel.adoc[leveloffset=+1]

--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -15,6 +15,32 @@ For an overview of the Compliance Operator, see xref:../../security/compliance_o
 
 To access the latest release, see xref:../../security/compliance_operator/co-management/compliance-operator-updating.adoc#olm-preparing-upgrade_compliance-operator-updating[Updating the Compliance Operator].
 
+[id="compliance-operator-release-notes-1-3-1"]
+== OpenShift Compliance Operator 1.3.1
+
+The following advisory is available for the OpenShift Compliance Operator 1.3.1:
+
+* link:https://access.redhat.com/errata/RHBA-2023:5669[RHBA-2023:5669 - OpenShift Compliance Operator bug fix and enhancement update]
+
+This update addresses a CVE in an underlying dependency.
+//
+// This will be un-commented for OCP 4.11-4.14 releases. Commented out in the main branch.
+//
+// [IMPORTANT]
+// ====
+// It is recommended to update the Compliance Operator to version 1.3.1 or later before updating your {product-title} cluster to version 4.14 or later.
+// ====
+
+[id="compliance-operator-1-3-1-new-features-and-enhancements"]
+=== New features and enhancements
+
+* You can install and use the Compliance Operator in an {product-title} cluster running in FIPS mode.
++
+[IMPORTANT]
+====
+To enable FIPS mode for your cluster, you must run the installation program from a {op-system-base} computer configured to operate in FIPS mode. For more information about configuring FIPS mode on RHEL, see link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/security_hardening/assembly_installing-the-system-in-fips-mode_security-hardening[Installing the system in FIPS mode].
+====
+
 [id="compliance-operator-release-notes-1-3-0"]
 == OpenShift Compliance Operator 1.3.0
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:


Link to docs preview (VPN required) :
[OpenShift Compliance Operator 1.3.1](https://file.rdu.redhat.com/antaylor/CO-1.3.1/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-release-notes-1-3-1)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

