### PR TITLE
[OSDOCS-8450] Clarify note about MHC machine set requirement

### DIFF
--- a/modules/machine-health-checks-about.adoc
+++ b/modules/machine-health-checks-about.adoc
@@ -9,7 +9,7 @@
 
 [NOTE]
 ====
-You can only apply a machine health check to control plane machines on clusters that use control plane machine sets.
+You can only apply a machine health check to machines that are managed by compute machine sets or control plane machine sets.
 ====
 
 To monitor machine health, create a resource to define the configuration for a controller. Set a condition to check, such as staying in the `NotReady` status for five minutes or displaying a permanent condition in the node-problem-detector, and a label for the set of machines to monitor.

--- a/modules/machine-health-checks-creating.adoc
+++ b/modules/machine-health-checks-creating.adoc
@@ -11,7 +11,7 @@ You can create a `MachineHealthCheck` resource for machine sets in your cluster.
 
 [NOTE]
 ====
-You can only apply a machine health check to control plane machines on clusters that use control plane machine sets.
+You can only apply a machine health check to machines that are managed by compute machine sets or control plane machine sets.
 ====
 
 .Prerequisites


### PR DESCRIPTION
Version(s):
4.12+

Issue:
[OSDOCS-8450](https://issues.redhat.com//browse/OSDOCS-8450)

Link to docs preview:
* [About machine health checks](https://67427--docspreview.netlify.app/openshift-enterprise/latest/machine_management/deploying-machine-health-checks#machine-health-checks-about_deploying-machine-health-checks)
* [Creating a machine health check resource](https://67427--docspreview.netlify.app/openshift-enterprise/latest/machine_management/deploying-machine-health-checks#machine-health-checks-creating_deploying-machine-health-checks)

QE review:
- [x] QE has approved this change.

Additional information:
