### PR TITLE
OCPBUGS#16215: Remove unsupported feature for VSphere storage

### DIFF
--- a/modules/dynamic-provisioning-vsphere-definition.adoc
+++ b/modules/dynamic-provisioning-vsphere-definition.adoc
@@ -14,14 +14,9 @@ kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
   name: <storage-class-name> <1>
-provisioner: kubernetes.io/vsphere-volume <2>
-parameters:
-  diskformat: thin <3>
+provisioner: csi.vsphere.vmware.com <2>
 ----
 <1> Name of the storage class. The persistent volume claim uses this storage class for provisioning the associated persistent volumes.
-<2> For more information about using VMware vSphere with {product-title},
+<2> For more information about using VMware vSphere CSI with {product-title},
 see the
-link:https://vmware.github.io/vsphere-storage-for-kubernetes/documentation/index.html[VMware vSphere documentation].
-<3>  `diskformat`: `thin`, `zeroedthick` and `eagerzeroedthick` are all
-valid disk formats. See vSphere docs for additional details regarding the
-disk format types. The default value is `thin`.
+link:https://kubernetes.io/docs/concepts/storage/volumes/#vsphere-csi-migration[Kubernetes documentation].


### PR DESCRIPTION
**Version(s):** 4.13+ 
**Issue:** [OCPBUGS-16215](https://issues.redhat.com/browse/OCPBUGS-16215)

**Link to docs preview:**

[Dynamic provisioning -> VMware VSphere object definition ](https://67209--docspreview.netlify.app/openshift-enterprise/latest/storage/dynamic-provisioning#vsphere-definition_dynamic-provisioning)

**QE review:**
- [x] QE has approved this change.

