### PR TITLE
[enterprise-4.12] modules/installation-user-infra-machines-*: PXE with Ignition kargs

### DIFF
--- a/modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-ca-certs.adoc
@@ -4,10 +4,16 @@
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing_bare_metal/installing-bare-metal-network-customizations.adoc
 
+:_content-type: PROCEDURE
 [id="installation-user-infra-machines-advanced-customizing-live-{boot}-ca-certs_{context}"]
 = Modifying a live install {boot-media} to use a custom certificate authority
 
 You can provide certificate authority (CA) certificates to Ignition with the `--ignition-ca` flag of the `customize` subcommand. You can use the CA certificates during both the installation boot and when provisioning the installed system.
+
+[NOTE]
+====
+Custom CA certificates affect how Ignition fetches remote resources but they do not affect the certificates installed onto the system.
+====
 
 .Procedure
 
@@ -21,6 +27,7 @@ ifeval::["{boot-media}" == "ISO image"]
 $ coreos-installer iso customize rhcos-<version>-live.x86_64.iso --ignition-ca cert.pem
 ----
 endif::[]
+
 ifeval::["{boot-media}" == "PXE environment"]
 . Retrieve the {op-system} `kernel`, `initramfs` and `rootfs` files from the link:https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/latest/[{op-system} image mirror] page and run the following command to create a new customized `initramfs` file for use with a custom CA:
 +
@@ -30,17 +37,14 @@ $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
     --ignition-ca cert.pem \
     -o rhcos-<version>-custom-initramfs.x86_64.img
 ----
+
+. Use the customized `initramfs` file in your PXE configuration. Add the `ignition.firstboot` and `ignition.platform.id=metal` kernel arguments if they are not already present.
 endif::[]
-+
+
 [IMPORTANT]
 ====
 The `coreos.inst.ignition_url` kernel parameter does not work with the `--ignition-ca` flag.
 You must use the `--dest-ignition` flag to create a customized image for each cluster.
 ====
-+
-[NOTE]
-====
-Custom CA certificates affect how Ignition fetches remote resources but they do not affect the certificates installed onto the system.
-====
-+
-Your CA certificate is applied and affects every subsequent boot of the {boot-media}.
+
+Applying your custom CA certificate affects every subsequent boot of {op-system}.

--- a/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-network-config.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing_bare_metal/installing-bare-metal-network-customizations.adoc
 
+:_content-type: PROCEDURE
 [id="installation-user-infra-machines-advanced-customizing-live-{boot}_network_keyfile_{context}"]
 = Modifying a live install {boot-media} with customized network settings
 You can embed a NetworkManager keyfile into the live {boot-media} and pass it through to the installed system with the `--network-keyfile` flag of the `customize` subcommand.
@@ -101,6 +102,8 @@ $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
     --network-keyfile bond0-proxy-em2.nmconnection \
     -o rhcos-<version>-custom-initramfs.x86_64.img
 ----
+
+. Use the customized `initramfs` file in your PXE configuration. Add the `ignition.firstboot` and `ignition.platform.id=metal` kernel arguments if they are not already present.
 endif::[]
 +
 Network settings are applied to the live system and are carried over to the destination system.

--- a/modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live-serial-console.adoc
@@ -59,13 +59,14 @@ $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
   --dest-console tty0 \//<2>
   --dest-console ttyS0,<options> \//<3>
   --dest-device /dev/sda \//<4>
-  -o rhcos-<version>-custom-initramfs.x86_64.img
+  -o rhcos-<version>-custom-initramfs.x86_64.img <5>
 ----
 +
 <1> The location of the Ignition config to install.
 <2> The desired secondary console. In this case, the graphical console. Omitting this option will disable the graphical console.
 <3> The desired primary console. In this case, the serial console. The `options` field defines the baud rate and other settings. A common value for this field is `115200n8`. If no options are provided, the default kernel value of `9600n8` is used. For more information on the format of this option, see the link:https://www.kernel.org/doc/html/latest/admin-guide/serial-console.html[Linux kernel serial console] documentation.
