### PR TITLE
OCPBUGS#23026: fix rhel attribute in repos

### DIFF
--- a/modules/microshift-adding-repos-to-image-builder.adoc
+++ b/modules/microshift-adding-repos-to-image-builder.adoc
@@ -19,13 +19,13 @@ Use the following procedure to add the {microshift-short} repositories to Image 
 
 . Create an Image Builder configuration file for adding the `{rpm-repo-version}` RPM repository source required to pull {product-title} RPMs by running the following command:
 +
-[source,terminal,subs="attributes+"]
+[source,text,subs="attributes+"]
 ----
-$ cat > {rpm-repo-version}.toml <<EOF
+cat > {rpm-repo-version}.toml <<EOF
 id = "{rpm-repo-version}"
 name = "Red Hat OpenShift Container Platform {ocp-version} for RHEL {op-system-version-major}"
 type = "yum-baseurl"
-url = "https://cdn.redhat.com/content/dist/layered/{rhel-major}/$(uname -m)/rhocp/{ocp-version}/os"
+url = "https://cdn.redhat.com/content/dist/layered/rhel9/$(uname -m)/rhocp/{ocp-version}/os"
 check_gpg = true
 check_ssl = true
 system = false
@@ -35,13 +35,13 @@ EOF
 
 . Create an Image Builder configuration file for adding the `fast-datapath` RPM repository by running the following command:
 +
-[source,terminal,subs="attributes+"]
+[source,text,subs="attributes+"]
 ----
-$ cat > fast-datapath.toml <<EOF
+cat > fast-datapath.toml <<EOF
 id = "fast-datapath"
 name = "Fast Datapath for RHEL 9"
 type = "yum-baseurl"
-url = "https://cdn.redhat.com/content/dist/layered/{rhel-major}/$(uname -m)/fast-datapath/os"
+url = "https://cdn.redhat.com/content/dist/layered/rhel9/$(uname -m)/fast-datapath/os"
 check_gpg = true
 check_ssl = true
 system = false

--- a/modules/microshift-adding-service-to-blueprint.adoc
+++ b/modules/microshift-adding-service-to-blueprint.adoc
@@ -15,9 +15,9 @@ Adding the {microshift-short} RPM package to an Image Builder blueprint enables 
 +
 .Image Builder blueprint example
 +
-[source,terminal]
+[source,text]
 ----
-$ cat > minimal-microshift.toml <<EOF
+cat > minimal-microshift.toml <<EOF
 name = "minimal-microshift"
 
 description = ""

--- a/modules/microshift-applying-manifests-example.adoc
+++ b/modules/microshift-applying-manifests-example.adoc
@@ -27,9 +27,9 @@ $ sudo mkdir -p ${MANIFEST_DIR}
 +
 .. Place the YAML file in the directory:
 +
-[source,terminal]
+[source,text]
 ----
-$ sudo tee ${MANIFEST_DIR}/busybox.yaml &>/dev/null <<EOF
+sudo tee ${MANIFEST_DIR}/busybox.yaml &>/dev/null <<EOF
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -62,9 +62,9 @@ EOF
 +
 .. Place the YAML file in the directory:
 +
-[source,terminal]
+[source,text]
 ----
-$ sudo tee ${MANIFEST_DIR}/kustomization.yaml &>/dev/null <<EOF
+sudo tee ${MANIFEST_DIR}/kustomization.yaml &>/dev/null <<EOF
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 namespace: busybox

--- a/modules/microshift-creating-ostree-iso.adoc
+++ b/modules/microshift-creating-ostree-iso.adoc
@@ -95,9 +95,9 @@ This command also returns the ID of the container saved in the `IMAGEID` variabl
 
 . Generate the installer blueprint file by running the following command:
 +
-[source,terminal]
+[source,text]
 ----
-$ cat > microshift-installer.toml <<EOF
+cat > microshift-installer.toml <<EOF
 name = "microshift-installer"
 
 description = ""

--- a/modules/microshift-firewall-update-for-service.adoc
+++ b/modules/microshift-firewall-update-for-service.adoc
@@ -10,7 +10,7 @@ Firewalld is often active when you run services on {microshift-short}. This can 
 
 * Services of the `NodePort` and `LoadBalancer` type are automatically available with OVN-Kubernetes.
 +
-In these cases, OVN-Kubernetes adds iptables rules so the traffic to the node IP address is delivered to the relevant ports. This is done using the PREROUTING rule chain and is then forwarded to the OVN-K to bypass the firewalld rules for local host ports and services. Iptables and firewalld are backed by nftables in {rhel-major}. The nftables rules, which the iptables generates, always has priority over the rules that the firewalld generates.
+In these cases, OVN-Kubernetes adds iptables rules so the traffic to the node IP address is delivered to the relevant ports. This is done using the PREROUTING rule chain and is then forwarded to the OVN-K to bypass the firewalld rules for local host ports and services. Iptables and firewalld are backed by nftables in {op-system} {op-system-version-major}. The nftables rules, which the iptables generates, always have priority over the rules that the firewalld generates.
 
 * Pods with the `HostPort` parameter settings are automatically available. This also includes the `router-default` pod, which uses ports 80 and 443.
 +

--- a/modules/microshift-updating-rpms-ostree.adoc
+++ b/modules/microshift-updating-rpms-ostree.adoc
@@ -34,7 +34,7 @@ $ cat > {rpm-repo-version}.toml <<EOF
 id = "{rpm-repo-version}"
 name = "Red Hat OpenShift Container Platform {ocp-version} for RHEL {op-system-version-major}"
 type = "yum-baseurl"
-url = "https://cdn.redhat.com/content/dist/layered/{rhel-major}/$(uname -m)/rhocp/{ocp-version}/os"
+url = "https://cdn.redhat.com/content/dist/layered/rhel9/$(uname -m)/rhocp/{ocp-version}/os"
 check_gpg = true
 check_ssl = true
 system = false


### PR DESCRIPTION
Version(s):
4.14+

Issue:
https://issues.redhat.com/browse/OCPBUGS-23026

Link to docs preview:
[rhel-9; install from RPMs](https://67618--docspreview.netlify.app/microshift/latest/microshift_install/microshift-install-rpm#installing-microshift-from-rpm-package_microshift-install-rpm)
[rhel9 in Image Builder URL and command block](https://67618--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree#adding-microshift-repos-image-builder_microshift-embed-in-rpm-ostree)
[second command block; example blueprint](https://67618--docspreview.netlify.app/microshift/latest/microshift_install/microshift-embed-in-rpm-ostree#adding-microshift-service-to-blueprint_microshift-embed-in-rpm-ostree)
[deploy apps code blocks](https://67618--docspreview.netlify.app/microshift/latest/microshift_running_apps/microshift-applications#microshift-manifests-overview_applications-microshift)

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->
 
SME approved