### PR TITLE
Adds RN for egress IP additional network interface support

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -468,6 +468,13 @@ Certain HTTP request and response headers can now be set or deleted either globa
 
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-set-or-delete-http-headers_configuring-ingress[Setting or deleting HTTP request and response headers in an Ingress Controller] and xref:../networking/routes/route-configuration.adoc#nw-route-set-or-delete-http-headers_route-configuration[Setting or deleting HTTP request and response headers in a route].
 
+[id="ocp-4-14-egress-ips-additional-networks"]
+==== Support for egress IPs on additional network interfaces (Technology Preview)
+
+Support for egress IPs on additional network interfaces is now available as a Technology Preview feature. This feature provides {product-title} administrators with a greater level of control over networking aspects such as routing, addressing, segmentation, and security policies. It also provides users with the option to route workload traffic over specific network interfaces for purposes such as traffic segmentation or meeting specialized requirements. 
+
+For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#nw-egress-ips-multi-nic-considerations_configuring-egress-ips-ovn[Considerations for using an egress IP on additional network interfaces].
+
 [id="ocp-4-14-registry"]
 === Registry
 
@@ -1482,6 +1489,11 @@ In the following tables, features are marked with the following statuses:
 [cols="4,1,1,1",options="header"]
 |====
 |Feature |4.12 |4.13 |4.14
+
+|Egress IPs on additional network interfaces
+|Not Available
+|Not Available
+|Technology Preview
 
 |PTP dual NIC hardware configured as boundary clock
 |Technology Preview


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8296

Link to docs preview:
https://66605--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-egress-ips-additional-networks

QE review:
No need. 


