### PR TITLE
Converting GCP parameters into stacked format

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -1387,51 +1387,82 @@ ifdef::gcp[]
 Additional GCP configuration parameters are described in the following table:
 
 .Additional GCP parameters
-[cols=".^1,.^6a,.^3a",options="header"]
+[cols=".^1l,.^6a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`controlPlane.platform.gcp.osImage.project`
+|controlPlane:
+  platform:
+    gcp:
+      osImage:
+        project:
 |Optional. By default, the installation program downloads and installs the {op-system-first} image that is used to boot control plane machines. You can override the default behavior by specifying the location of a custom {op-system} image that the installation program is to use for control plane machines only.
 |String. The name of GCP project where the image is located.
 
-|`controlPlane.platform.gcp.osImage.name`
+|controlPlane:
+  platform:
+    gcp:
+      osImage:
+        name:
 |The name of the custom {op-system} image that the installation program is to use to boot control plane machines. If you use `controlPlane.platform.gcp.osImage.project`, this field is required.
 |String. The name of the {op-system} image.
 
-|`compute.platform.gcp.osImage.project`
+|compute:
+  platform:
+    gcp:
+      osImage:
+        project:
 |Optional. By default, the installation program downloads and installs the {op-system} image that is used to boot compute machines. You can override the default behavior by specifying the location of a custom {op-system} image that the installation program is to use for compute machines only.
 |String. The name of GCP project where the image is located.
 
-|`compute.platform.gcp.osImage.name`
+|compute:
+  platform:
+    gcp:
+      osImage:
+        name:
 |The name of the custom {op-system} image that the installation program is to use to boot compute machines. If you use `compute.platform.gcp.osImage.project`, this field is required.
 |String. The name of the {op-system} image.
 
-|`platform.gcp.network`
+|platform:
+  gcp:
+    network:
 |The name of the existing Virtual Private Cloud (VPC) where you want to deploy your cluster. If you want to deploy your cluster into a shared VPC, you must set `platform.gcp.networkProjectID` with the name of the GCP project that contains the shared VPC.
 |String.
 
-|`platform.gcp.networkProjectID`
+|platform:
+  gcp:
+    networkProjectID:
 |Optional. The name of the GCP project that contains the shared VPC where you want to deploy your cluster.
 |String.
 
-|`platform.gcp.projectID`
+|platform:
+  gcp:
+    projectID:
 |The name of the GCP project where the installation program installs the cluster.
 |String.
 
-|`platform.gcp.region`
+|platform:
+  gcp:
+    region:
 |The name of the GCP region that hosts your cluster.
 |Any valid region name, such as `us-central1`.
 
-|`platform.gcp.controlPlaneSubnet`
+|platform:
+  gcp:
+    controlPlaneSubnet:
 |The name of the existing subnet where you want to deploy your control plane machines.
 |The subnet name.
 
-|`platform.gcp.computeSubnet`
+|platform:
+  gcp:
+    computeSubnet:
 |The name of the existing subnet where you want to deploy your compute machines.
 |The subnet name.
 
-|`platform.gcp.defaultMachinePlatform.zones`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      zones:
 |The availability zones where the installation program creates machines.
 |A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
@@ -1440,99 +1471,205 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use a zone where Ampere Altra Arm CPU's are available. You can find which zones are compatible with 64-bit ARM processors in the "GCP availability zones" link.
 ====
 
-|`platform.gcp.defaultMachinePlatform.osDisk.diskSizeGB`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      osDisk:
+        diskSizeGB:
 |The size of the disk in gigabytes (GB).
 |Any size between 16 GB and 65536 GB.
 
-|`platform.gcp.defaultMachinePlatform.osDisk.diskType`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      osDisk:
+        diskType:
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type].
 |The default disk type for all machines. Control plane nodes must use the `pd-ssd` disk type. Compute nodes can use the `pd-ssd`, `pd-balanced`, or `pd-standard` disk types.
 
-|`platform.gcp.defaultMachinePlatform.osImage.project`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      osImage:
+        project:
 |Optional. By default, the installation program downloads and installs the {op-system} image that is used to boot control plane and compute machines. You can override the default behavior by specifying the location of a custom {op-system} image that the installation program is to use for both types of machines.
 |String. The name of GCP project where the image is located.
 
-|`platform.gcp.defaultMachinePlatform.osImage.name`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      osImage:
+        name:
 |The name of the custom {op-system} image that the installation program is to use to boot control plane and compute machines. If you use `platform.gcp.defaultMachinePlatform.osImage.project`, this field is required.
 |String. The name of the RHCOS image.
 
-|`platform.gcp.defaultMachinePlatform.tags`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      tags:
 |Optional. Additional network tags to add to the control plane and compute machines.
 |One or more strings, for example `network-tag1`.
 
-|`platform.gcp.defaultMachinePlatform.type`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      type:
 |The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane and compute machines.
 |The GCP machine type, for example `n1-standard-4`.
 
-|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.name`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            name:
 |The name of the customer managed encryption key to be used for machine disk encryption.
 |The encryption key name.
 
-|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.keyRing`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            keyRing:
 |The name of the Key Management Service (KMS) key ring to which the KMS key belongs.
 |The KMS key ring name.
 
-|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.location`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            location:
 |The link:https://cloud.google.com/kms/docs/locations[GCP location] in which the KMS key ring exists.
 |The GCP location.
 
-|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKey.projectID`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            projectID:
 |The ID of the project in which the KMS key ring exists. This value defaults to the value of the `platform.gcp.projectID` parameter if it is not set.
 |The GCP project ID.
 
-|`platform.gcp.defaultMachinePlatform.osDisk.encryptionKey.kmsKeyServiceAccount`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      osDisk:
+        encryptionKey:
+          kmsKeyServiceAccount:
 |The GCP service account used for the encryption request for control plane and compute machines. If absent, the Compute Engine default service account is used. For more information about GCP service accounts, see Google's documentation on link:https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account[service accounts].
 |The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
 
-|`platform.gcp.defaultMachinePlatform.secureBoot`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      secureBoot:
 |Whether to enable Shielded VM secure boot for all machines in the cluster. Shielded VMs have additional security protocols such as secure boot, firmware and integrity monitoring, and rootkit protection. For more information on Shielded VMs, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
 |`Enabled` or `Disabled`. The default value is `Disabled`.
 
-|`platform.gcp.defaultMachinePlatform.confidentialCompute`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      confidentialCompute:
 |Whether to use Confidential VMs for all machines in the cluster. Confidential VMs provide encryption for data during processing. For more information on Confidential computing, see Google's documentation on link:https://cloud.google.com/confidential-computing[Confidential computing].
 |`Enabled` or `Disabled`. The default value is `Disabled`.
 
-|`platform.gcp.defaultMachinePlatform.onHostMaintenance`
+|platform:
+  gcp:
+    defaultMachinePlatform:
+      onHostMaintenance:
 |Specifies the behavior of all VMs during a host maintenance event, such as a software or hardware update. For Confidential VMs, this parameter must be set to `Terminate`. Confidential VMs do not support live VM migration.
 |`Terminate` or `Migrate`. The default value is `Migrate`.
 
-|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.name`
+|controlPlane:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            name:
 |The name of the customer managed encryption key to be used for control plane machine disk encryption.
 |The encryption key name.
 
-|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.keyRing`
+|controlPlane:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            keyRing:
 |For control plane machines, the name of the KMS key ring to which the KMS key belongs.
 |The KMS key ring name.
 
-|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.location`
+|controlPlane:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            location:
 |For control plane machines, the GCP location in which the key ring exists. For more information about KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
 |The GCP location for the key ring.
 
-|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKey.projectID`
+|controlPlane:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            projectID:
 |For control plane machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
 |The GCP project ID.
 
