### PR TITLE
OSDOCS#8034: additional custom security groups at ROSA cluster creation time

### DIFF
--- a/cli_reference/rosa_cli/rosa-manage-objects-cli.adoc
+++ b/cli_reference/rosa_cli/rosa-manage-objects-cli.adoc
@@ -18,6 +18,7 @@ include::modules/rosa-create-objects.adoc[leveloffset=+1]
 * See xref:../../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-aws-instance-types_rosa-service-definition[AWS Instance types] for a list of supported instance types.
 * See xref:../../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-account-wide-roles-and-policies_rosa-sts-about-iam-resources[Account-wide IAM role and policy reference] for a list of IAM roles needed for cluster creation.
 * See xref:../../rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc#rosa-sts-understanding-aws-account-association_rosa-sts-creating-a-cluster-with-customizations[Understanding AWS account association] for more information about the OCM role and user role.
+* See xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Security groups] for information about security group requirements.
 
 include::modules/rosa-edit-objects.adoc[leveloffset=+1]
 include::modules/rosa-delete-objects.adoc[leveloffset=+1]

--- a/cloud_experts_tutorials/rosa-mobb-cli-quickstart.adoc
+++ b/cloud_experts_tutorials/rosa-mobb-cli-quickstart.adoc
@@ -211,12 +211,13 @@ ROSA can be installed using command line parameters or in interactive mode.  For
   ```
   Cluster name:
   Multiple availability zones (y/N):
-  AWS region (select):
-  OpenShift version (select):
+  AWS region: (select)
+  OpenShift version: (select)
   Install into an existing VPC (y/N):
-  Compute nodes instance type (optional):
+  Compute nodes instance type (optional): (select)
   Enable autoscaling (y/N):
   Compute nodes [2]:
+  Additional Security Group IDs (optional): (select)
   Machine CIDR [10.0.0.0/16]:
   Service CIDR [172.30.0.0/16]:
   Pod CIDR [10.128.0.0/14]:

--- a/modules/creating-a-machine-pool-cli.adoc
+++ b/modules/creating-a-machine-pool-cli.adoc
@@ -31,6 +31,7 @@ $ rosa create machinepool --cluster=<cluster-name> \
 ifdef::openshift-rosa[]
                           --disk-size=<disk_size> <8>
                           --availability-zone=<az> <9>
+                          --additional-security-group-ids <sec_group_id> <10>
 
 endif::openshift-rosa[]
 ----
@@ -44,6 +45,7 @@ endif::openshift-rosa[]
 ifdef::openshift-rosa[]
 <8> Optional: Specifies the worker node disk size. The value can be in GB, GiB, TB, or TiB. Replace `<disk_size>` with a numeric value and unit, for example `--disk-size=200GiB`.
 <9> Optional: For Multi-AZ clusters, you can create a machine pool in a Single-AZ of your choice. Replace `<az>` with a Single-AZ.
+<10> Optional: For machine pools in clusters that do not have Red Hat managed VPCs, you can select additional custom security groups to use in your machine pools. You must have already created the security groups and associated them with the VPC you selected for this cluster. For more information, see the requirements for _Security groups_ in _Prepare your environment_.
 endif::openshift-rosa[]
 +
 [IMPORTANT]

--- a/modules/rosa-adding-node-labels.adoc
+++ b/modules/rosa-adding-node-labels.adoc
@@ -109,9 +109,9 @@ $ rosa list machinepools --cluster=<cluster_name>
 .Example output
 [source,terminal]
 ----
-ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS                  TAINTS    AVAILABILITY ZONES    SPOT INSTANCES
-Default      No           2         m5.xlarge                                        us-east-1a            N/A
-db-nodes-mp  No           2         m5.xlarge      app=db, tier=backend              us-east-1a            No
+ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS                  TAINTS    AVAILABILITY ZONES    SPOT INSTANCES   DISK SIZE   SG IDs
+Default      No           2         m5.xlarge                                        us-east-1a            N/A              300 GiB     sg-0e375ff0ec4a6cfa2
+db-nodes-mp  No           2         m5.xlarge      app=db, tier=backend              us-east-1a            No               300 GiB     sg-0e375ff0ec4a6cfa2
 ----
 
 . Verify that the labels are included for your machine pool in the output.

--- a/modules/rosa-adding-taints-cli.adoc
+++ b/modules/rosa-adding-taints-cli.adoc
@@ -40,9 +40,9 @@ $ rosa list machinepools --cluster=<cluster_name>
 +
 [source,terminal]
 ----
-ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONES    SPOT INSTANCES
-Default      No           2         m5.xlarge                          us-east-1a            N/A
-db-nodes-mp  No           2         m5.xlarge                          us-east-1a            No
+ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONES    SPOT INSTANCES     DISK SIZE   SG IDs
+Default      No           2         m5.xlarge                          us-east-1a            N/A                300 GiB     sg-0e375ff0ec4a6cfa2
+db-nodes-mp  No           2         m5.xlarge                          us-east-1a            No                 300 GiB     sg-0e375ff0ec4a6cfa2
 ----
 
 . Add or update the taints for a machine pool:
@@ -110,9 +110,9 @@ $ rosa list machinepools --cluster=<cluster_name>
 .Example output
 [source,terminal]
 ----
-ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS                                           AVAILABILITY ZONES    SPOT INSTANCES
-Default      No           2         m5.xlarge                                                                 us-east-1a            N/A
-db-nodes-mp  No           2         m5.xlarge                key1=value1:NoSchedule, key2=value2:NoExecute    us-east-1a            No
+ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS                                           AVAILABILITY ZONES    SPOT INSTANCES  DISK SIZE   SG IDs
+Default      No           2         m5.xlarge                                                                 us-east-1a            N/A             300GiB      sg-0e375ff0ec4a6cfa2
+db-nodes-mp  No           2         m5.xlarge                key1=value1:NoSchedule, key2=value2:NoExecute    us-east-1a            No              300GiB      sg-0e375ff0ec4a6cfa2
 ----
 
 . Verify that the taints are included for your machine pool in the output.

--- a/modules/rosa-adding-tuning.adoc
+++ b/modules/rosa-adding-tuning.adoc
@@ -34,9 +34,9 @@ $ rosa list machinepools --cluster=<cluster_name>
 +
 [source,terminal]
 ----
-ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONES    SUBNET  VERSION  AUTOREPAIR  TUNING CONFIGS  MESSAGE
-Default      No           2         m5.xlarge                          us-east-1a            N/A     4.12.14  Yes
-db-nodes-mp  No           2         m5.xlarge                          us-east-1a            No      4.12.14  Yes
+ID           AUTOSCALING  REPLICAS  INSTANCE TYPE  LABELS    TAINTS    AVAILABILITY ZONES    SUBNETS  VERSION  AUTOREPAIR  TUNING CONFIGS  MESSAGE
+Default      No           2         m5.xlarge                          us-east-1a            N/A      4.12.14  Yes
+db-nodes-mp  No           2         m5.xlarge                          us-east-1a            No       4.12.14  Yes         
 ----
 
 . You can add tuning configurations to an existing or new machine pool.

--- a/modules/rosa-aws-privatelink-create-cluster.adoc
+++ b/modules/rosa-aws-privatelink-create-cluster.adoc
@@ -2,7 +2,7 @@
 //
 // * rosa_install_access_delete_clusters/rosa-aws-privatelink-creating-cluster.adoc
 :_mod-docs-content-type: PROCEDURE
-[id="rosa-aws-privatelink-create-cluster.adoc_{context}"]
+[id="rosa-aws-privatelink-create-cluster_{context}"]
 = Creating an AWS PrivateLink cluster
 
 You can create an AWS PrivateLink cluster using the {product-title} (ROSA) CLI, `rosa`.
@@ -14,13 +14,15 @@ AWS PrivateLink is supported on existing VPCs only.
 
 .Prerequisites
 
-You have installed {product-title}.
+* You have available AWS service quotas.
+* You have enabled the ROSA service in the AWS Console.
+* You have installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your installation host.
 
 .Procedure
 
 Creating a cluster can take up to 40 minutes.
 
-. With AWS PrivateLink, you can create a cluster with a single availability zone (Single-AZ) or multiple availability zones (Multi-AZ). In either case, your machine's  classless inter-domain routing (CIDR) must match your virtual private cloud's CIDR. See https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc[Requirements for using your own VPC] and link:https://docs.openshift.com/container-platform/4.7/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-validation_installing-aws-vpc[VPC Validation] for more information.
+. With AWS PrivateLink, you can create a cluster with a single availability zone (Single-AZ) or multiple availability zones (Multi-AZ). In either case, your machine's classless inter-domain routing (CIDR) must match your virtual private cloud's CIDR. See https://docs.openshift.com/container-platform/4.13/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-requirements_installing-aws-vpc[Requirements for using your own VPC] and link:https://docs.openshift.com/container-platform/4.13/installing/installing_aws/installing-aws-vpc.html#installation-custom-aws-vpc-validation_installing-aws-vpc[VPC Validation] for more information.
 +
 [IMPORTANT]
 ====

--- a/modules/rosa-aws-provisioned.adoc
+++ b/modules/rosa-aws-provisioned.adoc
@@ -80,8 +80,7 @@ A *public subnet* connects directly to the internet through an internet gateway.
 
 * *NAT gateways*: One NAT Gateway per public subnet.
 
-=== Sample VPC Architecture
-
+.Sample VPC Architecture
 image::VPC-Diagram.png[VPC Reference Architecture]
 
 [id="rosa-security-groups_{context}"]
@@ -89,6 +88,7 @@ image::VPC-Diagram.png[VPC Reference Architecture]
 
 AWS security groups provide security at the protocol and port access level; they are associated with EC2 instances and Elastic Load Balancing (ELB) load balancers. Each security group contains a set of rules that filter traffic coming in and out of one or more EC2 instances. You must ensure the ports required for the OpenShift installation are open on your network and configured to allow access between hosts.
 
+.Required ports for default security groups
 [cols="2a,2a,2a,2a",options="header"]
 |===
 
@@ -131,3 +131,11 @@ AWS security groups provide security at the protocol and port access level; they
 |`19531`
 
 |===
+
+[id="rosa-security-groups-custom_{context}"]
+=== Additional custom security groups
+When you create a cluster using an existing non-managed VPC, you can add additional custom security groups during cluster creation. Custom security groups are subject to the following limitations:
+
+* You must create the custom security groups in AWS before you create the cluster. For more information, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-security-groups.html[Amazon EC2 security groups for Linux instances].
+* You must associate the custom security groups with the VPC that the cluster will be installed into. Your custom security groups cannot be associated with another VPC.
+* You might need to request additional quota for your VPC if you are adding additional custom security groups. For information on AWS quota requirements for ROSA, see _Required AWS service quotas_ in _Prepare your environment_. For information on requesting an AWS quota increase, see link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[Requesting a quota increase].

--- a/modules/rosa-create-objects.adoc
+++ b/modules/rosa-create-objects.adoc
@@ -116,14 +116,14 @@ $ rosa create cluster --cluster-name=<cluster_name> [arguments]
 |===
 |Option |Definition
 
+|--additional-compute-security-group-ids <sec_group_id>
+|The identifier of one or more additional security groups to use in addition to the default security groups. For more information on additional security groups, see the requirements for _Security groups_ in _Prepare your environment_.
+
 a|--cluster-name <cluster_name>
 |Required. The name of the cluster. When used with the `create cluster` command, this argument is used to set the cluster name and to generate a sub-domain for your cluster on `openshiftapps.com`. The value for this argument must be unique within your organization.
 
 |--compute-machine-type <instance_type>
 |The instance type for compute nodes in the cluster. This determines the amount of memory and vCPU that is allocated to each compute node. For more information on valid instance types, see _AWS Instance types_ in _ROSA service definition_.
-
-|--compute-nodes n
-|The number of worker nodes to provision per availability zone. Single-zone clusters require at least 2 nodes. Multi-zone clusters require at least 3 nodes. Default: `2` for single-zone clusters; `3` for multi-zone clusters.
 
 |--controlplane-iam-role <arn>
 |The ARN of the IAM role to attach to control plane instances.
@@ -179,6 +179,9 @@ OVN-Kubernetes, the default network provider in ROSA 4.11 and later, uses the `1
 
 |--region <region_name>
 |The name of the AWS region where your worker pool will be located, for example, `us-east-1`. This argument overrides the `AWS_REGION` environment variable.
