### PR TITLE
Web console docs fixes during ROSA review

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -741,7 +741,7 @@ Topics:
   File: web-console-overview
 - Name: Accessing the web console
   File: web-console
-- Name: Viewing cluster information
+- Name: Using the OpenShift Container Platform dashboard to get cluster information
   File: using-dashboard-to-get-cluster-information
 - Name: Adding user preferences
   File: adding-user-preferences

--- a/modules/customizing-cli-downloads.adoc
+++ b/modules/customizing-cli-downloads.adoc
@@ -27,18 +27,18 @@ the packages.
 apiVersion: console.openshift.io/v1
 kind: ConsoleCLIDownload
 metadata:
-  name: example-cli-download-links-for-foo
+  name: example-cli-download-links
 spec:
   description: |
-    This is an example of download links for foo
-  displayName: example-foo
+    This is an example of download links
+  displayName: example
   links:
-  - href: 'https://www.example.com/public/foo.tar'
-    text: foo for linux
-  - href: 'https://www.example.com/public/foo.mac.zip'
-    text: foo for mac
-  - href: 'https://www.example.com/public/foo.win.zip'
-    text: foo for windows
+  - href: 'https://www.example.com/public/example.tar'
+    text: example for linux
+  - href: 'https://www.example.com/public/example.mac.zip'
+    text: example for mac
+  - href: 'https://www.example.com/public/example.win.zip'
+    text: example for windows
 ----
 
 . Click the *Save* button.

--- a/modules/customizing-the-login-page.adoc
+++ b/modules/customizing-the-login-page.adoc
@@ -68,6 +68,11 @@ $ oc edit oauths cluster
 +
 [source,yaml]
 ----
+apiVersion: config.openshift.io/v1
+kind: OAuth
+metadata:
+  name: cluster
+# ...
 spec:
   templates:
     error:

--- a/modules/odc-access-web-terminal.adoc
+++ b/modules/odc-access-web-terminal.adoc
@@ -6,7 +6,7 @@
 [id="odc-access-web-terminal_{context}"]
 = Accessing the web terminal
 
-After the {web-terminal-op} is installed, you can access the web terminal.
+After the {web-terminal-op} is installed, you can access the web terminal. After the web terminal is initialized, you can use the preinstalled CLI tools like `oc`, `kubectl`, `odo`, `kn`, `tkn`, `helm`, `kubens`, `subctl`, and `kubectx` in the web terminal.
 You can re-run commands by selecting them from the list of commands you have run in the terminal. These commands persist across multiple terminal sessions.
 The web terminal remains open until you close it or until you close the browser window or tab.
 
@@ -19,16 +19,27 @@ The web terminal remains open until you close it or until you close the browser 
 
 . To launch the web terminal, click the command line terminal icon (image:odc-wto-icon.png[title="wto icon"]) in the masthead of the console. A web terminal instance is displayed in the *Command line terminal* pane. This instance is automatically logged in with your credentials.
 
-. Select the project where the `DevWorkspace` CR must be created from the *Project* drop-down list. By default, the current project is selected.
+. If a project has not been selected in the current session, select the project where the `DevWorkspace` CR must be created from the *Project* drop-down list. By default, the current project is selected.
 +
 [NOTE]
 ====
 * The `DevWorkspace` CR is created only if it does not already exist.
 ifndef::openshift-rosa,openshift-dedicated[]
-* The `openshift-terminal` project is the default project used for cluster administrators. They do not have the option to choose another project.
+* The `openshift-terminal` project is the default project used for cluster administrators. They do not have the option to choose another project.  The {web-terminal-op} installs the DevWorkspace Operator as a dependency.
 endif::openshift-rosa,openshift-dedicated[]
 ====
 
