### PR TITLE
OBSDOCS-93: Update install docs version and formatting

### DIFF
--- a/modules/cluster-logging-deploy-cli.adoc
+++ b/modules/cluster-logging-deploy-cli.adoc
@@ -4,9 +4,9 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-deploy-cli_{context}"]
-= Installing the {logging-title} using the CLI
+= Installing the {logging} using the CLI
 
-You can use the {product-title} CLI to install the OpenShift Elasticsearch and Red Hat OpenShift Logging Operators.
+You can use the {oc-first} to install the {es-op} and the {clo}.
 
 .Prerequisites
 
@@ -27,12 +27,9 @@ endif::[]
 
 .Procedure
 
-To install the OpenShift Elasticsearch Operator and Red Hat OpenShift Logging Operator using the CLI:
-
-. Create a namespace for the OpenShift Elasticsearch Operator.
-
-.. Create a namespace object YAML file (for example, `eo-namespace.yaml`) for the OpenShift Elasticsearch Operator:
+. Create a `Namespace` object for the {es-op}:
 +
+.Example `Namespace` object
 [source,yaml]
 ----
 apiVersion: v1
@@ -54,24 +51,16 @@ endif::[]
 metric, which would cause conflicts.
 <2> String. You must specify this label as shown to ensure that cluster monitoring scrapes the `openshift-operators-redhat` namespace.
 
-.. Create the namespace:
+. Apply the `Namespace` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc create -f eo-namespace.yaml
+$ oc apply -f <filename>.yaml
 ----
 
-. Create a namespace for the Red Hat OpenShift Logging Operator:
-
-.. Create a namespace object YAML file (for example, `olo-namespace.yaml`) for the Red Hat OpenShift Logging Operator:
+. Create a `Namespace` object for the {clo}:
 +
+.Example `Namespace` object
 [source,yaml]
 ----
 apiVersion: v1
@@ -84,24 +73,18 @@ metadata:
     openshift.io/cluster-monitoring: "true"
 ----
 
-.. Create the namespace:
+. Apply the `Namespace` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc create -f olo-namespace.yaml
+$ oc apply -f <filename>.yaml
 ----
 
-. Install the OpenShift Elasticsearch Operator by creating the following objects:
+. Install the {es-op} by creating the following objects:
 
-.. Create an Operator Group object YAML file (for example, `eo-og.yaml`) for the OpenShift Elasticsearch Operator:
+.. Create an `OperatorGroup` object for the {es-op}:
 +
+.Example `OperatorGroup` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -113,96 +96,57 @@ spec: {}
 ----
 <1> You must specify the `openshift-operators-redhat` namespace.
 
-.. Create an Operator Group object:
+.. Apply the `OperatorGroup` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc create -f eo-og.yaml
+$ oc apply -f <filename>.yaml
 ----
 
-.. Create a Subscription object YAML file (for example, `eo-sub.yaml`) to
-subscribe a namespace to the OpenShift Elasticsearch Operator.
+.. Create a `Subscription` object to subscribe a namespace to the {es-op}:
 +
-.Example Subscription
+.Example `Subscription` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
 kind: Subscription
 metadata:
-  name: "elasticsearch-operator"
-  namespace: "openshift-operators-redhat" <1>
+  name: elasticsearch-operator
+  namespace: openshift-operators-redhat <1>
 spec:
-  channel: "stable-5.5" <2>
-  installPlanApproval: "Automatic" <3>
-  source: "redhat-operators" <4>
-  sourceNamespace: "openshift-marketplace"
-  name: "elasticsearch-operator"
+  channel: <channel> <2>
+  installPlanApproval: Automatic <3>
+  source: redhat-operators <4>
+  sourceNamespace: openshift-marketplace
+  name: elasticsearch-operator
 ----
 <1> You must specify the `openshift-operators-redhat` namespace.
-<2> Specify `stable`, or `stable-5.<x>` as the channel. See the following note.
+<2> Specify `stable`, or `stable-y.z` as the channel, where `y` is the major version and `z` is the minor version. See the following note.
 <3> `Automatic` allows the Operator Lifecycle Manager (OLM) to automatically update the Operator when a new version is available. `Manual` requires a user with appropriate credentials to approve the Operator update.
 <4> Specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster,
 specify the name of the CatalogSource object created when you configured the Operator Lifecycle Manager (OLM).
 +
 [NOTE]
 ====
-Specifying `stable` installs the current version of the latest stable release. Using `stable` with `installPlanApproval: "Automatic"`, will automatically upgrade your operators to the latest stable major and minor release.
+Specifying `stable` installs the current version of the latest stable release. Using `stable` with `installPlanApproval: "Automatic"` automatically upgrades your Operators to the latest stable major and minor release.
 
