### PR TITLE
OSDOCS#8267: (4.14)  vSphere version reqs for EUS update

### DIFF
--- a/modules/updating-eus-to-eus-upgrade.adoc
+++ b/modules/updating-eus-to-eus-upgrade.adoc
@@ -11,7 +11,13 @@ Following this procedure reduces the total update duration and the number of tim
 
 .Prerequisites
 
-* Review the release notes for {product-title} <4.y+1> and <4.y+2>
+* Review the release notes for {product-title} <4.y+1> and <4.y+2>.
 * Review the release notes and product lifecycles for any layered products and Operator Lifecycle Manager (OLM) Operators. Some may require updates either before or during an EUS-to-EUS update.
 * Ensure that you are familiar with version-specific prerequisites, such as the removal of deprecated APIs, that are required prior to updating from {product-title} <4.y+1> to <4.y+2>.
-
+* If your cluster uses in-tree vSphere volumes, update vSphere to version 7.0u3L+ or 8.0u2+.
++
+[IMPORTANT]
+====
+If you do not update vSphere to 7.0u3L+ or 8.0u2+ before initiating an {product-title} update, known issues might occur with your cluster after the update.
+For more information, see link:https://access.redhat.com/node/7011683[Known Issues with OpenShift 4.12 to 4.13 or 4.13 to 4.14 vSphere CSI Storage Migration].
+====


### PR DESCRIPTION
[OSDOCS-8267](https://issues.redhat.com/browse/OSDOCS-8267)

Version(s): 4.14 only (#66676 is the twin PR for 4.13)

QE review:
- [x] QE has approved this change.

Preview: [EUS-to-EUS update](https://66675--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/eus-eus-update#updating-eus-to-eus-upgrade_eus-to-eus-update)

Additional information:
There are many Upgradeable=False triggers, but this one is special in that https://issues.redhat.com/browse/OCPBUGS-18131 landed the associated admin-ack in 4.12.37, our update floor for 4.12 to 4.13 is 4.12.16, and we decided against covering the gap with a conditional update risk.  So while we can usually expect the update user interfaces to inform the customer about these issues, customers running 4.12.(16 <= z < 37) could use this extra hint in the EUS update docs, to cover that gap.
