### PR TITLE
OCPBUGS-23013: Removing TP banner from kuryr migration docs.

### DIFF
--- a/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
+++ b/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn.adoc
@@ -6,9 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-:FeatureName: Migration from Kuryr to OVN-Kubernetes
-include::snippets/technology-preview.adoc[]
-
 As the administrator of a cluster that runs on {rh-openstack-first}, you can migrate to the OVN-Kubernetes network plugin from the Kuryr SDN network plugin.
 
 To learn more about OVN-Kubernetes, read xref:../../networking/ovn_kubernetes_network_provider/about-ovn-kubernetes#about-ovn-kubernetes[About the OVN-Kubernetes network plugin].


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14.0, 4.15.0
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: https://issues.redhat.com/browse/OCPBUGS-23013
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://67477--docspreview.netlify.app/openshift-enterprise/latest/networking/ovn_kubernetes_network_provider/migrate-from-kuryr-sdn
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] ~~QE has approved this change.~~
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
