### PR TITLE
OSDOCS-6268: Added ROSA with HCP specifics to the machine pool topic

### DIFF
--- a/modules/rosa-adding-tuning.adoc
+++ b/modules/rosa-adding-tuning.adoc
@@ -6,24 +6,23 @@
 [id="rosa-adding-tuning_{context}"]
 = Adding node tuning to a machine pool
 
-You can add tunings for compute (also known as worker) nodes in a machine pool to control their configuration.
+You can add tunings for compute, also called worker, nodes in a machine pool to control their configuration on {hcp-title-first} clusters.
+
+[NOTE]
+====
+This feature is only supported on {hcp-title-first} clusters.
+====
 
 .Prerequisites
 
-ifdef::openshift-rosa[]
 * You installed and configured the latest {product-title} (ROSA) CLI, `rosa`, on your workstation.
-* You logged in to your Red Hat account using the ROSA CLI (`rosa`).
-* You created a ROSA cluster.
-endif::openshift-rosa[]
-ifndef::openshift-rosa[]
-* You created an {product-title} cluster.
-endif::[]
+* You logged in to your Red Hat account using the ROSA CLI.
+* You created a {hcp-title-first} cluster.
 * You have an existing machine pool.
 * You have an existing tuning configuration.
 
 .Procedure
 
-ifdef::openshift-rosa[]
 . List the machine pools in the cluster:
 +
 [source,terminal]

--- a/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
+++ b/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.adoc
@@ -5,8 +5,6 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 :context: rosa-managing-worker-nodes
 toc::[]
 
-
-
 This document describes how to manage compute (also known as worker) nodes with {product-title} (ROSA).
 
 The majority of changes for compute nodes are configured on machine pools. A machine pool is a group of compute nodes in a cluster that have the same configuration, providing ease of management.
@@ -48,7 +46,6 @@ include::modules/rosa-adding-node-labels.adoc[leveloffset=+2]
 include::modules/rosa-adding-taints.adoc[leveloffset=+1]
 include::modules/rosa-adding-taints-ocm.adoc[leveloffset=+2]
 include::modules/rosa-adding-taints-cli.adoc[leveloffset=+2]
-
 
 include::modules/rosa-adding-tuning.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Version(s):
`enterprise-4.14+`

Issue:
[OSDOCS-6268](https://issues.redhat.com/browse/OSDOCS-6268)

Link to docs preview:
[Adding node tuning to a machine pool](https://file.rdu.redhat.com/eponvell/OSDOCS-6268_Node-Tuning-Note/rosa_cluster_admin/rosa_nodes/rosa-managing-worker-nodes.html#rosa-adding-tuning_rosa-managing-worker-nodes)
   ![image](https://github.com/openshift/openshift-docs/assets/16167833/81fc93fa-a3e6-4a90-b1ff-dea7c002baec)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Explicitly called out that you must use a ROSA with HCP cluster when using node tuning.