### PR TITLE
adjusting Jira link for 4.13

### DIFF
--- a/modules/support.adoc
+++ b/modules/support.adoc
@@ -32,5 +32,5 @@ To identify issues with your cluster, you can use Insights in {cluster-manager-u
 
 // TODO: verify that these settings apply for Service Mesh and OpenShift virtualization, etc.
 If you have a suggestion for improving this documentation or have found an
-error, submit a link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Documentation_issue&issuetype=1&components=12367614&priority=10200&versions=12391126[Jira issue] for the most relevant documentation component. Please
+error, submit a link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12332330&summary=Documentation_issue&issuetype=1&components=12367614&priority=10200&versions=12398149[Jira issue] for the most relevant documentation component. Please
 provide specific details, such as the section name and {product-title} version.


### PR DESCRIPTION
4.13 only

QE not required

Related to https://issues.redhat.com/browse/CCSENABLE-529

Preview: https://67052--docspreview.netlify.app/openshift-enterprise/latest/support/getting-support

If you click the link, it should try to open a Jira in the OCPBUGS project with a 4.13 affects version.