### PR TITLE
OSDOCS-7506 updated TechPreviewNoUpgrade feature sets for 4.14

### DIFF
--- a/modules/nodes-cluster-enabling-features-about.adoc
+++ b/modules/nodes-cluster-enabling-features-about.adoc
@@ -22,7 +22,6 @@ The following Technology Preview features are enabled by this feature set:
 --
 ** External cloud providers. Enables support for external cloud providers for clusters on vSphere, AWS, Azure, and GCP. Support for OpenStack is GA. This is an internal feature that most users do not need to interact with. (`ExternalCloudProvider`)
 ** Shared Resources CSI Driver and Build CSI Volumes in OpenShift Builds. Enables the Container Storage Interface (CSI). (`CSIDriverSharedResource`)
-** CSI volumes. Enables CSI volume support for the {product-title} build system. (`BuildCSIVolumes`)
 ** Swap memory on nodes. Enables swap memory use for {product-title} workloads on a per-node basis. (`NodeSwap`)
 ** OpenStack Machine API Provider. This gate has no effect and is planned to be removed from this feature set in a future release. (`MachineAPIProviderOpenStack`)
 ** Insights Operator. Enables the Insights Operator, which gathers {product-title} configuration data and sends it to Red Hat. (`InsightsConfigAPI`)
@@ -31,6 +30,13 @@ The following Technology Preview features are enabled by this feature set:
 ** Pod security admission enforcement. Enables the restricted enforcement mode for pod security admission. Instead of only logging a warning, pods are rejected if they violate pod security standards. (`OpenShiftPodSecurityAdmission`)
 ** StatefulSet pod availability upgrading limits. Enables users to define the maximum number of statefulset pods unavailable during updates which reduces application downtime. (`MaxUnavailableStatefulSet`)
 ** Admin Network Policy and Baseline Admin Network Policy. Enables `AdminNetworkPolicy` and `BaselineAdminNetworkPolicy` resources, which are part of the Network Policy V2 API, in clusters running the OVN-Kubernetes CNI plugin. Cluster administrators can apply cluster-scoped policies and safeguards for an entire cluster before namespaces are created. Network administrators can secure clusters by enforcing network traffic controls that cannot be overridden by users. Network administrators can enforce optional baseline network traffic controls that can be overridden by users in the cluster, if necessary. Currently, these APIs support only expressing policies for intra-cluster traffic. (`AdminNetworkPolicy`)
+** `MatchConditions` is a list of conditions that must be met for a request to be sent to this webhook. Match conditions filter requests that have already been matched by the rules, namespaceSelector, and objectSelector. An empty list of `matchConditions` matches all requests. (`admissionWebhookMatchConditions`)
+** Gateway API. To enable the {product-title} Gateway API, set the value of the `enabled` field to `true` in the `techPreview.gatewayAPI` specification of the `ServiceMeshControlPlane` resource.(`gateGatewayAPI`)
+** `sigstoreImageVerification`
+** `gcpLabelsTags`
+** `vSphereStaticIPs`
+** `routeExternalCertificate`
+** `automatedEtcdBackup`
 --
 
 ////


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-7506

Link to docs preview (VPN required):
[Understanding feature gates](https://file.rdu.redhat.com/antaylor/OSDOCS-7506/nodes/clusters/nodes-cluster-enabling-features.html#nodes-cluster-enabling-features-about_nodes-cluster-enabling)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
None