### PR TITLE
Fix Issue #55184 for Hacktoberfest - Update ocp-version attribute on …

### DIFF
--- a/_attributes/attributes-microshift.adoc
+++ b/_attributes/attributes-microshift.adoc
@@ -4,7 +4,7 @@
 :experimental:
 :imagesdir: images
 :OCP: OpenShift Container Platform
-:ocp-version: 4.14
+:ocp-version: 4.15
 :oc-first: pass:quotes[OpenShift CLI (`oc`)]
 :product-title-first: Red Hat build of MicroShift (MicroShift)
 :microshift-short: MicroShift


### PR DESCRIPTION
…main to `4.15`
See https://github.com/openshift/openshift-docs/pull/67271#issuecomment-1804501253

Version(s):
`main` only.

Issue:
#55184 

Link to docs preview:
https://67706--docspreview.netlify.app/openshift-dedicated/latest/osd_architecture/osd-understanding#osd-intro_osd-understanding

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
