### PR TITLE
OSD remove Nodes redirect

### DIFF
--- a/.s2i/httpd-cfg/01-commercial.conf
+++ b/.s2i/httpd-cfg/01-commercial.conf
@@ -716,8 +716,6 @@ AddType text/vtt                            vtt
     # Redirect to get Custom Metrics Autoscaler into OSD
     RewriteRule ^dedicated/nodes/cma/?(.*)$ - [L,R=302]
 
-    RewriteRule ^dedicated/nodes/?(.*)$ /dedicated/osd_cluster_admin/osd_nodes/osd-$1 [NE,R=301]
-
     RewriteRule ^dedicated/osd_notifications/notifications.html /dedicated/osd_cluster_admin/osd_logging/osd-accessing-the-service-logs.html [NE,R=301]
 
     RewriteRule ^dedicated/osd_policy/?(.*)$ /dedicated/osd_architecture/osd_policy/$1 [NE,R=301]


### PR DESCRIPTION
The OSD docs currently have a redirect to redirect all traffic from `dedicated/nodes/` to  `dedicated/osd_cluster_admin/osd_nodes/` that is no longer needed after the [Nodes content port](https://github.com/openshift/openshift-docs/pull/62147). This PR removes the redirect. As far as I know, the preview tools do not use the redirects, so a preview is not possible. 

Merge to `main` only. No CP.