### PR TITLE
OSDOCS#2464: Adjusting assessment of update risks, including force

### DIFF
--- a/modules/update-preparing-forced-update-risk.adoc
+++ b/modules/update-preparing-forced-update-risk.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
+
+:_content-type: CONCEPT
+[id="update-preparing-forced-update-risk"]
+= Assessing the risk of forced updates
+
+When updating a cluster, it's essential to understand the available options and their implications. For detailed information on cluster updates and available options, you can refer to the command-line documentation using the following command:
+
+[source,terminal]
+----
+$ oc adm upgrade --help
+----
+
+When running this command, the following information is included:
+
+`Cluster-side guards include checks for release verification and upgradeable conditions. Again, it is usually best to give these conditions time to resolve, or to actively work to resolve them.  But if you decide to trigger the update regardless of these concerns, use --force, which is passed through to ClusterVersion's spec.desiredUpdate.force.`
+
+It's important to understand the consequences of performing a forced update to determine if this decision outweighs the potential risks.
+If there is no other way to update a cluster, you can _force_ an update by using the `--force` option in the CLI, which allows you to forcefully update the cluster even when the update release image validation fails and the cluster is reporting errors.
+
+[IMPORTANT]
+====
+Use the `--force` option with caution. Only use the `--force` option if there are no other ways to update the cluster and if you are willing to accept the risks of waiving signature checks and other critical guards. 
+====
+
+The Cluster Version Operator (CVO) runs precondition checks before starting an update to determine if the cluster has the `Upgradeable=false` status condition, or any other warning condition. For example, the CVO verifies the target release signature and if the verification fails, the CVO returns `ReleaseAccepted=False`.
+
+Using the `--force` option ignores the safety checks of an update, resulting in potential downtime or data loss.
+
+
+

--- a/modules/update-preparing-unrecommended.adoc
+++ b/modules/update-preparing-unrecommended.adoc
@@ -1,0 +1,9 @@
+// Module included in the following assemblies:
+//
+// * updating/preparing_for_updates/updating-cluster-prepare.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="update-preparing-unrecommended"]
+= Assessing updates that are not recommended 
+
+Following the recommended update guidelines ensures that the update has been tested and validated. Updating clusters by unrecommended paths introduces potential risks, and a successful update becomes less likely. 

--- a/updating/preparing_for_updates/updating-cluster-prepare.adoc
+++ b/updating/preparing_for_updates/updating-cluster-prepare.adoc
@@ -46,8 +46,14 @@ include::modules/update-preparing-migrate.adoc[leveloffset=+2]
 // Providing the administrator acknowledgment
 include::modules/update-preparing-ack.adoc[leveloffset=+2]
 
+// Assessing updates that are not recommended
+include::modules/update-preparing-unrecommended.adoc[leveloffset=+1]
+
 // Assessing the risk of conditional updates
-include::modules/update-preparing-conditional.adoc[leveloffset=+1]
+include::modules/update-preparing-conditional.adoc[leveloffset=+2]
+
+// Assessing the risk of forced updates
+include::modules/update-preparing-forced-update-risk.adoc[leveloffset=+2]
 
 [role="_additional-resources"]
 .Additional resources


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-2464

Link to docs preview:
https://66149--docspreview.netlify.app/openshift-enterprise/latest/updating/preparing_for_updates/updating-cluster-prepare#update-preparing-unrecommended

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
