### PR TITLE
OSDOCS-8176: adds release note for MicroShift 4.13.17

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -291,3 +291,14 @@ Issued: 2023-10-10
 {product-title} release 4.13.15 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5469[RHBA-2023:5469] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:5467[RHBA-2023:5467] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+//release 4-13-16 was folded into 4-13-17
+
+[id="microshift-4-13-17-dp"]
+=== RHBA-2023:5674 - {product-title} 4.13.17 bug fix update
+
+Issued: 2023-10-17
+
+{product-title} release 4.13.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5674[RHBA-2023:5674] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5672[RHSA-2023:5672] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-8176

Link to docs preview:
https://66357--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-17-dp

QE review:
- N/A standard asynch release note, no new bugs added

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
