### PR TITLE
Adds link to web console RNs to supporting doc

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -230,7 +230,7 @@ With this update, Operators in OperatorHub are now filtered based on the nodes o
 
 With this update, you can now choose from a list of available versions for an Operator based on the selected channel on the *OperatorHub* page in the console. Additionally, you can view the metadata for that channel and version when available. When selecting an older version, a manual approval update strategy is required, otherwise the Operator will immediately update back to the latest version on the channel.
 
-//link to content in Operator book TBD
+For more information, see xref:../operators/admin/olm-adding-operators-to-cluster.adoc#olm-installing-specific-version-web-console_olm-adding-operators-to-a-cluster[Installing a specific version of an Operator in the web console].
 
 [id="console-supports-aws-sts-detection"]
 ===== OperatorHub support for AWS STS


### PR DESCRIPTION
Adds link to web console RNs to supporting doc

Version(s):
4.14

Issue:
N/A

Link to docs preview:
https://66162--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#console-supports-installing-specific-operator-versions

QE review:
QE not needed since just a link addition

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
