### PR TITLE
OCPBUGS#21900: Fixes gcp CPU manager image to include more arches

### DIFF
--- a/modules/setting-up-cpu-manager.adoc
+++ b/modules/setting-up-cpu-manager.adoc
@@ -118,7 +118,7 @@ metadata:
 spec:
   containers:
   - name: cpumanager
-    image: gcr.io/google_containers/pause-amd64:3.0
+    image: gcr.io/google_containers/pause:3.2
     resources:
       requests:
         cpu: 1


### PR DESCRIPTION
**Version(s):** 4.14+
**Issue:** [OCPBUGS-21900](https://issues.redhat.com/browse/OCPBUGS-21900)

**Link to docs preview:**
[Using CPU manager and Topology Manager -> Setting up CPU manager](https://67221--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/using-cpu-manager#seting_up_cpu_manager_using-cpu-manager-and-topology_manager)

**QE review:**
- [x] QE has approved this change.

