### PR TITLE
Rosa remove redirects

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -697,10 +697,6 @@ AddType text/vtt                            vtt
 
     RewriteRule ^dedicated/osd_policy/?(.*)$ /dedicated/osd_architecture/osd_policy/$1 [NE,R=301]
 
-    RewriteRule ^dedicated/support/getting-support.html /dedicated/osd_architecture/osd-support.html [NE,R=301]
-    RewriteRule ^dedicated/support/summarizing-cluster-specifications.html /dedicated/osd_support/osd-summarizing-cluster-specifications.html [NE,R=301]
-    RewriteRule ^dedicated/support/?(.*)$ /dedicated/osd_support/$1 [NE,R=301]
-
     # Redirects for PTP changes delivered in https://github.com/openshift/openshift-docs/pull/35889
     RewriteRule ^container-platform/(4\.9|4\.10|4\.11)/networking/configuring-ptp.html /container-platform/$1/networking/using-ptp.html [NE,R=302]
 


### PR DESCRIPTION
There are currently redirects for `dedicated/support/` for Dedicated. This PR removes those redirect as part of the ROSA/OSD content port project.

Preview. Note the **osd_support** in the current docs link:
Support overview at https://66349--docspreview.netlify.app/openshift-dedicated/latest/support/index.html)
 Current: Support overview at https://docs.openshift.com/dedicated/osd_support/index.html)