### PR TITLE
OCPBUGS-22968: OpenStack: Update LB limitations for 4.14

### DIFF
--- a/modules/nw-osp-loadbalancer-etp-local.adoc
+++ b/modules/nw-osp-loadbalancer-etp-local.adoc
@@ -11,4 +11,4 @@ Having the `ETP` option set to `Local` requires that health monitors be created 
 
 In {rh-openstack} 16.2, the OVN Octavia provider does not support health monitors. Therefore, setting the ETP to local is unsupported.
 
-In {rh-openstack} 16.2, the Amphora Octavia provider does not support HTTP monitors on UDP pools. As a result, UDP load balancer services have `UDP-CONNECT` monitors created instead. Due to implementation details, this configuration only functions properly with the OVN-Kubernetes CNI plugin. When the OpenShift SDN CNI plugin is used, the UDP services alive nodes are detected unreliably.
+In {rh-openstack} 16.2, the Amphora Octavia provider does not support HTTP monitors on UDP pools. As a result, UDP load balancer services have `UDP-CONNECT` monitors created instead. Due to implementation details, this configuration only functions properly with the OVN-Kubernetes CNI plugin. When the OpenShift SDN CNI plugin is used, the UDP services alive nodes are detected unreliably. This issue also affects the OVN Octavia provider in any {rh-openstack} version because the driver does not support HTTP health monitors.

--- a/modules/nw-osp-loadbalancer-source-ranges.adoc
+++ b/modules/nw-osp-loadbalancer-source-ranges.adoc
@@ -1,8 +1,0 @@
-// Module included in the following assemblies:
-// * networking/nw-osp-loadbalancer-limitations.adoc
-
-:_mod-docs-content-type: CONCEPT
-[id="nw-osp-loadbalancer-source-ranges_{context}"]
-= Load balancer source ranges
-
-Use the `.spec.loadBalancerSourceRanges` property to restrict the traffic that can pass through the load balancer according to source IP. This property is supported for use with the Amphora Octavia provider only. If your cluster uses the OVN Octavia provider, the option is ignored and traffic is unrestricted.

--- a/networking/load-balancing-openstack.adoc
+++ b/networking/load-balancing-openstack.adoc
@@ -8,7 +8,6 @@ toc::[]
 
 include::modules/nw-osp-loadbalancer-limitations.adoc[leveloffset=+1]
 include::modules/nw-osp-loadbalancer-etp-local.adoc[leveloffset=+2]
-include::modules/nw-osp-loadbalancer-source-ranges.adoc[leveloffset=+2]
 include::modules/installation-osp-kuryr-octavia-upgrade.adoc[leveloffset=+1]
 include::modules/installation-osp-api-octavia.adoc[leveloffset=+1]
 include::modules/installation-osp-api-scaling.adoc[leveloffset=+2]


### PR DESCRIPTION
In 4.14 `.spec.loadBalancerSourceRanges` are supported with OVN Octavia Provider thanks to OSASINFRA-3067. This commit removes the mention of this not being supported from the docs.

Moreover docs are updated to explain that HTTP health monitors are not supported by the OVN Octavia Provider and the consequences behind this.

Version(s):
4.15, 4.14

Issue:
https://issues.redhat.com/browse/OCPBUGS-22968

Link to docs preview:  https://67424--docspreview.netlify.app/openshift-enterprise/latest/networking/load-balancing-openstack
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
