### PR TITLE
Add OVN-Kubernetes explicitly and avoid ifeval

### DIFF
--- a/modules/nw-multi-network-policy-differences.adoc
+++ b/modules/nw-multi-network-policy-differences.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-multi-network-policy.adoc
+
+:_content-type: CONCEPT
 [id="nw-multi-network-policy-differences_{context}"]
 = Differences between multi-network policy and network policy
 

--- a/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
+++ b/modules/nw-networkpolicy-allow-application-all-namespaces.adoc
@@ -1,11 +1,10 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-multi-network-policy.adoc
+// * networking/network_policy/creating-network-policy.adoc
+
 :name: network
 :role: admin
-ifeval::[{product-version} >= 4.6]
-:ovn:
-endif::[]
 ifeval::["{context}" == "configuring-multi-network-policy"]
 :multi:
 :name: multi-network
@@ -16,7 +15,6 @@ endif::[]
 [id="nw-networkpolicy-allow-traffic-from-all-applications_{context}"]
 = Creating a {name} policy allowing traffic to an application from all namespaces
 
-
 [NOTE]
 ====
 If you log in with a user with the `cluster-admin` role, then you can create a network policy in any namespace in the cluster.
@@ -26,14 +24,7 @@ Follow this procedure to configure a policy that allows traffic from all pods in
 
 .Prerequisites
 
-* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as
-ifndef::ovn[]
-the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-ifdef::ovn[]
-the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-This mode is the default for OpenShift SDN.
+* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `{role}` privileges.
 * You are working in the namespace that the {name} policy applies to.
@@ -146,3 +137,9 @@ Commercial support is available at
 </body>
 </html>
 ----
+
+ifdef::multi[]
+:!multi:
+endif::multi[]
+:!name:
+:!role:

--- a/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
+++ b/modules/nw-networkpolicy-allow-application-particular-namespace.adoc
@@ -1,11 +1,10 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-multi-network-policy.adoc
+// * networking/network_policy/creating-network-policy.adoc
+
 :name: network
 :role: admin
-ifeval::[{product-version} >= 4.6]
-:ovn:
-endif::[]
 ifeval::["{context}" == "configuring-multi-network-policy"]
 :multi:
 :name: multi-network
@@ -28,14 +27,7 @@ Follow this procedure to configure a policy that allows traffic to a pod with th
 
 .Prerequisites
 
-* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as
-ifndef::ovn[]
-the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-ifdef::ovn[]
-the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-This mode is the default for OpenShift SDN.
+* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `{role}` privileges.
 * You are working in the namespace that the {name} policy applies to.
@@ -195,4 +187,8 @@ Commercial support is available at
 </html>
 ----
 
-
+ifdef::multi[]
+:!multi:
+endif::multi[]
+:!name:
+:!role:

--- a/modules/nw-networkpolicy-allow-external-clients.adoc
+++ b/modules/nw-networkpolicy-allow-external-clients.adoc
@@ -1,11 +1,10 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-multi-network-policy.adoc
+// * networking/network_policy/creating-network-policy.adoc
+
 :name: network
 :role: admin
-ifeval::[{product-version} >= 4.6]
-:ovn:
-endif::[]
 ifeval::["{context}" == "configuring-multi-network-policy"]
 :multi:
 :name: multi-network
@@ -27,14 +26,7 @@ Follow this procedure to configure a policy that allows external service from th
 
 .Prerequisites
 
-* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as
-ifndef::ovn[]
-the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-ifdef::ovn[]
-the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-This mode is the default for OpenShift SDN.
+* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `{role}` privileges.
 * You are working in the namespace that the {name} policy applies to.
@@ -92,3 +84,9 @@ endif::multi[]
 This policy allows traffic from all resources, including external traffic as illustrated in the following diagram:
 
 image::292_OpenShift_Configuring_multi-network_policy_1122.png[Allow traffic from external clients]
+
+ifdef::multi[]
+:!multi:
+endif::multi[]
+:!name:
+:!role:

--- a/modules/nw-networkpolicy-audit-concept.adoc
+++ b/modules/nw-networkpolicy-audit-concept.adoc
@@ -1,3 +1,8 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/logging-network-policy.adoc
+
+:_content-type: CONCEPT
 [id="nw-networkpolicy-audit-concept_{context}"]
 = Audit logging
 

