### PR TITLE
OSDOCS#1588 part 2: Adds second batch of MicroShift bugs to 4.14 RNs

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -175,6 +175,34 @@ The CIDR notation for grouping IP addresses was removed from the `clusterNetwork
 
 * Previously, the search logic for directories with `kustomization` files searched for `kustomization.yaml`. `kubectl` also searches for `kustomization.yaml` and `kustomization`. With this update, the search logic is extended for manifest input files to include `kustomization.yml` and `kustomization` in addition to the existing `kustomization.yaml`. (link:https://issues.redhat.com/browse/OCPBUGS-12744[*OCPBUGS-12744*])
 
+* Previously, {microshift-short} healthcheck produced logs that were not linked to the `systemd` unit, which made them hard to find. With this update, the logs are linked to the unit making them easier to access. (link:https://issues.redhat.com/browse/OCPBUGS-20174[*OCPBUGS-20174*])
+
+* Previously, the host needed a volume group named `rhel` in order for the driver to work. With this update, {microshift-short} examines volume groups that exist and selects one as the default. If there is only 1 volume group, that one is used. If there are multiple volume groups and one is named `microshift`, the `microshift` volume group is used. The CSI driver must be explicitly enabled if no volume groups exist. (link:https://issues.redhat.com/browse/OCPBUGS-9996[*OCPBUGS-9996*])
+
+* Previously, mixing upper and lower case letters in the hostname makes {microshift-short} fail. This is because the node name was taken directly from the hostname, and Kubernetes does not allow upper case names. With this update, the hostname only uses lower case host names. (link:https://issues.redhat.com/browse/OCPBUGS-8411[*OCPBUGS-8411*])
+
+* Previously, the log output volume of the `sysconfwatch-controller` contained duplicate messages. With this update, the log output volume for the `sysconfwatch-controller` was reduced to avoid filling the journal with duplicate messages. (link:https://issues.redhat.com/browse/OCPBUGS-8329[*OCPBUGS-8329*])
+
+* Previously, kubeconfigs used a certificate authority (CA) bundle that included 3 different signers: service network, localhost, and external. This made kubeconfigs interchangeable and capable of validating for other networks. With this update, the certificate authorities used to generate kubeconfig files for {microshift-short}'s embedded components were reconfigured to ensure the kubeconfigs are independent. (link:https://issues.redhat.com/browse/OCPBUGS-8301[*OCPBUGS-8301*])
+
+* Previously, an internal apiserver IP address was configured in a loopback device to fix certificate issues. As a result, OVN-Kubernetes picks up this virtual IP address as an apiserver backend making it unreachable. With this update, use a different virtual IP address to configure a loopback device. (link:https://issues.redhat.com/browse/OCPBUGS-8277[*OCPBUGS-8277*])
+
+* Previously, CRI-O was not configured with the correct default path to pause the container because pods with `shareProcessNamespace` set to `true` could not start. With this update, CRI-O is configured explicitly with the correct path. (link:https://issues.redhat.com/browse/OCPBUGS-7874[*OCPBUGS-7874*])
+
+* Previously, the mDNS server in {microshift-short} was advertising all IP addresses on the host. As a result, clients relying on mDNS to resolve the hostname for a route might have been given an internal IP address that could not be used by an application running on {microshift-short}. With this update, the mDNS server in {microshift-short} advertises internal IP addresses. (link:https://issues.redhat.com/browse/OCPBUGS-7205[*OCPBUGS-7205*])
+
+* Previously, using a `.local` suffix for a hostname broke the name resolution with DNS. As a result, {microshift-short} was unable to reach its own hostname. With this update, mDNS was fixed to use IP addresses instead of hostnames whenever possible. (link:https://issues.redhat.com/browse/OCPBUGS-10766[*OCPBUGS-10766*])
+
+* Previously, when IP addresses were used instead of hostnames to connect to the apiserver, external connectivity failed. As a result, certificates did not regenerate when the IP address was changed. The kubeconfig used names instead of IP addresses which required the use of `subjectAltNames` if IP addresses were alternativly used. With this update, the previous kubeconfigs for absent IP addresses and names are removed. (link:https://issues.redhat.com/browse/OCPBUGS-11395[*OCPBUGS-11395*])
+
+* Previously, installing EC builds of {microshift-short} on {op-system-base-full} 9.2 required OpenvSwitch 2.17, but {op-system} 9.2 includes OpenvSwitch 3.x by default. With this update, {microshift-short} works with OpenvSwitch 3.x on {op-system} 9.2 and later. (link:https://issues.redhat.com/browse/OCPBUGS-11538[*OCPBUGS-11538*])
+
+* Previously, the command `microshift show-config` was prevented from reporting the correct `memoryLimitMB` for etcd. With this update, `microshift show-config` reports the correct `memoryLimitMB` for etcd. (link:https://issues.redhat.com/browse/OCPBUGS-11734[*OCPBUGS-11734*])
+
+* Previously, OVN-Kubernetes failed to run on a disconnected {microshift-short} instance. With this update, the OVN-Kubernetes configuration supports running {microshift-short} on hosts with no default route. (link:https://issues.redhat.com/browse/OCPBUGS-11967[*OCPBUGS-11967*])
+
+* Previously, the networking smoke test created a `hello-microshift` pod using `busybox` and an image pulled from docker. With this update, quay.io is used to host the image. (link:https://issues.redhat.com/browse/OCPBUGS-19939[*OCPBUGS-19939*])
+
 [id="microshift-4-14-known-issues"]
 == Known issues
 


### PR DESCRIPTION
OSDOCS#1588 part 2: Adds second batch of MicroShift bugs to 4.14 RNs

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7587
https://issues.redhat.com/browse/OSDOCS-7588

Link to docs preview:
https://66223--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-bug-fixes

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
