### PR TITLE
[OSDOCS-8407]:Wrong placement of STS related documentation

### DIFF
--- a/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-getting-started-workflow.adoc
+++ b/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-getting-started-workflow.adoc
@@ -6,9 +6,9 @@ include::_attributes/attributes-openshift-dedicated.adoc[]
 
 toc::[]
 
-Before you create a {product-title} (ROSA) cluster that uses the AWS Security Token Service (STS), you must complete the AWS prerequisites, verify that the required AWS service quotas are available, and set up your environment.
+Before you create a {product-title} (ROSA) cluster, you must complete the AWS prerequisites, verify that the required AWS service quotas are available, and set up your environment.
 
-This document provides an overview of the ROSA with STS deployment workflow stages and refers to detailed resources for each stage.
+This document provides an overview of the ROSA workflow stages and refers to detailed resources for each stage.
 
 include::snippets/rosa-sts.adoc[]
 


### PR DESCRIPTION
<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->
4.14+
Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->
https://issues.redhat.com/browse/OSDOCS-8407
Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->
https://67800--docspreview.netlify.app/openshift-rosa/latest/rosa_install_access_delete_clusters/rosa_getting_started_iam/rosa-getting-started-workflow
QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->
**Reviewers: The original JIRA ticket which prompted this PR stated that there was wrong placement of STS related documentation. Reference to STS deployment was removed from this doc b/c it was included in a section that describes deploying a cluster WITHOUT AWS STS. The snippet (TIP) was left in the doc to inform readers that using STS is the preferred method.** 

![image](https://github.com/openshift/openshift-docs/assets/122639474/bbd87ef4-d0ef-4ec9-a28e-309fe937eebf)


<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
