### PR TITLE
removing an xref from a module

### DIFF
--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -168,7 +168,8 @@ CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard ent
 |Required for managed OpenShift-specific telemetry.
 |===
 +
-Managed clusters require enabling telemetry to allow Red Hat to react more quickly to problems, better support the customers, and better understand how product upgrades impact clusters. See xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about how remote health monitoring data is used by Red Hat.
+Managed clusters require enabling telemetry to allow Red Hat to react more quickly to problems, better support the customers, and better understand how product upgrades impact clusters.
+//See xref: ../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about how remote health monitoring data is used by Red Hat.
 
 . Allowlist the following Amazon Web Services (AWS) API URls:
 +


### PR DESCRIPTION
@mburke5678, you can't put an xref in a module. This one is/should be currently breaking the ROSA build.