### PR TITLE
OSDOCS-6810 adding 4.14 capabilities

### DIFF
--- a/installing/cluster-capabilities.adoc
+++ b/installing/cluster-capabilities.adoc
@@ -62,6 +62,15 @@ include::modules/insights-operator.adoc[leveloffset=+2]
 .Additional resources
 * xref:../support/remote_health_monitoring/using-insights-operator.adoc#using-insights-operator[Using Insights Operator]
 
+include::modules/machine-api-capability.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+* xref:../machine_management/index.html#index[Overview of machine management]
+* xref:../operators/operator-reference.html#machine-api-operator_cluster-operators-ref[Machine API Operator]
+* xref:../operators/operator-reference.html#cluster-autoscaler-operator_cluster-operators-ref[Cluster Autoscaler Operator]
+* xref:../operators/operator-reference.html#control-plane-machine-set-operator_cluster-operators-ref[Control Plane Machine Set Operator]
+
 include::modules/operator-marketplace.adoc[leveloffset=+2]
 
 [role="_additional-resources"]

--- a/modules/cluster-bare-metal-operator.adoc
+++ b/modules/cluster-bare-metal-operator.adoc
@@ -34,16 +34,16 @@ The Cluster Baremetal Operator provides the features for the `baremetal` capabil
 
 endif::cluster-caps[]
 
-The Cluster Baremetal Operator (CBO) deploys all the components necessary to take a bare-metal server to a fully functioning worker node ready to run {product-title} compute nodes. The CBO ensures that the metal3 deployment, which consists of the Bare Metal Operator (BMO) and Ironic containers, runs on one of the control plane nodes within the {product-title} cluster. The CBO also listens for {product-title} updates to resources that it watches and takes appropriate action. 
+The Cluster Baremetal Operator (CBO) deploys all the components necessary to take a bare-metal server to a fully functioning worker node ready to run {product-title} compute nodes. The CBO ensures that the metal3 deployment, which consists of the Bare Metal Operator (BMO) and Ironic containers, runs on one of the control plane nodes within the {product-title} cluster. The CBO also listens for {product-title} updates to resources that it watches and takes appropriate action.
 
 ifdef::cluster-caps[]
 The bare-metal capability is required for deployments using installer-provisioned infrastructure. Disabling the bare-metal capability can result in unexpected problems with these deployments.
 
-It is recommended that cluster administrators only disable the bare-metal capability during installations with user-provisioned infrastructure that do not have any `BareMetalHost` resources in the cluster. 
+It is recommended that cluster administrators only disable the bare-metal capability during installations with user-provisioned infrastructure that do not have any `BareMetalHost` resources in the cluster.
 
 [IMPORTANT]
 ====
-If the bare-metal capability is disabled, the cluster cannot provision or manage bare-metal nodes. Only disable the capability if there are no `BareMetalHost` resources in your deployment.
+If the bare-metal capability is disabled, the cluster cannot provision or manage bare-metal nodes. Only disable the capability if there are no `BareMetalHost` resources in your deployment. The `baremetal` capability depends on the `MachineAPI` capability. If you enable the `baremetal` capability, you must also enable `MachineAPI`.
 ====
 endif::cluster-caps[]
 

--- a/modules/cluster-image-registry-operator.adoc
+++ b/modules/cluster-image-registry-operator.adoc
@@ -13,8 +13,10 @@ ifeval::["{context}" == "cluster-capabilities"]
 :cluster-caps:
 endif::[]
 
+:_content-type: REFERENCE
 [id="cluster-image-registry-operator_{context}"]
-= Cluster Image Registry Operator
+ifdef::operator-ref[= Cluster Image Registry Operator]
+ifdef::cluster-caps[= Cluster Image Registry capability]
 
 [discrete]
 == Purpose
@@ -39,3 +41,10 @@ endif::[]
 == Project
 
 link:https://github.com/openshift/cluster-image-registry-operator[cluster-image-registry-operator]
+
+ifeval::["{context}" == "cluster-operators-ref"]
+:!operator-ref:
+endif::[]
+ifeval::["{context}" == "cluster-capabilities"]
+:!cluster-caps:
+endif::[]

--- a/modules/machine-api-capability.adoc
+++ b/modules/machine-api-capability.adoc
@@ -1,0 +1,14 @@
+// Module included in the following assemblies:
+//
+// * installing/cluster-capabilities.adoc
+
+:_content-type: REFERENCE
+[id="machine-api-capability_{context}"]
+= Machine API capability
+
+[discrete]
+== Purpose
+
+The `machine-api-operator`, `cluster-autoscaler-operator`, and `cluster-control-plane-machine-set-operator` Operators provide the features for the `MachineAPI` capability. You can disable this capability only if you install a cluster with user-provisioned infrastructure.
+
+The Machine API capability is responsible for all machine configuration and management in the cluster. If you disable the Machine API capability during installation, you need to manage all machine-related tasks manually.

--- a/snippets/capabilities-table.adoc
+++ b/snippets/capabilities-table.adoc
@@ -8,21 +8,19 @@ The following table describes the `baselineCapabilitySet` values.
 |Value|Description
 
 |`vCurrent`
-|Specify this option when you want to automatically add new, default capabilities that are introduced in new releases. 
+|Specify this option when you want to automatically add new, default capabilities that are introduced in new releases.
 
 |`v4.11`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.11. By specifying `v4.11`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.11 are `baremetal`, `marketplace`, and `openshift-samples`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.11. By specifying `v4.11`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.11 are `baremetal`, `MachineAPI`, `marketplace`, and `openshift-samples`.
 
 |`v4.12`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.12. By specifying `v4.12`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.12 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage` and `CSISnapshot`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.12. By specifying `v4.12`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.12 are `baremetal`, `MachineAPI`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, and `CSISnapshot`.
 
 |`v4.13`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.13. By specifying `v4.13`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.13 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot` and `NodeTuning`.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.13. By specifying `v4.13`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.13 are `baremetal`, `MachineAPI`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, and `NodeTuning`.
 
 |`v4.14`
-|Specify this option when you want to enable the default capabilities for {product-title} 4.14. By specifying `v4.14`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.14 are `baremetal`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, and `ImageRegistry`.
-
-// TODO: Add `Build` and `DeploymentConfig` to the list for 4.14.
+|Specify this option when you want to enable the default capabilities for {product-title} 4.14. By specifying `v4.14`, capabilities that are introduced in newer versions of {product-title} are not enabled. The default capabilities in {product-title} 4.14 are `baremetal`, `MachineAPI`, `marketplace`, `openshift-samples`, `Console`, `Insights`, `Storage`, `CSISnapshot`, `NodeTuning`, `ImageRegistry`, `Build`, and `DeploymentConfig`.
 
 |`None`
 |Specify when the other sets are too large, and you do not need any capabilities or want to fine-tune via `additionalEnabledCapabilities`.


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6810

Link to docs preview:
https://66670--docspreview.netlify.app/openshift-enterprise/latest/installing/cluster-capabilities

QE review:
- [x] QE has approved this change.
