### PR TITLE
Fix redirects for layered products after 4.14 release

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -227,11 +227,11 @@ AddType text/vtt                            vtt
     RewriteRule ^serverless/(1\.28|1\.29|1\.30)/?$ /serverless/$1/about/about-serverless.html [L,R=302]
 
     # redirect rel notes
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/serverless-release-notes.html$ /serverless/1.30/about/serverless-release-notes.html [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14)/serverless/serverless-release-notes.html$ /serverless/1.30/about/serverless-release-notes.html [L,R=302]
     RewriteRule ^(rosa|dedicated)/serverless/serverless-release-notes.html$ /serverless/1.30/about/serverless-release-notes.html [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent
-    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13)/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
+    RewriteRule ^container-platform/(4\.10|4\.11|4\.12|4\.13|4\.14))/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
 
     # redirect any links to existing ROSA/Dedicated embedded content to standalone equivalent
     RewriteRule ^(rosa|dedicated)/serverless/?(.*)$ /serverless/1.30/$2  [L,R=302]
@@ -254,7 +254,7 @@ AddType text/vtt                            vtt
     RewriteRule ^gitops/(1\.8|1\.9|1\.10)/?$ /gitops/$1/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # GitOps landing page
-    RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
+    RewriteRule ^container-platform/(4\.11|4\.12|4\.13|4\.14)/cicd/gitops/about-redhat-openshift-gitops.html /gitops/latest/understanding_openshift_gitops/about-redhat-openshift-gitops.html  [L,R=302]
 
     # redirect any links to existing OCP embedded content to standalone equivalent for each assembly
     RewriteRule ^container-platform/(4\.11|4\.12|4\.13)/cicd/gitops/gitops-release-notes.html/ /gitops/latest/release_notes/gitops-release-notes.html  [L,R=302]
@@ -286,7 +286,7 @@ AddType text/vtt                            vtt
 
     # Pipelines landing page
 
-    RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12|4\.13)/cicd/pipelines/about-pipelines.html /pipelines/latest/about/about-pipelines.html [NE,R=302]
+    RewriteRule ^container-platform/(4\.9|4\.10|4\.11|4\.12|4\.13|4\.14)/cicd/pipelines/about-pipelines.html /pipelines/latest/about/about-pipelines.html [NE,R=302]
 
     # redirect links to existing OCP embedded Pipelines content to standalone equivalent for each assembly
     # except the one recently renamed for now


### PR DESCRIPTION
Version(s):
Main only

Issue:
Add new redirects for layered products landing pages, now that 4.14 has released

