### PR TITLE
OSDOCS-8315: Removed the Tech Preview warning from the documentation

### DIFF
--- a/rosa_planning/rosa-understanding-terraform.adoc
+++ b/rosa_planning/rosa-understanding-terraform.adoc
@@ -9,9 +9,6 @@ toc::[]
 
 Terraform is an infrastructure-as-code tool that provides a way to configure your resources once and replicate those resources as desired. Terraform accomplishes the creation tasks by using declarative language. You declare what you want the final state of the infrastructure resource to be, and Terraform creates these resources to your specifications.
 
-:FeatureName: Red Hat Cloud Services Terraform Provider 
-include::snippets/technology-preview.adoc[]
-
 include::modules/rosa-sts-terraform-prerequisites.adoc[leveloffset=+1]
 
 [discrete]


### PR DESCRIPTION
Version(s):
`enterprise-4.13+`

Issue:
[OSDOCS-8315](https://issues.redhat.com/browse/OSDOCS-8315)

Link to docs preview:
- [Preparing Terraform to install ROSA clusters](https://file.rdu.redhat.com/eponvell/OSDOCS-8315_Remove-Tech-Preview/rosa_planning/rosa-understanding-terraform.html)
    Before:
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/46c7cae9-301a-475c-8534-9a6527654af2)
    
    After:
    ![image](https://github.com/openshift/openshift-docs/assets/16167833/d47656f5-5ba2-47d7-b07e-f46739a7296c)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Removed the Tech Preview warning from the Terraform documentation now that the RHCS provider is GA.