### PR TITLE
OSDOCS-6698: Updated the TP tables in the OCP 4.14 RN doc

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -847,8 +847,10 @@ With this release, you can remove the partitioning table before installation by 
 
 With this update, you can add the `nodeLabels` field in the `SiteConfig` CR to create custom roles for nodes in managed clusters. For more information about how to add custom labels, see xref:../scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites.adoc#ztp-deploying-a-site_ztp-deploying-far-edge-sites[Deploying a managed cluster with SiteConfig and {ztp}] or xref:../scalability_and_performance/ztp_far_edge/ztp-manual-install.adoc#ztp-generating-install-and-config-crs-manually_ztp-manual-install[Generating {ztp} installation and configuration CRs manually].
 
+////
 [id="ocp-4-14-hcp"]
 === Hosted control planes (Technology Preview)
+////
 
 [id="ocp-4-14-insights-operator"]
 === Insights Operator
@@ -1010,22 +1012,12 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.12 |4.13 |4.14
 
-|vSphere 7.0 Update 1 or earlier
-|Deprecated
-|Removed ^[1]^
-|Removed
-
-|VMware ESXi 7.0 Update 1 or earlier
+|`--cloud` parameter for `oc adm release extract`
 |General Availability
-|Removed ^[1]^
-|Removed
+|General Availability
+|Deprecated
 
 |CoreDNS wildcard queries for the `cluster.local` domain
-|Deprecated
-|Deprecated
-|Deprecated
-
-|`ingressVIP` and `apiVIP` settings in the `install-config.yaml` file for installer-provisioned infrastructure clusters
 |Deprecated
 |Deprecated
 |Deprecated
@@ -1040,15 +1032,26 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Deprecated
 
+|`ingressVIP` and `apiVIP` settings in the `install-config.yaml` file for installer-provisioned infrastructure clusters
+|Deprecated
+|Deprecated
+|Deprecated
+
 |`platform.gcp.licenses` for Google Cloud Provider
 |Deprecated
 |Deprecated
 |Removed
 
-|`--cloud` parameter for `oc adm release extract`
+|VMware ESXi 7.0 Update 1 or earlier
 |General Availability
-|General Availability
+|Removed ^[1]^
+|Removed
+
+|vSphere 7.0 Update 1 or earlier
 |Deprecated
+|Removed ^[1]^
+|Removed
+
 |====
 [.small]
 --
@@ -1160,6 +1163,7 @@ In the following tables, features are marked with the following statuses:
 |Deprecated
 |Deprecated
 |Deprecated
+
 |====
 
 //[discrete]
@@ -1194,6 +1198,24 @@ In the following tables, features are marked with the following statuses:
 |General Availability
 |Deprecated
 |Deprecated
+
+|====
+
+[discrete]
+=== OpenShift CLI (oc) deprecated and removed features
+[cols="4,1,1,1",options="header"]
+|====
+|Feature |4.12 |4.13 |4.14
+
+|`--include-local-oci-catalogs` parameter for `oc-mirror`
+|Not Available
+|General Availability
+|Removed
+
+|`--use-oci-feature` parameter for `oc-mirror`
+|General Availability
+|Deprecated
+|Removed
 
 |====
 
