### PR TITLE
Add 1.30.2 release notes, update the release notes template text

### DIFF
--- a/about/about-serverless.adoc
+++ b/about/about-serverless.adoc
@@ -11,7 +11,7 @@ toc::[]
 
 [NOTE]
 ====
-Because {ServerlessProductName} releases on a different cadence from {product-title}, the {ServerlessProductName} documentation is now available as separate documentation sets for each minor version of the product. 
+Because {ServerlessProductName} releases on a different cadence from {ocp-product-title}, the {ServerlessProductName} documentation is now available as separate documentation sets for each minor version of the product. 
 
 The {ServerlessProductName} documentation is available at link:https://docs.openshift.com/serverless/[].
 

--- a/about/serverless-release-notes.adoc
+++ b/about/serverless-release-notes.adoc
@@ -28,6 +28,7 @@ include::modules/serverless-deprecated-removed-features.adoc[leveloffset=+1]
 
 // Release notes included, most to least recent
 // OCP + OSD + ROSA
+include::modules/serverless-rn-1-30-2.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-30-1.adoc[leveloffset=+1]
 include::modules/serverless-rn-1-30-0.adoc[leveloffset=+1]
 // 1.30.0 additional resources

--- a/modules/odc-creating-functions.adoc
+++ b/modules/odc-creating-functions.adoc
@@ -6,7 +6,7 @@
 [id="odc-creating-functions_{context}"]
 = Creating a function in the web console
 
-You can create a function from a Git repository by using the *Developer* perspective of the {product-title} web console.
+You can create a function from a Git repository by using the *Developer* perspective of the {ocp-product-title} web console.
 
 .Prerequisites
 
@@ -33,8 +33,8 @@ $ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func
 $ oc apply -f https://raw.githubusercontent.com/openshift-knative/kn-plugin-func/serverless-1.30/pkg/pipelines/resources/tekton/task/func-s2i/0.1/func-s2i.yaml
 ----
 
-* You must log into the {product-title} web console.
-* You must create a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {product-title}.
+* You must log into the {ocp-product-title} web console.
+* You must create a project or have access to a project with the appropriate roles and permissions to create applications and other workloads in {ocp-product-title}.
 * You must create or have access to a Git repository that contains the code for your function. The repository must contain a `func.yaml` file and use the `s2i` build strategy.
  
 

--- a/modules/release-notes-template.adoc
+++ b/modules/release-notes-template.adoc
@@ -4,7 +4,7 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-X-YY-Z_{context}"]
-= Release notes for Red Hat {ServerlessProductName} X.YY[.Z]
+= Red Hat {ServerlessProductName} X.YY[.Z]
 // Substitute X-YY-Z with full version (e.g. 1-29-0)
 // Substitute X.YY[.Z] with:
 // * X.YY version for Y-stream releases (e.g. "1.29" for the 1.29.0 release)
@@ -14,7 +14,7 @@
 // Versions for the components in New features are here (both for 1.29 and 1.29.1):
 // https://gitlab.cee.redhat.com/serverless/p12n-config/-/blob/release-1.29/config.yaml
 
-{ServerlessProductName} X.YY[.Z] is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+{ServerlessProductName} X.YY[.Z] is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-X-YY-Z_{context}"]
 == New features

--- a/modules/serverless-rn-1-18-0.adoc
+++ b/modules/serverless-rn-1-18-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-18-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.18.0
+= Red Hat {ServerlessProductName} 1.18.0
 
-{ServerlessProductName} 1.18.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.18.0 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-1-18-0_{context}"]
 == New features

--- a/modules/serverless-rn-1-19-0.adoc
+++ b/modules/serverless-rn-1-19-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-19-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.19.0
+= Red Hat {ServerlessProductName} 1.19.0
 
-{ServerlessProductName} 1.19.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.19.0 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-1-19-0_{context}"]
 == New features

