### PR TITLE
OCPBUGS#22191: Removed duplicate any

### DIFF
--- a/nodes/pods/nodes-pods-autoscaling.adoc
+++ b/nodes/pods/nodes-pods-autoscaling.adoc
@@ -10,7 +10,7 @@ As a developer, you can use a horizontal pod autoscaler (HPA) to
 specify how {product-title} should automatically increase or decrease the scale of
 a replication controller or deployment configuration, based on metrics collected
 from the pods that belong to that replication controller or deployment
-configuration. You can create an HPA for any any deployment, deployment config, replica set, replication controller, or stateful set.
+configuration. You can create an HPA for any deployment, deployment config, replica set, replication controller, or stateful set.
 
 For information on scaling pods based on custom metrics, see xref:../../nodes/cma/nodes-cma-autoscaling-custom.adoc#nodes-cma-autoscaling-custom[Automatically scaling pods based on custom metrics].
 


### PR DESCRIPTION
[OCPBUGS-22191](https://issues.redhat.com/browse/OCPBUGS-22191)

Version(s):
4.15, 4.14, 4.13, 4.12, 4.11

Link to docs preview:
[Automatically scaling pods with the horizontal pod autoscaler](https://67359--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-autoscaling)

QE review:
- [ ] QE approval not required.