### PR TITLE
fix cron schedule definition

### DIFF
--- a/modules/op-default-pruner-configuration.adoc
+++ b/modules/op-default-pruner-configuration.adoc
@@ -25,7 +25,7 @@ spec:
       - pipelinerun
     keep: 100
     prune-per-resource: false
-    schedule: "* 8 * * *"
+    schedule: "0 8 * * *"
     startingDeadlineSeconds: 60
 # ...
 ----


### PR DESCRIPTION
`* 8 * * *` would be every minute after 8 o'clock for one hour.

If you want to start it at minute 0 you also need to set minute 0.

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
<!--- Specify the version or versions of OpenShift your PR applies to. -->

Issue:
<!--- Add a link to the Bugzilla, Jira, or GitHub issue, if applicable. --->

Link to docs preview:
<!--- Add direct link(s) to the exact page(s) with updated content from the preview build. --->

QE review:
- [ ] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
