### PR TITLE
Updating installing prep page for 4.14

### DIFF
--- a/installing/installing-preparing.adoc
+++ b/installing/installing-preparing.adoc
@@ -195,8 +195,8 @@ ifndef::openshift-origin[]
 |
 |xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[&#10003;]
 |xref:../installing/installing_aws/installing-restricted-networks-aws-installer-provisioned.adoc#installing-restricted-networks-aws-installer-provisioned[&#10003;]
-|
-|
+|xref:../installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc#installing-restricted-networks-azure-installer-provisioned[&#10003;]
+|xref:../installing/installing_azure/installing-restricted-networks-azure-installer-provisioned.adoc#installing-restricted-networks-azure-installer-provisioned[&#10003;]
 |
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[&#10003;]
 |xref:../installing/installing_gcp/installing-restricted-networks-gcp-installer-provisioned.adoc#installing-restricted-networks-gcp-installer-provisioned[&#10003;]


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6194

Link to docs preview:
https://66500--docspreview.netlify.app/openshift-enterprise/latest/installing/installing-preparing#supported-installation-methods-for-different-platforms

QE review:
- [x] QE has approved this change.

Adding Azure restricted install from https://issues.redhat.com/browse/OSDOCS-5174