### PR TITLE
PR for SRVKS-1121: Update DomainMapping `v1alpha1` to `v1beta1`

### DIFF
--- a/modules/serverless-create-domain-mapping.adoc
+++ b/modules/serverless-create-domain-mapping.adoc
@@ -26,7 +26,7 @@ Your custom domain must point to the IP address of the {ocp-product-title} clust
 +
 [source,yaml]
 ----
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1beta1
 kind: DomainMapping
 metadata:
  name: <domain_name> <1>
@@ -45,7 +45,7 @@ spec:
 .Example service domain mapping
 [source,yaml]
 ----
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1beta1
 kind: DomainMapping
 metadata:
  name: example.com
@@ -60,7 +60,7 @@ spec:
 .Example route domain mapping
 [source,yaml]
 ----
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1beta1
 kind: DomainMapping
 metadata:
  name: example.com

--- a/modules/serverless-domain-mapping-custom-tls-cert.adoc
+++ b/modules/serverless-domain-mapping-custom-tls-cert.adoc
@@ -53,7 +53,7 @@ The {cert-manager-operator} is a Technology Preview feature. For more informatio
 +
 [source,yaml]
 ----
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1beta1
 kind: DomainMapping
 metadata:
   name: <domain_name>

--- a/modules/serverless-domain-mapping-odc-admin.adoc
+++ b/modules/serverless-domain-mapping-odc-admin.adoc
@@ -37,7 +37,7 @@ Your custom domain must point to the IP address of the cluster.
 +
 [source,yaml]
 ----
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1beta1
 kind: DomainMapping
 metadata:
  name: <domain_name> <1>
@@ -56,7 +56,7 @@ spec:
 .Example domain mapping to a Knative service
 [source,yaml]
 ----
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1beta1
 kind: DomainMapping
 metadata:
  name: custom-ksvc-domain.example.com


### PR DESCRIPTION
**Affected versions for cherry-picking:** Serverless 1.31

**Tracking JIRA:** https://issues.redhat.com/browse/SRVKS-1121

**Description:** In the following sections , updated DomainMapping from `v1alpha1` to `v1beta1`

**Doc preview:** 

- [Creating a custom domain mapping](https://66248--docspreview.netlify.app/openshift-serverless/latest/knative-serving/config-custom-domains/create-domain-mapping#serverless-create-domain-mapping_create-domain-mapping)
- [Securing a service with a custom domain by using a TLS certificate](https://66248--docspreview.netlify.app/openshift-serverless/latest/knative-serving/config-custom-domains/domain-mapping-custom-tls-cert#serverless-domain-mapping-custom-tls-cert_domain-mapping-custom-tls-cert)
- [Mapping a custom domain to a service by using the Administrator perspective](https://66248--docspreview.netlify.app/openshift-serverless/latest/knative-serving/config-custom-domains/domain-mapping-odc-admin#serverless-domain-mapping-odc-admin_domain-mapping-odc-admin)

