### PR TITLE
OCPBUGS-19470 DPDK mount point should be /mnt/huge

### DIFF
--- a/modules/nw-openstack-hw-offload-testpmd-pod.adoc
+++ b/modules/nw-openstack-hw-offload-testpmd-pod.adoc
@@ -39,7 +39,7 @@ spec:
         cpu: '2'
         memory: 1000Mi
     volumeMounts:
-      - mountPath: /dev/hugepages
+      - mountPath: /mnt/huge
         name: hugepage
         readOnly: False
   volumes:

--- a/modules/nw-openstack-ovs-dpdk-testpmd-pod.adoc
+++ b/modules/nw-openstack-ovs-dpdk-testpmd-pod.adoc
@@ -42,7 +42,7 @@ spec:
         memory: 1000Mi
         openshift.io/dpdk1: 1
     volumeMounts:
-      - mountPath: /dev/hugepages
+      - mountPath: /mnt/huge
         name: hugepage
         readOnly: False
   runtimeClassName: performance-cnf-performanceprofile <2>

--- a/modules/nw-sriov-dpdk-example-intel.adoc
+++ b/modules/nw-sriov-dpdk-example-intel.adoc
@@ -108,7 +108,7 @@ spec:
       capabilities:
         add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
     volumeMounts:
-    - mountPath: /dev/hugepages <4>
+    - mountPath: /mnt/huge <4>
       name: hugepage
     resources:
       limits:
@@ -130,7 +130,7 @@ spec:
 <1> Specify the same `target_namespace` where the `SriovNetwork` object `intel-dpdk-network` is created. If you would like to create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and the `SriovNetwork` object.
 <2> Specify the DPDK image which includes your application and the DPDK library used by application.
 <3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
-<4> Mount a hugepage volume to the DPDK pod under `/dev/hugepages`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
+<4> Mount a hugepage volume to the DPDK pod under `/mnt/huge`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
 <5> Optional: Specify the number of DPDK devices allocated to DPDK pod. This resource request and limit, if not explicitly specified, will be automatically added by the SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by the SR-IOV Operator. It is enabled by default and can be disabled by setting `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
 <6> Specify the number of CPUs. The DPDK pod usually requires exclusive CPUs to be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and creating a pod with `Guaranteed` QoS.
 <7> Specify hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the DPDK pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepage requires adding kernel arguments to Nodes. For example, adding kernel arguments `default_hugepagesz=1GB`, `hugepagesz=1G` and `hugepages=16` will result in `16*1Gi` hugepages be allocated during system boot.

--- a/modules/nw-sriov-dpdk-example-mellanox.adoc
+++ b/modules/nw-sriov-dpdk-example-mellanox.adoc
@@ -113,7 +113,7 @@ spec:
       capabilities:
         add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
     volumeMounts:
-    - mountPath: /dev/hugepages <4>
+    - mountPath: /mnt/huge <4>
       name: hugepage
     resources:
       limits:
@@ -135,7 +135,7 @@ spec:
 <1> Specify the same `target_namespace` where `SriovNetwork` object `mlx-dpdk-network` is created. To create the pod in a different namespace, change `target_namespace` in both the `Pod` spec and `SriovNetwork` object.
 <2> Specify the DPDK image which includes your application and the DPDK library used by the application.
 <3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
-<4> Mount the hugepage volume to the DPDK pod under `/dev/hugepages`. The hugepage volume is backed by the `emptyDir` volume type with the medium being `Hugepages`.
+<4> Mount the hugepage volume to the DPDK pod under `/mnt/huge`. The hugepage volume is backed by the `emptyDir` volume type with the medium being `Hugepages`.
 <5> Optional: Specify the number of DPDK devices allocated for the DPDK pod. If not explicitly specified, this resource request and limit is automatically added by the SR-IOV network resource injector. The SR-IOV network resource injector is an admission controller component managed by SR-IOV Operator. It is enabled by default and can be disabled by setting the `enableInjector` option to `false` in the default `SriovOperatorConfig` CR.
 <6> Specify the number of CPUs. The DPDK pod usually requires that exclusive CPUs be allocated from the kubelet. To do this, set the CPU Manager policy to `static` and create a pod with `Guaranteed` Quality of Service (QoS).
 <7> Specify hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the DPDK pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepages requires adding kernel arguments to Nodes.

--- a/modules/nw-sriov-rdma-example-mellanox.adoc
+++ b/modules/nw-sriov-rdma-example-mellanox.adoc
@@ -115,7 +115,7 @@ spec:
       capabilities:
         add: ["IPC_LOCK","SYS_RESOURCE","NET_RAW"] <3>
     volumeMounts:
-    - mountPath: /dev/hugepages <4>
+    - mountPath: /mnt/huge <4>
       name: hugepage
     resources:
       limits:
@@ -135,7 +135,7 @@ spec:
 <1> Specify the same `target_namespace` where `SriovNetwork` object `mlx-rdma-network` is created. If you would like to create the pod in a different namespace, change `target_namespace` in both `Pod` spec and `SriovNetwork` object.
 <2> Specify the RDMA image which includes your application and RDMA library used by application.
 <3> Specify additional capabilities required by the application inside the container for hugepage allocation, system resource allocation, and network interface access.
-<4> Mount the hugepage volume to RDMA pod under `/dev/hugepages`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
+<4> Mount the hugepage volume to RDMA pod under `/mnt/huge`. The hugepage volume is backed by the emptyDir volume type with the medium being `Hugepages`.
 <5> Specify number of CPUs. The RDMA pod usually requires exclusive CPUs be allocated from the kubelet. This is achieved by setting CPU Manager policy to `static` and create pod with `Guaranteed` QoS.
 <6> Specify hugepage size `hugepages-1Gi` or `hugepages-2Mi` and the quantity of hugepages that will be allocated to the RDMA pod. Configure `2Mi` and `1Gi` hugepages separately. Configuring `1Gi` hugepage requires adding kernel arguments to Nodes.
 


### PR DESCRIPTION
[OCPBUGS-19470]: DPDK mount path should be /mnt/huge

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.11, 4,12, 4.13, 4.14, 4.15 and main
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-19470 
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:https://67418--docspreview.netlify.app/openshift-enterprise/latest/networking/hardware_networks/using-dpdk-and-rdma.html#example-vf-use-in-dpdk-mode-intel_using-dpdk-and-rdma
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:   An update across multiple pod specs for correct mount path for DPDK 
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->

