### PR TITLE
OSDOCS-8187 RNs for zstream 4.12.39

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -4182,3 +4182,29 @@ $ oc adm release info 4.12.37 --pullspecs
 ==== Updating
 
 To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-12-39"]
+=== RHSA-2023:5677 - {product-title} 4.12.39 bug fix and security update
+
+Issued: 2023-10-18
+
+{product-title} release 4.12.39, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:5677[RHSA-2023:5677] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5679[RHSA-2023:5679] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.12.39 --pullspecs
+----
+
+[id="ocp-4-12-39-bug-fixes"]
+==== Bug fixes
+
+* Previously, CoreDNS would crash if an EndpointSlice port was created without a port number. With this update, validation was added to CoreDNS so it will no longer crash in this situation. (link:https://issues.redhat.com/browse/OCPBUGS-20144[*OCPBUGS-20144*])
+
+* Previously, large clusters were slow to attach volumes through `cinder-csi-driver`. With this update, `cinder-csi-driver` is updated with slow volume attachment when the number of Cinder volumes in the project exceed 1000. (link:https://issues.redhat.com/browse/OCPBUGS-20124[*OCPBUGS-20124*])
+
+[id="ocp-4-12-39-updating"]
+==== Updating
+
+To update an existing {product-title} 4.12 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-8187](https://issues.redhat.com/browse/OSDOCS-8187 )

Link to docs preview:
[Preview](https://66218--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#ocp-4-12-38)

QE review:
- [ ] QE has approved this change.
Not needed

Additional information:
Expected merge date is October 18th, 2023. Links will not work until then. Changed from 4.12.38 to 4.12.39.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
