### PR TITLE
CNV-28944: Release note: PREVIEW Cluster-level eviction strategy change

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -69,6 +69,28 @@ The SVVP Certification applies to:
 //CNV-28096 Release note: NEW feature -- clone from cached snapshot
 * You can now enable volume snapshots as boot sources.
 
+//CNV-28724 Release note: storage profile defaults
+* The access mode and volume mode fields in storage profiles are populated automatically with their optimal values for the following additional Containerized Storage Interface (CSI) provisioners:
+
+** Dell PowerFlex
+** Dell PowerMax
+** Dell PowerScale
+** Dell Unity
+** Dell PowerStore
+** Hitachi Virtual Storage Platform (VSP)
+** IBM Fusion Hyper-Converged Infrastructure (HCI)
+** IBM Fusion General Parallel File System (GPFS2)
+** IBM Fusion Software-Defined Storage (SDS/ODF)
+** IBM Fusion block arrays
+** Hewlett Packard Enterprise 3PAR
+** Hewlett Packard Enterprise Nimble
+** Hewlett Packard Enterprise Alletra
+** Hewlett Packard Enterprise Primera
+
+//CNV-28725 Release note: NEW
+
+//CNV-28096 Release note: NEW feature -- clone from cached snapshot
+
 //CNV-28726 Release note: New
 * By default, Windows 11 and Windows Server 2022 virtual machines (VMs) have a non-persistent trusted platform module (TPM) device state, which is required to enable the VM snapshot feature. A non-persistent TPM will, however, render the VM incompatible with software that relies on TPM persistence, such as BitLocker.
 
@@ -194,6 +216,7 @@ link:https://access.redhat.com/support/offerings/techpreview[Technology Preview 
 //CNV-28723 Release note: PREVIEW
 
 //CNV-28944 Release note: Preview Cluster level eviction strategy change
+* You can now configure a xref:../../virt/nodes/virt-node-maintenance.adoc#eviction-strategies[VM eviction strategy] for the xref:../../virt/nodes/virt-node-maintenance.adoc#virt-configuring-cluster-eviction-strategy-cli_virt-node-maintenance[entire cluster].
 
 //CNV-29940 Release note: Preview UI Bridged network interface hot-plug for VMs
 * You can xref:../../virt/vm_networking/virt-hot-plugging-network-interfaces.adoc#virt-hot-plugging-network-interfaces[hot plug a bridge network interface] to a running virtual machine (VM). Hot plugging and hot unplugging is supported only for VMs created with {VirtProductName} 4.14 or later.


### PR DESCRIPTION
Version(s): 4.14

Issue: [CNV-28944](https://issues.redhat.com/browse/CNV-28944)

Link to docs preview: [Technology Preview features](https://66553--docspreview.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes#virt-4-14-technology-preview)

QE review:
- [x] QE has approved this change.

