### PR TITLE
OSSM-5103 [DOC] Kiali 2.4.4 Release Notes, Known Issues and Bug Fixes

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -23,7 +23,8 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 //Istio stays the same
 //Envoy updated to 1.24.12
 //According to distributed tracing release 2.9, the latest at time of OSSM 2.4.4, Jaeger has been updated to 1.47.0
-//Kiali updated to 1.65.9
+//Kiali updated to 1.65.9 
+//Kiali updated to 1.65.10 on 10/31/2023 due to security fix 
 |===
 |Component |Version
 
@@ -37,7 +38,7 @@ This release of {SMProductName} addresses Common Vulnerabilities and Exposures (
 |1.47.0
 
 |Kiali
-|1.65.9
+|1.65.10
 |===
 //Components updated for 2.4.4
 


### PR DESCRIPTION
[OSSM-5103](https://issues.redhat.com//browse/OSSM-5103) [DOC] Kiali 2.4.4 Release Notes, Known Issues and Bug Fixes

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSSM-5103

Link to docs preview:
https://67136--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/servicemesh-release-notes#new-features-red-hat-openshift-service-mesh-version-2-4-4 

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

Update only for Kiali. Update component table only for 2.4.4 to show 1.65.10.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
