### PR TITLE
OSDOCS#8094: Release notes for user-defined tags in GCP (TP)

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -77,6 +77,11 @@ Because {product-title} {product-version} now uses a {op-system-base} 9.2 based 
 
 User-defined tags for Microsoft Azure was previously introduced as Technology Preview in {product-title} 4.13 and is now generally available in {product-title} 4.14. For more information, see xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-user-defined-tags_installing-azure-customizations[Configuring the user-defined tags for Azure].
 
+[id="ocp-4-14-user-defined-tags-gcp"]
+==== User-defined labels and tags for Google Cloud Platform (Technology Preview)
+
+You can now configure user-defined labels and tags in Google Cloud Platform (GCP) for grouping resources and for managing resource access and cost. User-defined labels can be applied only to resources created by {product-title} installation program and its core components. User-defined tags can be applied only to resources created by the {product-title} Image Registry Operator. For more information, see xref:../installing/installing_gcp/installing-gcp-customizations.adoc#installing-gcp-user-defined-labels-and-tags_installing-gcp-customizations[Managing the user-defined labels and tags for GCP].
+
 [id="ocp-4-14-aws-security-groups"]
 ==== Applying existing AWS security groups to a cluster
 


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OSDOCS-8094

Link to docs preview: https://66290--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-user-defined-tags-gcp

QE review:
- [x] QE has approved this change. @jianli-wei 
