### PR TITLE
TELCODOCS-1305 - Adding 4.14 ZTP software versions

### DIFF
--- a/modules/ztp-gitops-ztp-max-spoke-clusters.adoc
+++ b/modules/ztp-gitops-ztp-max-spoke-clusters.adoc
@@ -43,7 +43,7 @@ Use the following representative configuration and network specifications to dev
 
 [IMPORTANT]
 ====
-The following guidelines are based on internal lab benchmark testing only and do not represent a complete real-world host specification.
+The following guidelines are based on internal lab benchmark testing only and do not represent complete bare-metal host specifications.
 ====
 
 .Representative three-node hub cluster machine specifications
@@ -52,10 +52,10 @@ The following guidelines are based on internal lab benchmark testing only and do
 |Requirement
 |Description
 
-|{product-title} version
+|{product-title}
 |version 4.13
 
-|{rh-rhacm} version
+|{rh-rhacm}
 |version 2.7
 
 |{cgu-operator-first}

--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -2,30 +2,55 @@
 //
 // * scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc
 
-:_content-type: CONCEPT
+:_content-type: REFERENCE
 [id="ztp-telco-ran-software-versions_{context}"]
-= Telco RAN {product-version} validated solution software versions
+= Telco RAN {product-version} validated software components
 
-The Red Hat Telco Radio Access Network (RAN) version {product-version} solution has been validated using the following Red Hat software products.
+The Red Hat Telco RAN {product-version} solution has been validated using the following Red Hat software products for {product-title}.
 
-.Telco RAN {product-version} validated solution software
+.Telco RAN DU {product-version} validated software components
 [cols=2*, width="80%", options="header"]
 |====
-|Product
+|Component
 |Software version
 
-|Hub cluster {product-title} version
-|4.13
+|RAN DU cluster version
+|4.14
+
+|Cluster Logging Operator
+|5.8
+
+|Local Storage Operator
+|4.14
+
+|PTP Operator
+|4.14
+
+|SRIOV Operator
+|4.14
+
+|SRIOV-FEC Operator
+|2.7
+|====
+
+.Telco RAN {product-version} hub cluster validated software components
+[cols=2*, width="80%", options="header"]
+|====
+|Component
+|Software version
+
+|Hub cluster version
+|4.14
 
 |{ztp} plugin
-|4.11, 4.12, or 4.13
+|4.14
 
 |{rh-rhacm-first}
-|2.7
+|2.9
 
 |{gitops-title}
 |1.9
 
 |{cgu-operator-first}
-|4.11, 4.12, or 4.13
+|4.14
 |====

--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -46,7 +46,7 @@ The Red Hat Telco RAN {product-version} solution has been validated using the fo
 |4.14
 
 |{rh-rhacm-first}
-|2.9
+|2.8, 2.9
 
 |{gitops-title}
 |1.9

--- a/modules/ztp-telco-ran-software-versions.adoc
+++ b/modules/ztp-telco-ran-software-versions.adoc
@@ -18,7 +18,7 @@ The Red Hat Telco RAN {product-version} solution has been validated using the fo
 |4.14
 
 |Cluster Logging Operator
-|5.8
+|5.7
 
 |Local Storage Operator
 |4.14


### PR DESCRIPTION
Adding ZTP solution software versions for 4.14.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
main, enterprise-4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-1305

Link to docs preview:
https://66252--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster#ztp-gitops-ztp-max-spoke-clusters_ztp-preparing-the-hub-cluster

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

