### PR TITLE
CMA fix bad link ROSA/OSD

### DIFF
--- a/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc
+++ b/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.adoc
@@ -119,8 +119,11 @@ spec:
 <2> Specifies that this trigger authentication uses a platform-native pod authentication method for authorization.
 <3> Specifies a pod identity. Supported values are `none`, `azure`, `aws-eks`, or `aws-kiam`. The default is `none`.
 
+// Remove ifdef after https://github.com/openshift/openshift-docs/pull/62147 merges
+ifndef::openshift-rosa,openshift-dedicated[]
 .Additional resources
 
 * For information about {product-title} secrets, see xref:../../nodes/pods/nodes-pods-secrets.adoc#nodes-pods-secrets[Providing sensitive data to pods].
+endif::openshift-rosa,openshift-dedicated[]
 
 include::modules/nodes-cma-autoscaling-custom-trigger-auth-using.adoc[leveloffset=+1]


### PR DESCRIPTION
The link in  Nodes -> Automatically scaling pods with the Custom Metrics Autoscaler Operator -> [Understanding the custom metrics autoscaler trigger authentications -> Additional references](https://docs.openshift.com/container-platform/4.12/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth.html#nodes-cma-autoscaling-custom-trigger-auth-using_nodes-cma-autoscaling-custom-trigger-auth) need to be hidden in ROSA and OSD. The link was introduced in [65703](https://github.com/openshift/openshift-docs/pull/65703). For some reason, the bad link passed Travis for that PR and the 4.11, 4.12, and 4.14 cherrypicks. The cherrypick for 4.13 failed Travis.  

Previews
[OCP](https://66709--docspreview.netlify.app/openshift-enterprise/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth) -- Link above _Using trigger authentications_ is present.
[ROSA](https://66709--docspreview.netlify.app/openshift-rosa/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth) -- Link above _Using trigger authentications_  is not present.
[OSD](https://66709--docspreview.netlify.app/openshift-dedicated/latest/nodes/cma/nodes-cma-autoscaling-custom-trigger-auth) -- Link above _Using trigger authentications_  is not present.