### PR TITLE
fix-ibm-rt: Fixed rendering issue with IBM and Oracle attri

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -152,8 +152,8 @@ endif::[]
 //Windows containers
 :productwinc: Red Hat OpenShift support for Windows Containers
 // IBM Cloud
-:ibmcloudBMProductName: IBM Cloud Bare Metal (Classic)
-:ibmcloudBMRegProductName: IBM Cloud&#174; Bare Metal (Classic)
+:ibm-cloud-bm: IBM Cloud Bare Metal (Classic)
+:ibm-cloud-bm-reg: IBM Cloud(R) Bare Metal (Classic)
 // IBM Power
 :ibmpowerProductName: IBM Power
 // IBM zSystems
@@ -196,9 +196,9 @@ endif::[]
 :3no-caps: Three-node OpenShift
 :run-once-operator: Run Once Duration Override Operator
 //Oracle
-:oci-first: Oracle&#174; Cloud Infrastructure
+:oci-first: Oracle(R) Cloud Infrastructure
 :oci: OCI
-:ocvs-first: Oracle&#174; Cloud VMware Solution (OCVS)
+:ocvs-first: Oracle(R) Cloud VMware Solution (OCVS)
 :ocvs: OCVS
 // Web terminal
 :web-terminal-op: Web Terminal Operator

--- a/installing/installing_ibm_cloud/install-ibm-cloud-prerequisites.adoc
+++ b/installing/installing_ibm_cloud/install-ibm-cloud-prerequisites.adoc
@@ -6,7 +6,7 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-You can use installer-provisioned installation to install {product-title} on {ibmcloudBMRegProductName} nodes. This document describes the prerequisites and procedures when installing {product-title} on IBM Cloud nodes.
+You can use installer-provisioned installation to install {product-title} on {ibm-cloud-bm-reg} nodes. This document describes the prerequisites and procedures when installing {product-title} on IBM Cloud nodes.
 
 [IMPORTANT]
 ====
@@ -20,6 +20,6 @@ Installer-provisioned installation of {product-title} requires:
 * One routable network
 * One provisioning network
 
-Before starting an installer-provisioned installation of {product-title} on {ibmcloudBMProductName}, address the following prerequisites and requirements.
+Before starting an installer-provisioned installation of {product-title} on {ibm-cloud-bm}, address the following prerequisites and requirements.
 
 include::modules/install-ibm-cloud-setting-up-ibm-cloud-infrastructure.adoc[leveloffset=+1]

--- a/modules/install-ibm-cloud-configuring-the-install-config-file.adoc
+++ b/modules/install-ibm-cloud-configuring-the-install-config-file.adoc
@@ -6,7 +6,7 @@
 [id="configuring-the-install-config-file_{context}"]
 = Configuring the install-config.yaml file
 
-The `install-config.yaml` file requires some additional details. Most of the information is teaching the installer and the resulting cluster enough about the available {ibmcloudBMRegProductName} hardware so that it is able to fully manage it. The material difference between installing on bare metal and installing on {ibmcloudBMProductName} is that you must explicitly set the privilege level for IPMI in the BMC section of the `install-config.yaml` file.
+The `install-config.yaml` file requires some additional details. Most of the information is teaching the installer and the resulting cluster enough about the available {ibm-cloud-bm-reg} hardware so that it is able to fully manage it. The material difference between installing on bare metal and installing on {ibm-cloud-bm-reg} is that you must explicitly set the privilege level for IPMI in the BMC section of the `install-config.yaml` file.
 
 .Procedure
 
@@ -59,7 +59,7 @@ pullSecret: '<pull_secret>'
 sshKey: '<ssh_pub_key>'
 ----
 +
-<1> The `bmc.address` provides a `privilegelevel` configuration setting with the value set to `OPERATOR`. This is required for {ibmcloudBMProductName} infrastructure.
+<1> The `bmc.address` provides a `privilegelevel` configuration setting with the value set to `OPERATOR`. This is required for {ibm-cloud-bm} infrastructure.
 <2> Add the MAC address of the private `provisioning` network NIC for the corresponding node.
 +
 [NOTE]

--- a/modules/install-ibm-cloud-configuring-the-public-subnet.adoc
+++ b/modules/install-ibm-cloud-configuring-the-public-subnet.adoc
@@ -6,7 +6,7 @@
 [id="configuring-the-public-subnet_{context}"]
 = Configuring the public subnet
 
-All of the {product-title} cluster nodes must be on the public subnet. {ibmcloudBMRegProductName} does not provide a DHCP server on the subnet. Set it up separately on the provisioner node.
+All of the {product-title} cluster nodes must be on the public subnet. {ibm-cloud-bm-reg} does not provide a DHCP server on the subnet. Set it up separately on the provisioner node.
 
 You must reset the BASH variables defined when preparing the provisioner node. Rebooting the provisioner node after preparing it will delete the BASH variables previously set.
 

