### PR TITLE
OSDOCS#8217: updating Agent doc MCE channel number

### DIFF
--- a/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
+++ b/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce.adoc
@@ -20,8 +20,10 @@ The following procedure is partially automated and requires manual steps after t
 * You have installed the OpenShift CLI (`oc`).
 * If you are installing in a disconnected environment, you must have a configured local mirror registry for disconnected installation mirroring.
 
+// Preparing an Agent-based cluster deployment for the multicluster engine for Kubernetes Operator while disconnected
 include::modules/preparing-an-inital-cluster-deployment-for-mce-disconnected.adoc[leveloffset=+1]
 
+// Preparing an Agent-based cluster deployment for the multicluster engine for Kubernetes Operator while connected
 include::modules/preparing-an-inital-cluster-deployment-for-mce-connected.adoc[leveloffset=+1]
 
 [role="_additional-resources"]

--- a/modules/preparing-an-inital-cluster-deployment-for-mce-connected.adoc
+++ b/modules/preparing-an-inital-cluster-deployment-for-mce-connected.adoc
@@ -5,7 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-an-inital-cluster-deployment-for-mce-connected_{context}"]
 
-= Preparing an agent-based cluster deployment for the multicluster engine for Kubernetes Operator while connected
+= Preparing an Agent-based cluster deployment for the multicluster engine for Kubernetes Operator while connected
 
 Create the required manifests for the multicluster engine for Kubernetes Operator, the Local Storage Operator (LSO), and to deploy an agent-based {product-title} cluster as a hub cluster.
 
@@ -57,7 +57,7 @@ The installer does not validate extra manifests.
     name: multicluster-engine
     namespace: multicluster-engine
   spec:
-    channel: "stable-2.1"
+    channel: "stable-2.3"
     name: multicluster-engine
     source: redhat-operators
     sourceNamespace: openshift-marketplace

--- a/modules/preparing-an-inital-cluster-deployment-for-mce-disconnected.adoc
+++ b/modules/preparing-an-inital-cluster-deployment-for-mce-disconnected.adoc
@@ -5,7 +5,7 @@
 :_mod-docs-content-type: PROCEDURE
 [id="preparing-an-inital-cluster-deployment-for-mce-disconnected_{context}"]
 
-= Preparing an agent-based cluster deployment for the multicluster engine for Kubernetes Operator while disconnected
+= Preparing an Agent-based cluster deployment for the multicluster engine for Kubernetes Operator while disconnected
 
 You can mirror the required {product-title} container images, the multicluster engine for Kubernetes Operator, and the Local Storage Operator (LSO) into your local mirror registry in a disconnected environment.
 Ensure that you note the local DNS hostname and port of your mirror registry.


### PR DESCRIPTION
[OSDOCS-8217](https://issues.redhat.com/browse/OSDOCS-8217)

Version(s): 4.13+

This PR updates the channel for the MCE Operator in on of the Agent docs' sample files. It also cleans up some other parts of the doc.

QE review:
- [x] QE has approved this change.

Preview: [Example `mce_subscription.yaml`](https://67878--docspreview.netlify.app/openshift-enterprise/latest/installing/installing_with_agent_based_installer/preparing-an-agent-based-installed-cluster-for-mce#preparing-an-inital-cluster-deployment-for-mce-connected_preparing-an-agent-based-installed-cluster-for-mce:~:text=Example%20mce_subscription.yaml)