### PR TITLE
OSDOCS#6447: Added multi arch release to use case

### DIFF
--- a/modules/oc-mirror-image-set-config-examples.adoc
+++ b/modules/oc-mirror-image-set-config-examples.adoc
@@ -36,11 +36,11 @@ mirror:
 // Moved to second; unchanged
 [discrete]
 [id="oc-mirror-image-set-examples-minimum-to-latest_{context}"]
-== Use case: Including all versions of {product-title} from a minimum to the latest
+== Use case: Including all versions of {product-title} from a minimum to the latest version for multi-architecture releases
 
-The following `ImageSetConfiguration` file uses a registry storage backend and includes all {product-title} versions starting at a minimum version of `4.10.10` to the latest version in the channel.
+The following `ImageSetConfiguration` file uses a registry storage backend and includes all {product-title} versions starting at a minimum version of `4.13.4` to the latest version in the channel. On every invocation of oc-mirror with this image set configuration, the latest release of the `stable-4.13` channel is evaluated, so running oc-mirror at regular intervals ensures that you automatically receive the latest releases of {product-title} images. 
 
-On every invocation of oc-mirror with this image set configuration, the latest release of the `stable-4.10` channel is evaluated, so running oc-mirror at regular intervals ensures that you automatically receive the latest releases of {product-title} images.
+By setting the value of `platform.architectures` to `multi`, you can ensure that the mirroring is supported for multi-architecture releases.
 
 .Example `ImageSetConfiguration` file
 [source,yaml]
@@ -53,9 +53,12 @@ storageConfig:
     skipTLS: false
 mirror:
   platform:
+    architectures: 
+      - "multi"
     channels:
-      - name: stable-4.10
-        minVersion: 4.10.10
+      - name: stable-4.13
+        minVersion: 4.13.4
+        maxVersion: 4.13.6
 ----
 
 // Updated:

--- a/modules/oc-mirror-imageset-config-params.adoc
+++ b/modules/oc-mirror-imageset-config-params.adoc
@@ -208,6 +208,8 @@ architectures:
   - s390x
 ----
 
+The default value is `amd64`. The value `multi` ensures that the mirroring is supported for all available architectures, eliminating the need to specify individual architectures.
+
 |`mirror.platform.channels`
 |The platform channel configuration of the image set.
 |Array of objects. For example:


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OSDOCS-6447

Link to docs preview: 
2nd Use Case: https://66238--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected#oc-mirror-image-set-examples_installing-mirroring-disconnected

QE review:
- [x] QE has approved this change. @kasturinarra 
- [x] SME has approved this change. @lmzuccarelli 