+
+|--replicas n
+|The number of worker nodes to provision per availability zone. Single-zone clusters require at least 2 nodes. Multi-zone clusters require at least 3 nodes. Default: `2` for single-zone clusters; `3` for multi-zone clusters.
 
 |--role-arn <arn>
 |The ARN of the installer role that {cluster-manager} uses to create the cluster. This is required if you have not already created account roles.
@@ -499,6 +502,10 @@ $ rosa create machinepool --cluster=<cluster_name> | <cluster_id> --replicas=<nu
 [cols="30,70"]
 |===
 |Option |Definition
+
+// Note for writers: This command works the same way as rosa create --additional-compute-security-group-ids but all subsequent machinepools are compute only so we don't specify compute here yet; consistency across commands to come in OCM-3111.
+|--additional-security-group-ids <sec_group_id>
+|The identifier of one or more additional security groups to use in addition to the default security groups for this machine pool. For more information on additional security groups, see the requirements for _Security groups_ in _Prepare your environment_.
 
 a|--cluster <cluster_name>\|<cluster_id>
 |Required: The name or ID of the cluster to which the machine pool will be added.

--- a/modules/rosa-enabling-autoscaling-nodes.adoc
+++ b/modules/rosa-enabling-autoscaling-nodes.adoc
@@ -25,9 +25,9 @@ $ rosa list machinepools --cluster=<cluster_name>
 +
 [source,terminal]
 ----
