### PR TITLE
[OSDOCS-3753] Remove overly specific example language

### DIFF
--- a/modules/machine-api-overview.adoc
+++ b/modules/machine-api-overview.adoc
@@ -22,7 +22,7 @@ For {product-title} {product-version} clusters, the Machine API performs all nod
 
 The two primary resources are:
 
-Machines:: A fundamental unit that describes the host for a node. A machine has a `providerSpec` specification, which describes the types of compute nodes that are offered for different cloud platforms. For example, a machine type for a worker node on Amazon Web Services (AWS) might define a specific machine type and required metadata.
+Machines:: A fundamental unit that describes the host for a node. A machine has a `providerSpec` specification, which describes the types of compute nodes that are offered for different cloud platforms. For example, a machine type for a compute node might define a specific machine type and required metadata.
 
 Machine sets:: `MachineSet` resources are groups of compute machines. Compute machine sets are to compute machines as replica sets are to pods. If you need more compute machines or must scale them down, you change the `replicas` field on the `MachineSet` resource to meet your compute need.
 +


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OSDOCS-3753](https://issues.redhat.com//browse/OSDOCS-3753)

Link to docs preview:
[Machine API overview](https://67072--docspreview.netlify.app/openshift-enterprise/latest/machine_management/#machine-api-overview_overview-of-machine-management)

QE review:
- [ ] QE has approved this change.

Additional information: