### PR TITLE
Jaeger monitor tab, disable spanmetrics units

### DIFF
--- a/modules/distr-tracing-otel-config-collector.adoc
+++ b/modules/distr-tracing-otel-config-collector.adoc
@@ -483,6 +483,7 @@ The Prometheus exporter exports data using the Prometheus or OpenMetrics formats
         resource_to_telemetry_conversion: <7>
           enabled: true
         metric_expiration: 180m <8>
+        add_metric_suffixes: false <9>
     service:
       pipelines:
         metrics:
@@ -496,4 +497,4 @@ The Prometheus exporter exports data using the Prometheus or OpenMetrics formats
 <6> If `true`, metrics are exported using the OpenMetrics format. Exemplars are only exported in the OpenMetrics format and only for histogram and monotonic sum metrics such as `counter`. Disabled by default.
 <7> If `enabled` is `true`, all the resource attributes are converted to metric labels by default. Disabled by default.
 <8> Defines how long metrics are exposed without updates. The default is `5m`.
-
+<9> Adds metrics types and units suffixes. The option needs to be disabled if monitor tab in Jaeger console is enabled. The default is `true`.


### PR DESCRIPTION
follow up for https://github.com/max-cx/openshift-docs/pull/11 
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
