### PR TITLE
Dualstack configuration procedure

### DIFF
--- a/modules/nw-multus-configure-dualstack-ip-address.adoc
+++ b/modules/nw-multus-configure-dualstack-ip-address.adoc
@@ -1,0 +1,58 @@
+// Module included in the following assemblies:
+//
+// * networking/multiple_networks/configuring-additional-network.adoc
+
+:_content-type: PROCEDURE 
+
+[id="nw-multus-configure-dualstack-ip-address_{context}"]
+= Creating a configuration for assignment of dual-stack IP addresses dynamically
+
+Dual-stack IP address assignment can be configured with the `ipRanges` parameter for:
+
+* IPv4 addresses
+* IPv6 addresses
+* multiple IP address assignment 
+
+.Procedure
+
+. Set `type` to `whereabouts`.
+
+. Use `ipRanges` to allocate IP addresses as shown in the following example:
++
+[source,yaml]
+----
+cniVersion: operator.openshift.io/v1
+kind: Network
+=metadata:
+  name: cluster
+spec:
+  additionalNetworks:
+  - name: whereabouts-shim
+    namespace: default
+    type: Raw
+    rawCNIConfig: |-
+      {
+       "name": "whereabouts-dual-stack",
+       "cniVersion": "0.3.1,
+       "type": "bridge",
+       "ipam": {
+         "type": "whereabouts",
+         "ipRanges": [
+                  {"range": "192.168.10.0/24"},
+                  {"range": "2001:db8::/64"}
+              ]
+       }
+      }
+
+----
+
+. Attach network to a pod. For more information, see "Adding a pod to an additional network".
+
+. Verify that all IP addresses are assigned.
+
+. Run the following command to ensure the IP addresses are assigned as metadata.
++
+[source,yaml]
+----
+$ oc exec -it mypod -- ip a
+----

--- a/networking/hardware_networks/configuring-sriov-ib-attach.adoc
+++ b/networking/hardware_networks/configuring-sriov-ib-attach.adoc
@@ -10,6 +10,13 @@ You can configure an InfiniBand (IB) network attachment for an Single Root I/O V
 
 include::modules/nw-sriov-ibnetwork-object.adoc[leveloffset=+1]
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
+
+include::modules/nw-multus-configure-dualstack-ip-address.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/attaching-pod.html#nw-multus-add-pod_attaching-pod[Attaching a pod to an additional network]
+
 include::modules/nw-sriov-network-attachment.adoc[leveloffset=+1]
 
 [id="configuring-sriov-ib-attach-next-steps"]

--- a/networking/hardware_networks/configuring-sriov-net-attach.adoc
+++ b/networking/hardware_networks/configuring-sriov-net-attach.adoc
@@ -10,6 +10,12 @@ You can configure an Ethernet network attachment for an Single Root I/O Virtuali
 
 include::modules/nw-sriov-network-object.adoc[leveloffset=+1]
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+2]
+include::modules/nw-multus-configure-dualstack-ip-address.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/attaching-pod.html#nw-multus-add-pod_attaching-pod[Attaching a pod to an additional network]
+
 include::modules/nw-sriov-network-attachment.adoc[leveloffset=+1]
 
 [id="configuring-sriov-net-attach-next-steps"]

--- a/networking/multiple_networks/configuring-additional-network.adoc
+++ b/networking/multiple_networks/configuring-additional-network.adoc
@@ -168,6 +168,12 @@ include::modules/configuring-pods-static-ip.adoc[leveloffset=+3]
 
 include::modules/nw-multus-ipam-object.adoc[leveloffset=+1]
 
+include::modules/nw-multus-configure-dualstack-ip-address.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../../networking/multiple_networks/attaching-pod.html#nw-multus-add-pod_attaching-pod
+
 include::modules/nw-multus-create-network.adoc[leveloffset=+1]
 
 include::modules/nw-multus-create-network-apply.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-4938
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://66173--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/configuring-sriov-net-attach#nw-multus-configure-dualstack-ip-address_configuring-sriov-net-attach
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
