### PR TITLE
OSDOCS-8322: update Red Hat Device Edge page

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -13,5 +13,8 @@
 :op-system-version: 9.2
 :op-system-version-major: 9
 :microshift-first: Red Hat build of MicroShift
-:microshift: MicroShift
+:microshift: Red Hat build of MicroShift
+//removing short form of MicroShift pending approval of use
 :microshift-version: 4.14
+:ansible: Red Hat Ansible Automation Platform
+:ansible-version: 2.4

--- a/modules/about-rhde.adoc
+++ b/modules/about-rhde.adoc
@@ -6,7 +6,7 @@
 [id="about-rhde_{context}"]
 = About {product-title}
 
-{product-title} is for organizations that need small-form-factor edge devices and support for bare metal, virtualized, or containerized applications. {product-title} helps address many of the emerging questions around large-scale edge computing at the device edge by incorporating Kubernetes features in a new, smaller, lighter-weight footprint with an edge-optimized Linux operating system built from the world's leading enterprise Linux platform in {op-system}.
+{product-title} is for organizations that need small-form-factor edge devices and support for bare metal, virtualized, or containerized applications. {product-title} helps address many of the emerging questions around large-scale edge computing at the device edge by incorporating Kubernetes features in a new, smaller, lighter-weight footprint with an edge-optimized Linux operating system built from the world's leading enterprise Linux platform in {op-system}. You can manage {product-title} using {ansible}.
 
 .{product-title} components
 image::RHDevice_Edge_Overview_1.png[]
@@ -25,10 +25,12 @@ The latest release notes for each product that is part of {product-title} are av
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/9.2_release_notes/index[{op-system-ostree-first}] release notes contain details about {op-system-ostree}
 
-[id="device-edge-compatibility"]
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{ansible-version}/html/red_hat_ansible_automation_platform_release_notes/index[{ansible} Release Notes]
+
+[id="device-edge-compatibility_{context}"]
 == {product-title} product release compatibility matrix
 
-The two products of {product-title} work together as a single solution for device-edge computing. To successfully pair your products, use the verified releases together for each as listed in the following table:
+{microshift-first} and {op-system} work together as a single solution for device-edge computing. To successfully pair your products, use the verified releases together for each as listed in the following table:
 
 [cols="4",%autowidth]
 |===
@@ -53,15 +55,30 @@ The two products of {product-title} work together as a single solution for devic
 ^|None
 |===
 
+[id="device-edge-compatibility-ansible_{context}"]
+== {ansible} compatibility
+
+* When {ansible} is used to manage {product-title} deployments, you can use any supported version listed here: link:https://access.redhat.com/support/policy/updates/ansible-automation-platform#dates[{ansible} Life Cycle].
+
+* To manage an older version of {op-system-first} with {ansible}, see the link:https://docs.ansible.com/ansible/latest/reference_appendices/release_and_maintenance.html#ansible-core-support-matrix[`ansible-core` support matrix] page.
+
+[id="prod-docs-rhde_{context}"]
+== {product-title} documentation
+
 For more information about the {product-title} products, see the following documentation:
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/4.14[Red Hat build of MicroShift]
 
-* link:https://access.redhat.com/documentation/en-us/edge_management/2023[Product Documentation for Edge management 2023]
-//the RHEL team owns the edge management page; date change to apply before GA
-
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/{op-system-version-major}/html/composing_installing_and_managing_rhel_for_edge_images/index[Composing, installing, and managing RHEL for Edge images]
 
-For details about {product-title} upgrade paths, see the following documentation:
+* link:https://access.redhat.com/documentation/en-us/red_hat_ansible_automation_platform/{ansible-version}[Product Documentation for {ansible}]
+
+//* link:https://access.redhat.com/documentation/en-us/edge_management/2023[Product Documentation for Edge management 2023]
+//the RHEL team owns the edge management page; date change was to apply before GA, but no other pages than 2022 exist as of 25Oct2023
+
+[id="upgrade-paths-rhde_{context}"]
+== Upgrade paths
+
+For details about {microshift} upgrade paths, see the following documentation:
 
 * link:https://access.redhat.com/documentation/en-us/red_hat_build_of_microshift/{microshift-version}/html/updates/index[{microshift} updates]


### PR DESCRIPTION
Version(s):
Versionless, no cherry-picks
rhde-docs is an unversioned branch of openshift-docs

Issue:
https://issues.redhat.com/browse/OSDOCS-8322

Link to docs preview:
[About Red Hat Device Edge](https://66754--docspreview.netlify.app/openshift-rhde/latest/overview/rhde-overview#about-rhde_device-edge-overview)

Additional info:
RHDE 4 is indicated on the Customer Portal for build purposes only.
<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