-Specifying `stable-5.<x>` installs the current minor version of a specific major release. Using `stable-5.<x>` with `installPlanApproval: "Automatic"`, will automatically upgrade your operators to the latest stable minor release within the major release you specify with `x`.
+Specifying `stable-y.z` installs the current minor version of a specific major release. Using `stable-y.z` with `installPlanApproval: "Automatic"` automatically upgrades your Operators to the latest stable minor release within the major `y` release.
 ====
 
-
-.. Create the Subscription object:
+.. Apply the `Subscription` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc apply -f <filename>.yaml
 ----
 +
-For example:
-+
-[source,terminal]
-----
-$ oc create -f eo-sub.yaml
-----
-+
-The OpenShift Elasticsearch Operator is installed to the `openshift-operators-redhat` namespace and copied to each project in the cluster.
+The {es-op} is installed to the `openshift-operators-redhat` namespace and copied to each project in the cluster.
 
-.. Verify the Operator installation:
-+
-[source,terminal]
-----
-$ oc get csv --all-namespaces
-----
-+
-.Example output
-[source,terminal]
-----
-NAMESPACE                                               NAME                                            DISPLAY                  VERSION               REPLACES   PHASE
-default                                                 elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0               Succeeded
-kube-node-lease                                         elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0               Succeeded
-kube-public                                             elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0               Succeeded
-kube-system                                             elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0               Succeeded
-openshift-apiserver-operator                            elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0               Succeeded
-openshift-apiserver                                     elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0               Succeeded
-openshift-authentication-operator                       elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0               Succeeded
-openshift-authentication                                elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0               Succeeded
-...
-----
-+
-There should be an OpenShift Elasticsearch Operator in each namespace. The version number might be different than shown.
+. Install the {clo} by creating the following objects:
 
-. Install the Red Hat OpenShift Logging Operator by creating the following objects:
-
-.. Create an Operator Group object YAML file (for example, `olo-og.yaml`) for the Red Hat OpenShift Logging Operator:
+.. Create an `OperatorGroup` object for the {clo}:
 +
+.Example `OperatorGroup` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1
@@ -216,23 +160,16 @@ spec:
 ----
 <1> You must specify the `openshift-logging` namespace.
 
-.. Create an Operator Group object:
+.. Apply the `OperatorGroup` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc create -f olo-og.yaml
+$ oc apply -f <filename>.yaml
 ----
 
-.. Create a Subscription object YAML file (for example, `olo-sub.yaml`) to
-subscribe a namespace to the Red Hat OpenShift Logging Operator.
+.. Create a `Subscription` object to subscribe a namespace to the {clo}:
 +
+.Example `Subscription` object
 [source,yaml]
 ----
 apiVersion: operators.coreos.com/v1alpha1
@@ -249,60 +186,35 @@ spec:
 <1> You must specify the `openshift-logging` namespace.
 <2> Specify `stable`, or `stable-5.<x>` as the channel.
 <3> Specify `redhat-operators`. If your {product-title} cluster is installed on a restricted network, also known as a disconnected cluster, specify the name of the CatalogSource object you created when you configured the Operator Lifecycle Manager (OLM).
-+
-[source,terminal]
-----
-$ oc create -f <file-name>.yaml
-----
-+
-For example:
-+
-[source,terminal]
-----
-$ oc create -f olo-sub.yaml
-----
-+
-The Red Hat OpenShift Logging Operator is installed to the `openshift-logging` namespace.
 
-.. Verify the Operator installation.
-+
-There should be a Red Hat OpenShift Logging Operator in the `openshift-logging` namespace. The Version number might be different than shown.
+.. Apply the `Subscription` object by running the following command:
 +
 [source,terminal]
 ----
-$ oc get csv -n openshift-logging
+$ oc apply -f <filename>.yaml
 ----
 +
-.Example output
-[source,terminal]
-----
-NAMESPACE                                               NAME                                         DISPLAY                  VERSION               REPLACES   PHASE
-...
-openshift-logging                                       clusterlogging.5.1.0-202007012112.p0         OpenShift Logging          5.1.0-202007012112.p0              Succeeded
-...
-----
+The {clo} is installed to the `openshift-logging` namespace.
 
-. Create an OpenShift Logging instance:
-
-.. Create an instance object YAML file (for example, `olo-instance.yaml`) for the Red Hat OpenShift Logging Operator:
+. Create a `ClusterLogging` custom resource (CR):
 +
 [NOTE]
 ====
-This default OpenShift Logging configuration should support a wide array of environments. Review the topics on tuning and
-configuring {logging} components for information about modifications you can make to your OpenShift Logging cluster.
+This default `ClusterLogging` CR configuration should support a wide array of environments. Review the topics on tuning and configuring {logging} components for information about modifications you can make to the {logging}.
 ====
 +
