### PR TITLE
OSDOCS#8294: adding workaround to known issue

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2703,7 +2703,13 @@ This issue affects the CPU load balancing features because these features depend
 
 * Agent-based installations on vSphere will fail due to a failure to remove node taint, which causes the installation to be stuck in a pending state.
 {sno-caps} clusters are not impacted.
-There is no current workaround.
+You can work around this issue by running the following command to manually remove the node taint:
++
+[source,terminal]
+----
+$ oc adm taint nodes <node_name> node.cloudprovider.kubernetes.io/uninitialized:NoSchedule-
+----
++
 (link:https://issues.redhat.com/browse/OCPBUGS-20049[*OCPBUGS-20049*])
 
 * There is a known issue with using Azure confidential virtual machines, which is a Technology Preview feature in this release. Configuring a cluster to encrypt the managed disk and the Azure VM Guest State (VMGS) blob with a platform-managed key (PMK) or a customer-managed key (CMK) is unsupported. To avoid this issue, only enable encryption of the VMGS blob by setting the value of the `securityEncryptionType` parameter to `VMGuestStateOnly`. (link:https://issues.redhat.com/browse/OCPBUGS-18379[*OCPBUGS-18379*])


### PR DESCRIPTION
https://issues.redhat.com/browse/OSDOCS-8294

Adding a workaround to a known issue in the release notes.

Version(s): 4.14

QE review:
- [x] QE has approved this change.

Preview: [Known Issue](https://66925--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-asynchronous-errata-updates:~:text=You%20can%20work%20around%20this%20issue%20by%20manually%20removing%20the%20node%20taint.)