### PR TITLE
MIG-1504: MTC 1.8.2 release notes

### DIFF
--- a/migration_toolkit_for_containers/mtc-release-notes.adoc
+++ b/migration_toolkit_for_containers/mtc-release-notes.adoc
@@ -17,6 +17,7 @@ You can migrate from xref:../migrating_from_ocp_3_to_4/about-migrating-from-3-to
 
 For information on the support policy for {mtc-short}, see link:https://access.redhat.com/support/policy/updates/openshift#app_migration[OpenShift Application and Cluster Migration Solutions], part of the _Red Hat {product-title} Life Cycle Policy_.
 
+include::modules/migration-mtc-release-notes-1-8-2.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8-1.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-8.adoc[leveloffset=+1]
 include::modules/migration-mtc-release-notes-1-7-14.adoc[leveloffset=+1]

--- a/modules/migration-mtc-release-notes-1-8-2.adoc
+++ b/modules/migration-mtc-release-notes-1-8-2.adoc
@@ -1,0 +1,33 @@
+// Module included in the following assemblies:
+//
+// * migration_toolkit_for_containers/mtc-release-notes.adoc
+:_mod-docs-content-type: REFERENCE
+[id="migration-mtc-release-notes-1-8-2_{context}"]
+= {mtc-full} 1.8.2 release notes
+
+[id="resolved-issues-1-8-2_{context}"]
+== Resolved issues
+
+This release has the following major resolved issues:
+
+.Backup phase fails after setting custom CA replication repository
+
+In previous releases of {mtc-full} ({mtc-short}), after editing the replication repository, adding a custom CA certificate, successfully connecting the repository, and triggering a migration, a failure occurred during the backup phase.
+
+.CVE-2023-26136: tough-cookie package before 4.1.3 are vulnerable to Prototype Pollution
+
+In previous releases of ({mtc-short}), versions before 4.1.3 of the `tough-cookie` package used in {mtc-short} were vulnerable to prototype pollution. This vulnerability occurred because CookieJar did not handle cookies properly when the value of the `rejectPublicSuffixes` was set to `false`.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2023-26136[(CVE-2023-26136)]
+
+.CVE-2022-25883 openshift-migration-ui-container: nodejs-semver: Regular expression denial of service
+
+In previous releases of ({mtc-short}), versions of the `semver` package before 7.5.2, used in {mtc-short}, were vulnerable to Regular Expression Denial of Service (ReDoS) from the function `newRange`, when untrusted user data was provided as a range.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2022-25883[(CVE-2022-25883)]
+
+
+[id="known-issues-1-8-2_{context}"]
+== Known issues
+
+There are no major known issues in this release.

--- a/modules/migration-mtc-release-notes-1-8.adoc
+++ b/modules/migration-mtc-release-notes-1-8.adoc
@@ -1,4 +1,3 @@
-
 // Module included in the following assemblies:
 //
 // * migration_toolkit_for_containers/mtc-release-notes.adoc
@@ -44,6 +43,31 @@ In this release, on migrating an application including a `BuildConfig` from a so
 .[UI] CA bundle file field is not properly cleared
 
 In this release, after enabling `Require SSL verification` and adding content to the CA bundle file for an MCG NooBaa bucket in MigStorage, the connection fails as expected. However, when reverting these changes by removing the CA bundle content and clearing `Require SSL verification`, the connection still fails. The issue is only resolved by deleting and re-adding the repository. (link:https://bugzilla.redhat.com/show_bug.cgi?id=2240052[*BZ#2240052*])
+
+
+.Backup phase fails after setting custom CA replication repository
+
+In ({mtc-short}), after editing the replication repository, adding a custom CA certificate, successfully connecting the repository, and triggering a migration, a failure occurs during the backup phase.
+
+This issue is resolved in {mtc-short} 1.8.2.
+
+
+.CVE-2023-26136: tough-cookie package before 4.1.3 are vulnerable to Prototype Pollution
+
+Versions before 4.1.3 of the `tough-cookie` package, used in {mtc-short}, are vulnerable to prototype pollution. This vulnerability occurs because CookieJar does not handle cookies properly when the value of the `rejectPublicSuffixes` is set to `false`.
+
+This issue is resolved in {mtc-short} 1.8.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2023-26136[(CVE-2023-26136)]
+
+
+.CVE-2022-25883 openshift-migration-ui-container: nodejs-semver: Regular expression denial of service
+
+In previous releases of ({mtc-short}), versions of the `semver` package before 7.5.2, used in {mtc-short}, are vulnerable to Regular Expression Denial of Service (ReDoS) from the function `newRange`, when untrusted user data is provided as a range.
+
+This issue is resolved in {mtc-short} 1.8.2.
+
+For more details, see link:https://access.redhat.com/security/cve/cve-2022-25883[(CVE-2022-25883)]
 
 
 [id="technical-changes-1-8_{context}"]


### PR DESCRIPTION
### Jira

* [MIG-1504](https://issues.redhat.com/browse/MIG-1504)

![image](https://github.com/openshift/openshift-docs/assets/106804821/ca38a857-7181-4ace-99e0-bd1b2b9ff739)


### Version

* OCP 4.11 → branch/enterprise-4.11
* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15

### Previews

* [MTC 1.8.2 release notes](https://67775--docspreview.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-release-notes#migration-mtc-release-notes-1-8-2_mtc-release-notes)
* [MTC 1.8.0 release notes](https://67775--docspreview.netlify.app/openshift-enterprise/latest/migration_toolkit_for_containers/mtc-release-notes#migration-mtc-release-notes-1-8_mtc-release-notes)

### QE review:

* [ ] QE has approved this change.