### PR TITLE
[INTERNAL FIX] eliminate-the-r: Removed remaining &#174; from docs

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -213,7 +213,7 @@ endif::[]
 :alibaba: Alibaba Cloud
 // IBM Cloud
 :ibmcloudBMProductName: IBM Cloud Bare Metal (Classic)
-:ibmcloudBMRegProductName: IBM Cloud&#174; Bare Metal (Classic)
+:ibmcloudBMRegProductName: IBM Cloud(R) Bare Metal (Classic)
 // IBM Power
 :ibmpowerProductName: IBM Power
 // IBM zSystems

--- a/modules/compliance-supported-profiles.adoc
+++ b/modules/compliance-supported-profiles.adoc
@@ -122,7 +122,7 @@ The Compliance Operator provides the following compliance profiles:
 |PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
 |Platform
 |0.1.47+
-|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
+|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards(R) Council Document Library]
 |`x86_64`
  `ppc64le`
 
@@ -130,7 +130,7 @@ The Compliance Operator provides the following compliance profiles:
 |PCI-DSS v3.2.1 Control Baseline for Red Hat OpenShift Container Platform 4
 |Node ^[2]^
 |0.1.47+
-|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards &#174; Council Document Library]
+|link:https://www.pcisecuritystandards.org/document_library?document=pci_dss[PCI Security Standards(R) Council Document Library]
 |`x86_64`
  `ppc64le`
 

--- a/modules/supported-platforms-for-openshift-clusters.adoc
+++ b/modules/supported-platforms-for-openshift-clusters.adoc
@@ -13,7 +13,7 @@ In {product-title} {product-version}, you can install a cluster that uses instal
 * Amazon Web Services (AWS)
 * Bare metal
 * Google Cloud Platform (GCP)
-* IBM Cloud&#174; VPC
+* IBM Cloud(R) VPC
 * Microsoft Azure
 * Microsoft Azure Stack Hub
 * Nutanix


### PR DESCRIPTION
[INTERNAL FIX] Removed Asciidoctor character sub that does not render on Customer Portal. 

Version(s):
4.13, 4.12, and 4.11

Link to docs preview:
* [IBM Cloud® Bare Metal (Classic)](https://67378--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_cloud/install-ibm-cloud-prerequisites)
* [Supported platforms for OpenShift Container Platform clusters](https://67378--docspreview.netlify.app/openshift-enterprise/latest/architecture/architecture-installation#supported-platforms-for-openshift-clusters_architecture-installation)
* [Compliance profiles](https://67378--docspreview.netlify.app/openshift-enterprise/latest/security/compliance_operator/co-scans/compliance-operator-supported-profiles#compliance-supported-profiles_compliance-operator-supported-profiles)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
