### PR TITLE
OCP 4.14 RN's: Doc update for oc-mirror catalog opm limitation

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2631,6 +2631,8 @@ To avoid this issue, you can enable confidential VMs on an existing cluster by u
 
 * When you run hosted control planes for {product-title} on a bare-metal platform, if a worker node fails, another node is not automatically added to the hosted cluster, even when other agents are available. As a workaround, manually delete the machine that is associated with the failed worker node. (link:https://issues.redhat.com/browse/MGMT-15939[*MGMT-15939*])
 
+* Since the source catalog bundles an architecture specific `opm` binary, you must run the mirroring from that architecture. For instance if you are mirroring a ppc64le catalog, you must run oc-mirror from a system that runs on the ppc64le architecture. (link:https://issues.redhat.com/browse/OCPBUGS-22264[*OCPBUGS-22264*])
+
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
Version(s): 4.14

Issue: https://issues.redhat.com/browse/OCPBUGS-22264

Link to docs preview: https://66745--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-known-issues

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

