### PR TITLE
4.14 GA Monitoring bugs p2

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -509,7 +509,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 ==== Automatic CSI migration for VMware vSphere
 This feature automatically translates in-tree objects to their counterpart CSI representations and should be completely transparent to users. Although storage class referencing to the in-tree storage plug-in will continue working, it is recommended that you switch the default storage class to the CSI storage class.
 
-In {product-title} 4.14, CSI migration for vSphere is enabled by default under all circumstances and requires no action by an administrator. 
+In {product-title} 4.14, CSI migration for vSphere is enabled by default under all circumstances and requires no action by an administrator.
 
 However, if you are using vSphere in-tree persistent volumes (PVs) and want to upgrade from {product-title} 4.12 or 4.13 to 4.14, update vSphere vCenter and ESXI host to 7.0 Update 3L or 8.0 Update 2, otherwise the {product-title} upgrade is blocked. If you do not want to update vSphere, you can proceed with an {product-title} upgrade by performing an administrator acknowledgment. However, with using the administrator acknowledgment, known issues can occur. link:https://access.redhat.com/node/7011683[Before proceeding with the administrator acknowledgement, carefully read this knowledge base article].
 
@@ -1291,15 +1291,19 @@ Targeting {product-title} 4.15, the OpenShift SDN CNI network plugin will not be
 [id="ocp-4-14-monitoring-bug-fixes"]
 ==== Monitoring
 
-* Before this update, the `prometheus-adapter` pods might flood the Prometheus HTTP servers with too many requests when users requested pod metrics across all namespaces. The issue also became visible when the Vertical Pod Autoscaler was deployed. In the worst cases, `prometheus-adapter` pods would hit their maximum TCP connection request limit, and liveness probes might fail, which led to Prometheus pod restarts. With this update, the requests from a `prometheus-adapter` pod to the Prometheus service are limited to 100 simultaneous requests, thereby fixing the issue. (link:https://issues.redhat.com/browse/OCPBUGS-20250[*OCPBUGS-20250*])
-
-* Before this update, the node-exporter could consume large amounts of CPU resources in some configurations. This update limits the number of CPUs that can be used simultaneously by the node-exporter. The number of CPUs is now set to `4` or to the number of CPUs available on the host, whichever is smaller. You can override this limit by using the `maxProcs` parameter in the config map settings for the node-exporter. See xref:../monitoring/config-map-reference-for-the-cluster-monitoring-operator.html#nodeexporterconfig[NodeExporterConfig] for more information. (link:https://issues.redhat.com/browse/OCPBUGS-13153[*OCPBUGS-13153*])
-
 * Before this update, large amounts of CPU resources might be consumed during metrics scraping as a result of the way the node-exporter collected network interface information. This release fixes this issue by improving the performance of node-exporter when collecting network interface information, thereby resolving the issue with excessive CPU usage during metrics scraping. (link:https://issues.redhat.com/browse/OCPBUGS-12714[*OCPBUGS-12714*])
 
 * Before this update, Thanos Querier failed to de-duplicate metrics by node roles. This update fixes the issue so that Thanos Querier now properly de-duplicates metrics by node roles. (link:https://issues.redhat.com/browse/OCPBUGS-12525[*OCPBUGS-12525*])
 
-* Before this update, the remote write endpoint for a user workload monitoring Prometheus pods did not have custom CA bundles injected so that the endpoint could not be protected using SSL. With this update, the trusted CA bundle has been added to user workload monitoring Prometheus pods so that users can secure the remote write endpoint using SSL. (link:https://issues.redhat.com/browse/OCPBUGS-11958[*OCPBUGS-11958*])
+* Before this update, the `btrfs` collector of node-exporter was always enabled, which caused increased CPU usage because Red Hat Enterprise Linux does not support the`btrfs` storage format. With this update, the `btrfs` collector is now disabled, thereby resolving the issue. (link:https://issues.redhat.com/browse/OCPBUGS-11434[*OCPBUGS-11434*])
+
+* Before this update, for the `cluster:capacity_cpu_cores:sum` metric, nodes with the`infra` role but not `master` role were not assigned a value of `infra` for the `label_node_role_kubernetes_io` label. With this update, nodes with the `infra` role, but not `master` role, are now correctly labeled as `infra` for this metric. (link:https://issues.redhat.com/browse/OCPBUGS-10387[*OCPBUGS-10387*])
+
+* Before this update, the lack of a startup probe prevented the Prometheus Adapter pods from starting when the Kubernetes API had many custom resource definitions installed because the program initialization would take longer than what was allowed by the liveness probe. With this update, the Prometheus Adapter pods are now configured with a startup probe that waits five minutes before failing, thereby resolving the issue. (link:https://issues.redhat.com/browse/OCPBUGS-7694[*OCPBUGS-7694*])
+
+* The `node_exporter` collector is meant to collect network interface metrics for physical interfaces only, but before this update, the `node-exporter` collector did not exclude Calico Virtual NICs when collecting these metrics. This update adds the `++cali[a-f0-9]*++` value to the`collector.netclass.ignored-devices` list to ensure that metrics are not collected for Calico Virtual NICs. (link:https://issues.redhat.com/browse/OCPBUGS-7282[*OCPBUGS-7282*])
+
+* With this release, as a security measure, Cross Origin Resource Sharing (CORS) headers are now disabled by default for Thanos Querier. If you still need to use CORS headers, you can enable them by setting the value of the `enableCORS` parameter to `true` for the `ThanosQuerierConfig` resource. (link:https://issues.redhat.com/browse/OCPBUGS-11889[*OCPBUGS-11889*])
 
 [discrete]
 [id="ocp-4-14-networking-bug-fixes"]


### PR DESCRIPTION
Version(s):
4.14

Issue:
[Bug Batching for 4.14 GA](https://issues.redhat.com/browse/OSDOCS-5987)

Link to docs preview:
[Preview](https://66487--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-bug-fixes)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
Not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
[Monitoring bugs](https://issues.redhat.com/secure/Dashboard.jspa?selectPageId=12347491#SIGwKWmOqDAaIiGh1DSCAiYg6oaN4RY8HF6AMAwlQMHEVU1ccdWpPFMCNc1SXIGgGCNeaPAtG0HT+ogCErGsyGEN+BWVIiyIogsILgh+5JftSCgaB47qFfMcT8UaPCIpglTgdQGgaM1dQLIU7oxHCe27BaQlWEAA) This PR is only half of the bugs.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
