### PR TITLE
Revert "Adds TP designation BACK to multi-nic docs"

### DIFF
--- a/modules/nw-egress-ips-about.adoc
+++ b/modules/nw-egress-ips-about.adoc
@@ -152,9 +152,6 @@ For more information, see link:https://docs.microsoft.com/en-us/azure/azure-reso
 [id="nw-egress-ips-multi-nic-considerations_{context}"]
 == Considerations for using an egress IP on additional network interfaces
 
-:FeatureName: Using an egress IP on additional network interfaces
-include::snippets/technology-preview.adoc[]
-
 In {product-title}, egress IPs provide administrators a way to control network traffic. Egress IPs can be used with the `br-ex`, or primary, network interface, which is a Linux bridge interface associated with Open vSwitch, or they can be used with additional network interfaces. 
 
 You can inspect your network interface type by running the following command:


### PR DESCRIPTION
**Please merge if acceptable. I am on PTO today and trying to get this in before docs freeze. Will be AFK most of the day.** 

Reverts openshift/openshift-docs#66704

It was requested today, 10/27, that I remove the TP designation *again*. 

Hi Steven,
Since Martin is on PTO, I'm reaching out for a doc change on the Multi-NIC egress IP feature in 4.14
I know that you have added, reverted, then re-added the TP designation to the multi-nic doc. I'm sorry that we probably need to change it again.
I consulted with PM on whether we should still GA that feature in 4.14, given ipv6 is broken. the answer I got was to add a known issue for the feature and remove it once the fix lands in 4.14.z (edited) 
[11:51](https://redhat-internal.slack.com/archives/C06324ND1NW/p1698378675905739)
so may I ask you to revert the TP designation again, and add a known issue to that feature in 4.14 doc?
[11:51](https://redhat-internal.slack.com/archives/C06324ND1NW/p1698378695498009)
The known issue is tracked in OCPBUG: https://issues.redhat.com/browse/OCPBUGS-17637