-. Click *Start* to initialize the web terminal using the selected project. After the web terminal is initialized, you can use the preinstalled CLI tools like `oc`, `kubectl`, `odo`, `kn`, `tkn`, `helm`, `kubens`, `subctl`, and `kubectx` in the web terminal.
+ifndef::openshift-rosa,openshift-dedicated[]
+. Optional: Set the web terminal timeout for the current session:
+.. Click Timeout.
+.. In the field that appears, enter the timeout value.
+.. From the drop-down list, select a timeout interval of *Seconds*, *Minutes*, *Hours*, or *Milliseconds*.
+
+. Optional: Select a custom image for the web terminal to use.
+.. Click Image. 
+.. In the field that appears, enter the URL of the image that you want to use.
+endif::openshift-rosa,openshift-dedicated[]
+
+. Click *Start* to initialize the web terminal using the selected project. 
 
 . Click *+* to open multiple tabs within the web terminal in the console.

--- a/modules/odc-configure-web-terminal-timeout-session.adoc
+++ b/modules/odc-configure-web-terminal-timeout-session.adoc
@@ -17,6 +17,11 @@ You can change the default timeout period for the web terminal for your current 
 .Procedure
 
 . Click the web terminal icon (image:odc-wto-icon.png[title="web terminal icon"]).
-. Click *Timeout* to display advanced configuration options for the web terminal timeout.
-. Set a value for the timeout. From the drop-down list, select a time interval of *Seconds*, *Minutes*, *Hours*, or *Milliseconds*.
+. Optional: Set the web terminal timeout for the current session:
+.. Click Timeout.
+.. In the field that appears, enter the timeout value.
+.. From the drop-down list, select a timeout interval of *Seconds*, *Minutes*, *Hours*, or *Milliseconds*.
+. Optional: Select a custom image for the web terminal to use.
+.. Click Image. 
+.. In the field that appears, enter the URL of the image that you want to use.
 . Click *Start* to begin a terminal instance using the specified timeout setting.

--- a/modules/odc-setting-user-preferences.adoc
+++ b/modules/odc-setting-user-preferences.adoc
@@ -12,11 +12,13 @@ You can set the default user preferences for your cluster.
 . Log in to the {product-title} web console using your login credentials.
 . Use the masthead to access the user preferences under the user profile.
 . In the *General* section:
+.. In the **Theme** field, you can set the theme that you want to work in. The console defaults to the selected theme each time you log in. 
 .. In the *Perspective* field, you can set the default perspective you want to be logged in to. You can select the *Administrator* or the *Developer* perspective as required. If a perspective is not selected, you are logged into the perspective you last visited.
-.. In the *Project* field, select a project you want to work in. The console will default to the project every time you log in.
+.. In the *Project* field, select a project you want to work in. The console defaults to the project every time you log in.
 .. In the *Topology* field, you can set the topology view to default to the graph or list view. If not selected, the console defaults to the last view you used.
 .. In the *Create/Edit resource method* field, you can set a preference for creating or editing a resource. If both the form and YAML options are available, the console defaults to your selection.
 . In the *Language* section, select *Default browser language* to use the default browser language settings. Otherwise, select the language that you want to use for the console.
+. In the *Notifications* section, you can toggle display notifications created by users for specific projects on the *Overview* page or notification drawer.  
 . In the *Applications* section:
 .. You can view the default *Resource type*. For example, if the {ServerlessOperatorName} is installed, the default resource type is *Serverless Deployment*. Otherwise, the default resource type is *Deployment*.
 .. You can select another resource type to be the default resource type from the *Resource Type* field.

--- a/modules/recognize-resource-limits-quotas.adoc
+++ b/modules/recognize-resource-limits-quotas.adoc
@@ -1,0 +1,12 @@
+// Module included in the following assemblies:
+// * web_console/using-dashboard-to-get-cluster-information.adoc
+
+:_mod-docs-content-type: CONCEPT
+[id="recognize-resource-limits-quotas"]
+= Recognizing resource and project limits and quotas
+
+You can view a graphical representation of available resources in the *Topology* view of the web console *Developer* perspective.
+
+If a resource has a message about resource limitations or quotas being reached, a yellow border appears around the resource name. Click the resource to open a side panel to see the message. If the *Topology* view has been zoomed out, a yellow dot indicates that a message is available.
+
+If you are using *List View* from the *View Shortcuts* menu, resources appear as a list. The *Alerts* column indicates if a message is available.

