### PR TITLE
OBSDOCS-152: Removing duplicated uninstall content

### DIFF
--- a/logging/cluster-logging-uninstall.adoc
+++ b/logging/cluster-logging-uninstall.adoc
@@ -8,12 +8,13 @@ toc::[]
 
 You can remove the {logging} from your {product-title} cluster.
 
-// The following include statements pull in the module files that comprise
-// the assembly. Include any combination of concept, procedure, or reference
-// modules required to cover the user story. You can also include other
-// assemblies.
-
 include::modules/cluster-logging-uninstall.adoc[leveloffset=+1]
+
+//Generic deleting operators from cluster using web console
+include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
+
+//Generic deleting operators from a cluster using CLI
+include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources

--- a/logging/v5_5/logging-5-5-administration.adoc
+++ b/logging/v5_5/logging-5-5-administration.adoc
@@ -14,9 +14,3 @@ include::modules/logging-deploy-loki-console.adoc[leveloffset=+1]
 
 //Generic installing operators from operator hub using CLI
 include::modules/olm-installing-from-operatorhub-using-cli.adoc[leveloffset=+1]
-
-//Generic deleting operators from cluster using web console
-include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
-
-//Generic deleting operators from a cluster using CLI
-include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]

--- a/logging/v5_6/logging-5-6-administration.adoc
+++ b/logging/v5_6/logging-5-6-administration.adoc
@@ -14,9 +14,3 @@ include::modules/logging-deploy-loki-console.adoc[leveloffset=+1]
 
 //Generic installing operators from operator hub using CLI
 include::modules/olm-installing-from-operatorhub-using-cli.adoc[leveloffset=+1]
-
-//Generic deleting operators from cluster using web console
-include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
-
-//Generic deleting operators from a cluster using CLI
-include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]

--- a/logging/v5_7/logging-5-7-administration.adoc
+++ b/logging/v5_7/logging-5-7-administration.adoc
@@ -14,9 +14,3 @@ include::modules/logging-deploy-loki-console.adoc[leveloffset=+1]
 
 //Generic installing operators from operator hub using CLI
 include::modules/olm-installing-from-operatorhub-using-cli.adoc[leveloffset=+1]
-
-//Generic deleting operators from cluster using web console
-include::modules/olm-deleting-operators-from-a-cluster-using-web-console.adoc[leveloffset=+1]
-
-//Generic deleting operators from a cluster using CLI
-include::modules/olm-deleting-operators-from-a-cluster-using-cli.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-152

Link to docs preview:
https://67289--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-uninstall#olm-deleting-operators-from-a-cluster-using-web-console_cluster-logging-uninstall

QE review:
Not required, just removing content from duplicated sections. Modules still appears untouched in docs.
