### PR TITLE
[OSDOCS-8167]: Release note about hosted control planes Operator limitations

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1900,6 +1900,12 @@ For more information about early access, xref:../updating/understanding_updates/
 
 * Currently, users cannot modify the `interface-specific` safe sysctl list by updating the `cni-sysctl-allowlist` config map in the `openshift-multus` namespace. As a workaround, you can modify, either manually or with a Daemon Set, the file `/etc/cni/tuning/allowlist.conf` on the node or nodes. (link:https://issues.redhat.com/browse/OCPBUGS-11046[*OCPBUGS-11046*])
 
+* In hosted control planes for {product-title}, the following Operators are not supported:
+
+** Descheduler Operator
+** File Integrity Operator
+** Vertical Pod Autoscaler Operator
+
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-8167
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