-ID        AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS    TINTS   AVAILABILITY ZONES
-default   No            2           m5.xlarge                        us-east-1a
-mp1       No            2           m5.xlarge                        us-east-1a
+ID        AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS    TAINTS   AVAILABILITY ZONES    DISK SIZE   SG IDs
+default   No            2           m5.xlarge                         us-east-1a            300GiB      sg-0e375ff0ec4a6cfa2
+mp1       No            2           m5.xlarge                         us-east-1a            300GiB      sg-0e375ff0ec4a6cfa2
 ----
 +
 . Get the ID of the machine pools that you want to configure.

--- a/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
+++ b/modules/rosa-hcp-sts-creating-a-cluster-cli.adoc
@@ -13,13 +13,7 @@ When using the {product-title} (ROSA) CLI, `rosa`, to create a cluster, you can 
 * You have completed the AWS prerequisites for {hcp-title}.
 * You have available AWS service quotas.
 * You have enabled the ROSA service in the AWS Console.
-* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
-+
-[NOTE]
-====
-To successfully install ROSA clusters, use the latest version of the ROSA CLI (`rosa`). Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
-====
-
+* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host. Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
 * You have logged in to your Red Hat account by using the ROSA CLI.
 * You have created an OIDC configuration.
 * You have verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.

--- a/modules/rosa-required-aws-service-quotas.adoc
+++ b/modules/rosa-required-aws-service-quotas.adoc
@@ -6,7 +6,11 @@
 [id="rosa-required-aws-service-quotas_{context}"]
 = Required AWS service quotas
 
