### PR TITLE
OSDOCS 8020 remove build.py from CI, replacing with build_for_portal.py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,15 +23,15 @@ jobs:
         - |
           ./scripts/get-updated-distros.sh |
             while read -r filename; do
-              if [ "$filename" == "_topic_maps/_topic_map.yml" ]; then python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.14 --no-upstream-fetch
+              if [ "$filename" == "_topic_maps/_topic_map.yml" ]; then python3 build_for_portal.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.14 --no-upstream-fetch
 
-              elif [ "$filename" == "_topic_maps/_topic_map_osd.yml" ]; then python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch
+              elif [ "$filename" == "_topic_maps/_topic_map_osd.yml" ]; then python3 build_for_portal.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch
 
-              elif [ "$filename" == "_topic_maps/_topic_map_ms.yml" ]; then python3 build.py --distro microshift --product "Microshift" --version 4 --no-upstream-fetch
+              elif [ "$filename" == "_topic_maps/_topic_map_ms.yml" ]; then python3 build_for_portal.py --distro microshift --product "Microshift" --version 4 --no-upstream-fetch
 
-              elif [ "$filename" == "_topic_maps/_topic_map_rosa.yml" ]; then python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch
+              elif [ "$filename" == "_topic_maps/_topic_map_rosa.yml" ]; then python3 build_for_portal.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch
 
-              elif [ "$filename" == "_distro_map.yml" ]; then python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.14 --no-upstream-fetch
+              elif [ "$filename" == "_distro_map.yml" ]; then python3 build_for_portal.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.14 --no-upstream-fetch
               fi
             done
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cherry-pick to enterprise-4.14 ONLY at this stage, for integration testing

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
OSDOCS 8020

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This PR alters the Travis CI to use build_for_portal.py, the script for converting sources for the Portal, instead of build.py, a "trimmed-down" version of the script which is now terminally outdated. No documentation content is altered.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
