### PR TITLE
OCPBUGS#20334: Revised index versions to current versions

### DIFF
--- a/modules/oc-mirror-image-set-config-examples.adoc
+++ b/modules/oc-mirror-image-set-config-examples.adoc
@@ -80,7 +80,7 @@ To receive all Operator versions in a specified range, you can set the `mirror.o
 ====
 
 .Example `ImageSetConfiguration` file
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
@@ -89,7 +89,7 @@ storageConfig:
     path: /home/user/metadata
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
       packages:
         - name: rhacs-operator
           channels:
@@ -108,7 +108,7 @@ To specify a maximum version instead of the latest, set the `mirror.operators.pa
 The following `ImageSetConfiguration` file uses a local storage backend and includes the Nutanix CSI Operator, the OpenShift Update Service (OSUS) graph image, and an additional Red Hat Universal Base Image (UBI).
 
 .Example `ImageSetConfiguration` file
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 kind: ImageSetConfiguration
 apiVersion: mirror.openshift.io/v1alpha2
@@ -123,7 +123,7 @@ mirror:
       type: ocp
     graph: true
   operators:
-  - catalog: registry.redhat.io/redhat/certified-operator-index:v4.11
+  - catalog: registry.redhat.io/redhat/certified-operator-index:v{product-version}
     packages:
     - name: nutanixcsioperator
       channels:
@@ -145,7 +145,7 @@ You can find the default channel by running the following command: `oc mirror li
 ====
 
 .Example `ImageSetConfiguration` file
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
@@ -155,7 +155,7 @@ storageConfig:
     skipTLS: false
 mirror:
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
     packages:
     - name: elasticsearch-operator
       channels:
@@ -171,7 +171,7 @@ mirror:
 The following `ImageSetConfiguration` file sets the `mirror.operators.full` field to `true` to include all versions for an entire Operator catalog.
 
 .Example `ImageSetConfiguration` file
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
@@ -181,7 +181,7 @@ storageConfig:
     skipTLS: false
 mirror:
   operators:
-    - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
+    - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
       full: true
 ----
 
@@ -198,7 +198,7 @@ By default, for each Operator in the catalog, oc-mirror includes the latest Oper
 This example also uses the `targetCatalog` field to specify an alternative namespace and name to mirror the catalog as.
 
 .Example `ImageSetConfiguration` file
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
@@ -208,7 +208,7 @@ storageConfig:
     skipTLS: false
 mirror:
   operators:
-  - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
+  - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
     targetCatalog: my-namespace/my-operator-catalog
 ----
 
@@ -220,7 +220,7 @@ mirror:
 The following `ImageSetConfiguration` file uses a registry storage backend and includes helm charts and an additional Red Hat Universal Base Image (UBI).
 
 .Example `ImageSetConfiguration` file
-[source,yaml]
+[source,yaml,subs=attributes+]
 ----
 apiVersion: mirror.openshift.io/v1alpha2
 kind: ImageSetConfiguration
@@ -234,9 +234,9 @@ mirror:
    architectures:
      - "s390x"
    channels:
-     - name: stable-4.13
+     - name: stable-{product-version}
  operators:
-   - catalog: registry.redhat.io/redhat/redhat-operator-index:v4.13
+   - catalog: registry.redhat.io/redhat/redhat-operator-index:v{product-version}
  helm:
    repositories:
      - name: redhat-helm-charts


### PR DESCRIPTION
Version(s): 4.11+

Issue: https://issues.redhat.com/browse/OCPBUGS-20334

Link to docs preview: https://67793--docspreview.netlify.app/openshift-enterprise/latest/installing/disconnected_install/installing-mirroring-disconnected#oc-mirror-image-set-examples_installing-mirroring-disconnected

QE review:
- [x] QE has approved this change. @zhouying7780

I have updated the current hardcoded values to the release version variables.