### PR TITLE
TELCODOCS-1418: Docs: Make necessary CPaaS changes for Rhel 9 

### DIFF
--- a/modules/deploying-lvms-on-sno-cluster.adoc
+++ b/modules/deploying-lvms-on-sno-cluster.adoc
@@ -50,19 +50,18 @@ For deploying {sno}, LVM Storage has the following limitations:
 [cols="1,1,1,1,1", width="100%", options="header"]
 |====
 |Architecture
-|RHEL 5
 |RHEL 6
 |RHEL 7
 |RHEL 8
+|RHEL 9
 
 |32-bit
 |16 TB
-|16 TB
+|-
 |-
 |-
 
 |64-bit
-|8 EB ^[1]^
 
 |8 EB ^[1]^
 
@@ -70,6 +69,7 @@ For deploying {sno}, LVM Storage has the following limitations:
 |8 EB ^[1]^
 
 500 TB ^[2]^
+|8 EB
 |8 EB
 
 |====

--- a/modules/lvms-download-log-files-and-diagnostics.adoc
+++ b/modules/lvms-download-log-files-and-diagnostics.adoc
@@ -12,5 +12,5 @@ When {lvms} is unable to automatically resolve a problem, use the must-gather to
 +
 [source,terminal,subs="attributes+"]
 ----
-$ oc adm must-gather --image=registry.redhat.io/lvms4/lvms-must-gather-rhel8:v{product-version} --dest-dir=<directory-name>
+$ oc adm must-gather --image=registry.redhat.io/lvms4/lvms-must-gather-rhel9:v{product-version} --dest-dir=<directory-name>
 ----


### PR DESCRIPTION
Updated RHEL 8 to RHEL 9, and added a RHEL 9 column.

Fixes: [TELCODOCS-1418](https://issues.redhat.com//browse/TELCODOCS-1418)

See https://issues.redhat.com/browse/TELCODOCS-1418 for additional details.

Preview URL: http://184.23.213.161:8080/TELCODOCS-1418/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-dowloading-log-files-and-diagnostics_logical-volume-manager-storage and http://184.23.213.161:8080/TELCODOCS-1418/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-deployment-limitations-for-sno-ran_logical-volume-manager-storage

For release(s): 4.15, 4.14
QE Review: 

- [x] QE has approved this change. 

Signed-off-by: John Wilkins <jowilkin@redhat.com>
