### PR TITLE
OSDOCS-8132 Confidential VMs and trusted launch for Azure

### DIFF
--- a/installing/installing_azure/installing-azure-customizations.adoc
+++ b/installing/installing_azure/installing-azure-customizations.adoc
@@ -49,6 +49,9 @@ include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-trusted-launch.adoc[leveloffset=+2]
+include::modules/installation-azure-confidential-vms.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-government-region.adoc
+++ b/installing/installing_azure/installing-azure-government-region.adoc
@@ -51,6 +51,9 @@ include::modules/installation-minimum-resource-requirements.adoc[leveloffset=+2]
 
 include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-trusted-launch.adoc[leveloffset=+2]
+include::modules/installation-azure-confidential-vms.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-network-customizations.adoc
+++ b/installing/installing_azure/installing-azure-network-customizations.adoc
@@ -47,6 +47,9 @@ include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-trusted-launch.adoc[leveloffset=+2]
+include::modules/installation-azure-confidential-vms.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-private.adoc
+++ b/installing/installing_azure/installing-azure-private.adoc
@@ -47,6 +47,9 @@ include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-trusted-launch.adoc[leveloffset=+2]
+include::modules/installation-azure-confidential-vms.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-azure-vnet.adoc
+++ b/installing/installing_azure/installing-azure-vnet.adoc
@@ -41,6 +41,9 @@ include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-trusted-launch.adoc[leveloffset=+2]
+include::modules/installation-azure-confidential-vms.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
+++ b/installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc
@@ -54,6 +54,9 @@ include::modules/installation-azure-tested-machine-types.adoc[leveloffset=+2]
 
 include::modules/installation-azure-arm-tested-machine-types.adoc[leveloffset=+2]
 
+include::modules/installation-azure-trusted-launch.adoc[leveloffset=+2]
+include::modules/installation-azure-confidential-vms.adoc[leveloffset=+2]
+
 include::modules/installation-azure-config-yaml.adoc[leveloffset=+2]
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]

--- a/modules/installation-azure-confidential-vms.adoc
+++ b/modules/installation-azure-confidential-vms.adoc
@@ -1,0 +1,92 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_azure/installing-azure-network-customizations
+
+:_content-type: PROCEDURE
+[id="installation-azure-confidential-vms_{context}"]
+= Enabling confidential VMs
+
+You can enable confidential VMs when installing your cluster. You can enable confidential VMs for compute nodes, control plane nodes, or all nodes. 
+
+:FeatureName: Using confidential VMs
+
+include::snippets/technology-preview.adoc[]
+
+//commenting out the second encryption option until https://issues.redhat.com/browse/OCPBUGS-18379 is resolved
+////
+Confidential VMs can operate in two modes: 
+
+* Only encrypting the virtual machine guest state storage, which contains the security state of the virtual machine
+* Encrypting the virtual machine guest state storage and the operating system storage
+
+If you encrypt the operating system storage, you can use a platform-managed encryption key or a key you manage.
+////
+
+You can use confidential VMs with the following VM sizes:
+
+* DCasv5-series
+* DCadsv5-series
+* ECasv5-series
+* ECadsv5-series
+
+
+[IMPORTANT]
+====
+Confidential VMs are currently not supported on 64-bit ARM architectures.
+====
+
+.Prerequisites
+* You have created an `install-config.yaml` file.
+
+.Procedure
+
+* Use a text editor to edit the `install-config.yaml` file prior to deploying your cluster and add the following stanza:
++
+[source,yaml]
+----
+controlPlane: <1>
+  platform:
+    azure:
+      settings:
+        securityType: ConfidentialVM <2>
+        confidentialVM:
+          uefiSettings:
+            secureBoot: Enabled <3>
+            virtualizedTrustedPlatformModule: Enabled <4>
+      osDisk:
+        securityProfile:
+          securityEncryptionType: VMGuestStateOnly <5>
+----
+<1> Specify `controlPlane.platform.azure` or `compute.platform.azure` to deploy confidential VMs on only control plane or compute nodes respectively. Specify `platform.azure.defaultMachinePlatform` to deploy confidential VMs on all nodes.
+<2> Enable confidential VMs. 
+<3> Enable secure boot. For more information, see the Azure documentation about link:https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch#secure-boot[secure boot].
+<4> Enable the virtualized Trusted Platform Module. For more information, see the Azure documentation about link:https://learn.microsoft.com/en-us/windows/security/hardware-security/tpm/trusted-platform-module-overview[virtualized Trusted Platform Modules].
+<5> Specify `VMGuestStateOnly` to encrypt the VM guest state.
+
+// commenting out the second option until https://issues.redhat.com/browse/OCPBUGS-18379 is fixed
+////
++
+.. To use confidential VMs that encrypt both the VM guest state and the OS disk:
++
+[source,yaml]
+----
+controlPlane:
+  platform:
+    azure:
+      settings:
+        securityType: ConfidentialVM
+        confidentialVM:
+          uefiSettings:
+            secureBoot: Enabled
+            virtualizedTrustedPlatformModule: Enabled
+      osDisk:
+        securityProfile:
+          securityEncryptionType: DiskWithVMGuestState <1>
+          diskEncryptionSet: <2>
+            resourceGroup: <your-resource-group-name>
+            name: <your-des-name>
+            subscriptionId: <subscription-uuid>
+----
+<1> Enable OS disk and VM guest state encryption.
+<2> Specify disk encryption set parameters for user-managed encryption, or omit the `diskEncryptionSet` stanza for platform-managed encryption.
+////

