### PR TITLE
TELCODOCS-1599 - updating clock_class_threshold to 135 for T-BC

### DIFF
--- a/snippets/ptp_PtpConfigBoundary.yaml
+++ b/snippets/ptp_PtpConfigBoundary.yaml
@@ -76,7 +76,7 @@ spec:
         summary_interval 0
         kernel_leap 1
         check_fup_sync 0
-        clock_class_threshold 7
+        clock_class_threshold 135
         #
         # Servo Options
         #


### PR DESCRIPTION
Updating clock_class_threshold to 135 for PTP T-BC config

Version(s):
enterprise-4.10+ (Verizon exception in place for 4.10) 

Issue:
https://issues.redhat.com/browse/TELCODOCS-1599

Link to docs preview:
https://66453--docspreview.netlify.app/openshift-enterprise/latest/networking/using-ptp#configuring-linuxptp-services-as-boundary-clock_using-ptp

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