--- a/modules/serverless-rn-1-20-0.adoc
+++ b/modules/serverless-rn-1-20-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-20-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.20.0
+= Red Hat {ServerlessProductName} 1.20.0
 
-{ServerlessProductName} 1.20.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.20.0 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-1-20-0_{context}"]
 == New features

--- a/modules/serverless-rn-1-21-0.adoc
+++ b/modules/serverless-rn-1-21-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-21-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.21.0
+= Red Hat {ServerlessProductName} 1.21.0
 
-{ServerlessProductName} 1.21.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.21.0 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-1-21-0_{context}"]
 == New features

--- a/modules/serverless-rn-1-22-0.adoc
+++ b/modules/serverless-rn-1-22-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-22-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.22.0
+= Red Hat {ServerlessProductName} 1.22.0
 
-{ServerlessProductName} 1.22.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.22.0 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-1-22-0_{context}"]
 == New features

--- a/modules/serverless-rn-1-23-0.adoc
+++ b/modules/serverless-rn-1-23-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-23-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.23.0
+= Red Hat {ServerlessProductName} 1.23.0
 
-{ServerlessProductName} 1.23.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.23.0 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-1-23-0_{context}"]
 == New features

--- a/modules/serverless-rn-1-24-0.adoc
+++ b/modules/serverless-rn-1-24-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-24-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.24.0
+= Red Hat {ServerlessProductName} 1.24.0
 
-{ServerlessProductName} 1.24.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.24.0 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-1.24.0_{context}"]
 == New features

--- a/modules/serverless-rn-1-25-0.adoc
+++ b/modules/serverless-rn-1-25-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-25-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.25.0
+= Red Hat {ServerlessProductName} 1.25.0
 
-{ServerlessProductName} 1.25.0 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.25.0 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-1.25.0_{context}"]
 == New features

--- a/modules/serverless-rn-1-26-0.adoc
+++ b/modules/serverless-rn-1-26-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-26_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.26
+= Red Hat {ServerlessProductName} 1.26
 
-{ServerlessProductName} 1.26 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.26 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [id="new-features-1.26_{context}"]
 == New features

--- a/modules/serverless-rn-1-27-0.adoc
+++ b/modules/serverless-rn-1-27-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-27_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.27
+= Red Hat {ServerlessProductName} 1.27
 
-{ServerlessProductName} 1.27 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.27 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [IMPORTANT]
 ====

--- a/modules/serverless-rn-1-28-0.adoc
+++ b/modules/serverless-rn-1-28-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-28-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.28
+= Red Hat {ServerlessProductName} 1.28
 
-{ServerlessProductName} 1.28 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in this topic.
+{ServerlessProductName} 1.28 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [IMPORTANT]
 ====

--- a/modules/serverless-rn-1-29-0.adoc
+++ b/modules/serverless-rn-1-29-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-29-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.29
+= Red Hat {ServerlessProductName} 1.29
 
-{ServerlessProductName} 1.29 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+{ServerlessProductName} 1.29 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 [IMPORTANT]
 ====
@@ -33,7 +33,7 @@ This change allows you to receive updates not only for the latest release, but a
 +
 Additionally, you can lock the version of the Knative (`kn`) CLI. For details, see section "Installing the Knative CLI".
 
-* You can now create {ServerlessProductName} functions through developer console using {product-title} Pipelines.
+* You can now create {ServerlessProductName} functions through developer console using {ocp-product-title} Pipelines.
 
 * Multi-container support for Knative Serving is now generally available (GA). This feature allows you to use a single Knative service to deploy a multi-container pod.
 

--- a/modules/serverless-rn-1-29-1.adoc
+++ b/modules/serverless-rn-1-29-1.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-29-1_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.29.1
+= Red Hat {ServerlessProductName} 1.29.1
 
