### PR TITLE
OSDOCS-8695: Documented the 4.13.22 z-stream release notes

### DIFF
--- a/release_notes/ocp-4-13-release-notes.adoc
+++ b/release_notes/ocp-4-13-release-notes.adoc
@@ -3451,3 +3451,31 @@ As a workaround, add a trivial change to one CR in the common-subscription polic
 ==== Updating
 
 To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].
+
+[id="ocp-4-13-22"]
+=== RHSA-2023:6846 - {product-title} 4.13.22 bug fix and security update
+
+Issued: 2023-11-15
+
+{product-title} release 4.13.22, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6846[RHSA-2023:6846] advisory. The RPM packages that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:6848[RHBA-2023:6848] advisory.
+
+Space precluded documenting all of the container images for this release in the advisory.
+
+You can view the container images in this release by running the following command:
+
+[source,terminal]
+----
+$ oc adm release info 4.13.22 --pullspecs
+----
+
+[id="ocp-4-13-22-bug-fixes"]
+==== Bug fixes
+
+* Previously, the copy command was missing the `-p` flag option. Now the command supports the `-p` flag so that the command preserves timestamps. (link:https://issues.redhat.com/browse/OCPBUGS-23021[*OCPBUGS-23021*])
+
+* Previously, a `Burstable` container could only run on reserved CPUs for nodes that were configured with a performance profile. This caused {op-system-base-full} 9 to change the behavior of CPU affinity and `cpuset` components, so that CPU affinity would not reset when `cpuset` was changed. Now, any component that interacts with the `cpuset` component of a newly running container will have its CPU affinity reset. This means that a `Burstable` container can now access all CPUs not currently assigned to a pinned `Guaranteed` container. (link:https://issues.redhat.com/browse/OCPBUGS-20365[*OCPBUGS-20365*])
+
+[id="ocp-4-13-22-updating"]
+==== Updating
+
+To update an existing {product-title} 4.13 cluster to this latest release, see xref:../updating/updating-cluster-cli.adoc#updating-cluster-cli[Updating a cluster using the CLI].


### PR DESCRIPTION
[OSDOCS-8695](https://issues.redhat.com/browse/OSDOCS-8695)

Version(s):
4.13

Link to docs preview:
[OCP 4.13 Release Notes](https://67841--docspreview.netlify.app/openshift-enterprise/latest/release_notes/ocp-4-13-release-notes#ocp-4-13-22)

QE review:
- [X] QE approval is not required for z-stream releases. 

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
