### PR TITLE
[enterprise-4.11] RHDEVDOCS-2966 tracker for Bug 1956414 - [DOC] Remo…

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -697,7 +697,7 @@ endif::[]
 endif::[]
 
 |`sshKey`
-| The SSH key or keys to authenticate access your cluster machines.
+| The SSH key to authenticate access to your cluster machines.
 [NOTE]
 ====
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.


### PR DESCRIPTION
…iple ssh-keys from user doc as it is currently not officially supported

Manually CP by editing: [RHDEVDOCS-2966](https://issues.redhat.com//browse/RHDEVDOCS-2966) tracker for Bug 1956414 - [DOC] Remove mention of mult… #32138 

