### PR TITLE
OCPBUGS#19368: Added guidance on internal CA

### DIFF
--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -22,6 +22,8 @@ In {product-title} version {product-version}, you can install a cluster on your 
 ** You configured the firewall to xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[grant access] to the sites that {product-title} requires. This includes the use of Telemetry.
 * If your Nutanix environment is using the default self-signed SSL certificate, replace it with a certificate that is signed by a CA. The installation program requires a valid CA-signed certificate to access to the Prism Central API. For more information about replacing the self-signed certificate, see the  https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html[Nutanix AOS Security Guide].
 +
+If your Nutanix environment uses an internal CA to issue certificates, you must configure a cluster-wide proxy as part of the installation process. For more information, see xref:../../networking/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI].
++
 [IMPORTANT]
 ====
 Use 2048-bit certificates. The installation fails if you use 4096-bit certificates with Prism Central 2022.x.

--- a/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned.adoc
@@ -17,6 +17,8 @@ In {product-title} {product-version}, you can install a cluster on Nutanix infra
 ** You configured the firewall to xref:../../installing/install_config/configuring-firewall.adoc#configuring-firewall[grant access] to the sites that {product-title} requires. This includes the use of Telemetry.
 * If your Nutanix environment is using the default self-signed SSL/TLS certificate, replace it with a certificate that is signed by a CA. The installation program requires a valid CA-signed certificate to access to the Prism Central API. For more information about replacing the self-signed certificate, see the  https://portal.nutanix.com/page/documents/details?targetId=Nutanix-Security-Guide-v6_1:mul-security-ssl-certificate-pc-t.html[Nutanix AOS Security Guide].
 +
+If your Nutanix environment uses an internal CA to issue certificates, you must configure a cluster-wide proxy as part of the installation process. For more information, see xref:../../networking/configuring-a-custom-pki.adoc#configuring-a-custom-pki[Configuring a custom PKI].
++
 [IMPORTANT]
 ====
 Use 2048-bit certificates. The installation fails if you use 4096-bit certificates with Prism Central 2022.x.


### PR DESCRIPTION
Version(s):
4.11+

Issue:
This PR address [ocpbugs-19368](https://issues.redhat.com/browse/OCPBUGS-19368).

Link to docs preview:

- Installing a cluster on Nutanix > [Prerequisites](https://67727--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#prerequisites)
- Installing a cluster on Nutanix in a restricted network > [Prerequisites](https://67727--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned#prerequisites)

QE review:
- [ ] QE has approved this change.
