### PR TITLE
ROSA change name of Cluster Admin -> Nodes book

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -421,7 +421,7 @@ Topics:
     File: dedicated-aws-dc
 - Name: Cluster autoscaling
   File: rosa-cluster-autoscaling
-- Name: Nodes
+- Name: Manage nodes using machine pools 
   Dir: rosa_nodes
   Distros: openshift-rosa
   Topics:


### PR DESCRIPTION
The recent [content port of the Nodes book](https://github.com/openshift/openshift-docs/pull/62147) into ROSA has created two _Nodes_ sections. The team decided to rename the existing Nodes section to incorporate _machine pools_, a ROSA-specific feature that is used in each of the assemblies in this section. 

 I changed the name of the **Cluster administration** -> **Nodes** book to incorporate machine pools and to solve the issue of two Nodes sections. I went with Managing compute nodes using machine pools to emphasize the action being performed (Managing).

Previews
Cluster administration -> [Manage compute nodes using machine pools ](https://67394--docspreview.netlify.app/openshift-rosa/latest/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about) -- This is the existing Nodes section. [Current docs](https://docs.openshift.com/rosa/rosa_cluster_admin/rosa_nodes/rosa-nodes-machinepools-about.html)
[Nodes](https://67394--docspreview.netlify.app/openshift-rosa/latest/nodes/) -- This is new new Nodes section. [Current docs](https://docs.openshift.com/rosa/nodes/index.html)

QE review:
No QE needed