### PR TITLE
OSDOCS-8456 z-stream release notes 4.13.21

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3417,3 +3417,37 @@ Future {product-title} versions will stop tolerating user modifications of syste
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-13-21"]
+=== RHSA-2023:6257 - {product-title} 4.13.21 bug fix and security update
+
+Issued: 2023-11-8
+
+{product-title} release 4.13.21, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6257[RHSA-2023:6257] advisory. There are no RPM packages for this release.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.21 --pullspecs
+----
+
+[id="ocp-4-13-21-bug-fixes"]
+==== Bug fixes
+
+*  Previously, egress IP could not be applied to the egress node on an Azure private cluster. This patch enables egress IP for Azure setups that use outbound rules to achieve outbound connectivity. An architectural constraint in Azure prevents the secondary IP acting as egress IP from having outbound connectivity in such setups. With this release, matching pods will have no outbound connectivity to the internet, but will be able to reach external servers in the infrastructure network. (link:https://issues.redhat.com/browse/OCPBUGS-22299[*OCPBUGS-22299*])
+
+[id="ocp-4-13-21-known-issue"]
+==== Known issue
+
+* TALM skips remediating a policy if all selected clusters are compliant when the `ClusterGroupUpdate` CR is started.
+The update of operators with a modified catalog source policy and a subscription policy in the same `ClusterGroupUpdate` CR does not complete. The subscription policy is skipped, as it is still compliant until the catalog source change is enforced.
++
+As a workaround, add a trivial change to one CR in the common-subscription policy, for example `metadata.annotations.upgrade: "1"`. This makes the policy non-compliant prior to the start of the `ClusterGroupUpdate` CR. (link:https://issues.redhat.com/browse/OCPBUGS-2812[*OCPBUGS-2812*])
+
+[id="ocp-4-13-21-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
Version(s): 
4.13
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
https://issues.redhat.com/browse/OSDOCS-8456
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
[
Link to docs preview: ](https://issues.redhat.com/browse/OSDOCS-8456)

I believe this is the correct preview @cbippley. The current link points to the Jira issue.

[RHSA-2023:6257 - OpenShift Container Platform 4.13.21 bug fix and security update](https://67452--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-21)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
not needed
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Expected merge date 11/8/23, errata links won't work until then.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
