### PR TITLE
[OSDOCS-8141]: machine mgmt RN tracker items

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -961,6 +961,11 @@ For more information, see xref:../operators/operator_sdk/osdk-multi-arch-support
 [id="ocp-4-14-machine-config-operator"]
 === Machine Config Operator
 
+[id="ocp-4-14-mco-ca-distribution"]
+==== Handling of registry certificate authorities
+
+The Machine Config Operator now handles distributing certificate authorities for image registries. This change does not affect end users.
+
 [id="ocp-4-14-additional-prometheus-metrics"]
 ==== Additional metrics available in Prometheus
 
@@ -1006,17 +1011,19 @@ With this release, control plane machine sets are supported for Nutanix clusters
 
 For more information, see xref:../machine_management/control_plane_machine_management/cpmso-getting-started.adoc#cpmso-getting-started[Getting started with the Control Plane Machine Set Operator].
 
-[id="ocp-4-14-mco-ca-distribution"]
-==== Handling of registry certificate authorities
-
-The Machine Config Operator now handles distributing certificate authorities for image registries. This change does not affect end users.
-
 [id="ocp-4-14-mapi-aws-placement-groups"]
 ==== Support for assigning AWS machines to placement groups
 
 With this release, you can configure a machine set to deploy machines within an existing AWS placement group. You can use this feature with Elastic Fabric Adapter (EFA) instances to improve network performance for machines within the specified placement group.
 
 You can use this feature with xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-aws-existing-placement-group_creating-machineset-aws[compute] and xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#machineset-aws-existing-placement-group_cpmso-using[control plane] machine sets.
+
+[id="ocp-4-14-mapi-azure-confidential-compute"]
+==== Support for Azure confidential VMs and trusted launch (Technology Preview)
+
+With this release, you can configure a machine set to deploy machines that use Azure confidential VMs, trusted launch, or both. These machines can use UEFI security features such as Secure Boot or a dedicated virtual Trusted Platform Module (vTPM) instance.
+
+You can use this feature with xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#creating-machineset-azure[compute] and xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#cpmso-supported-features-azure_cpmso-using[control plane] machine sets.
 
 [id="ocp-4-14-nodes"]
 === Nodes


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-8141](https://issues.redhat.com//browse/OSDOCS-8141)

Link to docs preview:
- [Handling of registry certificate authorities](https://66161--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-mco-ca-distribution) moved to correct section
- [Support for Azure confidential VMs and trusted launch](https://66161--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-mapi-azure-confidential-compute) new

QE review:
- [ ] QE has approved this change.

Additional information: