### PR TITLE
[OSDOCS-7791] fixing OSD on GCP regions

### DIFF
--- a/modules/sdpolicy-am-regions-availability-zones.adoc
+++ b/modules/sdpolicy-am-regions-availability-zones.adoc
@@ -40,10 +40,9 @@ The following Google Cloud regions are currently supported:
 * asia-east2, Hong Kong
 * asia-northeast1, Tokyo, Japan
 * asia-northeast2, Osaka, Japan
-* asia-northeast3, Seoul, Korea
 * asia-south1, Mumbai, India
 * asia-southeast1, Jurong West, Singapore
-* asia-southeast2, Jakarta, Indonesia
+* australia-southeast1, Sydney, Australia
 * europe-north1, Hamina, Finland
 * europe-west1, St. Ghislain, Belgium
 * europe-west2, London, England, UK
@@ -57,8 +56,6 @@ The following Google Cloud regions are currently supported:
 * us-east4, Ashburn, Northern Virginia, USA
 * us-west1, The Dalles, Oregon, USA
 * us-west2, Los Angeles, California, USA
-* us-west3, Salt Lake City, Utah, USA
-* us-west4, Las Vegas, Nevada, USA
 
 Multi-AZ clusters can only be deployed in regions with at least 3 availability zones (see link:https://aws.amazon.com/about-aws/global-infrastructure/regions_az/[AWS] and link:https://cloud.google.com/compute/docs/regions-zones[Google Cloud]).
 


### PR DESCRIPTION
[OSDOCS-7791] fixing OSD on GCP regions

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OSDOCS-7791

Link to docs preview:
https://66501--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd_policy/osd-service-definition#regions-availability-zones_osd-service-definition

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
