### PR TITLE
reformatting AWS install configuration parameters

### DIFF
--- a/modules/installation-configuration-parameters.adoc
+++ b/modules/installation-configuration-parameters.adoc
@@ -744,46 +744,76 @@ ifdef::aws[]
 Optional AWS configuration parameters are described in the following table:
 
 .Optional AWS parameters
-[cols=".^2,.^3,.^5a",options="header"]
+[cols=".^2l,.^3,.^5a",options="header"]
 |====
 |Parameter|Description|Values
 
-|`compute.platform.aws.amiID`
+|compute:
+  platform:
+    aws:
+      amiID:
 |The AWS AMI used to boot compute machines for the cluster. This is required for regions that require a custom {op-system} AMI.
 |Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
 
-|`compute.platform.aws.iamRole`
+|compute:
+  platform:
+    aws:
+      iamRole:
 |A pre-existing AWS IAM role applied to the compute machine pool instance profiles. You can use these fields to match naming schemes and include predefined permissions boundaries for your IAM roles. If undefined, the installation program creates a new IAM role.
 |The name of a valid AWS IAM role.
 
-|`compute.platform.aws.rootVolume.iops`
+|compute:
+  platform:
+    aws:
+      rootVolume:
+        iops:
 |The Input/Output Operations Per Second (IOPS) that is reserved for the root volume.
 |Integer, for example `4000`.
 
-|`compute.platform.aws.rootVolume.size`
+|compute:
+  platform:
+    aws:
+      rootVolume:
+        size:
 |The size in GiB of the root volume.
 |Integer, for example `500`.
 
-|`compute.platform.aws.rootVolume.type`
+|compute:
+  platform:
+    aws:
+      rootVolume:
+        type:
 |The type of the root volume.
 |Valid link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html[AWS EBS volume type],
 such as `io1`.
 
-|`compute.platform.aws.rootVolume.kmsKeyARN`
+|compute:
+  platform:
+    aws:
+      rootVolume:
+        kmsKeyARN:
 |The Amazon Resource Name (key ARN) of a KMS key. This is required to encrypt operating system volumes of worker nodes with a specific KMS key.
 |Valid link:https://docs.aws.amazon.com/kms/latest/developerguide/find-cmk-id-arn.html[key ID or the key ARN].
 
-|`compute.platform.aws.type`
+|compute:
+  platform:
+    aws:
+      type:
 |The EC2 instance type for the compute machines.
 |Valid AWS instance type, such as `m4.2xlarge`. See the *Supported AWS machine types* table that follows.
 //add an xref when possible.
 
-|`compute.platform.aws.zones`
+|compute:
+  platform:
+    aws:
+      zones:
 |The availability zones where the installation program creates machines for the compute machine pool. If you provide your own VPC, you must provide a subnet in that availability zone.
 |A list of valid AWS availability zones, such as `us-east-1c`, in a
 link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
