### PR TITLE
OSDOCS-6268: Relocated Node Tuning and added support for ROSA

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -147,8 +147,6 @@ Distros: openshift-rosa
 Topics:
 - Name: Creating ROSA with HCP clusters using the default options
   File: rosa-hcp-sts-creating-a-cluster-quickly
-- Name: Using the Node Tuning Operator on ROSA with HCP
-  File: rosa-tuning-config
 ---
 Name: Install ROSA Classic clusters
 Dir: rosa_install_access_delete_clusters
@@ -432,6 +430,8 @@ Topics:
     File: rosa-nodes-about-autoscaling-nodes
   - Name: Configuring cluster memory to meet container memory and risk requirements
     File: nodes-cluster-resource-configure
+- Name: Using the Node Tuning Operator on ROSA and ROSA with HCP clusters
+  File: rosa-tuning-config
 ---
 Name: Security and compliance
 Dir: security

--- a/modules/custom-tuning-specification.adoc
+++ b/modules/custom-tuning-specification.adoc
@@ -5,7 +5,7 @@
 // * rosa_hcp/rosa-tuning-config.adoc
 
 ifeval::["{context}" == "rosa-tuning-config"]
-:rosa-hcp-tuning:
+:rosa-tuning:
 endif::[]
 
 [id="custom-tuning-specification_{context}"]
@@ -27,7 +27,7 @@ The Operator Management state is set by adjusting the default Tuned CR. By defau
 
 The `profile:` section lists TuneD profiles and their names.
 
-ifndef::rosa-hcp-tuning[]
+ifndef::rosa-tuning[]
 [source,yaml]
 ----
 profile:
