### PR TITLE
Pipelines-RN-1.12.2 Release Notes for Pipelines 1.12.2

### DIFF
--- a/modules/op-release-notes-1-12.adoc
+++ b/modules/op-release-notes-1-12.adoc
@@ -202,3 +202,15 @@ With this update, {pipelines-title} General Availability (GA) 1.12.1 is availabl
 * Before this update, when using {pac}, if you created an access policy on the `Repository` custom resource (CR) that did not include a particular user and then added the user to the `OWNER` file in the Git repository, the user would have no rights for the {pac} CI process. For example, if the user created a pull request into the Git repository. the CI process would not run on this pull request automatically. With this update, a user who is not included in the access policy on the `Repository` CR but is included in the `OWNER` file is allowed to run the CI process for the repository.
 
 * With this update, the HTTP/2.0 protocol is not supported for webhooks. All webhook calls to {pipelines-title} must use the HTTP/1.1 protocol.
+
+[id="release-notes-1-12-2_{context}"]
+== Release notes for {pipelines-title} General Availability 1.12.2
+
+With this update, {pipelines-title} General Availability (GA) 1.12.2 is available on {OCP} 4.12 and later versions.
+
+[id="fixed-issues-1-12-2_{context}"]
+=== Fixed issues
+
+* Before this update, the generated Git secret for the latest pipeline run was deleted when the `max-keep-runs` parameter was exceeded. With this update, the Git secret is no longer deleted on the latest pipeline run.
+
+* With this update, the S2I cluster task uses a General Availability container image.


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **Please cherry-pick to**: `pipelines-docs-1.12`
• **Preview page**: [Release notes for Red Hat OpenShift Pipelines General Availability 1.12.2](https://67276--docspreview.netlify.app/openshift-pipelines/latest/about/op-release-notes#release-notes-1-12-2_op-release-notes)
• **SME Review**: Completed by @rupalibehera, @chmouel 
• **QE review**: Completed by @VeereshAradhya 
