### PR TITLE
OSDOCS-8236: Reorganize SRE Access Page

### DIFF
--- a/modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc
+++ b/modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc
@@ -1,7 +1,8 @@
 // Module included in the following assemblies:
 //
-// * authentication/assuming-an-aws-iam-role-for-a-service-account.adoc
 // * rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
+// * osd_architecture/osd_policy/osd-sre-access.adoc
+// * authentication/assuming-an-aws-iam-role-for-a-service-account.adoc
 
 :_mod-docs-content-type: CONCEPT
 [id="how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects_{context}"]

--- a/modules/rosa-policy-identity-access-management.adoc
+++ b/modules/rosa-policy-identity-access-management.adoc
@@ -8,7 +8,7 @@
 Most access by Red Hat site reliability engineering (SRE) teams is done by using cluster Operators through automated configuration management.
 
 [id="subprocessors_{context}"]
-== Subprocessors
+.Subprocessors
 For a list of the available subprocessors, see the link:https://access.redhat.com/articles/5528091[Red Hat Subprocessor List] on the Red Hat Customer Portal.
 
 [id="rosa-policy-sre-access_{context}"]

--- a/modules/rosa-sre-access-privatelink-vpc.adoc
+++ b/modules/rosa-sre-access-privatelink-vpc.adoc
@@ -1,3 +1,7 @@
+// Module included in the following assemblies:
+//
+// * rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
+
 :_mod-docs-content-type: CONCEPT
 [id="rosa-sre-access-privatelink-vpc.adoc_{context}"]
 = SRE access through PrivateLink VPC endpoint service

--- a/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
+++ b/rosa_architecture/rosa_policy_service_definition/rosa-sre-access.adoc
@@ -6,7 +6,269 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 Red Hat site reliability engineering (SRE) access to ROSA clusters is outlined through identity and access management.
 
