### PR TITLE
Fixed typos in GitOps 1.10 and 1.10.1 release notes.

### DIFF
--- a/modules/gitops-release-notes-1-10-0.adoc
+++ b/modules/gitops-release-notes-1-10-0.adoc
@@ -6,7 +6,7 @@
 [id="gitops-release-notes-1-10-0_{context}"]
 = Release notes for {gitops-title} 1.10.0
 
-{gitops-title} 1.10.0 is now available on {OCP} 4.12, 4.13 and 4.14.
+{gitops-title} 1.10.0 is now available on {OCP} 4.12, 4.13, and 4.14.
 
 [id="errata-updates-1-10.0_{context}"]
 == Errata updates

--- a/modules/gitops-release-notes-1-10-1.adoc
+++ b/modules/gitops-release-notes-1-10-1.adoc
@@ -6,7 +6,7 @@
 [id="gitops-release-notes-1-10-1_{context}"]
 = Release notes for {gitops-title} 1.10.1
 
-{gitops-title} 1.10.1 is now available on {OCP} 4.12, 4.13 and 4.14.
+{gitops-title} 1.10.1 is now available on {OCP} 4.12, 4.13, and 4.14.
 
 [id="errata-updates-1-10.1_{context}"]
 == Errata updates


### PR DESCRIPTION
- Jira issue: [RHDEVDOCS-5706](https://issues.redhat.com/browse/RHDEVDOCS-5706)
- CherryPick versions: GitOps 1.10 branch
- Doc preview: [gitops-release-notes-1-10-0](https://67290--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-10-0_gitops-release-notes) and [gitops-release-notes-1-10-1](https://67290--docspreview.netlify.app/openshift-gitops/latest/release_notes/gitops-release-notes#gitops-release-notes-1-10-1_gitops-release-notes)
- OCP team: DevTools
- SME reviews by: **NOT REQUIRED**
- QE reviews by: **NOT REQUIRED**
- Peer reviews by: 