### PR TITLE
Reformatting the required, network, and optional param tables

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -70,23 +70,24 @@ After installation, you cannot modify these parameters in the `install-config.ya
 Required installation configuration parameters are described in the following table:
 
 .Required parameters
-[cols=".^2,.^3,.^5a",options="header"]
+[cols=".^2l,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`apiVersion`
+|apiVersion:
 |The API version for the `install-config.yaml` content. The current version is `v1`. The installation program may also support older API versions.
 |String
 
-|`baseDomain`
+|baseDomain:
 |The base domain of your cloud provider. The base domain is used to create routes to your {product-title} cluster components. The full DNS name for your cluster is a combination of the `baseDomain` and `metadata.name` parameter values that uses the `<metadata.name>.<baseDomain>` format.
 |A fully-qualified domain or subdomain name, such as `example.com`.
 
-|`metadata`
+|metadata:
 |Kubernetes resource `ObjectMeta`, from which only the `name` parameter is consumed.
 |Object
 
-|`metadata.name`
+|metadata:
+  name:
 |The name of the cluster. DNS records for the cluster are all subdomains of `{{.metadata.name}}.{{.baseDomain}}`.
 ifndef::bare,nutanix,vsphere[]
 |String of lowercase letters, hyphens (`-`), and periods (`.`), such as `dev`.
@@ -98,12 +99,12 @@ ifdef::osp[]
 The string must be 14 characters or fewer long.
 endif::osp[]
 
-|`platform`
+|platform:
 |The configuration for the specific platform upon which to perform the installation: `alibabacloud`, `aws`, `baremetal`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`. For additional information about `platform.<platform>` parameters, consult the table for your specific platform that follows.
 |Object
 
 ifndef::openshift-origin[]
-|`pullSecret`
+|pullSecret:
 |Get a {cluster-manager-url-pull} to authenticate downloading container images for {product-title} components from services such as Quay.io.
 |
 [source,json]
@@ -124,23 +125,33 @@ ifndef::openshift-origin[]
 endif::[]
 
 ifdef::ibm-power-vs[]
-|`platform.powervs.userID`
+|platform:
+  powervs:
+    userID:
 |The UserID is the login for the user's IBM Cloud account.
 |String. For example, `existing_user_id`.
 
-|`platform.powervs.powervsResourceGroup`
+|platform:
+  powervs:
+    powervsResourceGroup:
 |The PowerVSResourceGroup is the resource group in which {ibmpowerProductName} Virtual Server resources are created. If using an existing VPC, the existing VPC and subnets should be in this resource group.
 |String. For example, `existing_resource_group`.
 
-|`platform.powervs.region`
+|platform:
+  powervs:
+    region:
 |Specifies the IBM Cloud colo region where the cluster will be created.
 |String. For example, `existing_region`.
 
-|`platform.powervs.zone`
+|platform:
+  powervs:
+    zone:
 |Specifies the IBM Cloud colo region where the cluster will be created.
 |String. For example, `existing_zone`.
 
-|`platform.powervs.serviceInstanceID`
+|platform:
+  powervs:
+    serviceInstanceID:
 |The ServiceInstanceID is the ID of the Power IAAS instance created from the IBM Cloud Catalog.
 |String. For example, `existing_service_instance_ID`.
 endif::ibm-power-vs[]
@@ -207,11 +218,11 @@ Globalnet is not supported with {rh-storage-first} disaster recovery solutions. 
 ====
 
 .Network parameters
