### PR TITLE
MIG-1505: MTC 1.8.2 update attributes

### DIFF
--- a/_attributes/common-attributes.adoc
+++ b/_attributes/common-attributes.adoc
@@ -66,7 +66,7 @@ endif::openshift-origin[]
 :mtc-short: MTC
 :mtc-full: Migration Toolkit for Containers
 :mtc-version: 1.8
-:mtc-version-z: 1.8.0
+:mtc-version-z: 1.8.2
 // builds (Valid only in 4.11 and later)
 :builds-v2title: Builds for Red Hat OpenShift
 :builds-v2shortname: OpenShift Builds v2


### PR DESCRIPTION
### Jira

* [MIG-1505](https://issues.redhat.com/browse/MIG-1505)

* Updating the MTC version to 1.8.2 following Release (for confirmation please see [pull/67775](https://github.com/openshift/openshift-docs/pull/67775) )

![image](https://github.com/openshift/openshift-docs/assets/106804821/476ae6f7-651b-4a11-a17b-3fce56385e14)


### Version

* OCP 4.11 → branch/enterprise-4.11
* OCP 4.12 → branch/enterprise-4.12
* OCP 4.13 → branch/enterprise-4.13
* OCP 4.14 → branch/enterprise-4.14
* OCP 4.15 → branch/enterprise-4.15


Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