-|`controlPlane.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
+|controlPlane:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKeyServiceAccount:
 |The GCP service account used for the encryption request for control plane machines. If absent, the Compute Engine default service account is used. For more information about GCP service accounts, see Google's documentation on link:https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account[service accounts].
 |The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
 
-|`controlPlane.platform.gcp.osDisk.diskSizeGB`
+|controlPlane:
+  platform:
+    gcp:
+      osDisk:
+        diskSizeGB:
 |The size of the disk in gigabytes (GB). This value applies to control plane machines.
 |Any integer between 16 and 65536.
 
-|`controlPlane.platform.gcp.osDisk.diskType`
+|controlPlane:
+  platform:
+    gcp:
+      osDisk:
+        diskType:
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for control plane machines.
 |Control plane machines must use the `pd-ssd` disk type, which is the default.
 
-|`controlPlane.platform.gcp.tags`
+|controlPlane:
+  platform:
+    gcp:
+      tags:
 |Optional. Additional network tags to add to the control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.tags` parameter for control plane machines.
 |One or more strings, for example `control-plane-tag1`.
 
-|`controlPlane.platform.gcp.type`
+|controlPlane:
+  platform:
+    gcp:
+      type:
 |The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for control plane machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter.
 |The GCP machine type, for example `n1-standard-4`.
 
-|`controlPlane.platform.gcp.zones`
+|controlPlane:
+  platform:
+    gcp:
+      zones:
 |The availability zones where the installation program creates control plane machines.
 |A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
@@ -1541,55 +1678,110 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use a zone where Ampere Altra Arm CPU's are available. You can find which zones are compatible with 64-bit ARM processors in the "GCP availability zones" link.
 ====
 
-|`controlPlane.platform.gcp.secureBoot`
+|controlPlane:
+  platform:
+    gcp:
+      secureBoot:
 |Whether to enable Shielded VM secure boot for control plane machines. Shielded VMs have additional security protocols such as secure boot, firmware and integrity monitoring, and rootkit protection. For more information on Shielded VMs, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
 |`Enabled` or `Disabled`. The default value is `Disabled`.
 
-|`controlPlane.platform.gcp.confidentialCompute`
+|controlPlane:
+  platform:
+    gcp:
+      confidentialCompute:
 |Whether to enable Confidential VMs for control plane machines. Confidential VMs provide encryption for data while it is being processed. For more information on Confidential VMs, see Google's documentation on link:https://cloud.google.com/confidential-computing[Confidential Computing].
 |`Enabled` or `Disabled`. The default value is `Disabled`.
 
-|`controlPlane.platform.gcp.onHostMaintenance`
+|controlPlane:
+  platform:
+    gcp:
+      onHostMaintenance:
 |Specifies the behavior of control plane VMs during a host maintenance event, such as a software or hardware update. For Confidential VMs, this parameter must be set to `Terminate`. Confidential VMs do not support live VM migration.
 |`Terminate` or `Migrate`. The default value is `Migrate`.
 
-|`compute.platform.gcp.osDisk.encryptionKey.kmsKey.name`
+|compute:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            name:
 |The name of the customer managed encryption key to be used for compute machine disk encryption.
 |The encryption key name.
 
-|`compute.platform.gcp.osDisk.encryptionKey.kmsKey.keyRing`
+|compute:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            keyRing:
 |For compute machines, the name of the KMS key ring to which the KMS key belongs.
 |The KMS key ring name.
 
-|`compute.platform.gcp.osDisk.encryptionKey.kmsKey.location`
+|compute:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            location:
 |For compute machines, the GCP location in which the key ring exists. For more information about KMS locations, see Google's documentation on link:https://cloud.google.com/kms/docs/locations[Cloud KMS locations].
 |The GCP location for the key ring.
 
-|`compute.platform.gcp.osDisk.encryptionKey.kmsKey.projectID`
+|compute:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKey:
+            projectID:
 |For compute machines, the ID of the project in which the KMS key ring exists. This value defaults to the VM project ID if not set.
 |The GCP project ID.
 
-|`compute.platform.gcp.osDisk.encryptionKey.kmsKeyServiceAccount`
+|compute:
+  platform:
+    gcp:
+      osDisk:
+        encryptionKey:
+          kmsKeyServiceAccount:
 |The GCP service account used for the encryption request for compute machines. If this value is not set, the Compute Engine default service account is used. For more information about GCP service accounts, see Google's documentation on link:https://cloud.google.com/compute/docs/access/service-accounts#compute_engine_service_account[service accounts].
 |The GCP service account email, for example `<service_account_name>@<project_id>.iam.gserviceaccount.com`.
 
