### PR TITLE
Move xref from module to assembly

### DIFF
--- a/modules/ocm-overview-tab.adoc
+++ b/modules/ocm-overview-tab.adoc
@@ -26,5 +26,5 @@ The **Overview** tab provides information about how your cluster was configured:
 * **Nodes** shows the actual and desired nodes on the cluster. These numbers might not match due to cluster scaling.
 * **Network** field shows the address and prefixes for network connectivity.
 * **Resource usage** section of the tab displays the resources in use with a graph.
-* **Advisor recommendations** section gives insight in relation to security, performance, availability, and stablility. This section requires the use of remote health functionality. See xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using Insights to identify issues with your cluster].
+* **Advisor recommendations** section gives insight in relation to security, performance, availability, and stablility. This section requires the use of remote health functionality. See _Using Insights to identify issues with your cluster_ in the _Additional resources_ section.
 * **Cluster history** section shows everything that has been done with the cluster including creation and when a new version is identified.

--- a/modules/osd-aws-privatelink-firewall-prerequisites.adoc
+++ b/modules/osd-aws-privatelink-firewall-prerequisites.adoc
@@ -169,7 +169,7 @@ CDN host names, such as `cdn01.quay.io`, are covered when you add a wildcard ent
 |===
 +
 Managed clusters require enabling telemetry to allow Red Hat to react more quickly to problems, better support the customers, and better understand how product upgrades impact clusters.
-//See xref: ../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring] for more information about how remote health monitoring data is used by Red Hat.
+For more information about how remote health monitoring data is used by Red Hat, see _About remote health monitoring_ in the _Additional resources_ section.
 
 . Allowlist the following Amazon Web Services (AWS) API URls:
 +

--- a/ocm/ocm-overview.adoc
+++ b/ocm/ocm-overview.adoc
@@ -44,6 +44,12 @@ Selecting an active, installed cluster shows tabs associated with that cluster. 
 * Settings
 
 include::modules/ocm-overview-tab.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+* xref:../support/remote_health_monitoring/using-insights-to-identify-issues-with-your-cluster.adoc#using-insights-to-identify-issues-with-your-cluster[Using Insights to identify issues with your cluster]
+
 include::modules/ocm-accesscontrol-tab.adoc[leveloffset=+2]
 include::modules/ocm-addons-tab.adoc[leveloffset=+2]
 include::modules/ocm-cluster-history.adoc[leveloffset=+2]

--- a/osd_planning/aws-ccs.adoc
+++ b/osd_planning/aws-ccs.adoc
@@ -16,4 +16,10 @@ include::modules/ccs-aws-scp.adoc[leveloffset=+1]
 include::modules/ccs-aws-iam.adoc[leveloffset=+1]
 include::modules/ccs-aws-provisioned.adoc[leveloffset=+1]
 include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+2]
+
+[role="_additional-resources"]
+.Additional resources
+
+*  xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+
 include::modules/aws-limits.adoc[leveloffset=+1]

--- a/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
+++ b/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc
@@ -20,6 +20,11 @@ include::modules/rosa-aws-iam.adoc[leveloffset=+1]
 include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
 include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+*  xref:../../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+
 == Next steps
 * xref:../../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-required-aws-service-quotas.adoc#rosa-required-aws-service-quotas[Review the required AWS service quotas]
 

--- a/rosa_planning/rosa-hcp-prereqs.adoc
+++ b/rosa_planning/rosa-hcp-prereqs.adoc
@@ -42,6 +42,11 @@ include::modules/rosa-sts-aws-requirements-security-req.adoc[leveloffset=+2]
 .Additional resources
 * xref:../rosa_planning/rosa-sts-aws-prereqs.adoc#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs[AWS firewall prerequisites]
 
+[role="_additional-resources"]
+.Additional resources
+
+*  xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+
 include::modules/rosa-sts-aws-requirements-ocm.adoc[leveloffset=+2]
 include::modules/rosa-sts-aws-requirements-association-concept.adoc[leveloffset=+3]
 include::modules/rosa-sts-aws-requirements-creating-association.adoc[leveloffset=+3]

--- a/rosa_planning/rosa-sts-aws-prereqs.adoc
+++ b/rosa_planning/rosa-sts-aws-prereqs.adoc
@@ -72,6 +72,11 @@ With the STS deployment model, Red Hat is no longer responsible for creating and
 include::modules/rosa-aws-provisioned.adoc[leveloffset=+1]
 include::modules/osd-aws-privatelink-firewall-prerequisites.adoc[leveloffset=+1]
 
+[role="_additional-resources"]
+.Additional resources
+
+*  xref:../support/remote_health_monitoring/about-remote-health-monitoring.adoc#about-remote-health-monitoring[About remote health monitoring]
+
 == Next steps
 * xref:../rosa_planning/rosa-sts-required-aws-service-quotas.adoc#rosa-sts-required-aws-service-quotas[Review the required AWS service quotas]
 


### PR DESCRIPTION
Manual revert of  https://github.com/openshift/openshift-docs/pull/66730 to move the link to the assembly

_**Previews:**_

**ROSA**
* Red Hat OpenShift Cluster Manager -> [Overview tab -> Advisor recommendations](https://66820--docspreview.netlify.app/openshift-rosa/latest/ocm/ocm-overview#ocm-overview-tab_ocm-overview) -- Removed link and added wording to see Additional references.

* Install ROSA Classic clusters -> Deploying ROSA without AWS STS -> AWS prerequisites for ROSA -> [AWS firewall prerequisites](https://66820--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs#osd-aws-privatelink-firewall-prerequisites_prerequisites) -- Text in Step 2, Removed link and added wording to see Additional references.

* Prepare your environment -> Detailed requirements for deploying ROSA using STS -> [AWS firewall prerequisites](https://66820--docspreview.netlify.app/openshift-rosa/latest/rosa_planning/rosa-sts-aws-prereqs.html#osd-aws-privatelink-firewall-prerequisites_rosa-sts-aws-prereqs) -- Text in Step 2, Removed link and added wording to see Additional references.

* [rosa_planning/rosa-hcp-prereqs.adoc](https://github.com/openshift/openshift-docs/pull/66820/files#diff-ae472f9b8243e7c137b8d4b369618f1677927074b6b7c431482293fd8409a854) -- File does not seem to be in use.

**OSD**
* Planning your environment -> Customer Cloud Subscriptions on AWS -> [AWS firewall prerequisites](https://66820--docspreview.netlify.app/openshift-dedicated/latest/osd_planning/aws-ccs#osd-aws-privatelink-firewall-prerequisites_aws-ccs) -- Text in Step 2, Removed link and added wording to see Additional references.

**_QE:_** 
No QE needed.

@EricPonvelle FYI