-{ServerlessProductName} 1.29.1 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+{ServerlessProductName} 1.29.1 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
 This release of {ServerlessProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on OpenShift Container Platform 4.10 and later versions.
 

--- a/modules/serverless-rn-1-30-0.adoc
+++ b/modules/serverless-rn-1-30-0.adoc
@@ -4,9 +4,9 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-30-0_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.30
+= Red Hat {ServerlessProductName} 1.30
 
-{ServerlessProductName} 1.30 is now available. New features, changes, and known issues that relate to {ServerlessProductName} on {product-title} are included in this topic.
+{ServerlessProductName} 1.30 is now available. New features, updates, and known issues that relate to {ServerlessProductName} on {ocp-product-title} are included in the following.
 
 [IMPORTANT]
 ====

--- a/modules/serverless-rn-1-30-1.adoc
+++ b/modules/serverless-rn-1-30-1.adoc
@@ -4,8 +4,8 @@
 
 :_content-type: REFERENCE
 [id="serverless-rn-1-30-1_{context}"]
-= Release notes for Red Hat {ServerlessProductName} 1.30.1
+= Red Hat {ServerlessProductName} 1.30.1
 
-{ServerlessProductName} 1.30.1 is now available. New features, changes, and known issues that pertain to {ServerlessProductName} on {product-title} are included in this topic.
+{ServerlessProductName} 1.30.1 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
 
-This release of {ServerlessProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on OpenShift Container Platform 4.10 and later versions.
+This release of {ServerlessProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on OpenShift Container Platform 4.11 and later versions.

--- a/modules/serverless-rn-1-30-2.adoc
+++ b/modules/serverless-rn-1-30-2.adoc
@@ -1,0 +1,11 @@
+// Module included in the following assemblies
+//
+// * /serverless/serverless-release-notes.adoc
+
+:_content-type: REFERENCE
+[id="serverless-rn-1-30-2_{context}"]
+= Red Hat {ServerlessProductName} 1.30.2
+
+{ServerlessProductName} 1.30.2 is now available. New features, updates, and known issues that pertain to {ServerlessProductName} on {ocp-product-title} are included in the following notes.
+
+This release of {ServerlessProductName} addresses Common Vulnerabilities and Exposures (CVEs), contains bug fixes, and is supported on OpenShift Container Platform 4.11 and later versions. Notably, this update addresses CVE-2023-44487 - HTTP/2 Rapid Stream Reset by disabling HTTP/2 transport on Serving, Eventing webhooks, and RBAC proxy containers.

--- a/modules/support-knowledgebase-search.adoc
+++ b/modules/support-knowledgebase-search.adoc
@@ -9,7 +9,7 @@
 [id="support-knowledgebase-search_{context}"]
 = Searching the Red Hat Knowledgebase
 
-In the event of an {product-title} issue, you can perform an initial search to determine if a solution already exists within the Red Hat Knowledgebase.
+In the event of an {ocp-product-title} issue, you can perform an initial search to determine if a solution already exists within the Red Hat Knowledgebase.
 
 .Prerequisites
 

--- a/modules/support-submitting-a-case.adoc
+++ b/modules/support-submitting-a-case.adoc
@@ -32,7 +32,7 @@ if this is not already autofilled).
 
 . Ensure that the account information presented is as expected, and if not, amend accordingly.
 
-. Check that the autofilled {product-title} Cluster ID is correct. If it is not, manually obtain your cluster ID.
+. Check that the autofilled {ocp-product-title} Cluster ID is correct. If it is not, manually obtain your cluster ID.
 +
 * To manually obtain your cluster ID using the {ocp-product-title} web console:
 .. Navigate to *Home* -> *Dashboards* -> *Overview*.


### PR DESCRIPTION
Version(s):
`serverless-docs-1.30`+

Issue:
No issue.

Link to docs preview:
Serverless 1.30.2 release notes: https://66939--docspreview.netlify.app/openshift-serverless/latest/about/serverless-release-notes#serverless-rn-1-30-2_serverless-release-notes

QE review:
- [ ] QE has approved this change.