--- a/modules/nw-networkpolicy-audit-configure.adoc
+++ b/modules/nw-networkpolicy-audit-configure.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/logging-network-policy.adoc
+
 :_content-type: PROCEDURE
 [id="nw-networkpolicy-audit-configure_{context}"]
 = Configuring egress firewall and network policy auditing for a cluster

--- a/modules/nw-networkpolicy-audit-disable.adoc
+++ b/modules/nw-networkpolicy-audit-disable.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/logging-network-policy.adoc
+
 :_content-type: PROCEDURE
 [id="nw-networkpolicy-audit-disable_{context}"]
 = Disabling egress firewall and network policy audit logging for a namespace

--- a/modules/nw-networkpolicy-audit-enable.adoc
+++ b/modules/nw-networkpolicy-audit-enable.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * networking/ovn_kubernetes_network_provider/logging-network-policy.adoc
+
 :_content-type: PROCEDURE
 [id="nw-networkpolicy-audit-enable_{context}"]
 = Enabling egress firewall and network policy audit logging for a namespace

--- a/modules/nw-networkpolicy-create-cli.adoc
+++ b/modules/nw-networkpolicy-create-cli.adoc
@@ -6,9 +6,6 @@
 
 :name: network
 :role: admin
-ifeval::[{product-version} >= 4.6]
-:ovn:
-endif::[]
 ifeval::["{context}" == "configuring-multi-network-policy"]
 :multi:
 :name: multi-network
@@ -30,14 +27,7 @@ endif::multi[]
 
 .Prerequisites
 
-* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as
-ifndef::ovn[]
-the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-ifdef::ovn[]
-the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-This mode is the default for OpenShift SDN.
+* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `{role}` privileges.
 * You are working in the namespace that the {name} policy applies to.
@@ -239,9 +229,6 @@ multinetworkpolicy.k8s.cni.cncf.io/deny-by-default created
 endif::multi[]
 ----
 
-ifdef::ovn[]
-:!ovn:
-endif::ovn[]
 ifdef::multi[]
 :!multi:
 endif::multi[]

--- a/modules/nw-networkpolicy-create-ocm.adoc
+++ b/modules/nw-networkpolicy-create-ocm.adoc
@@ -1,6 +1,7 @@
 // Module included in the following assemblies:
 //
 // * networking/network_policy/creating-network-policy.adoc
+// * networking/multiple_networks/configuring-multi-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
 :_content-type: PROCEDURE

--- a/modules/nw-networkpolicy-delete-cli.adoc
+++ b/modules/nw-networkpolicy-delete-cli.adoc
@@ -1,13 +1,10 @@
 // Module included in the following assemblies:
 //
 // * networking/network_policy/deleting-network-policy.adoc
-// * post_installation_configuration/network-configuration.adoc
+// * networking/multiple_networks/configuring-multi-network-policy.adoc
 
 :name: network
 :role: admin
-ifeval::[{product-version} >= 4.6]
-:ovn:
-endif::[]
 ifeval::["{context}" == "configuring-multi-network-policy"]
 :multi:
 :name: multi-network
@@ -29,14 +26,7 @@ endif::multi[]
 
 .Prerequisites
 
-* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as
-ifndef::ovn[]
-the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-ifdef::ovn[]
-the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-This mode is the default for OpenShift SDN.
+* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `{role}` privileges.
 * You are working in the namespace where the {name} policy exists.
@@ -68,9 +58,6 @@ multinetworkpolicy.k8s.cni.cncf.io/default-deny deleted
 endif::multi[]
 ----
 
-ifdef::ovn[]
-:!ovn:
-endif::ovn[]
 ifdef::multi[]
 :!multi:
 endif::multi[]

--- a/modules/nw-networkpolicy-deny-all-allowed.adoc
+++ b/modules/nw-networkpolicy-deny-all-allowed.adoc
@@ -1,11 +1,10 @@
 // Module included in the following assemblies:
 //
 // * networking/multiple_networks/configuring-multi-network-policy.adoc
+// * networking/network_policy/creating-network-policy.adoc
+
 :name: network
 :role: admin
