### PR TITLE
OBSDOCS-478: 1x.extra-small Loki support docs

### DIFF
--- a/logging/cluster-logging-support.adoc
+++ b/logging/cluster-logging-support.adoc
@@ -6,17 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-////
-Getting support - possibly add general OCP docs?
-ifdef::openshift-enterprise,openshift-webscale,openshift-dedicated,openshift-origin[]
-
-include::modules/support.adoc[leveloffset=+1]
-include::modules/support-knowledgebase-about.adoc[leveloffset=+1]
-include::modules/support-knowledgebase-search.adoc[leveloffset=+1]
-include::modules/support-submitting-a-case.adoc[leveloffset=+1]
-
-endif::openshift-enterprise,openshift-webscale,openshift-dedicated,openshift-origin[]
-////
 include::snippets/logging-supported-config-snip.adoc[]
 include::snippets/logging-compatibility-snip.adoc[]
 
@@ -29,6 +18,35 @@ The {logging-title} is not:
 * Historical or long term log retention or storage
 * A guaranteed log sink
 * Secure storage - audit logs are not stored by default
+
+[id="cluster-logging-support-CRDs"]
+== Supported API custom resource definitions
+
+LokiStack development is ongoing. Not all APIs are currently supported.
+
+.Loki API support states
+[cols="3",options="header"]
+|===
+|CustomResourceDefinition (CRD)
+|ApiVersion
+|Support state
+
+|LokiStack
+|lokistack.loki.grafana.com/v1
+|Supported in 5.5
+
+|RulerConfig
+|rulerconfig.loki.grafana/v1
+|Supported in 5.7
+
+|AlertingRule
+|alertingrule.loki.grafana/v1
+|Supported in 5.7
+
+|RecordingRule
+|recordingrule.loki.grafana/v1
+|Supported in 5.7
+|===
 
 include::modules/cluster-logging-maintenance-support-list.adoc[leveloffset=+1]
 include::modules/unmanaged-operators.adoc[leveloffset=+1]

--- a/logging/logging_alerts/custom-logging-alerts.adoc
+++ b/logging/logging_alerts/custom-logging-alerts.adoc
@@ -10,11 +10,6 @@ In logging 5.7 and later versions, users can configure the LokiStack deployment 
 
 LokiStack log-based alerts and recorded metrics are triggered by providing link:https://grafana.com/docs/loki/latest/query/[LogQL] expressions to the ruler component. The Loki Operator manages a ruler that is optimized for the selected LokiStack size, which can be `1x.extra-small`, `1x.small`, or `1x.medium`.
 
-[NOTE]
-====
-The `1x.extra-small` size is not supported. It is for demonstration purposes only.
-====
-
 To provide these expressions, you must create an `AlertingRule` custom resource (CR) containing Prometheus-compatible link:https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/[alerting rules], or a `RecordingRule` CR containing Prometheus-compatible link:https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/[recording rules].
 
 Administrators can configure log-based alerts or recorded metrics for `application`, `audit`, or `infrastructure` tenants. Users without administrator permissions can configure log-based alerts or recorded metrics for `application` tenants of the applications that they have access to.

--- a/modules/loki-deployment-sizing.adoc
+++ b/modules/loki-deployment-sizing.adoc
@@ -1,41 +1,77 @@
 // Module is included in the following assemblies:
-//cluster-logging-loki.adoc
+// * logging/cluster-logging-loki.adoc
+// * network_observability/installing-operators.adoc
+
+ifeval::["{context}" == "cluster-logging-loki"]
+:restricted:
+endif::[]
 
 :_mod-docs-content-type: CONCEPT
 [id="loki-deployment-sizing_{context}"]
-= Deployment Sizing
+= Loki deployment sizing
 
-Sizing for Loki follows the format of `N<x>._<size>_` where the value `<N>` is number of instances and `<size>` specifies performance capabilities.
+Sizing for Loki follows the format of `<N>x.<size>` where the value `<N>` is number of instances and `<size>` specifies performance capabilities.
 
-[NOTE]
-====
-1x.extra-small is for demo purposes only, and is not supported.
-====
+.Loki sizing
+[cols="1h,3*",options="header"]
+|===
+|
+|1x.extra-small
+|1x.small
+|1x.medium
 
-.Loki Sizing
-[options="header"]
-|========================================================================================
-|                              | 1x.extra-small  | 1x.small            | 1x.medium
-| *Data transfer*              | Demo use only.  | 500GB/day           | 2TB/day
-| *Queries per second (QPS)*   | Demo use only.  | 25-50 QPS at 200ms  | 25-75 QPS at 200ms
-| *Replication factor*         | None            | 2                   | 3
-| *Total CPU requests*         | 5 vCPUs         | 36 vCPUs            | 54 vCPUs
-| *Total Memory requests*      | 7.5Gi           | 63Gi                | 139Gi
-| *Total Disk requests*        | 150Gi           | 300Gi               | 450Gi
-|========================================================================================
+|Data transfer
+|100GB/day
+|500GB/day
+|2TB/day
 
-[id="CRD-API-support_{context}"]
-== Supported API Custom Resource Definitions
-LokiStack development is ongoing, not all APIs are supported currently supported.
+|Queries per second (QPS)
+|1-25 QPS at 200ms
+|25-50 QPS at 200ms
+|25-75 QPS at 200ms
 
-[options="header"]
-|=====================================================================
-| CustomResourceDefinition (CRD)| ApiVersion           | Support state
-| LokiStack      | lokistack.loki.grafana.com/v1       | Supported in 5.5
-| RulerConfig    | rulerconfig.loki.grafana/v1beta1    | Technology Preview
-| AlertingRule   | alertingrule.loki.grafana/v1beta1   | Technology Preview
-| RecordingRule  | recordingrule.loki.grafana/v1beta1  | Technology Preview
-|=====================================================================
+|Replication factor
+|2
+|2
+|2
 
-:FeatureName: Usage of `RulerConfig`, `AlertingRule` and `RecordingRule` custom resource definitions (CRDs).
-include::snippets/technology-preview.adoc[]
+|Total CPU requests
+|14 vCPUs
+|34 vCPUs
+|54 vCPUs
+
+ifdef::restricted[]
+|Total CPU requests if using the ruler
+|16 vCPUs
+|42 vCPUs
+|70 vCPUs
+endif::restricted[]
+
+|Total memory requests
+|31Gi
+|67Gi
+|139Gi
+
+ifdef::restricted[]
+|Total memory requests if using the ruler
+|35Gi
+|83Gi
+|171Gi
+endif::restricted[]
+
+|Total disk requests
+|430Gi
+|430Gi
+|590Gi
+
+ifdef::restricted[]
+|Total disk requests if using the ruler
+|650Gi
+|650Gi
+|910Gi
+endif::restricted[]
+|===
+
+ifeval::["{context}" == "cluster-logging-loki"]
+:!restricted:
+endif::[]

--- a/modules/network-observability-lokistack-create.adoc
+++ b/modules/network-observability-lokistack-create.adoc
@@ -5,6 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="network-observability-lokistack-create_{context}"]
 = Creating a LokiStack custom resource
+
 You can deploy a LokiStack using the web console or CLI to create a namespace, or new project.
 
 include::snippets/logging-clusteradmin-access-logs-snip.adoc[]
@@ -45,24 +46,3 @@ For more information about creating a `cluster-admin` group, see the "Additional
 You must not reuse the same `LokiStack` that is used for cluster logging.
 ====
 . Click *Create*.
-
-[id="deployment-sizing_{context}"]
-== Deployment Sizing
-Sizing for Loki follows the format of `N<x>._<size>_` where the value `<N>` is the number of instances and `<size>` specifies performance capabilities.
-
-[NOTE]
-====
-1x.extra-small is for demo purposes only, and is not supported.
-====
-
-.Loki Sizing
-[options="header"]
-|========================================================================================
-|                              | 1x.extra-small  | 1x.small            | 1x.medium
-| *Data transfer*              | Demo use only.  | 500GB/day           | 2TB/day
-| *Queries per second (QPS)*   | Demo use only.  | 25-50 QPS at 200ms  | 25-75 QPS at 200ms
-| *Replication factor*         | None            | 2                   | 3
-| *Total CPU requests*         | 5 vCPUs         | 36 vCPUs            | 54 vCPUs
-| *Total Memory requests*      | 7.5Gi           | 63Gi                | 139Gi
-| *Total Disk requests*        | 150Gi           | 300Gi               | 450Gi
-|========================================================================================

--- a/network_observability/installing-operators.adoc
+++ b/network_observability/installing-operators.adoc
@@ -27,15 +27,16 @@ include::modules/network-observability-loki-secret.adoc[leveloffset=+2]
 * For more information about the option to use different namespaces for the separate components, see the `spec.loki.tls.caCert.namespace` specification in the xref:../network_observability/flowcollector-api.adoc#network-observability-flowcollector-api-specifications_network_observability[Flow Collector API Reference] and callout number 5 in the xref:../network_observability/configuring-operator.adoc#network-observability-flowcollector-view_network_observability[Flow Collector sample resource].
 
 include::modules/network-observability-lokistack-create.adoc[leveloffset=+2]
+
 [role="_additional-resources"]
 .Additional resources
 * xref:../logging/cluster-logging-loki.adoc#logging-creating-new-group-cluster-admin-user-role_cluster-logging-loki[Creating a new group for the cluster-admin user role]
 
+include::modules/loki-deployment-sizing.adoc[leveloffset=+2]
 include::modules/network-observability-lokistack-ingestion-query.adoc[leveloffset=+2]
 include::modules/network-observability-auth-multi-tenancy.adoc[leveloffset=+2]
 include::modules/network-observability-multitenancy.adoc[leveloffset=+2]
 include::modules/network-observability-operator-install.adoc[leveloffset=+1]
-
 
 [role="_additional-resources"]
 [id="additional-resources_configuring-flow-collector-considerations"]
@@ -66,4 +67,3 @@ include::modules/network-observability-kafka-option.adoc[leveloffset=+1]
 xref:../network_observability/configuring-operator.adoc#network-observability-flowcollector-kafka-config_network_observability[Configuring the FlowCollector resource with Kafka].
 
 include::modules/network-observability-operator-uninstall.adoc[leveloffset=+1]
-


### PR DESCRIPTION
Version(s):
4.12+ (Logging 5.8)

Issue:
https://issues.redhat.com/browse/OBSDOCS-478

Link to docs preview:
- https://67435--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-support#cluster-logging-support-CRDs (moved content, may be outdated)
- https://67435--docspreview.netlify.app/openshift-enterprise/latest/logging/logging_alerts/custom-logging-alerts (removed note)
- https://67435--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-loki#loki-deployment-sizing_cluster-logging-loki
- https://67435--docspreview.netlify.app/openshift-enterprise/latest/network_observability/installing-operators#loki-deployment-sizing_network_observability (replaced duplicated content with module include)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
