### PR TITLE
OCPBUGS-12908 [DDF] JBoss Web Server is added twice.

### DIFF
--- a/welcome/oke_about.adoc
+++ b/welcome/oke_about.adoc
@@ -311,7 +311,7 @@ s| Feature s| {oke} s| {product-title} s| Operator name
 | Metering provided by Red Hat (deprecated) | Not Included | Included | N/A
 | Migration Toolkit for Containers Operator | Not Included | Included | Migration Toolkit for Containers Operator
 | Cost management for OpenShift | Not included | Included | N/A
-| Red Hat JBoss Web Server | Not included | Included | JWS Operator
+| JBoss Web Server provided by Red Hat | Not included | Included | JWS Operator
 | Red Hat Build of Quarkus | Not included | Included | N/A
 | Kourier Ingress Controller | Not included | Included | N/A
 | RHT Middleware Bundles Sub Compatibility (not included in {product-title}) | Not included | Included | N/A
@@ -344,7 +344,6 @@ s| Feature s| {oke} s| {product-title} s| Operator name
 | Red Hat Integration - Service Registry Operator | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Service Registry
 | API Designer provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | API Designer
 | JBoss EAP provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | JBoss EAP
-| JBoss Web Server provided by Red Hat | Not Included - Requires separate subscription | Not Included - Requires separate subscription | JBoss Web Server
 | Smart Gateway Operator | Not Included - Requires separate subscription | Not Included - Requires separate subscription | Smart Gateway Operator
 | Kubernetes NMState Operator | Included | Included | N/A
 |===


### PR DESCRIPTION
[OCPBUGS-12908](https://issues.redhat.com/browse/OCPBUGS-12908): [DDF] JBoss Web Server is added twice.

Version(s):
* enterprise-4.11, enterprise-4.12, enterprise-4.13, enterprise-4.14 

Issue:
[OCPBUGS-12908](https://issues.redhat.com/browse/OCPBUGS-12908): [DDF] JBoss Web Server is added twice.

Link to docs preview:
Visit https://66359--docspreview.netlify.app/openshift-enterprise/latest/welcome/oke_about
and ctrl+f for "JBoss Web Server"

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->