### PR TITLE
OCPBUGS#22446 moving note to prereqs

### DIFF
--- a/modules/cli-installing-cli-rpm.adoc
+++ b/modules/cli-installing-cli-rpm.adoc
@@ -13,6 +13,11 @@ ifdef::openshift-rosa[]
 endif::openshift-rosa[]
 subscription on your Red Hat account.
 
+[NOTE]
+====
+It is not supported to install the OpenShift CLI (`oc`) as an RPM for {op-system-base-full} 9. You must install the OpenShift CLI for {op-system-base} 9 by downloading the binary.
+====
+
 .Prerequisites
 
 * Must have root or sudo privileges.
@@ -66,11 +71,6 @@ endif::openshift-rosa[]
 ----
 # subscription-manager repos --enable="rhocp-{product-version}-for-rhel-8-x86_64-rpms"
 ----
-+
-[NOTE]
-====
-It is not supported to install the OpenShift CLI (`oc`) as an RPM for {op-system-base-full} 9. You must install the OpenShift CLI for {op-system-base} 9 by downloading the binary.
-====
 
 . Install the `openshift-clients` package:
 +


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OCPBUGS-22446](https://issues.redhat.com/browse/OCPBUGS-22446 )

Link to docs preview: [Preview](https://67641--docspreview.netlify.app/openshift-enterprise/latest/cli_reference/openshift_cli/getting-started-cli#cli-installing-cli-rpm_cli-developer-commands)
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
I don't think QE is needed for this change. Let me know if there is disagreement.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
Moving the note to the prereqs section.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
