### PR TITLE
RHDEVDOCS-5560: Document how to enable Openshift monitoring stack to …

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -121,6 +121,8 @@ Topics:
     File: monitoring-with-gitops-dashboards
   - Name: Monitoring Argo CD instances
     File: monitoring-argo-cd-instances
+  - Name: Monitoring the GitOps Operator performance
+    File: monitoring-the-gitops-operator-performance
   - Name: Monitoring application health status
     File: health-information-for-resources-deployment
   - Name: Monitoring Argo CD custom resource workloads

--- a/modules/gitops-accessing-the-gitops-operator-metrics.adoc
+++ b/modules/gitops-accessing-the-gitops-operator-metrics.adoc
@@ -1,0 +1,40 @@
+// Module included in the following assemblies:
+//
+// * observability/monitoring/monitoring-the-gitops-operator-performance.adoc
+
+:_content-type: PROCEDURE
+[id="gitops-accessing-the-gitops-operator-metrics_{context}"]
+= Accessing the {gitops-shortname} Operator metrics
+
+You can access the Operator metrics from the *Administrator* perspective of the {OCP} web console to track the performance of the Operator.
+
+.Prerequisites
+
+* You have access to the {OCP} web console.
+* The {gitops-title} Operator is installed in the default `openshift-gitops-operator` namespace.
+* The cluster monitoring is enabled on the `openshift-gitops-operator` namespace.
+
+.Procedure
+
+. In the *Administrator* perspective of the web console, go to *Observe* -> *Metrics*.
+
+. Enter the metric in the *Expression* field. You can choose from the following metrics:
+
+* `active_argocd_instances_total`
+* `active_argocd_instances_by_phase`
+* `active_argocd_instance_reconciliation_count`
+* `controller_runtime_reconcile_time_seconds_per_instance_bucket`
+* `controller_runtime_reconcile_time_seconds_per_instance_count`
+* `controller_runtime_reconcile_time_seconds_per_instance_sum`
+
+. (Optional): Filter the metric by its properties. For example, filter the `active_argocd_instances_by_phase` metric by the `Available` phase:
++
+.Example
+[source, terminal]
+----
+active_argocd_instances_by_phase{phase="Available"}
+----
+
+. (Optional): Click *Add query* to enter multiple queries.
+
+. Click *Run queries* to enable and observe the {gitops-shortname} Operator metrics.

--- a/modules/installing-gitops-operator-in-web-console.adoc
+++ b/modules/installing-gitops-operator-in-web-console.adoc
@@ -10,10 +10,45 @@ You can install {gitops-title} Operator from the OperatorHub by using the web co
 
 .Procedure
 
-. Open the *Administrator* perspective of the web console and navigate to *Operators* → *OperatorHub* in the menu on the left.
+. Open the *Administrator* perspective of the web console and go to *Operators* -> *OperatorHub*.
 
 . Search for `OpenShift GitOps`, click the *{gitops-title}* tile, and then click *Install*.
+
+. On the *Install Operator* page:
+
+.. Select an *Update channel*.
+
+.. Select a {gitops-shortname} *Version* to install.
+
+.. Choose an *Installed Namespace*. The default installation namespace is `openshift-gitops-operator`.
 +
-{gitops-title} will be installed in all namespaces of the cluster.
+[NOTE]
+====
+For the {gitops-shortname} version 1.10 and later, the default namespace changed from `openshift-operators` to `openshift-gitops operator`.
+====
+
+.. Select the *Enable Operator recommended cluster monitoring on this Namespace* checkbox to enable cluster monitoring.
++
+[NOTE]
+====
+You can enable cluster monitoring on any namespace by applying the `openshift.io/cluster-monitoring=true` label:
+
+[source,terminal]
+----
+$ oc label namespace <namespace> openshift.io/cluster-monitoring=true
+----
+
+.Example output
+[source,terminal]
+----
+namespace/<namespace> labeled
+----
+====
+
+. Click *Install* to make the {gitops-shortname} Operator available on the {OCP} cluster.
++
+{gitops-title} is installed in all namespaces of the cluster.
+
+. Verify that the {gitops-title} Operator is listed in *Operators* -> *Installed Operators*. The *Status* should resolve to *Succeeded*.
 
 After the {gitops-title} Operator is installed, it automatically sets up a ready-to-use Argo CD instance that is available in the `openshift-gitops` namespace, and an Argo CD icon is displayed in the console toolbar. You can create subsequent Argo CD instances for your applications under your projects.

