### PR TITLE
[enterprise-4.12] OCPBUGS-19822 Additional Network and MetalLB cannot use same network 

### DIFF
--- a/modules/nw-metallb-layer2-limitations.adoc
+++ b/modules/nw-metallb-layer2-limitations.adoc
@@ -34,3 +34,9 @@ The old node can continue to forward traffic for outdated clients until their ca
 
 During an unplanned failover, the service IPs are unreachable until the outdated clients refresh their cache entries.
 
+[id="additional_network_and_metallb_limitation_{context}"]
+== Additional Network and MetalLB cannot use same network
+
+Using the same VLAN for both MetalLB and an additional network interface set up on a source pod might result in a connection failure. This occurs when both the MetalLB IP and the source pod reside on the same node.
+
+To avoid connection failures, place the MetalLB IP in a different subnet from the one where the source pod resides. This configuration ensures that traffic from the source pod will take the default gateway. Consequently, the traffic can effectively reach its destination by using the OVN overlay network, ensuring that the connection functions as intended.


### PR DESCRIPTION
[OCPBUGS-19822]: Additional Network and MetalLB cannot use same network

Version(s): 4.12

Issue:https://issues.redhat.com/browse/OCPBUGS-19822

Link to docs preview: https://67238--docspreview.netlify.app/openshift-enterprise/latest/networking/metallb/about-metallb#additional_network_and_metallb_limitation_about-metallb-and-metallb-operator

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->


Additional information: Content already merged in https://github.com/openshift/openshift-docs/pull/66003
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
