### PR TITLE
Adds a batch of networking doc text

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1120,6 +1120,24 @@ Targeting {product-title} 4.15, the OpenShift SDN CNI network plugin will not be
 [id="ocp-4-14-networking-bug-fixes"]
 ==== Networking
 
+* Previously, when a client mutual TLS (mTLS) was configured on an ingress controller, and the certificate authority (CA) certificates in the CA bundle required more than 1 MB of certificate revocation lists (CRL) to be downloaded, the CRL config map could not be updated due to size limitations. Because of the missing CRLs, connections with valid client certificates might have been rejected with the following error: `unknown ca`. 
++
+With this update, CRLs are no longer placed in a config map, and the router now directly downloads CRLs. As a result, the CRL config map for each ingress controller no longer exists. CRLs are now downloaded directly and connections with valid client certificates are no longer rejected. (link:https://issues.redhat.com/browse/OCPBUGS-6661[*OCPBUGS-6661*])
+
+* Previously, a non-compliant upstream DNS server that provided a UDP response larger than {product-title}'s specified buffer size of 512 bytes caused CoreDNS to throw an overflow error. Consequently, it would not provide a response to a DNS query. 
++
+With this update, users can now configure the `protocolStrategy` field on the `dnses.operator.openshift.io` custom resource (CR) to be `TCP`. With this field set to  `TCP`, CoreDNS uses the TCP protocol for upstream requests and works around UDP overflow issues with non-compliant upstream DNS servers. (link:https://issues.redhat.com/browse/OCPBUGS-6829[*OCPBUGS-6829*])
+
+* Previously, if cluster administrators configured an infra node using a taint with the `NoExecute` effect, the Ingress Operator's canary pods would not be scheduled on these infra nodes. After some time, the DaemonSet configuration would get overridden, and the pods would be terminated on the infra nodes. 
++
+With this release, the Ingress Operator now configures the canary DaemonSet to tolerate a `node-role.kubernetes.io/infra` node taint that specifies the `NoExecute` effect. As a result, canary pods are scheduled on infra nodes regardless of what effect has been specified. (link:https://issues.redhat.com/browse/OCPBUGS-9274[*OCPBUGS-9274*])
+
+* Previously, when a client mutual TLS (mTLS) was configured on an ingress controller, if any of the client certificate authority (CA) certificates included a certificate revocation list (CRL) distribution point for a CRL issued by a different CA and that CRL expired, the mismatch between the distributing CA and the issuing CA caused the incorrect CRL to be downloaded. Consequently, the CRL bundle would be updated to contain an extra copy of the erroneously downloaded CRL, and the CRL that needed to be updated would be missing. Because of the missing CRL, connections with valid client certificates might have been rejected with the following error: `unknown ca`. 
++
+With this update, downloaded CRLs are now tracked by the CA that distributes them. When a CRL expires, the distributing CA's CRL distribution point is used to download an updated CRL. As a result, valid client certificates are no longer rejected. (link:https://issues.redhat.com/browse/OCPBUGS-9464[*OCPBUGS-9464*])
+
+
+
 [discrete]
 [id="ocp-4-14-node-bug-fixes"]
 ==== Node


### PR DESCRIPTION
Version(s):
4.14

Issue:
No issue. Release note bug doc text.

Link to docs preview:
https://66282--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-bug-fixes

QE not needed.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
