### PR TITLE
Fixes broken link redirect

### DIFF
--- a/modules/images-update-global-pull-secret.adoc
+++ b/modules/images-update-global-pull-secret.adoc
@@ -26,7 +26,7 @@ ifdef::image-pull-secrets[]
 ====
 To transfer your cluster to another owner, you must first initiate the transfer in {cluster-manager-url}, and then update the pull secret on the cluster. Updating a cluster's pull secret without initiating the transfer in {cluster-manager} causes the cluster to stop reporting Telemetry metrics in {cluster-manager}.
 
-For more information link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2021/html/managing_clusters/assembly-managing-clusters#transferring-cluster-ownership_assembly-managing-clusters[about transferring cluster ownership], see "Transferring cluster ownership" in the {cluster-manager-first} documentation.
+For more information link:https://access.redhat.com/documentation/en-us/openshift_cluster_manager/2023/html-single/managing_clusters/index#transferring-cluster-ownership_downloading-and-updating-pull-secrets[about transferring cluster ownership], see "Transferring cluster ownership" in the {cluster-manager-first} documentation.
 ====
 endif::image-pull-secrets[]
 


### PR DESCRIPTION

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSDOCS-5688

Link to docs preview:
https://67749--docspreview.netlify.app/openshift-enterprise/latest/openshift_images/managing_images/using-image-pull-secrets#images-update-global-pull-secret_using-image-pull-secrets

QE is not needed. This is a link update. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
