### PR TITLE
OCPBUGS-21644: Replaced nyc-1a with nyc-1 AWS LZ

### DIFF
--- a/modules/installation-aws-add-local-zone-locations.adoc
+++ b/modules/installation-aws-add-local-zone-locations.adoc
@@ -23,29 +23,29 @@ $ export CLUSTER_REGION="<region_name>" <1>
 ----
 <1> For `<region_name>`, specify a valid AWS region name, such as `us-east-1`.
 
-. Review the list of zones that your region contains by running the following command:
+. List the zones that are available in your region by running the following command:
 +
 [source,terminal]
 ----
-$ aws ec2 describe-availability-zones \
-    --filters Name=region-name,Values=${CLUSTER_REGION} \
-    --query 'AvailabilityZones[].ZoneName' \
+$ aws --region ${CLUSTER_REGION} ec2 describe-availability-zones \
+    --query 'AvailabilityZones[].[{ZoneName: ZoneName, GroupName: GroupName, Status: OptInStatus}]' \
+    --filters Name=zone-type,Values=local-zone \
     --all-availability-zones
 ----
 +
-Depending on the region, the list of available zones can be long. The different zones use the following naming conventions:
+Depending on the region, the list of available zones can be long. The command will return the following fields:
 +
-`${REGION}[a-z]`:: Availability zones available in the region.
-`${REGION}-LID-N[a-z]`:: Available AWS Local Zones. `${REGION}LID-N` is the zone group identifier, and `[a-z]` is the zone identifier.
-`${REGION}-wl1-LID-wlz-[1-9]`:: Available Wavelength zones.
+`ZoneName`:: The name of the Local Zone.
+`GroupName`:: The group that the zone is part of. You need to save this name to opt in.
+`Status`:: The status of the Local Zone group. If the status is `not-opted-in`, you must opt in the `GroupName` by running the commands that follow.
 
 . Export a variable to contain the name of the Local Zone to host your VPC by running the following command:
 +
 [source,terminal]
 ----
-$ export ZONE_GROUP_NAME="${CLUSTER_REGION}-<location_identifier>-<zone_identifier>" <1>
+$ export ZONE_GROUP_NAME="<value_of_GroupName>" <1>
 ----
-<1> For `<location_identifier>-<zone_identifier>`, specify the location identifier and zone identifier for the Local Zone that you selected for your region. For example, specify `nyc-1a` to use the US East (New York) Local Zone.
+<1> The `<value_of_GroupName>` specifies the name of the group of the Local Zone you want to create subnets on. For example, specify `us-east-1-nyc-1` to use the zone `us-east-1-nyc-1a`, US East (New York).
 
 . Opt in to the zone group on your AWS account by running the following command:
 +


### PR DESCRIPTION
[OCPBUGS-21644](https://issues.redhat.com/browse/OCPBUGS-21644)

Version(s):
4.12

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
[Opting into AWS Local Zones](https://66278--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-localzone#installation-aws-add-local-zone-locations_installing-aws-localzone)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