-ifeval::[{product-version} >= 4.6]
-:ovn:
-endif::[]
 ifeval::["{context}" == "configuring-multi-network-policy"]
 :multi:
 :name: multi-network
@@ -25,14 +24,7 @@ If you log in with a user with the `cluster-admin` role, then you can create a n
 
 .Prerequisites
 
-* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as
-ifndef::ovn[]
-the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-ifdef::ovn[]
-the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-This mode is the default for OpenShift SDN.
+* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `{role}` privileges.
 * You are working in the namespace that the {name} policy applies to.
@@ -95,3 +87,9 @@ ifdef::multi[]
 multinetworkpolicy.k8s.cni.cncf.io/deny-by-default created
 endif::multi[]
 ----
+
+ifdef::multi[]
+:!multi:
+endif::multi[]
+:!name:
+:!role:

--- a/modules/nw-networkpolicy-edit.adoc
+++ b/modules/nw-networkpolicy-edit.adoc
@@ -4,9 +4,6 @@
 
 :name: network
 :role: admin
-ifeval::[{product-version} >= 4.6]
-:ovn:
-endif::[]
 ifeval::["{context}" == "configuring-multi-network-policy"]
 :multi:
 :name: multi-network
@@ -28,14 +25,7 @@ endif::multi[]
 
 .Prerequisites
 
-* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as
-ifndef::ovn[]
-the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-ifdef::ovn[]
-the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-This mode is the default for OpenShift SDN.
+* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `{role}` privileges.
 * You are working in the namespace where the {name} policy exists.
@@ -99,9 +89,6 @@ where:
 `<namespace>`:: Optional: Specifies the namespace if the object is defined in a different namespace than the current namespace.
 --
 
-ifdef::ovn[]
-:!ovn:
-endif::ovn[]
 ifdef::multi[]
 :!multi:
 endif::multi[]

--- a/modules/nw-networkpolicy-multitenant-isolation.adoc
+++ b/modules/nw-networkpolicy-multitenant-isolation.adoc
@@ -3,10 +3,6 @@
 // * networking/network_policy/multitenant-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
-ifeval::[{product-version} >= 4.6]
-:ovn:
-endif::[]
-
 :_content-type: PROCEDURE
 [id="nw-networkpolicy-multitenant-isolation_{context}"]
 = Configuring multitenant isolation by using network policy
@@ -16,13 +12,7 @@ project namespaces.
 
 .Prerequisites
 
-* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as
-ifndef::ovn[]
-the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
-ifdef::ovn[]
-the OVN-Kubernetes network provider or the OpenShift SDN network provider with `mode: NetworkPolicy` set.
-endif::ovn[]
+* Your cluster uses a network plugin that supports `NetworkPolicy` objects, such as the OVN-Kubernetes network plugin or the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You are logged in to the cluster with a user with `admin` privileges.
@@ -157,7 +147,3 @@ Spec:
   Not affecting egress traffic
   Policy Types: Ingress
 ----
-
-ifdef::ovn[]
-:!ovn:
-endif::ovn[]

--- a/modules/nw-networkpolicy-object.adoc
+++ b/modules/nw-networkpolicy-object.adoc
@@ -5,8 +5,8 @@
 // * networking/network_policy/editing-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
 
+:_content-type: REFERENCE
 [id="nw-networkpolicy-object_{context}"]
-
 = Example NetworkPolicy object
 
 The following annotates an example NetworkPolicy object:

--- a/modules/nw-networkpolicy-project-defaults.adoc
+++ b/modules/nw-networkpolicy-project-defaults.adoc
@@ -13,7 +13,7 @@ As a cluster administrator, you can add network policies to the default template
 
 .Prerequisites
 
-* Your cluster uses a default CNI network provider that supports `NetworkPolicy` objects, such as the OpenShift SDN network provider with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
+* Your cluster uses a default CNI network plugin that supports `NetworkPolicy` objects, such as the OpenShift SDN network plugin with `mode: NetworkPolicy` set. This mode is the default for OpenShift SDN.
 * You installed the OpenShift CLI (`oc`).
 * You must log in to the cluster with a user with `cluster-admin` privileges.
 * You must have created a custom default project template for new projects.

