### PR TITLE
Removed table from 4.14rn

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2173,11 +2173,6 @@ In the following tables, features are marked with the following statuses:
 |====
 |Feature |4.12 |4.13 |4.14
 
-|Egress IPs on additional network interfaces
-|Not Available
-|Not Available
-|General Availability
-
 |PTP dual NIC hardware configured as boundary clock
 |Technology Preview
 |General Availability


### PR DESCRIPTION
Version(s):
4.14

Issue: No Jira issue

This PR reomove `Egress IPs on additional network interfaces` from the Technology Preview table. This feature was mistakenly left behind in https://github.com/openshift/openshift-docs/pull/67018.

Link to docs preview:

[Technology preview features](https://67045--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-technology-preview) > Networking Technology Preview features

QE review:
- [NA] QE has approved this change.