### PR TITLE
OSDOCS#4688: Added a xref to Google docs detailing supported machine …

### DIFF
--- a/modules/installation-gcp-regions.adoc
+++ b/modules/installation-gcp-regions.adoc
@@ -47,3 +47,8 @@ regions:
 * `us-west2` (Los Angeles, California, USA)
 * `us-west3` (Salt Lake City, Utah, USA)
 * `us-west4` (Las Vegas, Nevada, USA)
+
+[NOTE]
+====
+To determine which machine type instances are available by region and zone, see the Google link:https://cloud.google.com/compute/docs/regions-zones#available[documentation].
+====


### PR DESCRIPTION
Version(s):
4.11+

Issue:
This PR addresses [osdocs-4688](https://issues.redhat.com/browse/OSDOCS-4688).

Link to docs preview:

[Supported GCP regions](https://67483--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installing-gcp-account#installation-gcp-regions_installing-gcp-account)

QE review:
- [x] QE has approved this change.
