### PR TITLE
OCPBUGS-21857: release-notes: Customized sshd config need an update

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -65,6 +65,8 @@ Because {product-title} {product-version} now uses a {op-system-base} 9.2 based 
 
 * Some component configuration options and services might have changed between {op-system-base} 8.6 and {op-system-base} 9.2, which means existing machine configuration files might no longer be valid.
 
+* If you customized the default OpenSSH `/etc/ssh/sshd_config` server configuration file, you must update it according to this link:https://access.redhat.com/solutions/7030537[Red Hat Knowledgebase article].
+
 * {op-system-base} 6 base image containers are not supported on {op-system} container hosts but are supported on {op-system-base} 8 worker nodes. For more information, see the link:https://access.redhat.com/support/policy/rhel-container-compatibility[Red Hat Container Compatibility] matrix.
 
 * Some device drivers have been deprecated, see the link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9/html/considerations_in_adopting_rhel_9/assembly_hardware-enablement_considerations-in-adopting-rhel-9#unmaintained-hardware-support[{op-system-base} documentation] for more information.
@@ -747,6 +749,13 @@ If you are receiving pod security violations, see the following resources:
 ** The workload is running on a pod that was created directly without a pod controller.
 
 * If necessary, you can set a custom admission profile on the namespace or pod by setting the `pod-security.kubernetes.io/enforce` label.
+
+[discrete]
+[id="ocp-4-14-rhcos-ssh-key-location"]
+=== Change in SSH key location
+{product-title} {product-version} introduces a {op-system-base} 9.2 based {op-system}. Before this update, SSH keys were located in `/home/core/.ssh/authorized_keys` on {op-system}. With this update, on {op-system-base} 9.2 based {op-system}, SSH keys are located in `/home/core/.ssh/authorized_keys.d/ignition`.
+
+If you customized the default OpenSSH `/etc/ssh/sshd_config` server configuration file, you must update it according to this link:https://access.redhat.com/solutions/7030537[Red Hat Knowledgebase article].
 
 [discrete]
 [id="ocp-4-14-cert-manager-operator-1-11"]


### PR DESCRIPTION
With the update to RHEL 9.2 as a base, the default sshd_config has been updated to use 'drop-in' configuration files.

Clusters where openssh server configuration file
(`/etc/ssh/sshd_config`) had been customized via a MachineConfig will require this config to be updated to add the include directive at the begining of the file:

```
Include /etc/ssh/sshd_config.d/*.conf
```

See: https://issues.redhat.com/browse/OCPBUGS-18452
See: https://access.redhat.com/solutions/7030537

Version(s):
4.14 & 4.13

Issue:
https://issues.redhat.com/browse/OCPBUGS-18452

Link to docs preview:
N/A

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
