### PR TITLE
OCPBUGS-22918: Fixing instances where TP features use support terminology

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -824,12 +824,12 @@ You can use the `EgressService` CR to manage egress traffic in the following way
 For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-egress-traffic-for-vrf-loadbalancer-services.adoc#configuring-egress-traffic-loadbalancer-services[Configuring an egress service].
 
 [id="ocp-4-14-networking-metallb-vrf"]
-==== Support for VRF specification in MetalLB's BGPPeer resource (Technology Preview)
+==== VRF specification in MetalLB's BGPPeer resource (Technology Preview)
 
 With this update, you can specify a Virtual Routing and Forwarding (VRF) instance in a `BGPPeer` custom resource. MetalLB can advertise services through the interfaces belonging to the VRF. This is available as a Technology Preview feature. For more information, see xref:../networking/metallb/metallb-configure-bgp-peers.adoc#nw-metallb-bgp-peer-vrf_configure-metallb-bgp-peers[Exposing a service through a network VRF].
 
 [id="ocp-4-14-networking-nmstate-vrf"]
-==== Support for VRF specification in NMState's NodeNetworkConfigurationPolicy resource (Technology Preview)
+==== VRF specification in NMState's NodeNetworkConfigurationPolicy resource (Technology Preview)
 
 With this update, you can associate a Virtual Routing and Forwarding (VRF) instance with a network interface by using a `NodeNetworkConfigurationPolicy` custom resource. By associating a VRF instance with a network interface, you can support traffic isolation, independent routing decisions, and the logical separation of network resources. This feature is available as a Technology Preview feature. For more information, see xref:../networking/k8s_nmstate/k8s-nmstate-updating-node-network-config.adoc#virt-example-host-vrf_k8s_nmstate-updating-node-network-config[Example: Network interface with a VRF instance node network configuration policy].
 
@@ -880,9 +880,9 @@ Certain HTTP request and response headers can now be set or deleted either globa
 For more information, see xref:../networking/ingress-operator.adoc#nw-ingress-set-or-delete-http-headers_configuring-ingress[Setting or deleting HTTP request and response headers in an Ingress Controller] and xref:../networking/routes/route-configuration.adoc#nw-route-set-or-delete-http-headers_route-configuration[Setting or deleting HTTP request and response headers in a route].
 
 [id="ocp-4-14-egress-ips-additional-networks"]
-==== Support for egress IPs on additional network interfaces
+==== Egress IPs on additional network interfaces
 
-Support for egress IPs addresses on additional network interfaces is now available as a Technology Preview feature. This feature provides {product-title} administrators with a greater level of control over networking aspects such as routing, addressing, segmentation, and security policies. You can also route workload traffic over specific network interfaces for purposes such as traffic segmentation or meeting specialized requirements.
+You can use egress IPs addresses on additional network interfaces as a Technology Preview feature. This feature provides {product-title} administrators with a greater level of control over networking aspects such as routing, addressing, segmentation, and security policies. You can also route workload traffic over specific network interfaces for purposes such as traffic segmentation or meeting specialized requirements.
 
 For more information, see xref:../networking/ovn_kubernetes_network_provider/configuring-egress-ips-ovn.adoc#nw-egress-ips-multi-nic-considerations_configuring-egress-ips-ovn[Considerations for using an egress IP on additional network interfaces].
 
@@ -912,7 +912,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 [id="ocp-4-14-storage-rwop-access-mode"]
 ==== Read Write Once Pod access mode (Technology Preview)
-{product-title} {product-version} introduces a new access mode for persistent volumes (PVs) and persistent volume claims (PVCs) called ReadWriteOncePod (RWOP), which can be used only in a single pod on a single node. This is compared to the existing ReadWriteOnce access mode where a PV or PVC can be used on a single node by many pods. This feature is supported with Technology Preview status.
+{product-title} {product-version} introduces a new access mode for persistent volumes (PVs) and persistent volume claims (PVCs) called ReadWriteOncePod (RWOP), which can be used only in a single pod on a single node. This is compared to the existing ReadWriteOnce access mode where a PV or PVC can be used on a single node by many pods. This is available as a Technology Preview feature.
 
 For more information, see xref:../storage/understanding-persistent-storage.adoc#pv-access-modes_understanding-persistent-storage[Access modes].
 
