### PR TITLE
OSDOCS8295:Added issue link in RN related to oc-mirror

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1422,7 +1422,7 @@ Previously, container image references that have both tag and digest were not co
 "localhost:6000/cp/cpd/postgresql:13.7@sha256" is not a valid image reference: invalid reference format
 ----
 
-This behavior has been fixed, and the references are now accepted and correctly mirrored.
+This behavior has been fixed, and the references are now accepted and correctly mirrored.  (link:https://issues.redhat.com/browse/OCPBUGS-11840[OCPBUGS-11840])
 
 [discrete]
 [id="ocp-4-14-olm-bug-fixes"]


### PR DESCRIPTION
Version(s): 4.14

Issue: [OSDOCS-8295](https://issues.redhat.com/browse/OSDOCS-8295)
Related to [OSDOCS-6464](https://issues.redhat.com/browse/OSDOCS-6464)

Link to docs preview:
[Doc Preview](https://66602--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-bug-fixes) OpenShift CLI (oc) section in bug fixes.

QE review:
- QE not required.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
