### PR TITLE
OSDOCS#8266: Fixing ami command in multi-arch AWS machine set example

### DIFF
--- a/modules/multi-architecture-modify-machine-set-aws.adoc
+++ b/modules/multi-architecture-modify-machine-set-aws.adoc
@@ -101,9 +101,9 @@ $ oc get -o jsonpath=‘{.status.infrastructureName}{“\n”}’ infrastructure
 +
 [source,terminal]
 ----
-$ oc get configmap/coreos-bootimages /
-	  -n openshift-machine-config-operator /
-	  -o jsonpath='{.data.stream}' | jq /
+$ oc get configmap/coreos-bootimages \
+	  -n openshift-machine-config-operator \
+	  -o jsonpath='{.data.stream}' | jq \
 	  -r '.architectures.<arch>.images.aws.regions."<region>".image'
 ----
 <5> Specify an ARM64 supported machine type. For more information, refer to "Tested instance types for AWS 64-bit ARM"


### PR DESCRIPTION
**Version(s):** 4.13+
**Issue:** [OSDOCS-8266](https://issues.redhat.com//browse/OSDOCS-8266)

**Link to docs preview:**

[Creating a cluster with multi-architecture compute machines on AWS -> Adding an ARM64 compute machine set to your cluster](https://67667--docspreview.netlify.app/openshift-enterprise/latest/post_installation_configuration/configuring-multi-arch-compute-machines/creating-multi-arch-compute-nodes-aws#multi-architecture-modify-machine-set-aws_creating-multi-arch-compute-nodes-aws)

**QE review:**
- [x] QE has approved this change.
