### PR TITLE
Documentation for GitOps 1.10.1 release notes.

### DIFF
--- a/modules/gitops-release-notes-1-10-1.adoc
+++ b/modules/gitops-release-notes-1-10-1.adoc
@@ -1,0 +1,29 @@
+// Module included in the following assembly:
+//
+// * release_notes/gitops-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="gitops-release-notes-1-10-1_{context}"]
+= Release notes for {gitops-title} 1.10.1
+
+{gitops-title} 1.10.1 is now available on {OCP} 4.12, 4.13 and 4.14.
+
+[id="errata-updates-1-10.1_{context}"]
+== Errata updates
+
+[id="gitops-1-10-1-security-update-advisory_{context}"]
+=== RHSA-2023:6220 - {gitops-title} 1.10.1 security update advisory
+
+Issued: 2023-10-31
+
+The list of security fixes that are included in this release is documented in the following advisory:
+
+* link:https://access.redhat.com/errata/RHSA-2023:6220[RHSA-2023:6220]
+
+If you have installed the {gitops-title} Operator in the default namespace, run the following command to view the container images in this release:
+
+[source,terminal]
+----
+$ oc describe deployment gitops-operator-controller-manager -n openshift-gitops-operator
+----
+

--- a/release_notes/gitops-release-notes.adoc
+++ b/release_notes/gitops-release-notes.adoc
@@ -22,6 +22,8 @@ include::modules/go-compatibility-and-support-matrix.adoc[leveloffset=+1]
 include::modules/making-open-source-more-inclusive.adoc[leveloffset=+1]
 
 // Modules included, most to least recent
+include::modules/gitops-release-notes-1-10-1.adoc[leveloffset=+1]
+
 include::modules/gitops-release-notes-1-10-0.adoc[leveloffset=+1]
 
 include::modules/gitops-release-notes-1-9-2.adoc[leveloffset=+1]


### PR DESCRIPTION
- Jira issue: [RHDEVDOCS-5673](https://issues.redhat.com/browse/RHDEVDOCS-5673)
- CherryPick versions: GitOps 1.10 branch
- Doc preview: [gitops-release-notes-1-10-1](https://66524--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-10-1_gitops-release-notes)
- OCP team: DevTools
- SME reviews by: @reginapizza 
- QE reviews by: @varshab1210 
- Peer reviews by: @adellape 