-The table below describes the AWS service quotas and levels required to create and run an {product-title} cluster.
+The table below describes the AWS service quotas and levels required to create and run one {product-title} cluster. Although most default values are suitable for most workloads, you might need to request additional quota for the following cases:
+
+* ROSA clusters require at least 100 vCPUs, but the default maximum value for vCPUs assigned to Running On-Demand Standard Amazon EC2 instances is `5`. Therefore if you have not created a ROSA cluster using the same AWS account previously, you must request additional EC2 quota for `Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances`.
+
+* Some optional cluster configuration features, such as custom security groups, might require you to request additional quota. For example, because ROSA associates 1 security group with network interfaces in worker machine pools by default, and the default quota for `Security groups per network interface` is `5`, if you want to add 5 custom security groups, you must request additional quota, because this would bring the total number of security groups on worker network interfaces to 6.
 
 [NOTE]
 ====
@@ -15,22 +19,17 @@ The AWS SDK allows ROSA to check quotas, but the AWS SDK calculation does not ac
 
 If you need to modify or increase a specific quota, see Amazon's documentation on link:https://docs.aws.amazon.com/servicequotas/latest/userguide/request-quota-increase.html[requesting a quota increase]. Large quota requests are submitted to Amazon Support for review, and take some time to be approved. If your quota request is urgent, contact AWS Support.
 
-[IMPORTANT]
-====
-For On-Demand Standard (A, C, D, H, I, M, R, T, Z) Amazon EC2 instances, creating a ROSA cluster requires 100 vCPUs or greater. To request for your quota to be increased, open the Service Quotas console within the AWS console.
-====
-
 
 .ROSA-required service quota
 
 [options="header"]
 |===
