### PR TITLE
Updating virtctl RHEL installation

### DIFF
--- a/modules/virt-installing-virtctl-binary.adoc
+++ b/modules/virt-installing-virtctl-binary.adoc
@@ -3,10 +3,10 @@
 // * virt/getting_started/virt-using-the-cli-tools.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="virt-installing-virtctl-client_{context}"]
-= Installing the virtctl binary on {op-system-base} 9, Linux, Windows, or macOS
+[id="virt-installing-virtctl-binary_{context}"]
+= Installing the virtctl binary on {op-system-base} 9 or later, Linux, Windows, or macOS
 
-You can download the `virtctl` binary for your operating system from the {product-title} web console and then install it.
+You can download the `virtctl` binary by using the {product-title} web console and then install it on {op-system-base-full} 9 or later, Linux, Windows, or macOS.
 
 .Procedure
 
@@ -15,7 +15,7 @@ You can download the `virtctl` binary for your operating system from the {produc
 
 . Install `virtctl`:
 
-* For {op-system-base} 9 and other Linux operating systems:
+* For {op-system-base} and other Linux operating systems:
 
 .. Decompress the archive file:
 +

--- a/modules/virt-installing-virtctl-rhel8-rpm.adoc
+++ b/modules/virt-installing-virtctl-rhel8-rpm.adoc
@@ -3,10 +3,10 @@
 // * virt/getting_started/virt-using-the-cli-tools.adoc
 
 :_mod-docs-content-type: PROCEDURE
-[id="virt-installing-virtctl-client-yum_{context}"]
-= Installing the virtctl RPM on {op-system-base} 8
+[id="virt-installing-virtctl-rhel8-rpm_{context}"]
+= Installing the virtctl RPM package on {op-system-base} 8
 
-You can install the `virtctl` RPM package on {op-system-base-full} 8 by enabling the {VirtProductName} repository and installing the `kubevirt-virtctl` package.
+You can install the `virtctl` RPM package on {op-system-base-full} 8 by enabling the {VirtProductName} repository and then installing the `kubevirt-virtctl` RPM package.
 
 .Prerequisites
 
@@ -21,7 +21,7 @@ You can install the `virtctl` RPM package on {op-system-base-full} 8 by enabling
 # subscription-manager repos --enable cnv-{VirtVersion}-for-rhel-8-x86_64-rpms
 ----
 
-. Install the `kubevirt-virtctl` package by running the following command:
+. Install the `kubevirt-virtctl` RPM package by running the following command:
 +
 [source,terminal]
 ----

--- a/virt/getting_started/virt-using-the-cli-tools.adoc
+++ b/virt/getting_started/virt-using-the-cli-tools.adoc
@@ -14,13 +14,13 @@ You can access and modify virtual machine (VM) disk images by using the link:htt
 [id="installing-virtctl_virt-using-the-cli-tools"]
 == Installing virtctl
 
-To install `virtctl` on {op-system-base-full} 9, Linux, Windows, and MacOS operating systems, you download and install the `virtctl` binary file.
+To install `virtctl` on {op-system-base-full} 9 or later, Linux, Windows, and MacOS operating systems, you can download and install the `virtctl` binary file.
 
-To install `virtctl` on {op-system-base} 8, you enable the {VirtProductName} repository and then install the `kubevirt-virtctl` package.
+To install `virtctl` on {op-system-base} 8, you can enable the {VirtProductName} repository and then install the `kubevirt-virtctl` RPM package.
 
-include::modules/virt-installing-virtctl-client.adoc[leveloffset=+2]
+include::modules/virt-installing-virtctl-binary.adoc[leveloffset=+2]
 
-include::modules/virt-installing-virtctl-client-yum.adoc[leveloffset=+2]
+include::modules/virt-installing-virtctl-rhel8-rpm.adoc[leveloffset=+2]
 
 include::modules/virt-virtctl-commands.adoc[leveloffset=+1]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

Changes for 4.15: 

- Updated the virtctl binary installation title and wording so that it includes RHEL9+ and not just RHEL9.
- Updated file names.



<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.15
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: None
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: [Installing virtctl](https://67460--docspreview.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools)

Note: The CNV repo name (cnv-4.14-for-rhel-8-x86_64-rpms) in the [Installing RPM](https://67460--docspreview.netlify.app/openshift-enterprise/latest/virt/getting_started/virt-using-the-cli-tools#virt-installing-virtctl-rhel8-rpm_virt-using-the-cli-tools) procedure uses the CNV version attribute. **It is currently 4.14 but it will be updated in 4.15 when the attribute is updated.**
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

- No changes required for 4.14 (RHEL9 can be left as is). 
- This PR can be merged before 4.15 GA.

<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
