### PR TITLE
OSDOCS-8463: add build file 4.15 relnotes MicroShift

### DIFF
--- a/_topic_maps/_topic_map_ms.yml
+++ b/_topic_maps/_topic_map_ms.yml
@@ -33,8 +33,8 @@ Name: Release notes
 Dir: microshift_release_notes
 Distros: microshift
 Topics:
-- Name: Red Hat build of MicroShift 4.14 release notes
-  File: microshift-4-14-release-notes
+- Name: Red Hat build of MicroShift 4.15 release notes
+  File: microshift-4-15-release-notes
 ---
 Name: Getting started
 Dir: microshift_getting_started

--- a/microshift_networking/microshift-networking-settings.adoc
+++ b/microshift_networking/microshift-networking-settings.adoc
@@ -42,4 +42,4 @@ include::modules/microshift-mDNS.adoc[leveloffset=+1]
 [id="additional-resources_microshift-understanding-networking-settings_{context}"]
 [role="_additional-resources"]
 == Additional resources
-* xref:../microshift_release_notes/microshift-4-14-release-notes.adoc#microshift-4-14-known-issues[{microshift-short} {product-version} release notes --> Known issues]
+* xref:../microshift_release_notes/microshift-4-15-release-notes.adoc#microshift-4-15-known-issues[{microshift-short} {product-version} release notes --> Known issues]

--- a/microshift_release_notes/microshift-4-15-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-15-release-notes.adoc
@@ -1,0 +1,12 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="microshift-4-15-release-notes"]
+= {product-title} {product-version} release notes
+include::_attributes/attributes-microshift.adoc[]
+:context: release-notes
+
+Do not add or edit release notes here. Edit release notes directly in the branch
+that they are relevant for.
+
+Release note changes should be added/edited in their own PR.
+
+This file is here to allow builds to work.

--- a/microshift_welcome/index.adoc
+++ b/microshift_welcome/index.adoc
@@ -16,7 +16,7 @@ To get started with {microshift-short}, use the following links:
 
 * xref:../microshift_getting_started/microshift-understanding.adoc#microshift-understanding[Understanding {product-title}]
 * xref:../microshift_install/microshift-install-rpm.adoc#microshift-install-rpm[Installing {product-title}]
-* xref:../microshift_release_notes/microshift-4-14-release-notes.adoc#microshift-4-14-release-notes[{product-title} release notes]
+* xref:../microshift_release_notes/microshift-4-15-release-notes.adoc#microshift-4-15-release-notes[{product-title} release notes]
 
 For related information, use the following links:
 


### PR DESCRIPTION
Version(s):
Main

PR 1 of 2 setting up MicroShift 4.15 release notes

Issue:
https://issues.redhat.com/browse/OSDOCS-8463

Link to docs preview:
[Release notes build file](https://67337--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes)

QE review:
- N/A, docs plumbing

Additional info: Updating version info in [67345](https://github.com/openshift/openshift-docs/pull/67345).

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
