### PR TITLE
OSDOCS-8034  What's new summary for CLI security groups configuration

### DIFF
--- a/rosa_release_notes/rosa-release-notes.adoc
+++ b/rosa_release_notes/rosa-release-notes.adoc
@@ -16,6 +16,8 @@ toc::[]
 [id="rosa-q4-2023_{context}"]
 === Q4 2023
 
+* **Configure custom security groups.** With the release of ROSA CLI (`rosa`) version 1.2.31, administrators can use the `rosa create cluster` and `rosa create machinepool` commands to configure a new cluster or a new machine pool with up to 5 additional custom security groups. Additionally, administrators can create a new machine pool with up to 5 additional custom security groups by using OpenShift Cluster Manager. Configuring custom security groups gives administrators greater control over resource access in new clusters and machine pools. For more information, see xref:../rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-aws-prereqs.adoc#rosa-security-groups_prerequisites[Security groups].
+
 * **ROSA CLI update.** The ROSA CLI (`rosa`) was updated to a new version. For information about what has changed in this release, see the link:https://github.com/openshift/rosa/releases/tag/v1.2.29[ROSA CLI release notes]. For more information about the ROSA CLI (`rosa`), see xref:../cli_reference/rosa_cli/rosa-get-started-cli.adoc#rosa-about_rosa-getting-started-cli[About the ROSA CLI].
 
 * **Command update.** With the release of ROSA CLI (`rosa`) version 1.2.28, a new command, `rosa describe machinepool`, was added that allows you to check detailed information regarding a specific ROSA cluster machine pool. For more information, see xref:../cli_reference/rosa_cli/rosa-manage-objects-cli.adoc#rosa-describe-machinepool_rosa-managing-objects-cli[describe machinepool].


### PR DESCRIPTION
Do not merge until ROSA CLI 1.2.31 is released (planned Nov 27).

Version(s):
4.14, 4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-8034
https://issues.redhat.com/browse/OSDOCS-8785

Link to docs preview:
https://67456--docspreview.netlify.app/openshift-rosa/latest/rosa_release_notes/rosa-release-notes#rosa-q4-2023_rosa-whats-new

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
