### PR TITLE
Updated OSD link to Support book

### DIFF
--- a/modules/ocm-overview-tab.adoc
+++ b/modules/ocm-overview-tab.adoc
@@ -26,5 +26,5 @@ The **Overview** tab provides information about how your cluster was configured:
 * **Nodes** shows the actual and desired nodes on the cluster. These numbers might not match due to cluster scaling.
 * **Network** field shows the address and prefixes for network connectivity.
 * **Resource usage** section of the tab displays the resources in use with a graph.
-* **Advisor recommendations** section gives insight in relation to security, performance, availability, and stablility. This section requires the use of remote health functionality. See link:https://docs.openshift.com/container-platform/4.9/support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.html[Using Insights to identify issues with your cluster].
+* **Advisor recommendations** section gives insight in relation to security, performance, availability, and stablility. This section requires the use of remote health functionality. See xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using Insights to identify issues with your cluster].
 * **Cluster history** section shows everything that has been done with the cluster including creation and when a new version is identified.

--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -168,8 +168,7 @@ CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard ent
 |Required for managed OpenShift-specific telemetry.
 |===
 +
-Managed clusters require enabling telemetry to allow Red Hat to react more quickly to problems, better support the customers, and better understand how product upgrades impact clusters.
-See link:https://docs.openshift.com/container-platform/4.9/support/remote_health_monitoring/about-remote-health-monitoring.html[About remote health monitoring] for more information about how remote health monitoring data is used by Red Hat.
+Managed clusters require enabling telemetry to allow Red Hat to react more quickly to problems, better support the customers, and better understand how product upgrades impact clusters. See xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about how remote health monitoring data is used by Red Hat.
 
 . Allowlist the following Amazon Web Services (AWS) API URls:
 +


### PR DESCRIPTION
Two [hard links to the 4.9 Support book were added to the OSD docs](https://github.com/openshift/openshift-docs/commit/8fa0dbd95c93b1213ae9aa674b79ec51fad02fbe#diff-2a0a7b2d1cec0b83ca7caa06840d817fa5d62ad43830c6cf11fe4b124bfadb6cR28), as the Support book was not in the OSD docs. The Support book is now in the OSD docs and the link now stays in OSD rather than going to OCP.

Preview:
Red Hat OpenShift Cluster Manager -> OCM Overview -> Overview tab -> [Advisor recommendations, _Using Insights to identify issues with your cluster_ link](https://66730--docspreview.netlify.app/openshift-dedicated/latest/ocm/ocm-overview#ocm-overview-tab_ocm-overview).
Planning your environment -> Customer Cloud Subscriptions on AWS -> AWS firewall prerequisites -> [Step 2, _About remote health monitoring_ link](https://66730--docspreview.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs#osd-aws-privatelink-firewall-prerequisites_aws-ccs)
No QE needed.