### PR TITLE
[Travis CI] case instead of if-else, use build_for_portal script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,15 +21,38 @@ jobs:
         - |
           ./scripts/get-updated-distros.sh |
             while read -r filename; do
-              if [ "$filename" == "_topic_maps/_topic_map.yml" ]; then python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.15 --no-upstream-fetch || travis_terminate 1
-
-              elif [ "$filename" == "_topic_maps/_topic_map_osd.yml" ]; then python3 build.py --distro openshift-dedicated --product "OpenShift Dedicated" --version 4 --no-upstream-fetch || travis_terminate 1
-
-              elif [ "$filename" == "_topic_maps/_topic_map_ms.yml" ]; then python3 build.py --distro microshift --product "Microshift" --version 4 --no-upstream-fetch || travis_terminate 1
-
-              elif [ "$filename" == "_topic_maps/_topic_map_rosa.yml" ]; then python3 build.py --distro openshift-rosa --product "Red Hat OpenShift Service on AWS" --version 4 --no-upstream-fetch || travis_terminate 1
-
-              elif [ "$filename" == "_distro_map.yml" ]; then python3 build.py --distro openshift-enterprise --product "OpenShift Container Platform" --version 4.15 --no-upstream-fetch || travis_terminate 1
-              fi
+              case "$filename" in
+                "_topic_maps/_topic_map.yml")
+                  distro="openshift-enterprise"
+                  product="OpenShift Container Platform"
+                  version="4.15"
+                  ;;
+                "_topic_maps/_topic_map_osd.yml")
+                  distro="openshift-dedicated"
+                  product="OpenShift Dedicated"
+                  version="4"
+                  ;;
+                "_topic_maps/_topic_map_ms.yml")
+                  distro="microshift"
+                  product="Microshift"
+                  version="4"
+                  ;;
+                "_topic_maps/_topic_map_rosa.yml")
+                  distro="openshift-rosa"
+                  product="Red Hat OpenShift Service on AWS"
+                  version="4"
+                  ;;
+                "_distro_map.yml")
+                  distro="openshift-enterprise"
+                  product="OpenShift Container Platform"
+                  version="4.15"
+                  ;;
+                *)
+                  echo "Output from get-updated-distros.sh: $filename"
+                  echo -e "\033[1;33m No topic maps or distro_map modified!\033[0m"
+                  ;;
+              esac
+              python3 build_for_portal.py --distro "$distro" --product "$product" --version "$version" --no-upstream-fetch
+              if [ $? -ne 0 ]; then travis_terminate 1; fi
             done
         - if [ -d "drupal-build" ]; then python3 makeBuild.py || travis_terminate 1; fi

--- a/modules/installation-aws-user-infra-rhcos-ami.adoc
+++ b/modules/installation-aws-user-infra-rhcos-ami.adoc
@@ -44,7 +44,7 @@ ifndef::openshift-origin[]
 |`ami-031f4d165f4b429c4`
 
 |`ap-southeast-1`
-|`ami-0dc3e381a731ab9fc`
+|`ami-0dc12345a731ab9fc`
 
 |`ap-southeast-2`
 |`ami-032ae8d0f287a66a6`


### PR DESCRIPTION
Based on changes in https://github.com/openshift/openshift-docs/pull/66769

Includes the following changes:

- `build.py` script is old and doesn't contain the recent changes that are include in `build_for_portal.py`. Thank you @mramendi for the updates and suggestions.
- Uses `case` instead of if else loop.
- Uses variables for the build command, more cleaner.
- Checks if previous command failed and fails the build.

We will probably need to modify it for branches before cherry-picking.