### PR TITLE
[virt] DPDK vm: Update vm docs

### DIFF
--- a/modules/virt-configuring-vm-dpdk.adoc
+++ b/modules/virt-configuring-vm-dpdk.adoc
@@ -52,9 +52,7 @@ spec:
       memory:
         hugepages:
           pageSize: 1Gi <7>
-      resources:
-        requests:
-          memory: 8Gi
+          guest: 8Gi
       networks:
         - name: default
           pod: {}
@@ -81,11 +79,11 @@ $ oc apply -f <file_name>.yaml
 ----
 
 . Configure the guest operating system. The following example shows the configuration steps for {op-system-base} 8 OS:
-.. Configure isolated VM CPUs and specify huge pages by using the GRUB bootloader command-line interface. In the following example, 8 1G huge pages are specified. The first two CPUs (0 and 1) are set aside for house keeping tasks and the rest are isolated for the DPDK application.
+.. Configure huge pages by using the GRUB bootloader command-line interface. In the following example, 8 1G huge pages are specified.
 +
 [source,terminal]
 ----
-$ grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=8 isolcpus=2-9"
+$ grubby --update-kernel=ALL --args="default_hugepagesz=1GB hugepagesz=1G hugepages=8"
 ----
 
 .. To achieve low-latency tuning by using the `cpu-partitioning` profile in the TuneD application, run the following commands:
@@ -99,6 +97,7 @@ $ dnf install -y tuned-profiles-cpu-partitioning
 ----
 $ echo isolated_cores=2-9 > /etc/tuned/cpu-partitioning-variables.conf
 ----
+The first two CPUs (0 and 1) are set aside for house keeping tasks and the rest are isolated for the DPDK application.
 +
 [source,terminal]
 ----


### PR DESCRIPTION
Updating some relevant VM spec and guest changes needed in order to configure a DPDK VM on the `virt-configuring-vm-dpdk` document:
* Remove `isolcpus` from linux cmd.
* Refactor Hugepages API to be more specific.

Version(s):
4.13+

Issue:

Link to docs preview:
https://66246--docspreview.netlify.app/openshift-enterprise/latest/virt/vm_networking/virt-using-dpdk-with-sriov#virt-configuring-vm-dpdk_virt-using-dpdk-with-sriov

QE review:
- [x] QE has approved this change.


Additional information:

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
