### PR TITLE
[OSDOCS-5364]: Adding TP boilerplate to hosted control planes docs

### DIFF
--- a/hosted_control_planes/hcp-configuring.adoc
+++ b/hosted_control_planes/hcp-configuring.adoc
@@ -6,7 +6,10 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-To get started with hosted control planes for {product-title}, you first configure your hosted cluster on the provider that you want to use. Then, you complete a few management tasks. 
+To get started with hosted control planes for {product-title}, you first configure your hosted cluster on the provider that you want to use. Then, you complete a few management tasks.
+
+:FeatureName: Hosted control planes
+include::snippets/technology-preview.adoc[]
 
 You can view the procedures by selecting from one of the following providers:
 
@@ -42,6 +45,7 @@ You can view the procedures by selecting from one of the following providers:
 // To be added after ACM 2.9 goes live:
 
 //{ibmpowerProductName}
+//{ibmzProductName}
 
 
 

--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -8,5 +8,8 @@ toc::[]
 
 If you encounter issues with hosted control planes, see the following information to guide you through troubleshooting.
 
+:FeatureName: Hosted control planes
+include::snippets/technology-preview.adoc[]
+
 include::modules/hosted-control-planes-troubleshooting.adoc[leveloffset=+1]
 include::modules/debug-nodes-hcp.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-5364
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
- https://66362--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-configuring
- https://66362--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A (This PR adds TP boilerplate that is required for TP features. The two files that I added the boilerplate to were missing that text in error. This feature has been a TP feature since OCP 4.12, and will continue to be until mid-November, when the latest version of the MCE Operator is released.)
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
