### PR TITLE
OSDOCS#5162:Updates to dynamic plugin API

### DIFF
--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -1239,16 +1239,17 @@ Hook that returns the given feature flag from FLAGS redux state. It returns the 
 |===
 
 [discrete]
-== `YAMLEditor`
+== `CodeEditor`
 
-A basic lazy loaded YAML editor with hover help and completion.
+A basic lazy loaded Code editor with hover help and completion.
 
 .Example
 [source,text]
 ----
 <React.Suspense fallback={<LoadingBox />}>
-  <YAMLEditor
+  <CodeEditor
     value={code}
+    language="yaml"
   />
 </React.Suspense>
 ----
@@ -1257,24 +1258,16 @@ A basic lazy loaded YAML editor with hover help and completion.
 |===
 |Parameter Name |Description
 |`value` |String representing the yaml code to render.
-
-|`options` |Monaco editor options.
-
+|`language` |String representing the language of the editor.
+|`options` |Monaco editor options. For more details, please, visit link:https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.IStandaloneEditorConstructionOptions.html[Interface IStandAloneEditorConstructionOptions].
 |`minHeight` |Minimum editor height in valid CSS height values.
-
 |`showShortcuts` |Boolean to show shortcuts on top of the editor.
-
-|`toolbarLinks` |Array of ReactNode rendered on the toolbar links
-section on top of the editor.
-
+|`toolbarLinks` |Array of ReactNode rendered on the toolbar links section on top of the editor.
 |`onChange` |Callback for on code change event.
-
 |`onSave` |Callback called when the command CTRL / CMD + S is triggered.
-
-|`ref` |React reference to `{ editor?: IStandaloneCodeEditor }`. Using
-the `editor` property, you are able to access to all methods to control
-the editor.
+|`ref` |React reference to `{ editor?: IStandaloneCodeEditor }`. Using the `editor` property, you are able to access to all methods to control the editor. For more information, visit link:https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneCodeEditor.html[Interface IStandaloneCodeEditor].
 |===
+
 
 [discrete]
 == `ResourceYAMLEditor`
@@ -1476,6 +1469,149 @@ Creates full page ErrorBoundaryFallbackPage component to display the "Oh no! Som
 |===
 
 [discrete]
