### PR TITLE
ocpbugs#22215: Updated AMI to match us-west-2 region

### DIFF
--- a/modules/installation-aws-config-yaml.adoc
+++ b/modules/installation-aws-config-yaml.adoc
@@ -201,7 +201,7 @@ ifdef::aws-outposts[]
 endif::aws-outposts[]
 ifdef::vpc,restricted[]
 ifndef::secret,china[]
-    amiID: ami-96c6f8f7 <10>
+    amiID: ami-0c5d3e03c0ab9b19a <10>
 endif::secret,china[]
 ifdef::secret,china[]
     amiID: ami-96c6f8f7 <1> <10>
@@ -217,7 +217,7 @@ endif::china[]
     hostedZone: Z3URY6TWQ91KVV <12>
 endif::vpc,restricted[]
 ifndef::vpc,restricted,aws-outposts[]
-    amiID: ami-96c6f8f7 <9>
+    amiID: ami-0c5d3e03c0ab9b19a <9>
     serviceEndpoints: <10>
       - name: ec2
         url: https://vpce-id.ec2.us-west-2.vpce.amazonaws.com


### PR DESCRIPTION
Version(s):
4.14+

Issue:
This PR addresses [ocpbugs-22215](https://issues.redhat.com/browse/OCPBUGS-22215).

Link to docs preview:

Installing a private cluster on AWS > [Sample customized install-config.yaml file for AWS](https://67412--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-private#installation-aws-config-yaml_installing-aws-private)

QE review:
- [x] QE has approved this change.