### PR TITLE
OSDOCS-5987-oc: adds oc mirror bugs

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1419,14 +1419,37 @@ This caused the Ingress Operator to report the DNS status as `ready` when there 
 [id="ocp-4-14-openshift-cli-bug-fixes"]
 ==== OpenShift CLI (oc)
 
-Previously, container image references that have both tag and digest were not correctly interpreted by the oc-mirror plug-in and resulted in the following error:
-
-[source,yaml]
+* Previously, container image references that have both tag and digest were not correctly interpreted by the oc-mirror plug-in and resulted in the following error:
++
+[source,text]
 ----
 "localhost:6000/cp/cpd/postgresql:13.7@sha256" is not a valid image reference: invalid reference format
 ----
++
+This behavior has been fixed, and the references are now accepted and correctly mirrored.  (link:https://issues.redhat.com/browse/OCPBUGS-11840[*OCPBUGS-11840*])
 
-This behavior has been fixed, and the references are now accepted and correctly mirrored.  (link:https://issues.redhat.com/browse/OCPBUGS-11840[OCPBUGS-11840])
+* Previously, you were receiving `401 - Unauthorized` error for registries where the number of path components exceeded the expected maximum path components. This issue is fixed by ensuring that the oc-mirror fails when the number of path components exceeds maximum path components. You can now set the maximum path components by using the flag `--max-nested-paths`, which accepts an integer value. By default, there is no limit to the maximum path components and is set to `0`. The generated `ImageContentSourcePolicy` will contain source and mirror references up to the repository level.
+(link:https://issues.redhat.com/browse/OCPBUGS-8111[*OCPBUGS-8111*], link:https://issues.redhat.com/browse/OCPBUGS-11910[*OCPBUGS-11910*], link:https://issues.redhat.com/browse/OCPBUGS-11922[*OCPBUGS-11922*])
+
+* Previously, the oc-mirror flags `--short`, `-v`, and `--verbose` provided incorrect version information. You can now use the oc mirror `version` flag to know the correct version of oc-mirror. The oc-mirror flags `--short`, `-v`, and `--verbose` have been deprecated and will no longer be supported. (link:https://issues.redhat.com/browse/OCPBUGS-7845[*OCPBUGS-7845*])
+
+* Previously, mirroring from registry to disk would fail when several digests of an image were specified in the `imageSetConfig` without tags. The oc-mirror would add the default tag `latest` to the images. The issue is now fixed by using a truncated digest as the tag. (link:https://issues.redhat.com/browse/OCPBUGS-2633[*OCPBUGS-2633*])
+
+* Previously, oc-mirror would incorrectly add the Operator catalog to `ImageContentSourcePolicy` specification. This is an unexpected behavior because the Operator catalog is directly used from the destination registry through `CatalogSource` resource. This bug is fixed by ensuring that the oc-mirror does not add the Operator catalog as an entry to `ImageContentSourcePolicy`. (link:https://issues.redhat.com/browse/OCPBUGS-10051[*OCPBUGS-10051*])
+
+* Previously, mirroring images for Operators would fail when the registry domain name was not a part of the image reference. With this fix, the images are downloaded from `docker.io` if the registry domain name is not specified.(link:https://issues.redhat.com/browse/OCPBUGS-10348[*OCPBUGS-10348*])
+
+* Previously, when both tag and digest were included in container image references, oc-mirror would incorrectly interpret it resulting in an `invalid reference format` error. This issue has been fixed and the images are successfully mirrored. (link:https://issues.redhat.com/browse/OCPBUGS-11840[*OCPBUGS-11840*])
+
+* Previously, you could not create a `CatalogSource` resource if the name started with a number. With this fix, by default, the `CatalogSource` resource name is generated with the `cs-` prefix and is compliant with RFC 1035. (link:https://issues.redhat.com/browse/OCPBUGS-13332[*OCPBUGS-13332*])
+
+* Previously, when using the `registries.conf` file, some images were not included in the mapping. With this bug fix, you can now see the images included in the mapping without any errors. (link:https://issues.redhat.com/browse/OCPBUGS-13962[*OCPBUGS-13962*])
+
+* Previously, while using the insecure mirrors in the `registries.conf` file that is referenced in `--oci-registries-config` flag, oc-mirror tried to establish an HTTPS connection with the mirror registry. With this fix, you can configure oc-mirror to not use an HTTPS connection by specifying either `--source-skip-tls` or `--source-use-http` in the command line. (link:https://issues.redhat.com/browse/OCPBUGS-14402[*OCPBUGS-14402*])
+
+* Previously, image mirroring would fail when you attempted to mirror OCI indexes by using oc-mirror plugins. With this fix, you can mirror OCI indexes by using oc-mirror plugins. (link:https://issues.redhat.com/browse/OCPBUGS-15329[*OCPBUGS-15329*])
+
+* Previously, when mirroring several large catalogs on a low-bandwidth network, mirroring would be interrupted due to an expired authentication token resulting in the HTTP 401 unauthorized error. This issue is fixed by refreshing the authentication tokens before starting the mirroring process of each catalog. (link:https://issues.redhat.com/browse/OCPBUGS-20137[*OCPBUGS-20137*])
 
 [discrete]
 [id="ocp-4-14-olm-bug-fixes"]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-5987
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://66666--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-bug-fixes:~:text=Tuning%20Operator%20(NTO)-,OpenShift%20CLI%20(oc),-Previously%2C%20container%20image
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
