### PR TITLE
Notes the removal of the openshift_default_registry

### DIFF
--- a/release_notes/ocp-4-15-release-notes.adoc
+++ b/release_notes/ocp-4-15-release-notes.adoc
@@ -664,6 +664,11 @@ In the following tables, features are marked with the following statuses:
 [id="ocp-4-15-removed-features"]
 === Removed features
 
+[id="ocp-4-15-openshift-default-registry"]
+==== Removal of the OPENSHIFT_DEFAULT_REGISTRY
+
+{product-title} {product-version} has removed support for the `OPENSHIFT_DEFAULT_REGISTRY` variable. This variable was primarily used to enable backwards compatibility of the internal image registry for earlier setups. The `REGISTRY_OPENSHIFT_SERVER_ADDR` variable can be used in its place. 
+
 .APIs removed from Kubernetes 1.27
 [cols="2,2,2",options="header",]
 |===


### PR DESCRIPTION
Original PR that received acks: https://github.com/openshift/openshift-docs/pull/64546

This removal was planned for 4.15. Was incorrectly added to 4.14. 

Version(s):
4.15

Issue:
https://issues.redhat.com/browse/OSDOCS-7709

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE is not needed.