### PR TITLE
OBSDOCS-152: Remove duplicated content

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2508,8 +2508,6 @@ Topics:
   Dir: v5_7
   Distros: openshift-enterprise,openshift-origin
   Topics:
-  - Name: Configuring Logging
-    File: logging-5-7-configuration
   - Name: Administering Logging
     File: logging-5-7-administration
 #  Name: Logging Reference
@@ -2518,8 +2516,6 @@ Topics:
   Dir: v5_6
   Distros: openshift-enterprise,openshift-origin
   Topics:
-  - Name: Configuring Logging
-    File: logging-5-6-configuration
   - Name: Administering Logging
     File: logging-5-6-administration
   - Name: Logging Reference
@@ -2530,8 +2526,6 @@ Topics:
   Topics:
   - Name: Administering Logging
     File: logging-5-5-administration
-#  - Name: Configuring Logging
-#    File: logging-5-5-configuration
 - Name: About Logging
   File: cluster-logging
 - Name: Installing Logging

--- a/logging/log_collection_forwarding/log-forwarding.adoc
+++ b/logging/log_collection_forwarding/log-forwarding.adoc
@@ -50,6 +50,8 @@ endif::[]
 
 include::modules/logging-create-clf.adoc[leveloffset=+1]
 
+include::modules/logging-multiline-except.adoc[leveloffset=+1]
+
 [id="log-forwarding-audit-logs"]
 == Sending audit logs to the internal log store
 

--- a/logging/v5_5/logging-5-5-configuration.adoc
+++ b/logging/v5_5/logging-5-5-configuration.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-[id="logging-5-5-configuration"]
-= Configuring your logging deployment
-include::_attributes/common-attributes.adoc[]
-:context: logging-5-5-configuration
-
-toc::[]
-
-include::modules/logging-multiline-except.adoc[leveloffset=+1]

--- a/logging/v5_6/logging-5-6-configuration.adoc
+++ b/logging/v5_6/logging-5-6-configuration.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-[id="logging-configuration-5-6"]
-= Configuring your logging deployment
-include::_attributes/common-attributes.adoc[]
-:context: logging-5.6-configuration
-
-toc::[]
-
-include::modules/logging-multiline-except.adoc[leveloffset=+1]

--- a/logging/v5_7/logging-5-7-configuration.adoc
+++ b/logging/v5_7/logging-5-7-configuration.adoc
@@ -1,9 +1,0 @@
-:_mod-docs-content-type: ASSEMBLY
-[id="logging-5-7-configuration"]
-= Configuring your logging deployment
-include::_attributes/common-attributes.adoc[]
-:context: logging-5-7-configuration
-
-toc::[]
-
-include::modules/logging-multiline-except.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-152

Link to docs preview:
https://67287--docspreview.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/log-forwarding#logging-multiline-except_log-forwarding

QE review:
Not required, just removing content from duplicated sections. Module still appears untouched in docs.
