### PR TITLE
GH#63937:Removed the documentation related to the ClusterResourceOverride Operator.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2422,7 +2422,7 @@ Topics:
     Distros: openshift-enterprise,openshift-origin
   - Name: Configuring your cluster to place pods on overcommited nodes
     File: nodes-cluster-overcommit
-    Distros: openshift-enterprise,openshift-origin
+    Distros: openshift-enterprise
   - Name: Configuring the Linux cgroup version on your nodes
     File: nodes-cluster-cgroups-2
     Distros: openshift-enterprise


### PR DESCRIPTION
Description:  Adjusted the 'Distros' parameter to exclude 'openshift-origin' to ensure that the content no longer appears in the OKD documentation.

Version(s):
4.11+

Issue:
https://github.com/openshift/openshift-docs/issues/63937

Link to docs preview:
Our tooling doesn't build previews of the OKD documentation, so these aren't available. 
However, I did verify this change by [building the OKD docs locally](https://github.com/openshift/openshift-docs/pull/67151#issuecomment-1789180712).

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->


