### PR TITLE
OCPBUGS-19833 Updating upgrade instruction from 410

### DIFF
--- a/modules/nw-metalLB-basic-upgrade-operator.adoc
+++ b/modules/nw-metalLB-basic-upgrade-operator.adoc
@@ -59,5 +59,5 @@ $ oc get csv -n metallb-system
 [source,terminal,subs="attributes+"]
 ----
 NAME                                   DISPLAY            VERSION               REPLACES   PHASE
-metallb-operator.4.{product-version}.0-202207051316   MetalLB Operator   4.{product-version}.0-202207051316              Succeeded
+metallb-operator.{product-version}.0-202207051316   MetalLB Operator   {product-version}.0-202207051316              Succeeded
 ----

--- a/modules/olm-updating-metallb-operatorgroup.adoc
+++ b/modules/olm-updating-metallb-operatorgroup.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * operators/metallb/metallb-upgrading-operator.adoc
+
+:_content-type: PROCEDURE
+[id="olm-updating-metallb-operatorgroup_{context}"]
+= Editing the MetalLB Operator Operator group
+
+When upgrading from any MetalLB Operator version up to and including 4.10 to 4.11 and later, remove `spec.targetNamespaces` from the Operator group custom resource (CR). You must remove the spec regardless of whether you used the web console or the CLI to delete the MetalLB Operator.
+[NOTE]
+====
+The MetalLB Operator version 4.11 or later only supports the `AllNamespaces` install mode, whereas 4.10 or earlier versions support `OwnNamespace` or `SingleNamespace` modes.
+====
+
+.Prerequisites
+
+- You have access to an {product-title} cluster with `cluster-admin` permissions.
+- You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. List the Operator groups in the `metallb-system` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorgroup -n metallb-system
+----
++
+.Example output
+
+[source,terminal]
+----
+NAME                   AGE
+metallb-system-7jc66   85m
+----
+
+. Verify that the `spec.targetNamespaces` is present in the Operator group CR associated with the `metallb-system` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorgroup metallb-system-7jc66 -n metallb-system -o yaml
+----
++
+.Example output
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: ""
+  creationTimestamp: "2023-10-25T09:42:49Z"
+  generateName: metallb-system-
+  generation: 1
+  name: metallb-system-7jc66
+  namespace: metallb-system
+  resourceVersion: "25027"
+  uid: f5f644a0-eef8-4e31-a306-e2bbcfaffab3
+spec:
+  targetNamespaces:
+  - metallb-system
+  upgradeStrategy: Default
+status:
+  lastUpdated: "2023-10-25T09:42:49Z"
+  namespaces:
+  - metallb-system
+----
+
+. Edit the Operator group and remove the `targetNamespaces` and `metallb-system` present under the `spec` section by running the following command:
++
+[source,terminal]
+----
+$ oc edit n metallb-system
+----
++
+.Example output
++
+[source,terminal]
+----
+operatorgroup.operators.coreos.com/metallb-system-7jc66 edited
+----
+
+. Verify the `spec.targetNamespaces` is removed from the Operator group custom resource associated with the `metallb-system` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorgroup metallb-system-7jc66 -n metallb-system -o yaml
+----
++
+.Example output
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: ""
+  creationTimestamp: "2023-10-25T09:42:49Z"
+  generateName: metallb-system-
+  generation: 2
+  name: metallb-system-7jc66
+  namespace: metallb-system
+  resourceVersion: "61658"
+  uid: f5f644a0-eef8-4e31-a306-e2bbcfaffab3
+spec:
+  upgradeStrategy: Default
+status:
+  lastUpdated: "2023-10-25T14:31:30Z"
+  namespaces:
+  - ""
+----
+
+

--- a/networking/metallb/metallb-upgrading-operator.adoc
+++ b/networking/metallb/metallb-upgrading-operator.adoc
@@ -19,13 +19,16 @@ A summary of the upgrade procedure for the MetalLB Operator from 4.10 and earlie
 This procedure does not apply to automatic z-stream updates of the MetalLB Operator, which follow the standard straightforward method.
 ====
 
-For detailed steps to upgrade the MetalLB Operator from 4.10 and earlier, see the guidance that follows.
+For detailed steps to upgrade the MetalLB Operator from 4.10 and earlier, see the guidance that follows. As a cluster administrator, start the upgrade process by deleting the MetalLB Operator by using the OpenShift CLI (`oc`) or the web console.
 
 //Delete metallb using web console
 include::modules/olm-deleting-metallb-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
 
 //Delete metallb using cli
 include::modules/olm-deleting-metallb-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]
+
+//Delete targetNamespace
+include::modules/olm-updating-metallb-operatorgroup.adoc[leveloffset=+1]
 
 //Upgrade the MetalLB
 include::modules/nw-metalLB-basic-upgrade-operator.adoc[leveloffset=+1]


### PR DESCRIPTION
[OCPBUGS-19833]: Edit created Operator group for successful upgrade. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11, 4.12, 4.13, 4.14, 4.14, 4.15 main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:https://issues.redhat.com/browse/OCPBUGS-19833
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://66870--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/metallb-upgrading-operator
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
