### PR TITLE
Adding a manual TP note

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -990,9 +990,6 @@ By default, if you specify availability zones in the `install-config.yaml` file,
 within link:https://azure.microsoft.com/en-us/global-infrastructure/regions[a region]. To ensure high availability for your cluster, select a region with at least three availability zones. If your region contains fewer than three availability zones, the installation program places more than one control plane machine in the available zones.
 ====
 
-//setting for 4.14 NatGateway Tech Preview snippet
-:featureName: `NatGateway`
-
 .Additional Azure parameters
 [cols=".^2,.^3a,.^3a",options="header"]
 |====
@@ -1124,7 +1121,16 @@ you are using user-defined routing, you must have pre-existing networking
 available where the outbound routing has already been configured prior to
 installing a cluster. The installation program is not responsible for
 configuring user-defined routing. If you specify the `NatGateway` routing strategy, the installation program will only create one NAT gateway. If you specify the `NatGateway` routing strategy, your account must have the `Microsoft.Network/natGateways/read` and `Microsoft.Network/natGateways/write` permissions.
-include::snippets/technology-preview.adoc[]
+
+[IMPORTANT]
+====
+[subs="attributes+"]
+`NatGateway` is a Technology Preview feature only. Technology Preview features are not supported with Red Hat production service level agreements (SLAs) and might not be functionally complete. Red Hat does not recommend using them in production. These features provide early access to upcoming product features, enabling customers to test functionality and provide feedback during the development process.
+
+For more information about the support scope of Red Hat Technology Preview features, see link:https://access.redhat.com/support/offerings/techpreview/[Technology Preview Features Support Scope].
+====
+//You can't put a snippet within a conditional.
+
 |`LoadBalancer`, `UserDefinedRouting`, or `NatGateway`. The default is `LoadBalancer`.
 
 |`platform.azure.region`


### PR DESCRIPTION
4.14+

https://github.com/openshift/openshift-docs/pull/63181 introduced a TP snippet within a conditional that should have failed the build. This PR replaces the snippet include with a manual note.