--- a/modules/installation-azure-trusted-launch.adoc
+++ b/modules/installation-azure-trusted-launch.adoc
@@ -1,0 +1,39 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_azure/installing-azure-network-customizations
+
+:_content-type: PROCEDURE
+[id="installation-azure-trusted-launch_{context}"]
+= Enabling trusted launch for Azure VMs
+
+You can enable two trusted launch features when installing your cluster on Azure: link:https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch#secure-boot[secure boot] and link:https://learn.microsoft.com/en-us/windows/security/hardware-security/tpm/trusted-platform-module-overview[virtualized Trusted Platform Modules]. 
+
+See the Azure documentation about link:https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch#virtual-machines-sizes[virtual machine sizes] to learn what sizes of virtual machines support these features.
+
+:FeatureName: Trusted launch
+
+include::snippets/technology-preview.adoc[]
+
+.Prerequisites
+* You have created an `install-config.yaml` file.
+
+.Procedure
+
+* Use a text editor to edit the `install-config.yaml` file prior to deploying your cluster and add the following stanza:
++
+[source,yaml]
+----
+controlPlane: <1>
+  platform:
+    azure:
+      settings:
+        securityType: TrustedLaunch <2>
+        trustedLaunch:
+          uefiSettings:
+            secureBoot: Enabled <3>
+            virtualizedTrustedPlatformModule: Enabled <4>
+----
+<1> Specify `controlPlane.platform.azure` or `compute.platform.azure` to enable trusted launch on only control plane or compute nodes respectively. Specify `platform.azure.defaultMachinePlatform` to enable trusted launch on all nodes.
+<2> Enable trusted launch features. 
+<3> Enable secure boot. For more information, see the Azure documentation about link:https://learn.microsoft.com/en-us/azure/virtual-machines/trusted-launch#secure-boot[secure boot].
+<4> Enable the virtualized Trusted Platform Module. For more information, see the Azure documentation about link:https://learn.microsoft.com/en-us/windows/security/hardware-security/tpm/trusted-platform-module-overview[virtualized Trusted Platform Modules].

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1044,6 +1044,54 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
 |The availability zones where the installation program creates compute machines.
 |String list
 
