### PR TITLE
PR for SRVCOM-2388: Updated the procedure for "Deleting Operators from a cluster using the CLI" section.

### DIFF
--- a/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
+++ b/modules/olm-deleting-operators-from-a-cluster-using-cli.adoc
@@ -22,41 +22,41 @@ endif::openshift-dedicated,openshift-rosa[]
 
 .Procedure
 
-. Check the current version of the subscribed Operator (for example, `jaeger`) in the `currentCSV` field:
+. Ensure the latest version of the subscribed operator (for example, `serverless-operator`) is identified in the `currentCSV` field.
 +
 [source,terminal]
 ----
-$ oc get subscription jaeger -n openshift-operators -o yaml | grep currentCSV
+$ oc get subscription.operators.coreos.com serverless-operator -n openshift-serverless -o yaml | grep currentCSV
 ----
 +
 .Example output
 [source,terminal]
 ----
-  currentCSV: jaeger-operator.v1.8.2
+  currentCSV: serverless-operator.v1.28.0
 ----
 
-. Delete the subscription (for example, `jaeger`):
+. Delete the subscription (for example, `serverless-operator`):
 +
 [source,terminal]
 ----
-$ oc delete subscription jaeger -n openshift-operators
+$ oc delete subscription.operators.coreos.com serverless-operator -n openshift-serverless
 ----
 +
 .Example output
 [source,terminal]
 ----
-subscription.operators.coreos.com "jaeger" deleted
+subscription.operators.coreos.com "serverless-operator" deleted
 ----
 
 . Delete the CSV for the Operator in the target namespace using the `currentCSV` value from the previous step:
 +
 [source,terminal]
 ----
-$ oc delete clusterserviceversion jaeger-operator.v1.8.2 -n openshift-operators
+$ oc delete clusterserviceversion serverless-operator.v1.28.0 -n openshift-serverless
 ----
 +
 .Example output
 [source,terminal]
 ----
-clusterserviceversion.operators.coreos.com "jaeger-operator.v1.8.2" deleted
+clusterserviceversion.operators.coreos.com "serverless-operator.v1.28.0" deleted
 ----


### PR DESCRIPTION
**Affected versions for cherry-picking:** **4.11+** I have made the changes in the Openshift-main branch. (Changes are related to Serverless) 

**Tracking JIRA:** https://issues.redhat.com/browse/SRVCOM-2388

**Doc preview:** [Deleting Operators from a cluster using the CLI](https://66454--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-deleting-operators-from-cluster#olm-deleting-operator-from-a-cluster-using-cli_olm-deleting-operators-from-a-cluster)

**Description:** Updated the procedure for **Deleting Operators from a cluster using the CLI** section and replaced `jaeger` with `serverless-operator`.