### PR TITLE
updating guidelines about content type

### DIFF
--- a/contributing_to_docs/doc_guidelines.adoc
+++ b/contributing_to_docs/doc_guidelines.adoc
@@ -140,7 +140,7 @@ In {product-title} version {product-version}, you can install a cluster on {clou
 
 == Content type attributes
 
-Each `.adoc` file must contain a `:_content-type:` attribute in its metadata that indicates its file type. This information is used by some publication processes to sort and label files.
+Each `.adoc` file must contain a `:_mod-docs-content-type:` attribute in its metadata that indicates its file type. This information is used by some publication processes to sort and label files.
 
 Add the attribute from the following list that corresponds to your file type:
 


### PR DESCRIPTION
One of the WFM changes is the content type labels. This pr updates the contrib guidelines to adhere to the [updated rules](https://gitlab.cee.redhat.com/documentation-shared-content/ccs-official-shared-content/-/blob/main/ccs-official-shared-taxonomy/_instructions.adoc).