### PR TITLE
OCPBUGS#20300: small Agent install-config.yaml fixes

### DIFF
--- a/modules/installing-ocp-agent-inputs.adoc
+++ b/modules/installing-ocp-agent-inputs.adoc
@@ -50,7 +50,7 @@ $ cat << EOF > ./my-cluster/install-config.yaml
 apiVersion: v1
 baseDomain: test.example.com
 compute:
-  architecture: amd64 <1>
+- architecture: amd64 <1>
   hyperthreading: Enabled
   name: worker
   replicas: 0
@@ -66,7 +66,7 @@ networking:
   - cidr: 10.128.0.0/14
     hostPrefix: 23
   machineNetwork:
-  - cidr: 192.168.111.0/16
+  - cidr: 192.168.0.0/16
   networkType: OVNKubernetes <3>
   serviceNetwork:
   - 172.30.0.0/16


### PR DESCRIPTION
[OCPBUGS-20300](https://issues.redhat.com/browse/OCPBUGS-20300)

Versions: 4.13+

This PR fixes a few errors in the example install-config.yaml provided in the Agent docs
QE review:
- [x] QE has approved this change.

Preview: [install-config.yaml](https://67124--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/installing-with-agent-based-installer#installing-ocp-agent-inputs_installing-with-agent-based-installer:~:text=Create%20the%20install%2Dconfig.yaml%20file%3A)