### PR TITLE
OCPBUGS-18120 Create the subscription for the NUMA Resources Operator uses the incorrect apiVersion

### DIFF
--- a/modules/cnf-installing-numa-resources-operator-cli.adoc
+++ b/modules/cnf-installing-numa-resources-operator-cli.adoc
@@ -64,7 +64,7 @@ $ oc create -f nro-operatorgroup.yaml
 +
 [source,yaml,subs="attributes+"]
 ----
-apiVersion: operators.coreos.com/v1
+apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: numaresources-operator


### PR DESCRIPTION
[OCPBUGS-18120]: Create the subscription for the NUMA Resources Operator uses the incorrect apiVersion

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11, 4,12, 4.13, 4.14, 4.15 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-18120
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://67407--docspreview.netlify.app/openshift-enterprise/latest/scalability_and_performance/cnf-numa-aware-scheduling.html#cnf-installing-numa-resources-operator-cli_numa-aware
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
