### PR TITLE
Customer update backup repository password

### DIFF
--- a/modules/oadp-installing-dpa.adoc
+++ b/modules/oadp-installing-dpa.adoc
@@ -32,6 +32,15 @@ endif::[]
 ====
 If you do not want to specify backup or snapshot locations during the installation, you can create a default `Secret` with an empty `credentials-velero` file. If there is no default `Secret`, the installation will fail.
 ====
++
+[NOTE]
+====
+Velero creates a secret named `velero-repo-credentials` in the OADP namespace, which contains a default backup repository password.
+You can update the secret with your own password encoded as base64 *before* you run your first backup targeted to the backup repository. The value of the key to update is `Data[repository-password]`.
+
+After you create your DPA, the first time that you run a backup targeted to the backup repository, Velero creates a backup repository whose secret is `velero-repo-credentials`, which contains either the default password or the one you replaced it with.
+If you update the secret password *after* the first backup, the new password will not match the password in `velero-repo-credentials`, and therefore, Velero will not be able to connect with the older backups.
+====
 
 .Procedure
 


### PR DESCRIPTION
OADP 1.2; OCP 4.11+

Resolves https://issues.redhat.com/browse/OADP-2984 by adding a note to https://access.redhat.com/documentation/en-us/openshift_container_platform/4.13/html-single/backup_and_restore/index#oadp-installing-dpa_installing-oadp-aws

Preview: https://67139--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/installing-oadp-aws#oadp-installing-dpa_installing-oadp-aws [2nd note]

The same note appears in the "Installing the Data Protection Application" section for all five platforms (AWS, Azure, etc.) 

Approved by OADP QE. 