### PR TITLE
[enterprise-4.12] GH#63937:Removed the documentation related to the ClusterResourceOverride Operator.

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2301,8 +2301,8 @@ Topics:
     Distros: openshift-enterprise,openshift-origin
   - Name: Configuring your cluster to place pods on overcommited nodes
     File: nodes-cluster-overcommit
-    Distros: openshift-enterprise,openshift-origin
-  - Name: Enabling Linux control group version 2 (cgroup v2)
+    Distros: openshift-enterprise
+  - Name: Configuring the Linux cgroup version on your nodes
     File: nodes-cluster-cgroups-2
     Distros: openshift-enterprise
   - Name: Configuring the Linux cgroup on your nodes


### PR DESCRIPTION
Manual cherrypick of https://github.com/openshift/openshift-docs/commit/63ab070e0c158f3f6dab691c07ab2a2dbb57e884
xref https://github.com/openshift/openshift-docs/pull/67151