### PR TITLE
OSDOCS-8458: Documented the 4.11.53 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-11-release-notes.adoc
+++ b/release_notes/ocp-4-11-release-notes.adoc
@@ -3814,3 +3814,32 @@ A recent security update to Python caused provisioning of hosts on the bare meta
 ==== Updating
 
 To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-11-53"]
+=== RHSA-2023:6272 {product-title} 4.11.53 bug fix update and security update
+
+Issued: 2023-11-08
+
+{product-title} release 4.11.53, which includes security updates, is now available. Bug fixes included in the update are listed in the link:https://access.redhat.com/errata/RHSA-2023:6272[RHSA-2023:6272] advisory. RPM packages included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:6274[RHSA-2023:6274] advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.11.53 --pullspecs
+----
+
+[id="ocp-4-11-53-bug-fixes"]
+==== Bug fixes
+
+* Previously, `CoreDNS` crashed if an `EndpointSlice` port was created without a port number. With this update, validation is added to `CoreDNS`, so the server no longer crashes in this situation. (link:https://issues.redhat.com/browse/OCPBUGS-20359[*OCPBUGS-20359*])
+
+[id="ocp-4-11-53-known-issues"]
+==== Known issues
+
+* A recent security update to Python caused provisioning of hosts on the bare metal platform to fail. Until this issue is resolved, do not upgrade your {product-title} cluster to version 4.11.53 on the bare metal platform. If you do upgrade to this version and the issue is not fixed, you cannot scale nodes. (link:https://issues.redhat.com/browse/OCPBUGS-20486[*OCPBUGS-20486*])
+
+[id="ocp-4-11-53-upgrading"]
+==== Updating
+
+To update an existing {product-title} 4.11 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
[OSDOCS-8458](https://issues.redhat.com/browse/OSDOCS-8458)

Version(s):
4.11

Link to docs preview:
[4.11.53 Release Notes](https://67548--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-11-release-notes#ocp-4-11-53)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
