### PR TITLE
OSDOCS-8248: add kubeconfig refs to oc section

### DIFF
--- a/microshift_cli_ref/microshift-cli-tools-introduction.adoc
+++ b/microshift_cli_ref/microshift-cli-tools-introduction.adoc
@@ -21,10 +21,9 @@ Commands for multi-node deployments, projects, and developer tooling are not sup
 
 [role="_additional-resources"]
 [id="additional-resources_microshift-cli-tools"]
-.Additional resources
+== Additional resources
 
 * xref:..//microshift_cli_ref/microshift-oc-cli-install.adoc#microshift-oc-cli-install[Installing the OpenShift CLI tool for MicroShift].
-
 * link:https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/cli_tools/openshift-cli-oc[Detailed description of the OpenShift CLI (oc)].
-
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/9[Red Hat Enterprise Linux (RHEL) documentation for specific use cases].
+* xref:../microshift_configuring/microshift-cluster-access-kubeconfig.adoc#microshift-kubeconfig[Cluster access with kubeconfig]

--- a/modules/microshift-cli-oc-about.adoc
+++ b/modules/microshift-cli-oc-about.adoc
@@ -11,3 +11,8 @@ With the OpenShift command-line interface (CLI), the `oc` command, you can deplo
 * Working directly with project source code
 * Scripting {product-title} operations
 * Managing projects while restricted by bandwidth resources
+
+[NOTE]
+====
+A `kubeconfig` file must exist for the cluster to be accessible. The values are applied from built-in default values or a `config.yaml`, if one was created.
+====


### PR DESCRIPTION
Version(s):
4.13, 4.14, 4.15+

Issue:
https://issues.redhat.com/browse/OSDOCS-8248

Link to docs preview:
[About the OpenShift CLI](https://67104--docspreview.netlify.app/microshift/latest/microshift_cli_ref/microshift-cli-using-oc#microshift-cli-oc-about_microshift-using-oc)
[Additional resources](https://67104--docspreview.netlify.app/microshift/latest/microshift_cli_ref/microshift-cli-tools-introduction#additional-resources_microshift-cli-tools)

QE review:
- [x] QE has approved this change.

Manual CP to 4.13: https://github.com/openshift/openshift-docs/pull/67286

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
