### PR TITLE
OBSDOCS-577: Docs bug fix for an incorrect API

### DIFF
--- a/modules/distr-tracing-tempo-config-default.adoc
+++ b/modules/distr-tracing-tempo-config-default.adoc
@@ -37,8 +37,8 @@ spec:
 
 |`apiVersion:`
 |API version to use when creating the object.
-|`tempotracing.io/v1`
-|`tempotracing.io/v1`
+|`tempo.grafana.com/v1alpha1`
+|`tempo.grafana.com/v1alpha1`
 
 |`kind:`
 |Defines the kind of Kubernetes object to create.

--- a/modules/distr-tracing-tempo-config-query-frontend.adoc
+++ b/modules/distr-tracing-tempo-config-query-frontend.adoc
@@ -53,7 +53,7 @@ Query is a service that retrieves traces from storage and hosts the user interfa
 .Sample Query configuration
 [source,yaml]
 ----
-apiVersion: tempotracing.io/v1
+apiVersion: tempo.grafana.com/v1alpha1
 kind: "Tempo"
 metadata:
   name: "my-tempo"


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
OpenShift 4.11, 4.12, 4.13, 4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OBSDOCS-577

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
Three instances of `tempotracing.io/v1` in the text have been replaced by `tempo.grafana.com/v1alpha1` in https://66272--docspreview.netlify.app/openshift-enterprise/latest/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring#customizing-your-tempo-deployment

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
