### PR TITLE
[OSDOCS-8238] Add AliCloud IPI to TP table in 4.11 RNs

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -2346,6 +2346,11 @@ In the table below, features are marked with the following statuses:
 |-
 |TP
 |TP
+
+|Installing a cluster on Alibaba Cloud using installer-provisioned infrastructure
+|-
+|TP
+|TP
 |====
 
 [id="ocp-4-11-known-issues"]


### PR DESCRIPTION
Version(s):
4.11

Issue:
[OSDOCS-8238](https://issues.redhat.com//browse/OSDOCS-8238)

Link to docs preview:
[Installation Technology Preview features](https://66415--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-technology-preview)

QE review:
Not required.

Additional information:
Missing from 4.10+ TP tables, but correctly announced in 4.10 and has TP banners for all published versions