### PR TITLE
OSDOCS-8683: Removed the hyperthreading parameter from the vSphere docs

### DIFF
--- a/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs.adoc
+++ b/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs.adoc
@@ -7,6 +7,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Before you deploy an {product-title} on {{ibm-power-server-name}, you provide parameters to customize your cluster and the platform that hosts it. When you create the `install-config.yaml` file, you provide values for the required parameters through the command line. You can then modify the `install-config.yaml` file to customize your cluster further.
+Before you deploy an {product-title} on {ibm-power-server-name}, you provide parameters to customize your cluster and the platform that hosts it. When you create the `install-config.yaml` file, you provide values for the required parameters through the command line. You can then modify the `install-config.yaml` file to customize your cluster further.
 
 include::modules/installation-configuration-parameters.adoc[leveloffset=+1]

--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -468,7 +468,7 @@ See _Supported installation methods for different platforms_ in _Installing_ doc
 endif::aws[]
 |String
 endif::openshift-origin[]
-
+ifndef::vsphere[]
 |compute:
   hyperthreading:
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on compute machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
@@ -478,6 +478,7 @@ If you disable simultaneous multithreading, ensure that your capacity planning
 accounts for the dramatically decreased machine performance.
 ====
 |`Enabled` or `Disabled`
+endif::vsphere[]
 
 |compute:
   name:
@@ -548,6 +549,7 @@ endif::aws[]
 |String
 endif::openshift-origin[]
 
+ifndef::vsphere[]
 |controlPlane:
   hyperthreading:
 |Whether to enable or disable simultaneous multithreading, or `hyperthreading`, on control plane machines. By default, simultaneous multithreading is enabled to increase the performance of your machines' cores.
@@ -557,6 +559,7 @@ If you disable simultaneous multithreading, ensure that your capacity planning
 accounts for the dramatically decreased machine performance.
 ====
 |`Enabled` or `Disabled`
+endif::vsphere[]
 
 |controlPlane:
   name:
@@ -710,27 +713,29 @@ endif::ibm-power-vs[]
 [.small]
 --
 1. Not all CCO modes are supported for all cloud providers. For more information about CCO modes, see the "Managing cloud provider credentials" entry in the _Authentication and authorization_ content.
-+
 ifdef::aws,gcp[]
++
 [NOTE]
 ====
 ifdef::aws[If your AWS account has service control policies (SCP) enabled, you must configure the `credentialsMode` parameter to `Mint`, `Passthrough`, or `Manual`.]
 ifdef::gcp[If you are installing on GCP into a shared virtual private cloud (VPC), `credentialsMode` must be set to `Passthrough` or `Manual`.]
 ====
-+
 endif::aws,gcp[]
+ifdef::aws,gcp,azure[]
++
 [IMPORTANT]
 ====
-ifdef::aws,gcp,azure[Setting this parameter to `Manual` enables alternatives to storing administrator-level secrets in the `kube-system` project, which require additional configuration steps. For more information, see "Alternatives to storing administrator-level secrets in the kube-system project".]
+Setting this parameter to `Manual` enables alternatives to storing administrator-level secrets in the `kube-system` project, which require additional configuration steps. For more information, see "Alternatives to storing administrator-level secrets in the kube-system project".
 ====
---
-
+endif::aws,gcp,azure[]
 ifdef::ibm-power-vs[]
++
 [NOTE]
 ====
 Cloud connections are no longer supported in the `install-config.yaml` while deploying in the `dal10` region, as they have been replaced by the Power Edge Router (PER).
 ====
 endif::ibm-power-vs[]
+--
 
 ifdef::aws[]
 [id="installation-configuration-parameters-optional-aws_{context}"]

--- a/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
+++ b/modules/installation-installer-provisioned-vsphere-config-yaml.adoc
@@ -24,19 +24,17 @@ apiVersion: v1
 baseDomain: example.com <1>
 compute: <2>
 - architecture: amd64
-  hyperthreading: Enabled <3>
   name:  <worker_node>
   platform: {}
   replicas: 3
 controlPlane: <2>
   architecture: amd64
-  hyperthreading: Enabled <3>
   name: <parent_node>
   platform: {}
   replicas: 3
 metadata:
   creationTimestamp: null
-  name: test <4>
+  name: test <3>
 ifdef::network[]
 networking:
   clusterNetwork:
@@ -44,25 +42,25 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 10.0.0.0/16
-  networkType: OVNKubernetes <10>
+  networkType: OVNKubernetes <9>
   serviceNetwork:
   - 172.30.0.0/16
 endif::network[]
 platform:
-  vsphere: <5>
+  vsphere: <4>
     apiVIPs:
       - 10.0.0.1
-    failureDomains: <6>
+    failureDomains: <5>
     - name: <failure_domain_name>
       region: <default_region_name>
       server: <fully_qualified_domain_name>
       topology:
         computeCluster: "/<datacenter>/host/<cluster>"
         datacenter: <datacenter>
-        datastore: "/<datacenter>/datastore/<datastore>" <7>
+        datastore: "/<datacenter>/datastore/<datastore>" <6>
         networks:
         - <VM_Network_name>
-        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <8>
+        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <7>
         folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>"
       zone: <default_zone_name>
     ingressVIPs:
@@ -74,9 +72,9 @@ platform:
       port: 443
       server: <fully_qualified_domain_name>
       user: administrator@vsphere.local
-    diskType: thin <9>
+    diskType: thin <8>
 ifdef::restricted[]
-    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <10>
+    clusterOSImage: http://mirror.example.com/images/rhcos-47.83.202103221318-0-vmware.x86_64.ova <9>
 endif::restricted[]
 ifndef::openshift-origin[]
 fips: false
@@ -85,15 +83,15 @@ ifndef::restricted[]
 pullSecret: '{"auths": ...}'
 endif::restricted[]
 ifdef::restricted[]
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <11>
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <10>
 endif::restricted[]
 sshKey: 'ssh-ed25519 AAAA...'
 ifdef::restricted[]
-additionalTrustBundle: | <12>
+additionalTrustBundle: | <11>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <13>
+imageContentSources: <12>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -104,17 +102,10 @@ endif::restricted[]
 ----
 <1> The base domain of the cluster. All DNS records must be sub-domains of this base and include the cluster name.
 <2> The `controlPlane` section is a single mapping, but the `compute` section is a sequence of mappings. To meet the requirements of the different data structures, the first line of the `compute` section must begin with a hyphen, `-`, and the first line of the `controlPlane` section must not. Only one control plane pool is used.
-<3> Whether to enable or disable simultaneous multithreading, or `hyperthreading`. By default, simultaneous multithreading is enabled
-to increase the performance of your machines' cores. You can disable it by setting the parameter value to `Disabled`. If you disable simultaneous multithreading in some cluster machines, you must disable it in all cluster machines.
-+
-[IMPORTANT]
-====
-If you disable simultaneous multithreading, ensure that your capacity planning accounts for the dramatically decreased machine performance. Your machines must use at least 8 CPUs and 32 GB of RAM if you disable simultaneous multithreading.
-====
-<4> The cluster name that you specified in your DNS records.
-<5> Optional: Provides additional configuration for the machine pool parameters for the compute and control plane machines.
-<6> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-<7> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images. 
+<3> The cluster name that you specified in your DNS records.
+<4> Optional: Provides additional configuration for the machine pool parameters for the compute and control plane machines.
+<5> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+<6> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images. 
 +
 [IMPORTANT]
 ====
@@ -122,19 +113,19 @@ You can specify the path of any datastore that exists in a datastore cluster. By
 
 If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
 ====
-<8> Optional: Provides an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
-<9> The vSphere disk provisioning method.
+<7> Optional: Provides an existing resource pool for machine creation. If you do not specify a value, the installation program uses the root resource pool of the vSphere cluster.
+<8> The vSphere disk provisioning method.
 ifdef::network[]
-<10> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
+<9> The cluster network plugin to install. The supported values are `OVNKubernetes` and `OpenShiftSDN`. The default value is `OVNKubernetes`.
 endif::network[]
 ifdef::restricted[]
-<10> The location of the {op-system-first} image that is accessible from the bastion server.
-<11> For `<local_registry>`, specify the registry domain name, and optionally the
+<9> The location of the {op-system-first} image that is accessible from the bastion server.
+<10> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
 specify the base64-encoded user name and password for your mirror registry.
-<12> Provide the contents of the certificate file that you used for your mirror registry.
-<13> Provide the `imageContentSources` section from the output of the command to mirror the repository.
+<11> Provide the contents of the certificate file that you used for your mirror registry.
+<12> Provide the `imageContentSources` section from the output of the command to mirror the repository.
 endif::restricted[]
 
 [NOTE]

--- a/modules/installation-minimum-resource-requirements.adoc
+++ b/modules/installation-minimum-resource-requirements.adoc
@@ -63,6 +63,12 @@ endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
 :azure:
 endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
+:azure:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
+:azure:
+endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
 :bare-metal:
 endif::[]
@@ -102,11 +108,14 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :ibm-cloud-vpc:
 endif::[]
-ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
-:azure:
+ifeval::["{context}" == "installing-vsphere"]
+:vsphere:
 endif::[]
-ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
-:azure:
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:vsphere:
 endif::[]
 
 :_mod-docs-content-type: CONCEPT
@@ -122,12 +131,12 @@ Each cluster machine must meet the following minimum requirements:
 |Machine
 |Operating System
 ifndef::bare-metal[]
-ifndef::ibm-cloud-vpc[]
+ifndef::ibm-cloud-vpc,vsphere[]
 |vCPU ^[1]^
-endif::ibm-cloud-vpc[]
-ifdef::ibm-cloud-vpc[]
+endif::ibm-cloud-vpc,vsphere[]
+ifdef::ibm-cloud-vpc,vsphere[]
 |vCPU
-endif::ibm-cloud-vpc[]
+endif::ibm-cloud-vpc,vsphere[]
 |Virtual RAM
 endif::bare-metal[]
 ifdef::bare-metal[]
@@ -135,9 +144,12 @@ ifdef::bare-metal[]
 |RAM
 endif::bare-metal[]
 |Storage
-ifndef::ibm-z,ibm-cloud-vpc[]
+ifndef::ibm-z,ibm-cloud-vpc,vsphere[]
 |Input/Output Per Second (IOPS)^[2]^
-endif::ibm-z,ibm-cloud-vpc[]
+endif::ibm-z,ibm-cloud-vpc,vsphere[]
+ifdef::vsphere[]
+|Input/Output Per Second (IOPS)^[1]^
+endif::vsphere[]
 ifdef::ibm-z,ibm-cloud-vpc[]
 |Input/Output Per Second (IOPS)
 endif::ibm-z,ibm-cloud-vpc[]
@@ -172,7 +184,8 @@ endif::ibm-z[]
 ifndef::openshift-origin[]
 |Compute
 ifdef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}]