--- a/modules/removing-web-terminal-operator.adoc
+++ b/modules/removing-web-terminal-operator.adoc
@@ -19,18 +19,6 @@ You can uninstall the web terminal by removing the {web-terminal-op} and custom 
 . Scroll the filter list or type a keyword into the *Filter by name* box to find the {web-terminal-op}.
 . Click the Options menu {kebab} for the {web-terminal-op}, and then select *Uninstall Operator*.
 . In the *Uninstall Operator* confirmation dialog box, click *Uninstall* to remove the Operator, Operator deployments, and pods from the cluster. The Operator stops running and no longer receives updates.
-. Remove the custom resources:
-+
-[source,terminal]
-----
-$ oc delete devworkspaces.workspace.devfile.io --all-namespaces \
-    --selector 'console.openshift.io/terminal=true' --wait
-----
-+
-[source,terminal]
-----
-$ oc delete devworkspacetemplates.workspace.devfile.io --all-namespaces \
-    --selector 'console.openshift.io/terminal=true' --wait
-----
+// Removed steps, as they are in the following module. 
 
 // TODO: Add a verification section

--- a/modules/virt-about-the-overview-dashboard.adoc
+++ b/modules/virt-about-the-overview-dashboard.adoc
@@ -6,6 +6,13 @@
 [id="virt-about-the-overview-dashboard_{context}"]
 = About the {product-title} dashboards page
 
+Access the {product-title} dashboard, which captures high-level information
+about the cluster, by navigating to *Home* -> *Overview* from
+the {product-title} web console.
+
+The {product-title} dashboard provides various cluster information, captured in
+individual dashboard cards.
+
 The {product-title} dashboard consists of the following cards:
 
 * *Details* provides a brief overview of informational cluster details.
@@ -19,13 +26,13 @@ Status include *ok*, *error*, *warning*, *in progress*, and *unknown*. Resources
 ** Number of nodes
 ** Number of pods
 ** Persistent storage volume claims
-** Bare metal hosts in the cluster, listed according to their state (only available in *metal3* environment).
-* *Cluster Capacity* charts help administrators understand when additional resources are required in the cluster. The charts contain an inner ring that displays current consumption, while an outer ring displays thresholds configured for the resource, including information about:
+** Bare metal hosts in the cluster, listed according to their state (only available in *metal3* environment)
+* *Status* helps administrators understand how cluster resources are consumed. Click on a resource to jump to a detailed page listing pods and nodes that consume the largest amount of the specified cluster resource (CPU, memory, or storage).
+* *Cluster Utilization* shows the capacity of various resources over a specified period of time, to help administrators understand the scale and frequency of high resource consumption, including information about:
 ** CPU time
 ** Memory allocation
 ** Storage consumed
 ** Network resources consumed
-* *Cluster Utilization* shows the capacity of various resources over a specified period of time, to help administrators understand the scale and frequency of high resource consumption.
-* *Events* lists messages related to recent activity in the cluster, such as pod creation or virtual machine migration to another host.
-* *Top Consumers* helps administrators understand how cluster resources are consumed. Click on a resource to jump to a detailed page listing pods and nodes that consume the largest amount of the specified cluster resource (CPU, memory, or storage).
+** Pod count
+* *Activity* lists messages related to recent activity in the cluster, such as pod creation or virtual machine migration to another host.
 

--- a/web_console/configuring-web-console.adoc
+++ b/web_console/configuring-web-console.adoc
@@ -7,7 +7,7 @@ include::_attributes/common-attributes.adoc[]
 toc::[]
 
 You can modify the {product-title} web console to set a logout redirect URL
-or disable the console.
+or disable the quick start tutorials.
 
 == Prerequisites
 

--- a/web_console/customizing-the-web-console.adoc
+++ b/web_console/customizing-the-web-console.adoc
@@ -21,14 +21,7 @@ include::modules/creating-custom-links.adoc[leveloffset=+1]
 include::modules/customizing-the-web-console-URL.adoc[leveloffset=+1]
 endif::openshift-rosa,openshift-dedicated[]
 
