### PR TITLE
[DOC] OSSM-4998 Rel Notes Component Updates Only

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -144,7 +144,7 @@ endif::[]
 :product-rosa: Red Hat OpenShift Service on AWS
 :SMProductName: Red Hat OpenShift Service Mesh
 :SMProductShortName: Service Mesh
-:SMProductVersion: 2.4.3
+:SMProductVersion: 2.4.4
 :MaistraVersion: 2.4
 //Service Mesh v1
 :SMProductVersion1x: 1.1.18.2

--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -15,6 +15,28 @@ Module included in the following assemblies:
 
 This release adds improvements related to the following components and concepts.
 
+== New features {SMProductName} version 2.4.4
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.11 and later versions.
+
+=== Component versions included in {SMProductName} version 2.4.4
+//Same component versions as 2.4.3
+|===
+|Component |Version
+
+|Istio
+|1.16.7
+
+|Envoy Proxy
+|1.24.10
+
+|Jaeger
+|1.42.0
+
+|Kiali
+|1.65.8
+|===
+
 == New features {SMProductName} version 2.4.3
 
 * The {SMProductName} Operator is now available on ARM-based clusters as a Technology Preview feature.
@@ -227,6 +249,28 @@ spec:
 * HBONE protocol for sidecars is an experimental feature that is not supported.
 * {SMProductShortName} on ARM64 architecture is not supported.
 * OpenTelemetry API remains a Technology Preview feature.
+
+== New features {SMProductName} version 2.3.8
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.10 and later versions.
+
+=== Component versions included in {SMProductName} version 2.3.8
+//Component updates
+|===
+|Component |Version
+
+|Istio
+|1.14.6
+
+|Envoy Proxy
+|1.22.11
+
+|Jaeger
+|1.42.0
+
+|Kiali
+|1.57.11
+|===
 
 == New features {SMProductName} version 2.3.7
 
@@ -479,6 +523,28 @@ Additionally, the SMMR must also be configured for cluster-wide deployment. This
     - '*' <1>
 ----
 <1> Adds all namespaces to the mesh, including any namespaces you subsequently create. The following namespaces are not part of the mesh: kube, openshift, kube-* and openshift-*.
+
+== New features {SMProductName} version 2.2.11
+
+This release of {SMProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on {product-title} 4.10 and later versions.
+
+=== Component versions included in {SMProductName} version 2.2.11
+//Same component versions as 2.2.10
+|===
+|Component |Version
+
+|Istio
+|1.12.9
+
+|Envoy Proxy
+|1.20.8
+
+|Jaeger
+|1.42.0
+
+|Kiali
+|1.48.8
+|===
 
 == New features {SMProductName} version 2.2.10
 


### PR DESCRIPTION
[DOC] [OSSM-4998](https://issues.redhat.com//browse/OSSM-4998) Rel Notes Component Updates Only

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSSM-4998

Link to docs preview:
2.4.4: https://66174--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-4-4

2.3.8: https://66174--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-3-8

2.2.11: https://66174--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-2-11

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Component updates only for:

2.4.4
2.3.8
2.2.11

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
