### PR TITLE
OBSDOCS-542: Update logging pod names

### DIFF
--- a/_topic_maps/_topic_map.yml
+++ b/_topic_maps/_topic_map.yml
@@ -2532,7 +2532,7 @@ Topics:
     File: cluster-logging-memory
   - Name: Using tolerations to control Logging pod placement
     File: cluster-logging-tolerations
-  - Name: Moving the Logging resources with node selectors
+  - Name: Moving logging subsystem resources with node selectors
     File: cluster-logging-moving-nodes
   - Name: Configuring systemd-journald for Logging
     File: cluster-logging-systemd

--- a/_topic_maps/_topic_map_osd.yml
+++ b/_topic_maps/_topic_map_osd.yml
@@ -1005,7 +1005,7 @@ Topics:
     File: cluster-logging-memory
   - Name: Using tolerations to control Logging pod placement
     File: cluster-logging-tolerations
-  - Name: Moving the Logging resources with node selectors
+  - Name: Moving logging subsystem resources with node selectors
     File: cluster-logging-moving-nodes
   #- Name: Configuring systemd-journald and Fluentd
   #  File: cluster-logging-systemd

--- a/_topic_maps/_topic_map_rosa.yml
+++ b/_topic_maps/_topic_map_rosa.yml
@@ -1178,7 +1178,7 @@ Topics:
     File: cluster-logging-memory
   - Name: Using tolerations to control Logging pod placement
     File: cluster-logging-tolerations
-  - Name: Moving the Logging resources with node selectors
+  - Name: Moving logging subsystem resources with node selectors
     File: cluster-logging-moving-nodes
   #- Name: Configuring systemd-journald and Fluentd
   #  File: cluster-logging-systemd

--- a/logging/config/cluster-logging-moving-nodes.adoc
+++ b/logging/config/cluster-logging-moving-nodes.adoc
@@ -6,15 +6,6 @@ include::_attributes/common-attributes.adoc[]
 
 toc::[]
 
-
-
-
-
 You can use node selectors to deploy the Elasticsearch and Kibana pods to different nodes.
-
-// The following include statements pull in the module files that comprise
-// the assembly. Include any combination of concept, procedure, or reference
-// modules required to cover the user story. You can also include other
-// assemblies.
 
 include::modules/infrastructure-moving-logging.adoc[leveloffset=+1]

--- a/modules/cluster-logging-clo-status.adoc
+++ b/modules/cluster-logging-clo-status.adoc
@@ -33,31 +33,29 @@ $ oc get clusterlogging instance -o yaml
 ----
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
-
-....
-
+# ...
 status:  <1>
   collection:
     logs:
       fluentdStatus:
         daemonSet: fluentd  <2>
         nodes:
-          fluentd-2rhqp: ip-10-0-169-13.ec2.internal
-          fluentd-6fgjh: ip-10-0-165-244.ec2.internal
-          fluentd-6l2ff: ip-10-0-128-218.ec2.internal
-          fluentd-54nx5: ip-10-0-139-30.ec2.internal
-          fluentd-flpnn: ip-10-0-147-228.ec2.internal
-          fluentd-n2frh: ip-10-0-157-45.ec2.internal
+          collector-2rhqp: ip-10-0-169-13.ec2.internal
+          collector-6fgjh: ip-10-0-165-244.ec2.internal
+          collector-6l2ff: ip-10-0-128-218.ec2.internal
+          collector-54nx5: ip-10-0-139-30.ec2.internal
+          collector-flpnn: ip-10-0-147-228.ec2.internal
+          collector-n2frh: ip-10-0-157-45.ec2.internal
         pods:
           failed: []
           notReady: []
           ready:
-          - fluentd-2rhqp
-          - fluentd-54nx5
-          - fluentd-6fgjh
-          - fluentd-6l2ff
-          - fluentd-flpnn
-          - fluentd-n2frh
+          - collector-2rhqp
+          - collector-54nx5
+          - collector-6fgjh
+          - collector-6l2ff
+          - collector-flpnn
+          - collector-n2frh
   logstore: <3>
     elasticsearchStatus:
     - ShardAllocationEnabled:  all

--- a/modules/infrastructure-moving-logging.adoc
+++ b/modules/infrastructure-moving-logging.adoc
@@ -5,15 +5,15 @@
 
 :_mod-docs-content-type: PROCEDURE
 [id="infrastructure-moving-logging_{context}"]
-= Moving OpenShift Logging resources
+= Moving {logging} resources
 
-You can configure the Cluster Logging Operator to deploy the pods for {logging} components, such as Elasticsearch and Kibana, to different nodes. You cannot move the Cluster Logging Operator pod from its installed location.
+You can configure the {clo} to deploy the pods for {logging} components, such as Elasticsearch and Kibana, to different nodes. You cannot move the {clo} pod from its installed location.
 
 For example, you can move the Elasticsearch pods to a separate node because of high CPU, memory, and disk requirements.
 
 .Prerequisites
 
