### PR TITLE
[OSDOCS-8238] Add AliCloud IPI to TP table in 4.12 RNs

### DIFF
--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -2613,6 +2613,11 @@ In the following tables, features are marked with the following statuses:
 |Not Available
 |Technology Preview
 
+|Installing a cluster on Alibaba Cloud using installer-provisioned infrastructure
+|Technology Preview
+|Technology Preview
+|Technology Preview
+
 |====
 
 [discrete]


### PR DESCRIPTION
Version(s):
4.12

Issue:
[OSDOCS-8238](https://issues.redhat.com//browse/OSDOCS-8238)

Link to docs preview:
[Installation Technology Preview features](https://66416--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#installation-technology-preview-features)

QE review:
Not required.

Additional information:
Missing from 4.10+ TP tables, but correctly announced in 4.10 and has TP banners for all published versions