### PR TITLE
OCPBUGS-8495: Removing reference to block and file dashboard

### DIFF
--- a/modules/lvms-monitoring-logical-volume-manager-operator.adoc
+++ b/modules/lvms-monitoring-logical-volume-manager-operator.adoc
@@ -6,8 +6,7 @@
 [id="lvms-monitoring-using-lvms_{context}"]
 = Monitoring {lvms}
 
-When {lvms} is installed using the {product-title} Web Console, you can monitor the cluster by using the *Block and File* dashboard in the console by default.
-However, when you use {rh-rhacm} to install {lvms}, you need to configure {rh-rhacm} Observability to monitor all the {sno} clusters from one place.
+When you use {rh-rhacm} to install {lvms}, you must configure {rh-rhacm} Observability to monitor all the {sno} clusters from one place.
 
 [id="lvms-monitoring-using-lvms-metrics_{context}"]
 == Metrics


### PR DESCRIPTION
OCPBUGS#8495: Remove reference to a file and block dashboard as this doesn't exist for LVMS operator.

Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OCPBUGS-8495

Link to docs preview:
https://67547--docspreview.netlify.app/openshift-enterprise/latest/storage/persistent_storage/persistent_storage_local/persistent-storage-using-lvms.html#lvms-monitoring-using-lvms_logical-volume-manager-storage

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
