### PR TITLE
OCPBUGS#4970: Adding note to mandate allowedCIDRs

### DIFF
--- a/modules/nw-externalip-about.adoc
+++ b/modules/nw-externalip-about.adoc
@@ -122,6 +122,11 @@ When configuring policy restrictions, the following rules apply:
 * If `allowedCIDRs[]` and `rejectedCIDRs[]` are both set, then `rejectedCIDRs[]` has precedence over `allowedCIDRs[]`.
 * If `allowedCIDRs[]` is set, creating a `Service` object with `spec.ExternalIPs[]` will succeed only if the specified IP addresses are allowed.
 * If `rejectedCIDRs[]` is set, creating a `Service` object with `spec.ExternalIPs[]` will succeed only if the specified IP addresses are not rejected.
++
+[NOTE]
+====
+You must specify an empty `allowedCIDRs[]` in the `policy`` object for `spec.ExternalIPs[]` to succeed. 
+====
 
 [id="example-policy-objects_{context}"]
 == Example policy objects

--- a/modules/nw-externalip-about.adoc
+++ b/modules/nw-externalip-about.adoc
@@ -125,7 +125,7 @@ When configuring policy restrictions, the following rules apply:
 +
 [NOTE]
 ====
-You must specify an empty `allowedCIDRs[]` in the `policy`` object for `spec.ExternalIPs[]` to succeed. 
+You must specify an empty `allowedCIDRs[]` in the `policy` object for `spec.ExternalIPs[]` to succeed.
 ====
 
 [id="example-policy-objects_{context}"]


### PR DESCRIPTION
Version(s): 4.12+

Issue: https://issues.redhat.com/browse/OCPBUGS-4970

Link to docs preview: https://66196--ocpdocs-pr.netlify.app/openshift-enterprise/latest/networking/configuring_ingress_cluster_traffic/configuring-externalip.html#restrictions-on-ip-assignment_configuring-externalip

QE review:
- [ ] QE has approved this change.
