### PR TITLE
OSDOCS#8335: 4.13.19 z-stream release note in MicroShift

### DIFF
--- a/microshift_release_notes/microshift-4-13-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-13-release-notes.adoc
@@ -311,3 +311,12 @@ Issued: 2023-10-24
 {product-title} release 4.13.18, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:5904[RHBA-2023:5904] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:5902[RHSA-2023:5902] advisory.
 
 For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-13-19-dp"]
+=== RHBA-2023:6132 - {product-title} 4.13.19 bug fix update and security update
+
+Issued: 2023-10-30
+
+{product-title} release 4.13.19, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:6132[RHBA-2023:6132] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:6130[RHSA-2023:6130] advisory.
+
+For the `TopoLVM` image, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
**Version(s):** 4.13
**Issue:** [OSDOCS-8335](https://issues.redhat.com//browse/OSDOCS-8335)

**Link to docs preview:**

[MicroShift 4.13 release notes -> RHBA-2023:6132 - Red Hat build of MicroShift 4.13.19 bug fix update and security update](https://67081--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-13-release-notes#microshift-4-13-19-dp)

**QE review:**
- No QE required
