### PR TITLE
OBSDOCS-82: Fix totalLimitSize value

### DIFF
--- a/modules/cluster-logging-collector-tuning.adoc
+++ b/modules/cluster-logging-collector-tuning.adoc
@@ -1,6 +1,6 @@
 // Module included in the following assemblies:
 //
-// * logging/cluster-logging-collector.adoc
+// * logging/log_collection_forwarding/cluster-logging-collector.adoc
 
 :_mod-docs-content-type: PROCEDURE
 [id="cluster-logging-collector-tuning_{context}"]
@@ -45,7 +45,7 @@ These parameters are:
 
 |`totalLimitSize`
 |The maximum size of the buffer, which is the total size of the stage and the queue. If the buffer size exceeds this value, Fluentd stops adding data to chunks and fails with an error. All data not in chunks is lost.
-|`8G`
+|Approximately 15% of the node disk distributed across all outputs.
 
 |`flushInterval`
 |The interval between chunk flushes. You can use `s` (seconds), `m` (minutes), `h` (hours), or `d` (days).


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-82

Link to docs preview:
https://67882--docspreview.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-collector#cluster-logging-collector-tuning_cluster-logging-collector

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
