### PR TITLE
OSDOCS#8115: Add X710 Backplane and Base T to SR-IOV supported devices

### DIFF
--- a/modules/nw-sriov-supported-devices.adoc
+++ b/modules/nw-sriov-supported-devices.adoc
@@ -33,6 +33,16 @@
 |1572
 
 |Intel
+|X710 Backplane
+|8086
+|1581
+
+|Intel
+|X710 Base T
+|8086
+|15ff
+
+|Intel
 |XL710
 |8086
 |1583


### PR DESCRIPTION
Version(s):
4.14

Issue:
[OSDOCS-8115](https://issues.redhat.com/browse/OSDOCS-8115)

Link to docs preview:
[SR-IOV - Supported devices](https://66814--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/about-sriov#supported-devices_about-sriov)

QE review:
- [x] QE has approved this change.

Additional information:

N/A
