### PR TITLE
OSDOCS#5162: Fixes a broken link in API reference

### DIFF
--- a/modules/dynamic-plugin-api.adoc
+++ b/modules/dynamic-plugin-api.adoc
@@ -1265,7 +1265,7 @@ A basic lazy loaded Code editor with hover help and completion.
 |`toolbarLinks` |Array of ReactNode rendered on the toolbar links section on top of the editor.
 |`onChange` |Callback for on code change event.
 |`onSave` |Callback called when the command CTRL / CMD + S is triggered.
-|`ref` |React reference to `{ editor?: IStandaloneCodeEditor }`. Using the `editor` property, you are able to access to all methods to control the editor. For more information, visit link:https://microsoft.github.io/monaco-editor/api/interfaces/monaco.editor.IStandaloneCodeEditor.html[Interface IStandaloneCodeEditor].
+|`ref` |React reference to `{ editor?: IStandaloneCodeEditor }`. Using the `editor` property, you are able to access to all methods to control the editor. For more information, visit link:https://microsoft.github.io/monaco-editor/docs.html#interfaces/editor.IStandaloneCodeEditor.html[Interface IStandaloneCodeEditor].
 |===
 
 


### PR DESCRIPTION
OSDOCS#5162: Fixes a broken link in API reference

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-5162

Link to docs preview:
https://66693--docspreview.netlify.app/openshift-enterprise/latest/web_console/dynamic-plugin/dynamic-plugins-reference#troubleshooting-dynamic-plugin_dynamic-plugins-reference:~:text=Interface%20IStandaloneCodeEditor.

QE review:
No QE needed just a link fix

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
