### PR TITLE
OSDOCS-4495-re: Updated VPA recommendations note

### DIFF
--- a/modules/nodes-pods-vertical-autoscaler-using-about.adoc
+++ b/modules/nodes-pods-vertical-autoscaler-using-about.adoc
@@ -160,7 +160,9 @@ spec:
 
 [NOTE]
 ====
-There must be operating pods in the project before the VPA can determine recommended resources and apply the recommendations to new pods.
+Before a VPA can determine recommendations for resources and apply the recommended resources to new pods, operating pods must exist and be running in the project.
+
+If a workload's resource usage, such as CPU and memory, is consistent, the VPA can determine recommendations for resources in a few minutes. If a workload's resource usage is inconsistent, the VPA must collect metrics at various resource usage intervals for the VPA to make an accurate recommendation.
 ====
 
 [id="nodes-pods-vertical-autoscaler-using-pod_{context}"]
@@ -190,7 +192,9 @@ spec:
 
 [NOTE]
 ====
-There must be operating pods in the project before a VPA can determine recommended resources and apply the recommendations to new pods.
+Before a VPA can determine recommended resources and apply the recommendations to new pods, operating pods must exist and be running in the project.
+
+To obtain the most accurate recommendations from the VPA, wait at least 8 days for the pods to run and for the VPA to stabilize.
 ====
 
 [id="nodes-pods-vertical-autoscaler-using-manual_{context}"]
@@ -230,7 +234,9 @@ With the recommendations, you can edit the workload object to add CPU and memory
 
 [NOTE]
 ====
-There must be operating pods in the project before a VPA can determine recommended resources.
+Before a VPA can determine recommended resources and apply the recommendations to new pods, operating pods must exist and be running in the project.
+
+To obtain the most accurate recommendations from the VPA, wait at least 8 days for the pods to run and for the VPA to stabilize.
 ====
 
 [id="nodes-pods-vertical-autoscaler-using-exempt_{context}"]


### PR DESCRIPTION
[OSDOCS-4495](https://issues.redhat.com/browse/OSDOCS-4495)

Issue:
4.11 to 4.15

Link to docs preview:
* [Automatically applying VPA recommendations](https://67433--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-auto_nodes-pods-vertical-autoscaler)
* [Automatically applying VPA recommendations on pod creation](https://67433--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-pod_nodes-pods-vertical-autoscaler)
* [Manually applying VPA recommendations](https://67433--docspreview.netlify.app/openshift-enterprise/latest/nodes/pods/nodes-pods-vertical-autoscaler.html#nodes-pods-vertical-autoscaler-using-manual_nodes-pods-vertical-autoscaler)

QE review:
- [x] QE has approved this change. See #61643 . I closed the PR as I moved to a new laptop, so I had to create a new PR. 
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Add info:

[Slack comment](https://redhat-internal.slack.com/archives/CK1AE4ZCK/p1687532460227129) . Reach out to Joel Smith.