-[cols=".^2,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`networking`
+|networking:
 |The configuration for the cluster network.
 |Object
 
@@ -220,7 +231,8 @@ Globalnet is not supported with {rh-storage-first} disaster recovery solutions. 
 You cannot modify parameters specified by the `networking` object after installation.
 ====
 
-|`networking.networkType`
+|networking:
+  networkType:
 |The {openshift-networking} network plugin to install.
 |
 ifdef::openshift-origin[]
@@ -235,7 +247,8 @@ The default value is `OVNKubernetes`.
 endif::ibm-power-vs[]
 endif::openshift-origin[]
 
-|`networking.clusterNetwork`
+|networking:
+  clusterNetwork:
 |
 The IP address blocks for pods.
 
@@ -262,7 +275,9 @@ networking:
 endif::bare[]
 ----
 
-|`networking.clusterNetwork.cidr`
+|networking:
+  clusterNetwork:
+    cidr:
 |
 Required if you use `networking.clusterNetwork`. An IP address block.
 
@@ -280,7 +295,9 @@ ifdef::bare[]
 The prefix length for an IPv6 block is between `0` and `128`. For example, `10.128.0.0/14` or `fd01::/48`.
 endif::bare[]
 
-|`networking.clusterNetwork.hostPrefix`
+|networking:
+  clusterNetwork:
+    hostPrefix:
 |The subnet prefix length to assign to each individual node. For example, if `hostPrefix` is set to `23` then each node is assigned a `/23` subnet out of the given `cidr`. A `hostPrefix` value of `23` provides 510 (2^(32 - 23) - 2) pod IP addresses.
 |
 A subnet prefix.
@@ -294,7 +311,8 @@ For an IPv4 network the default value is `23`.
 For an IPv6 network the default value is `64`. The default value is also the minimum value for IPv6.
 endif::bare[]
 
-|`networking.serviceNetwork`
+|networking:
+  serviceNetwork:
 |
 The IP address block for services. The default value is `172.30.0.0/16`.
 
@@ -322,7 +340,8 @@ networking:
 endif::bare[]
 ----
 
-|`networking.machineNetwork`
+|networking:
+  machineNetwork:
 |
 The IP address blocks for machines.
 
@@ -342,7 +361,9 @@ networking:
   - cidr: 10.0.0.0/16
 ----
 
-|`networking.machineNetwork.cidr`
+|networking:
+  machineNetwork:
+    cidr:
 |
 Required if you use `networking.machineNetwork`. An IP address block. The default value is `10.0.0.0/16` for all platforms other than libvirt and {ibmpowerProductName} Virtual Server. For libvirt, the default value is `192.168.126.0/24`. For {ibmpowerProductName} Virtual Server, the default value is `192.168.0.0/24`.
 ifdef::ibm-cloud[]
@@ -374,44 +395,48 @@ Set the `networking.machineNetwork` to match the CIDR that the preferred NIC res
 Optional installation configuration parameters are described in the following table:
 
 .Optional parameters
-[cols=".^2,.^3a,.^3a",options="header"]
+[cols=".^2l,.^3a,.^3a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`additionalTrustBundle`
+|additionalTrustBundle:
 |A PEM-encoded X.509 certificate bundle that is added to the nodes' trusted certificate store. This trust bundle may also be used when a proxy has been configured.
 |String
 
-|`capabilities`
+|capabilities:
 |Controls the installation of optional core cluster components. You can reduce the footprint of your {product-title} cluster by disabling optional components. For more information, see the "Cluster capabilities" page in _Installing_.
 |String array
 
-|`capabilities.baselineCapabilitySet`
+|capabilities:
+  baselineCapabilitySet:
 |Selects an initial set of optional capabilities to enable. Valid values are `None`, `v4.11`, `v4.12` and `vCurrent`. The default value is `vCurrent`.
 |String
 
-|`capabilities.additionalEnabledCapabilities`
+|capabilities:
+  additionalEnabledCapabilities:
 |Extends the set of optional capabilities beyond what you specify in `baselineCapabilitySet`. You may specify multiple capabilities in this parameter.
 |String array
 
-|`cpuPartitioningMode`
+|cpuPartitioningMode:
 |Enables workload partitioning, which isolates {product-title} services, cluster management workloads, and infrastructure pods to run on a reserved set of CPUs. Workload partitioning can only be enabled during installation and cannot be disabled after installation. While this field enables workload partitioning, it does not configure workloads to use specific CPUs. For more information, see the _Workload partitioning_ page in the _Scalability and Performance_ section.
 |`None` or `AllNodes`. `None` is the default value.
 
-|`compute`
+|compute:
 |The configuration for the machines that comprise the compute nodes.
 |Array of `MachinePool` objects.
 
 ifndef::openshift-origin[]
 
 ifndef::aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
-|`compute.architecture`
+|compute:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
 |String
 endif::aws,bare,gcp,ibm-power,ibm-z,azure,ibm-power-vs[]
 
 ifdef::aws,azure,gcp,bare[]
-|`compute.architecture`
+|compute:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
 ifdef::aws,azure[]
  Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
@@ -420,20 +445,23 @@ endif::aws,azure[]
 endif::aws,azure,gcp,bare[]
 
 ifdef::ibm-z[]
-|`compute.architecture`
+|compute:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, heteregeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `s390x` (the default).
 |String
 endif::ibm-z[]
 
 ifdef::ibm-power,ibm-power-vs[]
-|`compute.architecture`
+|compute:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, heteregeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `ppc64le` (the default).
 |String
 endif::ibm-power,ibm-power-vs[]
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-|`compute.architecture`
+|compute:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
 ifdef::aws[]
 See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
@@ -441,7 +469,8 @@ endif::aws[]
 |String
 endif::openshift-origin[]
 
-|`compute.hyperthreading`
+|compute:
+  hyperthreading:
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on compute machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
 [IMPORTANT]
 ====
@@ -450,38 +479,43 @@ accounts for the dramatically decreased machine performance.
 ====
 |`Enabled` or `Disabled`
 
-|`compute.name`
+|compute:
+  name:
 |Required if you use `compute`. The name of the machine pool.
 |`worker`
 
-|`compute.platform`
+|compute:
+  platform:
 |Required if you use `compute`. Use this parameter to specify the cloud provider to host the worker machines. This parameter value must match the `controlPlane.platform` parameter value.
 ifdef::ibm-power-vs[]
 Example usage, `compute.platform.powervs.sysType`.
 endif::ibm-power-vs[]
 |`alibabacloud`, `aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
 
-|`compute.replicas`
+|compute:
+  replicas:
 |The number of compute machines, which are also known as worker machines, to provision.
 |A positive integer greater than or equal to `2`. The default value is `3`.
 
-|`featureSet`
+|featureSet:
 |Enables the cluster for a feature set. A feature set is a collection of {product-title} features that are not enabled by default. For more information about enabling a feature set during installation, see "Enabling features using feature gates".
 |String. The name of the feature set to enable, such as `TechPreviewNoUpgrade`.
 
-|`controlPlane`
+|controlPlane:
 |The configuration for the machines that comprise the control plane.
 |Array of `MachinePool` objects.
 
 ifndef::openshift-origin[]
 ifndef::aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
-|`controlPlane.architecture`
+|controlPlane:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` (the default).
 |String
 endif::aws,bare,gcp,ibm-z,ibm-power,azure,ibm-power-vs[]
 
 ifdef::aws,azure,gcp,bare[]
-|`controlPlane.architecture`
+|controlPlane:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64` and `arm64`.
 ifdef::aws,azure[]
  Not all installation options support the 64-bit ARM architecture. To verify if your installation option is supported on your platform, see _Supported installation methods for different platforms_ in _Selecting a cluster installation method and preparing it for users_.
@@ -490,20 +524,23 @@ endif::aws,azure[]
 endif::aws,azure,gcp,bare[]
 
 ifdef::ibm-z[]
-|`controlPlane.architecture`
+|controlPlane:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `s390x` (the default).
 |String
 endif::ibm-z[]
 
 ifdef::ibm-power,ibm-power-vs[]
-|`controlPlane.architecture`
+|controlPlane:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, heterogeneous clusters are not supported, so all pools must specify the same architecture. Valid values are `ppc64le` (the default).
 |String
 endif::ibm-power,ibm-power-vs[]
 endif::openshift-origin[]
 
 ifdef::openshift-origin[]
-|`controlPlane.architecture`
+|controlPlane:
+  architecture:
 |Determines the instruction set architecture of the machines in the pool. Currently, clusters with varied architectures are not supported. All pools must specify the same architecture. Valid values are `amd64`.
 ifdef::aws[]
 See _Supported installation methods for different platforms_ in _Installing_ documentation for information about instance availability.
@@ -511,7 +548,8 @@ endif::aws[]
 |String
 endif::openshift-origin[]
 
-|`controlPlane.hyperthreading`
+|controlPlane:
+  hyperthreading:
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on control plane machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
 [IMPORTANT]
 ====
@@ -520,27 +558,30 @@ accounts for the dramatically decreased machine performance.
 ====
 |`Enabled` or `Disabled`
 
-|`controlPlane.name`
+|controlPlane:
+  name:
 |Required if you use `controlPlane`. The name of the machine pool.
 |`master`
 
-|`controlPlane.platform`
+|controlPlane:
+  platform:
 |Required if you use `controlPlane`. Use this parameter to specify the cloud provider that hosts the control plane machines. This parameter value must match the `compute.platform` parameter value.
 ifdef::ibm-power-vs[]
 Example usage, `controlPlane.platform.powervs.processors`.
 endif::ibm-power-vs[]
 |`alibabacloud`, `aws`, `azure`, `gcp`, `ibmcloud`, `nutanix`, `openstack`, `powervs`, `vsphere`, or `{}`
 
-|`controlPlane.replicas`
+|controlPlane:
+  replicas:
 |The number of control plane machines to provision.
 |The only supported value is `3`, which is the default value.
 
-|`credentialsMode`
+|credentialsMode:
 |The Cloud Credential Operator (CCO) mode. If no mode is specified, the CCO dynamically tries to determine the capabilities of the provided credentials, with a preference for mint mode on the platforms where multiple modes are supported.
 |`Mint`, `Passthrough`, `Manual` or an empty string (`""`). ^[1]^
 
 ifndef::openshift-origin,ibm-power-vs[]
-|`fips`
+|fips:
 |Enable or disable FIPS mode. The default is `false` (disabled). If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 [IMPORTANT]
 ====
@@ -552,27 +593,31 @@ If you are using Azure File storage, you cannot enable FIPS mode.
 ====
 |`false` or `true`
 endif::openshift-origin,ibm-power-vs[]
-|`imageContentSources`
+|imageContentSources:
 |Sources and repositories for the release-image content.
 |Array of objects. Includes a `source` and, optionally, `mirrors`, as described in the following rows of this table.
 
-|`imageContentSources.source`
+|imageContentSources:
+  source:
 |Required if you use `imageContentSources`. Specify the repository that users refer to, for example, in image pull specifications.
 |String
 
-|`imageContentSources.mirrors`
+|imageContentSources:
+  mirrors:
 |Specify one or more repositories that may also contain the same images.
 |Array of strings
 
 ifndef::openshift-origin[]
 ifdef::aws[]
-|`platform.aws.lbType`
+|platform:
+  aws:
+    lbType:
 |Required to set the NLB load balancer type in AWS. Valid values are `Classic` or `NLB`. If no value is specified, the installation program defaults to `Classic`. The installation program sets the value provided here in the ingress cluster configuration object. If you do not specify a load balancer type for other Ingress Controllers, they use the type set in this parameter.
 |`Classic` or `NLB`. The default value is `Classic`.
 endif::aws[]
 endif::openshift-origin[]
 
-|`publish`
+|publish:
 |How to publish or expose the user-facing endpoints of your cluster, such as the Kubernetes API, OpenShift routes.
 |
 ifdef::aws,azure,gcp,ibm-cloud[]
@@ -592,7 +637,7 @@ endif::[]
 endif::ibm-power-vs[]
 endif::[]
 
-|`sshKey`
+|sshKey:
 | The SSH key to authenticate access to your cluster machines.
 [NOTE]
 ====
@@ -601,43 +646,63 @@ For production {product-title} clusters on which you want to perform installatio
 a|For example, `sshKey: ssh-ed25519 AAAA..`.
 
 ifdef::ibm-power-vs[]
-|`platform.powervs.vpcRegion`
+|platform:
+  powervs:
+    vpcRegion:
 |Specifies the IBM Cloud region in which to create VPC resources.
 |String. For example, `existing_vpc_region`.
 
-|`platform.powervs.vpcSubnets`
+|platform:
+  powervs:
+    vpcSubnets:
 |Specifies existing subnets (by name) where cluster resources will be created.
 |String. For example, `powervs_region_example_subnet`.
 
-|`platform.powervs.vpcName`
+|platform:
+  powervs:
+    vpcName:
 |Specifies the IBM Cloud VPC name.
 |String. For example, `existing_vpcName`.
 
-|`platform.powervs.cloudConnectionName`
+|platform:
+  powervs:
+    cloudConnectionName:
 |The CloudConnectionName is the name of an existing PowerVS Cloud connection.
 |String. For example, `existing_cloudConnectionName`.
 
-|`platform.powervs.clusterOSImage`
+|platform:
+  powervs:
+    clusterOSImage:
 |The ClusterOSImage is a pre-created {ibmpowerProductName} Virtual Server boot image that overrides the default image for cluster nodes.
 |String. For example, `existing_cluster_os_image`.
 
-|`platform.powervs.defaultMachinePlatform`
+|platform:
+  powervs:
+    defaultMachinePlatform:
 |The DefaultMachinePlatform is the default configuration used when installing on {ibmpowerProductName} Virtual Server for machine pools that do not define their own platform configuration.
 |String. For example, `existing_machine_platform`.
 
-|`platform.powervs.memoryGiB`
+|platform:
+  powervs:
+    memoryGiB:
 |The size of a virtual machine's memory, in GB.
 |The valid integer must be an integer number of GB that is at least 2 and no more than 64, depending on the machine type.
 
-|`platform.powervs.procType`
+|platform:
+  powervs:
+    procType:
 |The ProcType defines the processor sharing model for the instance.
 |The valid values are Capped, Dedicated, and Shared.
 
-|`platform.powervs.processors`
+|platform:
+  powervs:
+    processors:
 |The Processors defines the processing units for the instance.
 |The number of processors must be from .5 to 32 cores. The processors must be in increments of .25.
 
-|`platform.powervs.sysType`
+|platform:
+  powervs:
+    sysType:
 |The SysType defines the system type for the instance.
 |The system type must be either `e980` or `s922`.
 endif::ibm-power-vs[]


### PR DESCRIPTION
Version: 4.14+

Reformatting the required, network, and optional configuration parameter tables into stacked format. More PRs will follow for the platform specific sections.

Previous format:
`metadata.name`
New format:
```
metadata:
  name:
```

Preview: [Installation configuration parameters for AWS](https://67388--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws) (same file is included for all platforms)

No QE required because this only affects docs formatting.