### PR TITLE
Remove ROSA, Dedicated, MicroShift  builds for 4.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,14 +23,8 @@ jobs:
             while read -r filename; do
               if [ "$filename" == "_topic_maps/_topic_map.yml" ]; then python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.11 --no-upstream-fetch
 
-              elif [ "$filename" == "_topic_maps/_topic_map_osd.yml" ]; then python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch
-
-              elif [ "$filename" == "_topic_maps/_topic_map_ms.yml" ]; then python3 build.py --distro microshift --product "Microshift" --version 4 --no-upstream-fetch
-
-              elif [ "$filename" == "_topic_maps/_topic_map_rosa.yml" ]; then python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch
-
               elif [ "$filename" == "_distro_map.yml" ]; then python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.11 --no-upstream-fetch
               fi
             done
 
-          if [ -d "drupal-build" ]; then python3 makeBuild.py; fi
+          if [ -d "drupal-build" ]; then python3 makeBuild.py || travis_terminate 1; fi


### PR DESCRIPTION
Version(s):
4.11 only

Issue:
Remove ROSA, Dedicated, MicroShift  builds for 4.11