-* The Red Hat OpenShift Logging and Elasticsearch Operators must be installed. These features are not installed by default.
+* You have installed the {clo} and the {es-op}.
 
 .Procedure
 
@@ -24,13 +24,12 @@ For example, you can move the Elasticsearch pods to a separate node because of h
 $ oc edit ClusterLogging instance
 ----
 +
+.Example `ClusterLogging` CR
 [source,yaml]
 ----
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
-
-...
-
+# ...
 spec:
   collection:
     logs:
@@ -76,8 +75,7 @@ spec:
       replicas: 1
       resources: null
     type: kibana
-
-...
+# ...
 ----
 <1> Add a `nodeSelector` parameter with the appropriate value to the component you want to move. You can use a `nodeSelector` in the format shown or use `<key>: <value>` pairs, based on the value specified for the node.  If you added a taint to the infrasructure node, also add a matching toleration.
 
@@ -150,13 +148,9 @@ metadata:
 ----
 apiVersion: logging.openshift.io/v1
 kind: ClusterLogging
-
-...
-
+# ...
 spec:
-
-...
-
+# ...
   visualization:
     kibana:
       nodeSelector: <1>
@@ -184,12 +178,12 @@ cluster-logging-operator-84d98649c4-zb9g7       1/1     Running       0         
 elasticsearch-cdm-hwv01pf7-1-56588f554f-kpmlg   2/2     Running       0          28m
 elasticsearch-cdm-hwv01pf7-2-84c877d75d-75wqj   2/2     Running       0          28m
 elasticsearch-cdm-hwv01pf7-3-f5d95b87b-4nx78    2/2     Running       0          28m
-fluentd-42dzz                                   1/1     Running       0          28m
-fluentd-d74rq                                   1/1     Running       0          28m
-fluentd-m5vr9                                   1/1     Running       0          28m
-fluentd-nkxl7                                   1/1     Running       0          28m
-fluentd-pdvqb                                   1/1     Running       0          28m
-fluentd-tflh6                                   1/1     Running       0          28m
+collector-42dzz                                 1/1     Running       0          28m
+collector-d74rq                                 1/1     Running       0          28m
+collector-m5vr9                                 1/1     Running       0          28m
+collector-nkxl7                                 1/1     Running       0          28m
+collector-pdvqb                                 1/1     Running       0          28m
+collector-tflh6                                 1/1     Running       0          28m
 kibana-5b8bdf44f9-ccpq9                         2/2     Terminating   0          4m11s
 kibana-7d85dcffc8-bfpfp                         2/2     Running       0          33s
 ----
@@ -223,11 +217,11 @@ cluster-logging-operator-84d98649c4-zb9g7       1/1     Running   0          30m
 elasticsearch-cdm-hwv01pf7-1-56588f554f-kpmlg   2/2     Running   0          29m
 elasticsearch-cdm-hwv01pf7-2-84c877d75d-75wqj   2/2     Running   0          29m
 elasticsearch-cdm-hwv01pf7-3-f5d95b87b-4nx78    2/2     Running   0          29m
-fluentd-42dzz                                   1/1     Running   0          29m
-fluentd-d74rq                                   1/1     Running   0          29m
-fluentd-m5vr9                                   1/1     Running   0          29m
-fluentd-nkxl7                                   1/1     Running   0          29m
-fluentd-pdvqb                                   1/1     Running   0          29m
-fluentd-tflh6                                   1/1     Running   0          29m
+collector-42dzz                                 1/1     Running   0          29m
+collector-d74rq                                 1/1     Running   0          29m
+collector-m5vr9                                 1/1     Running   0          29m
+collector-nkxl7                                 1/1     Running   0          29m
+collector-pdvqb                                 1/1     Running   0          29m
+collector-tflh6                                 1/1     Running   0          29m
 kibana-7d85dcffc8-bfpfp                         2/2     Running   0          62s
 ----


### PR DESCRIPTION
Version(s):
4.11+

Issue:
https://issues.redhat.com/browse/OBSDOCS-542

Link to docs preview:
- https://67890--docspreview.netlify.app/openshift-enterprise/latest/logging/troubleshooting/cluster-logging-cluster-status
- https://67890--docspreview.netlify.app/openshift-enterprise/latest/logging/config/cluster-logging-moving-nodes

QE review:
- [x] QE has approved this change.
<!--- QE approval is required to merge a PR except for changes that do not impact the meaning of the docs. --->

Additional information:
<!--- Optional: Include additional context or expand the description here.--->

<!--- After you open your PR, ask for review from the OpenShift docs team:
  For community authors: Tag @openshift/team-documentation in a GitHub comment.--->
