### PR TITLE
[OSDOCS-8331] Machine mgmt updates for the Welcome page

### DIFF
--- a/welcome/index.adoc
+++ b/welcome/index.adoc
@@ -236,19 +236,13 @@ ifdef::openshift-enterprise,openshift-webscale,openshift-origin[]
 
 Manage machines, provide services to users, and follow monitoring and logging reports. This documentation helps you:
 
-- **xref:../architecture/architecture.adoc#architecture-overview-architecture[Understand {product-title} management]**: Learn about components
-of the {product-title} {product-version} control plane. See how {product-title} control plane and worker nodes are managed and updated through the xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#machine-api-overview_creating-machineset-aws[Machine API] and xref:../architecture/control-plane.adoc#operators-overview_control-plane[Operators].
+- **xref:../architecture/architecture.adoc#architecture-overview-architecture[Understand {product-title} management]**: Learn about components of the {product-title} {product-version} control plane. See how {product-title} control plane and compute nodes are managed and updated through the xref:../machine_management/index.adoc#machine-api-overview_overview-of-machine-management[Machine API] and xref:../architecture/control-plane.adoc#operators-overview_control-plane[Operators].
 
 - **Enable cluster capabilities that were disabled prior to installation** Cluster administrators can enable cluster capabilities that were disabled prior to installation. For more information, see xref:../post_installation_configuration/enabling-cluster-capabilities.adoc#enabling-cluster-capabilities[Enabling cluster capabilities].
 
 === Manage cluster components
 
-- **Manage machines**: Manage machines in your cluster on
-xref:../machine_management/creating_machinesets/creating-machineset-aws.adoc#creating-machineset-aws[AWS],
-xref:../machine_management/creating_machinesets/creating-machineset-azure.adoc#creating-machineset-azure[Azure],
-or
-xref:../machine_management/creating_machinesets/creating-machineset-gcp.adoc#creating-machineset-gcp[GCP]
-by xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[deploying health checks] and xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[applying autoscaling to machines].
+- **Manage machines**: Manage xref:../machine_management/index.adoc#machine-mgmt-intro-managing-compute_overview-of-machine-management[compute] and xref:../machine_management/index.adoc#machine-mgmt-intro-managing-control-plane_overview-of-machine-management[control plane] machines in your cluster with machine sets, by xref:../machine_management/deploying-machine-health-checks.adoc#deploying-machine-health-checks[deploying health checks], and xref:../machine_management/applying-autoscaling.adoc#applying-autoscaling[applying autoscaling].
 
 - **xref:../registry/index.adoc#registry-overview[Manage container registries]**: Each {product-title} cluster includes a built-in container registry for storing its images. You can also configure a separate link:https://access.redhat.com/documentation/en-us/red_hat_quay/[Red Hat Quay] registry to use with {product-title}. The link:https://quay.io[Quay.io] website provides a public container registry that stores {product-title} containers and Operators.
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
[OSDOCS-8331](https://issues.redhat.com//browse/OSDOCS-8331)

Link to docs preview:
* [Cluster administrator activities](https://67666--docspreview.netlify.app/openshift-enterprise/latest/welcome/#cluster-administrator-activities) (first bullet)
* [Manage cluster components](https://67666--docspreview.netlify.app/openshift-enterprise/latest/welcome/#manage-cluster-components) (first bullet)

QE review:
Not required for this, I think.

Additional information:
Should cherrypick clean through 4.12; 4.11 will need to be manual since there's no CPMS in that version.