### PR TITLE
[OSDOCS-8095] Fixes IBM VS CCM support status in 4.12 docs

### DIFF
--- a/modules/cluster-cloud-controller-manager-operator.adoc
+++ b/modules/cluster-cloud-controller-manager-operator.adoc
@@ -12,7 +12,7 @@
 ====
 This Operator is fully supported for Microsoft Azure Stack Hub and IBM Cloud.
 
-It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), IBM Cloud Power VS, Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
+It is available as a link:https://access.redhat.com/support/offerings/techpreview[Technology Preview] for Alibaba Cloud, Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, {rh-openstack-first}, and VMware vSphere.
 ====
 
 The Cluster Cloud Controller Manager Operator manages and updates the cloud controller managers deployed on top of {product-title}. The Operator is based on the Kubebuilder framework and `controller-runtime` libraries. It is installed via the Cluster Version Operator (CVO).

--- a/release_notes/ocp-4-12-release-notes.adoc
+++ b/release_notes/ocp-4-12-release-notes.adoc
@@ -2933,11 +2933,6 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 |General Availability
 
-|Cloud controller manager for IBM Cloud Power VS
-|Not Available
-|Not Available
-|Technology Preview
-
 |Cloud controller manager for Microsoft Azure
 |Technology Preview
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.12

Issue:
Correction of #65939

Link to docs preview:
[Machine management Technology Preview features](https://66424--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-12-release-notes#machine-management-technology-preview-features)
[Cluster Cloud Controller Manager Operator](https://66424--docspreview.netlify.app/openshift-enterprise/latest/operators/operator-reference#cluster-cloud-controller-manager-operator_cluster-operators-ref)

QE review:
N/A

Additional information:
https://issues.redhat.com/browse/OSDOCS-8095?focusedId=23284874&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23284874