### PR TITLE
Updating etcd-perf image location

### DIFF
--- a/modules/recommended-etcd-practices.adoc
+++ b/modules/recommended-etcd-practices.adoc
@@ -64,14 +64,14 @@ To validate the hardware for etcd before or after you create the {product-title}
 [source,terminal]
 +
 ----
-$ sudo podman run --volume /var/lib/etcd:/var/lib/etcd:Z quay.io/openshift-scale/etcd-perf
+$ sudo podman run --volume /var/lib/etcd:/var/lib/etcd:Z quay.io/cloud-bulldozer/etcd-perf
 ----
 
 ** If you use Docker, run this command:
 [source,terminal]
 +
 ----
-$ sudo docker run --volume /var/lib/etcd:/var/lib/etcd:Z quay.io/openshift-scale/etcd-perf
+$ sudo docker run --volume /var/lib/etcd:/var/lib/etcd:Z quay.io/cloud-bulldozer/etcd-perf
 ----
 --
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.10+

Additional information:
Updating the image location to the cloud-bulldozer org so we can get rid of the openshift-scale org

We need to cherry-pick this change to all branches.

cc: @sheriff-rh @dry923 @jtaleric 


