### PR TITLE
Fixed the version info

### DIFF
--- a/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
+++ b/modules/ipi-install-replacing-a-bare-metal-control-plane-node.adoc
@@ -39,7 +39,7 @@ $ oc get clusteroperator baremetal
 [source,terminal]
 ----
 NAME        VERSION   AVAILABLE   PROGRESSING   DEGRADED   SINCE   MESSAGE
-baremetal   4.12.0   True        False         False      3d15h
+baremetal   4.15.0   True        False         False      3d15h
 ----
 
 . Remove the old `BareMetalHost` and `Machine` objects:
@@ -179,11 +179,11 @@ $ oc get nodes
 [source,terminal]
 ----
 NAME                           STATUS      ROLES     AGE   VERSION
-control-plane-1.example.com    available   master    4m2s  v1.18.2
-control-plane-2.example.com    available   master    141m  v1.18.2
-control-plane-3.example.com    available   master    141m  v1.18.2
-compute-1.example.com          available   worker    87m   v1.18.2
-compute-2.example.com          available   worker    87m   v1.18.2
+control-plane-1.example.com    available   master    4m2s  v1.27.6
+control-plane-2.example.com    available   master    141m  v1.27.6
+control-plane-3.example.com    available   master    141m  v1.27.6
+compute-1.example.com          available   worker    87m   v1.27.6
+compute-2.example.com          available   worker    87m   v1.27.6
 ----
 +
 [NOTE]


### PR DESCRIPTION
fixed the version info



Version(s):
4.15.z

Issue:
changed the ocp version from 4.12 to 4.15 and updated the nodes version form 1.18.2 to 1.27.6

Link to docs preview:
https://docs.openshift.com/container-platform/4.14/installing/installing_bare_metal_ipi/ipi-install-expanding-the-cluster.html#replacing-a-bare-metal-control-plane-node_ipi-install-expanding

QE review:
- [x] QE has approved this change.

 /label peer-review-needed