### PR TITLE
OSDOCS-3991: Add Operator troubleshooting assembly to Operator book

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1758,6 +1758,9 @@ Topics:
   - Name: Managing platform Operators
     File: olm-managing-po
     Distros: openshift-enterprise,openshift-origin
+  - Name: Troubleshooting Operator issues
+    File: olm-troubleshooting-operator-issues
+    Distros: openshift-enterprise,openshift-origin
 - Name: Developing Operators
   Dir: operator_sdk
   Distros: openshift-origin,openshift-enterprise

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -460,6 +460,8 @@ Topics:
     File: olm-cs-podsched
 # - Name: Managing platform Operators  <= Tech Preview
 #   File: olm-managing-po
+  - Name: Troubleshooting Operator issues
+    File: olm-troubleshooting-operator-issues
 - Name: Developing Operators
   Dir: operator_sdk
   Topics:

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -607,6 +607,8 @@ Topics:
     File: olm-cs-podsched
 # - Name: Managing platform Operators  <= Tech Preview
 #   File: olm-managing-po
+  - Name: Troubleshooting Operator issues
+    File: olm-troubleshooting-operator-issues
 - Name: Developing Operators
   Dir: operator_sdk
   Topics:

--- a/operators/admin/olm-troubleshooting-operator-issues.adoc
+++ b/operators/admin/olm-troubleshooting-operator-issues.adoc
@@ -1,18 +1,12 @@
 :_content-type: ASSEMBLY
-[id="troubleshooting-operator-issues"]
+[id="olm-troubleshooting-operator-issues"]
 = Troubleshooting Operator issues
 include::_attributes/common-attributes.adoc[]
-:context: troubleshooting-operator-issues
+:context: olm-troubleshooting-operator-issues
 
-// This assembly is duplicated in operators/admin/olm-troubleshooting-operator-issues.adoc.
+// This assembly is a duplicate of support/troubleshooting-operator-issues.adoc. Most of the intro text is unnecessary in this context and has been removed.
 
 toc::[]
-
-Operators are a method of packaging, deploying, and managing an {product-title} application. They act like an extension of the software vendor's engineering team, watching over an {product-title} environment and using its current state to make decisions in real time. Operators are designed to handle upgrades seamlessly, react to failures automatically, and not take shortcuts, such as skipping a software backup process to save time.
-
-{product-title} {product-version} includes a default set of Operators that are required for proper functioning of the cluster. These default Operators are managed by the Cluster Version Operator (CVO).
-
-As a cluster administrator, you can install application Operators from the OperatorHub using the {product-title} web console or the CLI. You can then subscribe the Operator to one or more namespaces to make it available for developers on your cluster. Application Operators are managed by Operator Lifecycle Manager (OLM).
 
 If you experience Operator issues, verify Operator subscription status. Check Operator pod health across the cluster and gather Operator logs for diagnosis.
 
@@ -55,13 +49,13 @@ include::modules/troubleshooting-disabling-autoreboot-mco-cli.adoc[leveloffset=+
 endif::openshift-rosa,openshift-dedicated[]
 
 // Refreshing failing subscriptions
-// cannot delete resource "clusterserviceversions", "jobs" in API group "operators.coreos.com" in the namespace "openshift-apiserver"
+// OSD/ROSA cannot delete resource "clusterserviceversions", "jobs" in API group "operators.coreos.com" in the namespace "openshift-apiserver"
 ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/olm-refresh-subs.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated[]
 
 // Reinstalling Operators after failed uninstallation
-// cannot delete resource "customresourcedefinitions" 
+// OSD/ROSA gitcannot delete resource "customresourcedefinitions" 
 ifndef::openshift-rosa,openshift-dedicated[]
 include::modules/olm-reinstall.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated[]
@@ -73,5 +67,3 @@ ifndef::openshift-rosa,openshift-dedicated[]
 * xref:../../operators/admin/olm-deleting-operators-from-cluster.adoc#olm-deleting-operators-from-a-cluster[Deleting Operators from a cluster]
 * xref:../../operators/admin/olm-adding-operators-to-cluster.adoc#olm-adding-operators-to-a-cluster[Adding Operators to a cluster]
 endif::openshift-rosa,openshift-dedicated[]
-
-


### PR DESCRIPTION
Added the "Troubleshooting Operator issues" assembly to the Operators book. 

This is really part of the original content port effort to port the Operators book to OSD and ROSA ([OSDOCS-3991](https://issues.redhat.com//browse/OSDOCS-3991) and [#61793 ](https://github.com/openshift/openshift-docs/pull/61793)). However, adding this assembly was blocked until the Support book was ported.

Version(s):
4.13+

Issue:
[OSDOCS-3991](https://issues.redhat.com/browse/OSDOCS-3991)

Link to docs preview:
- OCP: https://66848--docspreview.netlify.app/openshift-enterprise/latest/operators/admin/olm-troubleshooting-operator-issues
- OSD: https://66848--docspreview.netlify.app/openshift-dedicated/latest/operators/admin/olm-troubleshooting-operator-issues
- ROSA: https://66848--docspreview.netlify.app/openshift-rosa/latest/operators/admin/olm-troubleshooting-operator-issues

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
