### PR TITLE
OSDOCS:7616: Adding Loki ResourceExhausted troubleshooting

### DIFF
--- a/modules/troubleshooting-network-observability-loki-resource-exhausted.adoc
+++ b/modules/troubleshooting-network-observability-loki-resource-exhausted.adoc
@@ -1,0 +1,16 @@
+// Module included in the following assemblies:
+
+// * networking/network_observability/troubleshooting-network-observability.adoc
+
+:_content-type: PROCEDURE
+[id="network-observability-troubleshooting-loki-resource-exhausted_{context}"]
+= Troubleshooting Loki ResourceExhausted error
+Loki may return a `ResourceExhausted` error when network flow data sent by Network Observability exceeds the configured maximum message size. If you are using the Loki Operator, this maximum message size is configured to 100 MiB. 
+
+.Procedure
+. Navigate to *Operators* -> *Installed Operators*, viewing *All projects* from the *Project* drop-down menu.
+. In the *Provided APIs* list, select the Network Observability Operator.
+. Click the *Flow Collector* then the *YAML view* tab. 
+.. If you are using the Loki Operator, check that the `spec.loki.batchSize` value does not exceed 98 MiB.
+.. If you are using a Loki installation method that is different from the Red Hat Loki Operator, such as Grafana Loki, verify that the `grpc_server_max_recv_msg_size` link:https://grafana.com/docs/loki/latest/configure/#server[Grafana Loki server setting] is higher than the `FlowCollector` resource `spec.loki.batchSize` value. If it is not, you must either increase the `grpc_server_max_recv_msg_size` value, or decrease the `spec.loki.batchSize` value so that it is lower than the limit. 
+. Click *Save* if you edited the *FlowCollector*.

--- a/network_observability/troubleshooting-network-observability.adoc
+++ b/network_observability/troubleshooting-network-observability.adoc
@@ -18,6 +18,8 @@ include::modules/troubleshooting-network-observability-network-flow.adoc[levelof
 
 include::modules/troubleshooting-network-observability-controller-manager-pod-out-of-memory.adoc[leveloffset=+1]
 
+include::modules/troubleshooting-network-observability-loki-resource-exhausted.adoc[leveloffset=+1]
+
 == Resource troubleshooting
 
 include::modules/troubleshooting-network-observability-loki-tenant-rate-limit.adoc[leveloffset=+1]


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-7616
https://issues.redhat.com/browse/NETOBSERV-1148
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://66927--docspreview.netlify.app/openshift-enterprise/latest/network_observability/troubleshooting-network-observability#network-observability-troubleshooting-loki-resource-exhausted_network-observability-troubleshooting
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