-|`compute.aws.region`
+|compute:
+  aws:
+    region:
 |The AWS region that the installation program creates compute resources in.
 |Any valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`. You can use the AWS CLI to access the regions available based on your selected instance type. For example:
 [source,terminal]
@@ -798,58 +828,108 @@ When running on ARM based AWS instances, ensure that you enter a region where AW
 endif::openshift-origin[]
 
 
-|`controlPlane.platform.aws.amiID`
+|controlPlane:
+  platform:
+    aws:
+      amiID:
 |The AWS AMI used to boot control plane machines for the cluster. This is required for regions that require a custom {op-system} AMI.
 |Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
 
-|`controlPlane.platform.aws.iamRole`
+|controlPlane:
+  platform:
+    aws:
+      iamRole:
 |A pre-existing AWS IAM role applied to the control plane machine pool instance profiles. You can use these fields to match naming schemes and include predefined permissions boundaries for your IAM roles. If undefined, the installation program creates a new IAM role.
 |The name of a valid AWS IAM role.
 
-|`controlPlane.platform.aws.rootVolume.kmsKeyARN`
+|controlPlane:
+  platform:
+    aws:
+      rootVolume:
+        iops:
+|The Input/Output Operations Per Second (IOPS) that is reserved for the root volume on control plane machines.
+|Integer, for example `4000`.
+
+|controlPlane:
+  platform:
+    aws:
+      rootVolume:
+        size:
+|The size in GiB of the root volume for control plane machines.
+|Integer, for example `500`.
+
+|controlPlane:
+  platform:
+    aws:
+      rootVolume:
+        type:
+|The type of the root volume for control plane machines.
+|Valid link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/EBSVolumeTypes.html[AWS EBS volume type],
+such as `io1`.
+
+|controlPlane:
+  platform:
+    aws:
+      rootVolume:
+        kmsKeyARN:
 |The Amazon Resource Name (key ARN) of a KMS key. This is required to encrypt operating system volumes of control plane nodes with a specific KMS key.
 |Valid link:https://docs.aws.amazon.com/kms/latest/developerguide/find-cmk-id-arn.html[key ID and the key ARN].
 
-|`controlPlane.platform.aws.type`
+|controlPlane:
+  platform:
+    aws:
+      type:
 |The EC2 instance type for the control plane machines.
 |Valid AWS instance type, such as `m6i.xlarge`. See the *Supported AWS machine types* table that follows.
 //add an xref when possible
 
-|`controlPlane.platform.aws.zones`
+|controlPlane:
+  platform:
+    aws:
+      zones:
 |The availability zones where the installation program creates machines for the
 control plane machine pool.
 |A list of valid AWS availability zones, such as `us-east-1c`, in a link:https://yaml.org/spec/1.2/spec.html#sequence//[YAML sequence].
 
-|`controlPlane.aws.region`
+|controlPlane:
+  aws:
+    region:
 |The AWS region that the installation program creates control plane resources in.
 |Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS region], such as `us-east-1`.
 
-|`platform.aws.amiID`
+|platform:
+  aws:
+    amiID:
 |The AWS AMI used to boot all machines for the cluster. If set, the AMI must
 belong to the same region as the cluster. This is required for regions that require a custom {op-system} AMI.
 |Any published or custom {op-system} AMI that belongs to the set AWS region. See _{op-system} AMIs for AWS infrastructure_ for available AMI IDs.
 
-|`platform.aws.hostedZone`
+|platform:
+  aws:
+    hostedZone:
 |An existing Route 53 private hosted zone for the cluster. You can only use a pre-existing hosted zone when also supplying your own VPC. The hosted zone must already be associated with the user-provided VPC before installation. Also, the domain of the hosted zone must be the cluster domain or a parent of the cluster domain. If undefined, the installation program creates a new hosted zone.
 |String, for example `Z3URY6TWQ91KVV`.
 
-|`platform.aws.hostedZoneRole`
+|platform:
+  aws:
+    hostedZoneRole:
 |An Amazon Resource Name (ARN) for an existing IAM role in the account containing the specified hosted zone. The installation program and cluster operators will assume this role when performing operations on the hosted zone. This parameter should only be used if you are installing a cluster into a shared VPC.
 |String, for example `arn:aws:iam::1234567890:role/shared-vpc-role`.
 
-|`platform.aws.serviceEndpoints.name`
-|The AWS service endpoint name. Custom endpoints are only required for cases
+|platform:
+  aws:
+    serviceEndpoints:
+      - name:
+        url:
+|The AWS service endpoint name and URL. Custom endpoints are only required for cases
 where alternative AWS endpoints, like FIPS, must be used. Custom API endpoints
 can be specified for EC2, S3, IAM, Elastic Load Balancing, Tagging, Route 53,
 and STS AWS services.
-|Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] name.
+|Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] name and valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] URL.
 
-|`platform.aws.serviceEndpoints.url`
-|The AWS service endpoint URL. The URL must use the `https` protocol and the
-host must trust the certificate.
-|Valid link:https://docs.aws.amazon.com/general/latest/gr/rande.html[AWS service endpoint] URL.
-
-|`platform.aws.userTags`
+|platform:
+  aws:
+    userTags:
 |A map of keys and values that the installation program adds as tags to all resources that it creates.
 |Any valid YAML map, such as key value pairs in the `<key>: <value>` format. For more information about AWS tags, see link:https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/Using_Tags.html[Tagging Your Amazon EC2 Resources] in the AWS documentation.
 
@@ -858,12 +938,16 @@ host must trust the certificate.
 You can add up to 25 user defined tags during installation. The remaining 25 tags are reserved for {product-title}.
 ====
 
-|`platform.aws.propagateUserTags`
+|platform:
+  aws:
+    propagateUserTags:
 | A flag that directs in-cluster Operators to include the specified user tags in the tags of the AWS resources that the Operators create.
 | Boolean values, for example `true` or `false`.
 
 
-|`platform.aws.subnets`
+|platform:
+  aws:
+    subnets:
 |If you provide the VPC instead of allowing the installation program to create the VPC for you, specify the subnet for the cluster to use. The subnet must be part of the same `machineNetwork[].cidr` ranges that you specify.
 
 For a standard cluster, specify a public and a private subnet for each availability zone.
@@ -873,7 +957,9 @@ For a private cluster, specify a private subnet for each availability zone.
 For clusters that use AWS Local Zones, you must add AWS Local Zone subnets to this list to ensure edge machine pool creation.
 |Valid subnet IDs.
 
-|`PreserveBootstrapIgnition`
+|platform:
+  aws:
+    PreserveBootstrapIgnition:
 |Prevents the S3 bucket from being deleted after completion of bootstrapping.
 |`true` or `false`. The default value is `false`, which results in the S3 bucket being deleted.
 


### PR DESCRIPTION
Version: 4.14+

Reformatting the AWS installation configuration parameter tables into stacked format. 

Previous format:
`controlPlane.aws.region`

New format:
```
controlPlane:
  aws:
    region:
```

Preview: [AWS configuration parameters](https://67573--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_aws/installation-config-parameters-aws#installation-configuration-parameters-optional-aws_installation-config-parameters-aws)
