### PR TITLE
RHDEVDOCS-5558: Document GitOps monitoring dashboards in admin console

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -117,6 +117,8 @@ Topics:
   Dir: monitoring
   Distros: openshift-gitops
   Topics:
+  - Name: Monitoring with GitOps dashboards
+    File: monitoring-with-gitops-dashboards
   - Name: Monitoring Argo CD instances
     File: monitoring-argo-cd-instances
   - Name: Monitoring application health status

--- a/modules/gitops-accessing-gitops-monitoring-dashboards.adoc
+++ b/modules/gitops-accessing-gitops-monitoring-dashboards.adoc
@@ -1,0 +1,32 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/monitoring-with-gitops-dashboards.adoc
+
+:_content-type: PROCEDURE
+[id="gitops-accessing-gitops-monitoring-dashboards_{context}"]
+= Accessing {gitops-shortname} monitoring dashboards
+
+The monitoring dashboards are deployed automatically by the Operator. You can access {gitops-shortname} monitoring dashboards from the *Administrator* perspective of the {OCP} web console. 
+
+[NOTE]
+====
+Disabling or changing the content of the dashboards is not supported.
+====
+
+.Prerequisites
+
+* You have access to the {OCP} web console.
+* The {gitops-title} Operator is installed in the default namespace, `openshift-gitops-operator`.
+* The cluster monitoring is enabled on the `openshift-gitops-operator` namespace.
+* You have installed an Argo CD application in your defined namespace, for example, `openshift-gitops`.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, go to *Observe* -> *Dashboards*.
+
+. From the *Dashboard* drop-down list, select the desired {gitops-shortname} dashboard: *{gitops-shortname} (Overview)*, *{gitops-shortname} / Components*, or *{gitops-shortname} /  gRPC Services*.
+
+. Optional: Choose a specific namespace, cluster, and interval from the *Namespace*, *Cluster*, and *Interval* drop-down lists.
+
+. View the desired {gitops-shortname} metrics in the {gitops-shortname} dashboard.
+

--- a/observability/monitoring/monitoring-with-gitops-dashboards.adoc
+++ b/observability/monitoring/monitoring-with-gitops-dashboards.adoc
@@ -1,0 +1,21 @@
+:_content-type: ASSEMBLY
+[id="monitoring-with-gitops-dashboards"]
+include::_attributes/common-attributes.adoc[]
+:context: monitoring-with-gitops-dashboards
+= Monitoring with {gitops-shortname} dashboards
+
+toc::[]
+
+You can access a graphical view of {gitops-shortname} instances with {gitops-title} monitoring dashboards to observe the behavior and usage of each instance across the cluster. 
+
+There are three {gitops-shortname} dashboards available:
+
+* *{gitops-shortname} Overview*: See an overview of all {gitops-shortname} instances installed on the cluster, including the number of applications, health and sync status, application and sync activity.
+* *{gitops-shortname} Components*: View detailed information, such as CPU or memory, for application-controller, repo-server, server, and other {gitops-shortname} components.
+* *{gitops-shortname} gRPC Services*: View metrics related to gRPC service activity between the various components in {gitops-title}.
+
+include::modules/gitops-accessing-gitops-monitoring-dashboards.adoc[leveloffset=+1]
+
+//[role="_additional-resources"]
+//.Additional resources
+//* <add-the-link-to-RHDEVDOCS-5560-once-created>


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **GitOps version for cherry-picking**: `gitops-docs-1.10`,  `gitops-docs-1.11`
• **JIRA issue**: [RHDEVDOCS-5558](https://issues.redhat.com/browse/RHDEVDOCS-5558)
• **Preview page**: [Monitoring with GitOps dashboards](https://66452--docspreview.netlify.app/openshift-gitops/latest/observability/monitoring/monitoring-with-gitops-dashboards)
• **SME Review**: Completed by @reginapizza 
• **QE review**: Completed by @varshab1210 
• **Peer-review** completed