### PR TITLE
OSDOCS#8355: Create release notes for ALBO 1.1.0

### DIFF
--- a/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
+++ b/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes.adoc
@@ -13,6 +13,38 @@ These release notes track the development of the AWS Load Balancer Operator in {
 
 For an overview of the AWS Load Balancer Operator, see xref:../../networking/aws_load_balancer_operator/understanding-aws-load-balancer-operator.adoc#aws-load-balancer-operator[AWS Load Balancer Operator in {product-title}].
 
+[id="aws-load-balancer-operator-release-notes-1.1.0"]
+== AWS Load Balancer Operator 1.1.0
+
+The AWS Load Balancer Operator version 1.1.0 supports the AWS Load Balancer Controller version 2.4.4.
+
+The following advisory is available for the AWS Load Balancer Operator version 1.1.0:
+
+* link:https://access.redhat.com/errata/RHEA-2023:6218[RHEA-2023:6218 Release of AWS Load Balancer Operator on OperatorHub Enhancement Advisory Update]
+
+[id="aws-load-balancer-operator-1.1.0-notable-changes"]
+=== Notable changes
+
+* This release uses the Kubernetes API version 0.27.2.
+
+[id="aws-load-balancer-operator-1.1.0-new-features"]
+=== New features
+
+// TODO: Add a link to the documentation for this feature once it exists.
+* The AWS Load Balancer Operator now supports a standardized Security Token Service (STS) flow by using the Cloud Credential Operator.
+
+[id="aws-load-balancer-operator-1.1.0-bug-fixes"]
+=== Bug fixes
+
+* A FIPS-compliant cluster must use TLS version 1.2. Previously, webhooks for the AWS Load Balancer Controller only accepted TLS 1.3 as the minimum version, resulting in an error such as the following on a FIPS-compliant cluster:
++
+[source,terminal]
+----
+remote error: tls: protocol version not supported
+----
++
+Now, the AWS Load Balancer Controller accepts TLS 1.2 as the minimum TLS version, resolving this issue. (link:https://issues.redhat.com/browse/OCPBUGS-14846[*OCPBUGS-14846*])
+
 [id="aws-load-balancer-operator-release-notes-1.0.0"]
 == AWS Load Balancer Operator 1.0.0
 


### PR DESCRIPTION
Version(s):
4.14+

Issue:
[OSDOCS-8355](https://issues.redhat.com/browse/OSDOCS-8355)

Link to docs preview:
[AWS Load Balancer Operator 1.1.0 Release Notes](https://66995--docspreview.netlify.app/openshift-enterprise/latest/networking/aws_load_balancer_operator/aws-load-balancer-operator-release-notes#aws-load-balancer-operator-release-notes-1.1.0)

QE review:
- [x] QE has approved this change.

Additional information:

These release notes refer to a feature that is not yet fully documented. I'll add a link to the documentation in the release notes within the PR for the feature documentation. The PR for the standardized STS flow is here: https://github.com/openshift/openshift-docs/pull/67219

I'd like to leave the "TODO" comment in this document for now and remove it when that PR is formally complete.