+|`compute.platform.azure.settings.securityType`
+|Enables confidential VMs or trusted launch for compute nodes. This option is not enabled by default.
+|`ConfidentialVM` or `TrustedLaunch`.
+
+|`compute.platform.azure.settings.confidentialVM.uefiSettings.secureBoot`
+|Enables secure boot on compute nodes if you are using confidential VMs.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`compute.platform.azure.settings.confidentialVM.uefiSettings.virtualizedTrustedPlatformModule`
+|Enables the virtualized Trusted Platform Module (vTPM) feature on compute nodes if you are using confidential VMs.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`compute.platform.azure.settings.trustedLaunch.uefiSettings.secureBoot`
+|Enables secure boot on compute nodes if you are using trusted launch.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`compute.platform.azure.settings.trustedLaunch.uefiSettings.virtualizedTrustedPlatformModule`
+|Enables the vTPM feature on compute nodes if you are using trusted launch.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`compute.platform.azure.osDisk.securityProfile.securityEncryptionType`
+|Enables the encryption of the virtual machine guest state for compute nodes. This parameter can only be used if you use Confidential VMs. 
+|`VMGuestStateOnly` is the only supported value. 
+
+|`controlPlane.platform.azure.settings.securityType`
+|Enables confidential VMs or trusted launch for control plane nodes. This option is not enabled by default.
+|`ConfidentialVM` or `TrustedLaunch`.
+
+|`controlPlane.platform.azure.settings.confidentialVM.uefiSettings.secureBoot`
+|Enables secure boot on control plane nodes if you are using confidential VMs.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`controlPlane.platform.azure.settings.confidentialVM.uefiSettings.virtualizedTrustedPlatformModule`
+|Enables the vTPM feature on control plane nodes if you are using confidential VMs.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`controlPlane.platform.azure.settings.trustedLaunch.uefiSettings.secureBoot`
+|Enables secure boot on control plane nodes if you are using trusted launch.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`controlPlane.platform.azure.settings.trustedLaunch.uefiSettings.virtualizedTrustedPlatformModule`
+|Enables the vTPM feature on control plane nodes if you are using trusted launch.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`controlPlane.platform.azure.osDisk.securityProfile.securityEncryptionType`
+|Enables the encryption of the virtual machine guest state for control plane nodes. This parameter can only be used if you use Confidential VMs.
+|`VMGuestStateOnly` is the only supported value. 
+
 |`controlPlane.platform.azure.type`
 |Defines the Azure instance type for control plane machines.
 |String
@@ -1051,6 +1099,30 @@ within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a re
 |`controlPlane.platform.azure.zones`
 |The availability zones where the installation program creates control plane machines.
 |String list
+
+|`platform.azure.defaultMachinePlatform.settings.securityType`
+|Enables confidential VMs or trusted launch for all nodes. This option is not enabled by default.
+|`ConfidentialVM` or `TrustedLaunch`.
+
+|`platform.azure.defaultMachinePlatform.settings.confidentialVM.uefiSettings.secureBoot`
+|Enables secure boot on all nodes if you are using confidential VMs.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`platform.azure.defaultMachinePlatform.settings.confidentialVM.uefiSettings.virtualizedTrustedPlatformModule`
+|Enables the virtualized Trusted Platform Module (vTPM) feature on all nodes if you are using confidential VMs.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`platform.azure.defaultMachinePlatform.settings.trustedLaunch.uefiSettings.secureBoot`
+|Enables secure boot on all nodes if you are using trusted launch.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`platform.azure.defaultMachinePlatform.settings.trustedLaunch.uefiSettings.virtualizedTrustedPlatformModule`
+|Enables the vTPM feature on all nodes if you are using trusted launch.
+|`Enabled` or `Disabled`. The default is `Disabled`.
+
+|`platform.azure.defaultMachinePlatform.osDisk.securityProfile.securityEncryptionType`
+|Enables the encryption of the virtual machine guest state for all nodes. This parameter can only be used if you use Confidential VMs.
+|`VMGuestStateOnly` is the only supported value. 
 
 |`platform.azure.defaultMachinePlatform.encryptionAtHost`
 |Enables host-level encryption for compute machines. You can enable this encryption alongside user-managed server-side encryption. This feature encrypts temporary, ephemeral, cached, and un-managed disks on the VM host. This parameter is not a prerequisite for user-managed server-side encryption.


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8132

Link to docs preview:
[Additional Azure configuration parameters](https://66191--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure#installation-configuration-parameters-additional-azure_installation-config-parameters-azure) (note that you will need to scroll to the right in the table due to long variable names)
[Enabling trusted launch for Azure VMs](https://66191--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations#installation-azure-trusted-launch_installing-azure-customizations)
[Enabling confidential VMs](https://66191--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-customizations#installation-azure-confidential-vms_installing-azure-customizations)
These two modules have been added to the Azure customizations, network customizations, existing VNet, private cluster, restricted cluster, and government region installation assemblies.

QE review:
- [x] QE has approved this change.
