### PR TITLE
OSDOCS-8220: Added a new requirement to Terraform

### DIFF
--- a/rosa_planning/rosa-understanding-terraform.adoc
+++ b/rosa_planning/rosa-understanding-terraform.adoc
@@ -19,6 +19,7 @@ include::modules/rosa-sts-terraform-prerequisites.adoc[leveloffset=+1]
 [id="additional-resources_rosa-terraform-prereq"]
 .Additional resources
 
+* See xref:../rosa_planning/rosa-cloud-expert-prereq-checklist.adoc#rosa-cloud-expert-prereq-checklist[Prerequisites checklist for deploying ROSA using STS] for a list of requirements that must be met before you can create ROSA clusters by using STS.
 * See xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc[About IAM resources for ROSA clusters that use STS] for information about the AWS account roles.
 * See xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc[Getting started with the ROSA CLI] for information about installing the ROSA CLI.
 * See Hashicorp's link:https://developer.hashicorp.com/terraform[Terraform documentation] for a comprehensive guide to Terraform.


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-8220](https://issues.redhat.com/browse/OSDOCS-8220)

Link to docs preview:
* [Preparing Terraform to install ROSA clusters](https://file.rdu.redhat.com/eponvell/OSDOCS-8220_Terraform-Prereqs/rosa_planning/rosa-understanding-terraform.html)
   ![image](https://github.com/openshift/openshift-docs/assets/16167833/c5e7d530-bc49-4dd2-aef0-f05c37827a11)



QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Added a new link to the Terraform overview that links to the AWS checklist.