### PR TITLE
TELCODOCS-1347: Readding nodeLabels to SiteConfig reference after restructure

### DIFF
--- a/modules/ztp-sno-siteconfig-config-reference.adoc
+++ b/modules/ztp-sno-siteconfig-config-reference.adoc
@@ -48,6 +48,9 @@ For example, `policygentemplates/common-ranGen.yaml` applies to all clusters wit
 For three-node deployments, define three hosts.
 For standard deployments, define three hosts with `role: master` and two or more hosts defined with `role: worker`.
 
+|`spec.clusters.nodes.nodeLabels`
+|Specify custom roles for your nodes in your managed clusters. These are additional roles are not used by any {product-title} components, only by the user. When you add a custom role, it can be associated with a custom machine config pool that references a specific configuration for that role. Adding custom labels or roles during installation makes the deployment process more effective and prevents the need for additional reboots after the installation is complete.
+
 |`spec.clusters.nodes.bmcAddress`
 |BMC address that you use to access the host. Applies to all cluster types. {ztp} supports iPXE and virtual media booting by using Redfish or IPMI protocols. To use iPXE booting, you must use {rh-rhacm} 2.8 or later. For more information about BMC addressing, see the "Additional resources" section.
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14+
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/TELCODOCS-1347
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://66874--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/ztp_far_edge/ztp-deploying-far-edge-sites#ztp-sno-siteconfig-config-reference_ztp-deploying-far-edge-sites
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: The `nodeLabel` content was accidentally removed in PR https://github.com/openshift/openshift-docs/pull/60679 while restructuring. All acks can be found in PR https://github.com/openshift/openshift-docs/pull/63519
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
