### PR TITLE
Fixes broken xrefs found while troubleshooting

### DIFF
--- a/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
+++ b/installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc
@@ -70,22 +70,22 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-requirements-user-infra_installing-bare-metal[Requirements for a cluster with user-provisioned infrastructure]
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#creating-machines-bare-metal_installing-bare-metal[Installing {op-system} and starting the {product-title} bootstrap process]
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-host-names-dhcp-user-infra_installing-bare-metal[Setting the cluster node hostnames through DHCP]
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-user-infra-machines-advanced_installing-bare-metal[Advanced RHCOS installation configuration]
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-network-user-infra_installing-bare-metal[Networking requirements for user-provisioned infrastructure]
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal[User-provisioned DNS requirements]
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-user-provisioned-validating-dns_installing-bare-metal[Validating DNS resolution for user-provisioned infrastructure]
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-load-balancing-user-infra_installing-bare-metal[Load balancing requirements for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-requirements-user-infra_installing-bare-metal-network-customizations[Requirements for a cluster with user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#creating-machines-bare-metal_installing-bare-metal-network-customizations[Installing {op-system} and starting the {product-title} bootstrap process]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-host-names-dhcp-user-infra_installing-bare-metal-network-customizations[Setting the cluster node hostnames through DHCP]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-user-infra-machines-advanced_installing-bare-metal-network-customizations[Advanced RHCOS installation configuration]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-network-user-infra_installing-bare-metal-network-customizations[Networking requirements for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal-network-customizations[User-provisioned DNS requirements]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-user-provisioned-validating-dns_installing-bare-metal-network-customizations[Validating DNS resolution for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-load-balancing-user-infra_installing-bare-metal-network-customizations[Load balancing requirements for user-provisioned infrastructure]
 
 include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal[User-provisioned DNS requirements]
-* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-load-balancing-user-infra_installing-bare-metal[Load balancing requirements for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-dns-user-infra_installing-bare-metal-network-customizations[User-provisioned DNS requirements]
+* xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-load-balancing-user-infra_installing-bare-metal-network-customizations[Load balancing requirements for user-provisioned infrastructure]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
@@ -109,7 +109,7 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-load-balancing-user-infra_installing-bare-metal[Load balancing requirements for user-provisioned infrastructure] for more information on the API and application ingress load balancing requirements.
+* See xref:../../installing/installing_bare_metal/installing-bare-metal-network-customizations.adoc#installation-load-balancing-user-infra_installing-bare-metal-network-customizations[Load balancing requirements for user-provisioned infrastructure] for more information on the API and application ingress load balancing requirements.
 
 // Network Operator specific configuration
 include::modules/nw-network-config.adoc[leveloffset=+1]

--- a/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
+++ b/installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc
@@ -62,7 +62,7 @@ include::modules/csr-management.adoc[leveloffset=+2]
 .Additional resources
 
 * See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-three-node-cluster_installing-restricted-networks-bare-metal[Configuring a three-node cluster] for details about deploying three-node clusters in bare metal environments.
-* See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-approve-csrs_installing-bare-metal[Approving the certificate signing requests for your machines] for more information about approving cluster certificate signing requests after installation.
+* See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-approve-csrs_installing-restricted-networks-bare-metal[Approving the certificate signing requests for your machines] for more information about approving cluster certificate signing requests after installation.
 
 include::modules/installation-network-user-infra.adoc[leveloffset=+2]
 
@@ -76,7 +76,7 @@ include::modules/installation-dns-user-infra.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-user-provisioned-validating-dns_installing-bare-metal[Validating DNS resolution for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-user-provisioned-validating-dns_installing-restricted-networks-bare-metal[Validating DNS resolution for user-provisioned infrastructure]
 
 include::modules/installation-load-balancing-user-infra.adoc[leveloffset=+2]
 
@@ -85,22 +85,22 @@ include::modules/installation-infrastructure-user-infra.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-requirements-user-infra_installing-bare-metal[Requirements for a cluster with user-provisioned infrastructure]
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#creating-machines-bare-metal_installing-bare-metal[Installing {op-system} and starting the {product-title} bootstrap process]
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-host-names-dhcp-user-infra_installing-bare-metal[Setting the cluster node hostnames through DHCP]
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-user-infra-machines-advanced_installing-bare-metal[Advanced RHCOS installation configuration]
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-network-user-infra_installing-bare-metal[Networking requirements for user-provisioned infrastructure]
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-dns-user-infra_installing-bare-metal[User-provisioned DNS requirements]
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-user-provisioned-validating-dns_installing-bare-metal[Validating DNS resolution for user-provisioned infrastructure]
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-load-balancing-user-infra_installing-bare-metal[Load balancing requirements for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-requirements-user-infra_installing-restricted-networks-bare-metal[Requirements for a cluster with user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#creating-machines-bare-metal_installing-restricted-networks-bare-metal[Installing {op-system} and starting the {product-title} bootstrap process]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-host-names-dhcp-user-infra_installing-restricted-networks-bare-metal[Setting the cluster node hostnames through DHCP]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-user-infra-machines-advanced_installing-restricted-networks-bare-metal[Advanced RHCOS installation configuration]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-network-user-infra_installing-restricted-networks-bare-metal[Networking requirements for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-dns-user-infra_installing-restricted-networks-bare-metal[User-provisioned DNS requirements]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-user-provisioned-validating-dns_installing-restricted-networks-bare-metal[Validating DNS resolution for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-load-balancing-user-infra_installing-restricted-networks-bare-metal[Load balancing requirements for user-provisioned infrastructure]
 
 include::modules/installation-user-provisioned-validating-dns.adoc[leveloffset=+1]
 
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-dns-user-infra_installing-bare-metal[User-provisioned DNS requirements]
-* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-load-balancing-user-infra_installing-bare-metal[Load balancing requirements for user-provisioned infrastructure]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-dns-user-infra_installing-restricted-networks-bare-metal[User-provisioned DNS requirements]
+* xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-load-balancing-user-infra_installing-restricted-networks-bare-metal[Load balancing requirements for user-provisioned infrastructure]
 
 include::modules/ssh-agent-using.adoc[leveloffset=+1]
 
@@ -124,7 +124,7 @@ include::modules/installation-bare-metal-config-yaml.adoc[leveloffset=+2]
 [role="_additional-resources"]
 .Additional resources
 
-* See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-load-balancing-user-infra_installing-bare-metal[Load balancing requirements for user-provisioned infrastructure] for more information on the API and application ingress load balancing requirements.
+* See xref:../../installing/installing_bare_metal/installing-restricted-networks-bare-metal.adoc#installation-load-balancing-user-infra_installing-restricted-networks-bare-metal[Load balancing requirements for user-provisioned infrastructure] for more information on the API and application ingress load balancing requirements.
 
 include::modules/installation-configure-proxy.adoc[leveloffset=+2]
 


### PR DESCRIPTION
Version(s):
4.11+ 
(files exist for all current versions)

Issue:
[OSDOCS-8462](https://issues.redhat.com//browse/OSDOCS-8462)

Link to docs preview:
* [Installing a user-provisioned bare metal cluster with network customizations](https://67335--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-bare-metal-network-customizations)
* [Installing a user-provisioned bare metal cluster on a restricted network](https://67335--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_bare_metal/installing-restricted-networks-bare-metal)

QE review:
N/A, fixing xrefs within assemblies

Additional information:
Internal xrefs in these two assemblies used the context id for the "normal" bare-metal assembly instead of their own. 
- [X] Will run this by the install writing team to verify.