### PR TITLE
OSDOCS-8446: Corrected confusing RN title

### DIFF
--- a/release_notes/ocp-4-14-release-notes.adoc
+++ b/release_notes/ocp-4-14-release-notes.adoc
@@ -1695,7 +1695,7 @@ As of {product-title} {product-version}, the `--cloud` parameter for the `oc adm
 For more information, see xref:../release_notes/ocp-4-14-release-notes.adoc#ocp-4-14-install-update-cco-manual-enhancements[Simplified installation and update experience for clusters with manually maintained cloud credentials].
 
 [id="ocp-4-14-rhv-deprecations"]
-==== Red Hat Virtualization (RHV) as a host platform for {product-title} will be deprecated
+==== Red Hat Virtualization (RHV) as a host platform for {product-title}
 
 Red Hat Virtualization (RHV) as a host platform for {product-title} was deprecated and is no longer supported. This platform will be removed from {product-title} in a future {product-title} release.
 


### PR DESCRIPTION
[INTERNAL FIX: Typo]

[OSDOCS-8446](https://issues.redhat.com/browse/OSDOCS-8446)

Version(s):
4.14

Link to docs preview:
[Red Hat Virtualization (RHV) as a host platform for OpenShift Container Platform](https://67549--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-14-release-notes#ocp-4-14-rhv-deprecations)

QE review:
- [X] QE not required

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
