### PR TITLE
OCPBUGS-21644: Replaced nyc-1a with nyc-1 AWS LZ

### DIFF
--- a/modules/installation-aws-add-local-zone-locations.adoc
+++ b/modules/installation-aws-add-local-zone-locations.adoc
@@ -48,7 +48,7 @@ $ export ZONE_GROUP_NAME="<value_of_GroupName>" <1>
 +
 where:
 
-<value_of_GroupName>:: Specifies the name of the group of the Local Zone you want to create subnets on. For example, specify `us-east-1-nyc-1` to use the zone `us-east-1-nyc-1a`, US East (New York).
+<value_of_GroupName>:: Specifies the name of the group of the Local Zone you want to create subnets on. For example, specify `us-east-1-nyc-1` to use the zone `us-east-1-nyc-1`, US East (New York).
 
 . Opt in to the zone group on your AWS account by running the following command:
 +

--- a/modules/installation-cloudformation-subnet-localzone.adoc
+++ b/modules/installation-cloudformation-subnet-localzone.adoc
@@ -23,10 +23,10 @@ Parameters:
     Description: VPC Id
     Type: String
   ZoneName:
-    Description: Local Zone Name (Example us-east-1-nyc-1a)
+    Description: Local Zone Name (Example us-east-1-nyc-1)
     Type: String
   SubnetName:
-    Description: Local Zone Name (Example cluster-public-us-east-1-nyc-1a)
+    Description: Local Zone Name (Example cluster-public-us-east-1-nyc-1)
     Type: String
   PublicRouteTableId:
     Description: Public Route Table ID to associate the Local Zone subnet

--- a/modules/installation-extend-edge-nodes-aws-local-zones.adoc
+++ b/modules/installation-extend-edge-nodes-aws-local-zones.adoc
@@ -9,7 +9,7 @@ endif::[]
 :_content-type: PROCEDURE
 [id="installation-extend-edge-nodes-aws-local-zones_{context}"]
 = Creating user workloads in AWS Local Zones
-After you create an Amazon Web Service (AWS) Local Zone environment, and you deploy your cluster, you can use edge worker nodes to create user workloads in Local Zone subnets. 
+After you create an Amazon Web Service (AWS) Local Zone environment, and you deploy your cluster, you can use edge worker nodes to create user workloads in Local Zone subnets.
 
 After the `openshift-installer` creates the cluster, the installation program automatically specifies a taint effect of `NoSchedule` to each edge worker node. This means that a scheduler does not add a new pod, or deployment, to a node if the pod does not match the specified tolerations for a taint. You can modify the taint for better control over how each node creates a workload in each Local Zone subnet.
 
@@ -53,13 +53,13 @@ metadata:
   name: <local_zone_application> <3>
   namespace: <local_zone_application_namespace> <4>
 spec:
-  selector: 
+  selector:
     matchLabels:
       app: <local_zone_application>
   replicas: 1
   template:
     metadata:
-      labels: 
+      labels:
         app: <local_zone_application>
         zone-group: ${ZONE_GROUP_NAME} <5>
     spec:
@@ -88,16 +88,16 @@ spec:
             - mountPath: "/mnt/storage"
               name: data
       volumes:
-      - name: data 
+      - name: data
         persistentVolumeClaim:
           claimName: <pvc_name>
 ----
 <1> `storageClassName`: For the Local Zone configuration, you must specify `gp2-csi`.
 <2> `kind`: Defines the `deployment` resource.
 <3> `name`: Specifies the name of your Local Zone application. For example, `local-zone-demo-app-nyc-1`.
-<4> `namespace:` Defines the namespace for the AWS Local Zone where you want to run the user workload. For example: `local-zone-app-nyc-1a`.
+<4> `namespace:` Defines the namespace for the AWS Local Zone where you want to run the user workload. For example: `local-zone-app-nyc-1`.
 <5> `zone-group`: Defines the group to where a zone belongs. For example, `us-east-1-iah-1`.
