### PR TITLE
OADP-3045: Updating Velero Version Relationship table

### DIFF
--- a/modules/velero-oadp-version-relationship.adoc
+++ b/modules/velero-oadp-version-relationship.adoc
@@ -11,8 +11,10 @@
 | 1.1.3 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.9 and later
 | 1.1.4 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.9 and later
 | 1.1.5 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.9 and later
-| 1.1.6 | link:https://{velero-domain}/docs/v1.9]/[1.9.] | 4.11 and later
+| 1.1.6 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.11 and later
+| 1.1.7 | link:https://{velero-domain}/docs/v1.9]/[1.9] | 4.11 and later
 | 1.2.0 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 | 1.2.1 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 | 1.2.2 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
+| 1.2.3 | link:https://{velero-domain}/docs/v1.11/[1.11] | 4.11 and later
 |===


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->
### PR

* [OADP-3045- Update Velero Versions after OADP 1.2.3 & 1.1.7](https://issues.redhat.com/browse/OADP-3045)



### Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
* OCP 4.11 → branch/enterprise-4.11
* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15

### Link to docs preview:

| 4.4.2.1. OADP-Velero-OpenShift Container Platform version relationship - PDF screenshot |
| ------------------- |
| ![image](https://github.com/openshift/openshift-docs/assets/106804821/12a21dbe-4adf-4ad0-a0b5-758200f11a2b) |

[Netlify preview -  OADP-Velero-OpenShift Container Platform version relationship](https://67401--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/oadp-installing-operator#velero-oadp-version-relationship_installing-oadp-operator)

QE review:
- [X ](https://github.com/openshift/openshift-docs/pull/67401#pullrequestreview-1714349755) QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
