### PR TITLE
Adds ipFowarding to ONVK docs

### DIFF
--- a/modules/nw-operator-cr.adoc
+++ b/modules/nw-operator-cr.adoc
@@ -346,6 +346,10 @@ The default value is `false`.
 This field has an interaction with the Open vSwitch hardware offloading feature.
 If you set this field to `true`, you do not receive the performance benefits of the offloading because egress traffic is processed by the host networking stack.
 
+|`ipForwarding`
+|`object`
+|You can control IP forwarding for all traffic on OVN-Kubernetes managed interfaces by using the `ipForwarding` specification in the `Network` resource. Specify `Restricted` to only allow IP forwarding for Kubernetes related traffic. Specify `Global` to allow forwarding of all IP traffic. For new installations, the default is `Restricted`. For updates to {product-title} 4.14, the default is `Global`.
+
 |====
 
 ifdef::operator[]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14.

Issue:
https://issues.redhat.com/browse/OCPBUGS-22211

Link to docs preview:
https://66668--docspreview.netlify.app/openshift-enterprise/latest/networking/cluster-network-operator#nw-operator-cr-cno-object_cluster-network-operator

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
