### PR TITLE
OSDOCS#6496: Document automated etcd backups

### DIFF
--- a/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
+++ b/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
@@ -26,3 +26,6 @@ include::modules/backup-etcd.adoc[leveloffset=+1]
 [id="additional-resources_backup-etcd"]
 == Additional resources
 * xref:../../hosted_control_planes/hcp-backup-restore-dr.adoc#hcp-backup-restore[Backing up and restoring etcd on a hosted cluster]
+
+// Creating automated etcd backups
+include::modules/etcd-creating-automated-backups.adoc[leveloffset=+1]

--- a/modules/etcd-creating-automated-backups.adoc
+++ b/modules/etcd-creating-automated-backups.adoc
@@ -1,0 +1,356 @@
+// Module included in the following assemblies:
+//
+// * backup_and_restore/control_plane_backup_and_restore/backing-up-etcd.adoc
+
+:_content-type: PROCEDURE
+[id="creating-automated-etcd-backups_{context}"]
+= Creating automated etcd backups
+
+The automated backup feature for etcd supports both recurring and single backups. Recurring backups create a cron job that starts a single backup each time the job triggers.
+
+:FeatureName: Automating etcd backups
+include::snippets/technology-preview.adoc[]
+
+[id="enabling-automated-etcd-backups_{context}"]
+== Enabling automated etcd backups
+
+Follow these steps to enable automated backups for etcd.
+
+[WARNING]
+====
+Enabling the `TechPreviewNoUpgrade` feature set on your cluster prevents minor version updates. The `TechPreviewNoUpgrade` feature set cannot be disabled. Do not enable this feature set on production clusters.
+====
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the OpenShift CLI (`oc`).
+
+.Procedure
+
+. Create a `FeatureGate` custom resource (CR) file named `enable-tech-preview-no-upgrade.yaml` with the following contents:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1
+kind: FeatureGate
+metadata:
+  name: cluster
+spec:
+  featureSet: TechPreviewNoUpgrade
+----
+
+. Apply the CR and enable automated backups:
++
+[source,terminal]
+----
+$ oc apply -f enable-tech-preview-no-upgrade.yaml
+----
+
+. It takes time to enable the related APIs. Verify the creation of the custom resource definition (CRD) by running the following command:
++
+[source,terminal]
+----
+$ oc get crd | grep backup
+----
++
+.Example output
+[source,terminal]
+----
+backups.config.openshift.io 2023-10-25T13:32:43Z
+etcdbackups.operator.openshift.io 2023-10-25T13:32:04Z
+----
+
+[id="creating-single-etcd-backup_{context}"]
+== Creating a single etcd backup
+
+Follow these steps to create a single etcd backup by creating and applying a custom resource (CR).
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the OpenShift CLI (`oc`).
+* You have a PVC to save backup data to.
+
+.Procedure
+
+. Create a CR file named `etcd-single-backup.yaml` with contents such as the following example:
++
+[source,yaml]
+----
+apiVersion: operator.openshift.io/v1alpha1
+kind: EtcdBackup
+metadata:
+  name: etcd-single-backup
+  namespace: openshift-etcd
+spec:
+  pvcName: etcd-backup-pvc <.>
+----
+<.> The name of the persistent volume claim (PVC) to save the backup to. Adjust this value according to your environment.
+
+. Apply the CR to start a single backup:
++
+[source,terminal]
+----
+$ oc apply -f etcd-single-backup.yaml
+----
+
+[id="creating-recurring-etcd-backups_{context}"]
+== Creating recurring etcd backups
+
+Follow these steps to create automated recurring backups of etcd.
+
+Use dynamically-provisioned storage to keep the created etcd backup data in a safe, external location if possible. If dynamically-provisioned storage is not available, consider storing the backup data on an NFS share to make backup recovery more accessible.
+
+.Prerequisites
+
+* You have access to the cluster as a user with the `cluster-admin` role.
+* You have access to the OpenShift CLI (`oc`).
+
+.Procedure
+
+. If dynamically-provisioned storage is available, complete the following steps to create automated recurring backups:
+
+.. Create a persistent volume claim (PVC) named `etcd-backup-pvc.yaml` with contents such as the following example:
++
+[source,yaml]
+----
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: etcd-backup-pvc
+  namespace: openshift-etcd
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 200Gi <.>
+  storageClassName: standard-csi <.>
+  volumeMode: Filesystem
+----
+<.> The amount of storage available to the PVC. Adjust this value for your requirements.
+<.> The name of the `StorageClass` required by the claim. Adjust this value according to your environment.
++
+[NOTE]
+====
+Each of the following providers require changes to the `accessModes` and `storageClassName` keys:
+
+[cols="1,1,1"]
+|===
+|Provider|`accessModes` value|`storageClassName` value
+
+|AWS with the `versioned-installer-efc_operator-ci` profile
+|`- ReadWriteMany`
+|`efs-sc`
+
+|Google Cloud Platform
+|`- ReadWriteMany`
+|`filestore-csi`
+
+|Microsoft Azure
+|`- ReadWriteMany`
+|`azurefile-csi`
+|===
+====
+
+.. Apply the PVC by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f etcd-backup-pvc.yaml
+----
+
+.. Verify the creation of the PVC by running the following command:
++
+[source,terminal]
+----
+$ oc get pvc
+----
++
+.Example output
+[source,terminal]
+----
+NAME              STATUS    VOLUME   CAPACITY   ACCESS MODES   STORAGECLASS   AGE
+etcd-backup-pvc   Pending                                      standard-csi   51s
+----
++
+[NOTE]
+====
+Dynamic PVCs stay in the `Pending` state until they are mounted.
+====
+
+. If dynamically-provisioned storage is unavailable, create a local storage PVC by completing the following steps:
++
+[WARNING]
+====
+If you delete or otherwise lose access to the node that contains the stored backup data, you can lose data.
+====
+
+.. Create a `StorageClass` CR file named `etcd-backup-local-storage.yaml` with the following contents:
++
+[source,yaml]
+----
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: etcd-backup-local-storage
+provisioner: kubernetes.io/no-provisioner
+volumeBindingMode: WaitForFirstConsumer
+----
+
+.. Apply the `StorageClass` CR by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f etcd-backup-local-storage.yaml
+----
+
+.. Create a PV named `etcd-backup-pv-fs.yaml` from the applied `StorageClass` with content such as the following example:
++
+[source,yaml]
+----
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: etcd-backup-pv-fs
+spec:
+  capacity:
+    storage: 100Gi <.>
+  volumeMode: Filesystem
+  accessModes:
+  - ReadWriteMany
+  persistentVolumeReclaimPolicy: Delete
+  storageClassName: local-storage
+  local:
+    path: /mnt/
+  nodeAffinity:
+    required:
+      nodeSelectorTerms:
+      - matchExpressions:
+        - key: kubernetes.io/hostname
+          operator: In
+          values:
+          - <example-master-node> <.>
+----
+<.> The amount of storage available to the PV. Adjust this value for your requirements.
+<.> Replace this value with the node to attach this PV to.
++
+[TIP]
+====
+Run the following command to list the available nodes:
+
+[source,terminal]
+----
+$ oc get nodes
+----
+====
+
+.. Verify the creation of the PV by running the following command:
++
+[source,terminal]
+----
+$ oc get pv
+----
++
+.Example output
+[source,terminal]
+----
+NAME                    CAPACITY   ACCESS MODES   RECLAIM POLICY   STATUS      CLAIM   STORAGECLASS    REASON   AGE
+etcd-backup-pv-fs       100Gi      RWX            Delete           Available           local-storage            10s
+----
+
+.. Create a PVC named `etcd-backup-pvc.yaml` with contents such as the following example:
++
+[source,yaml]
+----
+kind: PersistentVolumeClaim
+apiVersion: v1
+metadata:
+  name: etcd-backup-pvc
+spec:
+  accessModes:
+  - ReadWriteMany
+  volumeMode: Filesystem
+  resources:
+    requests:
+      storage: 10Gi <.>
+  storageClassName: local-storage
+----
+<.> The amount of storage available to the PVC. Adjust this value for your requirements.
+
+.. Apply the PVC by running the following command:
++
+[source,terminal]
+----
+$ oc apply -f etcd-backup-pvc.yaml
+----
+
+. Create a custom resource definition (CRD) file named `etcd-recurring-backups.yaml`. The contents of the created CRD define the schedule and retention type of automated backups.
++
+For the default retention type of `RetentionNumber` with 15 retained backups, use contents such as the following example:
++
+[source,yaml]
+----
+apiVersion: config.openshift.io/v1alpha1
+kind: Backup
+metadata:
+  name: etcd-recurring-backup
+spec:
+  etcd:
+    schedule: "20 4 * * *" <.>
+    timeZone: "UTC"
+    pvcName: etcd-backup-pvc
+----
+<.> The `CronTab` schedule for recurring backups. Adjust this value for your needs.
++
+To use retention based on the maximum number of backups, add the following key-value pairs to the `etcd` key:
++
+[source,yaml]
+----
+spec:
+  etcd:
+    retentionPolicy:
+      retentionType: RetentionNumber <.>
+      retentionNumber:
+        maxNumberOfBackups: 5 <.>
+----
+<.> The retention type. Defaults to `RetentionNumber` if unspecified.
+<.> The maximum number of backups to retain. Adjust this value for your needs. Defaults to 15 backups if unspecified.
++
+[WARNING]
+====
+A known issue causes the number of retained backups to be one greater than the configured value.
+====
++
+For retention based on the file size of backups, use the following:
++
+[source,yaml]
+----
+spec:
+  etcd:
+    retentionPolicy:
+      retentionType: RetentionSize
+      retentionSize:
+        maxSizeOfBackupsGb: 20 <.>
+----
+<.> The maximum file size of the retained backups in gigabytes. Adjust this value for your needs. Defaults to 10 GB if unspecified.
++
+[WARNING]
+====
+A known issue causes the maximum size of retained backups to be up to 10 GB greater than the configured value.
+====
+
+. Create the cron job defined by the CRD by running the following command:
++
+[source,terminal]
+----
+$ oc create -f etcd-recurring-backup.yaml
+----
+
+. To find the created cron job, run the following command:
++
+[source,terminal]
+----
+$ oc get cronjob -n openshift-etcd
+----


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-6496

Link to docs preview:
https://66678--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/control_plane_backup_and_restore/backing-up-etcd#creating-automated-etcd-backups_backup-etcd

QE review:
- [x] QE has approved this change.

Additional information:

I'm uncertain of my usage of some of the terminology in this PR, so any input on that would be greatly appreciated.