### PR TITLE
OCPBUGS#16976: Adding performance profile admonitions for cgroups known issue

### DIFF
--- a/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
+++ b/modules/cnf-tuning-nodes-for-low-latency-via-performanceprofile.adoc
@@ -14,6 +14,13 @@ The performance profile lets you control latency tuning aspects of nodes that be
 
 You can use a performance profile to specify whether to update the kernel to kernel-rt, to allocate huge pages, and to partition the CPUs for performing housekeeping duties or running workloads.
 
+[IMPORTANT]
+====
+In {product-title} {product-version}, if you apply a performance profile to your cluster, all nodes in the cluster will reboot. This reboot includes control plane nodes and worker nodes that were not targeted by the performance profile. This is a known issue in {product-title} {product-version} because this release uses Linux control group version 2 (cgroup v2) in alignment with RHEL 9. The low latency tuning features associated with the performance profile do not support cgroup v2, therefore the nodes reboot to switch back to the cgroup v1 configuration.
+
+To revert all nodes in the cluster to the cgroups v2 configuration, you must edit the `Node` resource. (link:https://issues.redhat.com/browse/OCPBUGS-16976[*OCPBUGS-16976*])
+====
+
 [NOTE]
 ====
 You can manually create the `PerformanceProfile` object or use the Performance Profile Creator (PPC) to generate a performance profile. See the additional resources below for more information on the PPC.

--- a/modules/cnf-understanding-low-latency.adoc
+++ b/modules/cnf-understanding-low-latency.adoc
@@ -20,6 +20,13 @@ Administrators must be able to manage their many Edge sites and local services i
 
 {product-title} uses the Node Tuning Operator to implement automatic tuning to achieve low latency performance for {product-title} applications. The cluster administrator uses this performance profile configuration that makes it easier to make these changes in a more reliable way. The administrator can specify whether to update the kernel to kernel-rt, reserve CPUs for cluster and operating system housekeeping duties, including pod infra containers, and isolate CPUs for application containers to run the workloads.
 
+[IMPORTANT]
+====
+In {product-title} 4.14, if you apply a performance profile to your cluster, all nodes in the cluster will reboot. This reboot includes control plane nodes and worker nodes that were not targeted by the performance profile. This is a known issue in {product-title} 4.14 because this release uses Linux control group version 2 (cgroup v2) in alignment with RHEL 9. The low latency tuning features associated with the performance profile do not support cgroup v2, therefore the nodes reboot to switch back to the cgroup v1 configuration.
+
+To revert all nodes in the cluster to the cgroups v2 configuration, you must edit the `Node` resource. (link:https://issues.redhat.com/browse/OCPBUGS-16976[*OCPBUGS-16976*])
+====
+
 [NOTE]
 ====
 Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performance profiles.


### PR DESCRIPTION
OCPBUGS-16976: Need to include info related to this known issue(#65921) in the docs. If you apply a performance profile, all nodes in the cluster reboot.

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-16976

Link to docs preview:
- https://66164--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning#cnf-understanding-low-latency_cnf-master
- https://66164--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-low-latency-tuning#cnf-tuning-nodes-for-low-latency-via-performanceprofile_cnf-master

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
