### PR TITLE
[OSDOCS-8685]:Correction required for 'autoscaling availability only on clusters purchased through Red Hat Marketplace'

### DIFF
--- a/osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.adoc
+++ b/osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes.adoc
@@ -7,7 +7,7 @@ toc::[]
 
 [IMPORTANT]
 ====
-Autoscaling is available only on clusters that were purchased through the Red Hat Marketplace.
+Autoscaling is available only on clusters that were purchased through Google Cloud Marketplace and Red Hat Marketplace.
 ====
 
 The autoscaler option can be configured to automatically scale the number of machines in a cluster.


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8685
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://67644--docspreview.netlify.app/openshift-dedicated/latest/osd_cluster_admin/osd_nodes/osd-nodes-about-autoscaling-nodes
QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