--- a/modules/install-ibm-cloud-preparing-the-provisioner-node.adoc
+++ b/modules/install-ibm-cloud-preparing-the-provisioner-node.adoc
@@ -4,7 +4,7 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-the-provisioner-node-for-openshift-install-on-ibm-cloud_{context}"]
-= Preparing the provisioner node on {ibmcloudBMProductName} infrastructure
+= Preparing the provisioner node on {ibm-cloud-bm} infrastructure
 
 Perform the following steps to prepare the provisioner node.
 

--- a/modules/install-ibm-cloud-setting-up-ibm-cloud-infrastructure.adoc
+++ b/modules/install-ibm-cloud-setting-up-ibm-cloud-infrastructure.adoc
@@ -3,9 +3,9 @@
 // installing_ibm_cloud/install-ibm-cloud-installing-on-ibm-cloud.adoc
 
 [id="setting-up-ibm-cloud-infrastructure_{context}"]
-= Setting up IBM Cloud Bare Metal (Classic) infrastructure
+= Setting up {ibm-cloud-bm-reg} infrastructure
 
-To deploy an {product-title} cluster on {ibmcloudBMRegProductName} infrastructure, you must first provision the IBM Cloud nodes.
+To deploy an {product-title} cluster on {ibm-cloud-bm} infrastructure, you must first provision the IBM Cloud nodes.
 
 [IMPORTANT]
 ====
@@ -29,7 +29,7 @@ Create all nodes with a single public VLAN and a single private VLAN.
 
 IBM Cloud public VLAN subnets use a `/28` prefix by default, which provides 16 IP addresses. That is sufficient for a cluster consisting of three control plane nodes, four worker nodes, and two IP addresses for the API VIP and Ingress VIP on the `baremetal` network. For larger clusters, you might need a smaller prefix.
 
-IBM Cloud private VLAN subnets use a `/26` prefix by default, which provides 64 IP addresses. {ibmcloudBMProductName} uses private network IP addresses to access the Baseboard Management Controller (BMC) of each node. {product-title} creates an additional subnet for the `provisioning` network. Network traffic for the `provisioning` network subnet routes through the private VLAN. For larger clusters, you might need a smaller prefix.
+IBM Cloud private VLAN subnets use a `/26` prefix by default, which provides 64 IP addresses. {ibm-cloud-bm} uses private network IP addresses to access the Baseboard Management Controller (BMC) of each node. {product-title} creates an additional subnet for the `provisioning` network. Network traffic for the `provisioning` network subnet routes through the private VLAN. For larger clusters, you might need a smaller prefix.
 
 .IP addresses per prefix
 [options="header"]
@@ -138,11 +138,11 @@ Define a consistent clock date and time format in each cluster node's BIOS setti
 [discrete]
 == Configure a DHCP server
 
-{ibmcloudBMProductName} does not run DHCP on the public or private VLANs. After provisioning IBM Cloud nodes, you must set up a DHCP server for the public VLAN, which corresponds to {product-title}'s `baremetal` network.
+{ibm-cloud-bm} does not run DHCP on the public or private VLANs. After provisioning IBM Cloud nodes, you must set up a DHCP server for the public VLAN, which corresponds to {product-title}'s `baremetal` network.
 
 [NOTE]
 ====
-The IP addresses allocated to each node do not need to match the IP addresses allocated by the {ibmcloudBMProductName} provisioning system.
+The IP addresses allocated to each node do not need to match the IP addresses allocated by the {ibm-cloud-bm} provisioning system.
 ====
 
 See the "Configuring the public subnet" section for details.


### PR DESCRIPTION
INTERNAL FIX. See [example](https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/installing/installing-on-ibm-z-and-ibm-linuxone) of unrendered character subs on the Customer portal. 

Specific changes were pushed to the [4.14 branch](https://github.com/openshift/openshift-docs/blob/enterprise-4.14/_attributes/common-attributes.adoc), so I added in the additional attributes.

Major change is swapping `&#174;` to `(R)`, as the (R) syntax does render on the CP. 


Version(s):
main, 4.15, and 4.14

Link to docs preview:
* [IBM Cloud Bare Metal (Classic)](https://67207--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/install-ibm-cloud-prerequisites)
* [IBM Z and IBM LinuxOne](https://67207--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_z/preparing-to-install-on-ibm-z)
* [IBM Power](https://67207--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_power/preparing-to-install-on-ibm-power)
* [IBM Power Virtual Server](https://67207--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/preparing-to-install-on-ibm-power-vs)

QE review:
- [ ] QE not required

Additional information:
* See [Slack chat ](https://redhat-internal.slack.com/archives/C85JYPHL3/p1698769220006819)for reason for changes
