### PR TITLE
Changed links from html to adoc

### DIFF
--- a/osd_getting_started/osd-getting-started.adoc
+++ b/osd_getting_started/osd-getting-started.adoc
@@ -53,7 +53,7 @@ include::modules/osd-grant-admin-privileges.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../osd_architecture/osd_policy/osd-service-definition.html#cluster-admin-user_osd-service-definition[Cluster administrator user]
+* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#cluster-admin-user_osd-service-definition[Customer administrator user]
 
 include::modules/access-cluster.adoc[leveloffset=+1]
 include::modules/deploy-app.adoc[leveloffset=+1]

--- a/osd_install_access_delete_cluster/config-identity-providers.adoc
+++ b/osd_install_access_delete_cluster/config-identity-providers.adoc
@@ -19,6 +19,6 @@ include::modules/config-htpasswd-idp.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../osd_architecture/osd_policy/osd-service-definition.html#cluster-admin-user_osd-service-definition[Cluster administrator user]
+* xref:../osd_architecture/osd_policy/osd-service-definition.adoc#cluster-admin-user_osd-service-definition[Customer administrator user]
 
 include::modules/access-cluster.adoc[leveloffset=+1]

--- a/rosa_getting_started/rosa-getting-started.adoc
+++ b/rosa_getting_started/rosa-getting-started.adoc
@@ -66,7 +66,7 @@ include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+2
 .Additional resources
 
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-cluster-admin-role_rosa-service-definition[Cluster administration role]
-* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Cluster administrator user]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Customer administrator user]
 
 include::modules/rosa-getting-started-access-cluster-web-console.adoc[leveloffset=+1]
 include::modules/deploy-app.adoc[leveloffset=+1]

--- a/rosa_getting_started/rosa-quickstart-guide-ui.adoc
+++ b/rosa_getting_started/rosa-quickstart-guide-ui.adoc
@@ -122,7 +122,7 @@ include::modules/rosa-getting-started-grant-admin-privileges.adoc[leveloffset=+2
 .Additional resources
 
 * xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-cluster-admin-role_rosa-service-definition[Cluster administration role]
-* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Cluster administrator user]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Customer administrator user]
 
 //This content is pulled from rosa-getting-started-access-cluster-web-console.adoc
 include::modules/rosa-getting-started-access-cluster-web-console.adoc[leveloffset=+1]

--- a/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc
+++ b/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster.adoc
@@ -24,7 +24,7 @@ include::modules/rosa-create-dedicated-cluster-admins.adoc[leveloffset=+1]
 [role="_additional-resources"]
 .Additional resources
 
-* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.html#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Cluster administrator user]
+* xref:../rosa_architecture/rosa_policy_service_definition/rosa-service-definition.adoc#rosa-sdpolicy-customer-admin-user_rosa-service-definition[Customer administrator user]
 
 [role="_additional-resources"]
 == Additional resources


### PR DESCRIPTION
After merging https://github.com/openshift/openshift-docs/pull/65765, I noticed that we missed a few instances where the links used `.html` instead of `.adoc`. This PR fixes those instances. 

Previews
[Granting administrator privileges to a user](https://67353--docspreview.netlify.app/openshift-dedicated/latest/osd_getting_started/osd-getting-started)
[Configuring an htpasswd identity provider](https://67353--docspreview.netlify.app/openshift-dedicated/latest/osd_install_access_delete_cluster/config-identity-providers#config-htpasswd-idp_config-identity-providers)
[Configuring an identity provider and granting cluster access](https://67353--docspreview.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-quickstart-guide-ui#rosa-getting-started-configure-an-idp-and-grant-access_rosa-quickstart-guide-ui)
[Granting administrator privileges to a user](https://67353--docspreview.netlify.app/openshift-rosa/latest/rosa_getting_started/rosa-getting-started#rosa-getting-started-grant-admin-privileges_rosa-getting-started)
[Granting cluster-admin access](https://67353--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa-sts-accessing-cluster#rosa-create-cluster-admins_rosa-sts-accessing-cluster)