--- a/modules/nw-networkpolicy-view-cli.adoc
+++ b/modules/nw-networkpolicy-view-cli.adoc
@@ -2,6 +2,7 @@
 //
 // * networking/network_policy/viewing-network-policy.adoc
 // * post_installation_configuration/network-configuration.adoc
+// * networking/multiple_networks/configuring-multi-network-policy.adoc
 
 :name: network
 :role: admin

--- a/modules/nw-pod-network-connectivity-verify.adoc
+++ b/modules/nw-pod-network-connectivity-verify.adoc
@@ -25,25 +25,25 @@ $ oc get podnetworkconnectivitycheck -n openshift-network-diagnostics
 .Example output
 [source,terminal]
 ----
-NAME                                                                                                                                AGE
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0   75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-1   73m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-2   75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-service-cluster                               75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-default-service-cluster                                 75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-load-balancer-api-external                                         75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-load-balancer-api-internal                                         75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-master-0            75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-master-1            75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-master-2            75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh      74m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-worker-c-n8mbf      74m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-worker-d-4hnrz      74m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-service-cluster                               75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-openshift-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0    75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-openshift-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-1    75m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-openshift-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-2    74m
-network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-openshift-apiserver-service-cluster                                75m
+NAME                                                                                                                                AGE
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0   75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-1   73m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-2   75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-service-cluster                               75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-default-service-cluster                                 75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-load-balancer-api-external                                         75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-load-balancer-api-internal                                         75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-master-0            75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-master-1            75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-master-2            75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh      74m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-worker-c-n8mbf      74m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-ci-ln-x5sv9rb-f76d1-4rzrp-worker-d-4hnrz      74m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-network-check-target-service-cluster                               75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-openshift-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0    75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-openshift-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-1    75m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-openshift-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-2    74m
+network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-openshift-apiserver-service-cluster                                75m
 ----
 
 . View the connection test logs:
@@ -64,143 +64,143 @@ where `<name>` specifies the name of the `PodNetworkConnectivityCheck` object.
 apiVersion: controlplane.operator.openshift.io/v1alpha1
 kind: PodNetworkConnectivityCheck
 metadata:
-  name: network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0
-  namespace: openshift-network-diagnostics
+  name: network-check-source-ci-ln-x5sv9rb-f76d1-4rzrp-worker-b-6xdmh-to-kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0
+  namespace: openshift-network-diagnostics
   ...
 spec:
-  sourcePod: network-check-source-7c88f6d9f-hmg2f
-  targetEndpoint: 10.0.0.4:6443
-  tlsClientCert:
-    name: ""
+  sourcePod: network-check-source-7c88f6d9f-hmg2f
+  targetEndpoint: 10.0.0.4:6443
+  tlsClientCert:
+    name: ""
 status:
