### PR TITLE
OSDOCS#7896: 4.14.2 MicroShift z-stream release note

### DIFF
--- a/microshift_release_notes/microshift-4-14-release-notes.adoc
+++ b/microshift_release_notes/microshift-4-14-release-notes.adoc
@@ -330,3 +330,12 @@ Issued: 2023-11-1
 {product-title} release 4.14.1 is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHBA-2023:6155[RHBA-2023:6155] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHBA-2023:6153[RHBA-2023:6153] advisory.
 
 For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].
+
+[id="microshift-4-14-2-dp"]
+=== RHSA-2023:6839 - {microshift-short} 4.14.2 bug fix and security update advisory
+
+Issued: 2023-11-16
+
+{product-title} release 4.14.2, which includes security updates, is now available. The list of bug fixes that are included in the update is documented in the link:https://access.redhat.com/errata/RHSA-2023:6839[RHSA-2023:6839] advisory. The images that are included in the update are provided by the link:https://access.redhat.com/errata/RHSA-2023:6837[RHSA-2023:6837] advisory.
+
+For the `TopoLVM image`, see link:https://catalog.redhat.com/software/containers/lvms4/topolvm-rhel9/63972de3adcb55263891b983?container-tabs=dockerfile[lvms4/topolvm-rhel9].


### PR DESCRIPTION
**Version(s):** 4.14

**Issue:** [OSDOCS-7896](https://issues.redhat.com//browse/OSDOCS-7896)

**Link to docs preview:**
[MicroShift release notes -> RHSA-2023:6839 - MicroShift 4.14.2 bug fix advisory and security update advisory](https://67892--docspreview.netlify.app/microshift/latest/microshift_release_notes/microshift-4-14-release-notes#microshift-4-14-2-dp)

**QE review:**
- No QE needed
