### PR TITLE
OCPBUGS-22260: Updated RHV depre. note

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -1709,9 +1709,9 @@ In the following tables, features are marked with the following statuses:
 === Deprecated features
 
 [id="ocp-4-13-rhv-deprecations"]
-==== Red Hat Virtualization (RHV) as a host platform for {product-title} will be deprecated
+==== Red Hat Virtualization (RHV) deprecation
 
-Red Hat Virtualization (RHV) as a host platform for {product-title} is now deprecated, and will be removed in the next {product-title} release, currently planned as {product-title} 4.14.
+Red Hat Virtualization (RHV) as a host platform for {product-title} is now deprecated.
 
 [id="ocp-4-13-ne-deprecations"]
 ==== Wildcard DNS queries for the cluster.local domain are deprecated


### PR DESCRIPTION
[OCPBUGS-22260](https://issues.redhat.com/browse/OCPBUGS-22260)

Version(s):
4.13

Link to docs preview:
[RHV Hat Virtualization (RHV)](https://66723--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-rhv-deprecations)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
