### PR TITLE
[enterprise-4.12] OCPBUGS#19016: Operator groups can overwrite ClusterRole bindings

### DIFF
--- a/modules/olm-installing-from-operatorhub-using-cli.adoc
+++ b/modules/olm-installing-from-operatorhub-using-cli.adoc
@@ -93,6 +93,10 @@ spec:
   targetNamespaces:
   - <namespace>
 ----
++
+--
+include::snippets/operator-group-unique-name.adoc[]
+--
 
 .. Create the `OperatorGroup` object:
 +

--- a/modules/olm-operatorgroups-rbac.adoc
+++ b/modules/olm-operatorgroups-rbac.adoc
@@ -21,6 +21,8 @@ When an Operator group is created, three cluster roles are generated. Each conta
 |`olm.opgroup.permissions/aggregate-to-view: <operatorgroup_name>`
 |===
 
+include::snippets/operator-group-unique-name.adoc[]
+
 The following RBAC resources are generated when a CSV becomes an active member of an Operator group, as long as the CSV is watching all namespaces with the `AllNamespaces` install mode and is not in a failed state with reason `InterOperatorGroupOwnerConflict`:
 
 * Cluster roles for each API resource from a CRD

--- a/modules/olm-operatorgroups-static.adoc
+++ b/modules/olm-operatorgroups-static.adoc
@@ -24,3 +24,5 @@ spec:
     matchLabels:
       something.cool.io/cluster-monitoring: "true"
 ----
+
+include::snippets/operator-group-unique-name.adoc[]

--- a/modules/olm-operatorgroups-target-namespace.adoc
+++ b/modules/olm-operatorgroups-target-namespace.adoc
@@ -19,6 +19,8 @@ spec:
   - my-namespace
 ----
 
+include::snippets/operator-group-unique-name.adoc[]
+
 You can alternatively specify a namespace using a label selector with the `spec.selector` parameter:
 
 [source,yaml]

--- a/modules/olm-policy-scoping-operator-install.adoc
+++ b/modules/olm-policy-scoping-operator-install.adoc
@@ -88,6 +88,10 @@ EOF
 ----
 +
 Any Operator installed in the designated namespace is tied to this Operator group and therefore to the service account specified.
++
+--
+include::snippets/operator-group-unique-name.adoc[]
+--
 
 . Create a `Subscription` object in the designated namespace to install an Operator:
 +

--- a/snippets/operator-group-unique-name.adoc
+++ b/snippets/operator-group-unique-name.adoc
@@ -1,5 +1,10 @@
 // Text snippet included in the following assemblies:
 //
+// * modules/olm-installing-from-operatorhub-using-cli.adoc
+// * modules/olm-operatorgroups-rbac.adoc
+// * modules/olm-operatorgroups-static.adoc
+// * modules/olm-operatorgroups-target-namespace.adoc
+// * modules/olm-policy-scoping-operator-install.adoc
 
 :_mod-docs-content-type: SNIPPET
 


### PR DESCRIPTION
Cherry Picked from d3107770492eeba598b2cdcc5d644c76ec65e383 xref: #64754