### PR TITLE
RHDEVDOCS-5697-new: Commenting out builds using shipwright files

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -1874,12 +1874,12 @@ Distros: openshift-enterprise,openshift-origin,openshift-online
 Topics:
 - Name: CI/CD overview
   File: index
-- Name: Builds using Shipwright
-  Dir: builds_using_shipwright
-  Distros: openshift-enterprise
-  Topics:
-  - Name: Overview of Builds
-    File: overview-openshift-builds
+# - Name: Builds using Shipwright
+#  Dir: builds_using_shipwright
+#  Distros: openshift-enterprise
+#  Topics:
+#  - Name: Overview of Builds
+#    File: overview-openshift-builds
 - Name: Builds using BuildConfig
   Dir: builds
   Distros: openshift-enterprise,openshift-origin,openshift-online

--- a/cicd/index.adoc
+++ b/cicd/index.adoc
@@ -15,13 +15,13 @@ toc::[]
 
 [id="openshift-builds"]
 == OpenShift Builds
-OpenShift Builds provides you the following two options to configure and run a build:
+OpenShift Builds provides you the following option to configure and run a build:
 
-* Builds using Shipwright
-+
-An extensible build framework based on the Shipwright project, which you can use to build container images on an {product-title} cluster. You can build container images from source code and Dockerfile by using image build tools, such as Source-to-Image (S2I) and Buildah.
-+
-For more information, see link:https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html[Overview of Builds].
+// * Builds using Shipwright
+// +
+// An extensible build framework based on the Shipwright project, which you can use to build container images on an {product-title} cluster. You can build container images from source code and Dockerfile by using image build tools, such as Source-to-Image (S2I) and Buildah.
+// +
+// For more information, see link:https://docs.openshift.com/builds/latest/about/overview-openshift-builds.html[Overview of Builds].
 
 * Builds using BuildConfig
 +


### PR DESCRIPTION
**Purpose**: To resolve this issue: https://issues.redhat.com/browse/RHDEVDOCS-5697

**Aligned team**: DevTools

**Version for cherrypicking**: enterprise-4.14

**Content for preview**:  https://66936--docspreview.netlify.app/openshift-enterprise/latest/cicd/

**Peer review**: 

**Note** : The release of Builds using Shipwright has been pushed to 21st November (earlier it was planned to have this release alongside OCP 4.14, 31st october). We need to comment out the Builds using Shipwright section in the topic map file. At the time of release, we need to uncomment the relevant files for Builds using Shipwright.

[This is the PR](https://github.com/openshift/openshift-docs/pull/65361) that was merged to have this Builds using Shipwright section on the docs.openshift.com site.