### PR TITLE
OSDOCS-8313 Operator roles created after cluster creation

### DIFF
--- a/modules/rosa-sharing-vpc-dns-and-roles.adoc
+++ b/modules/rosa-sharing-vpc-dns-and-roles.adoc
@@ -7,6 +7,11 @@
 
 After the *VPC Owner* creates a virtual private cloud, subnets, and an IAM role for sharing the VPC resources, reserve an `openshiftapps.com` DNS domain and create Operator roles to communicate back to the *VPC Owner*.
 
+[NOTE]
+====
+For shared VPC clusters, you can choose to create the Operator roles after the cluster creation steps. The cluster will be in a `waiting` state until the Ingress Operator role ARN is added to the shared VPC role trusted relationships.
+====
+
 image::372_OpenShift_on_AWS_persona_worflows_0923_2.png[]
 .Prerequisites
  


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
This PR adds a note that Operator roles can be created after cluster creation in shared VPC clusters. 

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
`main` , 4.13+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8313

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://67023--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-shared-vpc-config#rosa-sharing-vpc-dns-and-roles_rosa-shared-vpc-config 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
