### PR TITLE
OADP-2736: Restoring to a different cluster with OADP with STS enabled ROSA

### DIFF
--- a/modules/oadp-installing-oadp-rosa-sts.adoc
+++ b/modules/oadp-installing-oadp-rosa-sts.adoc
@@ -16,7 +16,7 @@ Restic is not supported in the OADP on ROSA with AWS STS environment. Ensure the
 
 .Prerequisites
 
-* A ROSA OpenShift Cluster with the required access and tokens. For instructions, see the procedure in _Preparing AWS credentials_.
+* A {openshift-rosa} cluster with the required access and tokens. For instructions, see the procedure in "Preparing AWS credentials". If you plan to use two different clusters for backing up and restoring, you need to prepare AWS credentials, including `ROLE_ARN`, for each cluster.
 
 
 .Procedure
@@ -74,7 +74,7 @@ spec:
 EOF
 ----
 
-. Create the `DataProtectionApplication resource`, which is used to configure the connection to the storage where the backups and volume snapshots will be stored:
+. Create the `DataProtectionApplication` resource, which is used to configure the connection to the storage where the backups and volume snapshots are stored:
 +
 [source,terminal]
 ----
@@ -100,28 +100,49 @@ spec:
       defaultPlugins:
       - openshift
       - aws
-    restic:
+    nodeAgent: <1>
       enable: false
+      uploaderType: restic
   snapshotLocations:
     - velero:
         config:
-          credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials <1>
-          enableSharedConfig: "true" <2>
-          profile: default <3>
-          region: ${REGION} <4>
+          credentialsFile: /tmp/credentials/openshift-adp/cloud-credentials-credentials <2>
+          enableSharedConfig: "true" <3>
+          profile: default <4>
+          region: ${REGION} <5>
         provider: aws
 EOF
 ----
+<1> See the first note below.
+<2> The `credentialsFile` field is the mounted location of the bucket credential on the pod.
+<3> The `enableSharedConfig` field allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
+<4> Use the profile name set in the AWS credentials file.
+<5> Specify `region` as your AWS region. This must be the same as the cluster region.
++
+You are now ready to backup and restore OpenShift applications, as described in the link:https://docs.openshift.com/container-platform/4.11/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html[OADP documentation].
 
-+
-<1> The `credentialsFile` is the mounted location of the bucket credential on the pod.
-<2> The `enableSharedConfig` allows the `snapshotLocations` to share or reuse the credential defined for the bucket.
-<3> Assume your Velero default for your `profile: default`.
-<4> Specify `region` as your AWS region. This must be the same as the cluster region.
-+
 [NOTE]
 ====
 The `enable` parameter of `restic` is set to `false` in this configuration because OADP does not support Restic in ROSA environments.
+
+If you are using OADP 1.2, replace this configuration:
+[source,terminal]
+
+----
+nodeAgent:
+  enable: false
+  uploaderType: restic
+----
+with the following:
+
+[source,terminal]
+----
+restic:
+  enable: false
+----
 ====
-+
-You are now ready to backup and restore OpenShift applications, as described in the link:https://docs.openshift.com/container-platform/4.11/backup_and_restore/application_backup_and_restore/backing_up_and_restoring/backing-up-applications.html[OADP documentation].
+
+[NOTE]
+====
+If you want to use two different clusters for backing up and restoring, the two clusters must have identical AWS S3 storage names in both the cloudstorage CR and the OADP `DataProtectionApplication` configuration.
+====

--- a/rosa_backing_up_and_restoring_applications/backing-up-applications.adoc
+++ b/rosa_backing_up_and_restoring_applications/backing-up-applications.adoc
@@ -25,7 +25,7 @@ include::modules/oadp-installing-oadp-rosa-sts.adoc[leveloffset=+1]
 
 [id="rosa-backing-up-applications-known-issues"]
 == Known issues
-.Restic is not supported or recommended
+.Restic, Kopia, and DataMover are not supported or recommended
 
 * link:https://issues.redhat.com/browse/OADP-1054[CloudStorage: openshift-adp-controller-manager crashloop seg fault with Restic enabled]
 * link:https://issues.redhat.com/browse/OADP-1057[Cloudstorage API: CSI Backup of an app with internal images partially fails with plugin panicked error]


### PR DESCRIPTION
Resolves: https://issues.redhat.com/browse/OADP-2736

OADP 1.3

OCP 4.12+

Preview: https://67339--docspreview.netlify.app/openshift-rosa/latest/rosa_backing_up_and_restoring_applications/backing-up-applications#oadp-installing-oadp-rosa-sts_rosa-backing-up-applications