### PR TITLE
OSDOCS-8225: Removed VPC note

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc
@@ -13,11 +13,6 @@ When you create a {product-title} (ROSA) cluster that uses the AWS Security Toke
 Only public and AWS PrivateLink clusters are supported with STS. Regular private clusters (non-PrivateLink) are not available for use with STS.
 ====
 
-[NOTE]
-====
-link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[AWS Shared VPCs] are not currently supported for ROSA installations.
-====
-
 .Prerequisites
 
 * You have completed the AWS prerequisites for ROSA with STS.

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -44,6 +44,7 @@ include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[levelo
 [role="_additional-resources"]
 .Additional resources
 * xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster] in _Managing objects with the ROSA CLI_.
+* xref:../rosa_install_access_delete_clusters/rosa-shared-vpc-config.adoc#rosa-shared-vpc-config[Configuring a shared VPC for ROSA clusters] for information on configuring a ROSA cluster within a shared VPC.
 
 include::modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-8225](https://issues.redhat.com/browse/OSDOCS-8225)

Link to docs preview:
* [Creating a ROSA cluster with STS using customizations](https://file.rdu.redhat.com/eponvell/OSDOCS-8225_VPC-Note-Removal/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#rosa-sts-creating-cluster-customizations-cli_rosa-sts-creating-a-cluster-with-customizations)
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/eb75accf-a501-4722-b0c3-4ec80005f035)


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Removed a note from the cluster creation topic that prohibited creating a cluster in a shared VPC. I also added a link to the instructions on how to create this shared VPC.