### PR TITLE
SRVKE-1273: Update Kafka install docs

### DIFF
--- a/modules/serverless-install-kafka-odc.adoc
+++ b/modules/serverless-install-kafka-odc.adoc
@@ -13,10 +13,9 @@ The Knative broker implementation for Apache Kafka provides integration options 
 * You have installed the {ServerlessOperatorName} and Knative Eventing on your cluster.
 * You have access to a Red Hat AMQ Streams cluster.
 * Install the OpenShift CLI (`oc`) if you want to use the verification steps.
-
 * You have cluster administrator permissions on {ocp-product-title}, or you have cluster or dedicated administrator permissions on {rosa-product-title} or {dedicated-product-title}.
-
 * You are logged in to the {ocp-product-title} web console.
+
 .Procedure
 
 . In the *Administrator* perspective, navigate to *Operators* -> *Installed Operators*.
@@ -31,6 +30,9 @@ The Knative broker implementation for Apache Kafka provides integration options 
 ====
 To use the Kafka channel, source, broker, or sink on your cluster, you must toggle the *enabled* switch for the options you want to use to *true*. These switches are set to *false* by default. Additionally, to use the Kafka channel, broker, or sink you must specify the bootstrap servers.
 ====
+
+** Use the form for simpler configurations that do not require full control of *KnativeKafka* object creation.
+** Edit the YAML for more complex configurations that require full control of *KnativeKafka* object creation. You can access the YAML by clicking the *Edit YAML* link on the *Create Knative Kafka* page.
 +
 .Example `KnativeKafka` custom resource
 [source,yaml]
@@ -54,6 +56,8 @@ spec:
             replicationFactor: <replication_factor> <7>
     sink:
         enabled: true <8>
+    logging:
+        level: INFO <9>
 ----
 <1> Enables developers to use the `KafkaChannel` channel type in the cluster.
 <2> A comma-separated list of bootstrap servers from your AMQ Streams cluster.
@@ -61,17 +65,14 @@ spec:
 <4> Enables developers to use the Knative broker implementation for Apache Kafka in the cluster.
 <5> A comma-separated list of bootstrap servers from your Red Hat AMQ Streams cluster.
 <6> Defines the number of partitions of the Kafka topics, backed by the `Broker` objects. The default is `10`.
-<7> Defines the replication factor of the Kafka topics, backed by the `Broker` objects. The default is `3`.
+<7> Defines the replication factor of the Kafka topics, backed by the `Broker` objects. The default is `3`. The `replicationFactor` value must be less than or equal to the number of nodes of your Red Hat AMQ Streams cluster.
 <8> Enables developers to use a Kafka sink in the cluster.
+<9> Defines the log level of the Kafka data plane. Allowed values are `TRACE`, `DEBUG`, `INFO`, `WARN` and `ERROR`. The default value is `INFO`.
 +
-[NOTE]
+[WARNING]
 ====
-The `replicationFactor` value must be less than or equal to the number of nodes of your Red Hat AMQ Streams cluster.
+Do not use `DEBUG` or `TRACE` as the logging level in production environments. The outputs from these logging levels are verbose and can degrade performance.
 ====
-
-.. Using the form is recommended for simpler configurations that do not require full control of *KnativeKafka* object creation.
-
-.. Editing the YAML is recommended for more complex configurations that require full control of *KnativeKafka* object creation. You can access the YAML by clicking the *Edit YAML* link in the top right of the *Create Knative Kafka* page.
 
 . Click *Create* after you have completed any of the optional configurations for Kafka. You are automatically directed to the *Knative Kafka* tab where *knative-kafka* is in the list of resources.
 


### PR DESCRIPTION
Version(s):
Serverless 1.29 - 1.31

Issue:
https://issues.redhat.com/browse/SRVKE-1273

Link to docs preview:
https://67612--docspreview.netlify.app/openshift-serverless/latest/install/installing-knative-eventing#serverless-install-kafka-odc_installing-knative-eventing

QE review:
- [x] QE has approved this change.

SME and QE approval were received on the previous version of this PR.

Additional information:

- PR to replace https://github.com/openshift/openshift-docs/pull/59705 using correct `serverless-docs` branch instead of `main`.
- Some additional editing from original PR to remove "recommendations" per https://redhat-documentation.github.io/supplementary-style-guide/#recommend