--- a/modules/installing-gitops-operator-using-cli.adoc
+++ b/modules/installing-gitops-operator-using-cli.adoc
@@ -8,9 +8,70 @@
 
 You can install {gitops-title} Operator from the OperatorHub by using the CLI.
 
+[NOTE]
+====
+For the {gitops-shortname} version 1.10 and later, the default namespace changed from `openshift-operators` to `openshift-gitops operator`.
+====
+
 .Procedure
 
-. Create a Subscription object YAML file to subscribe a namespace to the {gitops-title}, for example, `sub.yaml`:
+. Create a `openshift-gitops-operator` namespace:
++
+[source,terminal]
+----
+$ oc create ns openshift-gitops-operator
+----
++
+.Example output
+[source,terminal]
+----
+namespace/openshift-gitops-operator created
+----
++
+[NOTE]
+====
+You can enable cluster monitoring on `openshift-gitops-operator`, or any namespace, by applying the `openshift.io/cluster-monitoring=true` label:
+
+[source,terminal]
+----
+$ oc label namespace <namespace> openshift.io/cluster-monitoring=true
+----
+
+.Example output
+[source,terminal]
+----
+namespace/<namespace> labeled
+----
+====
+
+. Create a `OperatorGroup` object YAML file, for example, `gitops-operator-group.yaml`:
++
+.Example OperatorGroup
+[source,yaml]
+----
+apiVersion: operators.coreos.com/v1
+kind: OperatorGroup
+metadata:
+  name: openshift-gitops-operator
+  namespace: openshift-gitops-operator
+spec:
+  upgradeStrategy: Default
+----
+
+. Apply the `OperatorGroup` to the cluster:
++
+[source,terminal]
+----
+$ oc apply -f gitops-operator-group.yaml
+----
++
+.Example output
+[source,terminal]
+----
+operatorgroup.operators.coreos.com/openshift-gitops-operator created
+----
+
+. Create a `Subscription` object YAML file to subscribe a namespace to the {gitops-title} Operator, for example, `openshift-gitops-sub.yaml`:
 +
 .Example Subscription
 [source,yaml]
@@ -19,7 +80,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
   name: openshift-gitops-operator
-  namespace: openshift-operators
+  namespace: openshift-gitops-operator
 spec:
   channel: latest <1>
   installPlanApproval: Automatic
@@ -31,29 +92,52 @@ spec:
 <2> Specify the name of the Operator to subscribe to.
 <3> Specify the name of the CatalogSource that provides the Operator.
 <4> The namespace of the CatalogSource. Use `openshift-marketplace` for the default OperatorHub CatalogSources.
-+
+
 . Apply the `Subscription` to the cluster:
 +
 [source,terminal]
 ----
 $ oc apply -f openshift-gitops-sub.yaml
 ----
-. After the installation is complete, ensure that all the pods in the `openshift-gitops` namespace are running:
++
+.Example output
+[source,terminal]
+----
+subscription.operators.coreos.com/openshift-gitops-operator created
+----
+
+. After the installation is complete, verify that all the pods in the `openshift-gitops` namespace are running:
 +
 [source,terminal]
 ----
 $ oc get pods -n openshift-gitops
 ----
++
 .Example output
+[source,terminal]
+----
+NAME                                                      	  READY   STATUS    RESTARTS   AGE
+cluster-b5798d6f9-zr576                                   	  1/1 	  Running   0          65m
+kam-69866d7c48-8nsjv                                      	  1/1 	  Running   0          65m
+openshift-gitops-application-controller-0                 	  1/1 	  Running   0          53m
+openshift-gitops-applicationset-controller-6447b8dfdd-5ckgh       1/1 	  Running   0          65m
+openshift-gitops-dex-server-569b498bd9-vf6mr                      1/1     Running   0          65m
+openshift-gitops-redis-74bd8d7d96-49bjf                   	  1/1 	  Running   0          65m
+openshift-gitops-repo-server-c999f75d5-l4rsg              	  1/1 	  Running   0          65m
+openshift-gitops-server-5785f7668b-wj57t                  	  1/1 	  Running   0          53m
+----
+
+. Verify that the pods in the `openshift-gitops-operator` namespace are running:
 +
 [source,terminal]
 ----
