### PR TITLE
OCPBUGS-21804 update NTO command syntax

### DIFF
--- a/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
+++ b/modules/accessing-an-example-cluster-node-tuning-operator-specification.adoc
@@ -15,7 +15,7 @@ Use this process to access an example Node Tuning Operator specification.
 +
 [source,terminal]
 ----
-$ oc get Tuned/default -o yaml -n openshift-cluster-node-tuning-operator
+oc get tuned.tuned.openshift.io/default -o yaml -n openshift-cluster-node-tuning-operator
 ----
 
 The default CR is meant for delivering standard node-level tuning for the {product-title} platform and it can only be modified to set the Operator Management state. Any other custom changes to the default CR will be overwritten by the Operator. For custom tuning, create your own Tuned CRs. Newly created CRs will be combined with the default CR and custom tuning applied to {product-title} nodes based on node or pod labels and profile priorities.

--- a/modules/advanced-node-tuning-hosted-cluster.adoc
+++ b/modules/advanced-node-tuning-hosted-cluster.adoc
@@ -111,7 +111,7 @@ After the nodes are available, the containerized TuneD daemon calculates the req
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" get Tuneds -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="$HC_KUBECONFIG" get tuned.tuned.openshift.io -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output
@@ -127,7 +127,7 @@ rendered             123m
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" get Profiles -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="$HC_KUBECONFIG" get profile.tuned.openshift.io -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output

--- a/modules/cluster-node-tuning-operator-verify-profiles.adoc
+++ b/modules/cluster-node-tuning-operator-verify-profiles.adoc
@@ -9,7 +9,7 @@ Verify the TuneD profiles that are applied to your cluster node.
 
 [source,terminal]
 ----
-$ oc get profile -n openshift-cluster-node-tuning-operator
+$ oc get profile.tuned.openshift.io -n openshift-cluster-node-tuning-operator
 ----
 
 .Example output

--- a/modules/node-tuning-hosted-cluster.adoc
+++ b/modules/node-tuning-hosted-cluster.adoc
@@ -89,7 +89,7 @@ Now that you have created the `ConfigMap` object that contains a `Tuned` manifes
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" get Tuneds -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="$HC_KUBECONFIG" get tuned.tuned.openshift.io -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output
@@ -105,7 +105,7 @@ tuned-1    65s
 +
 [source,terminal]
 ----
-$ oc --kubeconfig="$HC_KUBECONFIG" get Profiles -n openshift-cluster-node-tuning-operator
+$ oc --kubeconfig="$HC_KUBECONFIG" get profile.tuned.openshift.io -n openshift-cluster-node-tuning-operator
 ----
 +
 .Example output


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OCPBUGS-21804

Link to docs preview:
[Verifying that the TuneD profiles are applied](https://file.rdu.redhat.com/antaylor/OCPBUGS-21804/scalability_and_performance/using-node-tuning-operator.html#verifying-tuned-profiles-are-applied_node-tuning-operator)
[Accessing an example Node Tuning Operator specification](https://file.rdu.redhat.com/antaylor/OCPBUGS-21804/scalability_and_performance/using-node-tuning-operator.html#accessing-an-example-node-tuning-operator-specification_node-tuning-operator)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None
