### PR TITLE
[ACM-7350]: 4.14z Adding reference to MCE must-gather in HyperShift troubleshooting docs

### DIFF
--- a/hosted_control_planes/hcp-troubleshooting.adoc
+++ b/hosted_control_planes/hcp-troubleshooting.adoc
@@ -12,4 +12,12 @@ If you encounter issues with hosted control planes, see the following informatio
 include::snippets/technology-preview.adoc[]
 
 include::modules/hosted-control-planes-troubleshooting.adoc[leveloffset=+1]
-include::modules/debug-nodes-hcp.adoc[leveloffset=+1]
+//lahinson - oct. 2023 - commenting out the following module per discussion in the HyperShift Office Hours meeting on 18 Oct.
+//include::modules/debug-nodes-hcp.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+.Additional resources
+
+* link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#trouble-hosted-cluster-backplane[Must-gather for a hosted cluster]
+
+//lahinson - oct. 2023 - the link above will not work until ACM 2.9 goes live in mid-November 2023


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/ACM-7350
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://66571--docspreview.netlify.app/openshift-enterprise/latest/hosted_control_planes/hcp-troubleshooting
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 

This PR is for the MCE 2.4 release that is scheduled for November 16. Do not merge until this date.

The link in this PR will not work until the RHACM docs are live on Nov. 16.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