-<4> The specified disk to install to. In this case, `/dev/sda`. If you omit this option, the {boot-media} automatically runs the installer which will fail unless you also specify the `coreos.inst.install_dev` kernel argument.
+<4> The specified disk to install to. If you omit this option, the {boot-media} automatically runs the installer which will fail unless you also specify the `coreos.inst.install_dev` kernel argument.
+<5> Use the customized `initramfs` file in your PXE configuration. Add the `ignition.firstboot` and `ignition.platform.id=metal` kernel arguments if they are not already present.
 +
 Your customizations are applied and affect every subsequent boot of the {boot-media}.
 endif::[]

--- a/modules/installation-user-infra-machines-advanced-customizing-live.adoc
+++ b/modules/installation-user-infra-machines-advanced-customizing-live.adoc
@@ -4,6 +4,7 @@
 // * installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
 // * installing_bare_metal/installing-bare-metal-network-customizations.adoc
 
+:_content-type: PROCEDURE
 [id="installation-user-infra-machines-advanced-customizing-live-{boot}_{context}"]
 = Customizing a live {op-system} {boot-media}
 You can customize a live {op-system} {boot-media} directly with the
@@ -30,6 +31,17 @@ $ coreos-installer iso customize rhcos-<version>-live.x86_64.iso \
     --dest-ignition bootstrap.ign \ <1>
     --dest-device /dev/sda <2>
 ----
+<1> The Ignition config file that is generated from the `openshift-installer` installation program.
+<2> When you specify this option, the {boot-media} automatically runs an installation. Otherwise, the image remains configured for installation, but does not install automatically unless you specify the `coreos.inst.install_dev` kernel argument.
+
+. Optional: To remove the {boot-media} customizations and return the image to its pristine state, run:
++
+[source,terminal]
+----
+$ coreos-installer iso reset rhcos-<version>-live.x86_64.iso
+----
++
+You can now re-customize the live {boot-media} or use it in its pristine state.
 endif::[]
 
 ifeval::["{boot-media}" == "PXE environment"]
@@ -40,21 +52,11 @@ ifeval::["{boot-media}" == "PXE environment"]
 $ coreos-installer pxe customize rhcos-<version>-live-initramfs.x86_64.img \
     --dest-ignition bootstrap.ign \ <1>
     --dest-device /dev/sda \ <2>
-    -o rhcos-<version>-custom-initramfs.x86_64.img
+    -o rhcos-<version>-custom-initramfs.x86_64.img <3>
 ----
-endif::[]
 <1> The Ignition config file that is generated from `openshift-installer`.
 <2> When you specify this option, the {boot-media} automatically runs an install. Otherwise, the image remains configured for installing, but does not do so automatically unless you specify the `coreos.inst.install_dev` kernel argument.
-+
-Your customizations are applied and affect every subsequent boot of the {boot-media}.
-
-ifeval::["{boot-media}" == "ISO image"]
-. To remove the ISO image customizations and return the image to its pristine state, run:
-+
-[source,terminal]
-----
-$ coreos-installer iso reset rhcos-<version>-live.x86_64.iso
-----
-+
-You can now re-customize the live ISO image or use it in its pristine state.
+<3> Use the customized `initramfs` file in your PXE configuration. Add the `ignition.firstboot` and `ignition.platform.id=metal` kernel arguments if they are not already present.
 endif::[]
+
+Applying your customizations affects every subsequent boot of {op-system}.


### PR DESCRIPTION
Certain `coreos-installer pxe customize` options won't be applied at runtime unless the PXE boot includes the `ignition.firstboot` and `ignition.platform.id` kernel arguments.  We were always implicitly assuming this, but it wasn't documented.

For https://github.com/coreos/fedora-coreos-tracker/issues/1426.

modules/installation-user-infra-machines-advanced-*: add content type

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.12
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: Manual CP of #66519 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
