### PR TITLE
ROX-20707: Update docs for location of watched images

### DIFF
--- a/modules/scan-inactive-images.adoc
+++ b/modules/scan-inactive-images.adoc
@@ -11,24 +11,18 @@
 
 You can also configure {product-title-short} to scan inactive (not deployed) images automatically.
 
-
 .Procedure
 
-. On the RHACS portal, navigate to *Vulnerability Management > Dashboard*.
-. On the *Dashboard* view header, select *IMAGES*.
-. Click *MANAGE WATCHES* to manage the scanning of watched images.
-. In the *MANAGE WATCHED IMAGES* dialog, enter the inactive image’s name for which you want to enable scanning.
-+
-Verify that you enter the name of the image and not the image `id`.
-Image name is the fully-qualified image name, beginning with the registry and ending with the tag. For example, `docker.io/vulnerables/cve-2017-7494:latest`.
-
-. Select *ADD IMAGE*. RHACS then scans the image and shows the error or success message.
-. (Optional) Click *REMOVE WATCH* to remove an image from the watchlist.
+. On the {product-title-short} portal, navigate to *Vulnerability Management (2.0) -> Workload CVEs (Tech preview)*.
+. Click *<number> Images* to display a list of images and locate the image you want to watch.
+. Click {kebab}, and then select *Watch image*. {product-title-short} then scans the image and shows an error or success message.
+. (Optional) To remove a watched image, click {kebab}, and then select *Unwatch image*.
+. (Optional) You can view the list of all watched images and add additional images to watch by clicking *Manage watched images* in the page header.
 +
 [IMPORTANT]
 ====
-On the {product-title-short} portal, click *Platform Configuration > System Configuration* to view the data retention configuration.
+On the {product-title-short} portal, click *Platform Configuration* -> *System Configuration* to view the data retention configuration.
 
-All the data related to the image removed from the watchlist continues to appear in the {product-title-short} portal for the number of days mentioned on the *System Configuration* page and is only removed after that period is over.
+All the data related to the image removed from the watched image list continues to appear in the {product-title-short} portal for the number of days mentioned on the *System Configuration* page and is only removed after that period is over.
 ====
-. Select *RETURN TO IMAGE LIST* to view the *IMAGES* page.
+. Click *Close* to return to the *Workload CVEs* page.


### PR DESCRIPTION
Version(s):

4.3+

[Issue](https://issues.redhat.com/browse/ROX-20707)

[Link to docs preview
](https://67639--docspreview.netlify.app/openshift-acs/latest/operating/examine-images-for-vulnerabilities#scan-inactive-images_examine-images-for-vulnerabilities)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
