### PR TITLE
Add xrefs to nodes content

### DIFF
--- a/operators/admin/olm-adding-operators-to-cluster.adoc
+++ b/operators/admin/olm-adding-operators-to-cluster.adoc
@@ -89,27 +89,21 @@ When you initiate the Operator installation, if the Operator has dependencies, t
 
 include::modules/olm-pod-placement.adoc[leveloffset=+1]
 
-// TODO: Uncondition these xrefs when the Nodes content is ported to OSD/ROSA.
-ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * Adding taints and tolerations xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-adding_nodes-scheduler-taints-tolerations[manually to nodes] or xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-adding-machineset_nodes-scheduler-taints-tolerations[with compute machine sets]
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors-project_nodes-scheduler-node-selectors[Creating project-wide node selectors]
 * xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-projects_nodes-scheduler-taints-tolerations[Creating a project with a node selector and toleration]
-endif::openshift-dedicated,openshift-rosa[]
 endif::[]
 
 include::modules/olm-overriding-operator-pod-affinity.adoc[leveloffset=+1]
 
-// TODO: Uncondition these xrefs when the Nodes content is ported to OSD/ROSA.
-ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/scheduling/nodes-scheduler-pod-affinity.adoc#nodes-scheduler-pod-affinity-about_nodes-scheduler-pod-affinity[Understanding pod affinity]
 * xref:../../nodes/scheduling/nodes-scheduler-node-affinity.adoc#nodes-scheduler-node-affinity-about_nodes-scheduler-node-affinity[Understanding node affinity]
-endif::openshift-dedicated,openshift-rosa[]
 // This xref points to a topic not currently included in the OSD and ROSA docs.
 ifndef::openshift-dedicated,openshift-rosa[]
 * xref:../../nodes/nodes/nodes-nodes-working.adoc#nodes-nodes-working-updating_nodes-nodes-working[Understanding how to update labels on nodes]

--- a/operators/admin/olm-cs-podsched.adoc
+++ b/operators/admin/olm-cs-podsched.adoc
@@ -39,30 +39,21 @@ endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-node-selector.adoc[leveloffset=+1]
 
-// TODO: Uncondition this xref when the Nodes content is ported to OSD/ROSA.
-ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/scheduling/nodes-scheduler-node-selectors.adoc#nodes-scheduler-node-selectors[Placing pods on specific nodes using node selectors]
-endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-priority-class-name.adoc[leveloffset=+1]
 
-// TODO: Uncondition this xref when the Nodes content is ported to OSD/ROSA.
-ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/pods/nodes-pods-priority.adoc#admin-guide-priority-preemption-priority-class_nodes-pods-priority[Pod priority classes]
-endif::openshift-dedicated,openshift-rosa[]
 
 include::modules/olm-tolerations.adoc[leveloffset=+1]
 
-// TODO: Uncondition this xref with the Nodes content is ported to OSD/ROSA.
-ifndef::openshift-dedicated,openshift-rosa[]
 [role="_additional-resources"]
 .Additional resources
 
 * xref:../../nodes/scheduling/nodes-scheduler-taints-tolerations.adoc#nodes-scheduler-taints-tolerations-about_nodes-scheduler-taints-tolerations[Understanding taints and tolerations]
-endif::openshift-dedicated,openshift-rosa[]

--- a/operators/admin/olm-deleting-operators-from-cluster.adoc
+++ b/operators/admin/olm-deleting-operators-from-cluster.adoc
@@ -11,9 +11,9 @@ The following describes how to delete, or uninstall, Operators that were previou
 [IMPORTANT]
 ====
 You must successfully and completely uninstall an Operator prior to attempting to reinstall the same Operator. Failure to fully uninstall the Operator properly can leave resources, such as a project or namespace, stuck in a "Terminating" state and cause "error resolving resource" messages to be observed when trying to reinstall the Operator.
-// TODO: Uncondition this xref when the Support content is ported to OSD/ROSA.
+
 ifndef::openshift-dedicated,openshift-rosa[]
-For more information, see xref:../../support/troubleshooting/troubleshooting-operator-issues.adoc#olm-reinstall_troubleshooting-operator-issues[Reinstalling Operators after failed uninstallation].
+For more information, see xref:../../operators/admin/olm-troubleshooting-operator-issues.adoc#olm-reinstall_olm-troubleshooting-operator-issues[Reinstalling Operators after failed uninstallation].
 endif::openshift-dedicated,openshift-rosa[]
 ====
 


### PR DESCRIPTION
The Operators book contains a number of xrefs that point to topics in the Nodes book. These xrefs had to be excluded for OSD and ROSA until the Nodes book was ported to OSD/ROSA. Now that these Nodes topics are available in OSD and ROSA, this PR is including those xrefs. There are no content changes.

Version(s):
* `enterprise-4.14+`

Link to docs preview:

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