+.Example `ClusterLogging` CR
 [source,yaml]
 ----
-apiVersion: "logging.openshift.io/v1"
-kind: "ClusterLogging"
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogging
 metadata:
-  name: "instance" <1>
-  namespace: "openshift-logging"
+  name: instance <1>
+  namespace: openshift-logging
 spec:
-  managementState: "Managed"  <2>
+  managementState: Managed  <2>
   logStore:
-    type: "elasticsearch"  <3>
+    type: elasticsearch  <3>
     retentionPolicy: <4>
       application:
         maxAge: 1d
@@ -313,40 +225,39 @@ spec:
     elasticsearch:
       nodeCount: 3 <5>
       storage:
-        storageClassName: "<storage-class-name>" <6>
+        storageClassName: <storage_class_name> <6>
         size: 200G
       resources: <7>
         limits:
-          memory: "16Gi"
+          memory: 16Gi
         requests:
-          memory: "16Gi"
+          memory: 16Gi
       proxy: <8>
         resources:
           limits:
             memory: 256Mi
           requests:
              memory: 256Mi
-      redundancyPolicy: "SingleRedundancy"
+      redundancyPolicy: SingleRedundancy
   visualization:
-    type: "kibana"  <9>
+    type: kibana  <9>
     kibana:
       replicas: 1
   collection:
     logs:
-      type: "fluentd"  <10>
+      type: fluentd  <10>
       fluentd: {}
 ----
 <1> The name must be `instance`.
-<2> The OpenShift Logging management state. In some cases, if you change the OpenShift Logging defaults, you must set this to `Unmanaged`.
-However, an unmanaged deployment does not receive updates until OpenShift Logging is placed back into a managed state. Placing a deployment back into a managed state might revert any modifications you made.
+<2> The {logging} management state. In some cases, if you change the {logging} defaults, you must set this to `Unmanaged`. However, an unmanaged deployment does not receive updates until the {logging} is placed back into a managed state. Placing a deployment back into a managed state might revert any modifications you made.
 <3> Settings for configuring Elasticsearch. Using the custom resource (CR), you can configure shard replication policy and persistent storage.
 <4> Specify the length of time that Elasticsearch should retain each log source. Enter an integer and a time designation: weeks(w), hours(h/H), minutes(m) and seconds(s). For example, `7d` for seven days. Logs older than the `maxAge` are deleted. You must specify a retention policy for each log source or the Elasticsearch indices will not be created for that source.
 <5> Specify the number of Elasticsearch nodes. See the note that follows this list.
-<6> Enter the name of an existing storage class for Elasticsearch storage. For best performance, specify a storage class that allocates block storage. If you do not specify a storage class, {product-title} deploys OpenShift Logging with ephemeral storage only.
-<7> Specify the CPU and memory requests for Elasticsearch as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that are sufficient for most deployments. The default values are `16Gi` for the memory request and `1` for the CPU request.
-<8> Specify the CPU and memory requests for the Elasticsearch proxy as needed. If you leave these values blank, the OpenShift Elasticsearch Operator sets default values that should be sufficient for most deployments. The default values are  `256Mi` for the memory request and `100m` for the CPU request.
-<9> Settings for configuring Kibana. Using the CR, you can scale Kibana for redundancy and configure the CPU and memory for your Kibana pods. For more information, see *Configuring the log visualizer*.
-<10> Settings for configuring Fluentd. Using the CR, you can configure Fluentd CPU and memory limits. For more information, see *Configuring Fluentd*.
+<6> Enter the name of an existing storage class for Elasticsearch storage. For best performance, specify a storage class that allocates block storage. If you do not specify a storage class, {product-title} deploys the {logging} with ephemeral storage only.
+<7> Specify the CPU and memory requests for Elasticsearch as needed. If you leave these values blank, the {es-op} sets default values that are sufficient for most deployments. The default values are `16Gi` for the memory request and `1` for the CPU request.
+<8> Specify the CPU and memory requests for the Elasticsearch proxy as needed. If you leave these values blank, the {es-op} sets default values that should be sufficient for most deployments. The default values are  `256Mi` for the memory request and `100m` for the CPU request.
+<9> Settings for configuring Kibana. Using the CR, you can scale Kibana for redundancy and configure the CPU and memory for your Kibana pods.
+<10> Settings for configuring Fluentd. Using the CR, you can configure Fluentd CPU and memory limits.
 +
 [NOTE]
 +
@@ -373,44 +284,81 @@ elasticsearch-cdm-x6kdekli-3   1/1     1            0           6m44s
 The number of primary shards for the index templates is equal to the number of Elasticsearch data nodes.
 ====
 
-.. Create the instance:
+. Apply the `ClusterLogging` custom resource (CR) by running the following command:
 +
 [source,terminal]
 ----
