### PR TITLE
OCP 4.14 release notes known issue for Compliance Operator

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2914,6 +2914,8 @@ To avoid this issue, you can enable confidential VMs on an existing cluster by u
 
 * Installation fails when installing {product-title} with the `bootMode` set to `UEFISecureBoot` on a node where Secure Boot is disabled. Subsequent attempts to install {product-title} with Secure Boot enabled will proceed normally. (link:https://issues.redhat.com/browse/OCPBUGS-19884)[*OCPBUGS-19884*])
 
+* In {product-title} {product-version}, a `MachineConfig` object with Ignition version 3.4 might fail scans of the `api-collector` pods with `CrashLoopBackOff` errors, causing the Compliance Operator to not work as expected. (link:https://issues.redhat.com/browse/OCPBUGS-18025[*OCPBUGS-18025*])
+
 [id="ocp-telco-ran-4-14-known-issues"]
 * When you run CNF latency tests on an {product-title} cluster, the `oslat` test can sometimes return results greater than 20 microseconds. This results in an `oslat` test failure.
 (link:https://issues.redhat.com/browse/RHEL-9279[*RHEL-9279*])

--- a/security/compliance_operator/co-management/compliance-operator-updating.adoc
+++ b/security/compliance_operator/co-management/compliance-operator-updating.adoc
@@ -8,6 +8,18 @@ toc::[]
 
 As a cluster administrator, you can update the Compliance Operator on your {product-title} cluster.
 
+[IMPORTANT]
+====
+Updating your {product-title} cluster to version 4.14 might cause the Compliance Operator to not work as expected. This is due to an ongoing known issue. For more information, see link:https://issues.redhat.com/browse/OCPBUGS-18025[OCPBUGS-18025].
+====
+//
+// This note will be updated with the release of CO 1.3.1 to state the following in branches 4.11-4.14:
+//
+// [IMPORTANT]
+// ====
+// It is recommended to update the Compliance Operator to version 1.3.1 or later before updating your {product-title} cluster to version 4.14 or later. For more information, see (link:https://issues.redhat.com/browse/OCPBUGS-18025[OCPBUGS-18025]).
+// ====
+
 include::modules/olm-preparing-upgrade.adoc[leveloffset=+1]
 include::modules/olm-changing-update-channel.adoc[leveloffset=+1]
 include::modules/olm-approving-pending-upgrade.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.14

Issue:
None

Link to docs preview:
[Known issues (near the bottom of the section)](https://file.rdu.redhat.com/antaylor/4.14-rns-co-known-issue/release_notes/ocp-4-14-release-notes.html#ocp-4-14-known-issues)

![image](https://github.com/openshift/openshift-docs/assets/46728411/e1c55ea7-8d91-4a79-bce2-532452300bb9)
**NOTE:** it says "branch build" in the preview, but will say 4.14 in the release.

[Updating the Compliance Operator](https://file.rdu.redhat.com/antaylor/4.14-rns-co-known-issue/security/compliance_operator/co-management/compliance-operator-updating.html)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Addresses a known issue in Compliance Operator with OCP 4.14.
