### PR TITLE
Restore errors and warnings

### DIFF
--- a/modules/migration-debugging-velero-resources.adoc
+++ b/modules/migration-debugging-velero-resources.adoc
@@ -61,6 +61,23 @@ $ oc -n {namespace} exec deployment/velero -c velero -- ./velero \
   backup describe 0e44ae00-5dc3-11eb-9ca8-df7e5254778b-2d8ql
 ----
 
+The following types of restore errors and warnings are shown in the output of a `velero describe` request:
+
+* `Velero`: A list of messages related to the operation of Velero itself, for example, messages related to connecting to the cloud, reading a backup file, and so on
+* `Cluster`: A list of messages related to backing up or restoring cluster-scoped resources
+* `Namespaces`: A list of list of messages related to backing up or restoring resources stored in namespaces
+
+One or more errors in one of these categories results in a `Restore` operation receiving the status of `PartiallyFailed` and not `Completed`. Warnings do not lead to a change in the completion status.
+
+[IMPORTANT]
+====
+* For resource-specific errors, that is, `Cluster` and `Namespaces` errors, the `restore describe --details` output includes a resource list that lists all resources that Velero succeeded in restoring. For any resource that has such an error, check to see if the resource is actually in the cluster.
+
+* If there are `Velero` errors, but no resource-specific errors, in the output of a `describe` command, it is possible that the restore completed without any actual problems in restoring workloads, but carefully validate post-restore applications.
++
+For example, if the output contains `PodVolumeRestore` or node sgent-related errors, check the status of `PodVolumeRestores` and `DataDownloads`. If none of these are failed or still running, then volume data might have been fully restored.
+====
+
 [discrete]
 [id="velero-logs-command_{context}"]
 == Logs command


### PR DESCRIPTION
OADP 1.3.0, OCP 4.12+

Resolves https://issues.redhat.com/browse/OADP-3057 by adding more information to the "Describe command" section of https://access.redhat.com/documentation/en-us/openshift_container_platform/4.14/html-single/backup_and_restore/index#migration-debugging-velero-resources_oadp-troubleshooting. 

Preview: https://67803--ocpdocs-pr.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/troubleshooting#migration-debugging-velero-resources_oadp-troubleshooting {"Describe command," text following the example through the "Important" note] 