### PR TITLE
OBSDOCS-114: Fix formatting YAML error

### DIFF
--- a/modules/cluster-logging-configuration-of-json-log-data-for-default-elasticsearch.adoc
+++ b/modules/cluster-logging-configuration-of-json-log-data-for-default-elasticsearch.adoc
@@ -33,14 +33,22 @@ Suppose the following:
 
 [source,yaml]
 ----
-outputDefaults:
- elasticsearch:
-    structuredTypeKey: kubernetes.labels.logFormat <1>
-    structuredTypeName: nologformat
-pipelines:
-- inputRefs: <application>
-  outputRefs: default
-  parse: json <2>
+apiVersion: logging.openshift.io/v1
+kind: ClusterLogForwarder
+metadata:
+# ...
+spec:
+# ...
+  outputDefaults:
+    elasticsearch:
+      structuredTypeKey: kubernetes.labels.logFormat <1>
+      structuredTypeName: nologformat
+  pipelines:
+  - inputRefs:
+    - application
+    outputRefs:
+    - default
+    parse: json <2>
 ----
 <1> Uses the value of the key-value pair that is formed by the Kubernetes `logFormat` label.
 <2> Enables parsing JSON logs.


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-114

Link to docs preview:
https://67884--docspreview.netlify.app/openshift-enterprise/latest/logging/log_collection_forwarding/cluster-logging-enabling-json-logging#cluster-logging-configuration-of-json-log-data-for-default-elasticsearch_cluster-logging-enabling-json-logging

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
