### PR TITLE
OBSDOCS-603: Add logging attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -133,6 +133,9 @@ endif::[]
 :logging-title-uc: Logging subsystem for Red Hat OpenShift
 :logging: logging subsystem
 :logging-uc: Logging subsystem
+:clo: Red Hat OpenShift Logging Operator
+:loki-op: Loki Operator
+:es-op: Elasticsearch Operator
 //serverless
 :ServerlessProductName: OpenShift Serverless
 :ServerlessProductShortName: Serverless

--- a/modules/viewing-resource-logs-cli-console.adoc
+++ b/modules/viewing-resource-logs-cli-console.adoc
@@ -7,11 +7,11 @@
 [id="viewing-resource-logs-cli-console_{context}"]
 = Viewing resource logs
 
-You can view the log for various resources in the {first-oc} and web console. Logs read from the tail, or end, of the log.
+You can view the log for various resources in the {oc-first} and web console. Logs read from the tail, or end, of the log.
 
 .Prerequisites
 
-* Access to the {first-oc}.
+* Access to the {oc-first}.
 
 .Procedure (UI)
 


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-603

Link to docs preview:
Fixed attribute module: https://67730--docspreview.netlify.app/openshift-enterprise/latest/logging/log_visualization/log-visualization#log-visualization-resource-logs

QE review:
N/A

Additional information:

Adding attributes for logging. There will be follow up PRs to replace these across the docs.
Also taking this opportunity to fix an attribute that's broken in one of the modules.
