### PR TITLE
[OSDOCS-8263]: Add reference to describe machinepool command

### DIFF
--- a/modules/rosa-list-objects.adoc
+++ b/modules/rosa-list-objects.adoc
@@ -523,3 +523,48 @@ Describe a cluster named `mycluster`.
 $ rosa describe cluster --cluster=mycluster
 ----
 
+[id="rosa-describe-machinepool_{context}"]
+== describe machinepool
+
+Describes a specific machine pool configured on a cluster.
+
+.Syntax
+[source,terminal]
+----
+$ rosa describe machinepool --cluster=<cluster_name> --machinepool=<machinepool_name>| <cluster_id> <machinepool_id> [arguments]
+----
+
+.Arguments
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--cluster
+|Required: The name or ID (string) of the cluster.
+
+|--machinepool
+|Required: The name or ID (string) of the machinepool.
+
+|===
+
+.Optional arguments inherited from parent commands
+[cols="30,70"]
+|===
+|Option |Definition
+
+|--help
+|Shows help for this command.
+
+|--debug
+|Enables debug mode.
+
+|--profile
+|Specifies an AWS profile (string) from your credentials file.
+|===
+
+.Example
+Describe a machine pool named `mymachinepool` on a cluster named `mycluster`.
+[source,terminal]
+----
+$ rosa describe machinepool --cluster=mycluster --machinepool=mymachinepool
+----


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8263
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://66546--docspreview.netlify.app/openshift-rosa/latest/cli_reference/rosa_cli/rosa-manage-objects-cli#rosa-describe-machinepool_rosa-managing-objects-cli
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
![image](https://github.com/openshift/openshift-docs/assets/122639474/2e4cc240-07db-42d7-9839-19a21d41003a)
This is a duplicate of https://github.com/openshift/openshift-docs/pull/66125; The doc updates were approved by QE, SME, peer, and merged. They had to removed b/c the latest ROSA CLI version had not been released. It has now been released and new content needs to be added to docs. 
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
