### PR TITLE
[OCPBUGS-17717] 4.12 Backport - Remove IPv4 restriction IBM P/Z

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -316,11 +316,11 @@ You can customize your installation configuration based on the requirements of y
 // But only for installer-provisioned
 // https://bugzilla.redhat.com/show_bug.cgi?id=2020416
 // Once BM UPI supports dual-stack, uncomment all the following conditionals and blocks
-ifndef::bare[]
+ifndef::bare,ibm-power,ibm-z[]
 Only IPv4 addresses are supported.
-endif::bare[]
+endif::bare,ibm-power,ibm-z[]
 
-ifdef::bare[]
+ifdef::bare,ibm-power,ibm-z[]
 * If you use the {openshift-networking} OVN-Kubernetes network plugin, both IPv4 and IPv6 address families are supported.
 
 * If you use the {openshift-networking} OpenShift SDN network plugin, only the IPv4 address family is supported.
@@ -352,7 +352,7 @@ networking:
   - 172.30.0.0/16
   - fd00:172:16::/112
 ----
-endif::bare[]
+endif::bare,ibm-power,ibm-z[]
 
 [NOTE]
 ====


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-17717
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
4.12 Backport of this PR: https://github.com/openshift/openshift-docs/pull/65085 
IBM Z introduced IPv6 support in 4.12 see [4.12 RNs](https://docs.openshift.com/container-platform/4.12/release_notes/ocp-4-12-release-notes.html#ocp-4-12-ibm-z) 

Link to docs preview: 
- https://66801--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/installing-ibm-z#installation-configuration-parameters-network_installing-ibm-z
- https://66801--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/installing-ibm-power#installation-configuration-parameters-network_installing-ibm-power
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: Has been approved here: https://github.com/openshift/openshift-docs/pull/65085 
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