-[id="customizing-web-console-recognize"]
-== Recognizing resource and project limits and quotas
-
-You can view a graphical representation of available resources in the *Topology* view of the web console *Developer* perspective.
-
-If a resource has a message about resource limitations or quotas being reached, a yellow border appears around the resource name. Click the resource to open a side panel to see the message. If the *Topology* view has been zoomed out, a yellow dot indicates that a message is available.
-
-If using *List View* from the *View Shortcuts* menu, resources appear as a list. The *Alerts* column indicates if a message is available.
+// moved _Recognizing resource and project limits and quotas_ to modules/recognize-resource-limits-quotas.adoc in web-console.adoc
 
 // Hiding in ROSA/OSD, as dedicated-admins cannot create resource "secrets" in openshift-config
 ifndef::openshift-rosa,openshift-dedicated[]

--- a/web_console/using-dashboard-to-get-cluster-information.adoc
+++ b/web_console/using-dashboard-to-get-cluster-information.adoc
@@ -6,11 +6,8 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-Access the {product-title} dashboard, which captures high-level information
-about the cluster, by navigating to *Home* -> *Dashboards* -> *Overview* from
-the {product-title} web console.
-
-The {product-title} dashboard provides various cluster information, captured in
-individual dashboard cards.
+The {product-title} web console captures high-level information
+about the cluster.
 
 include::modules/virt-about-the-overview-dashboard.adoc[leveloffset=+1]
+include::modules/recognize-resource-limits-quotas.adoc[leveloffset=+1]


### PR DESCRIPTION
Fixing various errors in the Web console docs as I find them during the [ROSA content port](https://github.com/openshift/openshift-docs/pull/66934). Mostly formatting, wording, and such.

[Using the OpenShift Container Platform dashboard to get cluster information](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/using-dashboard-to-get-cluster-information) - Changed the topic map to match the assembly name.
[Customizing CLI downloads](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/customizing-the-web-console#creating-custom-CLI-downloads_customizing-web-console) -- Removed _foo_ per ISG.
[Customizing the login page](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/customizing-the-web-console#customizing-the-login-page_customizing-web-console) -- Added metadata and `# ...` to codeblock.
[Accessing the web terminal](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/web_terminal/odc-using-web-terminal#odc-access-web-terminal_odc-using-web-terminal) -- Moved this sentence unchanged from [line 30](https://github.com/openshift/openshift-docs/pull/67647/files#diff-3280d02527d34051c6d259501fa40e60cdf0fc555e2183f992e78da26dcf2fffL30) of the same file. Added steps to set timeout and image. 
[Setting user preferences](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/adding-user-preferences#odc-setting-user-preferences_adding-user-preferences) -- Updated the preferences, based on what is on the page.
[Recognizing resource and project limits and quotas](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/using-dashboard-to-get-cluster-information#recognize-resource-limits-quotas) -- Moved [existing text](https://docs.openshift.com/container-platform/4.13/web_console/customizing-the-web-console.html#customizing-web-console-recognize) unchanged from Customizing to Using...to get Info, as it is more relevant there.
[Removing the Web Terminal Operator](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/web_terminal/uninstalling-web-terminal#removing-web-terminal-operator_uninstalling-web-terminal) -- Removed Step 5, as the steps are also [in the following assembly](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/web_terminal/uninstalling-web-terminal#removing-devworkspace-operator_uninstalling-web-terminal), and more relevant there. [Current docs](https://docs.openshift.com/container-platform/4.13/web_console/web_terminal/uninstalling-web-terminal.html#removing-web-terminal-operator_uninstalling-web-terminal).
[About the OpenShift Container Platform dashboards page](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/using-dashboard-to-get-cluster-information) -- Moved text from the assembly into the first module. Seems more relevant there. Updated the module to match what is in the UI. [Current docs.](https://docs.openshift.com/container-platform/4.13/web_console/using-dashboard-to-get-cluster-information.html)
[Configuring the web console](https://67647--docspreview.netlify.app/openshift-enterprise/latest/web_console/configuring-web-console) -- Fixed error.

