### PR TITLE
CMA fix redirect to get CMA docs in OSD

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -696,6 +696,10 @@ AddType text/vtt                            vtt
     RewriteRule ^dedicated/osd_private_connections/?(.*)$ /dedicated/osd_cluster_admin/osd_private_connections/$1 [NE,R=301]
 
     RewriteRule ^dedicated/nodes/rosa-managing-worker-nodes.html /dedicated/osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.html [NE,R=301]
+    
+    # Redirect to get Custom Metrics Autoscaler into OSD
+    RewriteRule ^dedicated/nodes/cma/?(.*)$ /dedicated/nodes/cma/$1 [NE,R=301]
+
     RewriteRule ^dedicated/nodes/?(.*)$ /dedicated/osd_cluster_admin/osd_nodes/osd-$1 [NE,R=301]
 
     RewriteRule ^dedicated/osd_notifications/notifications.html /dedicated/osd_cluster_admin/osd_logging/osd-accessing-the-service-logs.html [NE,R=301]

--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -698,7 +698,7 @@ AddType text/vtt                            vtt
     RewriteRule ^dedicated/nodes/rosa-managing-worker-nodes.html /dedicated/osd_cluster_admin/osd_nodes/osd-managing-worker-nodes.html [NE,R=301]
     
     # Redirect to get Custom Metrics Autoscaler into OSD
-    RewriteRule ^dedicated/nodes/cma/?(.*)$ /dedicated/nodes/cma/$1 [NE,R=301]
+    RewriteRule ^dedicated/nodes/cma/?(.*)$ - [L,R=302]
 
     RewriteRule ^dedicated/nodes/?(.*)$ /dedicated/osd_cluster_admin/osd_nodes/osd-$1 [NE,R=301]
 


### PR DESCRIPTION
There are currently redirects for dedicated/nodes/ for Dedicated. This PR adds a new redirect to get the Custom Metrics Autoscaler into OSD.

Preview:
OSD -> Nodes -> CMA
Current