### PR TITLE
Updates 4.14 RNs to remove OPENSHIFT_DEFAULT_REGISTRY entry

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1063,11 +1063,6 @@ Kubernetes 1.27 removed the following deprecated API, so you must migrate manife
 
 |===
 
-[id="ocp-4-14-openshift-default-registry"]
-==== Removal of the OPENSHIFT_DEFAULT_REGISTRY
-
-{product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups.
-
 [id="ocp-4-14-future-deprecation"]
 === Notice of future deprecation
 


### PR DESCRIPTION
Variable is not being removed until 4.15.

Version(s):
4.14 only

Issue:
https://issues.redhat.com/browse/OSDOCS-7709

Link to docs preview:
https://66470--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-removed-features