-include::modules/rosa-policy-identity-access-management.adoc[leveloffset=+1]
+
+// Module included in the following assemblies:
+//
+// * rosa_architecture/rosa_policy_service_definition/rosa-policy-shared-responsibility.adoc
+
+[id="rosa-policy-identity-access-management_{context}"]
+== Identity and access management
+Most access by Red Hat site reliability engineering (SRE) teams is done by using cluster Operators through automated configuration management.
+
+[id="subprocessors_{context}"]
+.Subprocessors
+For a list of the available subprocessors, see the link:https://access.redhat.com/articles/5528091[Red Hat Subprocessor List] on the Red Hat Customer Portal.
+
+== SRE access
+
+[id="rosa-policy-sre-access_{context}"]
+=== SRE access to {product-title} clusters
+SREs access {product-title} clusters through the web console or command-line tools. Authentication requires multi-factor authentication (MFA) with industry-standard requirements for password complexity and account lockouts. SREs must authenticate as individuals to ensure auditability. All authentication attempts are logged to a Security Information and Event Management (SIEM) system.
+
+SREs access private clusters using an encrypted HTTP connection. Connections are permitted only from a secured Red Hat network using either an IP allowlist or a private cloud provider link.
+
+.SRE access to ROSA clusters
+image::267_OpenShift_on_AWS_Access_Networking_1222.png[]
+
+[id="rosa-policy-privileged-access-control_{context}"]
+== Privileged access controls in {product-title}
+SRE adheres to the principle of least privilege when accessing {product-title} and AWS components. There are four basic categories of manual SRE access:
+
+- SRE admin access through the Red Hat Portal with normal two-factor authentication and no privileged elevation.
+- SRE admin access through the Red Hat corporate SSO with normal two-factor authentication and no privileged elevation.
+- OpenShift elevation, which is a manual elevation using Red Hat SSO. Access is limited to 2 hours, is fully audited, and requires management approval.
+- AWS access or elevation, which is a manual elevation for AWS console or CLI access. Access is limited to 60 minutes and is fully audited.
+
+Each of these access types have different levels of access to components:
+
+[cols= "4a,6a,5a,4a,3a",options="header"]
+
+|===
+
+| Component | Typical SRE admin access (Red Hat Portal) | Typical SRE admin access (Red Hat SSO) |OpenShift elevation | Cloud provider access or elevation
+
+| {cluster-manager} | R/W | No access | No access | No access
+| OpenShift console | No access | R/W | R/W | No access
+| Node operating system | No access | A specific list of elevated OS and network permissions. | A specific list of elevated OS and network permissions. | No access
+| AWS Console | No access | No access, but this is the account used to request cloud provider access. | No access | All cloud provider permissions using the SRE identity.
+
+|===
+
+[id="rosa-policy-sre-aws-infra-access_{context}"]
+=== SRE access to AWS accounts
+Red Hat personnel do not access AWS accounts in the course of routine {product-title} operations. For emergency troubleshooting purposes, the SREs have well-defined and auditable procedures to access cloud infrastructure accounts.
+
+SREs generate a short-lived AWS access token for a reserved role using the AWS Security Token Service (STS). Access to the STS token is audit-logged and traceable back to individual users. Both STS and non-STS clusters use the AWS STS service for SRE access. For non-STS clusters, the `BYOCAdminAccess` role has the `AdministratorAccess` IAM policy attached, and this role is used for administration. For STS clusters, the `ManagedOpenShift-Support-Role` has the `ManagedOpenShift-Support-Access` policy attached, and this role is used for administration.
+
+[id="rosa-sre-sts-view-aws-account_{context}"]
+=== SRE STS view of AWS accounts
+
+When SREs are on a VPN through two-factor authentication, they and Red Hat Support can assume the `ManagedOpenShift-Support-Role` in your AWS account. The `ManagedOpenShift-Support-Role` has all the permissions necessary for SREs to directly troubleshoot and manage AWS resources. Upon assumption of the `ManagedOpenShift-Support-Role`, SREs use a AWS Security Token Service (STS) to generate a unique, time-expiring URL to the customer's AWS web UI for their account. SREs can then perform multiple troubleshooting actions which include:
+
+* Viewing CloudTrail logs
+* Shutting down a faulty EC2 Instance
+
+All activities performed by SREs arrive from Red Hat IP addresses and are logged to CloudTrail to allow you to audit and review all activity. This role is only used in cases where access to AWS services is required to assist you. The majority of permissions are read-only. However, a select few permissions have more access, including the ability to reboot an instance or spin up a new instance. SRE access is limited to the policy permissions attached to the `ManagedOpenShift-Support-Role`.
+
+For a full list of permissions, see sts_support_permission_policy.json in the link:https://docs.openshift.com/rosa/rosa_architecture/rosa-sts-about-iam-resources.html[About IAM resources for ROSA clusters that use STS] user guide.
+
+[id="rosa-policy-rh-access_{context}"]
+== Red Hat support access
+Members of the Red Hat Customer Experience and Engagement (CEE) team typically have read-only access to parts of the cluster. Specifically, CEE has limited access to the core and product namespaces and does not have access to the customer namespaces.
+
+[cols= "2a,4a,4a,4a,4a",options="header"]
+
+|===
+
+| Role | Core namespace | Layered product namespace | Customer namespace | AWS account^*^
+
+|OpenShift SRE| Read: All
+
+Write: Very
+
+limited ^[1]^
+| Read: All
+
+Write: None
+| Read: None^[2]^
+
+Write: None
+|Read: All ^[3]^
+
+Write: All ^[3]^
+
+|CEE
+|Read: All
+
+Write: None
+
+|Read: All
+
+Write: None
+
+|Read: None^[2]^
+
+Write: None
+
+|Read: None
+
+Write: None
+
+|Customer administrator
+|Read: None
+
+Write: None
+
+|Read: None
+
+Write: None
+
+| Read: All
+
+Write: All
+
+|Read: All
+
+Write: All
+
+|Customer user
+|Read: None
+
+Write: None
+
+|Read: None
+
+Write: None
+
+|Read: Limited^[4]^
+
+Write: Limited^[4]^
+
+|Read: None
+
+Write: None
+
+|Everybody else
+|Read: None
+
+Write: None
+|Read: None
+
+Write: None
+|Read: None
+
+Write: None
+|Read: None
+
+Write: None
+
+|===
+--
+1. Limited to addressing common use cases such as failing deployments, upgrading a cluster, and replacing bad worker nodes.
+2. Red Hat associates have no access to customer data by default.
+3. SRE access to the AWS account is an emergency procedure for exceptional troubleshooting during a documented incident.
+4. Limited to what is granted through RBAC by the Customer Administrator, as well as namespaces created by the user.
+--
+
+[id="rosa-policy-customer-access_{context}"]
+== Customer access
+Customer access is limited to namespaces created by the customer and permissions that are granted using RBAC by the Customer Administrator role. Access to the underlying infrastructure or product namespaces is generally not permitted without `cluster-admin` access. More information on customer access and authentication can be found in the "Understanding Authentication" section of the documentation.
+
+[id="rosa-policy-access-approval_{context}"]
+== Access approval and review
+New SRE user access requires management approval. Separated or transferred SRE accounts are removed as authorized users through an automated process. Additionally, the SRE performs periodic access review, including management sign-off of authorized user lists.
+
+The access and identity authorization table includes responsibilities for managing authorized access to clusters, applications, and infrastructure resources. This includes tasks such as providing access control mechanisms, authentication, authorization, and managing access to resources.
+
+[cols="2a,3a,3a",options="header"]
+|===
+|Resource
+|Service responsibilities
+|Customer responsibilities
+
+|Logging
+|**Red Hat**
+
+- Adhere to an industry standards-based tiered internal access process for platform audit logs.
+
+- Provide native OpenShift RBAC capabilities.
+
+|- Configure OpenShift RBAC to control access to projects and by extension a project’s application logs.
+- For third-party or custom application logging solutions, the customer is responsible for access management.
+
+|Application networking
+|**Red Hat**
+
+- Provide native OpenShift RBAC and `dedicated-admin` capabilities.
+
+|- Configure OpenShift `dedicated-admin` and RBAC to control access to route configuration as required.
+- Manage organization administrators for Red Hat to grant access to {cluster-manager}. The cluster manager is used to configure router options and provide service load balancer quota.
+
+|Cluster networking
+|**Red Hat**
+
+- Provide customer access controls through {cluster-manager}.
+
+- Provide native OpenShift RBAC and `dedicated-admin` capabilities.
+
+|- Manage Red Hat organization membership of Red Hat accounts.
+- Manage organization administrators for Red Hat to grant access to {cluster-manager}.
+- Configure OpenShift `dedicated-admin` and RBAC to control access to route configuration as required.
+
+|Virtual networking management
+|**Red Hat**
+
+- Provide customer access controls through {cluster-manager}.
+
+|- Manage optional user access to AWS components through {cluster-manager}.
+
+|Virtual storage management
+|**Red Hat**
+
+- Provide customer access controls through
+OpenShift Cluster Manager.
+
+|- Manage optional user access to AWS components through {cluster-manager}.
+- Create AWS IAM roles and attached policies necessary to enable ROSA service access.
+
+|Virtual compute management
+|**Red Hat**
+
+- Provide customer access controls through
+OpenShift Cluster Manager.
+
+|- Manage optional user access to AWS components through {cluster-manager}.
+- Create AWS IAM roles and attached policies necessary to enable ROSA service access.
+
+|AWS software (public AWS services)
+|**AWS**
+
+**Compute:** Provide the Amazon EC2 service, used for ROSA control plane, infrastructure, and worker nodes.
+
+**Storage:** Provide Amazon EBS, used to allow ROSA to provision local node storage and persistent volume storage for the cluster.
+
+**Storage:** Provide Amazon S3, used for the service’s built-in image registry.
+
+**Networking:** Provide AWS Identity and Access Management (IAM), used by customers to control access to ROSA resources running on customer accounts.
+
+|- Create AWS IAM roles and attached policies necessary to enable ROSA service access.
+
+- Use IAM tools to apply the appropriate permissions to AWS
+resources in the customer account.
+
+- To enable ROSA across your AWS organization, the customer is
+responsible for managing AWS Organizations administrators.
+
+- To enable ROSA across your AWS organization, the customer is
+responsible for distributing the ROSA entitlement grant using AWS License Manager.
+
+|Hardware/AWS global infrastructure
+|**AWS**
+
+- For information regarding physical access controls for AWS data centers, see link:https://aws.amazon.com/compliance/data-center/controls/[Our Controls] on the AWS Cloud Security page.
+|- Customer is not responsible for AWS global infrastructure.
+|===
+
 include::modules/sre-cluster-access.adoc[leveloffset=+1]
 include::modules/rosa-sre-access-privatelink-vpc.adoc[leveloffset=+1]
 include::modules/how-service-accounts-assume-aws-iam-roles-in-sre-owned-projects.adoc[leveloffset=+1]


### PR DESCRIPTION
[OSDOCS-8236](https://issues.redhat.com//browse/OSDOCS-8236): Reorganize the SRE Access Page to avoid duplicate subheadings. Also review for RH style.

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OSDOCS-8236

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
