### PR TITLE
CNV-29941: Update InstanceTypes documentation

### DIFF
--- a/modules/virt-creating-vm-instancetype.adoc
+++ b/modules/virt-creating-vm-instancetype.adoc
@@ -50,12 +50,12 @@ The volume table only lists volumes in the `openshift-virtualization-os-images` 
 ====
 
 ifdef::virt-create-vms[]
-. Select either of the following instance type options:
-* `Red Hat provided`
-* `User provided`
+. Select either of the following instance type tab options:
+* *Red Hat provided*
+* *User provided*
 . Choose one:
-* If you select the `Red Hat provided` instance type, hover over each of the tile options. Then click the configuration appropriate for your workload.
-* If you select the ``User provided` instance type, either search for the instance type by name or click an existing name from the available list.  
+* If you selected the *Red Hat provided* option, hover over each of the tile selections to determine which instance type is most suitable for your workload. Then click the appropriate tile.
+* If you selected the *User provided* instance type, search for the instance type by name or click an existing name from the available list.  
 endif::[]
 ifdef::dynamic-key[]
 . Click the *Red Hat Enterprise Linux 9 VM* tile.

--- a/modules/virt-creating-vm-instancetype.adoc
+++ b/modules/virt-creating-vm-instancetype.adoc
@@ -20,7 +20,7 @@ endif::[]
 = {title} from an instance type
 
 ifdef::virt-create-vms[]
-You can create a virtual machine (VM) from an instance type by using the {product-title} web console.
+You can create a virtual machine (VM) from an instance type by using the {product-title} web console. You can choose either a Red Hat provided instance type or an instance type that you define.
 endif::[]
 ifdef::static-key[]
 You can add a statically managed SSH key when you create a virtual machine (VM) from an instance type by using the {product-title} web console. The key is added to the VM as a cloud-init data source at first boot. This method does not affect cloud-init user data.

--- a/modules/virt-creating-vm-instancetype.adoc
+++ b/modules/virt-creating-vm-instancetype.adoc
@@ -51,11 +51,8 @@ The volume table only lists volumes in the `openshift-virtualization-os-images` 
 
 ifdef::virt-create-vms[]
 . Select either of the following instance type tab options:
-* *Red Hat provided*
-* *User provided*
-. Choose one:
-* If you selected the *Red Hat provided* option, hover over each of the tile selections to determine which instance type is most suitable for your workload. Then click the appropriate tile.
-* If you selected the *User provided* instance type, search for the instance type by name or click an existing name from the available list.  
+* *Red Hat provided*: Hover over each of the tile selections and click the instance type that is most suitable for your workload.
+* *User provided*: Search for the instance type by name or click an existing name from the available list. 
 endif::[]
 ifdef::dynamic-key[]
 . Click the *Red Hat Enterprise Linux 9 VM* tile.

--- a/modules/virt-creating-vm-instancetype.adoc
+++ b/modules/virt-creating-vm-instancetype.adoc
@@ -50,7 +50,12 @@ The volume table only lists volumes in the `openshift-virtualization-os-images` 
 ====
 
 ifdef::virt-create-vms[]
-. Click an instance type tile and select the configuration appropriate for your workload.
+. Select either of the following instance type options:
+* `Red Hat provided`
+* `User provided`
+. Choose one:
+* If you select the `Red Hat provided` instance type, hover over each of the tile options. Then click the configuration appropriate for your workload.
+* If you select the ``User provided` instance type, either search for the instance type by name or click an existing name from the available list.  
 endif::[]
 ifdef::dynamic-key[]
 . Click the *Red Hat Enterprise Linux 9 VM* tile.


### PR DESCRIPTION
Version(s): 4.14

Issue: [CNV-29941](https://issues.redhat.com/browse/CNV-29941)

Link to docs preview: [Creating a VM from an instance type
](https://66577--docspreview.netlify.app/openshift-enterprise/latest/virt/virtual_machines/creating_vms/virt-creating-vms-from-rh-images#virt-creating-vm-instancetype_virt-creating-vms-from-rh-images)
QE review:
- [ ] QE has approved this change.

Additional information:

