### PR TITLE
OSSM-5357 [DOC]  Openshift Userworkload Monitoring integration documentation bug

### DIFF
--- a/modules/ossm-integrating-with-user-workload-monitoring.adoc
+++ b/modules/ossm-integrating-with-user-workload-monitoring.adoc
@@ -56,6 +56,7 @@ spec:
   external_services:
     istio:
       url_service_version: 'http://istiod-basic.istio-system:15014/version'
+      config_map_name: istio-basic # <1>
     prometheus:
       auth:
         token: secret:thanos-querier-web-token:token
@@ -68,6 +69,7 @@ spec:
       url: https://thanos-querier.openshift-monitoring.svc.cluster.local:9091
   version: v1.65
 ----
+<1> Set the `ServiceMeshControlPlane` name prefixed with `istio-`.
 
 . Configure the SMCP for external Prometheus:
 +
@@ -158,7 +160,7 @@ spec:
       replacement: "basic-istio-system" # <2>
       targetLabel: mesh_id
 ----
-<1> Since {product-title} monitoring ignores the `namespaceSelector` spec in `ServiceMonitor` and `PodMonitor` objects, you must apply the `PodMonitor` object in all mesh namespaces, including the control plane namespace.
+<1> Create  this `ServiceMonitor` object in the Istio control plane namespace because it monitors the Istiod service. In this example, the namespace is `istio-system`.
 <2> The string `"basic-istio-system"` is a combination of the SMCP name and its namespace, but any label can be used as long as it is unique for every mesh using user workload monitoring in the cluster. The `spec.prometheus.query_scope` of the Kiali resource configured in Step 2 needs to match this value.
 +
 [NOTE]


### PR DESCRIPTION
[DOC] [OSSM-5357](https://issues.redhat.com//browse/OSSM-5357) Openshift Userworkload Monitoring integration documentation bug

<!--- PR title format: [GH#<gh-issue-id>][BZ#<bz-issue-id>][OCPBUGS#<jira-issue-id>][OSDOCS#<jira-issue-id>]: <short-description-of-the-pr> --->

<!--- If your changes apply to the latest release and/or in-development version of OpenShift, open your PR against the `main` branch.

* For more details about the information requested in this template, see:
  https://github.com/openshift/openshift-docs/blob/main/contributing_to_docs/create_or_edit_content.adoc#submit-PR --->

Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OSSM-5357 

Link to docs preview:
https://67856--docspreview.netlify.app/openshift-enterprise/latest/service_mesh/v2x/ossm-observability#ossm-integrating-with-user-workload-monitoring_observability

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:

2 specific changes: 

1. Updates code block to add missing field for Step 2 Configure Kiali for user-workload monitoring: 

config_map_name: istio-basic # <1> 

2. Updates <1> under Step 6 per Kiali team to clarify ServiceMonitor:

Create  this `ServiceMonitor` in the Istio control plane namespace since it monitors the istiod service. In this example, the namespace is `istio-system`.

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
