### PR TITLE
OSDOCS#8733: updating OSUS Operator installation instructions

### DIFF
--- a/modules/update-service-install-web-console.adoc
+++ b/modules/update-service-install-web-console.adoc
@@ -18,13 +18,15 @@ Enter `Update Service` into the *Filter by keyword...* field to find the Operato
 
 . Choose *OpenShift Update Service* from the list of available Operators, and click *Install*.
 
-.. Channel `v1` is selected as the *Update Channel* since it is the only channel available in this release.
+.. Select an *Update channel*.
+
+.. Select a *Version*.
 
 .. Select *A specific namespace on the cluster* under *Installation Mode*.
 
 .. Select a namespace for *Installed Namespace* or accept the recommended namespace `openshift-update-service`.
 
-.. Select an *Approval Strategy*:
+.. Select an *Update approval* strategy:
 +
 ** The *Automatic* strategy allows Operator Lifecycle Manager (OLM) to automatically update the Operator when a new version is available.
 +
@@ -32,6 +34,6 @@ Enter `Update Service` into the *Filter by keyword...* field to find the Operato
 
 .. Click *Install*.
 
-. Verify that the OpenShift Update Service Operator is installed by switching to the *Operators* -> *Installed Operators* page.
+. Go to *Operators* -> *Installed Operators* and verify that the OpenShift Update Service Operator is installed.
 
-. Ensure that *OpenShift Update Service* is listed in the selected namespace with a *Status* of *Succeeded*.
+. Ensure that *OpenShift Update Service* is listed in the correct namespace with a *Status* of *Succeeded*.


### PR DESCRIPTION
[OSDOCS-8733](https://issues.redhat.com/browse/OSDOCS-8733)

Versions: 4.14+

This PR updates instructions to install the OSUS Operator on the web console .

QE review:
- [x] QE has approved this change.

Preview: [Installing the OpenShift Update Service Operator by using the web console](https://67883--docspreview.netlify.app/openshift-enterprise/latest/updating/updating_a_cluster/updating_disconnected_cluster/disconnected-update-osus#update-service-install-web-console_updating-restricted-network-cluster-osus)