### PR TITLE
TELCODOCS-1300 - telco RAN 4.14 final release notes updates 

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -612,37 +612,50 @@ With this release, the Performance Addon Operator (PAO) must-gather image is no 
 For further information about gathering debugging information relating to low-latency tuning, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#cnf-collecting-low-latency-tuning-debugging-data-for-red-hat-support_cnf-master[Collecting low latency tuning debugging data for Red Hat Support].
 
 [id="ocp-4-14-NRO-image-must-gather"]
-==== Collecting data for the NUMA Resources Operator with the must-gather image of the operator
+==== Collecting data for the NUMA Resources Operator with the must-gather image of the Operator
 
-In this release, the `must-gather` tool is updated to collect the data of the NUMA Resources Operator with the `must-gather` image of the operator.
+In this release, the `must-gather` tool is updated to collect the data of the NUMA Resources Operator with the `must-gather` image of the Operator.
 
-For further information about gathering debugging information for the NUMA Resources Operator, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-about-collecting-nro-data_numa-aware[Collecting NUMA Resources Operator data].
+For further information about gathering debugging information for the NUMA Resources Operator, see xref:../scalability_and_performance/cnf-numa-aware-scheduling.adoc#cnf-about-collecting-nro-data_numa-aware[Collecting NUMA Resources Operator data].
 
 [id="ocp-4-14-additional-power-savings-control"]
 ==== Enabling more control over the C-states for each pod
 
-With this release, you have more control over the C-states for your pods. Now, instead of disabling C-states completely, you can specify a maximum latency in microseconds for C-states. You can configure this option in the `cpu-c-states.crio.io` annotation, which helps to optimize power savings in high-priority applications by enabling some of the shallower C-states instead of disabling them completely.
+With this release, you have more control over the C-states for your pods. Now, instead of disabling C-states completely, you can specify a maximum latency in microseconds for C-states. You can configure this option in the `cpu-c-states.crio.io` annotation. This helps to optimize power savings in high-priority applications by enabling some of the shallower C-states instead of disabling them completely.
 
-For further information about enabling more control over the C-states, see xref:../scalability_and_performance/cnf-low-latency-tuning.html#node-tuning-operator-pod-power-saving-config_cnf-master[Optional: Power saving configurations].
+For further information about controlling pod C-states, see xref:../scalability_and_performance/cnf-low-latency-tuning.adoc#node-tuning-operator-pod-power-saving-config_cnf-master[Optional: Power saving configurations].
 
 [id="ocp-4-14-nw-ipv6-spoke-cluster-support"]
 ==== Support for provisioning IPv6 spoke clusters from dual-stack hub clusters
 With this update, you can provision IPv6 address spoke clusters from dual-stack hub clusters. In a zero touch provisioning (ZTP) environment, the HTTP server on the hub cluster that hosts the boot ISO now listens on both IPv4 and IPv6 networks. The provisioning service also checks the baseboard management controller (BMC) address scheme on the target spoke cluster and provides a matching URL for the installation media. These updates offer the ability to provision single-stack, IPv6 spoke clusters from a dual-stack hub cluster.
 
-[id="ocp-4-14-precaching-user-spec-images"]
-==== Pre-caching user-specified images with {cgu-operator-full}
+[id="ocp-custom-crs-with-pgt-ztp"]
+==== Using custom CRs with PolicyGenTemplate CRs in the {ztp-first} pipeline
 
-With this release, you can pre-cache your application workload images before upgrading your applications on {sno} clusters with {cgu-operator-full}. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc#talm-prechache-user-specified-images-concept_ztp-talm[Pre-caching user-specified images with TALM on single-node OpenShift clusters].
+You can now use {ztp} to include custom CRs in addition to the base source CRs provided by the {ztp} plugin in the `ztp-site-generate` container.
+For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-advanced-policy-config.adoc#ztp-adding-new-content-to-gitops-ztp_ztp-advanced-policy-config[Adding custom content to the {ztp} pipeline].
+
+[id="ocp-managed-clusters-version-independence-ztp"]
+==== {ztp} independence from managed cluster version
+
+You can now use {ztp} to provision managed clusters that are running different versions of {product-title}.
+This means that the hub cluster and the {ztp} plugin version can be independent of the version of {product-title} running on the managed clusters.
+For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-preparing-the-hub-cluster.adoc#ztp-preparing-the-ztp-git-repository-ver-ind_ztp-preparing-the-hub-cluster[Preparing the {ztp} site configuration repository for version independence].
+
+[id="ocp-4-14-precaching-user-spec-images"]
+==== Precaching user-specified images with {cgu-operator-full}
+
+With this release, you can precache your application workload images before upgrading your applications on {sno} clusters with {cgu-operator-full}. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc#talm-prechache-user-specified-images-concept_ztp-talm[Precaching user-specified images with {cgu-operator} on {sno} clusters].
 
 [id="ocp-4-14-ztp-siteconfig-disk-cleaning"]
-==== Disk cleaning option through SiteConfig and GitOps ZTP
+==== Disk cleaning option through SiteConfig and {ztp}
 
 With this release, you can remove the partitioning table before installation by using the `automatedCleaningMode` field in the `SiteConfig` CR. For more information, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and GitOps ZTP].
 
 [id="ocp-4-14-ztp-support-custom-node-labels"]
-==== Support for adding custom node labels in the SiteConfig CR through GitOps ZTP
+==== Support for adding custom node labels in the SiteConfig CR through {ztp}
 
-With this update, you can add the `nodeLabels` field in the `SiteConfig` CR to create custom roles for nodes in managed clusters. For more information about how to add custom labels, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and GitOps ZTP] or xref:../scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc#ztp-generating-install-and-config-crs-manually_ztp-manual-install[Generating GitOps ZTP installation and configuration CRs manually].
+With this update, you can add the `nodeLabels` field in the `SiteConfig` CR to create custom roles for nodes in managed clusters. For more information about how to add custom labels, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and {ztp}] or xref:../scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc#ztp-generating-install-and-config-crs-manually_ztp-manual-install[Generating {ztp} installation and configuration CRs manually].
 
 [id="ocp-4-14-hcp"]
 === Hosted control planes (Technology Preview)
@@ -989,7 +1002,7 @@ As of {product-title} 4.14, `DeploymentConfig` objects are deprecated. `Deployme
 Instead, use `Deployment` objects or another alternative to provide declarative updates for pods.
 
 [id="ocp-4-14-ztp-talm-defaultcatsrc-update"]
-==== Operator-specific CatalogSource CRs used in {gitops-shortname} ZTP are deprecated
+==== Operator-specific CatalogSource CRs used in {ztp} are deprecated
 
 From {product-title} {product-version}, you must only use the `DefaultCatSrc.yaml` `CatalogSource` CR when updating Operators with {cgu-operator-first}. All other `CatalogSource` CRs are deprecated and are planned to be removed in a future release. Red{nbsp}Hat will provide bug fixes and support for this feature during the current release lifecycle, but this feature will no longer receive enhancements and will be removed. For more information about `DefaultCatSrc` CR, see xref:../scalability_and_performance/ztp_far_edge/ztp-talm-updating-managed-policies.adoc#talo-operator-update_ztp-talm[Performing an Operator update].
 


### PR DESCRIPTION
Final new feature release notes updates for telco RAN 4.14.

Version(s):
enterprise-4.14

Issue:
https://issues.redhat.com/browse/TELCODOCS-1300

Link to docs preview:
https://66260--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-custom-crs-with-pgt-ztp

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
