### PR TITLE
OSDOCS#8294: adding Agent Known Issue to RNs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2154,6 +2154,11 @@ To make the required change, follow the instructions in link:https://access.redh
 
 * In hosted control planes for {product-title}, on the bare metal and {VirtProductName} platforms, the auto-repair function is disabled. (link:https://issues.redhat.com/browse/OCPBUGS-20028[*OCPBUGS-20028*])
 
+* Agent-based installations on vSphere will fail due to a failure to remove node taint, which causes the installation to be stuck in a pending state.
+{sno-caps} clusters are not impacted.
+There is no current workaround.
+(link:https://issues.redhat.com/browse/OCPBUGS-20049[*OCPBUGS-20049*])
+
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
[OSDOCS-8294](https://issues.redhat.com/browse/OSDOCS-8294)

Version(s):
4.14 only

This PR adds a known issue to the 4.14 release notes regarding failed agent installs on vSphere clusters with multiple worker nodes.

QE review:
- [x] QE has approved this change.

preview: [Known Issues](https://66650--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes.html#ocp-4-14-asynchronous-errata-updates:~:text=Agent%2Dbased%20installations%20on%20vSphere%20with%20multiple%20worker%20nodes%20might%20fail%20due%20to%20a%20failure%20to%20remove%20node%20taint%2C%20which%20causes%20the%20installation%20to%20be%20stuck%20in%20a%20pending%20state.)
