### PR TITLE
OSDOCS-8221: add version info to oc install for MicroShift

### DIFF
--- a/microshift_cli_ref/microshift-oc-cli-install.adoc
+++ b/microshift_cli_ref/microshift-oc-cli-install.adoc
@@ -6,7 +6,7 @@ include::_attributes/attributes-microshift.adoc[]
 
 toc::[]
 
-To use the OpenShift CLI (`oc`) tool, you must download and install it separately from your {product-title} installation.
+To use the OpenShift CLI (`oc`) tool, you must download and install it separately from your {microshift-short} installation.
 
 [id="installing-the-openshift-cli"]
 == Installing the OpenShift CLI

--- a/modules/cli-installing-cli.adoc
+++ b/modules/cli-installing-cli.adoc
@@ -93,6 +93,13 @@ endif::restricted[]
 
 You can install the OpenShift CLI (`oc`) binary on Linux by using the following procedure.
 
+ifdef::microshift[]
+[NOTE]
+====
+{product-title} version numbering matches {OCP} version numbering. Use the `oc` binary that matches your {microshift-short} version and has the appropriate RHEL compatibility.
+====
+
+endif::microshift[]
 .Procedure
 
 ifdef::openshift-origin[]
@@ -137,7 +144,13 @@ $ oc <command>
 == Installing the OpenShift CLI on Windows
 
 You can install the OpenShift CLI (`oc`) binary on Windows by using the following procedure.
+ifdef::microshift[]
+[NOTE]
+====
+{product-title} version numbering matches {OCP} version numbering. Use the `oc` binary that matches your {microshift-short} version and has the appropriate RHEL compatibility.
+====
 
+endif::microshift[]
 .Procedure
 
 ifdef::openshift-origin[]
@@ -175,7 +188,13 @@ C:\> oc <command>
 == Installing the OpenShift CLI on macOS
 
 You can install the OpenShift CLI (`oc`) binary on macOS by using the following procedure.
+ifdef::microshift[]
+[NOTE]
+====
+{product-title} version numbering matches {OCP} version numbering. Use the `oc` binary that matches your {microshift-short} version and has the appropriate RHEL compatibility.
+====
 
+endif::microshift[]
 .Procedure
 
 ifdef::openshift-origin[]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS#21810

Link to docs preview:
https://66388--docspreview.netlify.app/microshift/latest/microshift_cli_ref/microshift-oc-cli-install#cli-installing-cli_cli-oc-installing

//showing no change
https://66388--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli#cli-installing-cli_cli-developer-commands

QE review:
- N/A

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
