### PR TITLE
OSDOCS-8225.1: Moved the VPC link

### DIFF
--- a/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
+++ b/modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc
@@ -17,11 +17,6 @@ After a cluster installation using the interactive mode completes, a single comm
 Only public and AWS PrivateLink clusters are supported with STS. Regular private clusters (non-PrivateLink) are not available for use with STS.
 ====
 
-[NOTE]
-====
-link:https://docs.aws.amazon.com/vpc/latest/userguide/vpc-sharing.html[AWS Shared VPCs] are not currently supported for ROSA installations.
-====
-
 .Prerequisites
 
 * You have completed the AWS prerequisites for ROSA with STS.

--- a/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.adoc
@@ -44,7 +44,6 @@ include::modules/rosa-sts-creating-a-cluster-with-customizations-ocm.adoc[levelo
 [role="_additional-resources"]
 .Additional resources
 * xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-create-cluster-command_rosa-managing-objects-cli[create cluster] in _Managing objects with the ROSA CLI_.
-* xref:../rosa_install_access_delete_clusters/rosa-shared-vpc-config.adoc#rosa-shared-vpc-config[Configuring a shared VPC for ROSA clusters] for information on configuring a ROSA cluster within a shared VPC.
 
 include::modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc[leveloffset=+2]
 
@@ -57,6 +56,7 @@ include::modules/rosa-sts-creating-a-cluster-with-customizations-cli.adoc[levelo
 [id="additional-resources_rosa-sts-creating-a-cluster-with-customizations"]
 == Additional resources
 
+* For more information on configuring a ROSA cluster within a shared virtual private cloud (VPC), see xref:../rosa_install_access_delete_clusters/rosa-shared-vpc-config.adoc#rosa-shared-vpc-config[Configuring a shared VPC for ROSA clusters].
 * For more information about the AWS Identity Access Management (IAM) resources required to deploy {product-title} with STS, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-iam-resources[About IAM resources for clusters that use STS].
 * For details about optionally setting an Operator role name prefix, see xref:../rosa_architecture/rosa-sts-about-iam-resources.adoc#rosa-sts-about-operator-role-prefixes_rosa-sts-about-iam-resources[About custom Operator IAM role prefixes].
 * For an overview of the options that are presented when you create the AWS IAM resources and clusters by using interactive mode, see xref:../rosa_install_access_delete_clusters/rosa-sts-interactive-mode-reference.adoc#rosa-sts-interactive-mode-reference[Interactive cluster creation mode reference].


### PR DESCRIPTION
Continuation of #66350 - Also removed the note from the CLI module and relocated the link to the general additional resources.

[PREVIEW](https://file.rdu.redhat.com/eponvell/OSDOCS-8225-5_Moving-Link/rosa_install_access_delete_clusters/rosa-sts-creating-a-cluster-with-customizations.html#additional-resources_rosa-sts-creating-a-cluster-with-customizations)

![image](https://github.com/openshift/openshift-docs/assets/16167833/e42919da-309b-4847-93b6-e5fb33d315af)