### PR TITLE
OCPBUGS-07108: Adding disclaimer for Loki cluster-admin user role

### DIFF
--- a/modules/network-observability-lokistack-create.adoc
+++ b/modules/network-observability-lokistack-create.adoc
@@ -7,6 +7,9 @@
 = Creating a LokiStack custom resource
 You can deploy a LokiStack using the web console or CLI to create a namespace, or new project.
 
+include::snippets/logging-clusteradmin-access-logs-snip.adoc[]
+For more information about creating a `cluster-admin` group, see the "Additional resources" section.  
+
 .Procedure
 
 . Navigate to *Operators* -> *Installed Operators*, viewing *All projects* from the *Project* dropdown.

--- a/network_observability/installing-operators.adoc
+++ b/network_observability/installing-operators.adoc
@@ -27,6 +27,10 @@ include::modules/network-observability-loki-secret.adoc[leveloffset=+2]
 * For more information about the option to use different namespaces for the separate components, see the `spec.loki.tls.caCert.namespace` specification in the xref:../network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference] and callout number 5 in the xref:../network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource].
 
 include::modules/network-observability-lokistack-create.adoc[leveloffset=+2]
+[role="_additional-resources"]
+.Additional resources
+* xref:../logging/cluster-logging-loki.adoc#logging-creating-new-group-cluster-admin-user-role_cluster-logging-loki[Creating a new group for the cluster-admin user role]
+
 include::modules/network-observability-lokistack-ingestion-query.adoc[leveloffset=+2]
 include::modules/network-observability-auth-multi-tenancy.adoc[leveloffset=+2]
 include::modules/network-observability-multitenancy.adoc[leveloffset=+2]

--- a/snippets/logging-clusteradmin-access-logs-snip.adoc
+++ b/snippets/logging-clusteradmin-access-logs-snip.adoc
@@ -4,6 +4,7 @@
 // Text snippet included in the following modules:
 //
 // * modules/logging-creating-new-group-cluster-admin-user-role.adoc
+// * modules/network-observability-lokistack-create.adoc
 //
 :_mod-docs-content-type: SNIPPET
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.11+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OCPBUGS-17108
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://67334--docspreview.netlify.app/openshift-enterprise/latest/network_observability/installing-operators#network-observability-lokistack-create_network_observability
QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
