### PR TITLE
add-ibm-cloud-vpc-attr-internal

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -205,6 +205,9 @@ endif::[]
 :gcp-short: GCP
 //alibaba cloud
 :alibaba: Alibaba Cloud
+// IBM Cloud VPC
+:ibmcloudVPCProductName: IBM Cloud VPC
+:ibmcloudVPCRegProductName: IBM(R) Cloud VPC
 // IBM Cloud
 :ibm-cloud-bm: IBM Cloud Bare Metal (Classic)
 :ibm-cloud-bm-reg: IBM Cloud(R) Bare Metal (Classic)


### PR DESCRIPTION
[INTERNAL FIX]

Version(s):
main, 4.15

The main and 4.15 branches are missing two attributes that are defined in subsquent branches. See https://github.com/openshift/openshift-docs/blob/enterprise-4.14/_attributes/common-attributes.adoc

The [4.15 Welcome page](https://67532--docspreview.netlify.app/openshift-enterprise/latest/welcome/#cluster-installer-activities) shows an unrendered  {ibmcloudVPCRegProductName}: attribute. 

[Preview build link](https://67643--docspreview.netlify.app/openshift-enterprise/latest/welcome/)
