### PR TITLE
ROX-20485: Add updates to release notes for 4.1.5 patch release

### DIFF
--- a/modules/common-attributes.adoc
+++ b/modules/common-attributes.adoc
@@ -53,7 +53,7 @@ endif::[]
 :osp: Red Hat OpenShift
 :olm-first: Operator Lifecycle Manager (OLM)
 :olm: OLM
-:rhacs-version: 4.1.2
+:rhacs-version: 4.1.5
 :ocp-supported-version: 4.10
 :product-title: Red Hat Advanced Cluster Security for Kubernetes
 :product-version: 4.1

--- a/release_notes/41-release-notes.adoc
+++ b/release_notes/41-release-notes.adoc
@@ -17,6 +17,7 @@ toc::[]
 |`4.1.2` |26 July 2023
 |`4.1.3` |21 August 2023
 |`4.1.4` |17 October 2023
+|`4.1.5` |8 November 2023
 |====
 
 [id="about-this-release_{context}"]
@@ -448,6 +449,17 @@ This release of {product-title-short} fixes the following security vulnerabiliti
 * Various CVEs in containers, including link:https://access.redhat.com/security/cve/cve-2023-4527[CVE-2023-4527], link:https://access.redhat.com/security/cve/cve-2023-4806[CVE-2023-4806], link:https://access.redhat.com/security/cve/cve-2023-4813[CVE-2023-4813], and link:https://access.redhat.com/security/cve/cve-2023-4911[CVE-2023-4911]: glibc security issues
 
 A new default policy has been added, "Rapid Reset: Denial of Service Vulnerability in HTTP/2 Protocol". This policy alerts on deployments with images containing components that are susceptible to a Denial of Service (DoS) vulnerability for HTTP/2 servers, as described in link:https://access.redhat.com/security/cve/cve-2023-44487[CVE-2023-44487] and link:https://access.redhat.com/security/cve/cve-2023-39325[CVE-2023-39325]. This policy applies to the build or deploy life cycle stage.
+
+
+[id="resolved-in-version-415_{context}"]
+=== Resolved in version 4.1.5
+
+Release date: 8 November 2023
+
+This release of {product-title-short} includes updates to {op-system-base-full} base images and includes the following fixes:
+
+* All containers have been rebuilt and now include container CVE fixes for link:https://access.redhat.com/security/cve/cve-2023-44487[CVE-2023-44487]: Flaw in handling multiplexed streams in the HTTP/2 protocol and link:https://access.redhat.com/security/cve/CVE-2023-40217[CVE-2023-40217]: Python 3 ssl.SSLSocket vulnerability.
+* The HTTP/2 functionality in the {product-title-short} Operator webhook has been disabled to mitigate CVE-2023-44487.
 
 [id="known-issues_{context}"]
 === Known issues (updated 11 July 2023)


### PR DESCRIPTION
Version(s):
`rhacs-docs-4.1`

[Issue](https://issues.redhat.com/browse/ROX-20485)

[Link to docs preview
](https://67393--docspreview.netlify.app/openshift-acs/latest/release_notes/41-release-notes#resolved-in-version-415_release-notes-41)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
