### PR TITLE
OCPBUGS-22841: Update broken nvidia links

### DIFF
--- a/architecture/nvidia-gpu-architecture-overview.adoc
+++ b/architecture/nvidia-gpu-architecture-overview.adoc
@@ -52,16 +52,13 @@ include::modules/nvidia-gpu-red-hat-device-edge.adoc[leveloffset=+2]
 * link:https://cloud.redhat.com/blog/how-to-accelerate-workloads-with-nvidia-gpus-on-red-hat-device-edge[How to accelerate workloads with NVIDIA GPUs on Red Hat Device Edge]
 
 include::modules/nvidia-gpu-features.adoc[leveloffset=+1]
-
 [role="_additional-resources"]
 .Additional resources
-
 * link:https://docs.nvidia.com/ngc/ngc-deploy-on-premises/nvidia-certified-systems/index.html[NVIDIA-Certified Systems]
-* link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/openshift/nvaie-with-ocp.html[NVIDIA AI Enterprise with OpenShift]
+* link:https://docs.nvidia.com/ai-enterprise/index.html#deployment-guides[NVIDIA AI Enterprise]
 * link:https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/overview.html#[NVIDIA Container Toolkit]
-* link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/openshift/enable-gpu-monitoring-dashboard.html[Enabling the GPU Monitoring Dashboard]
-* link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/openshift/mig-ocp.html[MIG Support in OpenShift Container Platform]
-* link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/openshift/time-slicing-gpus-in-openshift.html[Time-slicing NVIDIA GPUs in OpenShift]
-* link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/openshift/mirror-gpu-ocp-disconnected.html[Deploy GPU Operators in a disconnected or airgapped environment]
-* link:https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/openshift/install-nfd.html[Installing the Node Feature Discovery (NFD) Operator]
-* link:https://docs.openshift.com/container-platform/4.13/hardware_enablement/psap-node-feature-discovery-operator.html#installing-the-node-feature-discovery-operator_node-feature-discovery-operator[{product-title} Installing the Node Feature Discovery Operator]
+* link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/enable-gpu-monitoring-dashboard.html[Enabling the GPU Monitoring Dashboard]
+* link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/mig-ocp.html[MIG Support in OpenShift Container Platform]
+* link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/time-slicing-gpus-in-openshift.html[Time-slicing NVIDIA GPUs in OpenShift]
+* link:https://docs.nvidia.com/datacenter/cloud-native/openshift/latest/mirror-gpu-ocp-disconnected.html[Deploy GPU Operators in a disconnected or airgapped environment]
+* link:https://docs.openshift.com/container-platform/4.13/hardware_enablement/psap-node-feature-discovery-operator.html[Installing the Node Feature Discovery Operator]


### PR DESCRIPTION
NVIDIA has updated recently the documentation, multiple links are in 404 here: https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html/architecture/nvidia-gpu-architecture-overview#nvidia-gpu-enablement_nvidia-gpu-architecture-overview

Note: This PR is only to update the links to NVIDIA links that have changed. There is no QE approval needed.

Jira: https://issues.redhat.com/browse/OCPBUGS-22841

Version(s): 4.13.z, 4.14.z

Dev: @egallen 