### PR TITLE
OSDOCS-8022: 4.14 add network observability to OCP RN

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -654,6 +654,10 @@ You can now use CMO settings to configure the following features of the console 
 * Resource requests
 * Resource limits
 
+[id="ocp-4-14-network-observability-1-4"]
+=== Network Observability Operator
+The Network Observability Operator releases updates independently from the {product-title} minor version release stream. Updates are available through a single, rolling stream which is supported on all currently supported versions of {product-title} 4. Information regarding new features, enhancements, and bug fixes for the Network Observability Operator is found in the xref:../network_observability/network-observability-operator-release-notes.adoc[Network Observability release notes].
+
 [id="ocp-4-14-scalability-and-performance"]
 === Scalability and performance
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
Need to add Network Observability stub RN to main OCP RN page. Also this RN reflects the new home of Network Observability under Monitoring. 
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://66518--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-network-observability-1-4
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
