### PR TITLE
OSDOCS-7831: Create index.adoc landing page explaining Tutorials

### DIFF
--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -84,6 +84,8 @@ Name: Tutorials
 Dir: cloud_experts_tutorials
 Distros: openshift-rosa
 Topics:
+- Name: ROSA tutorials
+  FIle: cloud-experts-index-tutorial
 #- Name: ROSA prerequisites
 #  File: rosa-mobb-prerequisites-tutorial
 - Name: Verifying Permissions for a ROSA STS Deployment

--- a/cloud_experts_tutorials/index.adoc
+++ b/cloud_experts_tutorials/index.adoc
@@ -1,0 +1,7 @@
+:_mod-docs-content-type: ASSEMBLY
+[id="tutorials-overview"]
+= Tutorials
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: tutorials-overview
+
+The tutorias in this section include end-to-end procedures written by Red Hat Cloud Experts to provide example use cases for {product-title}.

--- a/cloud_experts_tutorials/rosa-mobb-index-tutorial.adoc 
+++ b/cloud_experts_tutorials/rosa-mobb-index-tutorial.adoc 
@@ -1,0 +1,7 @@
+:_content-type: ASSEMBLY
+[id="rosa-mobb-index-tutorial"]
+= ROSA tutorials
+include::_attributes/attributes-openshift-dedicated.adoc[]
+:context: rosa-mobb-index-tutorial
+
+toc::[]


### PR DESCRIPTION
Version(s):
4.14+ 

Issue:
https://issues.redhat.com/browse/OSDOCS-7831

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
