### PR TITLE
4.14 GA Cluster Version Operator and Cloud Credential Operator bugs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1686,6 +1686,22 @@ Targeting {product-title} 4.15, the OpenShift SDN CNI network plugin will not be
 [id="ocp-4-14-cloud-cred-operator-bug-fixes"]
 ==== Cloud Credential Operator
 
+* Previously, the Cloud Credential Operator utility (`ccoctl`) used an incorrect Amazon Resource Names (ARN) prefix for AWS GovCloud (US) and AWS China regions. The incorrect ARN prefix caused the `ccoctl aws create-all` command that is used to create AWS resources during installation to fail. This release updates the ARN prefixes to the correct values. (link:https://issues.redhat.com/browse/OCPBUGS-13549[*OCPBUGS-13549*])
+
+* Previously, security changes to Amazon S3 buckets caused the Cloud Credential Operator utility (`ccoctl`) command that is used to create AWS resources during installation (`ccoctl aws create-all`) to fail. With this release, the `ccoctl` utility is updated to reflect the Amazon S3 security changes. (link:https://issues.redhat.com/browse/OCPBUGS-11671[*OCPBUGS-11671*])
+
+[discrete]
+[id="ocp-4-14-cluster-version-operator-bug-fixes"]
+==== Cluster Version Operator
+
+* Previously, the Cluster Version Operator (CVO) did not reconcile `SecurityContextConstraints` resources as expected. The CVO now properly reconciles `SecurityContextConstraints` resources towards the state defined in the release image, reverting any unsupported modifications to them.
++
+Users who want to upgrade from earlier {product-title} versions and who operate workloads depending on modified system `SecurityContextConstraints` resources must follow the procedure in link:https://access.redhat.com/solutions/7033949[https://access.redhat.com/solutions/7033949] to make sure their workloads are able to run without modified system `SecurityContextConstraint` resources. (link:https://issues.redhat.com/browse/OCPBUGS-19465[*OCPBUGS-19465*])
+
+* Previously, the Cluster Version Operator did not prioritize likely targets when deciding which conditional update risks to evaluate first.
++
+With this change, it begins doing so, and conditional updates where the risks happen to not apply will become available more quickly after coming to the Operator's attention. (link:https://issues.redhat.com/browse/OCPBUGS-5469[*OCPBUGS-5469*])
+
 [discrete]
 [id="ocp-4-14-dev-console-bug-fixes"]
 ==== Developer Console
@@ -2595,11 +2611,11 @@ To make the required change, follow the instructions in link:https://access.redh
 
 * Starting from `RHEL 5.14.0-284.28.1.el9_2`, if you configure a SR-IOV virtual function with a specific MAC address, configuration errors might occur in the i40e driver. Consequently, Intel 7xx Series NICs might have connectivity issues. As a workaround, avoid specifying MAC addresses in the `metadata.annotations` field in the Pod resource. Instead, use the default address that the driver assigns to the virtual function.(link:https://issues.redhat.com/browse/RHEL-7168[*RHEL-7168*], link:https://issues.redhat.com/browse/OCPBUGS-19536[*OCPBUGS-19536*], link:https://issues.redhat.com/browse/OCPBUGS-19407[*OCPBUGS-19407*], link:https://issues.redhat.com/browse/OCPBUGS-18873[*OCPBUGS-18873*])
 
-* Currently, defining a `sysctl` value for a setting with a slash in its name, such as for bond devices, in the `profile` field of a `Tuned` resource might not work. Values with a slash in the `sysctl` option name are not mapped correctly to the `/proc` filesystem. As a workaround, create a `MachineConfig` resource that places a configuration file with the required values in the `/etc/sysctl.d` node directory.(link:https://issues.redhat.com/browse/RHEL-3707[*RHEL-3707*])
+* Currently, defining a `sysctl` value for a setting with a slash in its name, such as for bond devices, in the `profile` field of a `Tuned` resource might not work. Values with a slash in the `sysctl` option name are not mapped correctly to the `/proc` filesystem. As a workaround, create a `MachineConfig` resource that places a configuration file with the required values in the `/etc/sysctl.d` node directory. (link:https://issues.redhat.com/browse/RHEL-3707[*RHEL-3707*])
 
 * Currently, due to an issue with Kubernetes, the CPU Manager is unable to return CPU resources from the last pod admitted to a node to the pool of available CPU resources. These resources can be allocated if a subsequent pod is admitted to the node. However, this in turn becomes the last pod, and again, the CPU manager cannot return the resources of this pod to the available pool.
 +
-This issue affects the CPU load balancing features because these features depend on the CPU Manager releasing CPUs to the available pool. Consequently, non-guaranteed pods might run with a reduced number of CPUs. As a workaround, schedule a pod with a `best-effort` CPU Manager policy on the affected node. This pod will be the last pod admitted, ensuring that resources are properly released to the available pool.(link:https://issues.redhat.com/browse/OCPBUGS-17792[*OCPBUGS-17792*])
+This issue affects the CPU load balancing features because these features depend on the CPU Manager releasing CPUs to the available pool. Consequently, non-guaranteed pods might run with a reduced number of CPUs. As a workaround, schedule a pod with a `best-effort` CPU Manager policy on the affected node. This pod will be the last pod admitted, ensuring that resources are properly released to the available pool. (link:https://issues.redhat.com/browse/OCPBUGS-17792[*OCPBUGS-17792*])
 
 * Currently, the Machine Config Operator (MCO) might apply an incorrect cgroup version argument for custom pools because of how the MCO handles machine configurations for worker pools and custom pools. As a consequence, nodes in the custom pool might have an incorrect cgroup kernel argument, resulting in unpredictable behavior. As a workaround, specify the cgroup version kernel arguments for worker and control plane pools only.(link:https://issues.redhat.com/browse/OCPBUGS-19352[*OCPBUGS-19352*])
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
[Bug Batching for 4.14 GA](https://issues.redhat.com/browse/OSDOCS-5987)

Link to docs preview:
[Preview](https://66420--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-bug-fixes)

QE review:
- [ ] QE has approved this change.
Not needed

Additional information:
[Cluster version operator bugs](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12347491#SIGwKWmOqDAaIiGh1DSCAiYg6oaN4RY8HF6AMAwlQMHEVU1ccdWpPFMCNc1SXIGgGCNeaPAtG0HT+ogCErGsyGEN+BWVIilQeDECwguCH7kl+1IKBoq3YIV8xxPxRo8IimCVOB1AaBozV1AshTujEcL7bsFpCVYQA)
[Cloud Credential Operator bugs](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12347491#SIGwKWmOqDAaIiGh1DSCAiYg6oaN4RY8HF6AMAwlQMHEVU1ccdWpPFMCNc1SXIGgGCNeaPAtG0HT+ogCErGsyGEN+BWVIixUogsILgh+5JftSCgaB47qFfMcT8UaPCIpglTgdQGgaM1dQLIU7oxHCe27BaQlWEAA)
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