-$ oc create -f <file-name>.yaml
+$ oc apply -f <filename>.yaml
 ----
 +
-For example:
-+
-[source,terminal]
-----
-$ oc create -f olo-instance.yaml
-----
-+
-This creates the {logging} components, the `Elasticsearch` custom resource and components, and the Kibana interface.
+This creates the {logging} components, the `Elasticsearch` CR and components, and the Kibana interface.
 
-. Verify the installation by listing the pods in the *openshift-logging* project.
+.Verification
+
+. Verify the {es-op} installation:
 +
-You should see several pods for components of the Logging subsystem, similar to the following list:
+[source,terminal]
+----
+$ oc get csv --all-namespaces
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE                                   NAME                                            DISPLAY                            VERSION                    REPLACES    PHASE
+default                                     elasticsearch-operator.5.1.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0                  Succeeded
+kube-node-lease                             elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0                  Succeeded
+kube-public                                 elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0                  Succeeded
+kube-system                                 elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0                  Succeeded
+openshift-apiserver-operator                elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0                  Succeeded
+openshift-apiserver                         elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0                  Succeeded
+openshift-authentication-operator           elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0                  Succeeded
+openshift-authentication                    elasticsearch-operator.5.5.0-202007012112.p0    OpenShift Elasticsearch Operator   5.5.0-202007012112.p0                  Succeeded
+...
+----
++
+There should be an {es-op} instance in each namespace. The version number might be different than shown.
+
+. Verify the {clo} installation.
++
+There should be a Red Hat OpenShift Logging Operator in the `openshift-logging` namespace. The Version number might be different than shown.
++
+[source,terminal]
+----
+$ oc get csv -n openshift-logging
+----
++
+.Example output
+[source,terminal]
+----
+NAMESPACE                                               NAME                                         DISPLAY                  VERSION                   REPLACES    PHASE
+...
+openshift-logging                                       clusterlogging.5.1.0-202007012112.p0         OpenShift Logging        5.1.0-202007012112.p0                 Succeeded
+...
+----
+
+. Verify the installation by listing the pods in the *openshift-logging* project. Run the following command:
 +
 [source,terminal]
 ----
 $ oc get pods -n openshift-logging
 ----
 +
+You should see several pods for components of the {logging}, similar to the following list:
++
 .Example output
 [source,terminal]
 ----
-NAME                                            READY   STATUS    RESTARTS   AGE
-cluster-logging-operator-66f77ffccb-ppzbg       1/1     Running   0          7m
-elasticsearch-cdm-ftuhduuw-1-ffc4b9566-q6bhp    2/2     Running   0          2m40s
-elasticsearch-cdm-ftuhduuw-2-7b4994dbfc-rd2gc   2/2     Running   0          2m36s
-elasticsearch-cdm-ftuhduuw-3-84b5ff7ff8-gqnm2   2/2     Running   0          2m4s
-collector-587vb                                   1/1     Running   0          2m26s
-collector-7mpb9                                   1/1     Running   0          2m30s
-collector-flm6j                                   1/1     Running   0          2m33s
-collector-gn4rn                                   1/1     Running   0          2m26s
-collector-nlgb6                                   1/1     Running   0          2m30s
-collector-snpkt                                   1/1     Running   0          2m28s
-kibana-d6d5668c5-rppqm                          2/2     Running   0          2m39s
+NAME                                                READY   STATUS    RESTARTS   AGE
+cluster-logging-operator-66f77ffccb-ppzbg           1/1     Running   0          7m
+elasticsearch-cdm-ftuhduuw-1-ffc4b9566-q6bhp        2/2     Running   0          2m40s
+elasticsearch-cdm-ftuhduuw-2-7b4994dbfc-rd2gc       2/2     Running   0          2m36s
+elasticsearch-cdm-ftuhduuw-3-84b5ff7ff8-gqnm2       2/2     Running   0          2m4s
+collector-587vb                                     1/1     Running   0          2m26s
+collector-7mpb9                                     1/1     Running   0          2m30s
+collector-flm6j                                     1/1     Running   0          2m33s
+collector-gn4rn                                     1/1     Running   0          2m26s
+collector-nlgb6                                     1/1     Running   0          2m30s
+collector-snpkt                                     1/1     Running   0          2m28s
+kibana-d6d5668c5-rppqm                              2/2     Running   0          2m39s
 ----


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-93
Fixes https://github.com/openshift/openshift-docs/issues/51419

Link to docs preview:
https://67879--docspreview.netlify.app/openshift-enterprise/latest/logging/cluster-logging-deploying#cluster-logging-deploy-cli_cluster-logging-deploying

QE review:
Not required. Had eng double check formatting changes. Meaning of content does not change.

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
