### PR TITLE
OBSDOCS-639: Fix version number and other minor edits

### DIFF
--- a/modules/logging-release-notes-5-8-0.adoc
+++ b/modules/logging-release-notes-5-8-0.adoc
@@ -45,7 +45,7 @@ In order to support multi-cluster log forwarding in additional namespaces other 
 === Log Console
 * With this update, you can enable the Logging Console Plugin when Elasticsearch is the default Log Store. (link:https://issues.redhat.com/browse/LOG-3856[LOG-3856])
 
-* With this update, OpenShift Application owners can receive notifications for application-logs-based alerts on the OpenShift Developer Console view for {product-title} version 4.14 and greater. (link:https://issues.redhat.com/browse/LOG-3548[LOG-3548])
+* With this update, {product-title} application owners can receive notifications for application log-based alerts on the {product-title} web console *Developer* perspective for {product-title} version 4.14 and later. (link:https://issues.redhat.com/browse/LOG-3548[LOG-3548])
 
 [id="logging-release-notes-5-8-0-known-issues"]
 == Known Issues
@@ -57,7 +57,7 @@ In order to support multi-cluster log forwarding in additional namespaces other 
 
 * Currently, `must-gather` cannot gather any logs on a FIPS-enabled cluster, because the required OpenSSL library is not available in the `cluster-logging-rhel9-operator`. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/LOG-4403[LOG-4403])
 
-* Currently, when deploying Logging 5.6.5 on a FIPS-enabled cluster, the collector pods cannot start and are stuck in `CrashLoopBackOff` status, while using FluentD as a collector. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/LOG-3933[LOG-3933])
+* Currently, when deploying the {logging} version 5.8 on a FIPS-enabled cluster, the collector pods cannot start and are stuck in `CrashLoopBackOff` status, while using FluentD as a collector. There is currently no workaround for this issue. (link:https://issues.redhat.com/browse/LOG-3933[LOG-3933])
 
 
 [id="logging-release-notes-5-8-0-CVEs"]


### PR DESCRIPTION
Version(s):
4.12+

Issue:
https://issues.redhat.com/browse/OBSDOCS-639

Link to docs preview:
- https://67864--docspreview.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-8-release-notes#logging-release-notes-5-8-0-known-issues
- https://67864--docspreview.netlify.app/openshift-enterprise/latest/logging/logging_release_notes/logging-5-8-release-notes#logging-release-notes-5-8-0-log-console

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
- Also fixed some minor issues re using the {product-title} attribute / dev console name
