### PR TITLE
CNV-35000: Added doc feedback section in release notes

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -11,7 +11,12 @@ toc::[]
 
 Red Hat is committed to replacing problematic language in our code, documentation, and web properties. We are beginning with these four terms: master, slave, blacklist, and whitelist. Because of the enormity of this endeavor, these changes will be implemented gradually over several upcoming releases. For more details, see link:https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language[our CTO Chris Wright's message].
 
+[id="virt-doc-feedback"]
+== Providing documentation feedback
 
+To report an error or to improve our documentation, log in to your link:https://issues.redhat.com[Red Hat Jira account] and submit a link:https://issues.redhat.com/secure/CreateIssueDetails!init.jspa?pid=12323181&issuetype=1&components=12333768&priority=10200&summary=%5BDoc%5D&customfield_12316142[Jira issue].
+
+[id="virt-about-cnv"]
 == About Red Hat {VirtProductName}
 
 Red Hat {VirtProductName} enables you to bring traditional virtual machines (VMs) into {product-title} where they run alongside containers, and are managed as native Kubernetes objects.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-35000](https://issues.redhat.com//browse/CNV-35000)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://67587--docspreview.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes#virt-4-14-doc-feedback
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review: N/A
<!--- [ ] QE has approved this change. --->
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

<!--- Additional information: --->
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
