### PR TITLE
OSDOCS-7764: Workflow correction to ROSA Shared VPC page

### DIFF
--- a/modules/rosa-sharing-vpc-cluster-creation.adoc
+++ b/modules/rosa-sharing-vpc-cluster-creation.adoc
@@ -17,6 +17,7 @@ image::372_OpenShift_on_AWS_persona_worflows_0923_4.png[]
 * You have the hosted zone ID from the *VPC Owner*.
 * You have the AWS region from the *VPC Owner*.
 * You have the subnet IDs from the *VPC Owner*.
+* You have the `SharedVPCRole` ARN from the *VPC Owner*.
 
 .Procedure
 * In a terminal, enter the following command to create the shared VPC:

--- a/modules/rosa-sharing-vpc-creation-and-sharing.adoc
+++ b/modules/rosa-sharing-vpc-creation-and-sharing.adoc
@@ -104,6 +104,5 @@ $ aws iam attach-role-policy --role-name <role_name> --policy-arn \  <1>
 <2> Replace _<AWS_account_ID>_ with the *VPC Owner's* AWS account ID.
 --
 +
-. In the link:https://us-east-1.console.aws.amazon.com/ram/[Resource Access Manager of the AWS console], create a resource share that shares the previously created public and private subnets with the *Cluster Creator's* AWS account ID.
 
-. After you create the resource share, provide the `SharedVPCRole` ARN to the *Cluster Creator* to continue configuration.
+. Provide the `SharedVPCRole` ARN to the *Cluster Creator* to continue configuration.

--- a/modules/rosa-sharing-vpc-hosted-zones.adoc
+++ b/modules/rosa-sharing-vpc-hosted-zones.adoc
@@ -16,6 +16,8 @@ image::372_OpenShift_on_AWS_persona_worflows_0923_3.png[]
 
 .Procedure
 
+. In the link:https://us-east-1.console.aws.amazon.com/ram/[Resource Access Manager of the AWS console], create a resource share that shares the previously created public and private subnets with the *Cluster Creator's* AWS account ID.
+
 . Update the VPC sharing IAM role and add the _Installer_ and _Ingress Operator Cloud Credentials_ roles to the principal section of the trust policy.
 +
 [source,terminal]


### PR DESCRIPTION
[OSDOCS-7764](https://issues.redhat.com//browse/OSDOCS-7764): Workflow correction on ROSA Shared VPC doc page

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7764

Link to docs preview:
https://66189--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
