### PR TITLE
Typo in Agent assembly title

### DIFF
--- a/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
+++ b/installing/installing_with_agent_based_installer/installing-with-agent-based-installer.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="installing-with-agent-based-installer"]
-= Installing a {product-title} cluster with the Agent-based Installer
+= Installing an {product-title} cluster with the Agent-based Installer
 include::_attributes/common-attributes.adoc[]
 :context: installing-with-agent-based-installer
 


### PR DESCRIPTION
Version(s): 4.13 only

Fixes a typo in the title of an Agent assembly

No QE required

Preview: https://66578--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer