### PR TITLE
OADP 2664  -  Upgrade to 1.3

### DIFF
--- a/modules/about-oadp-update-channels.adoc
+++ b/modules/about-oadp-update-channels.adoc
@@ -19,6 +19,8 @@ The following update channels are available:
 
 * The *stable-1.2* channel contains `oadp.v1.2._z_`, the most recent OADP 1.2 `ClusterServiceVersion`.
 
+* The *stable-1.3* channel contains `oadp.v1.3._z_`, the most recent OADP 1.3 `ClusterServiceVersion`.
+
 *Which update channel is right for you?*
 
 * The *stable* channel is now deprecated.  If you are already using the stable channel, you will continue to get updates from `oadp.v1.1._z_`.


### PR DESCRIPTION
OADP 1.3.0

OCP 4.11+

Resolves - https://issues.redhat.com/browse/OADP-2664

Deploy preview - https://66141--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp#about-oadp-update-channels_about-installing-oadp
