### PR TITLE
OSDOCS#8192: Updated dual-stack notes for vsphere

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -176,12 +176,6 @@ ifdef::vsphere[]
 [NOTE]
 ====
 On VMware vSphere, dual-stack networking must specify IPv4 as the primary address family.
-
-The following additional limitations apply to dual-stack networking:
-
-* Nodes report only their IPv6 IP address in `node.status.addresses`
-* Nodes with only a single NIC are supported
-* Pods configured for host networking report only their IPv6 addresses in `pod.status.IP`
 ====
 endif::vsphere[]
 


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OSDOCS-8192 

Link to docs preview: https://66239--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installation-config-parameters-vsphere#installation-configuration-parameters-network_installation-config-parameters-vsphere

QE review:
- [x] QE has approved this change. @rbbratta 