### PR TITLE
Add 4.14 RN xrefs for STS/CCO/OLM token auth

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -274,8 +274,7 @@ For more information, see xref:../operators/admin/olm-adding-operators-to-cluste
 
 With this release, OperatorHub detects when an Amazon Web Services (AWS) cluster is using the Security Token Service (STS). When detected, a "Cluster in STS Mode" notification displays with additional instructions before installing an Operator to ensure it runs correctly. The *Operator Installation* page is also modified to add the required *role ARN* field.
 
-For more information, see _Token authentication for Operators on cloud providers_.
-//xref :../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
+For more information, see xref:../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
 
 [id="ocp-4-14-developer-perspective"]
 ==== Developer Perspective
@@ -698,8 +697,7 @@ For more information, see xref:../authentication/understanding-and-managing-pod-
 
 With this release, some Operators managed by Operator Lifecycle Manager (OLM) on Amazon Web Services (AWS) clusters can use the Cloud Credential Operator (CCO) in manual mode with the Security Token Service (STS). These Operators authenticate with limited-privilege, short-term credentials that are managed outside the cluster.
 
-For more information, see _Token authentication for Operators on cloud providers_.
-//xref :../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
+For more information, see xref:../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
 
 [id="ocp-4-14-auth-op-noproxy"]
 ==== Authentication Operator honors `noProxy` during connection checks
@@ -944,8 +942,7 @@ For more information, see _{olmv1-first}_.
 
 With this release, Operators managed by Operator Lifecycle Manager (OLM) can support token authentication when running on Amazon Web Services (AWS) clusters that use the Security Token Service (STS). The Cloud Credential Operator (CCO) is updated to semi-automate provisioning certain limited-privilege, short-term credentials, provided that the Operator author has enabled their Operator to support AWS STS.
 
-For more information about enabling OLM-based Operators to support CCO-based workflows with AWS STS, see _Token authentication for Operators on cloud providers_.
-//xref :../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
+For more information about enabling OLM-based Operators to support CCO-based workflows with AWS STS, see xref:../operators/operator_sdk/osdk-token-auth.adoc#osdk-token-auth[Token authentication for Operators on cloud providers].
 
 [id="ocp-4-14-osdk-multi-platform"]
 ==== Configuring Operator projects with support for multiple platforms


### PR DESCRIPTION
Tidy up `xref`s from https://github.com/openshift/openshift-docs/pull/66133 now that the linked-to content has merged with https://github.com/openshift/openshift-docs/pull/64808.

OCP 4.14

Preview spots:

* https://66839--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#console-supports-aws-sts-detection
* https://66839--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-auth-cco-sts
* https://66839--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-osdk-cco-sts