-  conditions:
-  - lastTransitionTime: "2021-01-13T20:11:34Z"
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnectSuccess
-    status: "True"
-    type: Reachable
-  failures:
-  - latency: 2.241775ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: failed
-      to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443: connect:
-      connection refused'
-    reason: TCPConnectError
-    success: false
-    time: "2021-01-13T20:10:34Z"
-  - latency: 2.582129ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: failed
-      to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443: connect:
-      connection refused'
-    reason: TCPConnectError
-    success: false
-    time: "2021-01-13T20:09:34Z"
-  - latency: 3.483578ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: failed
-      to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443: connect:
-      connection refused'
-    reason: TCPConnectError
-    success: false
-    time: "2021-01-13T20:08:34Z"
-  outages:
-  - end: "2021-01-13T20:11:34Z"
-    endLogs:
-    - latency: 2.032018ms
-      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
-        tcp connection to 10.0.0.4:6443 succeeded'
-      reason: TCPConnect
-      success: true
-      time: "2021-01-13T20:11:34Z"
-    - latency: 2.241775ms
-      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
-        failed to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443:
-        connect: connection refused'
-      reason: TCPConnectError
-      success: false
-      time: "2021-01-13T20:10:34Z"
-    - latency: 2.582129ms
-      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
-        failed to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443:
-        connect: connection refused'
-      reason: TCPConnectError
-      success: false
-      time: "2021-01-13T20:09:34Z"
-    - latency: 3.483578ms
-      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
-        failed to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443:
-        connect: connection refused'
-      reason: TCPConnectError
-      success: false
-      time: "2021-01-13T20:08:34Z"
-    message: Connectivity restored after 2m59.999789186s
-    start: "2021-01-13T20:08:34Z"
-    startLogs:
-    - latency: 3.483578ms
-      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
-        failed to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443:
-        connect: connection refused'
-      reason: TCPConnectError
-      success: false
-      time: "2021-01-13T20:08:34Z"
-  successes:
-  - latency: 2.845865ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:14:34Z"
-  - latency: 2.926345ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:13:34Z"
-  - latency: 2.895796ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:12:34Z"
-  - latency: 2.696844ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:11:34Z"
-  - latency: 1.502064ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:10:34Z"
-  - latency: 1.388857ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:09:34Z"
-  - latency: 1.906383ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:08:34Z"
-  - latency: 2.089073ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:07:34Z"
-  - latency: 2.156994ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:06:34Z"
-  - latency: 1.777043ms
-    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
-      connection to 10.0.0.4:6443 succeeded'
-    reason: TCPConnect
-    success: true
-    time: "2021-01-13T21:05:34Z"
+  conditions:
+  - lastTransitionTime: "2021-01-13T20:11:34Z"
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnectSuccess
+    status: "True"
+    type: Reachable
+  failures:
+  - latency: 2.241775ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: failed
+      to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443: connect:
+      connection refused'
+    reason: TCPConnectError
+    success: false
+    time: "2021-01-13T20:10:34Z"
+  - latency: 2.582129ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: failed
+      to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443: connect:
+      connection refused'
+    reason: TCPConnectError
+    success: false
+    time: "2021-01-13T20:09:34Z"
+  - latency: 3.483578ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: failed
+      to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443: connect:
+      connection refused'
+    reason: TCPConnectError
+    success: false
+    time: "2021-01-13T20:08:34Z"
+  outages:
+  - end: "2021-01-13T20:11:34Z"
+    endLogs:
+    - latency: 2.032018ms
+      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
+        tcp connection to 10.0.0.4:6443 succeeded'
+      reason: TCPConnect
+      success: true
+      time: "2021-01-13T20:11:34Z"
+    - latency: 2.241775ms
+      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
+        failed to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443:
+        connect: connection refused'
+      reason: TCPConnectError
+      success: false
+      time: "2021-01-13T20:10:34Z"
+    - latency: 2.582129ms
+      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
+        failed to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443:
+        connect: connection refused'
+      reason: TCPConnectError
+      success: false
+      time: "2021-01-13T20:09:34Z"
+    - latency: 3.483578ms
+      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
+        failed to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443:
+        connect: connection refused'
+      reason: TCPConnectError
+      success: false
+      time: "2021-01-13T20:08:34Z"
+    message: Connectivity restored after 2m59.999789186s
+    start: "2021-01-13T20:08:34Z"
+    startLogs:
+    - latency: 3.483578ms
+      message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0:
+        failed to establish a TCP connection to 10.0.0.4:6443: dial tcp 10.0.0.4:6443:
+        connect: connection refused'
+      reason: TCPConnectError
+      success: false
+      time: "2021-01-13T20:08:34Z"
+  successes:
+  - latency: 2.845865ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:14:34Z"
+  - latency: 2.926345ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:13:34Z"
+  - latency: 2.895796ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:12:34Z"
+  - latency: 2.696844ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:11:34Z"
+  - latency: 1.502064ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:10:34Z"
+  - latency: 1.388857ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:09:34Z"
+  - latency: 1.906383ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:08:34Z"
+  - latency: 2.089073ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:07:34Z"
+  - latency: 2.156994ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:06:34Z"
+  - latency: 1.777043ms
+    message: 'kubernetes-apiserver-endpoint-ci-ln-x5sv9rb-f76d1-4rzrp-master-0: tcp
+      connection to 10.0.0.4:6443 succeeded'
+    reason: TCPConnect
+    success: true
+    time: "2021-01-13T21:05:34Z"
 ----


### PR DESCRIPTION
The use of ifeval is discouraged. This explicitly adds in OVN-Kubernetes support.

Version(s): 4.13+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: N/A

