### PR TITLE
[INTERNAL-FIX] fixed-kbase-link

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -943,14 +943,14 @@ For information about using the {secrets-store-operator} to mount secrets from a
 For more information, see xref:../storage/container_storage_interface/persistent-storage-csi-azure-file.adoc#persistent-storage-csi-azure-file-nfs_persistent-storage-csi-azure-file[NFS support].
 
 [id="ocp-4-14-oci"]
-=== Oracle&#174; Cloud Infrastructure
+=== Oracle(R) Cloud Infrastructure
 
 You can now install an {product-title} cluster on {oci-first} by using the Assisted installer or the Agent-based installer. For {product-title} {product-version}, {product-title} on {oci} is available as a Developer Preview feature.
 
 To install an {product-title} cluster on {oci}, choose one of the following installation options:
 
 * link:https://access.redhat.com/articles/7039183[Using the Assisted Installer to install a cluster on {oci-first}]
-* link:https://access.redhat.com/node/7038262/draft[Using the Agent-based Installer to install a cluster on {oci-first}]
+* link:https://access.redhat.com/node/7038262[Using the Agent-based Installer to install a cluster on {oci-first}]
 
 For more information about a Developer Preview feature, see link:https://access.redhat.com/support/offerings/devpreview[Developer Preview Support Scope] on the Red Hat Customer Portal.
 


### PR DESCRIPTION
INTERNAL FIXES:

* Asciidoc character subs does not render on CP
* Link had "draft" in URL

Version:
4.14

Preview link:
https://67320--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-oci