-|Quota name |Service code |Quota code| Default | Minimum required | Description
+|Quota name |Service code |Quota code| AWS default | Minimum required | Description
 
 |Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances
 |ec2
 |L-1216C47A
-|100
+|5
 |100
 | Maximum number of vCPUs assigned to the Running On-Demand Standard (A, C, D, H, I, M, R, T, Z) instances.
 
@@ -67,7 +66,7 @@ The default value of 5 vCPUs is not sufficient to create ROSA clusters. ROSA has
 
 [options="header"]
 |===
-|Quota name |Service code |Quota code| Default | Minimum required | Description
+|Quota name |Service code |Quota code| AWS default | Minimum required | Description
 
 |EC2-VPC Elastic IPs
 |ec2
@@ -97,6 +96,13 @@ The default value of 5 vCPUs is not sufficient to create ROSA clusters. ROSA has
 |5,000
 | The maximum number of network interfaces per Region.
 
+|Security groups per network interface
+|vpc
+|L-2AFB9258
+|5
+|5
+|The maximum number of security groups per network interface. This quota, multiplied by the quota for rules per security group, cannot exceed 1000.
+
 |Snapshots per Region
 |ebs
 |L-309BACF6
@@ -116,14 +122,14 @@ The default value of 5 vCPUs is not sufficient to create ROSA clusters. ROSA has
 |L-53DA6B97
 |50
 |50
-|
+|The maximum number of Application Load Balancers that can exist in each region.
 
 |Classic Load Balancers per Region
 |elasticloadbalancing
 |L-E9E9831D
 |20
 |20
-|
+|The maximum number of Classic Load Balancers that can exist in each region.
 |===
 
 [role="_additional-resources"]

--- a/modules/rosa-scaling-worker-nodes.adoc
+++ b/modules/rosa-scaling-worker-nodes.adoc
@@ -39,9 +39,9 @@ $ rosa list machinepools --cluster=<cluster_name>
 +
 [source,terminal]
 ----
-ID        AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS    TAINTS   AVAILABILITY ZONES
-default   No            2           m5.xlarge                        us-east-1a
-mp1       No            2           m5.xlarge                        us-east-1a
+ID        AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS    TAINTS   AVAILABILITY ZONES    DISK SIZE   SG IDs
+default   No            2           m5.xlarge                         us-east-1a            300GiB      sg-0e375ff0ec4a6cfa2
+mp1       No            2           m5.xlarge                         us-east-1a            300GiB      sg-0e375ff0ec4a6cfa2
 ----
 
 . Increase or decrease the number of compute node replicas in a machine pool:
@@ -67,9 +67,9 @@ $ rosa list machinepools --cluster=<cluster_name>
 .Example output
 [source,terminal]
 ----
-ID        AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS    TAINTS   AVAILABILITY ZONES
-default   No            2           m5.xlarge                        us-east-1a
-mp1       No            3           m5.xlarge                        us-east-1a
+ID        AUTOSCALING   REPLICAS    INSTANCE TYPE  LABELS    TAINTS   AVAILABILITY ZONES    DISK SIZE   SG IDs
+default   No            2           m5.xlarge                         us-east-1a            300GiB      sg-0e375ff0ec4a6cfa2
+mp1       No            3           m5.xlarge                         us-east-1a            300GiB      sg-0e375ff0ec4a6cfa2
 ----
 
 . In the output of the preceding command, verify that the compute node replica count is as expected for your machine pool. In the example output, the compute node replica count for the `mp1` machine pool is scaled to 3.

--- a/modules/rosa-sts-creating-a-cluster-quickly-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-quickly-cli.adoc
@@ -21,12 +21,7 @@ ifndef::quickstart[]
 * You have completed the AWS prerequisites for ROSA with STS.
 * You have available AWS service quotas.
 * You have enabled the ROSA service in the AWS Console.
-* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
-+
-[NOTE]
-====
-To successfully install ROSA clusters, use the latest version of the ROSA CLI.
-====
+* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host. Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
 * You have logged in to your Red Hat account by using the ROSA CLI.
 * You have verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.
 endif::[]

--- a/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-using-defaults-ocm.adoc
@@ -22,12 +22,7 @@ ifdef::quick-install[]
 * You have completed the AWS prerequisites for ROSA with STS.
 * You have available AWS service quotas.
 * You have enabled the ROSA service in the AWS Console.
-* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
-+
-[NOTE]
-====
-To successfully install ROSA clusters, use the latest version of the ROSA CLI.
-====
+* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host. Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
 * You have verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.
 * You have associated your AWS account with your Red Hat organization. When you associated your account, you applied the administrative permissions to the {cluster-manager} role. For detailed steps, see _Associating your AWS account with your Red Hat organization_.
 * You have created the required account-wide STS roles and policies. For detailed steps, see _Creating the account-wide STS roles and policies_.

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -22,12 +22,7 @@ Only public and AWS PrivateLink clusters are supported with STS. Regular private
 * You have completed the AWS prerequisites for ROSA with STS.
 * You have available AWS service quotas.
 * You have enabled the ROSA service in the AWS Console.
-* You have installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your installation host.
-+
-[NOTE]
-====
-To successfully install ROSA clusters, use latest version of the ROSA CLI.
-====
+* You have installed and configured the latest ROSA CLI, `rosa`, on your installation host. Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
 * If you want to use a customer managed AWS Key Management Service (KMS) key for encryption, you must create a symmetric KMS key. You must provide the Amazon Resource Name (ARN) when creating your cluster. To create a customer managed KMS key, follow the procedure for link:https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html#create-symmetric-cmk[Creating symmetric encryption KMS keys].
 +
 [IMPORTANT]
@@ -203,7 +198,7 @@ You can reference the ARN of your KMS key when you create the cluster in the nex
 +
 [IMPORTANT]
 ====
-To avoid cluster failure issues, do not install a ROSA cluster in an existing VPC created by the previous cluster's ROSA installer. If the cluster that created the VPC during the installation is deleted, the associated installer-created VPC also gets deleted, resulting in the failure of all the clusters installed in the same VPC.
+You cannot install a ROSA cluster into an existing managed VPC. Managed VPCs are created during the managed cluster deployment process, and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly. To determine whether a VPC is managed, look for the `red-hat-managed` tag; managed VPCs are tagged with `red-hat-managed:true`.
 ====
 +
 [source,terminal]
@@ -235,21 +230,24 @@ I: Using arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role for th
 ? Multiple availability zones (optional): No <7>
 ? AWS region: us-east-1
 ? PrivateLink cluster (optional): No
-? Install into an existing VPC (optional): No
+? Install into an existing VPC (optional): Yes <8>
 ? Select availability zones (optional): No
-? Enable Customer Managed key (optional): No <8>
+? Enable Customer Managed key (optional): No <9>
 ? Compute nodes instance type (optional):
 ? Enable autoscaling (optional): No
 ? Compute nodes: 2
+? Additional Security Group IDs (optional): <10>
+? > [*]  sg-0e375ff0ec4a6cfa2 ('sg-1')
+? > [ ]  sg-0e525ef0ec4b2ada7 ('sg-2')
 ? Machine CIDR: 10.0.0.0/16
 ? Service CIDR: 172.30.0.0/16
 ? Pod CIDR: 10.128.0.0/14
 ? Host prefix: 23
-? Encrypt etcd data (optional): No <9>
+? Encrypt etcd data (optional): No <11>
 ? Disable Workload monitoring (optional): No
 I: Creating cluster '<cluster_name>'
 I: To create this cluster again in the future, you can run:
-   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.8.9 --compute-nodes 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <10>
+   rosa create cluster --cluster-name <cluster_name> --role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Installer-Role --support-role-arn arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Support-Role --master-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-ControlPlane-Role --worker-iam-role arn:aws:iam::<aws_account_id>:role/ManagedOpenShift-Worker-Role --operator-roles-prefix <cluster_name>-<random_string> --region us-east-1 --version 4.8.9 --additional-compute-security-group-ids sg-0e375ff0ec4a6cfa2 --replicas 2 --machine-cidr 10.0.0.0/16 --service-cidr 172.30.0.0/16 --pod-cidr 10.128.0.0/14 --host-prefix 23 <12>
 I: To view a list of clusters and their status, run 'rosa list clusters'
 I: Cluster '<cluster_name>' has been created.
 I: Once the cluster is installed you will need to add an Identity Provider before you can login into the cluster. See 'rosa create idp --help' for more information.
