### PR TITLE
OSDOCS#7604: Updated link to Nutanix docs

### DIFF
--- a/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
+++ b/installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
@@ -53,10 +53,7 @@ include::modules/installation-nutanix-ccm.adoc[leveloffset=+1]
 
 include::modules/installation-launching-installer.adoc[leveloffset=+1]
 
-== Configuring the default storage container
-After you install the cluster, you must install the Nutanix CSI Operator and configure the default storage container for the cluster.
-
-For more information, see the Nutanix documentation for link:https://opendocs.nutanix.com/openshift/operators/csi/[installing the CSI Operator] and link:https://opendocs.nutanix.com/openshift/install/ipi/#openshift-image-registry-configuration[configuring registry storage].
+include::modules/registry-configuring-storage-nutanix.adoc[leveloffset=+1]
 
 include::modules/cluster-telemetry.adoc[leveloffset=+1]
 

--- a/modules/registry-configuring-storage-nutanix.adoc
+++ b/modules/registry-configuring-storage-nutanix.adoc
@@ -1,3 +1,6 @@
+// Module included in the following assemblies:
+//
+// * installing/installing_nutanix/installing-nutanix-installer-provisioned.adoc
 // * installing/installing-restricted-networks-nutanix-installer-provisioned.adoc
 
 :_mod-docs-content-type: PROCEDURE
@@ -6,4 +9,4 @@
 
 After you install the cluster, you must install the Nutanix CSI Operator and configure the default storage container for the cluster.
 
-For more information, see the Nutanix documentation for link:https://opendocs.nutanix.com/openshift/operators/csi/[installing the CSI Operator] and link:https://opendocs.nutanix.com/openshift/install/ipi/#openshift-image-registry-configuration[configuring registry storage].
+For more information, see the Nutanix documentation for link:https://opendocs.nutanix.com/openshift/operators/csi/[installing the CSI Operator] and link:https://opendocs.nutanix.com/openshift/post-install/[configuring registry storage].


### PR DESCRIPTION
Version(s):
4.11+

Issue:
This PR addresses [osdocs-7604](https://issues.redhat.com/browse/OSDOCS-7604).

Link to docs preview:

- Installing a cluster on Nutanix > [Configuring the default storage container](https://67804--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-nutanix-installer-provisioned#registry-configuring-storage-nutanix_installing-nutanix-installer-provisioned)
- Installing a cluster on Nutanix in a restricted network > [Configuring the default storage container](https://67804--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_nutanix/installing-restricted-networks-nutanix-installer-provisioned#registry-configuring-storage-nutanix_installing-restricted-networks-nutanix-installer-provisioned)

QE review:
- [N/A] QE has approved this change.

No QE required. Updating a link to supporting Nutanix docs.