### PR TITLE
WIP PR for SRVCOM-2712: adjustments for Serverless 1.31

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -213,22 +213,22 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12)/serverless/develop/serverless-traffic-management.html /container-platform/$1/serverless/knative-serving/traffic-splitting/traffic-splitting-overview.html [NE,R=302]
 
 
-    # redirect latest to 1.30
+    # redirect latest to 1.31
     RewriteRule ^serverless/?$ /serverless/latest [R=302]
-    RewriteRule ^serverless/latest/?(.*)$ /serverless/1\.30/$1 [NE,R=302]
+    RewriteRule ^serverless/latest/?(.*)$ /serverless/1\.31/$1 [NE,R=302]
 
     # redirect top-level without filespec to the about file
-    RewriteRule ^serverless/(1\.28|1\.29|1\.30)/?$ /serverless/$1/about/about-serverless.html [L,R=302]
+    RewriteRule ^serverless/(1\.28|1\.29|1\.30|1\.31)/?$ /serverless/$1/about/about-serverless.html [L,R=302]
 
     # redirect rel notes
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/serverless-release-notes.html$ /serverless/1.30/about/serverless-release-notes.html [L,R=302]
-    RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.30/about/serverless-release-notes.html [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/serverless-release-notes.html$ /serverless/1.31/about/serverless-release-notes.html [L,R=302]
+    RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.31/about/serverless-release-notes.html [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/?(.*)$ /serverless/1.31/$2  [L,R=302]
 
     # redirect any links to existing ROSA/Dedicated embedded content to standalone equivalent
-    RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
+    RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.31/$2  [L,R=302]
 
 
     # redirect gitops latest to 1.10

--- a/_distro_map.yml
+++ b/_distro_map.yml
@@ -309,6 +309,9 @@ openshift-serverless:
     serverless-docs-1.30:
       name: '1.30'
       dir: serverless/1.30
+    serverless-docs-1.31:
+      name: '1.31'
+      dir: serverless/1.31
 openshift-gitops:
   name: Red Hat OpenShift GitOps
   author: OpenShift documentation team <openshift-docs@redhat.com>

--- a/_templates/_page_openshift.html.erb
+++ b/_templates/_page_openshift.html.erb
@@ -201,6 +201,7 @@
               <%= distro %>
             </a>
             <select id="version-selector" onchange="versionSelector(this);">
+              <option value="1.31">1.31</option>
               <option value="1.30">1.30</option>
               <option value="1.29">1.29</option>
               <option value="1.28">1.28</option>


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
Serverless 1.31

Issue:
[SRVCOM-2712 - Github - Serverless updates for going GA](https://issues.redhat.com/browse/SRVCOM-2712)

Link to docs preview:
https://66455--docspreview.netlify.app/


QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
These are the adjustments to ensure that the docs pages redirect and appear correctly.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
