### PR TITLE
OSDOCS#8366: mastersSchedulable param for Agent

### DIFF
--- a/modules/sample-ztp-custom-resources.adoc
+++ b/modules/sample-ztp-custom-resources.adoc
@@ -34,6 +34,7 @@ You can customize the following {ztp} custom resources to specify more details a
       controlPlaneAgents: 1
       workerAgents: 0
     sshPublicKey: <YOUR_SSH_PUBLIC_KEY>
+    mastersSchedulable: true
 ----
 
 *cluster-deployment.yaml*


### PR DESCRIPTION
[OSDOCS-8366](https://issues.redhat.com/browse/OSDOCS-8366)

Version(s):
4.14+

This PR documents the `mastersSchedulable` parameter that was added as an available Agent configuration parameter.

QE review:
- [ ] QE has approved this change.

Preview: [agent-cluster-install.yaml](https://66980--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#sample-ztp-custom-resources_installing-with-agent-based-installer:~:text=single%2Dnode%20cluster.-,agent%2Dcluster%2Dinstall.yaml,-apiVersion%3A%20extensions)