### PR TITLE
OSDOCS-8337: temp revise short attribute

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -6,8 +6,9 @@
 :OCP: OpenShift Container Platform
 :ocp-version: 4.14
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
-:product-title-first: Red Hat build of MicroShift (MicroShift)
-:microshift-short: MicroShift
+//:product-title-first: Red Hat build of MicroShift (MicroShift)
+:microshift-short: Red Hat build of MicroShift
+//note that microshift-short was updated to the long form pending an approved short form
 :product-registry: OpenShift image registry
 :product-version: 4.14
 :rhel-major: rhel-9

--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -77,7 +77,7 @@ Distros: microshift
 Topics:
 - Name: The etcd service
   File: microshift-etcd
-- Name: The sos tool
+- Name: The sos report tool
   File: microshift-sos-report
 ---
 Name: API reference

--- a/microshift_install/microshift-embed-in-rpm-ostree.adoc
+++ b/microshift_install/microshift-embed-in-rpm-ostree.adoc
@@ -8,8 +8,6 @@ toc::[]
 
 You can embed {microshift-short} into a {op-system-ostree-first} {op-system-version} image. Use this guide to build a {op-system} image containing {microshift-short}.
 
-//include::snippets/microshift-tech-preview-snip.adoc[leveloffset=+1]
-
 include::modules/microshift-preparing-for-image-building.adoc[leveloffset=+1]
 
 include::modules/microshift-adding-repos-to-image-builder.adoc[leveloffset=+1]

--- a/microshift_install/microshift-install-rpm.adoc
+++ b/microshift_install/microshift-install-rpm.adoc
@@ -1,6 +1,6 @@
 :_content-type: ASSEMBLY
 [id="microshift-install-rpm"]
-= Installing {microshift-short} from an RPM package
+= Installing from an RPM package
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-install-rpm
 

--- a/microshift_support/microshift-etcd.adoc
+++ b/microshift_support/microshift-etcd.adoc
@@ -1,13 +1,13 @@
 :_content-type: ASSEMBLY
 [id="microshift-etcd"]
-= Using etcd
+= The etcd service
 include::_attributes/attributes-microshift.adoc[]
 :context: microshift-etcd
 
 toc::[]
 
 [role="_abstract"]
-{product-title} etcd is delivered as part of the {microshift-short} RPM. The etcd service is run as a separate process and the lifecycle is managed automatically by {microshift-short}.
+The etcd service is delivered as part of the {product-title} RPM. The etcd service is run as a separate process and the lifecycle is managed automatically by {product-title}.
 
 include::modules/microshift-observe-debug-etcd-server.adoc[leveloffset=+1]
 

--- a/modules/microshift-check-cluster-status.adoc
+++ b/modules/microshift-check-cluster-status.adoc
@@ -4,12 +4,12 @@
 
 :_content-type: PROCEDURE
 [id="microshift-check-cluster-status_{context}"]
-= Checking the status of a {microshift-short} cluster
+= Checking the status of a cluster
 
 You can check the status of a {microshift-short} cluster or see active pods by running a simple command. Given in the following procedure are three commands you can use to check cluster status. You can choose to run one, two, or all commands to help you retrieve the information you need to troubleshoot the cluster.
 
 .Procedure
-* You can check the {microshift-short} system status, which returns the cluster status, by running the following command:
+* You can check the system status, which returns the cluster status, by running the following command:
 +
 [source,terminal]
 ----
@@ -18,7 +18,7 @@ $ sudo systemctl status microshift
 +
 If {microshift-short} is failing to start, this command returns the logs from the previous run.
 
-* Optional: You can view the {microshift-short} logs by running the following command:
+* Optional: You can view the logs by running the following command:
 +
 [source,terminal]
 ----

--- a/modules/microshift-config-etcd.adoc
+++ b/modules/microshift-config-etcd.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="microshift-config-etcd_{context}"]
-= Configuring the memoryLimitMB value to set parameters for the {microshift-short} etcd server
+= Configuring the memoryLimitMB value to set parameters for the etcd server
 
 By default, etcd will use as much memory as necessary to handle the load on the system. In some memory constrained systems, it might be necessary to limit the amount of memory etcd is allowed to use at a given time.
 

--- a/modules/microshift-version-cli.adoc
+++ b/modules/microshift-version-cli.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: PROCEDURE
 [id="microshift-version-cli_{context}"]
-= Checking the {microshift-short} version using the command-line interface
+= Checking the version using the command-line interface
 
 To begin troubleshooting, you must know your {microshift-short} version. One way to get this information is by using the CLI.
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8337

Link to docs preview:
[Welcome page](https://66832--docspreview.netlify.app/microshift/latest/microshift_welcome/)
[Intro](https://66832--docspreview.netlify.app/microshift/latest/microshift_getting_started/microshift-understanding)
[sos reports](https://66832--docspreview.netlify.app/microshift/latest/microshift_support/microshift-sos-report)
[etcd](https://66832--docspreview.netlify.app/microshift/latest/microshift_support/microshift-etcd)
[Storage](https://66832--docspreview.netlify.app/microshift/latest/microshift_storage/understanding-ephemeral-storage-microshift)
[Troubleshooting](https://66832--docspreview.netlify.app/microshift/latest/microshift_troubleshooting/microshift-troubleshoot-cluster)

QE review:
- N/A docs plumbing

Additional information:
Short form is not approved as of Oct. 27, 2023, so updating new attribute to roll it back to the full form; also removing product title from unnecessary places and adding long form where needed.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
