### PR TITLE
[RHACS] Added instructions for configuring network baselining duration

### DIFF
--- a/modules/configuring-network-baselining-timeframe.adoc
+++ b/modules/configuring-network-baselining-timeframe.adoc
@@ -1,0 +1,28 @@
+// Module included in the following assemblies:
+//
+// * operating/manage-network-policies.adoc
+:_module-type: PROCEDURE
+[id="configuring-network-baselining-timeframe_{context}"]
+= Configuring network baselining time frame
+
+You can use the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` and the `ROX_BASELINE_GENERATION_DURATION` environment variables to configure the observation period and the network baseline generation duration.
+
+.Procedure
+
+* Set the `ROX_NETWORK_BASELINE_OBSERVATION_PERIOD` and the `ROX_BASELINE_GENERATION_DURATION` environment variables:
++
+[source,terminal]
+----
+$ oc -n stackrox set env deploy/central \ <1>
+  ROX_NETWORK_BASELINE_OBSERVATION_PERIOD=<value> <2>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+<2> Value must be time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` or `µs`, `ms`, `s`, `m`, `h`.
++
+[source,terminal]
+----
+$ oc -n stackrox set env deploy/central \ <1>
+  ROX_BASELINE_GENERATION_DURATION=<value> <2>
+----
+<1> If you use Kubernetes, enter `kubectl` instead of `oc`.
+<2> Value must be time units, for example: `300ms`, `-1.5h`, or `2h45m`. Valid time units are `ns`, `us` or `µs`, `ms`, `s`, `m`, `h`.

--- a/operating/manage-network-policies.adoc
+++ b/operating/manage-network-policies.adoc
@@ -65,5 +65,6 @@ include::modules/view-network-baselines-ng20.adoc[leveloffset=+2]
 
 include::modules/download-network-baselines.adoc[leveloffset=+2]
 
-include::modules/enable-alert-on-baseline-violations-ng20.adoc[leveloffset=+2]
+include::modules/configuring-network-baselining-timeframe.adoc[leveloffset=+2]
 
+include::modules/enable-alert-on-baseline-violations-ng20.adoc[leveloffset=+2]


### PR DESCRIPTION
For https://issues.redhat.com/browse/ROX-10763 Based on https://github.com/openshift/openshift-docs/pull/40493 which was already reviewed.

Preview: https://66583--docspreview.netlify.app/openshift-acs/latest/operating/manage-network-policies#configuring-network-baselining-timeframe_manage-network-policies

Cherry-pick into:
- `rhacs-docs-3.74`
- `rhacs-docs-4.0`
- `rhacs-docs-4.1`
- `rhacs-docs-4.2`
- `rhacs-docs-4.3`

