### PR TITLE
OSDOCS#8727:QE and Style Revisions of MOBB Content for Using AWS controllers for Kubernetes (ACK) on ROSA

### DIFF
--- a/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
+++ b/cloud_experts_tutorials/cloud-experts-using-aws-ack.adoc
@@ -18,22 +18,24 @@ toc::[]
 //  - Connor Wooley
 //---
 
-link:https://aws-controllers-k8s.github.io/community/[AWS Controllers for Kubernetes] (ACK) lets you define and use AWS service resources directly from {product-title} (ROSA). With ACK, you can take advantage of AWS-managed services for your applications without needing to define resources outside of the cluster or run services that provide supporting capabilities like databases or message queues within the cluster.
+link:https://aws-controllers-k8s.github.io/community/[AWS Controllers for Kubernetes] (ACK) lets you define and use AWS service resources directly from {product-title} (ROSA). With ACK, you can take advantage of AWS-managed services for your applications without needing to define resources outside of the cluster or run services that provide supporting capabilities such as databases or message queues within the cluster.
 
-Users can install various ACK Operators directly from OperatorHub. This makes it relatively easy to get started and start using it with your applications. This controller is a component of the AWS Controller for Kubernetes project. This project is currently in developer preview.
+You can install various ACK Operators directly from OperatorHub. This makes it easy to get started and use the Operators with your applications. This controller is a component of the AWS Controller for Kubernetes project, which is currently in developer preview.
 
-This tutorial shows you how to use the ACK S3 Operator as an example, but can be adapted for any other ACK Operator in the OperatorHub of your cluster.
+Use this tutorial to deploy the ACK S3 Operator. You can also adapt it for any other ACK Operator in the OperatorHub of your cluster.
 
+[id="cloud-experts-using-aws-ack-prerequisites"]
 == Prerequisites
 
 * A ROSA cluster
 * A user account with `cluster-admin` privileges
-* You have access to the OpenShift CLI (`oc`)
-* You have access to the AWS CLI (`aws`)
+* The OpenShift CLI (`oc`)
+* The Amazon Web Services (AWS) CLI (`aws`)
 
-=== Environment Setup
+[id="cloud-experts-using-aws-ack-environment-setup"]
+== Setting up your environment
 
-. Configure the following environment variables:
+. Configure the following environment variables, changing the cluster name to suit your cluster:
 +
 [source,terminal]
 ----
@@ -47,12 +49,18 @@ $ export POLICY_ARN=arn:aws:iam::aws:policy/AmazonS3FullAccess
 $ export AWS_PAGER=""
 $ export SCRATCH="/tmp/${ROSA_CLUSTER_NAME}/ack"
 $ mkdir -p ${SCRATCH}
+----
+. Ensure all fields output correctly before moving to the next section:
++
+[source,terminal]
+----
 $ echo "Cluster: ${ROSA_CLUSTER_NAME}, Region: ${REGION}, OIDC Endpoint: ${OIDC_ENDPOINT}, AWS Account ID: ${AWS_ACCOUNT_ID}"
 ----
 
-== Prepare AWS Account
+[id="cloud-experts-using-aws-ack-prep-aws"]
+== Preparing your AWS Account
 
-. Create an AWS IAM trust policy for the ACK Operator:
+. Create an AWS Identity Access Management (IAM) trust policy for the ACK Operator:
 +
 [source,terminal]
 ----
@@ -95,7 +103,8 @@ $ aws iam attach-role-policy --role-name "ack-${ACK_SERVICE}-controller" \
      --policy-arn ${POLICY_ARN}
 ----
 
-== Install the ACK S3 Controller
+[id="cloud-experts-using-aws-ack-install-ack"]
+== Installing the ACK S3 Controller
 
 . Create a project to install the ACK S3 Operator into:
 +
@@ -183,6 +192,7 @@ NAME                                 READY   STATUS    RESTARTS   AGE
 ack-s3-controller-585f6775db-s4lfz   1/1     Running   0          51s
 ----
 
+[id="cloud-experts-using-aws-ack-valid-deploy"]
 == Validating the deployment
 
 . Deploy an S3 bucket resource:
@@ -213,6 +223,7 @@ $ aws s3 ls | grep ${CLUSTER_NAME}-bucket
 2023-10-04 14:51:45 mrmc-test-maz-bucket
 ----
 
+[id="cloud-experts-using-aws-ack-clean-up"]
 == Cleaning up
 
 . Delete the S3 bucket resource:


### PR DESCRIPTION
This is a style revision and full QE review for the Using AWS controllers for Kubernetes (ACK) on ROSA cloud experts tutorial.

Version(s):
4.14+

Issue:
[OSDOCS-8727](https://issues.redhat.com/browse/OSDOCS-8727)

Link to docs preview:
[Tutorial: Using AWS Controllers for Kubernetes on ROSA](https://67839--docspreview.netlify.app/openshift-rosa/latest/cloud_experts_tutorials/cloud-experts-using-aws-ack)

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
