### PR TITLE
ROX-20500: Bump Scanner-DB memory requests to match new default.

### DIFF
--- a/modules/default-requirements-central-services.adoc
+++ b/modules/default-requirements-central-services.adoc
@@ -107,7 +107,7 @@ Scanner requires Scanner-DB to store data. The following table lists the minimum
 
 | *Request*
 | .2 cores
-| 200 MiB
+| 512 MiB
 
 | *Limit*
 | 2 cores


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): ACS `master` branch
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [ROX-20500](https://issues.redhat.com/browse/ROX-20500)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:  https://67004--docspreview.netlify.app/openshift-acs/latest/installing/acs-default-requirements#default-requirements-central-services-scanner_acs-default-requirements
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
