### PR TITLE
[OSDOCS-8154]:15 Days of Retention Needs to Be Changed to 11 Days

### DIFF
--- a/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
+++ b/modules/monitoring-modifying-retention-time-and-size-for-prometheus-metrics-data.adoc
@@ -6,7 +6,7 @@
 [id="modifying-retention-time-and-size-for-prometheus-metrics-data_{context}"]
 = Modifying the retention time and size for Prometheus metrics data
 
-By default, Prometheus automatically retains metrics data for 15 days. You can modify the retention time for
+By default, Prometheus automatically retains metrics data for 11 days. You can modify the retention time for
 ifndef::openshift-dedicated,openshift-rosa[]
 Prometheus
 endif::openshift-dedicated,openshift-rosa[]
@@ -21,7 +21,7 @@ Note the following behaviors of these data retention settings:
 * Data in the `/wal` and `/head_chunks` directories counts toward the retention size limit, but Prometheus never purges data from these directories based on size- or time-based retention policies.
 Thus, if you set a retention size limit lower than the maximum size set for the `/wal` and `/head_chunks` directories, you have configured the system not to retain any data blocks in the `/prometheus` data directories.
 * The size-based retention policy is applied only when Prometheus cuts a new data block, which occurs every two hours after the WAL contains at least three hours of data.
-* If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 15 days, and retention size is not set.
+* If you do not explicitly define values for either `retention` or `retentionSize`, retention time defaults to 11 days, and retention size is not set.
 * If you define values for both `retention` and `retentionSize`, both values apply.
 If any data blocks exceed the defined retention time or the defined size limit, Prometheus purges these data blocks.
 * If you define a value for `retentionSize` and do not define `retention`, only the `retentionSize` value applies.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8154
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://66138--docspreview.netlify.app/openshift-rosa/latest/monitoring/configuring-the-monitoring-stack#modifying-retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
**Per the JIRA ticket on which this PR is based: There is a lack of matching information between our ROSA docs

https://docs.openshift.com/rosa/monitoring/configuring-the-monitoring-stack.html#modifying-retention-time-and-size-for-prometheus-metrics-data_configuring-the-monitoring-stack
which advertises default retention for 15d, when the actual retention is 11d, as per this commit: [Openshift/managed-cluster-config](https://github.com/openshift/managed-cluster-config/commit/ad16ea9ee721d82220ae17d57bbe4a6e1698133e)**

![image](https://github.com/openshift/openshift-docs/assets/122639474/b66695d3-b0d3-4463-a275-094e02f88e4b)

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