-<6> `nodeSelector`: Targets edge worker nodes that match the specified labels. 
+<6> `nodeSelector`: Targets edge worker nodes that match the specified labels.
 <7> `tolerations`: Sets the values that match with the `taints` defined on the `MachineSet` manifest for the Local Zone node.
 
 . Create a `service` resource YAML file for the node. This resource exposes a pod from a targeted edge worker node to services that run inside your Local Zone network.

--- a/modules/installation-localzone-generate-k8s-manifest.adoc
+++ b/modules/installation-localzone-generate-k8s-manifest.adoc
@@ -30,7 +30,7 @@ contains the `install-config.yaml` file you created.
 +
 [IMPORTANT]
 ====
-Generally, the Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. See link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation. 
+Generally, the Maximum Transmission Unit (MTU) between an Amazon EC2 instance in a Local Zone and an Amazon EC2 instance in the Region is 1300. See link:https://docs.aws.amazon.com/local-zones/latest/ug/how-local-zones-work.html[How Local Zones work] in the AWS documentation.
 The cluster network MTU must be always less than the EC2 MTU to account for the overhead. The specific overhead is determined by your network plugin, for example:
 
 - OVN-Kubernetes: `100 bytes`
@@ -79,7 +79,7 @@ EOF
 ----
 $ export LZ_ZONE_NAME="<local_zone_name>" <1>
 ----
-<1> For `<local_zone_name>`, specify the Local Zone that you opted your AWS account into, such as `us-east-1-nyc-1a`.
+<1> For `<local_zone_name>`, specify the Local Zone that you opted your AWS account into, such as `us-east-1-nyc-1`.
 
 .. Review the instance types for the location that you will deploy to by running the following command:
 +
@@ -114,7 +114,7 @@ $ export AMI_ID=$(grep ami
 [source,terminal]
 ----
 $ export SUBNET_ID=$(aws cloudformation describe-stacks --stack-name "<subnet_stack_name>" \ <1>
-  | jq -r '.Stacks[0].Outputs[0].OutputValue') 
+  | jq -r '.Stacks[0].Outputs[0].OutputValue')
 ----
 <1> For `<subnet_stack_name>`, specify the name of the subnet stack that you created.
 

--- a/modules/machine-edge-pool-review-nodes.adoc
+++ b/modules/machine-edge-pool-review-nodes.adoc
@@ -18,7 +18,7 @@ $ oc get machineset -n openshift-machine-api
 [source,terminal]
 ----
 NAME                                  DESIRED   CURRENT   READY   AVAILABLE   AGE
-cluster-7xw5g-edge-us-east-1-nyc-1a   1         1         1       1           3h4m
+cluster-7xw5g-edge-us-east-1-nyc-1   1         1         1       1           3h4m
 cluster-7xw5g-worker-us-east-1a       1         1         1       1           3h4m
 cluster-7xw5g-worker-us-east-1b       1         1         1       1           3h4m
 cluster-7xw5g-worker-us-east-1c       1         1         1       1           3h4m
@@ -28,13 +28,13 @@ cluster-7xw5g-worker-us-east-1c       1         1         1       1           3h
 +
 [source,terminal]
 ----
-$ oc get machines -n openshift-machine-api 
+$ oc get machines -n openshift-machine-api
 ----
 +
 .Example output
 ----
 NAME                                        PHASE     TYPE          REGION      ZONE               AGE
-cluster-7xw5g-edge-us-east-1-nyc-1a-wbclh   Running   c5d.2xlarge   us-east-1   us-east-1-nyc-1a   3h
+cluster-7xw5g-edge-us-east-1-nyc-1-wbclh   Running   c5d.2xlarge   us-east-1   us-east-1-nyc-1   3h
 cluster-7xw5g-master-0                      Running   m6i.xlarge    us-east-1   us-east-1a         3h4m
 cluster-7xw5g-master-1                      Running   m6i.xlarge    us-east-1   us-east-1b         3h4m
 cluster-7xw5g-master-2                      Running   m6i.xlarge    us-east-1   us-east-1c         3h4m


### PR DESCRIPTION
[OCPBUGS-21644](https://issues.redhat.com/browse/OCPBUGS-21644)

Version(s):
4.13 and 4.12

Link to docs preview:
[Installing a cluster on AWS with worker nodes on AWS Local Zones](https://66255--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
