### PR TITLE
PR for SRVKS-1077: Document volume types supported by Openshift Serverless

### DIFF
--- a/knative-serving/config-applications/pvcs-for-serving.adoc
+++ b/knative-serving/config-applications/pvcs-for-serving.adoc
@@ -4,8 +4,14 @@ include::_attributes/common-attributes.adoc[]
 = Persistent Volume Claims for Serving
 :context: pvcs-for-serving
 
-Some serverless applications need permanent data storage. 
-To achieve this, you can configure persistent volume claims (PVCs) for your Knative services.
+Some serverless applications require permanent data storage. By configuring different volume types, you can provide data storage for Knative services. Serving supports mounting of the volume types such as `secret`, `configMap`, `projected`, and `emptyDir`. 
+
+You can configure persistent volume claims (PVCs) for your Knative services. The Persistent volume types are implemented as plugins. To determine if there are any persistent volume types available, you can check the available or installed storage classes in your cluster. Persistent volumes are supported, but require a feature flag to be enabled. 
+
+[WARNING]
+====
+The mounting of large volumes can lead to a considerable delay in the start time of the application.
+====
 
 // Enabling PVC for Serving
 include::modules/serverless-enabling-pvc-support.adoc[leveloffset=+1]

--- a/modules/serverless-enabling-pvc-support.adoc
+++ b/modules/serverless-enabling-pvc-support.adoc
@@ -30,7 +30,9 @@ spec:
 +
 [NOTE]
 ====
-Use the storage class that supports the access mode that you are requesting. For example, you can use the `ocs-storagecluster-cephfs` class for the `ReadWriteMany` access mode.
+Use the storage class that supports the access mode you are requesting. For example, you can use the `ocs-storagecluster-cephfs` storage class for the `ReadWriteMany` access mode. 
+
+The `ocs-storagecluster-cephfs` storage class is supported and comes from link:https://docs.openshift.com/container-platform/latest/storage/persistent_storage/persistent-storage-ocs.html[Red Hat OpenShift Data Foundation].
 ====
 +
 .PersistentVolumeClaim configuration


### PR DESCRIPTION
**Affected versions for cherry-picking:** Serverless 1.31

**Tracking JIRA:** https://issues.redhat.com/browse/SRVKS-1077

**Doc preview & Description:** 

- [Persistent Volume Claims for Serving](https://67478--docspreview.netlify.app/openshift-serverless/latest/knative-serving/config-applications/pvcs-for-serving) Added the volume types supported by Openshift Serverless. 
- [Enabling PVC support](https://67478--docspreview.netlify.app/openshift-serverless/latest/knative-serving/config-applications/pvcs-for-serving#serverless-enabling-pvc-support_pvcs-for-serving) Mentioned about the Red Hat OpenShift Data Foundation. 

