### PR TITLE
Adds known issue for early access users when upgrading

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1819,6 +1819,14 @@ As a workaround, if you have an installation configuration file, update it with 
 
 * When you deploy a cluster with a Network Type of `OVNKubernetes` on {ibmpowerProductName}, compute nodes may reboot because of a kernel stack overflow. As a workaround, you can deploy the cluster with a Network Type of `OpenShiftSDN`. (link:https://issues.redhat.com/browse/RHEL-3901[*RHEL-3901*])
 
+* The following known issue applies to users who updated their {product-title} deployment to an early access version of {product-version} using release candidate 3 or 4: 
++
+After the introduction of the node identify feature, some pods that were running as root are updated to run unprivileged. For users who updated to an early access version of {product-title} {product-version}, attempting to upgrade to the official version of {product-version} might not progress. In this scenario, the Network Operator reports the following state, indicating an issue with the update: `DaemonSet "/openshift-network-node-identity/network-node-identity" update is rolling`. 
++ 
+As a workaround, you can delete all pods in the `openshift-network-node-identify` namespace by running the following command: `oc delete --force=true -n openshift-network-node-identity --all pods`. After running this command, the update continues.
++
+For more information about early access, xref:../updating/understanding_updates/understanding-update-channels-release.adoc#candidate-version-channel_understanding-update-channels-releases[candidate-4.14 channel]. 
+
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8145

Link to docs preview:
https://66294--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-known-issues

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
