### PR TITLE
[OCPBUGS-22184] 4.13 backport - Add single stack restriction IBM Power and IBM Z

### DIFF
--- a/modules/nw-ovn-kubernetes-matrix.adoc
+++ b/modules/nw-ovn-kubernetes-matrix.adoc
@@ -64,7 +64,7 @@ endif::[]
 
 2. Egress router for OVN-Kubernetes supports only redirect mode.
 
-3. IPv6 is supported only on bare metal, IBM Power, and {ibmzProductName} clusters.
+3. IPv6 is supported only on bare metal, {ibmpowerProductName}, and {ibmzProductName} clusters.
 
-4. IPv6 single stack does not support xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState].
+4. IPv6 single stack does not support xref:../../networking/k8s_nmstate/k8s-nmstate-about-the-k8s-nmstate-operator.adoc#k8s-nmstate-about-the-k8s-nmstate-operator[Kubernetes NMState] and is not supported on {ibmpowerProductName} and {ibmzProductName} clusters.
 --


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12, 4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Backport of this PR: https://github.com/openshift/openshift-docs/pull/66587

Issue: https://issues.redhat.com/browse/OCPBUGS-22184
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://66700--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#nw-ovn-kubernetes-matrix_about-ovn-kubernetes
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: @holgwolf 
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