+== `QueryBrowser`
+
+A component that renders a graph of the results from a Prometheus PromQL query along with controls for interacting with the graph.
+
+.Example
+[source,tsx]
+----
+<QueryBrowser
+  defaultTimespan={15 * 60 * 1000}
+  namespace={namespace}
+  pollInterval={30 * 1000}
+  queries={[
+    'process_resident_memory_bytes{job="console"}',
+    'sum(irate(container_network_receive_bytes_total[6h:5m])) by (pod)',
+  ]}
+/>
+----
+
+[cols=",",options="header",]
+|===
+|Parameter Name |Description
+|`customDataSource` |(optional) Base URL of an API endpoint that handles PromQL queries. If provided, this is used instead of the default API for fetching data.
+|`defaultSamples` |(optional) The default number of data samples plotted for each data series. If there are many data series, QueryBrowser might automatically pick a lower number of data samples than specified here.
+|`defaultTimespan` |(optional) The default timespan for the graph in milliseconds - defaults to 1,800,000 (30 minutes).
+|`disabledSeries` |(optional) Disable (don't display) data series with these exact label / value pairs.
+|`disableZoom` |(optional) Flag to disable the graph zoom controls.
+|`filterLabels` |(optional) Optionally filter the returned data series to only those that match these label / value pairs.
+|`fixedEndTime` |(optional) Set the end time for the displayed time range rather than showing data up to the current time.
+|`formatSeriesTitle` |(optional) Function that returns a string to use as the title for a single data series.
+|`GraphLink` |(optional) Component for rendering a link to another page (for example getting more information about this query).
+|`hideControls` |(optional) Flag to hide the graph controls for changing the graph timespan, and so on.
+|`isStack` |(optional) Flag to display a stacked graph instead of a line graph. If showStackedControl is set, it will still be possible for the user to switch to a line graph.
+|`namespace` |(optional) If provided, data is only returned for this namespace (only series that have this namespace label).
+|`onZoom` |(optional) Callback called when the graph is zoomed.
+|`pollInterval` |(optional) If set, determines how often the graph is updated to show the latest data (in milliseconds).
+|`queries` |Array of PromQL queries to run and display the results in the graph.
+|`showLegend` |(optional) Flag to enable displaying a legend below the graph.
+|`showStackedControl` |Flag to enable displaying a graph control for switching between stacked graph mode and line graph mode.
+|`timespan` |(optional) The timespan that should be covered by the graph in milliseconds.
+|`units` |(optional) Units to display on the Y-axis and in the tooltip.
+|===
+
+[discrete]
+== `useAnnotationsModal`
+
+A hook that provides a callback to launch a modal for editing Kubernetes resource annotations.
+
+.Example
+[source,tsx]
+----
+const PodAnnotationsButton = ({ pod }) => {
+  const { t } = useTranslation();
+  const launchAnnotationsModal = useAnnotationsModal<PodKind>(pod);
+  return <button onClick={launchAnnotationsModal}>{t('Edit Pod Annotations')}</button>
+}
+----
+
+[cols=",",options="header",]
+|===
+|Parameter Name |Description
+|`resource` |The resource to edit annotations for an object of K8sResourceCommon type.
+|===
+
+.Returns
+A function which will launch a modal for editing a resource's annotations.
+
+[discrete]
+== `useDeleteModal`
+
+A hook that provides a callback to launch a modal for deleting a resource.
+
+.Example
+[source,tsx]
+----
+const DeletePodButton = ({ pod }) => {
+  const { t } = useTranslation();
+  const launchDeleteModal = useDeleteModal<PodKind>(pod);
+  return <button onClick={launchDeleteModal}>{t('Delete Pod')}</button>
+}
+----
+
+[cols=",",options="header",]
+|===
+|Parameter Name |Description
+|`resource` |The resource to delete.
+|`redirectTo` |(optional) A location to redirect to after deleting the resource.
+|`message` |	(optional) A message to display in the modal.
+|`btnText` |	(optional) The text to display on the delete button.
+|`deleteAllResources` |(optional) A function to delete all resources of the same kind.
+|===
+
+.Returns
+A function which will launch a modal for deleting a resource.
+
+[discrete]
+== `useLabelsModel`
+
+A hook that provides a callback to launch a modal for editing Kubernetes resource labels.
+
+.Example
+[source,tsx]
+----
+const PodLabelsButton = ({ pod }) => {
+  const { t } = useTranslation();
+  const launchLabelsModal = useLabelsModal<PodKind>(pod);
+  return <button onClick={launchLabelsModal}>{t('Edit Pod Labels')}</button>
+}
+----
+
+[cols=",",options="header",]
+|===
+|Parameter Name |Description
+|`resource` |The resource to edit labels for, an object of K8sResourceCommon type.
+|===
+
+.Returns
+A function which will launch a modal for editing a resource's labels.
+
+[discrete]
+== `useActiveNamespace`
+
+Hook that provides the currently active namespace and a callback for setting the active namespace.
+
+.Example
+[source,tsx]
+----
+const Component: React.FC = (props) => {
+   const [activeNamespace, setActiveNamespace] = useActiveNamespace();
+   return <select
+     value={activeNamespace}
+     onChange={(e) => setActiveNamespace(e.target.value)}
+   >
+     {
+       // ...namespace options
+     }
+   </select>
+}
+----
+
+.Returns
+A tuple containing the current active namespace and setter callback.
+
+[discrete]
 == `PerspectiveContext`
 
 Deprecated: Use the provided `usePerspectiveContext` instead. Creates the perspective context.
@@ -1510,3 +1646,41 @@ Deprecated: This hook is not related to console functionality. Hook that ensures
 |===
 
 :!power-bi-url:
+
+[discrete]
+== `YAMLEditor`
+
+Deprecated: A basic lazy loaded YAML editor with hover help and completion.
+
+.Example
+[source,text]
+----
+<React.Suspense fallback={<LoadingBox />}>
+  <YAMLEditor
+    value={code}
+  />
+</React.Suspense>
+----
+
+[cols=",",options="header",]
+|===
+|Parameter Name |Description
+|`value` |String representing the yaml code to render.
+
+|`options` |Monaco editor options.
+
+|`minHeight` |Minimum editor height in valid CSS height values.
+
+|`showShortcuts` |Boolean to show shortcuts on top of the editor.
+
+|`toolbarLinks` |Array of ReactNode rendered on the toolbar links
+section on top of the editor.
+
+|`onChange` |Callback for on code change event.
+
+|`onSave` |Callback called when the command CTRL / CMD + S is triggered.
+
+|`ref` |React reference to `{ editor?: IStandaloneCodeEditor }`. Using
+the `editor` property, you are able to access to all methods to control
+the editor.
+|===


### PR DESCRIPTION
OSDOCS#5162:Updates to dynamic plugin API

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-5162

Link to docs preview:
https://66505--docspreview.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/dynamic-plugins-reference#dynamic-plugin-api_dynamic-plugins-reference:~:text=flag%20to%20return-,CodeEditor,-A%20basic%20lazy

https://66505--docspreview.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/dynamic-plugins-reference#dynamic-plugin-api_dynamic-plugins-reference:~:text=error%20boundary%20page-,QueryBrowser,-A%20component%20that

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
FYI for peer reviewer- these should be treated like the rest api docs. Only note is there is a broken link in one of the references I have commented out for now.
