### PR TITLE
[OSDOCS#7874]: Added warning regarding oc-mirror for Operators vs clusters (release-signatures)

### DIFF
--- a/modules/oc-mirror-updating-cluster-manifests.adoc
+++ b/modules/oc-mirror-updating-cluster-manifests.adoc
@@ -27,12 +27,17 @@ The `ImageContentSourcePolicy` resource associates the mirror registry with the 
 $ oc apply -f ./oc-mirror-workspace/results-1639608409/
 ----
 
-. Apply the release image signatures to the cluster by running the following command:
+. If you mirrored release images, apply the release image signatures to the cluster by running the following command:
 +
 [source,terminal]
 ----
 $ oc apply -f ./oc-mirror-workspace/results-1639608409/release-signatures/
 ----
++
+[NOTE]
+====
+If you are mirroring Operators instead of clusters, you do not need to run `$ oc apply -f ./oc-mirror-workspace/results-1639608409/release-signatures/`. Running that command will return an error, as there are no release image signatures to apply.
+====
 
 // TODO: Any example output to show?
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-7874

Link to docs preview:
https://66592--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/mirroring-image-repository#oc-mirror-updating-cluster-manifests_mirroring-ocp-image-repository

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
