### PR TITLE
OCPBUGS18775: Setting up Custom Metrics Autoscaler following the CPU trigger documentation

### DIFF
--- a/modules/nodes-cma-autoscaling-custom-trigger-cpu.adoc
+++ b/modules/nodes-cma-autoscaling-custom-trigger-cpu.adoc
@@ -31,12 +31,11 @@ spec:
     metricType: Utilization <2>
     metadata:
       value: '60' <3>
-      containerName: api <4>
-
+  minReplicaCount: 1 <4>
 ----
 <1> Specifies CPU as the trigger type.
 <2> Specifies the type of metric to use, either `Utilization` or `AverageValue`.
 <3> Specifies the value that triggers scaling. Must be specified as a quoted string value.
 * When using `Utilization`, the target value is the average of the resource metrics across all relevant pods, represented as a percentage of the requested value of the resource for the pods.
 * When using `AverageValue`, the target value is the average of the metrics across all relevant pods.
-<4> Optional: Specifies an individual container to scale, based on the memory utilization of only that container, rather than the entire pod. In this example, only the container named `api` is to be scaled.
+<4> Specifies the minimum number of replicas when scaling down. For a CPU trigger, enter a value of `1` or greater, because the HPA cannot scale to zero if you are using only CPU metrics.


### PR DESCRIPTION
From the Custom Metrics Autoscaler Example [scaled object with a CPU target example code block](https://docs.openshift.com/container-platform/4.12/nodes/cma/nodes-cma-autoscaling-custom-trigger.html#nodes-cma-autoscaling-custom-trigger-cpu_nodes-cma-autoscaling-custom-trigger), add the `minReplicaCount` parameter and remove the `containerName` parameter.

Issue:
https://issues.redhat.com/browse/OCPBUGS-18775

Link to docs preview:
[Understanding the CPU trigger](https://66580--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger#nodes-cma-autoscaling-custom-trigger-cpu_nodes-cma-autoscaling-custom-trigger)

QE review:
- [ ] QE has approved this change.