-NAME                                                      	READY   STATUS	RESTARTS   AGE
-cluster-b5798d6f9-zr576                                   	1/1 	Running   0      	65m
-kam-69866d7c48-8nsjv                                      	1/1 	Running   0      	65m
-openshift-gitops-application-controller-0                 	1/1 	Running   0      	53m
-openshift-gitops-applicationset-controller-6447b8dfdd-5ckgh 1/1 	Running   0      	65m
-openshift-gitops-redis-74bd8d7d96-49bjf                   	1/1 	Running   0      	65m
-openshift-gitops-repo-server-c999f75d5-l4rsg              	1/1 	Running   0      	65m
-openshift-gitops-server-5785f7668b-wj57t                  	1/1 	Running   0      	53m
+$ oc get pods -n openshift-gitops-operator
 ----
++
+.Example output
+[source,terminal]
+----
+NAME                                                            READY   STATUS    RESTARTS   AGE
+openshift-gitops-operator-controller-manager-664966d547-vr4vb   2/2     Running   0          65m
+----
+

--- a/observability/monitoring/monitoring-the-gitops-operator-performance.adoc
+++ b/observability/monitoring/monitoring-the-gitops-operator-performance.adoc
@@ -1,0 +1,38 @@
+:_content-type: ASSEMBLY
+include::_attributes/common-attributes.adoc[]
+[id="monitoring-the-gitops-operator-performance"]
+= Monitoring the {gitops-shortname} Operator performance
+:context: monitoring-the-gitops-operator-performance
+
+toc::[]
+
+The {gitops-title} Operator emits metrics about its performance. With the OpenShift monitoring stack that picks up these metrics, you can monitor and analyze the Operator’s performance. The Operator exposes the following metrics, which you can view by using the {OCP} web console:
+
+.{gitops-shortname} Operator performance metrics
+|===
+|*Metric name* |*Type* |*Description*
+
+|`active_argocd_instances_total` |Gauge |The total number of active Argo CD instances currently managed by the Operator across the cluster at a given time.
+
+|`active_argocd_instances_by_phase` |Gauge |The number of active Argo CD instances in a given phase, such as pending, or available.
+
+|`active_argocd_instance_reconciliation_count` |Counter |The total number of reconciliations that have occurred for an instance in a given namespace at any given time.
+
+|`controller_runtime_reconcile_time_seconds_per_instance_bucket` |Counter |The number of reconciliation cycles completed under given time durations for an instance. For example, `controller_runtime_reconcile_time_seconds_per_instance_bucket{le="0.5"}` shows the number of reconciliations that took under 0.5 seconds to complete for a given instance.
+
+|`controller_runtime_reconcile_time_seconds_per_instance_count` |Counter |The total number of reconciliation cycles observed for a given instance.
+
+|`controller_runtime_reconcile_time_seconds_per_instance_sum`|Counter |The total amount of time taken for the observed reconciliations for a given instance.
+|===
+
+[NOTE]
+====
+Gauge is a value that can go up or down. Counter is a value that can only go up.
+====
+
+include::modules/gitops-accessing-the-gitops-operator-metrics.adoc[leveloffset=+1]
+
+[role="_additional-resources"]
+[id="additional-resources_monitoring-the-gitops-operator-performance"]
+== Additional resources
+* xref:../../installing_gitops/installing-openshift-gitops.adoc#installing-gitops-operator-in-web-console_installing-openshift-gitops[Installing {gitops-title} Operator in web console]


### PR DESCRIPTION
• **Aligned team**: Dev Tools
• **Please cherry-pick to**: `gitops-docs-1.10` `gitops-docs-1.11`
• **JIRA issues**: [RHDEVDOCS-5560](https://issues.redhat.com/browse/RHDEVDOCS-5560), [OCPBUGS-21819](https://issues.redhat.com/browse/OCPBUGS-21819)
• **Preview pages**: 

- [Installing Red Hat OpenShift GitOps Operator in web console](https://67805--docspreview.netlify.app/openshift-gitops/latest/installing_gitops/installing-openshift-gitops#installing-gitops-operator-in-web-console_installing-openshift-gitops)

- [Installing Red Hat OpenShift GitOps Operator using CLI](https://67805--docspreview.netlify.app/openshift-gitops/latest/installing_gitops/installing-openshift-gitops#installing-gitops-operator-using-cli_installing-openshift-gitops)

- [Monitoring the GitOps Operator performance](https://67805--docspreview.netlify.app/openshift-gitops/latest/observability/monitoring/monitoring-the-gitops-operator-performance)

• **SME Review**:  @iam-veeramalla, @jaideepr97
• **QE review**: @varshab1210 