@@ -932,7 +932,7 @@ For more information, see xref:../storage/container_storage_interface/persistent
 
 [id="ocp-4-14-storage-secrets-store-csi-driver-operator"]
 ==== Secrets Store CSI Driver Operator (Technology Preview)
-The Secrets Store Container Storage Interface (CSI) Driver Operator, `secrets-store.csi.k8s.io`, allows {product-title} to mount multiple secrets, keys, and certificates stored in enterprise-grade external secrets stores into pods as an inline ephemeral volume. The Secrets Store CSI Driver Operator communicates with the provider using gRPC to fetch the mount contents from the specified external secrets store. After the volume is attached, the data in it is mounted into the container’s file system. This feature is supported with Technology Preview status. For more information about the {secrets-store-driver}, see xref:../storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc#persistent-storage-csi-secrets-store[{secrets-store-driver}].
+The Secrets Store Container Storage Interface (CSI) Driver Operator, `secrets-store.csi.k8s.io`, allows {product-title} to mount multiple secrets, keys, and certificates stored in enterprise-grade external secrets stores into pods as an inline ephemeral volume. The Secrets Store CSI Driver Operator communicates with the provider using gRPC to fetch the mount contents from the specified external secrets store. After the volume is attached, the data in it is mounted into the container’s file system. This is available as a Technology Preview feature. For more information about the {secrets-store-driver}, see xref:../storage/container_storage_interface/persistent-storage-csi-secrets-store.adoc#persistent-storage-csi-secrets-store[{secrets-store-driver}].
 
 For information about using the {secrets-store-operator} to mount secrets from an external secrets store to a CSI volume, see xref:../nodes/pods/nodes-pods-secrets-store.adoc#nodes-pods-secrets-store[Providing sensitive data to pods by using an external secrets store].
 
@@ -1074,7 +1074,7 @@ For more information, see xref:../machine_management/control_plane_machine_manag
 With this release, you can configure a machine set to deploy machines within an existing AWS placement group. You can use this feature with Elastic Fabric Adapter (EFA) instances to improve network performance for machines within the specified placement group. You can use this feature with xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machineset-aws-existing-placement-group_creating-machineset-aws[compute] and xref:../machine_management/control_plane_machine_management/cpmso-using.adoc#machineset-aws-existing-placement-group_cpmso-using[control plane] machine sets.
 
 [id="ocp-4-14-mapi-azure-confidential-compute"]
-==== Support for Azure confidential VMs and trusted launch (Technology Preview)
+==== Azure confidential VMs and trusted launch (Technology Preview)
 
 With this release, you can configure a machine set to deploy machines that use Azure confidential VMs, trusted launch, or both. These machines can use Unified Extensible Firmware Interface (UEFI) security features such as Secure Boot or a dedicated virtual Trusted Platform Module (vTPM) instance.
 
@@ -1233,9 +1233,9 @@ With this release, you have more control over the C-states for your pods. Now, i
 With this update, you can provision IPv6 address spoke clusters from dual-stack hub clusters. In a zero touch provisioning (ZTP) environment, the HTTP server on the hub cluster that hosts the boot ISO now listens on both IPv4 and IPv6 networks. The provisioning service also checks the baseboard management controller (BMC) address scheme on the target spoke cluster and provides a matching URL for the installation media. These updates offer the ability to provision single-stack, IPv6 spoke clusters from a dual-stack hub cluster.
 
 [id="ocp-4-14-nw-shiftstack-dual-stack"]
-==== Support for dual-stack networking for {rh-openstack} clusters (Technology Preview)
+==== Dual-stack networking for {rh-openstack} clusters (Technology Preview)
 
-Dual-stack network configuration is now available for clusters that run on {rh-openstack}. You can configure dual-stack networking during the deployment of a cluster on installer-provisioned infrastructure.
+Dual-stack network configuration is now available for clusters that run on {rh-openstack}. This is a Technology Preview feature. You can configure dual-stack networking during the deployment of a cluster on installer-provisioned infrastructure.
 
 For more information, see xref:../installing/installing_openstack/installing-openstack-installer-custom.adoc#install-osp-dualstack_installing-openstack-installer-custom[Configuring a cluster with dual-stack networking].
 


### PR DESCRIPTION
There are instances in the RNs where the phrase "support" was used in relation to Tech Preview features, which are not supported by Red Hat. This PR removes these instances to avoid any confusion.

Issue:
https://issues.redhat.com/browse/OCPBUGS-22918

Version(s):
4.14

Link to docs preview:
https://67360--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes
