### PR TITLE
Preventing infinite redirect loop for virt content

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -425,9 +425,15 @@ AddType text/vtt                            vtt
     RewriteRule ^container-platform/(4\.4|4\.5)/authentication/certificates/(.*)$ /container-platform/$1/security/certificates/$2 [NE,R=301]
     RewriteRule ^container-platform/(4\.4|4\.5)/authentication/(allowing-javascript-access-api-server|encrypting-etcd|certificate-types-descriptions)\.html$ /container-platform/$1/security/$2\.html [NE,R=301]
 
+
+    # The following rule prevents an infinite redirect loop when browsing to /container-platform/4.14/virt/about_virt/about-virt.html
+    RewriteRule ^container-platform/4\.14/virt/about_virt/about-virt.html$ - [L]
+
     # OpenShift Virtualization (CNV) catchall redirect; use when CNV releases asynchronously from OCP. Do not change the 302 to a 301.
     # When uncommented, this redirects all `virt` directory traffic to the about-virt page.
-    # To activate the redirects, uncomment the next line and update the version number to the pending release.
+    # Pay mind to the redirect directly above this which prevents redirect loops.
+    # To activate the redirects, uncomment the next and previous lines and update the version number to the pending release.
+
     RewriteRule container-platform/4\.14/virt/(?!about-virt\.html)(.+)$ /container-platform/4.14/virt/about_virt/about-virt.html [NE,R=302]
 
     # Serverless Redirects


### PR DESCRIPTION
Adding a rule to prevent infinite redirect loop for virt content.
cc @kalexand-rh 