### PR TITLE
Updated GitOps RN 1.10.0 with a missed deprecated issue.

### DIFF
--- a/modules/gitops-release-notes-1-10-0.adoc
+++ b/modules/gitops-release-notes-1-10-0.adoc
@@ -102,6 +102,8 @@ As an alternative to `.spec.resourceCustomizations`, you can use `.spec.resource
 To prevent data loss during upgrade to {gitops-title} Operator v1.10.0, ensure that you backup `.spec.resourceCustomization` value if it is used in your Argo CD CRs.
 ==== 
 
+* With this update, the deprecated legacy Configuration Management Plugins (CMPs) feature, specified in the `argocd-cm` config map or the Operator through the `.spec.configManagementPlugins` field in Argo CD CR, has been removed in Argo CD v2.8. To continue using your legacy plugins, consider migrating them to the new sidecar available in the Operator through the `.spec.repo.sidecarContainers` field in Argo CD CR. link:https://issues.redhat.com/browse/GITOPS-3462[GITOPS-3462]
+
 
 [id="fixed-issues-1-10-0_{context}"]
 == Fixed issues


### PR DESCRIPTION
**This  PR addreses a customer issue missed during the release of GitOps 1.10.0**

- Aligned team: DevTools
- GitOps version: V1.10.0

- JIRA issue: [RHDEVDOCS-5664](https://issues.redhat.com/browse/RHDEVDOCS-5664)
- Preview pages: [GitOps 1.10.0 RNs](https://66270--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes.html#deprecated-features-1-10-0_gitops-release-notes)
- SME review: @reginapizza , @svghadi 
- QE review: @trdoyle81
- Peer review: @ekristova , @Srivaralakshmi @stevsmit 