### PR TITLE
OSDOCS-8327: Documented the OCI platform RN

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -197,7 +197,7 @@ endif::[]
 :3no-caps: Three-node OpenShift
 :run-once-operator: Run Once Duration Override Operator
 //Oracle
-:oci-first: Oracle&#174; Cloud Infrastructure
+:oci-first: Oracle&#174; Cloud Infrastructure (OCI)
 :oci: OCI
 :ocvs-first: Oracle&#174; Cloud VMware Solution (OCVS)
 :ocvs: OCVS

--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -923,6 +923,18 @@ For information about using the {secrets-store-operator} to mount secrets from a
 
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-azure-file.adoc#persistent-storage-csi-azure-file-nfs_persistent-storage-csi-azure-file[NFS support].
 
+[id="ocp-4-14-oci"]
+=== Oracle&#174; Cloud Infrastructure
+
+You can now install an {product-title} cluster on {oci-first} by using the Assisted installer or the Agent-based installer. For {product-title} {product-version}, {product-title} on {oci} is available as a Developer Preview feature.
+
+To install an {product-title} cluster on {oci}, choose one of the following installation options:
+
+* link:https://access.redhat.com/articles/7039183[Using the Assisted Installer to install a cluster on {oci-first}]
+* link:https://access.redhat.com/node/7038262/draft[Using the Agent-based Installer to install a cluster on {oci-first}]
+
+For more information about a Developer Preview feature, see link:https://access.redhat.com/support/offerings/devpreview[Developer Preview Support Scope] on the Red Hat Customer Portal.
+
 [id="ocp-4-14-olm"]
 === Operator lifecycle
 


### PR DESCRIPTION
[OSDOCS-8327](https://issues.redhat.com/browse/OSDOCS-8327)

Version(s):
4.14

Link to docs preview:
[Oracle® Cloud Infrastructure](https://66774--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-oci)

QE review:
- [x] QE not needed for Dev Preview feature. See comment on https://issues.redhat.com/browse/OSDOCS-7595

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
