### PR TITLE
[enterprise-4.12] RHDEVDOCS 5669 use a variable for Pipelines version in links, enable ARM64 tkn for all docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -94,7 +94,8 @@ endif::[]
 //pipelines
 :pipelines-title: Red Hat OpenShift Pipelines
 :pipelines-shortname: OpenShift Pipelines
-:pipelines-ver: pipelines-1.11
+:pipelines-ver: pipelines-1.12
+:pipelines-version-number: 1.12
 :tekton-chains: Tekton Chains
 :tekton-hub: Tekton Hub
 :artifact-hub: Artifact Hub

--- a/modules/op-installing-tkn-on-linux-using-rpm.adoc
+++ b/modules/op-installing-tkn-on-linux-using-rpm.adoc
@@ -49,30 +49,30 @@ For {op-system-base-full} version 8, you can install the {pipelines-title} CLI a
 +
 * Linux (x86_64, amd64)
 +
-[source,terminal]
+[source,terminal,subs="attributes"]
 ----
-# subscription-manager repos --enable="pipelines-1.11-for-rhel-8-x86_64-rpms"
+# subscription-manager repos --enable="pipelines-{pipelines-version-number}-for-rhel-8-x86_64-rpms"
 ----
 +
 * Linux on {ibmzProductName} and {linuxoneProductName} (s390x)
 +
-[source,terminal]
+[source,terminal,subs="attributes"]
 ----
-# subscription-manager repos --enable="pipelines-1.11-for-rhel-8-s390x-rpms"
+# subscription-manager repos --enable="pipelines-{pipelines-version-number}-for-rhel-8-s390x-rpms"
 ----
 +
 * Linux on {ibmpowerProductName} (ppc64le)
 +
-[source,terminal]
+[source,terminal,subs="attributes"]
 ----
-# subscription-manager repos --enable="pipelines-1.11-for-rhel-8-ppc64le-rpms"
+# subscription-manager repos --enable="pipelines-{pipelines-version-number}-for-rhel-8-ppc64le-rpms"
 ----
 +
 * Linux on ARM (aarch64, arm64)
 +
-[source,terminal]
+[source,terminal,subs="attributes"]
 ----
-# subscription-manager repos --enable="pipelines-1.11-for-rhel-8-arm64-rpms"
+# subscription-manager repos --enable="pipelines-{pipelines-version-number}-for-rhel-8-aarch64-rpms"
 ----
 . Install the `openshift-pipelines-client` package:
 +

--- a/modules/op-installing-tkn-on-linux.adoc
+++ b/modules/op-installing-tkn-on-linux.adoc
@@ -14,13 +14,13 @@ For Linux distributions, you can download the CLI as a `tar.gz` archive.
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-amd64.tar.gz[Linux (x86_64, amd64)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-s390x.tar.gz[Linux on {ibmzProductName} and {linuxoneProductName} (s390x)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-ppc64le.tar.gz[Linux on {ibmpowerProductName} (ppc64le)]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipeline/1.9.1/tkn-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-linux-arm64.tar.gz[Linux on ARM (aarch64, arm64)]
 
 // Binaries also need to be updated in the following modules:
 // op-installing-pipelines-as-code-cli.adoc

--- a/modules/op-installing-tkn-on-macos.adoc
+++ b/modules/op-installing-tkn-on-macos.adoc
@@ -14,9 +14,9 @@ For macOS, you can download the CLI as a `tar.gz` archive.
 
 . Download the relevant CLI tool.
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-macos-amd64.tar.gz[macOS]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-macos-amd64.tar.gz[macOS]
 
-* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-macos-arm64.tar.gz[macOS on ARM]
+* link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-macos-arm64.tar.gz[macOS on ARM]
 
 . Unpack and extract the archive.
 

--- a/modules/op-installing-tkn-on-windows.adoc
+++ b/modules/op-installing-tkn-on-windows.adoc
@@ -12,7 +12,7 @@ For Windows, you can download the CLI as a `zip` archive.
 
 .Procedure
 
-.  Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/1.11.0/tkn-windows-amd64.zip[CLI tool].
+.  Download the link:https://mirror.openshift.com/pub/openshift-v4/clients/pipelines/{pipelines-version-number}.0/tkn-windows-amd64.zip[CLI tool].
 
 . Extract the archive with a ZIP program.
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/66521