### PR TITLE
[OSDOCS-8167]: Release note about operators that aren't tested for hosted control planes

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -2893,6 +2893,18 @@ This issue affects the CPU load balancing features because these features depend
 
 * Broadcom network interface controllers in legacy Single Root I/O Virtualization (SR-IOV) do not support quality of service (QoS) and tag protocol identifier (TPID) settings for the SRIOV VLAN. This affects Broadcom BCM57414, Broadcom BCM57508, and Broadcom BCM57504. (link:https://issues.redhat.com/browse/RHEL-9881[*RHEL-9881*])
 
+* In hosted control planes for {product-title}, the following Operators and components are not tested (link:https://issues.redhat.com/browse/OCPSTRAT-605[*OCPSTRAT-605*]):
+
+** Performance Addon Operator
+** {sandboxed-containers-first}
+** {gitops-title}
+** {SMProductName}
+** {pipelines-title}
+** {openshift-dev-spaces-productname}
+** Red Hat's single sign-on technology
+** The web terminal in the {product-title} web console
+** Migration toolkit for applications
+
 * In hosted control planes for {product-title}, installing the File Integrity Operator on a hosted cluster fails. (link:https://issues.redhat.com/browse/OCPBUGS-3410[*OCPBUGS-3410*])
 
 * In hosted control planes for {product-title}, the Vertical Pod Autoscaler Operator fails to install on a hosted cluster. (link:https://issues.redhat.com/browse/PODAUTO-65[*PODAUTO-65*])


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14z
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OSDOCS-8167
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://67216--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-known-issues (Ctrl+F to "OCPSTRAT-605")
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: I am following the change management guidelines to add this known issue in between releases.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