@@ -1233,6 +1255,11 @@ From {product-title} {product-version}, you must only use the `DefaultCatSrc.yam
 As of {product-title} 4.14, the `--cloud` parameter for the `oc adm release extract` command is deprecated. The introduction of the `--included` and `--install-config` parameters make the `--cloud` parameter unnecessary.
 
 For more information, see xref:../release_notes/ocp-4-14-release-notes.adoc#ocp-4-14-install-update-cco-manual-enhancements[Simplified installation and update experience for clusters with manually maintained cloud credentials].
+
+[id="ocp-4-14-rhv-deprecations"]
+==== Red Hat Virtualization (RHV) as a host platform for {product-title} will be deprecated
+
+Red Hat Virtualization (RHV) as a host platform for {product-title} was deprecated and is no longer supported. This platform will be removed from {product-title} in a future {product-title} release.
 
 [id="ocp-4-14-removed-features"]
 === Removed features
@@ -1664,7 +1691,7 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.12 |4.13 |4.14
 
-|Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds
+|Automatic device discovery and provisioning with Local Storage Operator
 |Technology Preview
 |Technology Preview
 |Technology Preview
@@ -1690,11 +1717,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Automatic device discovery and provisioning with Local Storage Operator
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
 |NFS support for Azure File CSI Operator Driver
 |Generally Available
 |Generally Available
@@ -1703,6 +1725,11 @@ In the following tables, features are marked with the following statuses:
 |Read Write Once Pod access mode
 |Not available
 |Not available
+|Technology Preview
+
+|Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds
+|Technology Preview
+|Technology Preview
 |Technology Preview
 
 |{secrets-store-operator}
@@ -1725,27 +1752,12 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|Selectable Cluster Inventory
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|Multi-architecture compute machines
-|Technology Preview
-|General Availability
-|General Availability
-
-|Mount shared entitlements in BuildConfigs in RHEL
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
-|Enabling NIC partitioning for SR-IOV devices
+|Azure Tagging
 |Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
 
-|Azure Tagging
+|Enabling NIC partitioning for SR-IOV devices
 |Not Available
 |Technology Preview
 |Technology Preview
@@ -1755,9 +1767,39 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
-|Installing a cluster on Alibaba Cloud using installer-provisioned infrastructure
+|User-defined labels and tags for Google Cloud Platform (GCP)
+|Not Available
+|Not Available
+|Technology Preview
+
+|Installing a cluster on Alibaba Cloud by using installer-provisioned infrastructure
 |Technology Preview
 |Technology Preview
+|Technology Preview
+
+|Mount shared entitlements in BuildConfigs in RHEL
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Multi-architecture compute machines
+|Technology Preview
+|General Availability
+|General Availability
+
+|{product-title} on Oracle Cloud Infrastructure (OCI)
+|Not Available
+|Not Available
+|Developer Preview
+
+|Selectable Cluster Inventory
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
+|Static IP addresses with vSphere (IPI only)
+|Not Available
+|Not Available
 |Technology Preview
 
 |====
@@ -1800,6 +1842,16 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.12 |4.13 |4.14
 
+|IBM Secure Execution on {ibmzProductName} and {linuxoneProductName}
+|Technology Preview
+|General Availability
+|General Availability
+
+|{ibmpowerProductName} Virtual Server using installer-provisioned infrastructure
+|Not Available
+|Technology Preview
+|Technology Preview
+
 |`kdump` on `arm64` architecture
 |Technology Preview
 |Technology Preview
@@ -1815,16 +1867,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |Technology Preview
 
-|IBM Secure Execution on {ibmzProductName} and {linuxoneProductName}
-|Technology Preview
-|General Availability
-|General Availability
-
-|{ibmpowerProductName} Virtual Server using installer-provisioned infrastructure
-|Not Available
-|Technology Preview
-|Technology Preview
-
 |====
 
 [discrete]
@@ -1836,14 +1878,14 @@ In the following tables, features are marked with the following statuses:
 |Feature |4.12 |4.13 |4.14
 
 |Driver Toolkit
-|Technology Preview
+|General Availability
 |General Availability
 |General Availability
 
 |Hub and spoke cluster support
-|Not Available
 |Technology Preview
-|Technology Preview
+|General Availability
+|General Availability
 
 |====
 
@@ -1980,6 +2022,7 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
+
 [discrete]
 === {rh-openstack-first} Technology Preview features
 
@@ -1987,9 +2030,8 @@ In the following tables, features are marked with the following statuses:
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.12 |4.13 |4.14
-
-
 |====
+
 
 [discrete]
 === Architecture Technology Preview features
@@ -1999,23 +2041,18 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.12 |4.13 |4.14
 
-|Hosted control planes for {product-title} on bare metal
-|Technology Preview
-|Technology Preview
-|Technology Preview
-
 |Hosted control planes for {product-title} on Amazon Web Services (AWS)
 |Technology Preview
 |Technology Preview
 |Technology Preview
-
+// Needs to move to GA after Nov 15, 2023
+|Hosted control planes for {product-title} on bare metal
+|Technology Preview
+|Technology Preview
+|Technology Preview
+// Needs to move to GA after Nov 15, 2023
 |Hosted control planes for {product-title} on {VirtProductName}
 |Not Available
-|Technology Preview
-|Technology Preview
-
-|Multi-cluster Engine Operator
-|Technology Preview
 |Technology Preview
 |Technology Preview
 


### PR DESCRIPTION
[OSDOCS-6729](https://issues.redhat.com/browse/OSDOCS-6729)

Version(s):
4.14

Link to docs preview:
* [Technology Preview features](https://66382--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-technology-preview)
* [Deprecated and Removed features](https://66382--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-deprecated-removed-features)

QE review:
- [ ] QE not required
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Key update items sent by JU Lim (PM):

- Table 11 - CSI Google Filestore Driver Operator goes GA in OCP 4.14.  See [OCPSTRAT-498](https://issues.redhat.com//browse/OCPSTRAT-498) (CSI operator for Google Cloud File (GA)) for details.
- Table 12 - GCP Tagging TP in OCP 4.14.
- Table 12 - Static IP assignment with vSphere IPI is TP in OCP 4.14
- Table 12 - add OpenShift on Oracle Cloud Infrastructure Dev Preview in OCP 4.14
- Table 21 - HCP on BM is GA in OCP 4.14
- Table 21 - HCP on OpenShift Virtualization is GA in OCP 4.14
