### PR TITLE
OSDOCS-4738: include the machines' IP addresses in .spec.noProxy

### DIFF
--- a/networking/enable-cluster-wide-proxy.adoc
+++ b/networking/enable-cluster-wide-proxy.adoc
@@ -14,9 +14,14 @@ Production environments can deny direct access to the internet and instead have 
 +
 [NOTE]
 ====
-The Proxy object `status.noProxy` field is populated with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration.
+The Proxy object `status.noProxy` field is populated with the values of the `networking.machineNetwork[].cidr`, `networking.clusterNetwork[].cidr`, and `networking.serviceNetwork[]` fields from your installation configuration with most installation types.
 
 For installations on Amazon Web Services (AWS), Google Cloud Platform (GCP), Microsoft Azure, and {rh-openstack-first}, the `Proxy` object `status.noProxy` field is also populated with the instance metadata endpoint (`169.254.169.254`).
+====
++
+[IMPORTANT]
+====
+If your installation type does not include setting the `networking.machineNetwork[].cidr` field, you must include the machine IP addresses manually in the `.status.noProxy` field to make sure that the traffic between nodes can bypass the proxy.
 ====
 
 include::modules/nw-proxy-configure-object.adoc[leveloffset=+1]


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-4738

Link to docs preview:
[Enable cluster-wide proxy](https://67302--docspreview.netlify.app/openshift-enterprise/latest/networking/enable-cluster-wide-proxy)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