@@ -280,7 +278,13 @@ Tags that are added by Red Hat are required for clusters to stay in compliance w
 {product-title} does not support adding additional tags outside of ROSA cluster-managed resources. These tags can be lost when AWS resources are managed by the ROSA cluster. In these cases, you might need custom solutions or tools to reconcile the tags and keep them intact.
 ====
 <7> Optional: Multiple availability zones are recommended for production workloads. The default is a single availability zone.
-<8> Optional: Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN in the preceding step.
+<8> Optional: You can create a cluster in an existing VPC, or ROSA can create a new VPC to use.
++
+[IMPORTANT]
+====
+You cannot install a ROSA cluster into an existing managed VPC. Managed VPCs are created during the managed cluster deployment process, and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly. To determine whether a VPC is managed, look for the `red-hat-managed` tag; managed VPCs are tagged with `red-hat-managed:true`.
+====
+<9> Optional: Enable this option if you are using your own AWS KMS key to encrypt the control plane, infrastructure, worker node root volumes, and PVs. Specify the ARN for the KMS key that you added to the account-wide role ARN in the preceding step.
 +
 [IMPORTANT]
 ====
@@ -289,14 +293,15 @@ Only persistent volumes (PVs) created from the default storage class are encrypt
 PVs created by using any other storage class are still encrypted, but the PVs are not encrypted with this key unless the storage class is specifically configured to use this key.
 ====
 
-<9> Optional: Only enable this option if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted but not the keys.
+<10> Optional: You can select additional custom security groups to use in your cluster. You must have already created the security groups and associated them with the VPC you selected for this cluster. For more information, see the requirements for _Security groups_ in _Prepare your environment_.
+<11> Optional: Enable this option only if your use case requires etcd key value encryption in addition to the control plane storage encryption that encrypts the etcd volumes by default. With this option, the etcd key values are encrypted but not the keys.
 +
 [IMPORTANT]
 ====
 By enabling etcd encryption for the key values in etcd, you will incur a performance overhead of approximately 20%. The overhead is a result of introducing this second layer of encryption, in addition to the default control plane storage encryption that encrypts the etcd volumes. Red Hat recommends that you enable etcd encryption only if you specifically require it for your use case.
 ====
 +
-<10> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
+<12> The output includes a custom command that you can run to create a cluster with the same configuration in the future.
 --
 +
 As an alternative to using the `--interactive` mode, you can specify the customization options directly when you run the `rosa create cluster` command. Run the `rosa create cluster --help` command to view a list of available CLI options, or see _create cluster_ in _Managing objects with the ROSA CLI_.

--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -18,12 +18,7 @@ Only public and AWS PrivateLink clusters are supported with STS. Regular private
 * You have completed the AWS prerequisites for ROSA with STS.
 * You have available AWS service quotas.
 * You have enabled the ROSA service in the AWS Console.
-* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
-+
-[NOTE]
-====
-To successfully install ROSA clusters, use the latest version of the ROSA CLI.
-====
+* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host. Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
 * You have verified that the AWS Elastic Load Balancing (ELB) service role exists in your AWS account.
 * If you are configuring a cluster-wide proxy, you have verified that the proxy is accessible from the VPC that the cluster is being installed into. The proxy must also be accessible from the private subnets of the VPC.
 
@@ -288,7 +283,7 @@ If you are using private API endpoints, you cannot access your cluster until you
 +
 [IMPORTANT]
 ====
-To avoid cluster failure issues, do not install a ROSA cluster in an existing VPC created by the previous cluster's ROSA installer. If the cluster that created the VPC during the installation is deleted, the associated installer-created VPC also gets deleted, resulting in the failure of all the clusters installed in the same VPC.
+You cannot install a ROSA cluster into an existing managed VPC. Managed VPCs are created during the managed cluster deployment process, and must only be associated with a single cluster to ensure that cluster provisioning and deletion operations work correctly. To determine whether a VPC is managed, look for the `red-hat-managed` tag; managed VPCs are tagged with `red-hat-managed:true`.
 ====
 +
 [NOTE]

--- a/modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc
+++ b/modules/rosa-sts-creating-account-wide-sts-roles-and-policies.adoc
@@ -22,12 +22,7 @@ ifdef::quick-install[]
 * You have completed the AWS prerequisites for ROSA with STS.
 * You have available AWS service quotas.
 * You have enabled the ROSA service in the AWS Console.
-* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host.
-+
-[NOTE]
-====
-To successfully install ROSA clusters, use the latest version of the ROSA CLI.
-====
+* You have installed and configured the latest ROSA CLI (`rosa`) on your installation host. Run `rosa version` to see your currently installed version of the ROSA CLI. If a newer version is available, the CLI provides a link to download this upgrade.
 * You have logged in to your Red Hat account by using the ROSA CLI.
 endif::[]
 

--- a/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
+++ b/modules/rosa-sts-interactive-cluster-creation-mode-options.adoc
@@ -93,6 +93,9 @@ Tags that are added by Red Hat are required for clusters to stay in compliance w
 |`Enable autoscaling (optional)`
 |Enable compute node autoscaling. The autoscaler adjusts the size of the cluster to meet your deployment demands. The default is `No`.
 
+|`Additional Compute Security Group IDs (optional)`
+|Select the additional custom security group IDs to use with this cluster. The default is none selected. Only security groups associated with the selected VPC are displayed. You can select a maximum of 5 additional security groups.
+
 |`Compute nodes`
 |Specify the number of compute nodes to provision into each availability zone. Clusters deployed in a single availability zone require at least 2 nodes. Clusters deployed in multiple zones must have at least 3 nodes. The maximum number of worker nodes is 180 nodes. The default value is `2`.
 

--- a/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
@@ -14,6 +14,11 @@ You can edit machine pool configuration options such as scaling, adding node lab
 include::modules/creating-a-machine-pool.adoc[leveloffset=+1]
 include::modules/creating-a-machine-pool-ocm.adoc[leveloffset=+2]
 include::modules/creating-a-machine-pool-cli.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Security groups]
+
 include::modules/configuring-machine-pool-disk-volume.adoc[leveloffset=+1]
 include::modules/configuring-machine-pool-disk-volume-ocm.adoc[leveloffset=+2]
 include::modules/configuring-machine-pool-disk-volume-cli.adoc[leveloffset=+2]

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -46,6 +46,9 @@ include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[levelo
 * xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster] in _Managing objects with the ROSA CLI_.
 
 include::modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Security groups]
 
 [id="next-steps_{context}"]
 == Next steps

--- a/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
+++ b/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
@@ -23,7 +23,9 @@ include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-*  xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+* xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Security groups]
+* xref:../../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[Required AWS service quotas]
 
 == Next steps
 * xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-required-aws-service-quotas.adoc#rosa-required-aws-service-quotas[Review the required AWS service quotas]

--- a/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
+++ b/rosa_planning/rosa-cloud-expert-prereq-checklist.adoc
@@ -157,6 +157,16 @@ Prerequisites needed from a networking standpoint.
 
 * Configure your firewall to allow access to the domains and ports listed in xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS firewall prerequisites].
 
+=== Additional custom security groups
+
+When you create a cluster using an existing non-managed VPC, you can add additional custom security groups during cluster creation. Complete these prerequisites before you create the cluster:
+
+* Create the custom security groups in AWS before you create the cluster.
+* Associate the custom security groups with the VPC that you are using to create the cluster. Do not associate the custom security groups with any other VPC.
+* You may need to request additional AWS quota for `Security groups per network interface`.
+
+For more details see the detailed requirements for xref:../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Security groups].
+
 === Custom DNS
 
 * If you want to use custom DNS, then the ROSA installer must be able to use VPC DNS with default DHCP options so it can resolve hosts locally.


### PR DESCRIPTION
- added reqs and limits for additional custom security groups to environment preparation and to cloud expert brief prerequisite list
- updated required aws service quotas section with clearer examples and new security group quota requirement
- added security group selection to the interactive cluster creation process for ROSA Classic clusters
- added security group selection to interactive cluster reference table
- updated command usage examples to include new command and output where relevant
- rebased to incorporate changes from tag related updates
- applied SME and QE review feedback to additional security groups content

Version(s):
4.14, 4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8034

Link to docs preview:
- https://66328--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-cloud-expert-prereq-checklist#custom-security-groups
- https://66328--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs#rosa-security-groups_rosa-sts-aws-prereqs
- https://66328--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-required-aws-service-quotas
- https://66328--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations
- https://66328--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference
- https://66328--docspreview.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-create-cluster-command_rosa-managing-objects-cli

QE review:
- [x] QE has approved this change.

Additional information:
