### PR TITLE
OBSDOCS-579: fix-incorrect-TP-prereq-for-custom-alert-creation

### DIFF
--- a/modules/monitoring-creating-new-alerting-rules.adoc
+++ b/modules/monitoring-creating-new-alerting-rules.adoc
@@ -18,8 +18,6 @@ If you create a customized `AlertingRule` resource based on an existing platform
 
 * You have access to the cluster as a user that has the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
-* You have enabled Technology Preview features, and all nodes in the cluster are ready.
-
 
 .Procedure
 

--- a/modules/monitoring-modifying-core-platform-alerting-rules.adoc
+++ b/modules/monitoring-modifying-core-platform-alerting-rules.adoc
@@ -13,8 +13,6 @@ For example, you can change the severity label of an alert, add a custom label, 
 
 * You have access to the cluster as a user with the `cluster-admin` cluster role.
 * You have installed the OpenShift CLI (`oc`).
-* You have enabled Technology Preview features, and all nodes in the cluster are ready.
-
 
 .Procedure
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OBSDOCS-579
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Links to docs preview:
- https://66271--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts#creating-new-alerting-rules_managing-alerts
- https://66271--docspreview.netlify.app/openshift-enterprise/latest/monitoring/managing-alerts#modifying-core-platform-alerting-rules_managing-alerts
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @juzhao 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Removes incorrect TP prerequisite for creating and modifying custom alerts and alerting rules for OCP 4.14. The feature is GA in 4.14 and no longer TP.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