-ifndef::ibm-z,ibm-power,ibm-cloud-vpc[|{op-system}, {op-system-base} 8.6, {op-system-base} 8.7, or {op-system-base} 8.8 ^[3]^]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[|{op-system}, {op-system-base} 8.6, {op-system-base} 8.7, or {op-system-base} 8.8 ^[3]^]
+ifdef::vsphere[|{op-system}, {op-system-base} 8.6, {op-system-base} 8.7, or {op-system-base} 8.8 ^[2]^]
 |2
 |8 GB
 |100 GB
@@ -206,16 +219,20 @@ endif::ibm-z[]
 ifdef::bare-metal[]
 1. One CPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = CPUs.
 endif::bare-metal[]
-ifndef::ibm-z,bare-metal,ibm-cloud-vpc[]
+ifndef::ibm-z,bare-metal,ibm-cloud-vpc,vsphere[]
 1. One vCPU is equivalent to one physical core when simultaneous multithreading (SMT), or hyperthreading, is not enabled. When enabled, use the following formula to calculate the corresponding ratio: (threads per core × cores) × sockets = vCPUs.
-endif::ibm-z,bare-metal,ibm-cloud-vpc[]
-ifndef::ibm-z,ibm-power,ibm-cloud-vpc[]
+endif::ibm-z,bare-metal,ibm-cloud-vpc,vsphere[]
+ifndef::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[]
 2. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
 3. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
