### PR TITLE
OCPBUGS#14093: Replaced broken link with correct RHEL 8 link for Netw…

### DIFF
--- a/networking/changing-cluster-network-mtu.adoc
+++ b/networking/changing-cluster-network-mtu.adoc
@@ -17,5 +17,5 @@ include::modules/nw-cluster-mtu-change.adoc[leveloffset=+1]
 == Additional resources
 
 * xref:../installing/installing_bare_metal/installing-bare-metal.adoc#installation-user-infra-machines-advanced_network_installing-bare-metal[Using advanced networking options for PXE and ISO installations]
-* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html/configuring_and_managing_networking/assembly_manually-creating-networkmanager-profiles-in-key-file-format_configuring-and-managing-networking[Manually creating NetworkManager profiles in key file format]
+* link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#proc_manually-creating-a-networkmanager-profile-in-keyfile-format_assembly_networkmanager-connection-profiles-in-keyfile-format[Manually creating NetworkManager profiles in key file format]
 * link:https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/8/html-single/configuring_and_managing_networking/index#configuring-a-dynamic-ethernet-connection-using-nmcli_configuring-an-ethernet-connection[Configuring a dynamic Ethernet connection using nmcli]


### PR DESCRIPTION
Version(s):
4.15
4.14
4.13
4.12
4.11

Issue:
[OCPBUGS-14093](https://issues.redhat.com/browse/OCPBUGS-14093)

Link to docs preview:
[Changing the MTU for the cluster network: Additional resource](https://67408--docspreview.netlify.app/openshift-enterprise/latest/networking/changing-cluster-network-mtu#changing-cluster-network-mtu-additional-resources)

QE review:
- [ ] QE approval not required.

