### PR TITLE
Update to SDN deprecation notice

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1708,7 +1708,7 @@ As of {product-title} 4.14, the `oc registry login` command no longer stores reg
 [id="ocp-4-14-future-deprecation-sdn"]
 ==== Future deprecation of the OpenShift SDN network plugin
 
-Targeting {product-title} 4.15, the OpenShift SDN CNI network plugin will not be an option for new installations, but will continue to be supported in clusters upgrading to 4.15 and 4.16 from clusters previously installed with the OpenShift SDN network plugin. In a future release, targeting no earlier than 4.17, the OpenShift SDN network plugin will be removed and and will no longer be supported.
+It is currently planned that the OpenShift SDN CNI network plugin will not be an option for new installations in the next minor release of {product-title}. However, at that time, it is planned to be supported in clusters that were previously installed with the OpenShift SDN network plugin. In a subsequent future release, the OpenShift SDN network plugin will be removed and no longer supported.
 
 [id="ocp-4-14-bug-fixes"]
 == Bug fixes


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
Follow-up to https://issues.redhat.com/browse/OSDOCS-7623 and https://github.com/openshift/openshift-docs/pull/65601

Link to docs preview:
https://66933--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-future-deprecation

No new QE review required; QE acked in the original PR.
