### PR TITLE
[OSDOCS-8403] Note ShiftStack support exception requirement for Kuryr 4.14 + RHOSP 17.1

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1588,6 +1588,13 @@ In the following tables, features are marked with the following statuses:
 
 |====
 
+[NOTE]
+====
+Clusters that use Kuryr are not supported on {rh-openstack} 17.1. 
+
+If you have a cluster that uses Kuryr and need to run it on {rh-openstack} 17.1, apply for a support exception.
+====
+
 //[discrete]
 //=== Web console deprecated and removed features
 


### PR DESCRIPTION
Version(s): 4.14

Issue: [OSDOCS-8403](https://issues.redhat.com//browse/OSDOCS-8403)

Link to docs preview: https://67002--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes

QE review:
- [x]     QE has approved this change.