### PR TITLE
OSDOCS#8333: Agent known issue in RNs

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -2887,6 +2887,17 @@ This affects the achievable latency of such clusters and might prevent proper op
 +
 To work around this issue: If your control plane nodes are schedulable, and the pods can run on worker nodes, use `nodeSelector` or Affinity to schedule the pod in worker nodes.
 
+* Agent-based installations on vSphere will fail due to a failure to remove node taint, which causes the installation to be stuck in a pending state.
+{sno-caps} clusters are not impacted.
+You can work around this issue by running the following command to manually remove the node taint:
++
+[source,terminal]
+----
+$ oc adm taint nodes <node_name> node.cloudprovider.kubernetes.io/uninitialized:NoSchedule-
+----
++
+(link:https://issues.redhat.com/browse/OCPBUGS-20049[*OCPBUGS-20049*])
+
 [id="ocp-4-13-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
[OSDOCS-8294](https://issues.redhat.com/browse/OSDOCS-8294)

Version(s):
4.13 only

This PR adds a known issue to the 4.13 release notes regarding failed agent installs on vSphere clusters with multiple worker nodes. 

🚨 Change management has been completed for this PR 🚨 

QE review:
- [x] QE has approved this change.

preview: [Known issues](https://66896--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-asynchronous-errata-updates:~:text=Agent%2Dbased%20installations%20on%20vSphere%20will%20fail%20due%20to%20a%20failure%20to%20remove)