### PR TITLE
OSDOCS#8122: Release notes for 1.11.5 and 1.12.1

### DIFF
--- a/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
+++ b/security/cert_manager_operator/cert-manager-operator-release-notes.adoc
@@ -12,6 +12,34 @@ These release notes track the development of {cert-manager-operator}.
 
 For more information, see xref:../../security/cert_manager_operator/index.adoc#cert-manager-operator-about[About the {cert-manager-operator}].
 
+[id="cert-manager-operator-release-notes-1.12.1"]
+== Release notes for {cert-manager-operator} 1.12.1
+
+Issued: 2023-11-15
+
+The following advisory is available for the {cert-manager-operator} 1.12.1:
+
+* link:https://access.redhat.com/errata/RHSA-2023:6269-02[RHSA-2023:6269-02]
+
+Version `1.12.1` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.12.5`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.12/#v1125[cert-manager project release notes for v1.12.5].
+
+[id="cert-manager-operator-1.12.1-bug-fixes"]
+=== Bug fixes
+
+* Previously, in a multi-architecture environment, the cert-manager Operator pods were prone to failures because of the invalid node affinity configuration. With this fix, the cert-manager Operator pods run without any failures. (link:https://issues.redhat.com/browse/OCPBUGS-19446[*OCPBUGS-19446*])
+
+[id="cert-manager-operator-1.12.1-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-44487[CVE-2023-44487]
+* link:https://access.redhat.com/security/cve/CVE-2023-39325[CVE-2023-39325]
+* link:https://access.redhat.com/security/cve/CVE-2023-4527[CVE-2023-4527]
+* link:https://access.redhat.com/security/cve/CVE-2023-4806[CVE-2023-4806]
+* link:https://access.redhat.com/security/cve/CVE-2023-4813[CVE-2023-4813]
+* link:https://access.redhat.com/security/cve/CVE-2023-4911[CVE-2023-4911]
+* link:https://access.redhat.com/security/cve/CVE-2023-38545[CVE-2023-38545]
+* link:https://access.redhat.com/security/cve/CVE-2023-38546[CVE-2023-38546]
+
 [id="cert-manager-operator-release-notes-1.12.0"]
 == Release notes for {cert-manager-operator} 1.12.0
 
@@ -24,6 +52,7 @@ The following advisories are available for the {cert-manager-operator} 1.12.0:
 
 Version `1.12.0` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.12.4`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.12/#v1124[cert-manager project release notes for v1.12.4].
 
+
 [id="cert-manager-operator-1.12.0-bug-fixes"]
 === Bug fixes
 
@@ -34,6 +63,41 @@ Version `1.12.0` of the {cert-manager-operator} is based on the upstream cert-ma
 * Previously, the {cert-manager-operator} did not support enabling the  `--enable-certificate-owner-ref` flag. Now, the {cert-manager-operator} supports enabling the `--enable-certificate-owner-ref` flag by adding the `spec.controllerConfig.overrideArgs` field in the `cluster` object. After enabling the `--enable-certificate-owner-ref` flag, cert-manager can automatically delete the secret when the `Certificate` resource is removed from the cluster. For more information on enabling the `--enable-certificate-owner-ref` flag and deleting the TLS secret automatically, see xref:../../security/cert_manager_operator/cert-manager-customizing-api-fields.adoc#cert-manager-override-flag-controller_cert-manager-customizing-api-fields[Deleting a TLS secret automatically upon Certificate removal] (link:https://issues.redhat.com/browse/CM-98[*CM-98*])
 
 * Previously, the {cert-manager-operator} could not pull the `jetstack-cert-manager-container-v1.12.4-1` image. The cert-manager controller, CA injector, and Webhook pods were stuck in the `ImagePullBackOff` state. Now, the {cert-manager-operator} pulls the `jetstack-cert-manager-container-v1.12.4-1` image to run the cert-manager controller, CA injector, and Webhook pods successfully. (link:https://issues.redhat.com/browse/OCPBUGS-19986[*OCPBUGS-19986*])
+
+[id="cert-manager-operator-release-notes-1.11.5"]
+== Release notes for {cert-manager-operator} 1.11.5
+
+Issued: 2023-11-15
+
+The following advisory is available for the {cert-manager-operator} 1.11.5:
+
+* link:https://access.redhat.com/errata/RHSA-2023:6279-03[RHSA-2023:6279-03]
+
+The golang version is updated to the version `1.20.10` to fix Common Vulnerabilities and Exposures (CVEs). Version `1.11.5` of the {cert-manager-operator} is based on the upstream cert-manager version `v1.11.5`. For more information, see the link:https://cert-manager.io/docs/release-notes/release-notes-1.11/#v1115[cert-manager project release notes for v1.11.5].
+
+[id="cert-manager-operator-1.11.5-bug-fixes"]
+=== Bug fixes
+
+* Previously, in a multi-architecture environment, the cert-manager Operator pods were prone to failures because of the invalid node affinity configuration. With this fix, the cert-manager Operator pods run without any failures. (link:https://issues.redhat.com/browse/OCPBUGS-19446[*OCPBUGS-19446*])
+
+[id="cert-manager-operator-1.11.5-CVEs"]
+=== CVEs
+
+* link:https://access.redhat.com/security/cve/CVE-2023-44487[CVE-2023-44487]
+* link:https://access.redhat.com/security/cve/CVE-2023-39325[CVE-2023-39325]
+* link:https://access.redhat.com/security/cve/CVE-2023-29409[CVE-2023-29409]
+* link:https://access.redhat.com/security/cve/CVE-2023-2602[CVE-2023-2602]
+* link:https://access.redhat.com/security/cve/CVE-2023-2603[CVE-2023-2603]
+* link:https://access.redhat.com/security/cve/CVE-2023-4527[CVE-2023-4527]
+* link:https://access.redhat.com/security/cve/CVE-2023-4806[CVE-2023-4806]
+* link:https://access.redhat.com/security/cve/CVE-2023-4813[CVE-2023-4813]
+* link:https://access.redhat.com/security/cve/CVE-2023-4911[CVE-2023-4911]
+* link:https://access.redhat.com/security/cve/CVE-2023-28484[CVE-2023-28484]
+* link:https://access.redhat.com/security/cve/CVE-2023-29469[CVE-2023-29469]
+* link:https://access.redhat.com/security/cve/CVE-2023-38545[CVE-2023-38545]
+* link:https://access.redhat.com/security/cve/CVE-2023-38546[CVE-2023-38546]
+
+
 
 [id="cert-manager-operator-release-notes-1.11.4"]
 == Release notes for {cert-manager-operator} 1.11.4


### PR DESCRIPTION
Version(s): 4.12+

Issue: https://issues.redhat.com/browse/OSDOCS-8122

Link to docs preview:

1.12.1 - https://66585--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes#cert-manager-operator-release-notes-1.12.1

1.11.5 - https://66585--docspreview.netlify.app/openshift-enterprise/latest/security/cert_manager_operator/cert-manager-operator-release-notes#cert-manager-operator-release-notes-1.11.5

QE review:
- [x] QE has approved this change. @lunarwhite 
- [x] SME has approved this change. @swghosh 