### PR TITLE
[OSDOCS-8095] Fixes IBM VS CCM support status in 4.14 docs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -321,7 +321,7 @@ For more information, see _Token authentication for Operators on cloud providers
 [id="ocp-4-14-auth-op-noproxy"]
 ==== Authentication Operator honors `noProxy` during connection checks
 
-With this release, if the `noProxy` field is set and the route is reachable without the cluster-wide proxy, the Authentication Operator will bypass the proxy and perform connection checks directly through the configured ingress route. Previously, the Authentication Operator always performed connection checks through the cluster-wide proxy, regardless of the `noProxy` setting. 
+With this release, if the `noProxy` field is set and the route is reachable without the cluster-wide proxy, the Authentication Operator will bypass the proxy and perform connection checks directly through the configured ingress route. Previously, the Authentication Operator always performed connection checks through the cluster-wide proxy, regardless of the `noProxy` setting.
 
 For more information, see xref:../networking/enable-cluster-wide-proxy.adoc#configure-the-cluster-wide-proxy[Configuring the cluster-wide proxy].
 
@@ -1200,7 +1200,7 @@ With this release, the Ingress Operator now configures the canary DaemonSet to t
 +
 With this update, downloaded CRLs are now tracked by the CA that distributes them. When a CRL expires, the distributing CA's CRL distribution point is used to download an updated CRL. As a result, valid client certificates are no longer rejected. (link:https://issues.redhat.com/browse/OCPBUGS-9464[*OCPBUGS-9464*])
 
-* Previously, when the Gateway API was enabled for {SMProductName}, the Ingress Operator would fail to configure and would return the following error: `the spec.techPreview.controlPlaneMode field is not supported in version 2.4+; use spec.mode`. With this release, the {SMProductShortName} `spec.techPreview.controlPlaneMode` API field in the `ServiceMeshControlPlane` custom resource (CR) has been replaced with `spec.mode`. As a result, the Ingress Operator is able to create a `ServiceMeshControlPlane` custom resource, and the Gateway API works properly. (link:https://issues.redhat.com/browse/OCPBUGS-10714[*OCPBUGS-10714*]) 
+* Previously, when the Gateway API was enabled for {SMProductName}, the Ingress Operator would fail to configure and would return the following error: `the spec.techPreview.controlPlaneMode field is not supported in version 2.4+; use spec.mode`. With this release, the {SMProductShortName} `spec.techPreview.controlPlaneMode` API field in the `ServiceMeshControlPlane` custom resource (CR) has been replaced with `spec.mode`. As a result, the Ingress Operator is able to create a `ServiceMeshControlPlane` custom resource, and the Gateway API works properly. (link:https://issues.redhat.com/browse/OCPBUGS-10714[*OCPBUGS-10714*])
 
 * Previously, when configuring DNS for Gateway API gateways, the Ingress Operator would attempt to create a DNS record for a gateway listener, even if the listener specified a hostname with a domain that was outside of the cluster's base domain. Consequently, the Ingress Operator attempted, and failed, to publish DNS records, and would return the following error: `failed to publish DNS record to zone`.
 +
@@ -1756,7 +1756,7 @@ In the following tables, features are marked with the following statuses:
 |Technology Preview
 
 |Cloud controller manager for IBM Cloud Power VS
-|Technology Preview
+|Not Available
 |Technology Preview
 |Technology Preview
 
@@ -1883,13 +1883,13 @@ As a workaround, if you have an installation configuration file, update it with 
 
 * When you deploy a cluster with a Network Type of `OVNKubernetes` on {ibmpowerProductName}, compute nodes may reboot because of a kernel stack overflow. As a workaround, you can deploy the cluster with a Network Type of `OpenShiftSDN`. (link:https://issues.redhat.com/browse/RHEL-3901[*RHEL-3901*])
 
-* The following known issue applies to users who updated their {product-title} deployment to an early access version of {product-version} using release candidate 3 or 4: 
+* The following known issue applies to users who updated their {product-title} deployment to an early access version of {product-version} using release candidate 3 or 4:
 +
-After the introduction of the node identify feature, some pods that were running as root are updated to run unprivileged. For users who updated to an early access version of {product-title} {product-version}, attempting to upgrade to the official version of {product-version} might not progress. In this scenario, the Network Operator reports the following state, indicating an issue with the update: `DaemonSet "/openshift-network-node-identity/network-node-identity" update is rolling`. 
-+ 
+After the introduction of the node identify feature, some pods that were running as root are updated to run unprivileged. For users who updated to an early access version of {product-title} {product-version}, attempting to upgrade to the official version of {product-version} might not progress. In this scenario, the Network Operator reports the following state, indicating an issue with the update: `DaemonSet "/openshift-network-node-identity/network-node-identity" update is rolling`.
++
 As a workaround, you can delete all pods in the `openshift-network-node-identify` namespace by running the following command: `oc delete --force=true -n openshift-network-node-identity --all pods`. After running this command, the update continues.
 +
-For more information about early access, xref:../updating/understanding_updates/understanding-update-channels-release.adoc#candidate-version-channel_understanding-update-channels-releases[candidate-4.14 channel]. 
+For more information about early access, xref:../updating/understanding_updates/understanding-update-channels-release.adoc#candidate-version-channel_understanding-update-channels-releases[candidate-4.14 channel].
 
 * Currently, users cannot modify the `interface-specific` safe sysctl list by updating the `cni-sysctl-allowlist` config map in the `openshift-multus` namespace. As a workaround, you can modify, either manually or with a Daemon Set, the file `/etc/cni/tuning/allowlist.conf` on the node or nodes. (link:https://issues.redhat.com/browse/OCPBUGS-11046[*OCPBUGS-11046*])
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
Correction of #65941

Link to docs preview:
[Machine management Technology Preview features](https://66426--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#machine-management-technology-preview-features)

QE review:
N/A

Additional information:
https://issues.redhat.com/browse/OSDOCS-8095?focusedId=23284874&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-23284874