-endif::ibm-z,ibm-power,ibm-cloud-vpc[]
+endif::ibm-z,ibm-power,ibm-cloud-vpc,vsphere[]
 ifdef::ibm-power[]
 2. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
 endif::ibm-power[]
+ifdef::vsphere[]
+1. {product-title} and Kubernetes are sensitive to disk performance, and faster storage is recommended, particularly for etcd on the control plane nodes which require a 10 ms p99 fsync duration. Note that on many cloud platforms, storage size and IOPS scale together, so you might need to over-allocate storage volume to obtain sufficient performance.
+2. As with all user-provisioned installations, if you choose to use {op-system-base} compute machines in your cluster, you take responsibility for all operating system life cycle management and maintenance, including performing system updates, applying patches, and completing all other required tasks. Use of {op-system-base} 7 compute machines is deprecated and has been removed in {product-title} 4.10 and later.
+endif::vsphere[]
 --
 
 ifdef::azure[]
@@ -243,6 +260,12 @@ ifeval::["{context}" == "installing-azure-vnet"]
 :!azure:
 endif::[]
 ifeval::["{context}" == "installing-azure-user-infra"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
+:!azure:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
 :!azure:
 endif::[]
 ifeval::["{context}" == "installing-bare-metal"]
@@ -284,9 +307,12 @@ endif::[]
 ifeval::["{context}" == "installing-ibm-cloud-private"]
 :!ibm-cloud-vpc:
 endif::[]
-ifeval::["{context}" == "installing-restricted-networks-azure-installer-provisioned"]
-:!azure:
+ifeval::["{context}" == "installing-vsphere"]
+:!vsphere:
 endif::[]
-ifeval::["{context}" == "installing-restricted-networks-azure-user-provisioned"]
-:!azure:
+ifeval::["{context}" == "installing-vsphere-network-customizations"]
+:!vsphere:
+endif::[]
+ifeval::["{context}" == "installing-restricted-networks-vsphere"]
+:!vsphere:
 endif::[]

--- a/modules/installation-vsphere-config-yaml.adoc
+++ b/modules/installation-vsphere-config-yaml.adoc
@@ -7,6 +7,7 @@
 ifeval::["{context}" == "installing-restricted-networks-vsphere"]
 :restricted:
 endif::[]
+// Verify the validity of the following ifdef statement in a later Jira
 ifdef::openshift-origin[]
 :restricted:
 endif::[]
@@ -26,77 +27,75 @@ apiVersion: v1
 baseDomain: example.com <1>
 compute: <2>
 - architecture: amd64
-  hyperthreading: Enabled <3>
   name: <worker_node>
   platform: {}
-  replicas: 0 <4>
+  replicas: 0 <3>
 controlPlane: <2>
   architecture: amd64
-  hyperthreading: Enabled <3>
   name: <parent_node>
   platform: {}
-  replicas: 3 <5>
+  replicas: 3 <4>
 metadata:
   creationTimestamp: null
-  name: test <6>
+  name: test <5>
 networking:
 ---
 platform:
   vsphere:
-    failureDomains: <7>
+    failureDomains: <6>
     - name: <failure_domain_name>
       region: <default_region_name>
       server: <fully_qualified_domain_name>
       topology:
         computeCluster: "/<datacenter>/host/<cluster>"
-        datacenter: <datacenter> <8>
-        datastore: "/<datacenter>/datastore/<datastore>" <9>
+        datacenter: <datacenter> <7>
+        datastore: "/<datacenter>/datastore/<datastore>" <8>
         networks:
         - <VM_Network_name>
-        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <10>
-        folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <11>
+        resourcePool: "/<datacenter>/host/<cluster>/Resources/<resourcePool>" <9>
+        folder: "/<datacenter_name>/vm/<folder_name>/<subfolder_name>" <10>
       zone: <default_zone_name>
     vcenters:
     - datacenters:
       - <datacenter>
-      password: <password> <12>
+      password: <password> <11>
       port: 443
-      server: <fully_qualified_domain_name> <13>
+      server: <fully_qualified_domain_name> <12>
       user: administrator@vsphere.local
-    diskType: thin <14>
+    diskType: thin <13>
 ifndef::restricted[]
 ifndef::openshift-origin[]
-fips: false <15>
+fips: false <14>
 endif::openshift-origin[]
 ifndef::openshift-origin[]
-pullSecret: '{"auths": ...}' <16>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
 pullSecret: '{"auths": ...}' <15>
 endif::openshift-origin[]
+ifdef::openshift-origin[]
+pullSecret: '{"auths": ...}' <14>
+endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-fips: false <15>
-pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <16>
-endif::openshift-origin[]
-ifdef::openshift-origin[]
+fips: false <14>
 pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <15>
 endif::openshift-origin[]
+ifdef::openshift-origin[]
+pullSecret: '{"auths":{"<local_registry>": {"auth": "<credentials>","email": "you@example.com"}}}' <14>
+endif::openshift-origin[]
 endif::restricted[]
 ifndef::openshift-origin[]
-sshKey: 'ssh-ed25519 AAAA...' <17>
+sshKey: 'ssh-ed25519 AAAA...' <16>
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-sshKey: 'ssh-ed25519 AAAA...' <16>
+sshKey: 'ssh-ed25519 AAAA...' <15>
 endif::openshift-origin[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-additionalTrustBundle: | <18>
+additionalTrustBundle: | <17>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <19>
+imageContentSources: <18>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -105,11 +104,11 @@ imageContentSources: <19>
   source: quay.io/openshift-release-dev/ocp-v4.0-art-dev
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-additionalTrustBundle: | <17>
+additionalTrustBundle: | <16>
   -----BEGIN CERTIFICATE-----
   ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ
   -----END CERTIFICATE-----
-imageContentSources: <18>
+imageContentSources: <17>
 - mirrors:
   - <local_registry>/<local_repository_name>/release
   source: quay.io/openshift-release-dev/ocp-release
@@ -125,32 +124,18 @@ base and include the cluster name.
 sequence of mappings. To meet the requirements of the different data structures,
 the first line of the `compute` section must begin with a hyphen, `-`, and the
 first line of the `controlPlane` section must not. Both sections define a single machine pool, so only one control plane is used. {product-title} does not support defining multiple compute pools.
-<3> Whether to enable or disable simultaneous multithreading, or
-`hyperthreading`. By default, simultaneous multithreading is enabled
-to increase the performance of your machines' cores. You can disable it by
-setting the parameter value to `Disabled`. If you disable simultaneous
-multithreading in some cluster machines, you must disable it in all cluster
-machines.
-+
-[IMPORTANT]
-====
-If you disable simultaneous multithreading, ensure that your capacity planning
-accounts for the dramatically decreased machine performance.
-Your machines must use at least 8 CPUs and 32 GB of RAM if you disable
-simultaneous multithreading.
-====
-<4> You must set the value of the `replicas` parameter to `0`. This parameter
+<3> You must set the value of the `replicas` parameter to `0`. This parameter
 controls the number of workers that the cluster creates and manages for you,
 which are functions that the cluster does not perform when you
 use user-provisioned infrastructure. You must manually deploy worker
 machines for the cluster to use before you finish installing {product-title}.
-<5> The number of control plane machines that you add to the cluster. Because
+<4> The number of control plane machines that you add to the cluster. Because
 the cluster uses this values as the number of etcd endpoints in the cluster, the
 value must match the number of control plane machines that you deploy.
-<6> The cluster name that you specified in your DNS records.
-<7> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
-<8> The vSphere datacenter.
-<9> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
+<5> The cluster name that you specified in your DNS records.
+<6> Establishes the relationships between a region and zone. You define a failure domain by using vCenter objects, such as a `datastore` object. A failure domain defines the vCenter location for {product-title} cluster nodes.
+<7> The vSphere datacenter.
+<8> The path to the vSphere datastore that holds virtual machine files, templates, and ISO images.
 +
 [IMPORTANT]
 ====
@@ -158,18 +143,18 @@ You can specify the path of any datastore that exists in a datastore cluster. By
 
 If you must specify VMs across multiple datastores, use a `datastore` object to specify a failure domain in your cluster's `install-config.yaml` configuration file. For more information, see "VMware vSphere region and zone enablement".
 ====
-<10> Optional: For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
-<11> Optional: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
-<12> The password associated with the vSphere user.
-<13> The fully-qualified hostname or IP address of the vCenter server.
+<9> Optional: For installer-provisioned infrastructure, the absolute path of an existing resource pool where the installation program creates the virtual machines, for example, `/<datacenter_name>/host/<cluster_name>/Resources/<resource_pool_name>/<optional_nested_resource_pool_name>`. If you do not specify a value, resources are installed in the root of the cluster `/example_datacenter/host/example_cluster/Resources`.
+<10> Optional: For installer-provisioned infrastructure, the absolute path of an existing folder where the installation program creates the virtual machines, for example, `/<datacenter_name>/vm/<folder_name>/<subfolder_name>`. If you do not provide this value, the installation program creates a top-level folder in the datacenter virtual machine folder that is named with the infrastructure ID. If you are providing the infrastructure for the cluster and you do not want to use the default `StorageClass` object, named `thin`, you can omit the `folder` parameter from the `install-config.yaml` file.
+<11> The password associated with the vSphere user.
+<12> The fully-qualified hostname or IP address of the vCenter server.
 +
 [IMPORTANT]
 ====
 The Cluster Cloud Controller Manager Operator performs a connectivity check on a provided hostname or IP address. Ensure that you specify a hostname or an IP address to a reachable vCenter server. If you provide metadata to a non-existent vCenter server, installation of the cluster fails at the bootstrap stage.
 ====
-<14> The vSphere disk provisioning method.
+<13> The vSphere disk provisioning method.
 ifndef::openshift-origin[]
-<15> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
+<14> Whether to enable or disable FIPS mode. By default, FIPS mode is not enabled. If FIPS mode is enabled, the {op-system-first} machines that {product-title} runs on bypass the default Kubernetes cryptography suite and use the cryptography modules that are provided with {op-system} instead.
 +
 [IMPORTANT]
 ====
@@ -178,13 +163,13 @@ To enable FIPS mode for your cluster, you must run the installation program from
 endif::openshift-origin[]
 ifndef::restricted[]
 ifndef::openshift-origin[]
-<16> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<17> The public portion of the default SSH key for the `core` user in
+<15> The pull secret that you obtained from {cluster-manager-url}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<16> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 endif::openshift-origin[]
 ifdef::openshift-origin[]
-<16> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
-<17> The public portion of the default SSH key for the `core` user in
+<15> You obtained the {cluster-manager-url-pull}. This pull secret allows you to authenticate with the services that are provided by the included authorities, including Quay.io, which serves the container images for {product-title} components.
+<16> The public portion of the default SSH key for the `core` user in
 {op-system-first}.
 +
 [NOTE]
@@ -195,19 +180,6 @@ endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<16> For `<local_registry>`, specify the registry domain name, and optionally the
-port, that your mirror registry uses to serve content. For example
-`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
-specify the base64-encoded user name and password for your mirror registry.
-<17> The public portion of the default SSH key for the `core` user in
-{op-system-first}.
-+
-[NOTE]
-====
-For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
-====
-endif::openshift-origin[]
-ifdef::openshift-origin[]
 <15> For `<local_registry>`, specify the registry domain name, and optionally the
 port, that your mirror registry uses to serve content. For example
 `registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
@@ -220,18 +192,31 @@ specify the base64-encoded user name and password for your mirror registry.
 For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
 ====
 endif::openshift-origin[]
+ifdef::openshift-origin[]
+<14> For `<local_registry>`, specify the registry domain name, and optionally the
+port, that your mirror registry uses to serve content. For example
+`registry.example.com` or `registry.example.com:5000`. For `<credentials>`,
+specify the base64-encoded user name and password for your mirror registry.
+<15> The public portion of the default SSH key for the `core` user in
+{op-system-first}.
++
+[NOTE]
+====
+For production {product-title} clusters on which you want to perform installation debugging or disaster recovery, specify an SSH key that your `ssh-agent` process uses.
+====
+endif::openshift-origin[]
 endif::restricted[]
 ifdef::restricted[]
 ifndef::openshift-origin[]
-<18> Provide the contents of the certificate file that you used for your mirror
-registry.
-<19> Provide the `imageContentSources` section from the output of the command to
-mirror the repository.
-endif::openshift-origin[]
-ifdef::openshift-origin[]
 <17> Provide the contents of the certificate file that you used for your mirror
 registry.
 <18> Provide the `imageContentSources` section from the output of the command to
+mirror the repository.
+endif::openshift-origin[]
+ifdef::openshift-origin[]
+<16> Provide the contents of the certificate file that you used for your mirror
+registry.
+<17> Provide the `imageContentSources` section from the output of the command to
 mirror the repository.
 endif::openshift-origin[]
 endif::restricted[]


### PR DESCRIPTION
[OSDOCS-8693](https://issues.redhat.com/browse/OSDOCS-8683)

Version(s):
4.15 to 4.11

Link to docs preview:
* [Installing a cluster on vSphere with customizations](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-customizations#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-customizations)
* [Installing a cluster on vSphere with network customizations](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-installer-provisioned-network-customizations#installation-installer-provisioned-vsphere-config-yaml_installing-vsphere-installer-provisioned-network-customizations)
* [Installing a cluster on vSphere with user-provisioned infrastructure-changed](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere#installation-vsphere-config-yaml_installing-vsphere)
* [Installing a cluster on vSphere with network customizations-changed](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-vsphere-network-customizations#installation-vsphere-config-yaml_installing-vsphere-network-customizations)
* [Installing a cluster on vSphere in a restricted network](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-installer-provisioned-vsphere#installation-installer-provisioned-vsphere-config-yaml_installing-restricted-networks-installer-provisioned-vsphere)
* [Installing a cluster on vSphere in a restricted network with user-provisioned infrastructure - changed](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_vsphere/installing-restricted-networks-vsphere#installation-vsphere-config-yaml_installing-restricted-networks-vsphere)
* [Installation configuration parameters-AWS](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws)
* [Installation configuration parameters for GCP](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_gcp/installation-config-parameters-gcp)
* [Installation configuration parameters for Azure](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_azure/installation-config-parameters-azure)
* [Installation configuration parameters for IBM Power Virtual Server](https://67569--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_ibm_powervs/installation-config-parameters-ibm-power-vs)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
* We cannot use the [.small] role because it might collide with the CSS "small" syntax. See [Slack thread](https://app.slack.com/client/E030G10V24F?selected_team_id=E030G10V24F#:~:text=It%27s%20an%20arbitrary%20Asciidoctor%20markup%20that%20IMO%20should%20not%20be%20used%20for%20docs.%20it%27s%20not%20that%20it%27s%20deprecated%2C%20just%20that%20%5Bsmall%5D%20maps%20to%20a%20css%20.small%20class%20which%20may%20or%20may%20not%20be%20included%20in%20the%20next%20portal%20build).
