### PR TITLE
Removes TP designation for multi nic egress IPs

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -152,9 +152,6 @@ For more information, see link:https://docs.microsoft.com/en-us/azure/azure-reso
 [id="nw-egress-ips-multi-nic-considerations_{context}"]
 == Considerations for using an egress IP on additional network interfaces
 
-:FeatureName: Using an egress IP on additional network interfaces
-include::snippets/technology-preview.adoc[]
-
 In {product-title}, egress IPs provide administrators a way to control network traffic. Egress IPs can be used with the `br-ex`, or primary, network interface, which is a Linux bridge interface associated with Open vSwitch, or they can be used with additional network interfaces. 
 
 You can inspect your network interface type by running the following command:


### PR DESCRIPTION
Follow up to https://github.com/openshift/openshift-docs/pull/63879. Removes TP designation. 

https://66629--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn#nw-egress-ips-multi-nic-considerations_configuring-egress-ips-ovn
