### PR TITLE
OSDOCS-8269: Known Issue - Broadcom NICs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -633,7 +633,7 @@ With this release, the `MaxUnavailableStatefulSet` featureset configuration para
 [id="ocp-4-14-pdb-unhealthy-pod-eviction-policy"]
 ==== Pod disruption budget (PDB) unhealthy pod eviction policy
 
-With this release, specifying an unhealthy pod eviction policy for pod disruption budgets (PDBs) is Generally Available in {product-title} and has been removed from the `TechPreviewNoUpgrade` featureset. This helps evict malfunctioning applications during a node drain. 
+With this release, specifying an unhealthy pod eviction policy for pod disruption budgets (PDBs) is Generally Available in {product-title} and has been removed from the `TechPreviewNoUpgrade` featureset. This helps evict malfunctioning applications during a node drain.
 
 For more information, see xref:../nodes/pods/nodes-pods-configuring.adoc#pod-disruption-eviction-policy_nodes-pods-configuring[Specifying the eviction policy for unhealthy pods].
 
@@ -2092,6 +2092,8 @@ You can control IP forwarding for all traffic on OVN-Kubernetes managed interfac
 To make the required change, follow the instructions in link:https://access.redhat.com/solutions/7024383[OpenShift on OpenStack with compute Availability Zones: Missing rootVolume availability zone].
 +
 (link:https://issues.redhat.com/browse/OCPBUGS-15997[*OCPBUGS-15997*])
+
+* Broadcom network interface controllers in legacy Single Root I/O Virtualization (SR-IOV) do not support quality of service (QoS) and tag protocol identifier (TPID) settings for the SRIOV VLAN. This affects Broadcom BCM57414, Broadcom BCM57508, and Broadcom BCM57504. (link:https://issues.redhat.com/browse/RHEL-9881[*RHEL-9881*])
 
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-8269

Version(s):
4.14 
Discussing possible backport to 4.12 and 4.13, but just 4.14 for now

Issue:
https://issues.redhat.com/browse/OSDOCS-8269

Link to docs preview:
https://66575--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-known-issues
