### PR TITLE
Corrected SPO SELinux/Seccomp references

### DIFF
--- a/modules/spo-replicating-controllers.adoc
+++ b/modules/spo-replicating-controllers.adoc
@@ -1,24 +1,12 @@
 // Module included in the following assemblies:
 //
-// * security/security_profiles_operator/spo-seccomp.adoc
 // * security/security_profiles_operator/spo-selinux.adoc
-
-ifeval::["{context}" == "spo-seccomp"]
-:seccomp:
-:type: seccomp
-:kind: SeccompProfile
-endif::[]
-ifeval::["{context}" == "spo-selinux"]
-:selinux:
-:type: SELinux
-:kind: SelinuxProfile
-endif::[]
 
 :_mod-docs-content-type: PROCEDURE
 [id="spo-replicating-controllers_{context}"]
 = Replicating controllers and SecurityContextConstraints
 
-When deploying {type} policies for replicating controllers, such as deployments or daemon sets, note that the `Pod` objects spawned by the controllers are not running with the identity of the user who creates the workload. Unless a `ServiceAccount` is selected, the pods might revert to using a restricted `SecurityContextConstraints` (SCC) which does not allow use of custom security policies.
+When you deploy SELinux policies for replicating controllers, such as deployments or daemon sets, note that the `Pod` objects spawned by the controllers are not running with the identity of the user who creates the workload. Unless a `ServiceAccount` is selected, the pods might revert to using a restricted `SecurityContextConstraints` (SCC) which does not allow use of custom security policies.
 
 .Procedure
 
@@ -29,14 +17,14 @@ When deploying {type} policies for replicating controllers, such as deployments 
 kind: RoleBinding
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  name: spo-use-seccomp-scc
+  name: spo-nginx
   namespace: nginx-secure
 subjects:
 - kind: ServiceAccount
   name: spo-deploy-test
 roleRef:
   kind: Role
-  name: spo-use-seccomp-scc
+  name: spo-nginx
   apiGroup: rbac.authorization.k8s.io
 ----
 
@@ -48,7 +36,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
   creationTimestamp: null
-  name: spo-use-seccomp-scc
+  name: spo-nginx
   namespace: nginx-secure
 rules:
 - apiGroups:
@@ -112,15 +100,4 @@ spec:
 The SELinux type is not specified in the workload and is handled by the SCC. When the pods are created by the deployment and the `ReplicaSet`, the pods will run with the appropriate profile.
 ====
 
-Ensure your SCC is only usable by the correct service account. Refer to _Additional resources_ for more information.
-
-ifeval::["{context}" == "spo-seccomp"]
-:!seccomp:
-:!type:
-:!kind:
-endif::[]
-ifeval::["{context}" == "spo-selinux"]
-:!selinux:
-:!type:
-:!kind:
-endif::[]
+Ensure that your SCC is usable by only the correct service account. Refer to _Additional resources_ for more information.


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OSDOCS-9073

Link to docs preview (VPN required):
[Replicating controllers and SecurityContextConstraints](https://file.rdu.redhat.com/antaylor/spo-idefs/security/security_profiles_operator/spo-selinux.html#spo-replicating-controllers_spo-selinux)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
I noticed this error while reviewing https://github.com/openshift/openshift-docs/pull/62471
