### PR TITLE
Release note typo PerformaceProfile > PerformanceProfile

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2877,7 +2877,7 @@ If NMEA sentences are lost on their way to the e810 NIC, the T-GM cannot synchro
 A proposed fix is to report a `FREERUN` event when the NMEA string is lost.
 (link:https://issues.redhat.com/browse/OCPBUGS-19838[*OCPBUGS-19838*])
 
-* Currently, due to differences in setting up a container's cgroup hierarchy, containers that use the `crun` OCI runtime along with a `PerformaceProfile` configuration encounter performance degradation.
+* Currently, due to differences in setting up a container's cgroup hierarchy, containers that use the `crun` OCI runtime along with a `PerformanceProfile` configuration encounter performance degradation.
 As a workaround, use the `runc` OCI container runtime.
 Although the `runc` container runtime has lower performance during container startup, shutdown operations, and `exec` probes, the `crun` and `runc` container runtimes are functionally identical.
 It is anticipated that an upcoming z-stream release will include a fix for this issue.


### PR DESCRIPTION
Typo fix!

Version(s):
enterprise-4.14

QE review:
- [x] QE not required