### PR TITLE
OSDOCS-7442: 4.12 backport

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -22,6 +22,9 @@ include::modules/installing-ocp-agent.adoc[leveloffset=+1]
 * See xref:../../installing/installing_with_agent_based_installer/preparing-to-install-with-agent-based-installer.adoc#root-device-hints_preparing-to-install-with-agent-based-installer[About root device hints].
 * See link:https://nmstate.io/examples.html[NMState state examples].
 
+// Gathering log data from a failed Agent-based installation
+include::modules/installing-ocp-agent-gather-log.adoc[leveloffset=+1]
+
 include::modules/sample-ztp-custom-resources.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/installing-ocp-agent-gather-log.adoc
+++ b/modules/installing-ocp-agent-gather-log.adoc
@@ -1,0 +1,71 @@
+// Module included in the following assemblies:
+//
+// * installing/installing-with-agent-based-installer/installing-with-agent-based-installer.adoc
+
+:_content-type: PROCEDURE
+[id="installing-ocp-agent-gather-log_{context}"]
+= Gathering log data from a failed Agent-based installation
+
+Use the following procedure to gather log data about a failed Agent-based installation to provide for a support case.
+
+.Procedure
+
+. Run the following command and collect the output:
++
+[source,terminal]
+----
+$ ./openshift-install --dir <install_directory> agent wait-for bootstrap-complete --log-level=debug
+----
++
+.Example error message
+[source,terminal]
+----
+...
+ERROR Bootstrap failed to complete: : bootstrap process timed out: context deadline exceeded
+----
+
+. If the output from the previous command indicates a failure, or if the bootstrap is not progressing, run the following command on node 0 and collect the output:
++
+[source,terminal]
+----
+$ ssh core@<node-ip> sudo /usr/local/bin/agent-gather -O > <local_tmp_path>/agent-gather.tar.xz
+----
++
+[NOTE]
+====
+You only need to gather data from node 0, but gathering this data from every node can be helpful.
+====
+
+. If the bootstrap completes and the cluster nodes reboot, run the following command and collect the output:
++
+[source,terminal]
+----
+$ ./openshift-install --dir <install_directory> agent wait-for install-complete --log-level=debug
+----
+
+. If the output from the previous command indicates a failure, perform the following steps:
+
+.. Export the `kubeconfig` file to your environment by running the following command:
++
+[source,terminal]
+----
+$ export KUBECONFIG=<install_directory>/auth/kubeconfig
+----
+
+.. To gather information for debugging, run the following command:
++
+[source,terminal]
+----
+$ oc adm must-gather
+----
+
+.. Create a compressed file from the `must-gather` directory that was just created in your working directory by running the following command:
++
+[source,terminal]
+----
+$ tar cvaf must-gather.tar.gz <must_gather_directory>
+----
+
+. Excluding the `/auth` subdirectory, attach the installation directory used during the deployment to your support case on the link:https://access.redhat.com[Red Hat Customer Portal].
+
+. Attach all other data gathered from this procedure to your support case.


### PR DESCRIPTION
[OSDOCS-7442](https://issues.redhat.com/browse/OSDOCS-7442)

Version(s): 4.12 only

This is the 4.12 backport of #64183, which adds steps for gathering data about a failed install for a support case.

QE review:
- [ ] QE has approved this change.
(QE had approved the original 4.13+ implementation, and the reporter of the ticket had asked in the comments for this content to be backported to 4.12)

Preview: [Gathering log data from a failed Agent-based installation](https://66221--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-gather-log_installing-with-agent-based-installer)