-|`compute.platform.gcp.osDisk.diskSizeGB`
+|compute:
+  platform:
+    gcp:
+      osDisk:
+        diskSizeGB:
 |The size of the disk in gigabytes (GB). This value applies to compute machines.
 |Any integer between 16 and 65536.
 
-|`compute.platform.gcp.osDisk.diskType`
+|compute:
+  platform:
+    gcp:
+      osDisk:
+        diskType:
 |The link:https://cloud.google.com/compute/docs/disks#disk-types[GCP disk type] for compute machines.
 |`pd-ssd`, `pd-standard`, or `pd-balanced`. The default is `pd-ssd`.
 
-|`compute.platform.gcp.tags`
+|compute:
+  platform:
+    gcp:
+      tags:
 |Optional. Additional network tags to add to the compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.tags` parameter for compute machines.
 |One or more strings, for example `compute-network-tag1`.
 
-|`compute.platform.gcp.type`
+|compute:
+  platform:
+    gcp:
+      type:
 |The link:https://cloud.google.com/compute/docs/machine-types[GCP machine type] for compute machines. If set, this parameter overrides the `platform.gcp.defaultMachinePlatform.type` parameter.
 |The GCP machine type, for example `n1-standard-4`.
 
-|`compute.platform.gcp.zones`
+|compute:
+  platform:
+    gcp:
+      zones:
 |The availability zones where the installation program creates compute machines.
 |A list of valid link:https://cloud.google.com/compute/docs/regions-zones#available[GCP availability zones], such as `us-central1-a`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
@@ -1598,15 +1790,24 @@ link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 When running your cluster on GCP 64-bit ARM infrastructures, ensure that you use a zone where Ampere Altra Arm CPU's are available. You can find which zones are compatible with 64-bit ARM processors in the "GCP availability zones" link.
 ====
 
-|`compute.platform.gcp.secureBoot`
+|compute:
+  platform:
+    gcp:
+      secureBoot:
 |Whether to enable Shielded VM secure boot for compute machines. Shielded VMs have additional security protocols such as secure boot, firmware and integrity monitoring, and rootkit protection. For more information on Shielded VMs, see Google's documentation on link:https://cloud.google.com/shielded-vm[Shielded VMs].
 |`Enabled` or `Disabled`. The default value is `Disabled`.
 
-|`compute.platform.gcp.confidentialCompute`
+|compute:
+  platform:
+    gcp:
+      confidentialCompute:
 |Whether to enable Confidential VMs for compute machines. Confidential VMs provide encryption for data while it is being processed. For more information on Confidential VMs, see Google's documentation on link:https://cloud.google.com/confidential-computing[Confidential Computing].
 |`Enabled` or `Disabled`. The default value is `Disabled`.
 
-|`compute.platform.gcp.onHostMaintenance`
+|compute:
+  platform:
+    gcp:
+      onHostMaintenance:
 |Specifies the behavior of compute VMs during a host maintenance event, such as a software or hardware update. For Confidential VMs, this parameter must be set to `Terminate`. Confidential VMs do not support live VM migration.
 |`Terminate` or `Migrate`. The default value is `Migrate`.
 


### PR DESCRIPTION
Versions: 4.14, 4.15

Converting GCP config parameters into stacked format. Modeled after https://docs.openshift.com/container-platform/4.14/distr_tracing/distr_tracing_tempo/distr-tracing-tempo-configuring.html#distr-tracing-tempo-config-query_distr-tracing-tempo-configuring

Preview: https://67377--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp#installation-configuration-parameters-additional-gcp_installation-config-parameters-gcp

Previous formatting:
`controlPlane.platform.gcp.osImage.project`
New formatting:
```
controlPlane:
  platform:
    gcp:
      osImage:
        project:
```

No QE needed as this only affects doc formatting. Previous PR: https://github.com/openshift/openshift-docs/pull/67388