### PR TITLE
OSDOCS 8020 fix an ID was was causing build failure while testing the new scripts

### DIFF
--- a/operators/operator_sdk/osdk-multi-arch-support.adoc
+++ b/operators/operator_sdk/osdk-multi-arch-support.adoc
@@ -35,7 +35,7 @@ include::modules/osdk-multi-arch-node-preference.adoc[leveloffset=+2]
 .Additional resources
 * xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-configuring-preferred_nodes-scheduler-node-affinity[Configuring a preferred node affinity rule]
 
-[id="next-steps_osdk-multi-arch-support.adoc"]
+[id="next-steps_osdk-multi-arch-support"]
 == Next steps
 
 * xref:../../operators/operator_sdk/osdk-generating-csvs.adoc#olm-enabling-operator-for-multi-arch_osdk-generating-csvs[Label the platforms your Operator supports for Operator Lifecycle Manager (OLM)]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
enterprise-4.14

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
OSDOCS 8020

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://66319--docspreview.netlify.app/openshift-enterprise/latest/operators/operator_sdk/osdk-multi-arch-support#next-steps_osdk-multi-arch-support

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

This PR removes an ".adoc" extension from an ID. IDs with file-like extensions cause errors in ccutil (Portal) builds. No documentation content is changed.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
