### PR TITLE
[OSDOCS-6569]: Add monitoring dashboard docs for hosted control planes

### DIFF
--- a/hosted_control_planes/hcp-managing.adoc
+++ b/hosted_control_planes/hcp-managing.adoc
@@ -17,6 +17,7 @@ include::modules/updating-node-pools-for-hcp.adoc[leveloffset=+1]
 include::modules/hosted-control-planes-pause-reconciliation.adoc[leveloffset=+1]
 //using service-level DNS for control plane services
 include::modules/hosted-control-planes-metrics-sets.adoc[leveloffset=+1]
+include::modules/hosted-control-planes-monitoring-dashboard.adoc[leveloffset=+1]
 //automated machine management
 include::modules/scale-down-data-plane.adoc[leveloffset=+1]
 include::modules/delete-hosted-cluster.adoc[leveloffset=+1]

--- a/modules/hosted-control-planes-monitoring-dashboard.adoc
+++ b/modules/hosted-control-planes-monitoring-dashboard.adoc
@@ -1,0 +1,61 @@
+// Module included in the following assemblies:
+//
+// * hosted_control_planes/hcp-managing.adoc
+
+:_content-type: PROCEDURE
+[id="hosted-control-planes-monitoring-dashboard_{context}"]
+= Creating monitoring dashboards for hosted clusters
+
+The HyperShift Operator can create or delete monitoring dashboards in the management cluster for each hosted cluster that it manages.
+
+[#hosted-control-planes-enable-dashboard]
+== Enabling monitoring dashboards
+
+To enable monitoring dashboards in a hosted cluster, complete the following steps:
+
+.Procedure
+
+. Create the `hypershift-operator-install-flags` config map in the `local-cluster` namespace, being sure to specify the `--monitoring-dashboards` flag in the `data.installFlagsToAdd` section. For example:
+
++
+[source,yaml]
+----
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: hypershift-operator-install-flags
+  namespace: local-cluster
+data:
+  installFlagsToAdd: "--monitoring-dashboards"
+  installFlagsToRemove: ""
+----
+
+. Wait a couple of minutes for the HyperShift Operator deployment in the `hypershift` namespace to be updated to include the following environment variable:
+
++
+----
+    - name: MONITORING_DASHBOARDS
+      value: "1"
+----
+
++
+When monitoring dashboards are enabled, for each hosted cluster that the HyperShift Operator manages, the Operator creates a config map named `cp-[NAMESPACE]-[NAME]` in the `openshift-config-managed` namespace, where `NAMESPACE` is the namespace of the hosted cluster and `NAME` is the name of the hosted cluster. As a result, a new dashboard is added in the administrative console of the management cluster.
+
+. To view the dashboard, log in to the management cluster's console and go to the dashboard for the hosted cluster by clicking *Observe -> Dashboards*.
+
+. Optional: To disable a monitoring dashboards in a hosted cluster, remove the `--monitoring-dashboards` flag from the `hypershift-operator-install-flags` config map. When you delete a hosted cluster, its corresponding dashboard is also deleted.
+
+[#hosted-control-planes-customize-dashboards]
+== Dashboard customization
+
+To generate dashboards for each hosted cluster, the HyperShift Operator uses a template that is stored in the `monitoring-dashboard-template` config map in the operator namespace (`hypershift`). This template contains a set of Grafana panels that contain the metrics for the dashboard. You can edit the content of the config map to customize the dashboards.
+
+When a dashboard is generated, the following strings are replaced with values that correspond to a specific hosted cluster:
+
+|===
+| Name | Description
+| [x-]`__NAME__` | The name of the hosted cluster
+| [x-]`__NAMESPACE__` | The namespace of the hosted cluster
+| [x-]`__CONTROL_PLANE_NAMESPACE__` | The namespace where the control plane pods of the hosted cluster are placed
+| [x-]`__CLUSTER_ID__` | The UUID of the hosted cluster, which matches the `_id` label of the hosted cluster metrics
+|===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-6569
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://66381--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-managing#hosted-control-planes-monitoring-dashboard_hcp-managing
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
