### PR TITLE
OSDOCS#8239: Added Required Azure roles back to docs

### DIFF
--- a/installing/installing_azure/installing-azure-account.adoc
+++ b/installing/installing_azure/installing-azure-account.adoc
@@ -32,6 +32,7 @@ include::modules/installation-azure-subscription-tenant-id.adoc[leveloffset=+1]
 
 include::modules/installation-azure-identities.adoc[leveloffset=+1]
 
+include::modules/installation-azure-permissions.adoc[leveloffset=+2]
 include::modules/minimum-required-permissions-ipi-azure.adoc[leveloffset=+2]
 include::modules/installation-using-azure-managed-identities.adoc[leveloffset=+2]
 include::modules/installation-creating-azure-service-principal.adoc[leveloffset=+2]

--- a/modules/installation-azure-permissions.adoc
+++ b/modules/installation-azure-permissions.adoc
@@ -7,15 +7,11 @@
 [id="installation-azure-permissions_{context}"]
 = Required Azure roles
 
-{product-title} needs a service principal so it can manage Microsoft Azure resources. Before you can create a service principal, review the following information:
+An {product-title} cluster requires an Azure identity to create and manage Azure resources. Before you create the identity, verify that your environment meets the following requirements:
 
-Your Azure account subscription must have the following roles:
-
-* `User Access Administrator`
-* `Contributor`
-
-Your Azure Active Directory (AD) must have the following permission:
-
-* `"microsoft.directory/servicePrincipals/createAsOwner"`
+* The Azure account that you use to create the identity is assigned the `User Access Administrator` and `Contributor` roles. These roles are required when:
+** Creating a service principal or user-assigned managed identity.
+** Enabling a system-assigned managed identity on a virtual machine.
+* If you are going to use a service principal to complete the installation, verify that the Azure account that you use to create the identity is assigned the `microsoft.directory/servicePrincipals/createAsOwner` permission in Azure Active Directory.
 
 To set roles on the Azure portal, see the link:https://docs.microsoft.com/en-us/azure/role-based-access-control/role-assignments-portal[Manage access to Azure resources using RBAC and the Azure portal] in the Azure documentation.


### PR DESCRIPTION
Version(s):
4.14+

Issue:
This issue addresses [osdocs-8239](https://issues.redhat.com/browse/OSDOCS-8239).

Link to docs preview:

[Required Azure roles](https://66497--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installing-azure-account#installation-azure-permissions_installing-azure-account)

QE review:
- [x] QE has approved this change.
