### PR TITLE
Update oc-mirror-installing-plugin.adoc

### DIFF
--- a/modules/oc-mirror-installing-plugin.adoc
+++ b/modules/oc-mirror-installing-plugin.adoc
@@ -49,9 +49,9 @@ $ sudo mv oc-mirror /usr/local/bin/.
 
 .Verification
 
-* Run `oc mirror help` to verify that the plugin was successfully installed:
+* Run `oc-mirror help` to verify that the plugin was successfully installed:
 +
 [source,terminal]
 ----
-$ oc mirror help
+$ oc-mirror help
 ----


### PR DESCRIPTION
Fixing the typo error in oc mirror command

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: In 4.14 document there is a incorrect command of oc mirror
It should be:
$ oc-mirror
It is:
$ oc mirror
 % ./oc version
 Client Version: 4.14.0-rc.0
 Kustomize Version: v5.0.1
 Server Version: 4.14.0-rc.4
 Kubernetes Version: v1.27.6+6936c15
Gives the below error:
 $ oc mirror
 error: unknown command "mirror" for "oc"
https://issues.redhat.com/browse/OSDOCS-8223
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
