### PR TITLE
CNV#28731: hosted control planes on OCP Virt RN

### DIFF
--- a/virt/release_notes/virt-4-14-release-notes.adoc
+++ b/virt/release_notes/virt-4-14-release-notes.adoc
@@ -50,6 +50,9 @@ The SVVP Certification applies to:
 ** Red Hat Enterprise Linux CoreOS workers. In the Microsoft SVVP Catalog, they are named __Red Hat OpenShift Container Platform 4 on RHEL CoreOS 9__.
 ** Intel and AMD CPUs.
 
+//CNV-28731 Release note: NEW
+* Creating hosted control plane clusters on {VirtProductName} was previously Technology Preview and is now generally available. For more information, see link:https://access.redhat.com/documentation/en-us/red_hat_advanced_cluster_management_for_kubernetes/2.9/html/clusters/cluster_mce_overview#hosted-control-planes-manage-kubevirt[Managing hosted control plane clusters on {VirtProductName}] in the {rh-rhacm-first} documentation.
+
 //CNV-28732 Release note: NEW
 * Using {VirtProductName} on Amazon Web Services (AWS) bare-metal {product-title} clusters was previously Technology Preview and is now generally available.
 +
@@ -102,8 +105,6 @@ For more information, see xref:../../virt/install/preparing-cluster-for-virt.ado
 //CNV-28096 Release note: NEW feature -- clone from cached snapshot
 
 //CNV-28726 Release note: New; CNV-28726_revert to remove based on RN reviews
-
-//CNV-28731 Release note: NEW
 
 //CNV-28729 Release note: New
 * You can use a xref:../../virt/virtual_machines/advanced_vm_management/virt-schedule-vms.adoc#virt-vm-custom-scheduler_virt-schedule-vms[custom scheduler] to schedule a virtual machine (VM) on a node.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s): 4.14 only (RN)
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue: [CNV-28731](https://issues.redhat.com//browse/CNV-28731)
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview: https://67602--docspreview.netlify.app/openshift-enterprise/latest/virt/release_notes/virt-4-14-release-notes#virt-4-14-new
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [x] QE has approved this change. Satheesaran Sundaramoorthi acked this PR.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information: To be merged when RHACM 2.9 releases. I ~will change the link to point to the 2.9 docs before merging~ changed the link to point to the 2.9 docs, but it currently 404s (2.9 docs are not live yet. Per @lahinson the release date moved). I will confirm that the link works before I merge this PR on the new ACM 2.9 release date.
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
