### PR TITLE
OSDOCS-8089:updates rns with ki HAProxy

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2919,6 +2919,12 @@ It is anticipated that an upcoming z-stream release will include a fix for this 
 +
 To work around this issue: If your control plane nodes are schedulable, and the pods can run on worker nodes, use `nodeSelector` or Affinity to schedule the pod in worker nodes.(link:https://issues.redhat.com/browse/OCPBUGS-18581[*OCPBUGS-18581*])
 
+* Currently, the update to HAProxy version 2.6.13 in {product-title} {product-version} causes an increase in P99 latency for re-encrypt traffic. This is observed when the volume of ingress traffic puts the HAProxy component of the `IngressController` custom resource (CR) under a considerable load. The latency increase does not affect overall throughput, which remains consistent.
++
+The default `IngressController` CR is configured with 4 HAProxy threads. If you experience elevated P99 latencies during high ingress traffic conditions, specifically with re-encrypt traffic, it's recommended to increase the number of HAProxy threads to reduce latency. (link:https://issues.redhat.com/browse/OCPBUGS-18936[*OCPBUGS-18936*])
+
+* For {sno-caps} on {product-version} and Google Cloud Platform (GCP), there is a known issue with the Cloud Network Config Controller (CNCC) entering a `CrashLoopBackOff` state. This occurs at initialization time when the CNCC tries to reach the GCP internal load balancer address and the resulting hairpin traffic is not correctly prevented in OVN-Kubernetes shared gateway mode on GCP causing it to get dropped. Cluster Network Operator will show a `Progressing=true` status in such case. Currently, there is no workaround for this issue. (link:https://issues.redhat.com/browse/OCPBUGS-20554[*OCPBUGS-20554*])
+
 [id="ocp-4-14-asynchronous-errata-updates"]
 == Asynchronous errata updates
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-8089
https://issues.redhat.com/browse/OSDOCS-8240
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
https://66979--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-known-issues:~:text=OCPBUGS%2D18581)-,Currently,-%2C%20the%20update%20to
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
PTAL @tssurya and @qiliRedHat @huiran0826 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
