### PR TITLE
[RHACS] Fix date for 3.74.7 release

### DIFF
--- a/release_notes/374-release-notes.adoc
+++ b/release_notes/374-release-notes.adoc
@@ -19,7 +19,7 @@ toc::[]
 |`3.74.4` | 5 June 2023
 |`3.74.5` | 13 July 2023
 |`3.74.6` | 28 September 2023
-|`3.74.7` |17 October 2023
+|`3.74.7` |24 October 2023
 |====
 
 [id="about-this-release-374"]
@@ -417,7 +417,7 @@ This release of {product-title-short} fixes the following security vulnerabiliti
 [id="resolved-in-version-3747"]
 === Resolved in version 3.74.7
 
-Release date: 17 October 2023
+Release date: 24 October 2023
 
 This release of {product-title-short} fixes the following security vulnerabilities:
 


### PR DESCRIPTION
Version(s):
`rhacs-docs-3.74`

Issue: none

Link to docs preview:

QE review: **N/A**
- [ ] QE has approved this change.

Additional information:

Fix error in date for patch release.