### PR TITLE
OCPBUGS#16954: AWS Outposts documentation doesn't reflect the correct support status

### DIFF
--- a/installing/installing_aws/installing-aws-outposts-remote-workers.adoc
+++ b/installing/installing_aws/installing-aws-outposts-remote-workers.adoc
@@ -6,9 +6,13 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-In {product-title} version {product-version}, you can install a cluster on
-Amazon Web Services (AWS) with remote workers running in AWS Outposts.
-This can be achieved by customizing the default AWS installation and performing some manual steps.
+In {product-title} version {product-version}, you can install a cluster on Amazon Web Services (AWS) with remote workers running in AWS Outposts. This can be achieved by customizing the default AWS installation and performing some manual steps.
+
+ifdef::openshift-enterprise[]
+:FeatureName: Installing a cluster on AWS with remote workers on AWS Outposts
+include::snippets/technology-preview.adoc[]
+:!FeatureName:
+endif::[]
 
 For more info about AWS Outposts see link:https://docs.aws.amazon.com/outposts/index.html[AWS Outposts Documentation].
 


### PR DESCRIPTION
https://issues.redhat.com/browse/OCPBUGS-16954 AWS Outposts documentation doesn't reflect the correct support status

Applies to OpenShift version : 4.12, 4.13 & 4.14

Preview: [Installing a cluster on AWS with remote workers on AWS Outposts](https://67464--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installing-aws-outposts-remote-workers)

Reporter review completed by @makentenza 
Peer review completed by @stesmith

Thank you.