### PR TITLE
Added supportability of OCP version 4.14 to GitOps 1.10.0

### DIFF
--- a/modules/gitops-release-notes-1-10-0.adoc
+++ b/modules/gitops-release-notes-1-10-0.adoc
@@ -6,7 +6,7 @@
 [id="gitops-release-notes-1-10-0_{context}"]
 = Release notes for {gitops-title} 1.10.0
 
-{gitops-title} 1.10.0 is now available on {OCP} 4.12 and 4.13.
+{gitops-title} 1.10.0 is now available on {OCP} 4.12, 4.13 and 4.14.
 
 [id="errata-updates-1-10.0_{context}"]
 == Errata updates

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -23,8 +23,11 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 |*OpenShift GitOps* 8+|*Component Versions*|*OpenShift Versions*
 
 |*Version* |*`kam`*    |*Helm*  |*Kustomize* |*Argo CD*|*Argo Rollouts*|*ApplicationSet* |*Dex*     |*RH SSO* |
-|1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |1.5.0 TP |NA |2.35.1 GA |7.5.1 GA |4.12-4.13
+
+|1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |1.5.0 TP |NA |2.35.1 GA |7.5.1 GA |4.12-4.14
+
 |1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 TP |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
+
 |1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
 |===
 

--- a/modules/go-compatibility-and-support-matrix.adoc
+++ b/modules/go-compatibility-and-support-matrix.adoc
@@ -26,7 +26,7 @@ In {OCP} 4.13, the `stable` channel has been removed. Before upgrading to {OCP} 
 
 |1.10.0 |0.0.50 TP |3.12.1 GA |5.1.0 GA |2.8.3 GA |1.5.0 TP |NA |2.35.1 GA |7.5.1 GA |4.12-4.14
 
-|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 TP |NA     |2.35.1 GA |7.5.1 GA |4.12-4.13
+|1.9.0    |0.0.49 TP |3.11.2 GA|5.0.1 GA   |2.7.2 GA |1.5.0 TP |NA     |2.35.1 GA |7.5.1 GA |4.12-4.14
 
 |1.8.0    |0.0.47 TP |3.10.0 GA|4.5.7 GA   |2.6.3 GA |NA     |NA     |2.35.1 GA |7.5.1 GA |4.10-4.13
 |===


### PR DESCRIPTION
- Jira issue: [RHDEVDOCS-5637](https://issues.redhat.com/browse/RHDEVDOCS-5637)
- CherryPick versions: GitOps 1.10 branch
- Doc preview: [gitops-release-notes-1-10-0](https://67102--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-10-0_gitops-release-notes)
- OCP team: DevTools
- SME reviews by: @reginapizza 
- QE reviews by: @varshab1210 
- Peer reviews by: 