### PR TITLE
[RHACS] fix date in patch release

### DIFF
--- a/release_notes/40-release-notes.adoc
+++ b/release_notes/40-release-notes.adoc
@@ -17,7 +17,7 @@ toc::[]
 |`4.0.2` |31 May 2023
 |`4.0.3` | 13 July 2023
 |`4.0.4` |9 August 2023
-|`4.0.5` |17 October 2023
+|`4.0.5` |24 October 2023
 |====
 
 [id="about-this-release-40"]
@@ -496,7 +496,7 @@ Release date: 9 August 2023
 [id="resolved-in-version-405"]
 === Resolved in version 4.0.5
 
-Release date: 17 October 2023
+Release date: 24 October 2023
 
 This release of {product-title-short} fixes the following security vulnerabilities:
 


### PR DESCRIPTION
Version(s):
`rhacs-docs-4.01`

Issue: none

[Link to docs preview
](https://66798--docspreview.netlify.app/openshift-acs/latest/release_notes/40-release-notes)

QE review: **N/A**
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Fixes error in release date.

