### PR TITLE
TELCODOCS-1298:Updating variables to 4.14 where appropriate

### DIFF
--- a/hardware_enablement/kmm-kernel-module-management.adoc
+++ b/hardware_enablement/kmm-kernel-module-management.adoc
@@ -76,7 +76,8 @@ include::modules/kmm-signing-a-prebuilt-driver-container.adoc[leveloffset=+1]
 include::modules/kmm-building-and-signing-a-moduleloader-container-image.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-For information on creating a service account, see link:https://docs.openshift.com/container-platform/4.12/authentication/understanding-and-creating-service-accounts.html#service-accounts-managing_understanding-service-accounts[Creating service accounts].
+
+* xref:../authentication/understanding-and-creating-service-accounts.adoc#service-accounts-managing_understanding-service-accounts[Creating service accounts].
 
 // Added for TELCODOCS-1277
 include::modules/kmm-customizing-upgrades-for-kernel-modules.adoc[leveloffset=+1]
@@ -85,14 +86,14 @@ include::modules/kmm-customizing-upgrades-for-kernel-modules.adoc[leveloffset=+1
 include::modules/kmm-day1-kernel-module-loading.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.openshift.com/container-platform/4.13/post_installation_configuration/machine-configuration-tasks.html#machine-config-operator_post-install-machine-configuration-tasks[Machine Config Operator]
+* xref:../post_installation_configuration/machine-configuration-tasks.adoc#machine-config-operator_post-install-machine-configuration-tasks[Machine Config Operator]
 
 include::modules/kmm-day1-supported-use-cases.adoc[leveloffset=+2]
 include::modules/kmm-day1-oot-kernel-module-loading-flow.adoc[leveloffset=+2]
 include::modules/kmm-day1-kernel-module-image.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
-* link:https://docs.openshift.com/container-platform/4.13/hardware_enablement/psap-driver-toolkit.html[Driver Toolkit]
+* xref:../hardware_enablement/psap-driver-toolkit.adoc#driver-toolkit[Driver Toolkit]
 
 include::modules/kmm-day1-in-tree-module-replacement.adoc[leveloffset=+2]
 include::modules/kmm-day1-mco-yaml-creation.adoc[leveloffset=+2]


### PR DESCRIPTION
[TELCODOCS-1298](https://issues.redhat.com//browse/TELCODOCS-1298): Update variables and hardcoded instances to 4.14 where appropriate

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-1298

Link to docs preview:
https://66251--docspreview.netlify.app/openshift-enterprise/latest/hardware_enablement/kmm-kernel-module-management
