### PR TITLE
[enterprise-4.11] OCPBUGS-19833 Updating upgrade instruction from 410

### DIFF
--- a/modules/nw-metalLB-basic-upgrade-operator.adoc
+++ b/modules/nw-metalLB-basic-upgrade-operator.adoc
@@ -59,6 +59,6 @@ $ oc get csv -n metallb-system
 [source,terminal]
 ----
 NAME                                   DISPLAY            VERSION               REPLACES   PHASE
-metallb-operator.4.11.0-202207051316   MetalLB Operator   4.11.0-202207051316              Succeeded
+metallb-operator.{product-version}.0-202207051316   MetalLB Operator   {product-version}.0-202207051316              Succeeded
 ----
 

--- a/modules/olm-updating-metallb-operatorgroup.adoc
+++ b/modules/olm-updating-metallb-operatorgroup.adoc
@@ -1,0 +1,113 @@
+// Module included in the following assemblies:
+//
+// * operators/metallb/metallb-upgrading-operator.adoc
+
+:_mod-docs-content-type: PROCEDURE
+[id="olm-updating-metallb-operatorgroup_{context}"]
+= Editing the MetalLB Operator Operator group
+
+When upgrading from any MetalLB Operator version up to and including 4.10 to 4.11 and later, remove `spec.targetNamespaces` from the Operator group custom resource (CR). You must remove the spec regardless of whether you used the web console or the CLI to delete the MetalLB Operator.
+[NOTE]
+====
+The MetalLB Operator version 4.11 or later only supports the `AllNamespaces` install mode, whereas 4.10 or earlier versions support `OwnNamespace` or `SingleNamespace` modes.
+====
+
+.Prerequisites
+
+- You have access to an {product-title} cluster with `cluster-admin` permissions.
+- You have installed the OpenShift CLI (`oc`).
+
+.Procedure
+
+. List the Operator groups in the `metallb-system` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorgroup -n metallb-system
+----
++
+.Example output
+
+[source,terminal]
+----
+NAME                   AGE
+metallb-system-7jc66   85m
+----
+
+. Verify that the `spec.targetNamespaces` is present in the Operator group CR associated with the `metallb-system` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorgroup metallb-system-7jc66 -n metallb-system -o yaml
+----
++
+.Example output
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: ""
+  creationTimestamp: "2023-10-25T09:42:49Z"
+  generateName: metallb-system-
+  generation: 1
+  name: metallb-system-7jc66
+  namespace: metallb-system
+  resourceVersion: "25027"
+  uid: f5f644a0-eef8-4e31-a306-e2bbcfaffab3
+spec:
+  targetNamespaces:
+  - metallb-system
+  upgradeStrategy: Default
+status:
+  lastUpdated: "2023-10-25T09:42:49Z"
+  namespaces:
+  - metallb-system
+----
+
+. Edit the Operator group and remove the `targetNamespaces` and `metallb-system` present under the `spec` section by running the following command:
++
+[source,terminal]
+----
+$ oc edit n metallb-system
+----
++
+.Example output
++
+[source,terminal]
+----
+operatorgroup.operators.coreos.com/metallb-system-7jc66 edited
+----
+
+. Verify the `spec.targetNamespaces` is removed from the Operator group custom resource associated with the `metallb-system` namespace by running the following command:
++
+[source,terminal]
+----
+$ oc get operatorgroup metallb-system-7jc66 -n metallb-system -o yaml
+----
++
+.Example output
+[source,terminal]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  annotations:
+    olm.providedAPIs: ""
+  creationTimestamp: "2023-10-25T09:42:49Z"
+  generateName: metallb-system-
+  generation: 2
+  name: metallb-system-7jc66
+  namespace: metallb-system
+  resourceVersion: "61658"
+  uid: f5f644a0-eef8-4e31-a306-e2bbcfaffab3
+spec:
+  upgradeStrategy: Default
+status:
+  lastUpdated: "2023-10-25T14:31:30Z"
+  namespaces:
+  - ""
+----
+
+

--- a/networking/metallb/metallb-upgrading-operator.adoc
+++ b/networking/metallb/metallb-upgrading-operator.adoc
@@ -17,7 +17,7 @@ The automatic upgrade procedure does not work as expected from {product-title} 4
 This procedure does not apply to automatic z-stream updates of the MetalLB Operator, which follow the standard straightforward method.
 ====
 
-For detailed steps to upgrade the Operator, see the guidance that follows.
+For detailed steps to upgrade the MetalLB Operator from 4.10 and earlier, see the guidance that follows. As a cluster administrator, start the upgrade process by deleting the MetalLB Operator by using the OpenShift CLI (`oc`) or the web console.
 
 //Delete metallb using web console
 include::modules/olm-deleting-metallb-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
@@ -25,7 +25,10 @@ include::modules/olm-deleting-metallb-operators-from-a-cluster-using-web-console
 //Delete metallb using cli
 include::modules/olm-deleting-metallb-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]
 
-//Upgrade the Operator
+//Delete targetNamespace
+include::modules/olm-updating-metallb-operatorgroup.adoc[leveloffset=+1]
+
+//Upgrade the MetalLB
 include::modules/nw-metalLB-basic-upgrade-operator.adoc[leveloffset=+1]
 
 [id="additional-resources"]


### PR DESCRIPTION
[OCPBUGS-19833]: Edit created Operator group for successful upgrade.

Cherry Picked from https://github.com/openshift/openshift-docs/pull/66870/commits/4d774ffb659a7218cc07e562610f3247a18be58c xref: https://github.com/openshift/openshift-docs/pull/66870

Version(s): 4.11

Issue: https://issues.redhat.com/browse/OCPBUGS-19833

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
