### PR TITLE
OSDOCS-8424 remove Infrastructure Node references from ROSA

### DIFF
--- a/modules/ossm-rn-new-features.adoc
+++ b/modules/ossm-rn-new-features.adoc
@@ -242,11 +242,15 @@ spec:
             PILOT_ENABLE_GATEWAY_API_DEPLOYMENT_CONTROLLER: "true"
 ----
 
+ifndef::openshift-rosa[]
+
 === Control plane deployment on infrastructure nodes
 {SMProductShortName} control plane deployment is now supported and documented on OpenShift infrastructure nodes. For more information, see the following documentation:
 
 * Configuring all {SMProductShortName} control plane components to run on infrastructure nodes
 * Configuring individual {SMProductShortName} control plane components to run on infrastructure nodes
+
+endif::openshift-rosa[]
 
 === Istio 1.16 support
 {SMProductShortName} 2.4 is based on Istio 1.16, which brings in new features and product enhancements. While many Istio 1.16 features are supported, the following exceptions should be noted:

--- a/service_mesh/v2x/installing-ossm.adoc
+++ b/service_mesh/v2x/installing-ossm.adoc
@@ -28,9 +28,13 @@ Do not install Community versions of the Operators. Community Operators are not 
 
 include::modules/ossm-install-ossm-operator.adoc[leveloffset=+1]
 
+ifndef::openshift-rosa[]
+
 include::modules/ossm-config-operator-infrastructure-node.adoc[leveloffset=+1]
 
 include::modules/ossm-confirm-operator-infrastructure-node.adoc[leveloffset=+1]
+
+endif::openshift-rosa[]
 
 == Next steps
 

--- a/service_mesh/v2x/ossm-create-smcp.adoc
+++ b/service_mesh/v2x/ossm-create-smcp.adoc
@@ -14,6 +14,8 @@ include::modules/ossm-control-plane-cli.adoc[leveloffset=+2]
 
 include::modules/ossm-validate-smcp-cli.adoc[leveloffset=+2]
 
+ifndef::openshift-rosa[]
+
 include::modules/ossm-about-control-plane-components-and-infrastructure-nodes.adoc[leveloffset=+1]
 
 include::modules/ossm-config-control-plane-infrastructure-node-console.adoc[leveloffset=+2]
@@ -25,6 +27,8 @@ include::modules/ossm-config-control-plane-infrastructure-node-cli.adoc[leveloff
 include::modules/ossm-config-individual-control-plane-infrastructure-node-cli.adoc[leveloffset=+2]
 
 include::modules/ossm-confirm-smcp-infrastructure-node.adoc[leveloffset=+2]
+
+endif::openshift-rosa[]
 
 include::modules/ossm-about-control-plane-and-cluster-wide-deployment.adoc[leveloffset=+1]
 


### PR DESCRIPTION
This PR removes references and procedures that direct users to run Service Mesh (RH Workloads) on Infrastructure Nodes.

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.13+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

https://issues.redhat.com/browse/OSDOCS-8424

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

Removed from these locations:
https://67291--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/installing-ossm

https://67291--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/ossm-create-smcp

https://67291--docspreview.netlify.app/openshift-rosa/latest/service_mesh/v2x/servicemesh-release-notes


QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
