### PR TITLE
CNV-26967: Adding placeholder text for CNV asynchronous release

### DIFF
--- a/virt/about_virt/about-virt.adoc
+++ b/virt/about_virt/about-virt.adoc
@@ -7,15 +7,17 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 //To prepare to release asynchronously, uncomment the text below and (if necessary) update the version numbers. Then, comment out the rest of the module.
-//Documentation for {VirtProductName} will be available for {product-title} {product-version} in the near future.
+Documentation for {VirtProductName} will be available for {product-title} {product-version} in the near future.
 
-//ifdef::openshift-origin[]
-//In the meantime, the link:https://docs.okd.io/4.12/virt/about-virt.html[{VirtProductName} 4.12 documentation] is available as part of the {product-title} 4.12 documentation.
-//endif::[]
+ifdef::openshift-origin[]
+In the meantime, the link:https://docs.okd.io/4.13/virt/about-virt.html[{VirtProductName} 4.13 documentation] is available as part of the {product-title} 4.13 documentation.
+endif::[]
 
-//ifdef::openshift-enterprise[]
-//In the meantime, the link:https://docs.openshift.com/container-platform/4.12/virt/about-virt.html[{VirtProductName} 4.12 documentation] is available as part of the {product-title} 4.12 documentation.
-//endif::[]
+ifdef::openshift-enterprise[]
+In the meantime, the link:https://docs.openshift.com/container-platform/4.13/virt/about-virt.html[{VirtProductName} 4.13 documentation] is available as part of the {product-title} 4.13 documentation.
+endif::[]
+
+////
 
 Learn about {VirtProductName}'s capabilities and support scope.
 
@@ -45,3 +47,5 @@ include::modules/virt-sno-differences.adoc[leveloffset=+1]
 * xref:../../virt/live_migration/virt-about-live-migration.adoc#virt-about-live-migration[About live migration]
 * xref:../../virt/nodes/virt-node-maintenance.adoc#eviction-strategies[Eviction strategies]
 * link:https://access.redhat.com/articles/6994974[Tuning & Scaling Guide]
+
+////


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-26967](https://issues.redhat.com//browse/CNV-26967)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://66949--docspreview.netlify.app/openshift-enterprise/latest/virt/about_virt/about-virt
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
<!--- [ ] QE has approved this change. --->
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: OpenShift Virtualization 4.14 docs should not be published on the customer-facing site and the upstream OKD site until GA. This PR adds placeholder text to the about-virt.adoc file to prepare for CNV asynchronous release from OCP.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
