### PR TITLE
[enterprise-4.11] RHDEVDOCS-2966 tracker for Bug 1956414 - [DOC] Remove mention of mult…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -525,7 +525,7 @@ endif::aws,bare,ibm-power,ibm-z[]
 
 ifdef::aws,bare[]
 |`compute.architecture`
-|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. 
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
 ifdef::aws[]
  Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
 endif::aws[]
@@ -592,7 +592,7 @@ endif::aws,bare,ibm-z,ibm-power[]
 ifndef::openshift-origin[]
 ifdef::aws,bare[]
 |`controlPlane.architecture`
-|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`. 
+|Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
 ifdef::aws[]
  Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
 endif::aws[]
@@ -702,13 +702,8 @@ endif::[]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
-a|One or more keys. For example:
-```
-sshKey:
-  <key1>
-  <key2>
-  <key3>
-```
+a|For example, `sshKey: ssh-ed25519 AAAA..`.
+
 |====
 
 ifdef::aws[]


### PR DESCRIPTION
…iple ssh-keys from user doc as it is currently not officially supported

Manually CP by editing: [RHDEVDOCS-2966](https://issues.redhat.com//browse/RHDEVDOCS-2966) tracker for Bug 1956414 - [DOC] Remove mention of mult… #32138 

