### PR TITLE
[enterprise-4.14] add RHEL9 info for EUS upgrades

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -53,6 +53,21 @@ This release adds improvements related to the following components and concepts.
 [id="ocp-4-14-rhcos"]
 === {op-system-first}
 
+[id="ocp-4-14-rhcos-rhel-9-2-packages"]
+==== {op-system} now uses {op-system-base} 9.2
+
+{op-system} now uses {op-system-base-full} 9.2 packages in {product-title} {product-version}. This enables you to have the latest fixes, features, and enhancements, as well as the latest hardware support and driver updates. {product-title} 4.12 is an Extended Update Support (EUS) release that will continue to use {op-system-base} 8.6 EUS packages for the entirety of its lifecycle.
+
+[id="ocp-4-14-rhel-9-considerations"]
+===== Considerations for upgrading to {product-title} with {op-system-base} 9.2
+
+Because {product-title} {product-version} now uses a {op-system-base} 9.2 based {op-system}, consider the following before upgrading:
+
+* Some component configuration options and services might have changed between {op-system-base} 8.6 and {op-system-base} 9.2, which means existing machine configuration files might no longer be valid.
+
+* {op-system-base} 6 base image containers are not supported on {op-system} container hosts but are supported on {op-system-base} 8 worker nodes. For more information, see the link:https://access.redhat.com/support/policy/rhel-container-compatibility[Red Hat Container Compatibility] matrix.
+
+* Some device drivers have been deprecated, see the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/considerations_in_adopting_rhel_9/assembly_hardware-enablement_considerations-in-adopting-rhel-9#unmaintained-hardware-support[{op-system-base} documentation] for more information.
 
 [id="ocp-4-14-installation-and-update"]
 === Installation and update


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: n/a
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://66180--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-rhcos-rhel-9-2-packages
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