@@ -51,8 +51,8 @@ profile:
 
     # tuned_profile_n profile settings
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
+endif::rosa-tuning[]
+ifdef::rosa-tuning[]
 [source,json]
 ----
 {
@@ -70,11 +70,12 @@ ifdef::rosa-hcp-tuning[]
 ----
 endif::[]
 
+ifndef::rosa-tuning[]
 *Recommended profiles*
 
 The `profile:` selection logic is defined by the `recommend:` section of the CR. The `recommend:` section is a list of items to recommend the profiles based on a selection criteria.
 
-ifndef::rosa-hcp-tuning[]
+
 [source,yaml]
 ----
 recommend:
@@ -82,23 +83,9 @@ recommend:
 # ...
 <recommend-item-n>
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-[source,json]
-----
-"recommend": [
-    {
-      "recommend-item-1": details_of_recommendation,
-      # ...
-      "recommend-item-n": details_of_recommendation,
-    }
-  ]
-----
-endif::[]
 
 The individual items of the list:
 
-ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 - machineConfigLabels: <1>
@@ -121,41 +108,9 @@ ifndef::rosa-hcp-tuning[]
 <7> Optional operand configuration.
 <8> Turn debugging on or off for the TuneD daemon. Options are `true` for on or `false` for off. The default is `false`.
 <9> Turn `reapply_sysctl` functionality on or off for the TuneD daemon. Options are `true` for on and `false` for off.
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-[source,json]
-----
-{
-  "profile": [
-    {
-    # ...
-    }
-  ],
-  "recommend": [
-    {
-      "profile": <tuned_profile_name>, <1>
-      "priority": <priority>, <2>
-      "machineConfigLabels": { <Key_Pair_for_MachineConfig> <3>
-      },
-      "match": [ <4>
-        {
-          "label": <label_information> <5>
-        },
-      ]
-    },
-  ]
-}
-----
-<1> Profile ordering priority. Lower numbers mean higher priority (`0` is the highest priority).
-<2> A TuneD profile to apply on a match. For example `tuned_profile_1`.
-<3> Optional: A dictionary of key-value pairs `MachineConfig` labels. The keys must be unique.
-<4> If omitted, profile match is assumed unless a profile with a higher priority matches first or `machineConfigLabels` is set.
-<5> The label for the profile matched items.
-endif::[]
 
 `<match>` is an optional list recursively defined as follows:
 
-ifndef::rosa-hcp-tuning[]
 [source,yaml]
 ----
 - label: <label_name> <1>
@@ -167,24 +122,13 @@ ifndef::rosa-hcp-tuning[]
 <2> Optional node or pod label value. If omitted, the presence of `<label_name>` is enough to match.
 <3> Optional object type (`node` or `pod`). If omitted, `node` is assumed.
 <4> An optional `<match>` list.
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
-[source,yaml]
-----
-"match": [
-        {
-          "label": <1>
-        },
-]
-----
-<1> Node or pod label name.
-endif::[]
+endif::rosa-tuning[]
 
-If `<match>` is not omitted, all nested `<match>` sections must also evaluate to `true`. Otherwise, `false` is assumed and the profile with the respective `<match>` section will not be applied or recommended. Therefore, the nesting (child `<match>` sections) works as logical AND operator. Conversely, if any item of the `<match>` list matches, the entire `<match>` list evaluates to `true`. Therefore, the list acts as logical OR operator.
+If `<match>` is not omitted, all nested `<match>` sections must also evaluate to `true`. Otherwise, `false` is assumed and the profile with the respective `<match>` section will not be applied or recommended. Therefore, the nesting (child `<match>` sections) works as logical AND Operator. Conversely, if any item of the `<match>` list matches, the entire `<match>` list evaluates to `true`. Therefore, the list acts as logical OR Operator.
 
 If `machineConfigLabels` is defined, machine config pool based matching is turned on for the given `recommend:` list item. `<mcLabels>` specifies the labels for a machine config. The machine config is created automatically to apply host settings, such as kernel boot parameters, for the profile `<tuned_profile_name>`. This involves finding all machine config pools with machine config selector matching `<mcLabels>` and setting the profile `<tuned_profile_name>` on all nodes that are assigned the found machine config pools. To target nodes that have both master and worker roles, you must use the master role.
 
-The list items `match` and `machineConfigLabels` are connected by the logical OR operator. The `match` item is evaluated first in a short-circuit manner. Therefore, if it evaluates to `true`, the `machineConfigLabels` item is not considered.
+The list items `match` and `machineConfigLabels` are connected by the logical OR Operator. The `match` item is evaluated first in a short-circuit manner. Therefore, if it evaluates to `true`, the `machineConfigLabels` item is not considered.
 
 [IMPORTANT]
 ====
@@ -193,7 +137,7 @@ When using machine config pool based matching, it is advised to group nodes with
 
 .Example: node or pod label based matching
 
-ifndef::rosa-hcp-tuning[]
+ifndef::rosa-tuning[]
 [source,yaml]
 ----
 - match:
@@ -212,8 +156,8 @@ ifndef::rosa-hcp-tuning[]
 - priority: 30
   profile: openshift-node
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
+endif::rosa-tuning[]
+ifdef::rosa-tuning[]
 [source,JSON]
 ----
 [
@@ -264,7 +208,7 @@ Finally, the profile `openshift-node` has the lowest priority of `30`. It lacks 
 image::node-tuning-operator-workflow-revised.png[Decision workflow]
 
 .Example: machine config pool based matching
-ifndef::rosa-hcp-tuning[]
+ifndef::rosa-tuning[]
 [source,yaml]
 ----
 apiVersion: tuned.openshift.io/v1
@@ -288,8 +232,8 @@ spec:
     priority: 20
     profile: openshift-node-custom
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
+endif::rosa-tuning[]
+ifdef::rosa-tuning[]
 [source,JSON]
 ----
 {
@@ -349,7 +293,7 @@ This functionality takes advantage of `spec.providerID` node object values in th
 The `openshift` profile that both `openshift-control-plane` and `openshift-node` profiles inherit settings from is now updated to use this functionality through the use of conditional profile loading. Neither NTO nor TuneD currently include any Cloud provider-specific profiles. However, it is possible to create a custom profile `provider-<cloud-provider>` that will be applied to all Cloud provider-specific cluster nodes.
 
 .Example GCE Cloud provider profile
-ifndef::rosa-hcp-tuning[]
+ifndef::rosa-tuning[]
 [source,yaml]
 ----
 apiVersion: tuned.openshift.io/v1
@@ -365,8 +309,8 @@ spec:
       # Your tuning for GCE Cloud provider goes here.
     name: provider-gce
 ----
-endif::rosa-hcp-tuning[]
-ifdef::rosa-hcp-tuning[]
+endif::rosa-tuning[]
+ifdef::rosa-tuning[]
 [source,JSON]
 ----
 {
@@ -392,3 +336,6 @@ endif::[]
 ====
 Due to profile inheritance, any setting specified in the `provider-<cloud-provider>` profile will be overwritten by the `openshift` profile and its child profiles.
 ====
+ifeval::["{context}" == "rosa-tuning-config"]
+:!rosa-tuning:
+endif::[]

--- a/modules/node-tuning-operator.adoc
+++ b/modules/node-tuning-operator.adoc
@@ -13,6 +13,9 @@ endif::[]
 ifeval::["{context}" == "cluster-capabilities"]
 :cluster-caps:
 endif::[]
+ifeval::["{context}" == "rosa-tuning-config"]
+:rosa-tuning:
+endif::[]
 
 :_content-type: CONCEPT
 [id="about-node-tuning-operator_{context}"]
@@ -57,12 +60,16 @@ The cluster administrator configures a performance profile to define node-level 
 Currently, disabling CPU load balancing is not supported by cgroup v2. As a result, you might not get the desired behavior from performance profiles if you have cgroup v2 enabled. Enabling cgroup v2 is not recommended if you are using performance profiles.
 ====
 
+ifndef::rosa-tuning[]
 The Node Tuning Operator is part of a standard {product-title} installation in version 4.1 and later.
+endif::rosa-tuning[]
 
+ifndef::rosa-tuning[]
 [NOTE]
 ====
 In earlier versions of {product-title}, the Performance Addon Operator was used to implement automatic tuning to achieve low latency performance for OpenShift applications. In {product-title} 4.11 and later, this functionality is part of the Node Tuning Operator.
 ====
+endif::rosa-tuning[]
 endif::cluster-caps[]
 
 ifdef::operators[]
@@ -71,3 +78,6 @@ ifdef::operators[]
 
 link:https://github.com/openshift/cluster-node-tuning-operator[cluster-node-tuning-operator]
 endif::operators[]
+ifeval::["{context}" == "rosa-tuning-config"]
+:!rosa-tuning:
+endif::[]

--- a/modules/rosa-creating-node-tuning.adoc
+++ b/modules/rosa-creating-node-tuning.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="rosa-creating-node-tuning_{context}"]
-= Creating node tuning configurations on {hcp-title}
+= Creating node tuning configurations
 
-You can create tuning configurations using the {product-title} (ROSA) CLI, `rosa`.
+You can create tuning configurations for {product-title} (ROSA) and {hcp-title} cluster by using ROSA CLI.
 
 .Prerequisites
 
@@ -20,7 +20,7 @@ You can create tuning configurations using the {product-title} (ROSA) CLI, `rosa
 +
 [source,terminal]
 ----
-$ rosa create tuning-config -c <cluster_id> --name <name_of_tuning> --spec-path <path_to_spec_file>
+$ rosa create tuning-config -c <cluster_id> --spec-path <path_to_spec_file>
 ----
 +
 You must supply the path to the `spec.json` file or the command returns an error.

--- a/modules/rosa-deleting-node-tuning.adoc
+++ b/modules/rosa-deleting-node-tuning.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: PROCEDURE
 [id="rosa-deleting-node-tuning_{context}"]
-= Deleting node tuning configurations on {hcp-title}
+= Deleting node tuning configurations
 
-You can delete tuning configurations by using the {product-title} (ROSA) CLI, `rosa`.
+You can delete tuning configurations for {product-title} (ROSA) and {hcp-title} cluster by using ROSA CLI.
 
 [NOTE]
 ====
@@ -16,7 +16,7 @@ You cannot delete a tuning configuration referenced in a machine pool. You must 
 .Prerequisites
 
 * You have downloaded the latest version of the ROSA CLI.
-* You have a cluster on the latest version .
+* You have a cluster on the latest version.
 * Your cluster has a node tuning configuration that you want delete.
 
 .Procedure

--- a/modules/rosa-modifying-node-tuning.adoc
+++ b/modules/rosa-modifying-node-tuning.adoc
@@ -4,15 +4,15 @@
 
 :_content-type: PROCEDURE
 [id="rosa-modifying-node-tuning_{context}"]
-= Modifying your node tuning configurations for {hcp-title}
+= Modifying your node tuning configurations
 
-You can view and update the node tuning configurations using the {product-title} (ROSA) CLI, `rosa`.
+You can view and update the node tuning configurations for {product-title} (ROSA) and {hcp-title} cluster by using ROSA CLI.
 
 .Prerequisites
 
 * You have downloaded the latest version of the ROSA CLI.
-* You have a cluster on the latest version 
-* Your cluster has a node tuning configuration added to it
+* You have a cluster on the latest version.
+* Your cluster has a node tuning configuration added to it.
 
 .Procedure
 
@@ -20,16 +20,14 @@ You can view and update the node tuning configurations using the {product-title}
 +
 [source,terminal]
 ----
-$ rosa describe tuning-config -c <cluster_id> <1> 
-       --name <name_of_tuning> <2> 
-       [-o json] <3>
+$ rosa describe tuning-config -c <cluster_id> <1>
+       [-o json] <2>
 ----
 +
 The following items in this spec file are:
 +
-<1> Provide the cluster ID for the cluster that you own that you want to apply a node tuning configurations. 
-<2> Provide the name of your tuning configuration.
-<3> Optionally, you can provide the output type. If you do not specify any outputs, you only see the ID and name of the tuning configuration.
+<1> Provide the cluster ID for the cluster that you own that you want to apply a node tuning configurations.
+<2> Optionally, you can provide the output type. If you do not specify any outputs, you only see the ID and name of the tuning configuration.
 +
 .Sample output without specifying output type
 [source,terminal]
@@ -80,8 +78,9 @@ Spec:    {
 
 . After verifying the tuning configuration, you edit the existing configurations with the `rosa edit` command:
 +
+[source,terminal]
 ----
-$ rosa edit tuning-config -c <cluster_id> --name <name_of_tuning> --spec-path <path_to_spec_file>
+$ rosa edit tuning-config -c <cluster_id> --spec-path <path_to_spec_file>
 ----
 +
 In this command, you use the `spec.json` file to edit your configurations.
@@ -92,7 +91,7 @@ In this command, you use the `spec.json` file to edit your configurations.
 +
 [source,terminal]
 ----
-$ rosa describe tuning-config -c <cluster_id> --name <name_of_tuning>
+$ rosa describe tuning-config -c <cluster_id>
 ----
 +
 .Sample output

--- a/rosa_cluster_admin/rosa-tuning-config.adoc
+++ b/rosa_cluster_admin/rosa-tuning-config.adoc
@@ -1,12 +1,12 @@
 :_content-type: ASSEMBLY
 [id="rosa-tuning-config"]
-= Using the Node Tuning Operator on {hcp-title} clusters
+= Using the Node Tuning Operator on {product-title} and {hcp-title} clusters
 include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-tuning-config
 
 toc::[]
 
-{hcp-title-first} supports the Node Tuning Operator to improve performance of your nodes on your {hcp-title} clusters. Prior to creating a node tuning configuration, you must create a custom tuning specification.
+{product-title} (ROSA) and {hcp-title-first} support the Node Tuning Operator to improve performance of your nodes on your ROSA and {hcp-title} clusters. Before creating a node tuning configuration, you must create a custom tuning specification.
 
 :FeatureName: {hcp-title-first} 
 include::snippets/technology-preview.adoc[]


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-6268](https://issues.redhat.com/browse/OSDOCS-6268)

Link to docs preview:
- [Using the Node Tuning Operator on Red Hat OpenShift Service on AWS and ROSA with HCP clusters](https://file.rdu.redhat.com/eponvell/OSDOCS-6268_Node-Tuning-ROSA/rosa_cluster_admin/rosa-tuning-config.html)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR removes the Node Tuning topic from the ROSA with HCP folder and relocates it to the Cluster Administration book. I also added references for support for ROSA.