### PR TITLE
OSDOCS#8243: Adds notes for 4.13.18 Microshift release

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -295,10 +295,19 @@ For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers
 //release 4-13-16 was folded into 4-13-17
 
 [id="microshift-4-13-17-dp"]
-=== RHBA-2023:5674 - {product-title} 4.13.17 bug fix update
+=== RHBA-2023:5674 - {product-title} 4.13.17 bug fix and security update
 
 Issued: 2023-10-17
 
-{product-title} release 4.13.17 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5674[RHBA-2023:5674] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5672[RHSA-2023:5672] advisory.
+{product-title} release 4.13.17, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5674[RHBA-2023:5674] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5672[RHSA-2023:5672] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-18-dp"]
+=== RHBA-2023:5904 - {product-title} 4.13.18 bug fix and security update
+
+Issued: 2023-10-24
+
+{product-title} release 4.13.18, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5904[RHBA-2023:5904] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5902[RHSA-2023:5902] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
[OSDOCS-8243](https://issues.redhat.com//browse/OSDOCS-8243): Adds notes for 4.13.18 Microshift release

Version(s):
4.13

Issue:
https://issues.redhat.com/browse/OSDOCS-8243

Link to docs preview:
https://66776--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-18-dp

QE review:
- [ ] QE has approved this change.
No QE needed for this change

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
