### PR TITLE
CO 1.3.1 for OCP 4.14 - includes Known Issue

### DIFF
--- a/security/compliance_operator/compliance-operator-release-notes.adoc
+++ b/security/compliance_operator/compliance-operator-release-notes.adoc
@@ -15,6 +15,23 @@ For an overview of the Compliance Operator, see xref:../../security/compliance_o
 
 To access the latest release, see xref:../../security/compliance_operator/co-management/compliance-operator-updating.adoc#olm-preparing-upgrade_compliance-operator-updating[Updating the Compliance Operator].
 
+[id="compliance-operator-release-notes-1-3-1"]
+== OpenShift Compliance Operator 1.3.1
+
+The following advisory is available for the OpenShift Compliance Operator 1.3.1:
+
+* link:https://access.redhat.com/errata/RHBA-2023:5669[RHBA-2023:5669 - OpenShift Compliance Operator bug fix update]
+
+[id="compliance-operator-1-3-1-bug-fixes"]
+=== Bug fixes
+
+* Before this update, `api-checks-pod` would crash due to an outdated MachineConfig dependency. With this update, the dependency enables the Compliance Operator to support Ignition 3.4, and resolves this issue. (link:https://issues.redhat.com/browse/OCPBUGS-18025[*OCPBUGS-18025*])
+
+[id="compliance-operator-1-3-1-known-issue"]
+=== Known issue
+
+* In {product-title} {product-version}, a `MachineConfig` with Ignition version 3.4 fail with `ocp4-pci-dss` scans of the api-collector pods might fail with `CrashLoopBackOff` errors.
+
 [id="compliance-operator-release-notes-1-3-0"]
 == OpenShift Compliance Operator 1.3.0
 


### PR DESCRIPTION
Version(s):
4.14 only

Issue:
None

Link to docs preview:
[OpenShift Compliance Operator 1.3.1](https://file.rdu.redhat.com/antaylor/co-1.3.1/security/compliance_operator/compliance-operator-release-notes.html#compliance-operator-release-notes-1-3-1)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
This PR addresses a known issue in 4.14 only as part of the latest Compliance Operator release, with an expected release date shortly after 4.14.
