### PR TITLE
4.14 GA Bugs for Baremetal, Etcd, and Management Console

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1667,6 +1667,8 @@ Targeting {product-title} 4.15, the OpenShift SDN CNI network plugin will not be
 [id="ocp-4-14-bare-metal-hardware-bug-fixes"]
 ==== Bare Metal Hardware Provisioning
 
+* Previously, if the hostname of a bare-metal machine was not provided by either reverse DNS or DHCP, it would default to `localhost` during bare-metal cluster provisioning on installer-provisioned infrastructure. This issue caused Kubernetes node name conflicts and prevented the cluster from being deployed. Now, if the hostname is detected to be `localhost`, the provisioning agent sets the persistent hostname to the name of the `BareMetalHost` object. (link:https://issues.redhat.com/browse/OCPBUGS-9072[*OCPBUGS-9072*])
+
 [discrete]
 [id="ocp-4-14-builds-bug-fixes"]
 ==== Builds
@@ -1723,6 +1725,8 @@ With this change, it begins doing so, and conditional updates where the risks ha
 [id="ocp-4-14-cloud-etcd-operator-bug-fixes"]
 ==== etcd Cluster Operator
 
+* Previously, the `etcdctl` binary was cached on the local machine indefinitely, making updates to the binary impossible. The binary is now properly updated on every invocation of the `cluster-backup.sh` script. (link:https://issues.redhat.com/browse/OCPBUGS-19499[*OCPBUGS-19499*])
+
 [discrete]
 [id="ocp-4-14-hosted-control-plane-bug-fixes"]
 ==== Hosted Control Plane
@@ -1767,6 +1771,34 @@ With this change, it begins doing so, and conditional updates where the risks ha
 [discrete]
 [id="ocp-4-14-management-console-bug-fixes"]
 ==== Management Console
+
+* Previously, alerts loaded from non-Prometheus datasources such as logs. This caused the source of all alerts to be displayed always as *Prometheus*. With this update, alert sources are displayed correctly. (link:https://issues.redhat.com/browse/OCPBUGS-9907[*OCPBUGS-9907*])
+
+* Previously, there was an issue with Patternfly 4 where you could not select or change the log component under the logs section of master node once a selection was already made. With this update, when you change to the log component from the log section of the master node, refresh the page to reload the default options. (link:https://issues.redhat.com/browse/OCPBUGS-18727[*OCPBUGS-18727*])
+
+* Previously, an empty page was displayed when viewing route details on the *Metrics* tab of the *`alertmanager-main`* page. With this update, user privileges were updated so you can view the route details on the *Metrics* tab. (link:https://issues.redhat.com/browse/OCPBUGS-15021[*OCPBUGS-15021*])
+
+* Previously, {product-rosa} used custom branding and the favicon would disappear so no specific branding appeared when custom branding was being used. With this update, {product-rosa} branding is now part of the branding API. (link:https://issues.redhat.com/browse/OCPBUGS-14716[*OCPBUGS#14716*])
+
+* Previously, the {product-title} web console did not render the monitoring *Dashboard* page when a proxy was expected. As a result, the websocket connection failed. With this update, the web console also detects proxy settings from environment variables. (link:https://issues.redhat.com/browse/OCPBUGS-14550[*OCPBUGS-14550*])
+
+* Previously, if the `console.openshift.io/disable-operand delete: "true"` and `operator.openshift.io/uninstall-message: "some message"` annotations were used on an operator CSV, the uninstall instructions did not show up in the web console. With this update, the instructions to opt out of the installment are available. (link:https://issues.redhat.com/browse/OCPBUGS-13782[*OCPBUGS-13782*])
+
+* Previously, the size on the *PersistentVolumeClaims* namespace *Details* page was incorrect. With this update, the Prometheus query on *PersistentVolumeClaims* namespace *Details* page includes the namespace label and the size is now correct. (link:https://issues.redhat.com//browse/OCPBUGS-13208[*OCPBUGS-13208*])
+
+* Previously, after customizing the routes for console and downloads, the downloads route did not update in the `ConsoleCLIDownloads` link and pointed to the default downloads route. With this update, the `ConsoleCLIDownloads` link updates when the custom downloads route is set. (link:https://issues.redhat.com/browse/OCPBUGS-12990[*OCPBUGS-12990*])
+
+* Previously, the print preview displayed incomplete topology information from the list view. With this update, a full list of resources is printed when they are longer than one page. (link:https://issues.redhat.com/browse/OCPBUGS-11219[*OCPBUGS-11219*])
+
+* Previously, dynamic plugins that proxy to services with longer response times timed out at 30 seconds with a 504 error message. With this update, a 5-minute HAProxy timeout annotation was added to the console route to match the maximum timeout of most browsers. (link:https://issues.redhat.com/browse/OCPBUGS-9917[*OCPBUGS-9917*])
+
+* Previously, the provided API page used the `displayName` of the provided API, but this value was not always set. As a result, the list was empty but you could still click all instances to get to the YAML of a new instance. With this update, if the `displayName` is not set, the list displays text. (link:https://issues.redhat.com/browse/OCPBUGS-8682[*OCPBUGS-8682*])
+
+* Previously, the `CronJobs` table and details view did not have a `suspend` indication. With this update, `spec.suspend` was added to the list and details view for `CronJobs`. (link:https://issues.redhat.com/browse/OCPBUGS-8299[*OCPBUGS-8299*])
+
+* Previously, when enabling a single plugin in the configuration of the console operator, the redeployed console fails. With this update, the list of plugins is now unique and pods run as expected. (link:https://issues.redhat.com/browse/OCPBUGS-5059[*OCPBUGS-5059*])
+
+* Previously, after upgrading a plugin image, old plugin files were still requested. With this update, the `?cacheBuster=${getRandomChars()}` query string was added when `plugin-entry.js` resources are requested. (link:https://issues.redhat.com/browse/OCPBUGS-3495[*OCPBUGS-3495*])
 
 [discrete]
 [id="ocp-4-14-monitoring-bug-fixes"]


### PR DESCRIPTION
Version(s):
4.14

Issue:
[Bug Batching for 4.14 GA](https://issues.redhat.com/browse/OSDOCS-5987)

Link to docs preview:
[Preview](https://66216--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-bug-fixes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Additional information:
[Baremetal and Management Console bugs](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12347491#SIGwKWmOqDAaIiGh1DSCAiYg6oaN4RY8HF6AMAwlQMHEVU1ccdWpPFMCNc1SXIGgGCNeaPAtG0HT+ogCErGsyGEN+BWVIilR7AcDpLYiGoLCC4IfuSX7UgoGgeO6hXzHE-FGjwiKYJU4HUBoGjNXUCyFO6MRwsduwWkJVhAA)
[Etcd bug](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12347491#SIGwKWmOqDAaIiGh1DSCAiYg6oaN4RY8HF6AMAwlQMHEVU1ccdWpPFMCNc1SXIGgGCNeaPAtG0HT+ogCErGsyGEN+BWVIilQjQsILgh+5JftSCgaB47qFfMcT8UaPCIpgK00BoGjNXUCyFO6MRwntuwWkJVhAA)
