### PR TITLE
OSDOCS-8157 adding azure confidential/trusted VMs to RN's

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -110,6 +110,16 @@ To learn how to configure this credentials management strategy during installati
 
 User-defined tags for Microsoft Azure was previously introduced as Technology Preview in {product-title} 4.13 and is now generally available in {product-title} 4.14. For more information, see xref:../installing/installing_azure/installing-azure-customizations.adoc#installing-azure-user-defined-tags_installing-azure-customizations[Configuring the user-defined tags for Azure].
 
+[id="ocp-4-14-confidential-vms-azure"]
+==== Confidential VMs for Azure (Technology Preview)
+
+You can enable confidential VMs when you install your cluster on Azure. You can use confidential computing to encrypt the virtual machine guest state storage during installation. This feature is in Technology Preview due to known issues which are listed in the Known Issues section of this page. For more information, see xref:../installing/installing_azure/installing-azure-customizations.adoc#installation-azure-confidential-vms_installing-azure-customizations[Enabling confidential VMs].
+
+[id="ocp-4-14-trusted-launch-azure"]
+==== Trusted launch for Azure (Technology Preview)
+
+You can enable trusted launch features when you install your cluster on Azure as a Technology Preview. These features include secure boot and virtualized Trusted Platform Modules. For more information, see xref:../installing/installing_azure/installing-azure-customizations.adoc#installation-azure-trusted-launch_installing-azure-customizations[Enabling trusted launch for Azure VMs].
+
 [id="ocp-4-14-user-defined-tags-gcp"]
 ==== User-defined labels and tags for Google Cloud Platform (Technology Preview)
 


### PR DESCRIPTION
Version(s):
4.14

Issue:
https://issues.redhat.com/browse/OSDOCS-8157

Link to docs preview:
[Trusted launch](https://66836--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-trusted-launch-azure)
[Confidential VMs](https://66836--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-confidential-vms-azure)

QE review:
- [x] QE has approved this change.