### PR TITLE
OSDOCS-8026: Network Observability Z-Stream Release Notes - 1.4.1

### DIFF
--- a/networking/network_observability/network-observability-operator-release-notes.adoc
+++ b/networking/network_observability/network-observability-operator-release-notes.adoc
@@ -12,6 +12,28 @@ The Network Observability Operator enables administrators to observe and analyze
 These release notes track the development of the Network Observability Operator in the {product-title}.
 
 For an overview of the Network Observability Operator, see xref:../../networking/network_observability/network-observability-overview.adoc#dependency-network-observability[About Network Observability Operator].
+[id="network-observability-operator-release-notes-1-4-1"]
+== Network Observability Operator 1.4.1
+The following advisory is available for the Network Observability Operator 1.4.1:
+
+* link:https://access.redhat.com/errata/RHSA-2023:5974[2023:5974 Network Observability Operator 1.4.1]
+
+=== CVEs
+* link:https://access.redhat.com/security/cve/cve-2023-44487[2023-44487]
+* link:https://access.redhat.com/security/cve/cve-2023-39325[2023-39325]
+* link:https://access.redhat.com/security/cve/cve-2023-29406[2023-29406]
+* link:https://access.redhat.com/security/cve/CVE-2023-29409[2023-29409]
+* link:https://access.redhat.com/security/cve/cve-2023-39322[2023-39322]
+* link:https://access.redhat.com/security/cve/cve-2023-39318[2023-39318]
+* link:https://access.redhat.com/security/cve/cve-2023-39319[2023-39319]
+* link:https://access.redhat.com/security/cve/cve-2023-39321[2023-39321]
+
+=== Bug fixes
+
+* In 1.4, there was a known issue when sending network flow data to Kafka. The Kafka message key was ignored, causing an error with connection tracking. Now the key is used for partitioning, so each flow from the same connection is sent to the same processor. (link:https://issues.redhat.com/browse/NETOBSERV-926[*NETOBSERV-926*])
+
+* In 1.4, the `Inner` flow direction was introduced to account for flows between pods running on the same node. Flows with the `Inner` direction were not taken into account in the generated Prometheus metrics derived from flows, resulting in under-evaluated bytes and packets rates.
+Now, derived metrics are including flows with the `Inner` direction, providing correct bytes and packets rates. (link:https://issues.redhat.com/browse/NETOBSERV-1344[*NETOBSERV-1344*])
 
 [id="network-observability-operator-release-notes-1-4"]
 == Network Observability Operator 1.4.0


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8206
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://66302--docspreview.netlify.app/openshift-enterprise/latest/networking/network_observability/network-observability-operator-release-notes
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
