### PR TITLE
[enterprise-4.12] OBSDOCS-539: Put 5.8 logging docs live

### DIFF
--- a/logging/cluster-logging-loki.adoc
+++ b/logging/cluster-logging-loki.adoc
@@ -17,7 +17,7 @@ include::modules/cluster-logging-loki-deploy.adoc[leveloffset=+1]
 include::modules/logging-creating-new-group-cluster-admin-user-role.adoc[leveloffset=+1]
 
 include::modules/logging-loki-gui-install.adoc[leveloffset=+1]
-////
+
 include::modules/logging-loki-restart-hardening.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
@@ -34,7 +34,6 @@ include::modules/logging-loki-reliability-hardening.adoc[leveloffset=+1]
 ifdef::openshift-enterprise[]
 * xref:../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity[Placing pods relative to other pods using affinity and anti-affinity rules]
 endif::[]
-////
 
 include::modules/logging-loki-retention.adoc[leveloffset=+1]
 


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/pull/65038