### PR TITLE
OSDOCS#8320: Noting the deprecation/change in behavior for registry c…

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1305,6 +1305,16 @@ If you have Operator projects that were previously created or maintained with Op
 
 * xref:../operators/operator_sdk/java/osdk-java-updating-projects.adoc#osdk-upgrading-projects_osdk-java-updating-projects[Updating Java-based Operator projects]
 
+[discrete]
+[id="ocp-4-14-credentials-podman-default"]
+=== oc commands now default to storing and obtaining credentials from Podman configuration locations
+
+Previously, OpenShift CLI (`oc`) commands that used the registry configuration, for example `oc adm release` or `oc image` commands, obtained credentials from Docker configuration file locations, such as `~/.docker/config.json`, first. If a registry entry could not be found in the Docker configuration locations, `oc` commands obtained the credentials from Podman configuration file locations, such as `${XDG_RUNTIME_DIR}/containers/auth.json`.
+
+With this release, `oc` commands now default to obtaining the credentials from Podman configuration locations first. If a registry entry cannot be found in the Podman configuration locations, `oc` commands obtain the credentials from Docker configuration locations.
+
+Additionally, the `oc registry login` command now stores credentials in the Podman configuration locations instead of the Docker configuration file locations.
+
 [id="ocp-4-14-deprecated-removed-features"]
 == Deprecated and removed features
 
@@ -1621,6 +1631,13 @@ For more information, see xref:../release_notes/ocp-4-14-release-notes.adoc#ocp-
 
 Red Hat Virtualization (RHV) as a host platform for {product-title} was deprecated and is no longer supported. This platform will be removed from {product-title} in a future {product-title} release.
 
+[id="ocp-4-14-dep-registry-auth-preference"]
+==== Using the REGISTRY_AUTH_PREFERENCE environment variable is now deprecated
+
+Using the `REGISTRY_AUTH_PREFERENCE` environment variable to specify your preferred location to obtain registry credentials for OpenShift CLI (`oc`) commands is now deprecated.
+
+OpenShift CLI (`oc`) commands now default to obtaining the credentials from Podman configuration locations first, but will fall back to checking the deprecated Docker configuration file locations.
+
 [id="ocp-4-14-removed-features"]
 === Removed features
 
@@ -1644,6 +1661,11 @@ Kubernetes 1.27 removed the following deprecated API, so you must migrate manife
 ==== Support for the LatencySensitive feature set is removed
 
 As of {product-title} 4.14, support for the `LatencySensitive` feature set is removed.
+
+[id="ocp-4-14-removed-store-registry-credentials"]
+==== oc registry login no longer stores credentials in Docker configuration file locations
+
+As of {product-title} 4.14, the `oc registry login` command no longer stores registry credentials in the Docker file locations, such as `~/.docker/config.json`. The `oc registry login` command now stores credentials in the Podman configuration file locations, such as `${XDG_RUNTIME_DIR}/containers/auth.json`.
 
 [id="ocp-4-14-future-deprecation"]
 === Notice of future deprecation


### PR DESCRIPTION
…onfig file locations

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8320

Link to docs preview:
* https://66761--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-credentials-podman-default
* https://66761--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-dep-registry-auth-preference
* https://66761--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-removed-store-registry-credentials

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

Some wording reused from this 4.10 release note: https://docs.openshift.com/container-platform/4.10/release_notes/ocp-4-10-release-notes.html#ocp-4-10-oc-commands-obtain-credentials-from-podman-config
