### PR TITLE
OSDOCS#8300: Adds developer console release notes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -265,6 +265,7 @@ With this release, there are several updates to the *Administrator* perspective 
 * Narrow down the list of resources in a list view or search page with exact search capabilities. This will help when you have similarly named resources and fuzzy search does not narrow down your search.
 * Provide direct feedback about features and report a bug by clicking the *Help* button on the toolbar and clicking *Share Feedback* from the drop-down list.
 * Display and hide tooltips in the YAML editor. The tooltips will persist so you don't have to change it every time you navigate to the page.
+* Configure the web terminal image for all users. For more information, see xref:../web_console/web_terminal/configuring-web-terminal.adoc#configuring-web-terminal
 
 [id="web-console-dynamic-plugin-enhancements"]
 ===== Dynamic plugin enhancements
@@ -294,6 +295,25 @@ For more information, see xref:../operators/operator_sdk/osdk-token-auth.adoc#os
 
 [id="ocp-4-14-developer-perspective"]
 ==== Developer Perspective
+
+With this release, there are several updates to the *Developer* perspective of the web console. You can now perform the following actions:
+
+* Change the default timeout period for the web terminal for your current session. For more information, see xref:../web_console/web_terminal/configuring-web-terminal.adoc#odc-configure-web-terminal-timeout-session_configuring-web-terminal[Configuring the web terminal timeout for a session].
+* Test {serverlessproductshortname} functions in the web console from the *Topology* view and the Serverless Service *List* and *Detail* pages so you can use a {serverlessproductshortname} function with a CloudEvent or HTTP request.
+* View status, start time, and duration of the latest build for `BuildConfigs` and Shipwright builds. You can also view this information on the *Details* page.
+
+[id="developer-console-quick-starts"]
+===== New quick starts
+
+With this release, new quick starts are available to discover developer tools such as installing the Cryostat Operator and getting started with the JBoss EAP using a helm chart.
+
+[id="developer-perspective-pipeline-page-improvements"]
+===== {pipelines-shortname} page improvements
+
+In {product-title} {product-version}, you can see the following navigation improvements on the *Pipelines* page:
+
+* Autodetection of PAC in Git import flow.
+* {serverlessproductshortname} functions in the samples catalog.
 
 [id="ocp-4-14-openshift-cli"]
 === OpenShift CLI (oc)


### PR DESCRIPTION
OSDOCS#8300: Adds developer console release notes

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8300

Link to docs preview:
https://66671--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-developer-perspective

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
