### PR TITLE
TELCODOCS-1548: Added bare metal release notes.

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -230,6 +230,10 @@ By default, the installation program downloads and installs the {op-system-first
 
 For more information about these parameters, see xref:../installing/installing_azure/installation-config-parameters-azure.adoc#installation-configuration-parameters-additional-azure_installation-config-parameters-azure[Additional Azure configuration parameters].
 
+[id="ocp-4-14-install-sno-on-cloud-providers"]
+==== Installing {sno} on cloud providers
+
+{product-title} {product-version} expands support for installing {sno} on cloud providers. Installation options for {sno} include Amazon Web Services (AWS), Google Cloud Platform (GCP), and Microsoft Azure. For more information about the supported platforms, see xref:../installing/installing_sno/install-sno-installing-sno.adoc#supported-cloud-providers-for-single-node-openshift_install-sno-installing-sno-with-the-assisted-installer[Supported cloud providers for single node openshift].
 
 [id="ocp-4-14-post-installation"]
 === Post-installation configuration
@@ -1752,6 +1756,8 @@ With this change, it begins doing so, and conditional updates where the risks ha
 
 * Previously, a script provided in the documentation for checking invalid HTTPS certificates in the {rh-openstack} API assumed a recent version of the {rh-openstack} client. For users who did not have a recent version of the client, this script failed. Now, manual instructions are added to the documentation that users can follow to perform the check with any version of the client. (link:https://issues.redhat.com/browse/OCPBUGS-7954[*OCPBUGS-7954*])
 
+* Previously, if the hostname of a bare-metal machine was not provided by reverse DNS or DHCP, it would default to `localhost` during bare-metal cluster provisioning on installer-provisioned infrastructure. This issue caused Kubernetes node name conflicts and prevented the cluster from being deployed. Now, if the hostname is detected to be `localhost`, the provisioning agent sets the persistent hostname to the name of the `BareMetalHost` object. (link:https://issues.redhat.com/browse/OCPBUGS-9072[*OCPBUGS-9072*])
+
 [discrete]
 [id="ocp-4-14-kube-controller-bug-fixes"]
 ==== Kubernetes Controller Manager
@@ -2661,6 +2667,9 @@ To avoid this issue, you can enable confidential VMs on an existing cluster by u
 * When you run hosted control planes for {product-title} on a bare-metal platform, if a worker node fails, another node is not automatically added to the hosted cluster, even when other agents are available. As a workaround, manually delete the machine that is associated with the failed worker node. (link:https://issues.redhat.com/browse/MGMT-15939[*MGMT-15939*])
 
 * Since the source catalog bundles an architecture specific `opm` binary, you must run the mirroring from that architecture. For instance if you are mirroring a ppc64le catalog, you must run oc-mirror from a system that runs on the ppc64le architecture. (link:https://issues.redhat.com/browse/OCPBUGS-22264[*OCPBUGS-22264*])
+
+* Installation fails when installing {product-title} with the `bootMode` set to `UEFISecureBoot` on a node where Secure Boot is disabled. Subsequent attempts to install {product-title} with Secure Boot enabled will proceed normally. (link:https://issues.redhat.com/browse/OCPBUGS-19884)[*OCPBUGS-19884*])
+
 
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates


### PR DESCRIPTION
Added bare metal release notes.

Version(s): 4.14

Issue: https://issues.redhat.com/browse/TELCODOCS-1548?src=confmacro

Link to docs preview: 

- http://184.23.213.161:8080/TELCODOCS-1548-4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-install-sno-on-cloud-providers

- http://184.23.213.161:8080/TELCODOCS-1548-4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-asynchronous-errata-updates <--scroll up to previous bullet point. 

- http://184.23.213.161:8080/TELCODOCS-1548-4.14/release_notes/ocp-4-14-release-notes.html#ocp-4-14-bug-fixes last bullet of Installer bullet list.

