### PR TITLE
OADP 1.3 DataMover restore hook issue

### DIFF
--- a/backup_and_restore/application_backup_and_restore/installing/data-mover-intro.adoc
+++ b/backup_and_restore/application_backup_and_restore/installing/data-mover-intro.adoc
@@ -23,6 +23,7 @@ include::snippets/technology-preview.adoc[leveloffset=+1]
 
 * You must perform a data cleanup after you perform a backup, if you are using OADP 1.1 Data Mover. See xref:../../../backup_and_restore/application_backup_and_restore/installing/oadp-cleaning-up-after-data-mover-1-1-backup-doc.adoc#oadp-cleaning-up-after-data-mover-1-1-backup-doc[Cleaning up after a backup using OADP 1.1 Data Mover].
 
+include::snippets/snip-post-mig-hook[]
 
 [id="oadp-data-mover-prerequisites"]
 == OADP Data Mover prerequisites

--- a/snippets/snip-post-mig-hook
+++ b/snippets/snip-post-mig-hook
@@ -1,0 +1,10 @@
+:_content-type: SNIPPET
+
+[NOTE]
+====
+Post-migration hooks are not likely to work well with the OADP 1.3 Data Mover.
+
+The OADP 1.1 and OADP 1.2 Data Movers use synchronous processes to back up and restore application data. Because the processes are synchronous, users can be sure that any post-restore hooks start only after the persistent volumes (PVs) of the related pods are released by the persistent volume claim (PVC) of the Data Mover.
+
+However, the OADP 1.3 Data Mover uses an asynchronous process. As a result of this difference in sequencing, a post-restore hook might be called before the related PVs were released by the PVC of the Data Mover. If this happens, the pod remains in `Pending` status and cannot run the hook. The hook attempt might time out before the pod is released, leading to a `PartiallyFailed` restore operation.
+====


### PR DESCRIPTION
OADP 1.3; OCP 4.11+

Resolves https://issues.redhat.com/browse/OADP-3059 by writing a short note to describe the problem. 

Preview: https://67817--docspreview.netlify.app/openshift-enterprise/latest/backup_and_restore/application_backup_and_restore/installing/data-mover-intro [end of introduction] 

OADP QA approved. 
