### PR TITLE
[virt] DPDK checkup: Label the CM and Job

### DIFF
--- a/modules/virt-checking-cluster-dpdk-readiness.adoc
+++ b/modules/virt-checking-cluster-dpdk-readiness.adoc
@@ -103,6 +103,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dpdk-checkup-config
+  labels:
+    kiagnose/checkup-type: kubevirt-dpdk
 data:
   spec.timeout: 10m
   spec.param.networkAttachmentDefinitionName: <network_name> <1>
@@ -129,6 +131,8 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: dpdk-checkup
+  labels:
+    kiagnose/checkup-type: kubevirt-dpdk
 spec:
   backoffLimit: 0
   template:
@@ -185,6 +189,8 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: dpdk-checkup-config
+  labels:
+    kiagnose/checkup-type: kubevirt-dpdk
 data:
   spec.timeout: 10m
   spec.param.NetworkAttachmentDefinitionName: "dpdk-network-1"


### PR DESCRIPTION
In order for a user or a future UI implementation to be able to get ConfigMap and Job objects that were manually created by oc, label them as belonging to the checkup.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.15+

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://67463--docspreview.netlify.app/openshift-enterprise/latest/virt/monitoring/virt-running-cluster-checkups#virt-checking-cluster-dpdk-readiness_virt-running-cluster-checkups

QE review:
- [X] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
Similar to PR #65282.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
