### PR TITLE
[OSDOCS#7419]: Corrected API version in buildconfig example

### DIFF
--- a/modules/builds-manually-add-source-clone-secrets.adoc
+++ b/modules/builds-manually-add-source-clone-secrets.adoc
@@ -10,7 +10,7 @@ Source clone secrets can be added manually to a build configuration by adding a 
 
 [source,yaml]
 ----
-apiVersion: "v1"
+apiVersion: "build.openshift.io/v1"
 kind: "BuildConfig"
 metadata:
   name: "sample-build"


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-7419

Link to docs preview:
https://66249--docspreview.netlify.app/openshift-enterprise/latest/cicd/builds/creating-build-inputs#builds-manually-add-source-clone-secrets_creating-build-inputs

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
