### PR TITLE
OCPBUGS-18470: updating LVMS upgrade procedure

### DIFF
--- a/modules/lvms-upgrading-lvms-on-sno.adoc
+++ b/modules/lvms-upgrading-lvms-on-sno.adoc
@@ -6,17 +6,59 @@
 [id="lvms-upgrading-lvms-on-sno_{context}"]
 = Upgrading {lvms} on {sno} clusters
 
-Currently, it is not possible to upgrade from {rh-storage} Logical Volume Manager Operator 4.11 to {lvms} 4.12 on {sno} clusters.
+You can upgrade the {lvms-first} Operator to ensure compatibility with your {sno} version.
 
-[IMPORTANT]
-====
-The data will not be preserved during this process.
-====
+.Prerequisites
+
+* You have upgraded your {sno} cluster.
+
+* You have installed a previous version of the {lvms} Operator.
+
+* You have installed the OpenShift CLI (`oc`).
+
+* You have logged in as a user with `cluster-admin` privileges.
 
 .Procedure
 
-. Back up any data that you want to preserve on the persistent volume claims (PVCs).
-. Delete all PVCs provisioned by the {rh-storage} Logical Volume Manager Operator and their pods.
-. Reinstall {lvms} on {product-title} 4.12.
-. Recreate the workloads.
-. Copy the backup data to the PVCs created after upgrading to 4.12.
+. Update the `Subscription` resource for the {lvms} Operator by running the following command:
++
+[source,terminal]
+----
+$ oc patch subscription lvms-operator -n openshift-storage --type merge --patch '{"spec":{"channel":"<update-channel>"}}' <1>
+----
+<1> Replace `<update-channel>` with the version of the {lvms} Operator that you want to install, for example `stable-{product-version}`.
+
+. View the upgrade events to check that the installation is complete by running the following command:
++
+[source,terminal]
+----
+$ oc get events -n openshift-storage
+----
++
+.Example output
+[source,terminal, subs="attributes"]
+----
+...
+8m13s       Normal    RequirementsUnknown   clusterserviceversion/lvms-operator.v{product-version}   requirements not yet checked
+8m11s       Normal    RequirementsNotMet    clusterserviceversion/lvms-operator.v{product-version}   one or more requirements couldn't be found
+7m50s       Normal    AllRequirementsMet    clusterserviceversion/lvms-operator.v{product-version}   all requirements found, attempting install
+7m50s       Normal    InstallSucceeded      clusterserviceversion/lvms-operator.v{product-version}   waiting for install components to report healthy
+7m49s       Normal    InstallWaiting        clusterserviceversion/lvms-operator.v{product-version}   installing: waiting for deployment lvms-operator to become ready: deployment "lvms-operator" waiting for 1 outdated replica(s) to be terminated
+7m39s       Normal    InstallSucceeded      clusterserviceversion/lvms-operator.v{product-version}   install strategy completed with no errors
+...
+----
+
+.Verification
+
+* Verify the version of the {lvms} Operator by running the following command:
++
+[source,terminal]
+----
+$ oc get subscription lvms-operator -n openshift-storage -o jsonpath='{.status.installedCSV}'
+----
++
+.Example output
+[source,terminal, subs="attributes"]
+----
+lvms-operator.v{product-version}
+----


### PR DESCRIPTION
OCPBUGS#18470: The upgrade procedure is specific to 4.11 -> 4.12, so it is out of date for 4.13. Updating to make it correct going forward.

Version(s):
4.13+

Issue:
https://issues.redhat.com/browse/OCPBUGS-18470

Link to docs preview:
https://file.emea.redhat.com/rohennes/OCPBUGS-18470-lvm-upgrade/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-upgrading-lvms-on-sno_logical-volume-manager-storage

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
