### PR TITLE
RHDEVDOCS 5668 fix include location for Tekton Results assembly

### DIFF
--- a/records/using-tekton-results-for-openshift-pipelines-observability.adoc
+++ b/records/using-tekton-results-for-openshift-pipelines-observability.adoc
@@ -1,7 +1,7 @@
 :_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
 [id="using-tekton-results-for-openshift-pipelines-observability"]
 = Using Tekton Results for {pipelines-shortname} observability
-include::_attributes/common-attributes.adoc[]
 :context: using-tekton-results-for-openshift-pipelines-observability
 
 toc::[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
please cp to pipelines-docs-1.12 only

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
RHDEVDOCS 5668


Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://66404--docspreview.netlify.app/openshift-pipelines/latest/records/using-tekton-results-for-openshift-pipelines-observability

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
This PR changes the location of the include statement in one assembly of the standalone Pipelines documentation. Because of the wrong include location, the title of the assembly failed to render correctly - see https://docs.openshift.com/pipelines/1.12/records/using-tekton-results-for-openshift-pipelines-observability.html . Documentation content is not altered, therefore QE/Dev review is not required.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
