### PR TITLE
Removing NooBaa from OADP documentation

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp.adoc
@@ -16,7 +16,9 @@ To back up Kubernetes resources and internal images, you must have object storag
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-azure.adoc#installing-oadp-azure[Microsoft Azure]
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-gcp.adoc#installing-oadp-gcp[Google Cloud Platform]
 * xref:../../../backup_and_restore/application_backup_and_restore/installing/installing-oadp-mcg.adoc#installing-oadp-mcg[Multicloud Object Gateway]
-* AWS S3 compatible object storage, such as Noobaa or Minio
+* AWS S3 compatible object storage, such as Multicloud Object Gateway or MinIO
+
+include::snippets/snip-noobaa-and-mcg.adoc[]
 
 :FeatureName: The `CloudStorage` API, which automates the creation of a bucket for object storage,
 include::snippets/technology-preview.adoc[]

--- a/modules/oadp-about-backup-snapshot-locations-secrets.adoc
+++ b/modules/oadp-about-backup-snapshot-locations-secrets.adoc
@@ -16,7 +16,7 @@ You specify backup and snapshot locations and their secrets in the `DataProtecti
 [discrete]
 == Backup locations
 
-You specify S3-compatible object storage, such as Multicloud Object Gateway, Noobaa, or Minio, as a backup location.
+You specify S3-compatible object storage, such as Multicloud Object Gateway or MinIO, as a backup location.
 
 Velero backs up {product-title} resources, Kubernetes objects, and internal images as an archive file on object storage.
 

--- a/modules/oadp-configuring-noobaa-for-dr.adoc
+++ b/modules/oadp-configuring-noobaa-for-dr.adoc
@@ -4,15 +4,17 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="oadp-configuring-noobaa-for-dr_{context}"]
-= Configuring NooBaa for disaster recovery on {rh-storage}
+= Configuring Multicloud Object Gateway (MCG) for disaster recovery on {rh-storage}
 
-If you use cluster storage for your NooBaa bucket `backupStorageLocation` on {rh-storage}, configure NooBaa as an external object store.
+If you use cluster storage for your MCG bucket `backupStorageLocation` on {rh-storage}, configure MCG as an external object store.
 
 [WARNING]
 ====
-Failure to configure NooBaa as an external object store might lead to backups not being available.
+Failure to configure MCG as an external object store might lead to backups not being available.
 ====
+
+include::snippets/snip-noobaa-and-mcg.adoc[]
 
 .Procedure
 
-* Configure NooBaa as an external object store as described in link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.11/html/managing_hybrid_and_multicloud_resources/adding-storage-resources-for-hybrid-or-multicloud_rhodf#doc-wrapper[Adding storage resources for hybrid or Multicloud].
+* Configure MCG as an external object store as described in link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.13/html/managing_hybrid_and_multicloud_resources/adding-storage-resources-for-hybrid-or-multicloud_rhodf#doc-wrapper[Adding storage resources for hybrid or Multicloud].

--- a/modules/oadp-creating-object-bucket-claim.adoc
+++ b/modules/oadp-creating-object-bucket-claim.adoc
@@ -6,13 +6,15 @@
 [id="oadp-creating-object-bucket-claim_{context}"]
 = Creating an Object Bucket Claim for disaster recovery on {rh-storage}
 
-If you use cluster storage for your NooBaa bucket `backupStorageLocation` on {rh-storage}, create an Object Bucket Claim (OBC) using the OpenShift Web Console.
+If you use cluster storage for your Multicloud Object Gateway (MCG) bucket `backupStorageLocation` on {rh-storage}, create an Object Bucket Claim (OBC) using the OpenShift Web Console.
 
 [WARNING]
 ====
 Failure to configure an Object Bucket Claim (OBC) might lead to backups not being available.
 ====
 
+include::snippets/snip-noobaa-and-mcg.adoc[]
+
 .Procedure
 
-* Create an Object Bucket Claim (OBC) using the OpenShift Web Console as described in link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.13/html/managing_hybrid_and_multicloud_resources/object-bucket-claim#creating-an-object-bucket-claim-using-the-openshift-web-console_rhodf[Creating an Object Bucket Claim using the OpenShift Web Console].
+* Create an Object Bucket Claim (OBC) using the OpenShift web console as described in link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.13/html/managing_hybrid_and_multicloud_resources/object-bucket-claim#creating-an-object-bucket-claim-using-the-openshift-web-console_rhodf[Creating an Object Bucket Claim using the OpenShift Web Console].

--- a/modules/oadp-s3-compatible-backup-storage-providers.adoc
+++ b/modules/oadp-s3-compatible-backup-storage-providers.adoc
@@ -11,10 +11,10 @@ OADP is compatible with many object storage providers for use with different bac
 [id="oadp-s3-compatible-backup-storage-providers-supported"]
 == Supported backup storage providers
 
-The following AWS S3 compatible object storage providers, are fully supported by OADP through the AWS plugin for use as backup storage locations:
+The following AWS S3 compatible object storage providers are fully supported by OADP through the AWS plugin for use as backup storage locations:
 
 * MinIO
-* Multicloud Object Gateway (MCG) with NooBaa
+* Multicloud Object Gateway (MCG)
 * Amazon Web Services (AWS) S3
 
 [NOTE]
@@ -33,11 +33,13 @@ The following AWS S3 compatible object storage providers, are known to work with
 * IBM Cloud
 * Oracle Cloud
 * DigitalOcean
-* NooBaa
+* NooBaa, unless installed using Multicloud Object Gateway (MCG)
 * Tencent Cloud
 * Ceph RADOS v12.2.7
 * Quobyte
 * Cloudian HyperStore
+
+include::snippets/snip-noobaa-and-mcg.adoc[]
 
 [id="oadp-s3-compatible-backup-storage-providers-known-limitations"]
 == Backup storage providers with known limitations

--- a/snippets/snip-noobaa-and-mcg.adoc
+++ b/snippets/snip-noobaa-and-mcg.adoc
@@ -1,0 +1,8 @@
+:_content-type: SNIPPET
+
+[NOTE]
+====
+Unless specified otherwise, "NooBaa" refers to the open source project that provides lightweight object storage, while "Multicloud Object Gateway (MCG)" refers to the Red Hat distribution of NooBaa.
+
+For more information on the MCG, see link:https://access.redhat.com/documentation/en-us/red_hat_openshift_data_foundation/4.13/html-single/managing_hybrid_and_multicloud_resources/index#accessing-the-multicloud-object-gateway-with-your-applications_rhodf[Accessing the Multicloud Object Gateway with your applications].
+====


### PR DESCRIPTION
OADP 1.3, OCP 4.11+

Resolves https://issues.redhat.com/browse/OADP-2854 by removing most references to NooBaa in downstream documentation and resolving the specific question about support the Jira raised.  

Previews:
1.  https://66247--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp [NooBaa removed from last item in bulleted list]

2. https://66247--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp#oadp-s3-compatible-backup-storage-providers-supported [NooBaa removed from "Multicloud Object Gateway (MCG) with NooBaa" in list of supported; but kept in list of unsupported]

3. https://66247--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/about-installing-oadp#oadp-configuring-noobaa-for-dr_about-installing-oadp [MCG replaces NooBaa throughout section]

4. https://66247--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws#oadp-about-backup-snapshot-locations_installing-oadp-aws [NooBaa removed from first paragraph of  "Backup locations"]

5. https://66247--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws#oadp-about-backup-snapshot-locations_installing-oadp-aws [`NooBaa` CR left in text]

6. https://66247--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-ocs#oadp-creating-object-bucket-claim_installing-oadp-ocs [Changes "NooBaa bucket" to "MCG bucket" in first sentence. 