### PR TITLE
OCPBUGS-19822 Additional Network and Mettalb cannot use same network

### DIFF
--- a/modules/nw-metallb-bgp-limitations.adoc
+++ b/modules/nw-metallb-bgp-limitations.adoc
@@ -18,6 +18,13 @@ However, you can anticipate that a change in the number of `speaker` pods affect
 To avoid or reduce the likelihood of a service interruption, you can specify a node selector when you add a BGP peer.
 By limiting the number of nodes that start BGP sessions, a fault on a node that does not have a BGP session has no affect on connections to the service.
 
+[id="additional_network_and_metallb_limitation_{context}"]
+== Additional Network and MetalLB cannot use same network
+
+There is a limitation when using the same VLAN for both MetalLB and an additional network interface on a source pod. In such cases, a connection failure occurs, when the MetalLB IP and the source pod share the same node.
+
+You can address this by ensuring the MetalLB IP is in another subnet so the traffic coming from a pod would take the default gateway, which is OVN-K and reach the destination via the OVN overlay. Alternatively use a MACVLAN interface instead of a VLAN interface.
+
 [id="nw-metallb-bgp-limitations-single-asn_{context}"]
 == Support for a single ASN and a single router ID only
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
