### PR TITLE
Security Profiles Operator 0.8.2 release notes

### DIFF
--- a/security/security_profiles_operator/spo-release-notes.adoc
+++ b/security/security_profiles_operator/spo-release-notes.adoc
@@ -12,6 +12,30 @@ These release notes track the development of the Security Profiles Operator in {
 
 For an overview of the Security Profiles Operator, see xref:../../security/security_profiles_operator/spo-overview.adoc#[Security Profiles Operator Overview].
 
+[id="spo-release-notes-0-8-2"]
+== Security Profiles Operator 0.8.2
+
+The following advisory is available for the Security Profiles Operator 0.8.2:
+
+* link:https://access.redhat.com/errata/RHBA-2023:5958[RHBA-2023:5958 - OpenShift Security Profiles Operator bug fix update]
+
+[id="spo-0-8-2-bug-fixes"]
+=== Bug fixes
+
+* Previously, `SELinuxProfile` objects did not inherit custom attributes from the same namespace. With this update, the issue has now been resolved and `SELinuxProfile` object attributes are inherited from the same namespace as expected. (link:https://issues.redhat.com/browse/OCPBUGS-17164[*OCPBUGS-17164*])
+
+* Previously, RawSELinuxProfiles would hang during the creation process and would not reach an `Installed` state. With this update, the issue has been resolved and RawSELinuxProfiles are created successfully. (link:https://issues.redhat.com/browse/OCPBUGS-19744[*OCPBUGS-19744*])
+
+* Previously, patching the `enableLogEnricher` to `true` would cause the `seccompProfile` `log-enricher-trace` pods to be stuck in a `Pending` state. With this update, `log-enricher-trace` pods reach an `Installed` state as expected. (link:https://issues.redhat.com/browse/OCPBUGS-22182[*OCPBUGS-22182*])
+
+* Previously, the Security Profiles Operator generated high cardinality metrics, causing Prometheus pods using high amounts of memory. With this update, the following metrics will no longer apply in the Security Profiles Operator namespace:
++
+** `rest_client_request_duration_seconds`
+** `rest_client_request_size_bytes`
+** `rest_client_response_size_bytes`
++
+(link:https://issues.redhat.com/browse/OCPBUGS-22406[*OCPBUGS-22406*])
+
 [id="spo-release-notes-0-8-0"]
 == Security Profiles Operator 0.8.0
 


### PR DESCRIPTION
Version(s):
4.12+

Issue:
None 

Link to docs preview:
[Security Profiles Operator 0.8.2](https://file.rdu.redhat.com/antaylor/SPO-0.8.1/security/security_profiles_operator/spo-release-notes.html#spo-release-notes-0-8-2)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
