### PR TITLE
Adds TP designation BACK to multi-nic docs

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -152,6 +152,9 @@ For more information, see link:https://docs.microsoft.com/en-us/azure/azure-reso
 [id="nw-egress-ips-multi-nic-considerations_{context}"]
 == Considerations for using an egress IP on additional network interfaces
 
+:FeatureName: Using an egress IP on additional network interfaces
+include::snippets/technology-preview.adoc[]
+
 In {product-title}, egress IPs provide administrators a way to control network traffic. Egress IPs can be used with the `br-ex`, or primary, network interface, which is a Linux bridge interface associated with Open vSwitch, or they can be used with additional network interfaces. 
 
 You can inspect your network interface type by running the following command:


### PR DESCRIPTION
Original PR that removes TP designation: https://github.com/openshift/openshift-docs/pull/66629 

Original follow-up PR: https://github.com/openshift/openshift-docs/pull/63879 

Preview: https://66704--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn#nw-egress-ips-multi-nic-considerations_configuring-egress-ips-ovn 
